### PR TITLE
[IMP] base, bus: do not use registry when dispatching notifications

### DIFF
--- a/addons/auth_oauth/__init__.py
+++ b/addons/auth_oauth/__init__.py
@@ -3,3 +3,12 @@
 
 from . import controllers
 from . import models
+
+
+from odoo.service.security import SESSION_TOKEN_FIELDS
+
+SESSION_TOKEN_FIELDS |= {'oauth_access_token'}
+
+
+def uninstall_hook(env):
+    SESSION_TOKEN_FIELDS.discard('oauth_access_token')

--- a/addons/auth_oauth/__manifest__.py
+++ b/addons/auth_oauth/__manifest__.py
@@ -22,5 +22,6 @@ Allow users to login through OAuth2 Provider.
             'auth_oauth/static/**/*',
         ],
     },
+    'uninstall_hook': 'uninstall_hook',
     'license': 'LGPL-3',
 }

--- a/addons/auth_oauth/models/res_users.py
+++ b/addons/auth_oauth/models/res_users.py
@@ -140,6 +140,3 @@ class ResUsers(models.Model):
                 if res:
                     return
             raise
-
-    def _get_session_token_fields(self):
-        return super(ResUsers, self)._get_session_token_fields() | {'oauth_access_token'}

--- a/addons/auth_totp/__init__.py
+++ b/addons/auth_totp/__init__.py
@@ -2,3 +2,11 @@
 from . import controllers
 from . import models
 from . import wizard
+
+from odoo.service.security import SESSION_TOKEN_FIELDS
+
+SESSION_TOKEN_FIELDS |= {'totp_secret'}
+
+
+def uninstall_hook(env):
+    SESSION_TOKEN_FIELDS.discard('totp_secret')

--- a/addons/auth_totp/__manifest__.py
+++ b/addons/auth_totp/__manifest__.py
@@ -33,5 +33,6 @@ can setup API keys to replace their main password.
             'auth_totp/static/src/**/*',
         ],
     },
+    'uninstall_hook': 'uninstall_hook',
     'license': 'LGPL-3',
 }

--- a/addons/auth_totp/models/res_users.py
+++ b/addons/auth_totp/models/res_users.py
@@ -76,9 +76,6 @@ class Users(models.Model):
         self.ensure_one()
         return self.totp_enabled or super()._rpc_api_keys_only()
 
-    def _get_session_token_fields(self):
-        return super()._get_session_token_fields() | {'totp_secret'}
-
     def _totp_check(self, code):
         sudo = self.sudo()
         key = base64.b32decode(sudo.totp_secret)

--- a/odoo/service/security.py
+++ b/odoo/service/security.py
@@ -1,20 +1,75 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import hmac
+from hashlib import sha256
+from functools import lru_cache, wraps
+
 import odoo
 import odoo.exceptions
+
+
+def lru_cache_ignoring_first_argument(func):
+    first = None
+
+    @lru_cache
+    def _cached(*args):
+        return func(first, *args)
+
+    @wraps(func)
+    def wrapper(*args):
+        nonlocal first
+        first, *rest = args
+        return _cached(*rest)
+
+    wrapper.cache_clear = _cached.cache_clear
+    return wrapper
+
+
+SESSION_TOKEN_FIELDS = {"id", "login", "password", "active"}
+
 
 def check(db, uid, passwd):
     res_users = odoo.registry(db)['res.users']
     return res_users.check(db, uid, passwd)
 
-def compute_session_token(session, env):
-    self = env['res.users'].browse(session.uid)
-    return self._compute_session_token(session.sid)
 
-def check_session(session, env):
-    self = env['res.users'].browse(session.uid)
-    expected = self._compute_session_token(session.sid)
+@lru_cache_ignoring_first_argument
+def compute_session_token_with_cr(cr, sid, uid):
+    session_fields = ", ".join(sorted(SESSION_TOKEN_FIELDS))
+    cr.execute(
+        """SELECT %s, (SELECT value FROM ir_config_parameter WHERE key='database.secret')
+                            FROM res_users
+                            WHERE id=%%s"""
+        % (session_fields),
+        (uid,),
+    )
+    if cr.rowcount != 1:
+        return False
+    data_fields = cr.fetchone()
+    # generate hmac key
+    key = ("%s" % (data_fields,)).encode("utf-8")
+    # hmac the session id
+    data = sid.encode("utf-8")
+    h = hmac.new(key, data, sha256)
+    # keep in the cache the token
+    return h.hexdigest()
+
+
+def compute_session_token(session, env):
+    return compute_session_token_with_cr(env.cr, session.sid, session.uid)
+
+
+def check_session_with_cr(session, cr):
+    expected = compute_session_token_with_cr(cr, session.sid, session.uid)
     if expected and odoo.tools.misc.consteq(expected, session.session_token):
         return True
     return False
+
+
+def check_session(session, env):
+    return check_session_with_cr(session, env.cr)
+
+
+def clear_session_cache():
+    compute_session_token_with_cr.cache_clear()


### PR DESCRIPTION
Previously, dispatching notifications required an environment, which in turn required a registry. This approach was suboptimal because the registry cache is limited. Instantiating many registries when many databases active on the same server can lead to overall performance degradation.

This PR removes the dependency on the environment:

- Notifications are now fetched directly using the cursor.
- `check_session` has been updated to use only a cursor as well.