### PR TITLE
[FIX] l10n_es_edi_tbai: credit notes need to have an original invoice

### DIFF
--- a/addons/l10n_es_edi_tbai/models/account_edi_format.py
+++ b/addons/l10n_es_edi_tbai/models/account_edi_format.py
@@ -114,8 +114,9 @@ class AccountEdiFormat(models.Model):
                 error_msg = _("TicketBAI: Cannot post invoice while chain head (%s) has not been posted", chain_head.name)
             if (
                 invoice.move_type == 'out_refund'
-                and not invoice.reversed_entry_id._l10n_es_tbai_is_in_chain()
-                and invoice.reversed_entry_id.edi_document_ids.filtered(lambda d: d.edi_format_id.code == 'es_tbai')  # avoid imported ones
+                and not invoice.reversed_entry_id or (
+                    not invoice.reversed_entry_id._l10n_es_tbai_is_in_chain()
+                    and invoice.reversed_entry_id.edi_document_ids.filtered(lambda d: d.edi_format_id.code == 'es_tbai'))  # avoid imported ones
             ):
                 error_msg = _("TicketBAI: Cannot post a reversal move while the source document (%s) has not been posted", invoice.reversed_entry_id.name)
 


### PR DESCRIPTION
Because of https://github.com/odoo/odoo/pull/170616 we relaxed the constraint of needing a chained original refund invoice in the case it is imported.  But that way, we allowed to post a credit note without the original invoice and that would give problems later in the flow as the XML rendering will give an error.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
