### PR TITLE
[FIX] sale_mrp: use the correct bom when valuating nested kits

### DIFF
--- a/addons/sale_mrp/models/account_move.py
+++ b/addons/sale_mrp/models/account_move.py
@@ -14,9 +14,18 @@ class AccountMoveLine(models.Model):
             # We give preference to the bom in the stock moves for the sale order lines
             # If there are changes in BOMs between the stock moves creation and the
             # invoice validation a wrong price will be taken
-            boms = so_line.move_ids.filtered(lambda m: m.state != 'cancel').mapped('bom_line_id.bom_id').filtered(lambda b: b.type == 'phantom')
-            if boms:
-                bom = boms[0]
+            moves = so_line.move_ids
+            bom = moves.filtered(lambda m: m.state != 'cancel').bom_line_id.bom_id.filtered(lambda b: b.type == 'phantom')[:1]
+            # In the case of nested kits, the above method doesn't allow us to go back to the "root" bom,
+            # Since we lost the relevant information we have to fallback to another method for finding an appropriate bom
+            # This bom may be technically incorrect in the sense that
+            # it's possibly not the one that was actually used for this operation
+            if bom and bom.product_tmpl_id != so_line.product_template_id:
+                bom = self.env['mrp.bom']._bom_find(
+                    products=so_line.product_id, company_id=so_line.company_id.id,
+                    picking_type=moves.picking_type_id, bom_type='phantom',
+                )[so_line.product_id]
+            if bom:
                 is_line_reversing = self.move_id.move_type == 'out_refund'
                 qty_to_invoice = self.product_uom_id._compute_quantity(self.quantity, self.product_id.uom_id)
                 account_moves = so_line.invoice_lines.move_id.filtered(lambda m: m.state == 'posted' and bool(m.reversed_entry_id) == is_line_reversing)
@@ -25,7 +34,6 @@ class AccountMoveLine(models.Model):
                 reversal_cogs = posted_invoice_lines.move_id.reversal_move_id.line_ids.filtered(lambda l: l.display_type == 'cogs' and l.product_id == self.product_id and l.balance > 0)
                 qty_invoiced -= sum([line.product_uom_id._compute_quantity(line.quantity, line.product_id.uom_id) for line in reversal_cogs])
 
-                moves = so_line.move_ids
                 average_price_unit = 0
                 components_qty = so_line._get_bom_component_qty(bom)
                 storable_components = self.env['product.product'].search([('id', 'in', list(components_qty.keys())), ('type', '=', 'product')])


### PR DESCRIPTION
Steps
---
* install `mrp`, `account_accountant`, `sale_management`
* in the settings enable: *Automatic Accounting*, *Units of Measure*
* create the following product with the following bom:
```
        main kit: storable, bom kit, in Units
                sub kit: storable, bom kit, in mm
                        compo: storable
```
* on the main kit's product category, set the inventory valuation to
  automatic
* Create SO for the main kit.
* Confirm > Create Invoice > Confirm
* => Error (Units mismatch)

Cause
---
As of commit https://github.com/odoo/odoo/commit/31e1352df686d8a23628ade83d321929c49d6f4e, we give preference to the BOM from the BOM Lines when computing
anglo-saxon valution.  
But when we have nested kits, this will be the nested-most bom, and
the info about any parent bom has been "lost".

Fix
---
Ideally we still would like to give preference to the actual bom the was
used when we can find it. But now we fallback to the first bom for the correct product in problematic cases.

Note that this may be incorrect from a point of view of finding the
actual BOM that was used for this sale order line.

opw-4040770