### PR TITLE
[FIX] mail: correct default fallback domain when creating mixin

### DIFF
--- a/addons/mail/models/mail_alias_mixin_optional.py
+++ b/addons/mail/models/mail_alias_mixin_optional.py
@@ -185,7 +185,7 @@ class AliasMixinOptional(models.AbstractModel):
             'alias_parent_thread_id': self.id if self.id else False,
             'alias_parent_model_id': self.env['ir.model']._get_id(self._name),
         }
-        if self.env.context.get('default_alias_domain_id'):
+        if 'default_alias_domain_id' in self.env.context:
             values['alias_domain_id'] = self.env.context['default_alias_domain_id']
         return values
 


### PR DESCRIPTION
Before this commit, creating a mail alias mixin (typically a project) with an unspecified domain in a multi-company setup could lead to access errors "We could not create alias Inactive Alias because domain <client domain> belongs to company <company 1> while the owner document belongs to company <company 2>"

Steps to reproduce:
1. Start with a clean DB
2. install an app that uses mail (e.g. CRM or Project)
3. Create a second company
4. Set a domain for the 1st company (the one created by default)
5. Erase the domain of the second company (the one created at step 3)
6. Try to install the Field Service app

After this commit, not specifying the domain gets correctly interpreted and a default None value is used.

opw-4051655