### PR TITLE
[FIX] website_payment: prevent infinite loading on donation page

### DIFF
--- a/addons/website_payment/static/src/js/payment_form.js
+++ b/addons/website_payment/static/src/js/payment_form.js
@@ -88,6 +88,7 @@ PaymentForm.include({
                     _t("Payment processing failed"),
                     _t("Some information is missing to process your payment.")
                 );
+                this._enableButton();
                 return;
             }
         }


### PR DESCRIPTION
Steps to Reproduce:
1. As a visitor (not a portal user), attempt to make a donation.
2. Enter an incorrect email or leave the country field unselected.
3. Click on the "Donate" button.
4. Observe that the page continues to load indefinitely.

Description:
When a non-portal user attempts to make a donation and either enters an incorrect email or forgets to select the country, the page continues to load indefinitely. This issue occurred because the submit button was disabled and the UI was blocked, preventing users from correcting their input and resubmitting the form.

Technical:
- Used the `_enableButton` method to unblock the UI and re-enable the "Donate" button if email or country validation fails.

This fix ensures that visitors receive immediate feedback on incorrect or missing inputs, improving the user experience and preventing indefinite loading issue.

task-4008417