### PR TITLE
[IMP] mail: remove separator along with company logo

### DIFF
--- a/addons/mail/data/mail_templates_email_layouts.xml
+++ b/addons/mail/data/mail_templates_email_layouts.xml
@@ -23,16 +23,6 @@
     <table role="presentation" cellspacing="0" cellpadding="0" border="0" style="width: 100%; margin-top: 5px;">
         <tbody>
             <tr>
-                <td valign="center" t-if="company and not company.uses_default_logo">
-                    <img t-att-src="'/logo.png?company=%s' % company.id" style="padding: 0px; margin: 0px; height: auto; max-width: 200px; max-height: 36px;" t-att-alt="'%s' % company.name"/>
-                </td>
-            </tr>
-            <tr>
-                <td valign="center">
-                    <hr width="100%" style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin: 10px 0px;"/>
-                </td>
-            </tr>
-            <tr>
                 <td valign="center" style="white-space:nowrap;">
                     <table cellspacing="0" cellpadding="0" border="0">
                         <tbody>


### PR DESCRIPTION
This commit removes the company logo and separator beneath it from the mail
notification layout as it was taking a lot of space and sometimes the logo size varies.

Task-4055465
