### PR TITLE
[IMP] *: deprecate `pycompat.to_text`

### DIFF
--- a/addons/auth_ldap/models/res_company_ldap.py
+++ b/addons/auth_ldap/models/res_company_ldap.py
@@ -5,10 +5,9 @@ import ldap
 import logging
 from ldap.filter import filter_format
 
-from odoo import _, api, fields, models, tools
+from odoo import _, fields, models
 from odoo.exceptions import AccessDenied
 from odoo.tools.misc import str2bool
-from odoo.tools.pycompat import to_text
 
 _logger = logging.getLogger(__name__)
 
@@ -136,7 +135,7 @@ class CompanyLDAP(models.Model):
             return False
         try:
             conn = self._connect(conf)
-            conn.simple_bind_s(dn, to_text(password))
+            conn.simple_bind_s(dn, password)
             conn.unbind()
         except ldap.INVALID_CREDENTIALS:
             return False
@@ -173,8 +172,8 @@ class CompanyLDAP(models.Model):
             conn = self._connect(conf)
             ldap_password = conf['ldap_password'] or ''
             ldap_binddn = conf['ldap_binddn'] or ''
-            conn.simple_bind_s(to_text(ldap_binddn), to_text(ldap_password))
-            results = conn.search_st(to_text(conf['ldap_base']), ldap.SCOPE_SUBTREE, filter, retrieve_attributes, timeout=60)
+            conn.simple_bind_s(ldap_binddn, ldap_password)
+            results = conn.search_st(conf['ldap_base'], ldap.SCOPE_SUBTREE, filter, retrieve_attributes, timeout=60)
             conn.unbind()
         except ldap.INVALID_CREDENTIALS:
             _logger.error('LDAP bind failed.')
@@ -235,7 +234,7 @@ class CompanyLDAP(models.Model):
             return False
         try:
             conn = self._connect(conf)
-            conn.simple_bind_s(dn, to_text(old_passwd))
+            conn.simple_bind_s(dn, old_passwd)
             conn.passwd_s(dn, old_passwd, new_passwd)
             changed = True
             conn.unbind()

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -24,7 +24,7 @@ from odoo.addons.calendar.models.calendar_recurrence import (
 )
 from odoo.tools.translate import _
 from odoo.tools.misc import get_lang
-from odoo.tools import pycompat, html2plaintext, is_html_empty, single_email_re
+from odoo.tools import html2plaintext, is_html_empty, single_email_re
 from odoo.exceptions import UserError, ValidationError
 
 _logger = logging.getLogger(__name__)
@@ -1448,15 +1448,14 @@ class Meeting(models.Model):
         date_deadline = fields.Datetime.context_timestamp(self_tz, fields.Datetime.from_string(stop))
 
         # convert into string the date and time, using user formats
-        to_text = pycompat.to_text
-        date_str = to_text(date.strftime(format_date))
-        time_str = to_text(date.strftime(format_time))
+        date_str = date.strftime(format_date)
+        time_str = date.strftime(format_time)
 
         if zallday:
             display_time = _("All Day, %(day)s", day=date_str)
         elif zduration < 24:
             duration = date + timedelta(minutes=round(zduration*60))
-            duration_time = to_text(duration.strftime(format_time))
+            duration_time = duration.strftime(format_time)
             display_time = _(
                 u"%(day)s at (%(start)s To %(end)s) (%(timezone)s)",
                 day=date_str,
@@ -1465,8 +1464,8 @@ class Meeting(models.Model):
                 timezone=timezone,
             )
         else:
-            dd_date = to_text(date_deadline.strftime(format_date))
-            dd_time = to_text(date_deadline.strftime(format_time))
+            dd_date = date_deadline.strftime(format_date)
+            dd_time = date_deadline.strftime(format_time)
             display_time = _(
                 u"%(date_start)s at %(time_start)s To\n %(date_end)s at %(time_end)s (%(timezone)s)",
                 date_start=date_str,

--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -224,7 +224,7 @@ class IrHttp(models.AbstractModel):
                               else, such as `'[lang]'` (used for url_return).
         '''
         Lang = request.env['res.lang']
-        location = pycompat.to_text(path_or_uri).strip()
+        location = path_or_uri.strip()
         force_lang = lang_code is not None
         try:
             url = werkzeug.urls.url_parse(location)
@@ -235,7 +235,7 @@ class IrHttp(models.AbstractModel):
         if url and not url.netloc and not url.scheme and (url.path or force_lang):
             location = werkzeug.urls.url_join(request.httprequest.path, location)
             lang_url_codes = [info.url_code for info in Lang._get_frontend().values()]
-            lang_code = pycompat.to_text(lang_code or request.context['lang'])
+            lang_code = lang_code or request.context['lang']
             lang_url_code = Lang._get_data(code=lang_code).url_code
             lang_url_code = lang_url_code if lang_url_code in lang_url_codes else lang_code
             if (len(lang_url_codes) > 1 or force_lang) and cls._is_multilang_url(location, lang_url_codes):

--- a/addons/iap/tools/iap_tools.py
+++ b/addons/iap/tools/iap_tools.py
@@ -9,7 +9,7 @@ import threading
 import uuid
 
 from odoo import exceptions, _
-from odoo.tools import email_normalize, pycompat
+from odoo.tools import email_normalize
 
 _logger = logging.getLogger(__name__)
 
@@ -171,7 +171,7 @@ def iap_authorize(env, key, account_token, credit, dbuuid=False, description=Non
     except InsufficientCreditError as e:
         if credit_template:
             arguments = json.loads(e.args[0])
-            arguments['body'] = pycompat.to_text(env['ir.qweb']._render(credit_template))
+            arguments['body'] = env['ir.qweb']._render(credit_template)
             e.args = (json.dumps(arguments),)
         raise e
     return transaction_token

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -24,7 +24,7 @@ from odoo.addons.mail.models.mail_notification import MailNotification
 from odoo.addons.mail.models.res_users import Users
 from odoo.addons.mail.tools.discuss import Store
 from odoo.tests import common, new_test_user
-from odoo.tools import email_normalize, formataddr, mute_logger, pycompat
+from odoo.tools import email_normalize, formataddr, mute_logger
 from odoo.tools.translate import code_translations
 
 mail_new_test_user = partial(new_test_user, context={'mail_create_nolog': True,
@@ -256,7 +256,7 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
         )
 
     def from_string(self, text):
-        return email.message_from_string(pycompat.to_text(text), policy=email.policy.SMTP)
+        return email.message_from_string(text, policy=email.policy.SMTP)
 
     def assertHtmlEqual(self, value, expected, message=None):
         tree = html.fragment_fromstring(value, parser=html.HTMLParser(encoding='utf-8'), create_parent='body')

--- a/addons/privacy_lookup/wizard/privacy_lookup_wizard.py
+++ b/addons/privacy_lookup/wizard/privacy_lookup_wizard.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import UserError
-from odoo.tools import pycompat, SQL
+from odoo.tools import SQL
 
 
 class PrivacyLookupWizard(models.TransientModel):
@@ -45,7 +45,7 @@ class PrivacyLookupWizard(models.TransientModel):
 
     def _get_query(self):
         name = self.name.strip()
-        email = "%%%s%%" % pycompat.to_text(self.email.strip())
+        email = f"%{self.email.strip()}%"
         email_normalized = tools.email_normalize(self.email.strip())
 
         # Step 1: Retrieve users/partners liked to email address or name

--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -16,7 +16,7 @@ import odoo.modules.registry
 from odoo import http
 from odoo.exceptions import UserError
 from odoo.http import content_disposition, request
-from odoo.tools import lazy_property, osutil, pycompat
+from odoo.tools import lazy_property, osutil
 from odoo.tools.misc import xlsxwriter
 from odoo.tools.translate import _
 
@@ -221,11 +221,11 @@ class ExportXlsxWriter:
                 # here. xlsxwriter does not support bytes values in Python 3 ->
                 # assume this is base64 and decode to a string, if this
                 # fails note that you can't export
-                cell_value = pycompat.to_text(cell_value)
+                cell_value = cell_value.decode()
             except UnicodeDecodeError:
-                raise UserError(_("Binary fields can not be exported to Excel unless their content is base64-encoded. That does not seem to be the case for %s.", self.field_names)[column])
+                raise UserError(_("Binary fields can not be exported to Excel unless their content is base64-encoded. That does not seem to be the case for %s.", self.field_names)[column]) from None
         elif isinstance(cell_value, (list, tuple, dict)):
-            cell_value = pycompat.to_text(cell_value)
+            cell_value = str(cell_value)
 
         if isinstance(cell_value, str):
             if len(cell_value) > self.worksheet.xls_strmax:
@@ -542,11 +542,15 @@ class CSVExport(ExportFormat, http.Controller):
         for data in rows:
             row = []
             for d in data:
+                if d is None or d is False:
+                    d = ''
+                elif isinstance(d, bytes):
+                    d = d.decode()
                 # Spreadsheet apps tend to detect formulas on leading =, + and -
                 if isinstance(d, str) and d.startswith(('=', '-', '+')):
                     d = "'" + d
 
-                row.append(pycompat.to_text(d))
+                row.append(d)
             writer.writerow(row)
 
         return fp.getvalue()

--- a/addons/web/models/ir_qweb_fields.py
+++ b/addons/web/models/ir_qweb_fields.py
@@ -7,7 +7,6 @@ from werkzeug.urls import url_quote
 from markupsafe import Markup
 
 from odoo import api, models, fields
-from odoo.tools import pycompat
 from odoo.tools import html_escape as escape
 
 
@@ -106,9 +105,9 @@ class Image(models.AbstractModel):
         for name, value in atts.items():
             if value:
                 img.append(' ')
-                img.append(escape(pycompat.to_text(name)))
+                img.append(escape(name))
                 img.append('="')
-                img.append(escape(pycompat.to_text(value)))
+                img.append(escape(value))
                 img.append('"')
         img.append('/>')
 

--- a/addons/website/models/ir_qweb.py
+++ b/addons/website/models/ir_qweb.py
@@ -173,8 +173,10 @@ class IrQWeb(models.AbstractModel):
 
         name = self.URL_ATTRS.get(tagName)
         if request:
-            if name and name in atts:
-                atts[name] = self.env['ir.http']._url_for(atts[name])
+            value = atts.get(name) if name else None
+            if value is not None and value is not False:
+                atts[name] = self.env['ir.http']._url_for(str(value))
+
             # Adapt background-image URL in the same way as image src.
             atts = self._adapt_style_background_image(atts, self.env['ir.http']._url_for)
 

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -24,7 +24,7 @@ from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.http import request
 from odoo.modules.module import get_manifest
 from odoo.osv.expression import AND, OR, FALSE_DOMAIN
-from odoo.tools import pycompat, SQL, Query, sql as sqltools
+from odoo.tools import SQL, Query, sql as sqltools
 from odoo.tools.translate import _, xml_translate
 
 logger = logging.getLogger(__name__)
@@ -778,7 +778,7 @@ class Website(models.Model):
                         shape_el = el.xpath("//*[hasclass('o_we_shape')]")
                         if shape_el:
                             shape_el[0].attrib['class'] += ' o_footer_extra_shape_mapping'
-                    rendered_snippet = pycompat.to_text(etree.tostring(el))
+                    rendered_snippet = etree.tostring(el, encoding='unicode')
                     rendered_snippets.append(rendered_snippet)
                 except ValueError as e:
                     logger.warning(e)

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -17,7 +17,7 @@ from psycopg2.sql import Identifier, SQL, Placeholder
 from odoo import api, fields, models, tools, _, _lt, Command
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.osv import expression
-from odoo.tools import format_list, pycompat, unique, OrderedSet, sql as sqltools
+from odoo.tools import format_list, unique, OrderedSet, sql as sqltools
 from odoo.tools.safe_eval import safe_eval, datetime, dateutil, time
 
 _logger = logging.getLogger(__name__)
@@ -433,7 +433,7 @@ class IrModel(models.Model):
     def _instanciate(self, model_data):
         """ Return a class for the custom model given by parameters ``model_data``. """
         class CustomModel(models.Model):
-            _name = pycompat.to_text(model_data['model'])
+            _name = model_data['model']
             _description = model_data['name']
             _module = False
             _custom = True

--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -1241,7 +1241,15 @@ class IrQWeb(models.AbstractModel):
         """ Generates a text value (an instance of text_type) from an arbitrary
             source.
         """
-        return pycompat.to_text(expr)
+        if expr is None or expr is False:
+            return ''
+
+        if isinstance(expr, str):
+            return expr
+        elif isinstance(expr, bytes):
+            return expr.decode()
+        else:
+            return str(expr)
 
     # order
 

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -21,7 +21,7 @@ from odoo.http import request
 from odoo.models import check_method_name
 from odoo.modules.module import get_resource_from_path
 from odoo.osv.expression import expression
-from odoo.tools import config, pycompat, lazy_property, frozendict, SQL
+from odoo.tools import config, lazy_property, frozendict, SQL
 from odoo.tools.convert import _fix_multiple_roots
 from odoo.tools.misc import file_path, get_diff, ConstantMapping
 from odoo.tools.template_inheritance import apply_inheritance_specs, locate_node
@@ -246,7 +246,7 @@ actual arch.
                         lambda term: translation_dictionary[term][lang],
                         arch_fs
                     )
-            view.arch = pycompat.to_text(arch_fs or view.arch_db)
+            view.arch = arch_fs or view.arch_db
 
     def _inverse_arch(self):
         for view in self:

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -30,7 +30,7 @@ from .models import check_property_field_value_name
 from .netsvc import ColoredFormatter, GREEN, RED, DEFAULT, COLOR_PATTERN
 from .tools import (
     float_repr, float_round, float_compare, float_is_zero, human_size,
-    OrderedSet, pycompat, sql, SQL, date_utils, unique,
+    OrderedSet, sql, SQL, date_utils, unique,
     image_process, merge_sequences, is_list_of,
     html_normalize, html_sanitize,
     DEFAULT_SERVER_DATE_FORMAT as DATE_FORMAT,
@@ -974,7 +974,12 @@ class Field(MetaField('DummyField', (object,), {})):
         """ Convert ``value`` from the ``write`` format to the SQL format. """
         if value is None or value is False:
             return None
-        return pycompat.to_text(value)
+        if isinstance(value, str):
+            return value
+        elif isinstance(value, bytes):
+            return value.decode()
+        else:
+            return str(value)
 
     def convert_to_cache(self, value, record, validate=True):
         """ Convert ``value`` to the cache format; ``value`` may come from an
@@ -2013,7 +2018,8 @@ class Char(_String):
             return None
         # we need to convert the string to a unicode object to be able
         # to evaluate its length (and possibly truncate it) reliably
-        return super().convert_to_column(pycompat.to_text(value)[:self.size], record, values, validate)
+        value = value.decode() if isinstance(value, bytes) else str(value)
+        return super().convert_to_column(value[:self.size], record, values, validate)
 
 
 class Text(_String):

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -59,7 +59,7 @@ from .tools import (
     DEFAULT_SERVER_DATE_FORMAT, DEFAULT_SERVER_DATETIME_FORMAT, format_list,
     frozendict, get_lang, lazy_classproperty, OrderedSet,
     ormcache, partition, populate, Query, split_every, unique,
-    SQL, pycompat, sql,
+    SQL, sql,
 )
 from .tools.lru import LRU
 from .tools.misc import CountingStream, LastOrderedSet, ReversedIterable
@@ -3083,7 +3083,7 @@ class BaseModel(metaclass=MetaModel):
         if isinstance(value, SQL):
             sql_value = value
         elif need_wildcard:
-            sql_value = SQL("%s", f"%{pycompat.to_text(value)}%")
+            sql_value = SQL("%s", f"%{value}%")
         else:
             sql_value = SQL("%s", field.convert_to_column(value, self, validate=False))
 

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -117,12 +117,12 @@ import logging
 import pytz
 import reprlib
 import traceback
-from datetime import date, datetime, time
 import warnings
+from datetime import date, datetime, time
 
 import odoo.modules
 from odoo.models import check_property_field_value_name, READ_GROUP_NUMBER_GRANULARITY
-from odoo.tools import pycompat, Query, SQL, get_lang
+from odoo.tools import Query, SQL, get_lang
 from odoo.tools.sql import pattern_to_translated_trigram_pattern, value_to_translated_trigram_pattern
 
 # Domain operators.
@@ -1033,7 +1033,7 @@ class expression(object):
 
                 else:
                     if operator in ('ilike', 'not ilike'):
-                        right = f'%{pycompat.to_text(right)}%'
+                        right = f'%{right}%'
                         unaccent = self._unaccent
                     else:
                         unaccent = lambda x: x

--- a/odoo/tools/pycompat.py
+++ b/odoo/tools/pycompat.py
@@ -32,6 +32,7 @@ def to_text(source):
     * bytes are decoded as UTF-8
     * rest is textified via the current version's relevant data model method
     """
+    warnings.warn("Deprecated since Odoo 18.0.", DeprecationWarning, 2)
     if source is None or source is False:
         return u''
 

--- a/odoo/tools/pycompat.py
+++ b/odoo/tools/pycompat.py
@@ -3,6 +3,7 @@
 import csv
 import codecs
 import io
+import typing
 import warnings
 
 _reader = codecs.getreader('utf-8')
@@ -23,21 +24,20 @@ def csv_writer(stream, **params):
     return csv.writer(_writer(stream), **params)
 
 
-def to_text(source):
-    """ Generates a text value (an instance of text_type) from an arbitrary
-    source.
+def to_text(source: typing.Any) -> str:
+    """ Generates a text value from an arbitrary source.
 
     * False and None are converted to empty strings
     * text is passed through
     * bytes are decoded as UTF-8
-    * rest is textified via the current version's relevant data model method
+    * rest is textified
     """
     warnings.warn("Deprecated since Odoo 18.0.", DeprecationWarning, 2)
     if source is None or source is False:
-        return u''
+        return ''
 
     if isinstance(source, bytes):
-        return source.decode('utf-8')
+        return source.decode()
 
     if isinstance(source, str):
         return source


### PR DESCRIPTION
Moved off of #166700 where it originally lived because it's blocking that and requires quite a bit more work, but should ultimately be feasible: after cleaning up the blatantly useless calls there's less than a dozen either load-bearing or unclear uses.