### PR TITLE
[FIX] l10n_uy, l10n_latam_invoice_document:  Fix Document type on Debit and Credit Notes

### DIFF
--- a/addons/l10n_latam_invoice_document/wizards/account_move_reversal.py
+++ b/addons/l10n_latam_invoice_document/wizards/account_move_reversal.py
@@ -58,6 +58,7 @@ class AccountMoveReversal(models.TransientModel):
                     'journal_id': record.journal_id.id,
                     'partner_id': record.move_ids.partner_id.id,
                     'company_id': record.move_ids.company_id.id,
+                    'reversed_entry_id': record.move_ids.id,
                 })
                 record.l10n_latam_available_document_type_ids = refund.l10n_latam_available_document_type_ids
 

--- a/addons/l10n_uy/models/account_move.py
+++ b/addons/l10n_uy/models/account_move.py
@@ -1,6 +1,16 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import models
 
+# Let us match the document types to properly suggest the DN and CN documents
+# NOTE: this can be avoided if we have an extra subclassification of UY documents
+UY_DOC_SUBTYPES = [
+    ["0"],  # not electronic
+    ["101", "102", "103", "201", "202", "203"],  # e-ticket
+    ["111", "112", "113", "211", "212", "213"],  # e-invoice
+    ["121", "122", "123", "221", "222", "223"],  # e-inv-expo
+    ["151", "152", "153", "251", "252", "253"],  # e-boleta (not implemented yet)
+]
+
 
 class AccountMove(models.Model):
 
@@ -22,3 +32,19 @@ class AccountMove(models.Model):
             where_string += " AND l10n_latam_document_type_id = %(l10n_latam_document_type_id)s"
             param['l10n_latam_document_type_id'] = self.l10n_latam_document_type_id.id or 0
         return where_string, param
+
+    def _get_l10n_latam_documents_domain(self):
+        """ If this is a reversal or debit, suggest only related subtypes """
+        self.ensure_one()
+        domain = super()._get_l10n_latam_documents_domain()
+        if self.country_code == "UY" and (original_move := self.reversed_entry_id or self.debit_origin_id):
+            matching_subtype_codes = [
+                subtype for subtype in UY_DOC_SUBTYPES
+                if original_move.l10n_latam_document_type_id.code in subtype
+            ]
+            if matching_subtype_codes:
+                # restrict to the codes from the subtype matching the one of the original_move (e.g. 'e-ticket')
+                codes = self.env["l10n_latam.document.type"].search(domain).mapped('code')
+                allowed_codes = set(codes).intersection(set(matching_subtype_codes[0]))
+                domain += [("code", "in", tuple(allowed_codes))]
+        return domain

--- a/addons/l10n_uy/tests/__init__.py
+++ b/addons/l10n_uy/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_doc_types

--- a/addons/l10n_uy/tests/test_doc_types.py
+++ b/addons/l10n_uy/tests/test_doc_types.py
@@ -1,0 +1,63 @@
+from odoo import Command
+from odoo.tests.common import tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged("-at_install", "post_install", "post_install_l10n")
+class TestDocTypes(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref='uy'):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        service_vat_22 = cls.env["product.product"].create({
+            "name": "Virtual Home Staging (VAT 22)",
+            "list_price": 38.25,
+            "standard_price": 45.5,
+            "type": "service",
+            "default_code": "VAT 22",
+        })
+
+        cls.invoice = cls.env["account.move"].create({
+            "partner_id": cls.env["res.partner"].create({"name": "test partner UY"}).id,
+            "move_type": "out_invoice",
+            "l10n_latam_document_type_id": cls.env.ref("l10n_uy.dc_e_inv_exp").id,
+            "invoice_line_ids": [Command.create({
+                "product_id": service_vat_22.id,
+                "quantity": 1.0,
+                "price_unit": 100.0,
+            })]
+        })
+        cls.invoice.action_post()
+
+    def test_credit_note(self):
+        self.assertEqual(self.invoice.l10n_latam_document_type_id.code, "121", "Not Export e-Invoice")
+
+        refund_wizard = self.env["account.move.reversal"]\
+            .with_context({"active_ids": self.invoice.ids, "active_model": "account.move"})\
+            .create({
+                "reason": "Mercadería defectuosa",
+                "journal_id": self.invoice.journal_id.id
+            })
+        res = refund_wizard.refund_moves()
+        refund = self.env["account.move"].browse(res["res_id"])
+
+        self.assertEqual(refund.l10n_latam_document_type_id.code, "122", "Not Export e-Invoice Credit Note")
+        expected_docs = ["122"] if self.env['ir.module.module']._get('l10n_uy_edi').state == 'installed' else ['122', '222']
+        self.assertEqual(refund.l10n_latam_available_document_type_ids.mapped("code"), expected_docs, "Bad Domain")
+
+    def test_debit_note(self):
+        self.assertEqual(self.invoice.l10n_latam_document_type_id.code, "121", "Not Export e-self.invoice")
+
+        debit_note_wizard = self.env["account.debit.note"]\
+            .with_context({"active_ids": self.invoice.ids, "active_model": "account.move"})\
+            .create({
+                "reason": "Mercadería defectuosa",
+            })
+        res = debit_note_wizard.create_debit()
+        debit_note = self.env["account.move"].browse(res["res_id"])
+
+        self.assertEqual(debit_note.l10n_latam_document_type_id.code, "123", "Not Export e-Invoice Debit Note")
+        expected_docs = ["123"] if self.env['ir.module.module']._get('l10n_uy_edi').state == 'installed' else ['123', '223']
+        self.assertEqual(debit_note.l10n_latam_available_document_type_ids.mapped("code"), expected_docs, "Bad Domain")


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

Ensure that credit and debit notes in the Uruguayan localization select the correct document type based on the originating document. This update ensures alignment with regulatory requirements: electronic invoices, electronic tickets, export invoices, electronic boletas, and non-electronic documents each dictate the corresponding document type for credit and debit notes created from them

### Steps to reproduce:

1. Install l10n_uy module
2. Create and validate an invoice of tyoe "(121) Export e-Invoice" ![image](https://github.com/user-attachments/assets/baa1e0f7-6ae1-44c8-b5a7-9754c00f1db0)
3. Create Credit Note clicking the button on the invoice form. 
![image](https://github.com/user-attachments/assets/51213b2f-5f73-4dfa-8e39-546545fc7e07)

### Current behavior before PR:

1. The new Credit Note document type suggested is `(0) Credit None` (a different type of the original invoice)
2. Also the domain show all the document types of type Credit, so the user can select a wrong document 

![image](https://github.com/user-attachments/assets/3fe49fc0-8e0e-4744-9d08-608db510c246)

### Desired behavior after PR is merged:

1. The new credit Note document type will match the original invocie
2. The domain will be restricted to the possible credit note subtypes 

![image](https://github.com/user-attachments/assets/b03dfc5f-5151-4de7-9546-624c01c81424)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
