### PR TITLE
[IMP] repair: add dedicated final product location

### DIFF
--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -186,8 +186,8 @@
                             <field name="picking_type_id" options="{'no_create': True}" readonly="state in ('done', 'cancel')"/>
                         </group>
                         <group string="Locations" groups="stock.group_stock_multi_locations" name="locations">
+                            <field name="product_location_src_id" readonly="state != 'draft'" options="{'no_create': True}"/>
                             <field name="location_id" readonly="state != 'draft'" options="{'no_create': True}"/>
-                            <field name="recycle_location_id" readonly="state != 'draft'" options="{'no_create': True}"/>
                         </group>
                     </page>
                 </notebook>

--- a/addons/repair/views/stock_picking_views.xml
+++ b/addons/repair/views/stock_picking_views.xml
@@ -5,7 +5,18 @@
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="stock.view_picking_type_form"/>
         <field name="arch" type="xml">
+            <xpath expr="//field[@name='default_location_src_id']" position="attributes">
+                <attribute name="invisible">code=='repair_operation'</attribute>
+            </xpath>
+            <xpath expr="//field[@name='default_location_dest_id']" position="attributes">
+                <attribute name="string">Default Component Destination Location</attribute>
+            </xpath>
+            <xpath expr="//field[@name='default_location_dest_id']" position="before">
+                <field name="default_product_location_src_id" options="{'no_create': True}" invisible="code != 'repair_operation'" required="code == 'repair_operation'"/>
+                <field name="default_location_src_id" string="Default Component Source Location" invisible="code != 'repair_operation'" options="{'no_create': True}" required="code in ('internal', 'outgoing')"/>
+            </xpath>
             <xpath expr="//field[@name='default_location_dest_id']" position="after">
+                <field name="default_product_location_dest_id" options="{'no_create': True}" invisible="code != 'repair_operation'" required="code == 'repair_operation'"/>
                 <field name="default_remove_location_dest_id" options="{'no_create': True}" invisible="code != 'repair_operation'" required="code == 'repair_operation'"/>
                 <field name="default_recycle_location_dest_id" options="{'no_create': True}" invisible="code != 'repair_operation'" required="code == 'repair_operation'"/>
             </xpath>


### PR DESCRIPTION
Before this commit
==================
The operation type of repair did not have specific source and destination locations for products and components.

After this commit
=================
The operation type of repair includes source and destination locations for products and components. Additionally, location changes in the repair module will be updated accordingly.

TaskId: 4028900
