### PR TITLE
[FIX] uom: can not delete uom category

### DIFF
--- a/addons/uom/models/uom_uom.py
+++ b/addons/uom/models/uom_uom.py
@@ -24,7 +24,7 @@ class UoMCategory(models.Model):
             self.uom_ids[0].factor = 1
         else:
             reference_count = sum(uom.uom_type == 'reference' for uom in self.uom_ids)
-            if reference_count == 0 and self._origin.id:
+            if reference_count == 0 and self._origin.id and self.uom_ids:
                 raise UserError(_('UoM category %s must have at least one reference unit of measure.', self.name))
             if self.reference_uom_id:
                 new_reference = self.uom_ids.filtered(lambda o: o.uom_type == 'reference' and o._origin.id != self.reference_uom_id.id)


### PR DESCRIPTION
* STEP TO REPRODUCE: create a new uom category and add a new line ->
Save. Then delete one line (uom_ids) -> raise UserError because the
system force an uom category need to have at least one reference unit.
* Fix by allowing to delete uom categ when it only has one single line of
reference (by first delete the line and then delete the category), just like behaviour in v15 when we just make a user warning
and still allow user to delete it

Related forum issue:
https://www.odoo.com/forum/help-1/unit-of-measure-categories-archive-option-255227

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
