### PR TITLE
[IMP] product_barcodelookup: product template view improvements

### DIFF
--- a/addons/account/models/product.py
+++ b/addons/account/models/product.py
@@ -139,6 +139,21 @@ class ProductTemplate(models.Model):
         products.invalidate_recordset(['taxes_id', 'supplier_taxes_id'])
         return products
 
+    def _get_list_price(self, price):
+        """ Get the product sales price from a public price based on taxes defined on the product """
+        self.ensure_one()
+        if not self.taxes_id:
+            return self.super._get_list_price(price)
+        computed_price = self.taxes_id.compute_all(price, self.currency_id)
+        total_included = computed_price["total_included"]
+
+        if price == total_included:
+            # Tax is configured as price included
+            return total_included
+        # calculate base from tax
+        included_computed_price = self.taxes_id.with_context(force_price_include=True).compute_all(price, self.currency_id)
+        return included_computed_price['total_excluded']
+
 
 class ProductProduct(models.Model):
     _inherit = "product.product"

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -1463,3 +1463,9 @@ class ProductTemplate(models.Model):
         This method is meant to be overriden in other standard modules.
         """
         return self.env['product.pricelist'].browse(self.env.context.get('pricelist'))
+
+    def _get_list_price(self, price):
+        """ Get the product sales price from a public price based on taxes defined on the product.
+        To be overridden in accounting module."""
+        self.ensure_one()
+        return price

--- a/addons/website_sale/views/product_views.xml
+++ b/addons/website_sale/views/product_views.xml
@@ -160,6 +160,7 @@
                        domain="[('id', '!=', id), '|', ('company_id', '=', company_id), ('company_id', '=', False)]"
                        invisible="not sale_ok"
                        placeholder="Displayed in bottom of product pages"/>
+                <field name="description_ecommerce" invisible="1" />         <!-- Adding this field as we needed in product_barcodelookup module to store value in this field -->
             </group>
             <xpath expr="//page[@name='sales']/group[@name='sale']" position="inside">
                 <group string="eCommerce Shop" name="shop" invisible="not sale_ok">

--- a/addons/website_sale_comparison/views/website_sale_comparison_template.xml
+++ b/addons/website_sale_comparison/views/website_sale_comparison_template.xml
@@ -44,7 +44,7 @@
                                                 <tr>
                                                     <th class="text-start" t-att-colspan="2">
                                                         <span t-if="category" t-field="category.name"/>
-                                                        <span t-else="">Uncategorized</span>
+                                                        <span t-else="">Others</span>
                                                     </th>
                                                 </tr>
                                             </t>


### PR DESCRIPTION
[IMP] account,product,website_sale: add helpers for barcodelookup

This commit adds a hooks to compute a gross price based on product
taxes. This is needed for `product_barcodelookup` module.
Also change a wording in the ecommerce product template

Related: https://github.com/odoo/enterprise/pull/63740
Task: 3965079
