### PR TITLE
[17.0][FIX] stock_delivery: Address the package type and weight issue…

### DIFF
--- a/addons/stock_delivery/models/stock_picking.py
+++ b/addons/stock_delivery/models/stock_picking.py
@@ -167,6 +167,10 @@ class StockPicking(models.Model):
         #`package_carrier_type` will be the same in these cases.
         if context['current_package_carrier_type'] in ['fixed', 'base_on_rule']:
             context['current_package_carrier_type'] = 'none'
+        # Update the context 'default_package_type_id' passed from JS
+        # to populate the scanned package type in the package wizard opened from the barcode.
+        if self.env.context.get('default_package_type_id'):
+            context['default_delivery_package_type_id'] = self.env.context.get('default_package_type_id')
         return {
             'name': _('Package Details'),
             'type': 'ir.actions.act_window',


### PR DESCRIPTION
… when the package type is scanned using the barcode

Description of the issue this PR addresses: 
This PR aims to resolve the issue where the IoT scale is connected but unable to retrieve the weight from the scale.

Steps to reproduce:
1. Enable packaging configuration.
2. Create a sales order and confirm it; this will generate a delivery.
3. Find that delivery in the ‘Barcode’ app.
4. Add/scan the product.
5. Scan the package type.

Current behavior before PR:
Following the above steps, when the package type is scanned using the barcode, the scanned package type is not populated in the opened package wizard. Consequently, the shipping weight field is not visible, preventing the retrieval of the weight from the IoT scale.
Please refer to the screen recording before the PR: 
https://github.com/user-attachments/assets/e4764005-6758-4f80-a189-e27e8897f853

Desired behavior after PR is merged:
After merging this PR, when the package type is scanned using the barcode, the scanned package type will be correctly populated in the opened wizard. As a result, the shipping weight will be visible, and it will be able to retrieve the scale weight from IoT.
Please refer to the screen recording after the PR:
https://github.com/user-attachments/assets/f408ee60-2495-48a5-96ea-3ced502c85dc

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
