### PR TITLE
[IMP] odoo: remove usage of psycopg2.sql

### DIFF
--- a/addons/fleet/report/fleet_report.py
+++ b/addons/fleet/report/fleet_report.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from psycopg2 import sql
 
-from odoo import tools
-from odoo import api, fields, models
+from odoo import fields, models
+from odoo.tools.sql import drop_view_if_exists, SQL
 
 
 class FleetReport(models.Model):
@@ -148,9 +147,5 @@ FROM (
             contract_costs cc)
 ) c
 """
-        tools.drop_view_if_exists(self.env.cr, self._table)
-        self.env.cr.execute(
-            sql.SQL("""CREATE or REPLACE VIEW {} as ({})""").format(
-                sql.Identifier(self._table),
-                sql.SQL(query)
-            ))
+        drop_view_if_exists(self.env.cr, self._table)
+        self.env.cr.execute(SQL("""CREATE or REPLACE VIEW %s as (%s)""", SQL.identifier(self._table), SQL(query)))

--- a/addons/hr_timesheet/report/timesheets_analysis_report.py
+++ b/addons/hr_timesheet/report/timesheets_analysis_report.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from psycopg2 import sql
 
-from odoo import api, tools, fields, models
+from odoo import api, fields, models
+from odoo.tools.sql import drop_view_if_exists, SQL
 
 
 class TimesheetsAnalysisReport(models.Model):
@@ -70,10 +70,5 @@ class TimesheetsAnalysisReport(models.Model):
         return "WHERE A.project_id IS NOT NULL"
 
     def init(self):
-        tools.drop_view_if_exists(self.env.cr, self._table)
-        self.env.cr.execute(
-            sql.SQL("CREATE or REPLACE VIEW {} as ({})").format(
-                sql.Identifier(self._table),
-                sql.SQL(self._table_query)
-            )
-        )
+        drop_view_if_exists(self.env.cr, self._table)
+        self.env.cr.execute(SQL("""CREATE or REPLACE VIEW %s as (%s)""", SQL.identifier(self._table), SQL(self._table_query)))

--- a/addons/l10n_nl/migrations/3.3/post-migrate_update_taxes.py
+++ b/addons/l10n_nl/migrations/3.3/post-migrate_update_taxes.py
@@ -1,26 +1,25 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import api, SUPERUSER_ID
-from psycopg2 import sql
+from odoo.tools import SQL
 
 
-def _get_tax_ids_for_xml_id(cr, xml_id):
-    cr.execute(sql.SQL(
+def _get_tax_ids_for_xml_id(env, xml_id):
+    rows = env.execute_query(SQL(
         """
         SELECT res_id
         FROM ir_model_data
         WHERE model = 'account.tax'
-        AND name LIKE '%' || {xml_id}
-        """
-    ).format(xml_id=sql.Literal(xml_id)))
-
-    return [line['res_id'] for line in cr.dictfetchall()]
+        AND name LIKE %s
+        """, f"%{xml_id}"
+    ))
+    return [res_id for res_id, in rows]
 
 
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
 
-    goods_taxes = env['account.tax'].browse(_get_tax_ids_for_xml_id(cr, 'btw_X0_producten'))
-    services_taxes = env['account.tax'].browse(_get_tax_ids_for_xml_id(cr, 'btw_X0_diensten'))
+    goods_taxes = env['account.tax'].browse(_get_tax_ids_for_xml_id(env, 'btw_X0_producten'))
+    services_taxes = env['account.tax'].browse(_get_tax_ids_for_xml_id(env, 'btw_X0_diensten'))
 
     old_3bl_tax_tags = env['account.account.tag']._get_tax_tags('3bl (omzet)', 'nl')
     old_3b_tax_tags = env['account.account.tag']._get_tax_tags('3b (omzet)', 'nl')
@@ -61,22 +60,19 @@ def migrate(cr, version):
 
     for new_tax_tag_id, tax_ids, old_tax_tag_ids, repartition_line_ids in insert_query_params:
         insert_query_parts.append(
-            sql.SQL(
-                cr.mogrify(
-                    """
+            SQL("""
                     SELECT tag_aml_rel.account_move_line_id, %s
                     FROM account_account_tag_account_move_line_rel tag_aml_rel
                     JOIN account_move_line_account_tax_rel aml_at_rel ON aml_at_rel.account_move_line_id = tag_aml_rel.account_move_line_id
                     WHERE aml_at_rel.account_tax_id = ANY(%s)
                     AND tag_aml_rel.account_account_tag_id = ANY(%s)
                     """,
-                    [new_tax_tag_id, tax_ids, old_tax_tag_ids]
-                ).decode()
+                    new_tax_tag_id, tax_ids, old_tax_tag_ids
             )
         )
 
         if len(old_tax_tag_ids) > 1:
-            cr.execute(
+            cr.execute(SQL(
                 """
                 DELETE FROM account_account_tag_account_tax_repartition_line_rel tag_aml_rel
                 WHERE tag_aml_rel.account_account_tag_id = %s
@@ -87,25 +83,24 @@ def migrate(cr, version):
                     AND sub_tag_aml_rel.account_account_tag_id = %s
                 ) >= 1
                 """,
-                [old_tax_tag_ids[0], old_tax_tag_ids[1]]
-            )
+                old_tax_tag_ids[0], old_tax_tag_ids[1]
+            ))
 
-        cr.execute(
+        cr.execute(SQL(
             """
             UPDATE account_account_tag_account_tax_repartition_line_rel
             SET account_account_tag_id = %s
             WHERE account_tax_repartition_line_id = ANY(%s)
             AND account_account_tag_id = ANY(%s)
             """,
-            [new_tax_tag_id, repartition_line_ids, old_tax_tag_ids]
-        )
+            new_tax_tag_id, repartition_line_ids, old_tax_tag_ids
+        ))
 
-    cr.execute(
-        sql.SQL(
+    cr.execute(SQL(
             """
             INSERT INTO account_account_tag_account_move_line_rel (account_move_line_id, account_account_tag_id)
-                {select_statement}
+                %s
             ON CONFLICT DO NOTHING
-            """
-        ).format(select_statement=sql.SQL(" UNION ").join(insert_query_parts)).as_string(cr)
-    )
+            """,
+            SQL(" UNION ").join(insert_query_parts)
+    ))


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
task-4044840

Current behavior before PR:
code of addons uses `psycopg2.sql`

Desired behavior after PR is merged:
Use `odoo.tools.sql.SQL`

odoo/enterprise#67077

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
