### PR TITLE
[PERF] test_website_slides_full: certification tour is slow

### DIFF
--- a/addons/test_website_slides_full/__manifest__.py
+++ b/addons/test_website_slides_full/__manifest__.py
@@ -13,7 +13,6 @@ certification flow including purchase, certification, failure and success.
         'website_sale_slides',
         'website_slides_forum',
         'website_slides_survey',
-        'payment_demo'
     ],
     'data': [
         'data/res_groups_data.xml',

--- a/addons/test_website_slides_full/static/tests/tours/slides_certification_member.js
+++ b/addons/test_website_slides_full/static/tests/tours/slides_certification_member.js
@@ -1,63 +1,29 @@
 import { registry } from "@web/core/registry";
-import * as tourUtils from '@website_sale/js/tours/tour_utils';
-import { clickOnExtraMenuItem } from "@website/js/tours/tour_utils";
 
 /**
- * The purpose of this tour is to check the whole certification flow:
+ * This tour validates the complete certification flow for a student (= portal user).
  *
- * -> student (= demo user) checks 'on payment' course content
- * -> clicks on "buy course"
- * -> is redirected to webshop on the product page
- * -> buys the course
- * -> fails 3 times, exhausting their attempts
- * -> is removed to the members of the course
- * -> buys the course again
- * -> succeeds the certification
- * -> has the course marked as completed
- * -> has the certification in their user profile
+ * The tour consists of two main scenarios:
  *
+ * 1. **Failure Attempts**
+ *    - The student is redirected to the "All Courses" page.
+ *    - Navigates to the certification course.
+ *    - Starts the certification process.
+ *    - Fails the test 3 times, exhausting all attempts.
+ *    - Is removed from the course members.
+ *
+ * 2. **Successful Attempt**
+ *    - The student is redirected to the "All Courses" page.
+ *    - Navigates to the certification course.
+ *    - Starts the certification process.
+ *    - Successfully completes the certification.
+ *    - The course is marked as completed.
+ *    - The certification is added to their user profile.
  */
 
-var initTourSteps = [{
+var startCertificationSurvey = [{
     content: 'eLearning: go to certification course',
     trigger: 'a:contains("DIY Furniture - TEST")',
-    run: "click",
-}, {
-    content: 'eLearning: does not have access to certification',
-    trigger: '.o_wslides_course_main',
-    run() {
-        // check that user doesn't have access to course content
-        if (
-            document.querySelectorAll(
-                ".o_wslides_slides_list_slide .o_wslides_js_slides_list_slide_link"
-            ).length === 0
-        ) {
-            document
-                .querySelector(".o_wslides_course_main")
-                .classList.add("empty-content-success");
-        }
-    }
-}, {
-    content: 'eLearning: previous step check',
-    trigger: '.o_wslides_course_main.empty-content-success',
-}];
-
-var buyCertificationSteps = [{
-    content: 'eLearning: try to buy course',
-    trigger: 'a:contains("Add to Cart")',
-    run: "click",
-},
-    tourUtils.goToCart(),
-    tourUtils.goToCheckout(),
-    ...tourUtils.payWithDemo(),
-    clickOnExtraMenuItem({}),
-{
-    content: 'eCommerce: go back to e-learning home page',
-    trigger: '.nav-item a:contains("Courses")',
-    run: "click",
-}, {
-    content: 'eLearning: go into bought course',
-    trigger: 'a:contains("DIY Furniture")',
     run: "click",
 }, {
     content: 'eLearning: user should be enrolled',
@@ -143,18 +109,16 @@ var certificationCompletionSteps = [{
     content: 'Survey: back to course home page',
     trigger: 'a:contains("Go back to course")',
     run: "click",
-},
-    clickOnExtraMenuItem({}),
-{
-    content: 'eLearning: back to e-learning home page',
-    trigger: '.nav-item a:contains("Courses")',
-    run: "click",
 }, {
     content: 'eLearning: course should be completed',
-    trigger: '.o_wslides_course_card:contains("DIY Furniture") .badge:contains("Completed")',
+    trigger: '.o_wslides_channel_completion_completed',
 }];
 
 var profileSteps = [{
+    content: 'eLearning: back to e-learning home page',
+    trigger: 'a:contains("Courses")',
+    run: "click",
+}, {
     content: 'eLearning: access user profile',
     trigger: '.o_wslides_home_aside_loggedin a:contains("View")',
     run: "click",
@@ -163,21 +127,22 @@ var profileSteps = [{
     trigger: '.o_wprofile_slides_course_card_body:contains("Furniture Creation Certification")',
 }];
 
-registry.category("web_tour.tours").add('certification_member', {
+registry.category("web_tour.tours").add('certification_member_failure', {
     url: '/slides',
     steps: () => [].concat(
-        initTourSteps,
-        buyCertificationSteps,
+        startCertificationSurvey,
         failCertificationSteps,
         retrySteps,
         failCertificationSteps,
         retrySteps,
-        failCertificationSteps,
-        [{
-            trigger: 'a:contains("Go back to course")',
-            run: "click",
-        }],
-        buyCertificationSteps,
+        failCertificationSteps
+    )
+});
+
+registry.category("web_tour.tours").add('certification_member_success', {
+    url: '/slides',
+    steps: () => [].concat(
+        startCertificationSurvey,
         succeedCertificationSteps,
         certificationCompletionSteps,
         profileSteps


### PR DESCRIPTION
Currently 'certification_member' tour is too slow that We had to increase the
default timeout of 60 seconds.

The purpose of this PR is to reduce tour time by removing steps / decrease fail
attempt or optimizing tour steps.

Changes:

As the purpose of the test/tour is to check course certification flow,
**NOT** to test the ecommerce checkout flow, which is taking too much time.

We removed course purchase flow and used python to create sale order for the member.

--> Python prepares certification data (course / survey)
--> Python creates a sale order for the course and confirms it, should add the
member to the course (so we do the steps in python rather than in the tour
inside the ecommerce shop)
--> Python runs test first,
--> The tour fails the certification 3 times,
--> Python checks that the member is kicked out of the course.
--> Python creates a second sale order and confirms it, should add the member again
and run it,
--> The tour succeeds the certification (with the profile steps at the end)
--> Python do some extra bonus checks, verifying membership status, course completion..

Improvement:

Tour average runtime (Before this PR): **~59-62 seconds**
Tour average runtime (After this PR):  **~36-39 seconds**
Performance Improvement: **~38%**

Task-3478117