### PR TITLE
[FIX] bus: fix non deterministic subscription test

### DIFF
--- a/addons/bus/static/tests/bus_test_helpers.js
+++ b/addons/bus/static/tests/bus_test_helpers.js
@@ -108,10 +108,13 @@ export function waitUntilSubscribe() {
 export function waitForChannels(channels, { operation = "add" } = {}) {
     const { env } = MockServer.current;
     const def = new Deferred();
+    let done = false;
 
     function check({ crashOnFail = false } = {}) {
         const userChannels = new Set(env["bus.bus"].channelsByUser[env.uid]);
-        const success = channels.every((c) => userChannels.has(c));
+        const success = channels.every((c) =>
+            operation === "add" ? userChannels.has(c) : !userChannels.has(c)
+        );
         if (!success && !crashOnFail) {
             return;
         }
@@ -128,10 +131,15 @@ export function waitForChannels(channels, { operation = "add" } = {}) {
         } else {
             def.reject(new Error(message));
         }
+        done = true;
     }
 
     const failTimeout = setTimeout(() => check({ crashOnFail: true }), TIMEOUT);
-    after(() => check({ crashOnFail: true }));
+    after(() => {
+        if (!done) {
+            check({ crashOnFail: true });
+        }
+    });
     onWebsocketEvent("subscribe", check);
     check();
     return def;


### PR DESCRIPTION
Before this PR, the "bus subscription updated when joining locally pinned thread" test was sometimes failing.

Internally, it uses the waitForChannels helper, which was rewritten in [1] to handle subscription updates before the helper is called.

However, the helper only works for channel addition, not deletion. The helper only works in this case due to a race condition.

This PR fixes the helper to properly handle deletion.

runbot-65320

[1]: https://github.com/odoo/odoo/pull/168438