### PR TITLE
[FIX] sale_purchase: add missing sale origin on PO

### DIFF
--- a/addons/sale_purchase/models/sale_order_line.py
+++ b/addons/sale_purchase/models/sale_order_line.py
@@ -262,11 +262,10 @@ class SaleOrderLine(models.Model):
             purchase_order = supplier_po_map.get(partner_supplier.id)
             if not purchase_order:
                 purchase_order = line._match_or_create_purchase_order(supplierinfo)
-            else:  # if not already updated origin in this loop
-                so_name = line.order_id.name
-                origins = (purchase_order.origin or '').split(', ')
-                if so_name not in origins:
-                    purchase_order.write({'origin': ', '.join(origins + [so_name])})
+            so_name = line.order_id.name
+            origins = (purchase_order.origin or '').split(', ')
+            if so_name not in origins:
+                purchase_order.write({'origin': ', '.join(origins + [so_name])})
             supplier_po_map[partner_supplier.id] = purchase_order
 
             # add a PO line to the PO

--- a/addons/sale_purchase/tests/test_sale_purchase.py
+++ b/addons/sale_purchase/tests/test_sale_purchase.py
@@ -80,6 +80,8 @@ class TestSalePurchase(TestCommonSalePurchaseNoChart):
 
         self.assertEqual(len(purchase_order), 1, "Only one PO should have been created, from the 2 Sales orders")
         self.assertEqual(len(purchase_order.order_line), 2, "The purchase order should have 2 lines")
+        self.assertIn(self.sale_order_1.name, purchase_order.origin, "The PO should have SO 1 in its source documents")
+        self.assertIn(self.sale_order_2.name, purchase_order.origin, "The PO should have SO 2 in its source documents")
         self.assertEqual(len(purchase_lines_so1), 1, "Only one SO line from SO 1 should have create a PO line")
         self.assertEqual(len(purchase_lines_so2), 1, "Only one SO line from SO 2 should have create a PO line")
         self.assertEqual(len(purchase_order.activity_ids), 0, "No activity should be scheduled on the PO")


### PR DESCRIPTION
Steps
-----
1. Have a product of type "Service" with "Subcontract Service" activated on the Purchase page and with at least a vendor.
2. Create a Sales Order with this product. When confirming it, a PO will be automatically created.
3. Create another Sales Order with the product.
4. The PO now has 2 lines, but the "Source Document" in "Other Information" of the PO only contains the name of the first SO.

Cause
-----
Refactor e54b57ee74893170134438a9b5873db4dfd03ddc changed the logic. If a PO is found by _purchase_service_match_purchase_order, it should have its origin modified to include the new SO (not the case currently).

opw-4049834