### PR TITLE
[FIX] point_of_sale: res_config settings issue 

### DIFF
--- a/addons/point_of_sale/tests/common.py
+++ b/addons/point_of_sale/tests/common.py
@@ -160,13 +160,6 @@ class TestPoSCommon(ValuationReconciliationTestCommon):
         })
 
         # Set basic defaults
-        cls.pos_sale_journal = cls.env['account.journal'].create({
-            'type': 'general',
-            'name': 'Point of Sale',
-            'code': 'POSS',
-            'company_id': cls.company.id,
-            'sequence': 20
-        })
         cls.sales_account = cls.company_data['default_account_revenue']
         cls.invoice_journal = cls.company_data['default_journal_sale']
         cls.receivable_account = cls.company_data['default_account_receivable']
@@ -250,17 +243,20 @@ class TestPoSCommon(ValuationReconciliationTestCommon):
         config = cls.env['pos.config'].create({
             'name': 'PoS Shop Test',
             'invoice_journal_id': cls.invoice_journal.id,
-            'journal_id': cls.pos_sale_journal.id,
             'available_pricelist_ids': cls.currency_pricelist.ids,
             'pricelist_id': cls.currency_pricelist.id,
         })
         cls.company_data['default_journal_cash'].pos_payment_method_ids.unlink()
-        cls.cash_pm1 = cls.env['pos.payment.method'].create({
-            'name': 'Cash',
-            'journal_id': cls.company_data['default_journal_cash'].id,
-            'receivable_account_id': cls.pos_receivable_cash.id,
-            'company_id': cls.env.company.id,
-        })
+        cls.cash_pm1 = config.payment_method_ids.filtered(lambda c: c.journal_id.type == 'cash')
+        if cls.cash_pm1:
+            cls.cash_pm1.write({'receivable_account_id': cls.pos_receivable_cash.id})
+        else:
+            cls.cash_pm1 = cls.env['pos.payment.method'].create({
+                'name': 'Cash',
+                'journal_id': cls.company_data['default_journal_cash'].id,
+                'receivable_account_id': cls.pos_receivable_cash.id,
+                'company_id': cls.env.company.id,
+            })
         cls.bank_pm1 = cls.env['pos.payment.method'].create({
             'name': 'Bank',
             'journal_id': cls.company_data['default_journal_bank'].id,

--- a/addons/point_of_sale/tests/test_point_of_sale.py
+++ b/addons/point_of_sale/tests/test_point_of_sale.py
@@ -26,6 +26,13 @@ class TestPointOfSale(TransactionCase):
             "company_id": self.company2.id,
             "sequence": 1,  # force this pricelist to be first
         })
+        self.bank_journal = self.env['account.journal'].create({
+            'name': 'Bank',
+            'type': 'bank',
+            'company_id': self.company1.id,
+            'code': 'BNK',
+            'sequence': 11,
+        })
 
         self.env.user.company_id = self.company1
 

--- a/addons/point_of_sale/tests/test_pos_products_with_tax.py
+++ b/addons/point_of_sale/tests/test_pos_products_with_tax.py
@@ -638,6 +638,13 @@ class TestPoSProductsWithTax(TestPoSCommon):
             'taxes_id': [],
         })
         # configure a session on Branch XX
+        self.xx_bank_journal = self.env['account.journal'].with_company(branch_xx).create({
+            'name': 'Bank',
+            'type': 'bank',
+            'company_id': branch_xx.id,
+            'code': 'BNK',
+            'sequence': 15,
+        })
         xx_config = self.env['pos.config'].with_company(branch_xx).create({
             'name': 'Branch XX config',
             'company_id': branch_xx.id,

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -34,7 +34,7 @@
                         A session is currently opened for this PoS. Some settings can only be changed after the session is closed.
                         <button class="btn-link" style="padding:0" name="pos_open_ui" type="object" context="{'pos_config_id': pos_config_id}">Click here to close the session</button>
                     </div>
-                    <div class="o_notification_alert alert alert-warning" invisible="pos_company_has_template" role="alert">
+                    <div class="o_notification_alert alert alert-warning" invisible="pos_company_has_template or chart_template" role="alert">
                         There is no Chart of Accounts configured on the company. Please go to the invoicing settings to install a Chart of Accounts.
                     </div>
                     <div invisible="not pos_config_id">


### PR DESCRIPTION
In this commit:
================
- The warning message regarding the installation of the Chart of Accounts will
  now only be visible when no package is selected.

- A default journal for pos orders will be created and selected in the
  new pos_config.

- Default payment methods will be created and selected by default for the
  creation of new pos_config to avoid blocking points for users,
  as these are mandatory fields.

Task - 4016050