### PR TITLE
[IMP] product, *: simplify kanban archs

### DIFF
--- a/addons/mrp/static/tests/tours/mrp_product_catalog.js
+++ b/addons/mrp/static/tests/tours/mrp_product_catalog.js
@@ -10,11 +10,11 @@ registry.category("web_tour.tours").add('test_mrp_bom_product_catalog', {
             run: "click",
         },
         {
-            trigger: 'div.o_kanban_record:nth-child(1)',
+            trigger: '.o_kanban_record:nth-child(1)',
             run: "click",
         },
         {
-            trigger: 'div.o_product_added',
+            trigger: '.o_product_added',
             run: "click",
         },
         {
@@ -34,11 +34,11 @@ registry.category("web_tour.tours").add('test_mrp_production_product_catalog', {
             run: "click",
         },
         {
-            trigger: 'div.o_kanban_record:nth-child(1)',
+            trigger: '.o_kanban_record:nth-child(1)',
             run: "click",
         },
         {
-            trigger: 'div.o_product_added',
+            trigger: '.o_product_added',
             run: "click",
         },
         {

--- a/addons/product/static/src/product_catalog/kanban_record.xml
+++ b/addons/product/static/src/product_catalog/kanban_record.xml
@@ -1,19 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="ProductCatalogKanbanRecord">
-        <div role="article"
-             t-att-class="getRecordClasses()"
+        <article
+             t-att-class="getRecordClasses() + (productCatalogData.quantity ? ' o_product_added' : '')"
              t-att-data-id="props.record.id"
              t-att-tabindex="props.record.model.useSampleModel ? -1 : 0"
              t-on-click="onGlobalClick"
              t-ref="root">
-            <div class="d-flex flex-column h-100"
-                 t-att-class="{'o_product_added': productCatalogData.quantity}">
-                <t t-call="{{ templates[this.constructor.KANBAN_BOX_ATTRIBUTE] }}"
+            <div class="d-flex flex-column h-100">
+                <t t-call="{{ templates[this.constructor.KANBAN_CARD_ATTRIBUTE] }}"
                    t-call-context="this.renderingContext"/>
                 <t t-component="orderLineComponent" productId="props.record.resId" t-props="productCatalogData"/>
             </div>
             <t t-call="{{ this.constructor.menuTemplate }}"/>
-        </div>
+        </article>
     </t>
 </templates>

--- a/addons/product/static/src/product_catalog/order_line/order_line.scss
+++ b/addons/product/static/src/product_catalog/order_line/order_line.scss
@@ -10,7 +10,7 @@ div.o_product_catalog_quantity {
     }
 }
 
-.o_kanban_view .o_kanban_renderer .o_kanban_record .o_product_added {
+.o_kanban_view .o_kanban_renderer .o_kanban_record.o_product_added {
     background-color: $o-component-active-bg;
     border-color: $o-component-active-border;
 }

--- a/addons/product/static/src/product_catalog/order_line/order_line.xml
+++ b/addons/product/static/src/product_catalog/order_line/order_line.xml
@@ -18,7 +18,7 @@
         <span t-elif="props.readOnly" class="my-2 pt-3 border-top" t-out="props.warning">
             You can't edit this product in the catalog.
         </span>
-        <div t-else="" class="d-flex justify-content-end align-items-center">
+        <div t-else="" class="d-flex justify-content-end align-items-center m-2">
             <div t-if="isInOrder()"
                     class="input-group o_product_catalog_quantity o_product_catalog_cancel_global_click w-50">
                 <button class="btn btn-primary border"

--- a/addons/product/views/product_document_views.xml
+++ b/addons/product/views/product_document_views.xml
@@ -55,51 +55,34 @@
                 <field name="mimetype"/>
                 <field name="type"/>
                 <field name="name"/>
-                <field name="create_uid"/>
                 <field name="active"/>
+                <field name="res_model"/>
                 <templates>
                     <t t-name="kanban-menu">
-                        <a t-if="widget.editable" type="edit" class="dropdown-item">Edit</a>
+                        <a t-if="widget.editable" type="open" class="dropdown-item">Edit</a>
                         <a t-if="widget.deletable" type="delete" class="dropdown-item">Delete</a>
                         <a t-attf-href="/web/content/#{record.ir_attachment_id.raw_value}?download=true" download="" class="dropdown-item">Download</a>
                     </t>
-                    <t t-name="kanban-box">
-                        <div class="oe_kanban_global_area o_kanban_attachment">
-                            <field name="res_model" invisible="True"/>
-                            <div class="ribbon ribbon-top-right" invisible="active">
-                                <span class="text-bg-danger">Archived</span>
+                    <t t-name="kanban-card" class="o_kanban_attachment flex-row">
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
+                        <widget name="web_ribbon" title="Variant" bg_color="text-bg-secondary" invisible="not active or res_model != 'product.product'" groups="product.group_product_variant"/>
+                        <aside class="o_kanban_image m-2">
+                            <t t-set="webimage" t-value="new RegExp('image.*(gif|jpeg|jpg|png|webp)').test(record.mimetype.value)"/>
+                            <t t-set="binaryPreviewable"
+                                t-value="new RegExp('(image|video|application/pdf|text)').test(record.mimetype.value) &amp;&amp; record.type.raw_value === 'binary'"/>
+                            <div t-attf-class="o_kanban_image_wrapper #{(webimage or binaryPreviewable) ? 'o_kanban_previewer' : ''}">
+                                <div t-if="record.type.raw_value == 'url'" class="o_url_image fa fa-link fa-3x text-muted" aria-label="Image is a link"/>
+                                <img t-elif="webimage" t-attf-src="/web/image/#{record.ir_attachment_id.raw_value}" width="100" height="100" alt="Document" class="o_attachment_image"/>
+                                <div t-else="" class="o_image o_image_thumbnail" t-att-data-mimetype="record.mimetype.value"/>
                             </div>
-                            <div class="ribbon ribbon-top-right" invisible="not active or res_model != 'product.product'" groups="product.group_product_variant">
-                                <span class="text-bg-secondary">Variant</span>
+                        </aside>
+                        <main class="ms-2 p-2">
+                            <field name="name" class=" fw-bolder fs-5 text-truncate"/>
+                            <field  t-if="record.type.raw_value == 'url'" name="url" widget="url"/>
+                            <div class="d-flex flex-column mt-2">
+                                <field name="res_name" class="text-decoration-underline fst-italic" invisible="res_model != 'product.product'"/>
                             </div>
-                            <div class="o_kanban_image">
-                                <t t-set="webimage" t-value="new RegExp('image.*(gif|jpeg|jpg|png|webp)').test(record.mimetype.value)"/>
-                                <t t-set="binaryPreviewable"
-                                   t-value="new RegExp('(image|video|application/pdf|text)').test(record.mimetype.value) &amp;&amp; record.type.raw_value === 'binary'"/>
-                                <div t-attf-class="o_kanban_image_wrapper #{(webimage or binaryPreviewable) ? 'o_kanban_previewer' : ''}">
-                                    <div t-if="record.type.raw_value == 'url'" class="o_url_image fa fa-link fa-3x text-muted" aria-label="Image is a link"/>
-                                    <img t-elif="webimage" t-attf-src="/web/image/#{record.ir_attachment_id.raw_value}" width="100" height="100" alt="Document" class="o_attachment_image"/>
-                                    <div t-else="" class="o_image o_image_thumbnail" t-att-data-mimetype="record.mimetype.value"/>
-                                </div>
-                            </div>
-                            <div class="o_kanban_details h-100">
-                                <div class="o_kanban_details_wrapper h-100 justify-content-between">
-                                    <div class="o_kanban_record_title">
-                                        <field name="name" class="o_text_overflow"/>
-                                    </div>
-                                    <div class="o_kanban_record_body"
-                                         name="body"
-                                         t-if="record.type.raw_value == 'url'">
-                                        <field name="url" widget="url" invisible="type == 'binary'"/>
-                                    </div>
-                                    <div class="o_kanban_record_bottom flex-column" name="bottom">
-                                        <div class="mt-2" invisible="res_model != 'product.product'">
-                                            <field name="res_name" style="font-style: italic; text-decoration-line: underline;"/>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        </main>
                     </t>
                 </templates>
             </kanban>

--- a/addons/product/views/product_pricelist_views.xml
+++ b/addons/product/views/product_pricelist_views.xml
@@ -35,18 +35,10 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile" sample="1">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_global_click">
-                            <div id="product_pricelist" class="o_kanban_record_top mb0">
-                                <div class="o_kanban_record_headings">
-                                    <strong class="o_kanban_record_title">
-                                        <span><field name="name"/></span>
-                                    </strong>
-                                </div>
-                                <strong>
-                                    <i class="fa fa-money" role="img" aria-label="Currency" title="Currency"></i> <field name="currency_id"/>
-                                </strong>
-                            </div>
+                    <t t-name="kanban-card" class="flex-row fw-bolder">
+                        <field name="name"/>
+                        <div class="ms-auto align-items-center">
+                            <i class="fa fa-money" role="img" aria-label="Currency" title="Currency"></i> <field name="currency_id"/>
                         </div>
                     </t>
                 </templates>

--- a/addons/product/views/product_supplierinfo_views.xml
+++ b/addons/product/views/product_supplierinfo_views.xml
@@ -67,28 +67,16 @@
         <field name="model">product.supplierinfo</field>
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
-                <field name="min_qty"/>
-                <field name="delay"/>
-                <field name="price"/>
-                <field name="partner_id"/>
                 <field name="currency_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div class="oe_kanban_global_click">
-                            <div class="row mb4">
-                                <strong class="col-6">
-                                    <span t-esc="record.partner_id.value"/>
-                                </strong>
-                                <strong class="col-6 text-end">
-                                    <strong><field name="price" widget="monetary"/></strong>
-                                </strong>
-                                <div class="col-6">
-                                    <span t-esc="record.min_qty.value"/>
-                                </div>
-                                <div class="col-6 text-end">
-                                    <span t-esc="record.delay.value"/> days
-                                </div>
-                            </div>
+                    <t t-name="kanban-card">
+                        <div class="d-flex fw-bolder mb4">
+                            <field name="partner_id" />
+                            <field name="price" widget="monetary" class="ms-auto"/>
+                        </div>
+                        <div class="d-flex">
+                            <field name="min_qty"/>
+                            <field name="delay" class="ms-auto me-1"/>days
                         </div>
                     </t>
                 </templates>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -627,50 +627,40 @@ action = {
         <field name="model">product.product</field>
         <field name="arch" type="xml">
             <kanban records_draggable="0" js_class="product_kanban_catalog">
-                <field name="id" invisible="1"/>
-                <field name="default_code" invisible="1"/>
-                <field name="image_128" invisible="1"/>
+                <field name="id"/>
                 <templates>
                     <t t-name="kanban-menu">
                         <div class="o_product_catalog_cancel_global_click">
-                            <a role="menuitem" type="edit" class="dropdown-item border-top-0">Edit</a>
+                            <a role="menuitem" type="open" class="dropdown-item border-top-0">Edit</a>
                         </div>
                     </t>
-                    <t t-name="kanban-box">
-                        <div class="d-flex flex-grow-1">
-                            <div class="oe_kanban_details p-2 d-flex">
-                                <div class="o_kanban_record_top flex-column m-0"
-                                     t-attf-id="product-{{record.id.raw_value}}">
-                                    <div class="d-flex">
-                                        <field style="margin-top: 2px;"
-                                            class="me-1"
-                                            name="is_favorite"
-                                            widget="boolean_favorite"
-                                            nolabel="1"
-                                            readonly="1"/>
-                                        <h4 class="text-reset">
-                                            <strong class="o_kanban_record_title"><field name="name"/></strong>
-                                        </h4>
-                                    </div>
-                                    <div t-if="record.default_code.value">
-                                        [<field name="default_code"/>]
-                                    </div>
-                                    <!-- Used by @web/product/js/product_catalog/order_line to
-                                         show the price using a t-portal. -->
-                                    <div name="o_kanban_price"
-                                         t-attf-id="product-{{record.id.raw_value}}-price"
-                                         class="d-flex flex-column"/>
-                                    <field name="product_template_attribute_value_ids"
-                                           widget="many2many_tags"
-                                           domain="[('id', 'in', parent.ids)]"
-                                           groups="product.group_product_variant"
-                                           options="{'color_field': 'color'}"/>
+                    <t t-name="kanban-card" class="p-0">
+                    <!-- TODO : not getting border when select record -->
+                        <div class="d-flex flex-grow-1 m-2">
+                            <div class="p-2 pt-1 d-flex flex-column m-0"
+                                    t-attf-id="product-{{record.id.raw_value}}">
+                                <div class="d-flex">
+                                    <field class="mt-1 me-1"
+                                        name="is_favorite"
+                                        widget="boolean_favorite"
+                                        nolabel="1"
+                                        readonly="1"/>
+                                    <field name="name" class="fw-bolder fs-4 text-reset mb-1"/>
                                 </div>
+                                <div t-if="record.default_code.value">
+                                    [<field name="default_code"/>]
+                                </div>
+                                <!-- Used by @web/product/js/product_catalog/order_line to
+                                        show the price using a t-portal. -->
+                                <div name="o_kanban_price"
+                                        t-attf-id="product-{{record.id.raw_value}}-price"/>
+                                <field name="product_template_attribute_value_ids"
+                                        widget="many2many_tags"
+                                        domain="[('id', 'in', parent.ids)]"
+                                        groups="product.group_product_variant"
+                                        options="{'color_field': 'color'}"/>
                             </div>
-                            <div class="o_kanban_image">
-                                <img t-att-src="kanban_image('product.product', 'image_128', record.id.raw_value)"
-                                     alt="Product" invisible="not image_128"/>
-                            </div>
+                            <field name="image_128" widget="image" alt="Product" invisible="not image_128" class="ms-auto" options="{'size': [55, 55]}"/>
                         </div>
                     </t>
                 </templates>

--- a/addons/sale/views/product_document_views.xml
+++ b/addons/sale/views/product_document_views.xml
@@ -19,12 +19,12 @@
         <field name="model">product.document</field>
         <field name="inherit_id" ref="product.product_document_kanban"/>
         <field name="arch" type="xml">
-            <div name="bottom" position="inside">
-                <div class="mt-2">
+            <xpath expr="//main/div" position="inside">
+                <div class="d-flex mt-2">
                     <span>Sales visibility</span>
                     <field name="attached_on_sale" class="ms-2" widget="selection"/>
                 </div>
-            </div>
+            </xpath>
         </field>
     </record>
 

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -255,8 +255,8 @@
             <field name="model">product.product</field>
             <field name="inherit_id" ref="product.product_view_kanban_catalog"/>
             <field name="arch" type="xml">
-                <field name="default_code" invisible="1" position="after">
-                    <field name="is_storable" invisible="1"/>
+                <field name="id" position="after">
+                    <field name="is_storable"/>
                 </field>
                 <div name="o_kanban_price" position="after">
                     <div t-if="record.is_storable.raw_value"
@@ -266,7 +266,7 @@
                         <field name="uom_id" class="ms-1" groups="uom.group_uom"/>
                     </div>
                 </div>
-                <a role="menuitem" type="edit" position="after">
+                <a role="menuitem" type="open" position="after">
                     <a role="menuitem" type="object" name="action_product_forecast_report" class="dropdown-item border-top-0">View Availability</a>
                 </a>
             </field>

--- a/addons/website_sale/views/product_document_views.xml
+++ b/addons/website_sale/views/product_document_views.xml
@@ -19,12 +19,12 @@
         <field name="model">product.document</field>
         <field name="inherit_id" ref="sale.product_document_kanban"/>
         <field name="arch" type="xml">
-            <div name="bottom" position="inside">
-                <div class="mt-2" invisible="res_model == 'product.product'">
+            <xpath expr="//main/div" position="inside">
+                <div class="d-flex mt-2" invisible="res_model == 'product.product'">
                     <span>Publish on website</span>
                     <field name="shown_on_product_page" class="ms-2" widget="boolean_toggle"/>
                 </div>
-            </div>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
*sale,website_sale,purchase,stock
In this commit we have simplified the kanban arch for the product and their view related modules.the goal is to simplify them, make them easier to read and use bootstrap utility classnames.

- Previously, we used kanban-box, but now we are using kanban-card instead.
- Deprecated oe_kanban_global_click and oe_kanban_global_click_edit.
- More use of <field/> tags
- Removed the oe_kanban_colorpicker class and replaced it with the kanban_color_picker widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- kanban_image from rendering context, is deprecated so we use <field name="..." widget="image"/> instead
- kanban_color, kanban_getcolor and kanban_getcolorname are deprecated use new attribute highlight_color="color_field_name" on root node
- oe_kanban_colorpicker is deprecated, use kanban_color_picker widget instead

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
