### PR TITLE
[IMP] mrp_workorder: compute has_operation_note

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -102,6 +102,7 @@ class MrpWorkorder(models.Model):
     worksheet_google_slide = fields.Char(
         'Worksheet URL', related='operation_id.worksheet_google_slide', readonly=True)
     operation_note = fields.Html("Description", related='operation_id.note', readonly=True)
+    has_operation_note = fields.Boolean("Has Description", compute='_compute_has_operation_note')
     move_raw_ids = fields.One2many(
         'stock.move', 'workorder_id', 'Raw Moves',
         domain=[('raw_material_production_id', '!=', False), ('production_id', '=', False)])
@@ -381,6 +382,11 @@ class MrpWorkorder(models.Model):
                 order.is_user_working = True
             else:
                 order.is_user_working = False
+
+    def _compute_has_operation_note(self):
+        relevant_workorders = self.env['mrp.workorder'].search_fetch(['&', ('id', 'in', self.ids), ('operation_note', '!=', False)], ['id'])
+        for workorder in self:
+            workorder.has_operation_note = workorder.id in relevant_workorders.ids
 
     def _compute_scrap_move_count(self):
         data = self.env['stock.scrap']._read_group([('workorder_id', 'in', self.ids)], ['workorder_id'], ['__count'])


### PR DESCRIPTION
This commit adds a new field 'has_operation_note' to the mrp.workorder model so we can avoid unnecessarily fetching the 'operation_note' field.

This change is required to improve the performance of Shop Floor as we don't want to fetch and sanitize the operation note for every workorder yet we still have to know if there is one to display the relevant button.

See the Enterprise commit for a detailed explanation of the issue: https://github.com/odoo/enterprise/pull/66176/commits/55179d707406520c9898ac93163ad302bd90a175

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
