### PR TITLE
[IMP] stock: forbid quant duplication

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -244,6 +244,9 @@ class StockQuant(models.Model):
             domain_operator = 'in'
         return [('id', domain_operator, quant_query)]
 
+    def copy(self, default=None):
+        raise UserError(_('You cannot duplicate stock quants.'))
+
     @api.model_create_multi
     def create(self, vals_list):
         """ Override to handle the "inventory mode" and create a quant as

--- a/addons/stock/tests/test_quant.py
+++ b/addons/stock/tests/test_quant.py
@@ -70,6 +70,18 @@ class StockQuant(TransactionCase):
         quants = self.env['stock.quant']._gather(product_id, location_id, lot_id=lot_id, package_id=package_id, owner_id=owner_id, strict=strict)
         return quants.filtered(lambda q: not (q.quantity == 0 and q.reserved_quantity == 0))
 
+    def test_copy_quant(self):
+        """
+        You should not be allowed to duplicate quants.
+        """
+        quant = self.env['stock.quant'].create([{
+            'location_id': self.stock_location.id,
+            'product_id': self.product.id,
+            'inventory_quantity': 10,
+        }])
+        with self.assertRaises(UserError):
+            quant.copy()
+
     def test_get_available_quantity_1(self):
         """ Quantity availability with only one quant in a location.
         """


### PR DESCRIPTION
### Issue:
Stock quants are not meant to be duplicated. This commit ensures that it is not possible to copy such records.

opw-4035690
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
