### PR TITLE
[FIX] l10n_ro_efactura: neutralize

### DIFF
--- a/addons/l10n_ro_efactura/data/neutralize.sql
+++ b/addons/l10n_ro_efactura/data/neutralize.sql
@@ -1,0 +1,7 @@
+UPDATE res_company
+    SET l10n_ro_edi_test_env = true,
+        l10n_ro_edi_client_id = NULL,
+        l10n_ro_edi_client_secret = NULL,
+        l10n_ro_edi_access_token = NULL,
+        l10n_ro_edi_refresh_token = NULL;
+


### PR DESCRIPTION
This commit adds the missing neutralization necessary for the l10n_ro_efactura
module introduced in [1]

The purpose of the standard neutralization framework is to allow us to
create database copies that will not interact with external systems in
ways that could impact the production database (or if it is not possible
to prevent the interactions, make sure that they are benign or won't
result in actual changes), or impact the customers of the operator of
the production database.

This is mainly useful to allow safe support investigation on database
duplicates.

[1] https://github.com/odoo/odoo/pull/144061
