### PR TITLE
[FIX] point_of_sale: handle non existing cash payment method on closing register

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -709,7 +709,7 @@ class PosSession(models.Model):
                 'payment_amount': total_default_cash_payment_amount,
                 'moves': cash_in_out_list,
                 'id': default_cash_payment_method_id.id
-            } if default_cash_payment_method_id else None,
+            } if default_cash_payment_method_id else {},
             'non_cash_payment_methods': [{
                 'name': pm.name,
                 'amount': sum(non_cash_payments_grouped_by_method_id[pm].mapped('amount')),

--- a/addons/pos_hr/models/pos_session.py
+++ b/addons/pos_hr/models/pos_session.py
@@ -44,7 +44,7 @@ class PosSession(models.Model):
         payments = orders.payment_ids.filtered(lambda p: p.payment_method_id.type != "pay_later")
         cash_payment_method_ids = self.payment_method_ids.filtered(lambda pm: pm.type == 'cash')
         default_cash_payment_method_id = cash_payment_method_ids[0] if cash_payment_method_ids else None
-        default_cash_payments = payments.filtered(lambda p: p.payment_method_id == default_cash_payment_method_id) if default_cash_payment_method_id else []
+        default_cash_payments = payments.filtered(lambda p: p.payment_method_id == default_cash_payment_method_id) if default_cash_payment_method_id else self.env['pos.payment']
         non_cash_payment_method_ids = self.payment_method_ids - default_cash_payment_method_id if default_cash_payment_method_id else self.payment_method_ids
         non_cash_payments_grouped_by_method_id = {pm.id: orders.payment_ids.filtered(lambda p: p.payment_method_id == pm) for pm in non_cash_payment_method_ids}
 


### PR DESCRIPTION
### Steps to reproduce:
- Install PoS
- Go to Configuration > Point of Sales
- Add a new PoS, checking (Log in with Employees) option doing so.
- Open the register of the newly created PoS, logging as the admin
- Close the register, An error `'list' object has no attribute 'grouped'` shows up

### Investigation:
- when `default_cash_payment_method_id` is `None`, the `default_cash_payments` falls back to an empty list `[]` which doesn't support `grouped`

task-4062902