### PR TITLE
[IMP] hw_drivers: allow iotbox to be used as a kiosk

### DIFF
--- a/addons/hw_drivers/browser.py
+++ b/addons/hw_drivers/browser.py
@@ -1,0 +1,147 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+import logging
+import subprocess
+from enum import Enum
+from odoo.addons.hw_drivers.tools import helpers
+
+
+_logger = logging.getLogger(__name__)
+MIN_IMAGE_VERSION = 24.08
+
+
+class BrowserState(Enum):
+    """Enum to represent the state of the browser"""
+    NORMAL = 'normal'
+    KIOSK = 'kiosk'
+    FULLSCREEN = 'fullscreen'
+
+
+class Browser:
+    """Methods to interact with a browser"""
+
+    def __init__(self, url, _x_screen, env, kiosk=False):
+        """
+        :param url: URL to open in the browser
+        :param _x_screen: X screen number
+        :param env: Environment variables (e.g. os.environ.copy())
+        :param kiosk: Whether the browser should be in kiosk mode
+        """
+        self.url = url
+        # helpers.get_version returns a string formatted as: <L|W><version> (L: Linux, W: Windows)
+        self.browser = 'chromium-browser' if float(helpers.get_version()[1:]) >= MIN_IMAGE_VERSION else 'firefox'
+        self._x_screen = _x_screen
+        self._set_environment(env)
+        self.kiosk_args = [
+            '--kiosk',
+            '--incognito',
+            '--disable-infobars',
+            '--noerrdialogs',
+            '--no-first-run',
+        ]
+        self.fullscreen_args = ['--start-fullscreen']
+        self.chromium_additional_args = self.kiosk_args if kiosk else []
+
+        self.instance = None
+
+    def _set_environment(self, env):
+        """
+        Set the environment variables for the browser
+        :param env: Environment variables (os.environ.copy())
+        """
+        self.env = env
+        self.env['DISPLAY'] = f':0.{self._x_screen}'
+        self.env['XAUTHORITY'] = '/run/lightdm/pi/xauthority'
+        for key in ['HOME', 'XDG_RUNTIME_DIR', 'XDG_CACHE_HOME']:
+            self.env[key] = '/tmp/' + self._x_screen
+
+    def open_browser(self, url=None, state=BrowserState.NORMAL):
+        """
+        open the browser with the given URL, or reopen it if it is already open
+        :param url: URL to open in the browser
+        :param state: State of the browser (normal, kiosk, fullscreen)
+        :return: Browser instance (subprocess.Popen instance)
+        """
+        self.url = url or self.url
+
+        # Reopen to take new url or additional args into account
+        if self.instance:
+            self.close_browser()
+
+        if state == BrowserState.KIOSK:
+            self.enable_kiosk_mode()
+        elif state == BrowserState.FULLSCREEN:
+            self.fullscreen()
+
+        self.instance = subprocess.Popen(
+            [
+                self.browser,
+                self.url,
+                '--disk-cache-dir=/dev/null',   # Disable disk cache
+                '--disk-cache-size=1',          # Set disk cache size to 1 byte
+                '--log-level=3',                # Reduce amount of logs
+                *self.chromium_additional_args,
+            ],
+            env=self.env,
+        )
+        helpers.save_browser_state(url=self.url)
+        return self.instance
+
+    def close_browser(self):
+        """close the browser"""
+        if self.instance:
+            self.instance.kill()
+        self.instance = None
+
+    def xdotool_keystroke(self, keystroke):
+        """
+        Execute a keystroke using xdotool
+        :param keystroke: Keystroke to execute
+        """
+        subprocess.run([
+            'xdotool', 'search',
+            '--sync', '--onlyvisible',
+            '--screen', self._x_screen,
+            '--class', self.browser,
+            'key', keystroke,
+        ], check=False)
+
+    def xdotool_type(self, text):
+        """
+        Type text using xdotool
+        :param text: Text to type
+        """
+        subprocess.run([
+            'xdotool', 'search',
+            '--sync', '--onlyvisible',
+            '--screen', self._x_screen,
+            '--class', self.browser,
+            'type', text,
+        ], check=False)
+
+    def open_new_tab(self, url):
+        """
+        Open a new tab with the given URL
+        :param url: URL to open in the new tab
+        """
+        self.url = url
+        self.xdotool_keystroke('ctrl+t')
+        self.xdotool_type(self.url)
+        self.xdotool_keystroke('Return')
+
+    def refresh(self):
+        """Refresh the current tab"""
+        self.xdotool_keystroke('ctrl+r')
+
+    def fullscreen(self):
+        """Adds required arguments to chromium-browser cli to open it """
+        self.chromium_additional_args = self.fullscreen_args
+
+    def enable_kiosk_mode(self):
+        """Adds required arguments to chromium-browser cli to open it in kiosk mode"""
+        self.chromium_additional_args = self.kiosk_args
+
+    def disable_kiosk_mode(self):
+        """Removes arguments to chromium-browser cli to open it without kiosk mode"""
+        if '--kiosk' in self.chromium_additional_args:
+            self.chromium_additional_args = [arg for arg in self.chromium_additional_args if arg not in self.kiosk_args]
+            self.open_browser()

--- a/addons/hw_drivers/main.py
+++ b/addons/hw_drivers/main.py
@@ -33,12 +33,13 @@ iot_devices = {}
 
 
 class Manager(Thread):
+    server_url = None
+
     def send_alldevices(self, iot_client=None):
         """
         This method send IoT Box and devices informations to Odoo database
         """
-        server = helpers.get_odoo_server_url()
-        if server:
+        if self.server_url:
             subject = helpers.read_file_first_line('odoo-subject.conf')
             if subject:
                 domain = helpers.get_ip().replace('.', '-') + subject.strip('*')
@@ -76,7 +77,7 @@ class Manager(Thread):
             try:
                 resp = http.request(
                     'POST',
-                    server + "/iot/setup",
+                    self.server_url + "/iot/setup",
                     body=json.dumps(data).encode('utf8'),
                     headers={
                         'Content-type': 'application/json',
@@ -96,11 +97,11 @@ class Manager(Thread):
         """
         Thread that will load interfaces and drivers and contact the odoo server with the updates
         """
-        server_url = helpers.get_odoo_server_url()
+        self.server_url = helpers.get_odoo_server_url()
 
         helpers.start_nginx_server()
         _logger.info("IoT Box Image version: %s", helpers.get_version(detailed_version=True))
-        if platform.system() == 'Linux' and server_url:
+        if platform.system() == 'Linux' and self.server_url:
             helpers.check_git_branch()
             helpers.generate_password()
         is_certificate_ok, certificate_details = helpers.get_certificate_status()
@@ -108,7 +109,7 @@ class Manager(Thread):
             _logger.warning("An error happened when trying to get the HTTPS certificate: %s",
                             certificate_details)
 
-        iot_client = server_url and WebsocketClient(server_url)
+        iot_client = self.server_url and WebsocketClient(self.server_url)
         # We first add the IoT Box to the connected DB because IoT handlers cannot be downloaded if
         # the identifier of the Box is not found in the DB. So add the Box to the DB.
         self.send_alldevices(iot_client)
@@ -128,7 +129,7 @@ class Manager(Thread):
         schedule and schedule.every().day.at("00:00").do(helpers.get_certificate_status)
 
         # Set up the websocket connection
-        if server_url and iot_client.iot_channel:
+        if self.server_url and iot_client.iot_channel:
             iot_client.start()
         # Check every 3 seconds if the list of connected devices has changed and send the updated
         # list to the connected DB.

--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -35,9 +35,13 @@ try:
 except ImportError:
     _logger.warning('Could not import library crypt')
 
-#----------------------------------------------------------
-# Helper
-#----------------------------------------------------------
+
+class Orientation(Enum):
+    """xrandr screen orientation for kiosk mode"""
+    NORMAL = 'normal'
+    INVERTED = 'inverted'
+    LEFT = 'left'
+    RIGHT = 'right'
 
 
 class CertificateStatus(Enum):
@@ -524,3 +528,25 @@ def disconnect_from_server():
     """Disconnect the IoT Box from the server"""
     unlink_file('odoo-remote-server.conf')
     get_odoo_server_url.cache_clear()
+
+
+def save_browser_state(url=None, orientation=None):
+    """
+    Save the browser state to the file
+    :param url: The URL the browser is on (if None, the URL is not saved)
+    :param orientation: The orientation of the screen (if None, the orientation is not saved)
+    """
+    if url:
+        write_file('browser-url.conf', url)
+    if orientation:
+        write_file('screen-orientation.conf', orientation.value)
+
+
+def load_browser_state():
+    """
+    Load the browser state from the file
+    :return: The URL the browser is on and the orientation of the screen (default to NORMAL)
+    """
+    url = read_file_first_line('browser-url.conf')
+    orientation = read_file_first_line('screen-orientation.conf') or Orientation.NORMAL
+    return url, Orientation(orientation)

--- a/addons/hw_drivers/tools/sync_touchscreen.sh
+++ b/addons/hw_drivers/tools/sync_touchscreen.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+if [ $# -eq 0 ]; then
+    echo "No output screen specified, assuming :0.0"
+    screen=1
+else
+    screen="$1"
+fi
+
+# Get touchscreen name
+touchscreen_name=$(udevadm info --export-db | awk '/ID_INPUT_TOUCHSCREEN=1/' RS= | grep "^E: NAME=" | cut -d '"' -f2)
+if [ -z "$touchscreen_name" ]; then
+    echo "No touchscreen found"
+    exit 1
+fi
+
+# Get touchscreen device ids (Elo Touchscreen appears twice in the list)
+device_id_0=$(xinput list | grep "$touchscreen_name" | head -1 | cut -d "=" -f2 | cut -d$'\t' -f1)
+device_id_1=$(xinput list | grep "$touchscreen_name" | tail -1 | cut -d "=" -f2 | cut -d$'\t' -f1)
+
+# Get screen name: default will return the 1st line (e.g. HDMI-1)
+output_name=$(xrandr --listactivemonitors | awk '{print $NF}' | tail -n +2 | awk -v screen="$screen" 'NR==screen')
+
+# Map touchscreen matrix to screen configuration (orientation)
+xinput map-to-output $device_id_0 "$output_name"
+xinput map-to-output $device_id_1 "$output_name"

--- a/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.js
+++ b/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.js
@@ -154,9 +154,7 @@ export class ClosePosPopup extends Component {
                     Accept: "application/json",
                     "Content-Type": "application/json",
                 },
-                body: JSON.stringify({
-                    action: "close",
-                }),
+                body: JSON.stringify({ params: { action: "close" } }),
             }).catch(() => {
                 console.log("Failed to send data to customer display");
             });

--- a/addons/point_of_sale/static/src/app/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.js
@@ -148,13 +148,15 @@ export class Navbar extends Component {
                     "Content-Type": "application/json",
                 },
                 body: JSON.stringify({
-                    action: "open",
-                    access_token: this.pos.config.access_token,
-                    id: this.pos.config.id,
+                    params: {
+                        action: "open",
+                        access_token: this.pos.config.access_token,
+                        pos_id: this.pos.config.id,
+                    },
                 }),
             })
                 .then(() => {
-                    this.notification.add("Connection successful");
+                    this.notification.add("Connection successful", { type: "success" });
                 })
                 .catch(() => {
                     this.notification.add("Connection failed", { type: "danger" });

--- a/addons/point_of_sale/static/src/app/pos_app.js
+++ b/addons/point_of_sale/static/src/app/pos_app.js
@@ -71,8 +71,10 @@ export class Chrome extends Component {
                     "Content-Type": "application/json",
                 },
                 body: JSON.stringify({
-                    action: "set",
-                    data: selectedOrder.getCustomerDisplayData(),
+                    params: {
+                        action: "set",
+                        data: selectedOrder.getCustomerDisplayData(),
+                    },
                 }),
             }).catch(() => {
                 console.log("Failed to send data to customer display");

--- a/addons/point_of_sale/static/src/customer_display/customer_display_data_service.js
+++ b/addons/point_of_sale/static/src/customer_display/customer_display_data_service.js
@@ -30,9 +30,7 @@ export const CustomerDisplayDataService = {
                             Accept: "application/json",
                             "Content-Type": "application/json",
                         },
-                        body: JSON.stringify({
-                            action: "get",
-                        }),
+                        body: JSON.stringify({ params: { action: "get" } }),
                     }
                 );
                 const payload = await response.json();

--- a/addons/pos_self_order/static/src/app/self_order_index.js
+++ b/addons/pos_self_order/static/src/app/self_order_index.js
@@ -37,6 +37,15 @@ export class selfOrderIndex extends Component {
     setup() {
         this.selfOrder = useSelfOrder();
         window.posmodel = this.selfOrder;
+
+        // Disable cursor on touch devices (required on IoT Box Kiosk)
+        if (
+            "ontouchstart" in window ||
+            navigator.maxTouchPoints > 0 ||
+            navigator.msMaxTouchPoints > 0
+        ) {
+            document.body.classList.add("touch-device");
+        }
     }
     get selfIsReady() {
         return this.selfOrder.models["product.product"].length > 0;

--- a/addons/pos_self_order/static/src/app/self_order_index.scss
+++ b/addons/pos_self_order/static/src/app/self_order_index.scss
@@ -4,6 +4,10 @@
 
     --btn-group-gap: 0;
 
+    // Disable zoom
+    touch-action: pan-x pan-y;
+    height: 100%;
+
     // Target 4K devices
     @media #{screen and (min-width: 3839px), (min-height: 3839px)} {
         --root-font-size: #{$o-so-font-size-4k};
@@ -13,6 +17,7 @@
 html, body {
     height: 100%;
     overflow: hidden;
+    overscroll-behavior: none;  // disable swipe to go back
 }
 
 body {
@@ -75,4 +80,8 @@ ul, ol {
 }
 li {
     list-style-type: none;
+}
+
+.touch-device * {
+    cursor: none !important;
 }

--- a/addons/web/static/src/webclient/actions/action_install_kiosk_pwa.js
+++ b/addons/web/static/src/webclient/actions/action_install_kiosk_pwa.js
@@ -8,7 +8,7 @@ import { Component, onWillStart } from "@odoo/owl";
  * Client action to use in a dialog to display the URL of a Kiosk, containing a
  * link to Install the corresponding PWA
  */
-class InstallKiosk extends Component {
+export class InstallKiosk extends Component {
     static template = "web.ActionInstallKioskPWA";
     static props = { ...standardActionServiceProps };
 

--- a/addons/web/static/src/webclient/actions/action_install_kiosk_pwa.xml
+++ b/addons/web/static/src/webclient/actions/action_install_kiosk_pwa.xml
@@ -1,9 +1,9 @@
 <templates>
 
     <t t-name="web.ActionInstallKioskPWA">
-        <div class="text-center my-3">
+        <div class="my-3 px-3 py-2">
             <div class="fs-2 mb-2">From your Kiosk, open this URL:</div>
-            <i class="fa fa-share-square-o me-1"/><a t-att-href="url" target="_blank" t-esc="url"></a>
+            <i class="fa fa-share-square-o me-1 mb-3"/><a t-att-href="url" target="_blank" t-esc="url"></a>
         </div>
         <footer class="border-top d-flex p-3 justify-content-center justify-content-md-end flex-wrap gap-1 w-100">
             <button class="btn btn-secondary" special="cancel" t-on-click="() => this.dialog.closeAll()">Close</button>


### PR DESCRIPTION
- Moved browser logic inside of a class (Browser),
- Added screen rotation logic,
- Added support for touchscreens: 
    - Screen matrix sync with screen orientation, 
    - Cursor hiding in kiosk, 
    - Disabled zoom in kiosk,
- Added screen orientation and browser url configuration saving logic.

Enterprise PR: [https://github.com/odoo/enterprise/pull/67092](https://github.com/odoo/enterprise/pull/67092)
Task: 3598744