### PR TITLE
[FIX] web: no content help on the settings only if a search is done

### DIFF
--- a/addons/web/static/src/webclient/settings_form_view/settings_form_controller.js
+++ b/addons/web/static/src/webclient/settings_form_view/settings_form_controller.js
@@ -18,15 +18,19 @@ export class SettingsFormController extends formView.Controller {
         useSubEnv({ searchState: this.searchState });
         useEffect(
             () => {
-                if (
-                    this.rootRef.el.querySelector(".o_settings_container:not(.d-none)") ||
-                    this.rootRef.el.querySelector(
-                        ".settings .o_settings_container:not(.d-none) .o_setting_box.o_searchable_setting"
-                    )
-                ) {
-                    this.state.displayNoContent = false;
+                if (this.searchState.value) {
+                    if (
+                        this.rootRef.el.querySelector(".o_settings_container:not(.d-none)") ||
+                        this.rootRef.el.querySelector(
+                            ".settings .o_settings_container:not(.d-none) .o_setting_box.o_searchable_setting"
+                        )
+                    ) {
+                        this.state.displayNoContent = false;
+                    } else {
+                        this.state.displayNoContent = true;
+                    }
                 } else {
-                    this.state.displayNoContent = true;
+                    this.state.displayNoContent = false;
                 }
             },
             () => [this.searchState.value]

--- a/addons/web/static/tests/webclient/settings_form_view/settings_form_view_tests.js
+++ b/addons/web/static/tests/webclient/settings_form_view/settings_form_view_tests.js
@@ -282,6 +282,29 @@ QUnit.module("SettingsFormView", (hooks) => {
         );
     });
 
+    QUnit.test("don't show noContentHelper if no search is done", async function (assert) {
+        await makeView({
+            type: "form",
+            resModel: "res.config.settings",
+            serverData,
+            arch: `
+                <form string="Settings" class="oe_form_configuration o_base_settings" js_class="base_settings">
+                    <div class="o_setting_container">
+                        <div class="settings">
+                            <div class="app_settings_block" string="Settings" data-key="settings">
+                                <h2>Setting title</h2>
+                                <h3 class="o_setting_tip">Settings will appear below</h3>
+                            </div>
+                        </div>
+                    </div>
+                </form>`,
+        });
+        assert.isNotVisible(
+            target.querySelector(".o_nocontent_help"),
+            "record not found message shown"
+        );
+    });
+
     QUnit.test("unhighlight section not matching anymore", async function (assert) {
         await makeView({
             type: "form",


### PR DESCRIPTION
Before this commit, if a settings app doesn't have settings (for instance if a setting header is not selected), the no content helper was always shown. The issue with this, is that the settings page is not a multi-record view, it's a customize form view, the content helper, it should only be shown if a search is performed and that no setting is found.

This commit, fix this, and allow the no content helper to appear only if a search is performed and no setting is found.

opw-4016050