### PR TITLE
[IMP] mass_mailing_sms: improve test and unsubscribe flows

### DIFF
--- a/addons/mail/static/src/views/web/fields/emojis_text_field/emojis_text_field.xml
+++ b/addons/mail/static/src/views/web/fields/emojis_text_field/emojis_text_field.xml
@@ -8,5 +8,8 @@
         <xpath expr="//*[hasclass('o_field_input_buttons')]" position="inside">
             <t t-call="mail.EmojisFieldButton"/>
         </xpath>
+        <xpath expr="//*[hasclass('o_field_input_buttons')]" position="attributes">
+            <attribute name="style" add="visibility: visible;" separator=" " />
+        </xpath>
     </t>
 </templates>

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -91,7 +91,7 @@ class MailingMailing(models.Model):
              'Keep it empty if you prefer the first characters of your email content to appear instead.')
     email_from = fields.Char(
         string='Send From',
-        compute='_compute_email_from', readonly=False, required=True, store=True, precompute=True)
+        compute='_compute_email_from', readonly=False, store=True, precompute=True)
     favorite = fields.Boolean('Favorite', copy=False, tracking=True)
     favorite_date = fields.Datetime(
         'Favorite Date',
@@ -237,6 +237,10 @@ class MailingMailing(models.Model):
     _percentage_valid = models.Constraint(
         'CHECK(ab_testing_pc >= 0 AND ab_testing_pc <= 100)',
         'The A/B Testing Percentage needs to be between 0 and 100%',
+    )
+    _email_from = models.Constraint(
+        "CHECK(email_from IS NOT NULL OR mailing_type != 'mail')",
+        "email from is required for mailing"
     )
 
     @api.constrains('mailing_model_id', 'mailing_filter_id')

--- a/addons/mass_mailing/models/mailing_trace.py
+++ b/addons/mass_mailing/models/mailing_trace.py
@@ -57,6 +57,7 @@ class MailingTrace(models.Model):
     _order = 'create_date DESC'
 
     trace_type = fields.Selection([('mail', 'Email')], string='Type', default='mail', required=True)
+    is_test_trace = fields.Boolean('Generated for testing')
     # mail data
     mail_mail_id = fields.Many2one('mail.mail', string='Mail', index='btree_not_null')
     mail_mail_id_int = fields.Integer(

--- a/addons/mass_mailing/security/ir.model.access.csv
+++ b/addons/mass_mailing/security/ir.model.access.csv
@@ -8,7 +8,6 @@ access_mailing_list_mm_user,access.mailing.list.mm.user,model_mailing_list,mass_
 access_utm_stage,utm.stage,utm.model_utm_stage,mass_mailing.group_mass_mailing_user,1,1,1,1
 access_mailing_mailing_mm_user,access.mailing.mailing.mm.user,model_mailing_mailing,mass_mailing.group_mass_mailing_user,1,1,1,1
 access_mailing_mailing_system,access.mailing.mailing.system,model_mailing_mailing,base.group_system,1,1,1,1
-access_mailing_trace_user,mailing.trace.user,model_mailing_trace,mass_mailing.group_mass_mailing_user,1,1,1,1
 access_mailing_trace_mm_user,access.mailing.trace.mm.user,model_mailing_trace,mass_mailing.group_mass_mailing_user,1,1,1,1
 access_mailing_trace_report_mm_user,access.mailing.trace.report.mm.user,model_mailing_trace_report,mass_mailing.group_mass_mailing_user,1,0,0,0
 access_utm_campaign_mass_mailing_user,utm.campaign,utm.model_utm_campaign,mass_mailing.group_mass_mailing_user,1,1,1,1

--- a/addons/mass_mailing/static/src/scss/mass_mailing.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.scss
@@ -100,7 +100,7 @@ body.editor_has_snippets .o_field_mass_mailing_html div.d-flex:has(iframe) {
             .o_mailing_list_kanban_stats > a {
                 flex-wrap: wrap;
                 &:hover {
-                    font-weight: normal !important;
+                    color: rgb(1, 126, 132) !important;
                 }
                 @include media-breakpoint-down(sm) {
                     font-size: 1.4rem !important;
@@ -116,14 +116,14 @@ body.editor_has_snippets .o_field_mass_mailing_html div.d-flex:has(iframe) {
                 outline: 0;
                 padding: 0;
                 font-weight: 300;
-                &:hover {
-                    font-weight: normal;
-                }
                 &.o_mailing_list_kanban_big_nb {
                     text-align: left;
                     font-size: 300%;
                     @include media-breakpoint-up(sm) {
                         text-align: right;
+                    }
+                    &:hover {
+                        color: rgb(113, 75, 103) !important;
                     }
                 }
             }

--- a/addons/mass_mailing/views/mailing_trace_views.xml
+++ b/addons/mass_mailing/views/mailing_trace_views.xml
@@ -20,6 +20,7 @@
                 <filter string="Replied" name="filter_replied" domain="[('trace_status', '=', 'reply')]"/>
                 <filter string="Bounced" name="filter_bounced" domain="[('trace_status', '=', 'bounce')]"/>
                 <filter string="Failed" name="filter_failed" domain="[('trace_status', '=', 'error')]"/>
+                <filter string="Test Traces" name="filter_is_test_trace" domain="[('is_test_trace', '=', 'True')]"/>
                 <group expand="0" string="Group By">
                     <filter string="State" name="state" domain="[]" context="{'group_by': 'trace_status'}"/>
                     <filter string="Open Date" name="group_open_date" domain="[('trace_status', 'in', ['open', 'reply'])]" context="{'group_by': 'open_datetime:day'}"/>
@@ -45,6 +46,7 @@
                 <field name="failure_type" optional="show"/>
                 <field name="open_datetime" optional="hide"/>
                 <field name="reply_datetime" optional="hide"/>
+                <field name="is_test_trace" optional="hide"/>
                 <button name="action_view_contact" type="object"
                         string="Open Recipient" icon="fa-user"/>
             </list>
@@ -66,6 +68,7 @@
                 <field name="failure_type" optional="show"/>
                 <field name="open_datetime" optional="hide"/>
                 <field name="reply_datetime" optional="hide"/>
+                <field name="is_test_trace" optional="hide"/>
                 <button name="action_view_contact" type="object"
                         string="Open Recipient" icon="fa-user"/>
             </list>
@@ -89,6 +92,8 @@
                                 </div>
                         </button>
                     </div>
+                    <field name="is_test_trace" invisible="1"/>
+                    <widget name="web_ribbon" title="Test" bg_color="text-bg-danger" invisible="is_test_trace != True"/>
                     <group>
                         <group string="Status">
                             <field name="failure_type" invisible="not failure_type"/>

--- a/addons/mass_mailing_sms/security/ir.model.access.csv
+++ b/addons/mass_mailing_sms/security/ir.model.access.csv
@@ -1,3 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_mailing_sms_test,access.mailing.sms.test,model_mailing_sms_test,mass_mailing.group_mass_mailing_user,1,1,1,0
 access_phone_blacklist_remove_mass_mailing_user,acesss.phone.blacklist.remove.mass_mailing_user,phone_validation.model_phone_blacklist_remove,mass_mailing.group_mass_mailing_user,1,1,1,1
+access_sms_tracker_mailing_user,access.sms.tracker.mailing.user,model_sms_tracker,mass_mailing.group_mass_mailing_user,1,1,1,1

--- a/addons/mass_mailing_sms/tests/test_mailing_controllers.py
+++ b/addons/mass_mailing_sms/tests/test_mailing_controllers.py
@@ -5,8 +5,10 @@ import werkzeug.urls
 
 from odoo.tests.common import users
 from odoo.addons.mass_mailing_sms.tests.common import MassSMSCommon
-from odoo.tests import HttpCase
+from odoo.tests import HttpCase, tagged
 
+
+@tagged('mailing_portal', 'post_install', '-at_install')
 class TestMailingListSms(HttpCase, MassSMSCommon):
 
     @users('user_marketing')
@@ -31,6 +33,7 @@ class TestMailingListSms(HttpCase, MassSMSCommon):
 
         trace = mailing.mailing_trace_ids.filtered(lambda t: t.res_id == partner.id)
         self.assertTrue(trace, 'Trace not found for the partner')
+        self.assertEqual(trace.sms_number, '+911234657890')
 
         unsubscribe_url = werkzeug.urls.url_join(mailing.get_base_url(), f'/sms/{mailing.id}/unsubscribe/{trace.sms_code}')
         response = self.opener.get(url=unsubscribe_url, data={'sms_number': trace.sms_number})

--- a/addons/mass_mailing_sms/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_mailing_views.xml
@@ -154,10 +154,12 @@
             <!-- Option page tweaks -->
             <xpath expr="//field[@name='email_from']" position="attributes">
                 <attribute name="invisible">mailing_type != 'mail'</attribute>
-                <attribute name="readonly">state in ('sending', 'done')</attribute>
             </xpath>
             <xpath expr="//label[@for='reply_to']" position="attributes">
                 <attribute name="invisible">mailing_type != 'mail'</attribute>
+            </xpath>
+            <xpath expr="//field[@name='reply_to']" position="attributes">
+                <attribute name="required">mailing_type == 'mail'</attribute>
             </xpath>
             <xpath expr="//div[@name='reply_to_details']" position="attributes">
                 <attribute name="invisible">mailing_type != 'mail'</attribute>
@@ -169,8 +171,7 @@
                 <attribute name="invisible">mailing_type != 'mail'</attribute>
             </xpath>
             <xpath expr="//field[@name='mail_server_id']" position="attributes">
-                <attribute name="invisible">mailing_type != 'mail' or not mail_server_available</attribute>
-                <attribute name="readonly">state in ('sending', 'done')</attribute>
+                <attribute name="invisible" add="mailing_type != 'mail'" separator=" or "/>
             </xpath>
             <!-- A/B Testing -->
             <xpath expr="//field[@name='ab_testing_mailings_count']" position="after">

--- a/addons/mass_mailing_sms/views/mailing_trace_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_trace_views.xml
@@ -41,6 +41,7 @@
                 <field name="failure_type" optional="show"/>
                 <field name="open_datetime" optional="hide"/>
                 <field name="reply_datetime" optional="hide"/>
+                <field name="is_test_trace" optional="hide"/>
                 <button name="action_view_contact" type="object"
                         string="Open Recipient" icon="fa-user"/>
             </list>
@@ -90,6 +91,8 @@
                             <span widget="statinfo">Open Recipient</span>
                         </button>
                     </div>
+                    <field name="is_test_trace" invisible="1"/>
+                    <widget name="web_ribbon" title="Test" bg_color="text-bg-danger" invisible="is_test_trace != True"/>
                     <div class="alert alert-info text-center"
                         invisible="trace_status != 'error' or
                                    failure_type in ('sms_not_delivered', 'sms_not_allowed', 'sms_invalid_destination', 'sms_rejected', 'sms_rejected')"

--- a/addons/mass_mailing_sms/views/mass_mailing_sms_templates_portal.xml
+++ b/addons/mass_mailing_sms/views/mass_mailing_sms_templates_portal.xml
@@ -4,26 +4,27 @@
         <t t-call="portal.frontend_layout">
             <div class="container mb64">
                 <div class="row">
-                    <div class="col-lg-6 offset-lg-3">
-                        <h3>SMS Subscription</h3>
-
-                        <form t-att-action="'/sms/%s/unsubscribe/%s' % (mailing_id, trace_code)" method="post">
-                            <p>Please enter your phone number</p>
+                    <div class="col-lg-6 offset-lg-3 mt-5">
+                        <form t-att-action="'/sms/%s/%s' % (mailing_id, trace_code)" method="post">
+                            <p>Please confirm your phone number to unsubscribe :</p>
                             <div class="mb-3 row">
-                                <label for="sms_number" class="col-sm-2 col-form-label">Number</label>
                                 <div class="col-sm-10">
-                                    <input type="text" class="form-control" name="sms_number" id="sms_number" t-att-required="true"/>
+                                    <input type="text" class="form-control" name="sms_number" id="sms_number" t-att-required="true" placeholder='e.g. "+1 (555) 123-4567"'/>
                                 </div>
                             </div>
                             <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
                             <input type="hidden" name="trace_code" t-att-value="trace_code"/>
                             <input type="hidden" name="mailing_id" t-att-value="mailing_id"/>
                             <div class="mb-3 row">
-                                <div class="col-sm-10 offset-sm-2">
-                                    <button type="submit" class="btn btn-primary">Unsubscribe me</button>
+                                <div class="col-sm-10">
+                                    <button type="submit" class="btn btn-primary">Unsubscribe</button>
                                 </div>
                             </div>
                         </form>
+                    </div>
+                    <div t-if="unsubscribe_error" class="alert alert-danger text-center w-auto offset-lg-3" role="alert">
+                        <p>There was an error when trying to unsubscribe <strong t-out="sms_number"/><br />
+                        <t t-out="unsubscribe_error"/></p>
                     </div>
                 </div>
             </div>
@@ -37,15 +38,14 @@
                     <div class="col-lg-6 offset-lg-3">
                         <h3>SMS Subscription</h3>
 
-                        <div t-if="unsubscribe_error" class="alert alert-danger text-center" role="alert">
-                            <p>There was an error when trying to unsubscribe <strong t-esc="sms_number"/></p>
-                            <p t-esc="unsubscribe_error"/>
-                        </div>
-                        <div t-else="" class="alert alert-success text-center" role="status">
+                        <div class="alert alert-success text-center" role="status">
                             <t t-if="lists_optout">
                                 <p><strong t-esc="sms_number"/> has been successfully removed from</p>
                                 <t t-foreach="lists_optout" t-as="list_id">
-                                    <strong t-esc="list_id.name"/><br />
+                                    <t t-if="list_id.is_public">
+                                        <strong t-out="list_id.name"/><br />
+                                    </t>
+                                    <t t-else=""><strong>Mailing List</strong></t>
                                 </t>
                             </t>
                             <p t-else="">

--- a/addons/mass_mailing_sms/wizard/mailing_sms_test.py
+++ b/addons/mass_mailing_sms/wizard/mailing_sms_test.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from markupsafe import Markup
+from uuid import uuid4
 from werkzeug.urls import url_join
 
 from odoo import fields, models, _
@@ -13,11 +14,30 @@ class MailingSmsTest(models.TransientModel):
     _description = 'Test SMS Mailing'
 
     def _default_numbers(self):
-        return self.env.user.partner_id.phone_sanitized or ""
+        previous_numbers = self.env['mailing.sms.test'].search([('create_uid', '=', self.env.uid)], order='create_date desc', limit=1).numbers
+        return previous_numbers or self.env.user.partner_id.phone_sanitized or ""
 
     numbers = fields.Text(string='Number(s)', required=True,
                           default=_default_numbers, help='Carriage-return-separated list of phone numbers')
     mailing_id = fields.Many2one('mailing.mailing', string='Mailing', required=True, ondelete='cascade')
+
+    def _prepare_test_trace_values(self, record, sms_number, sms_uuid, body):
+        trace_code = self.env['mailing.trace']._get_random_code()
+        trace_values = {
+            'is_test_trace': True,
+            'mass_mailing_id': self.mailing_id.id,
+            'model': record._name,
+            'res_id': record.id,
+            'sms_code': trace_code,
+            'sms_number': sms_number,
+            'sms_tracker_ids': [(0, 0, {'sms_uuid': sms_uuid})],
+            'trace_type': 'sms',
+        }
+        unsubscribe_info = self.env['sms.composer']._get_unsubscribe_info(
+            self.env['sms.composer']._get_unsubscribe_url(self.mailing_id.id, trace_code)
+        )
+        body = '%s\n%s' % (body or '', unsubscribe_info)
+        return trace_values, body
 
     def action_send_sms(self):
         self.ensure_one()
@@ -31,35 +51,60 @@ class MailingSmsTest(models.TransientModel):
         if record:
             # Returns a proper error if there is a syntax error with qweb
             body = self.env['mail.render.mixin']._render_template(body, self.mailing_id.mailing_model_real, record.ids)[record.id]
+        # create and send SMS for valid numbers (skip other, likely to crash)
+        sms_values_list, trace_values_list = [], []
+        for sanitized_number in sanitized_numbers:
+            if not sanitized_number:
+                continue
+            sms_values = {
+                'number': sanitized_number,
+                'uuid': uuid4().hex,
+                'state': 'outgoing',
+            }
+            # include unsubscribe link and generate fake trace to test unsubscribe
+            # flow if sms_allow_unsubscribe is enabled
+            sms_body = body
+            if self.mailing_id.sms_allow_unsubscribe:
+                trace_values, sms_body = self._prepare_test_trace_values(record, sanitized_number, sms_values['uuid'], sms_body)
+                trace_values_list.append(trace_values)
+            sms_values['body'] = sms_body
+            sms_values_list.append(sms_values)
+        sms_sudo = self.env['sms.sms'].sudo().create(sms_values_list)
+        if trace_values_list:
+            self.env['mailing.trace'].create(trace_values_list)
 
-        new_sms_messages_sudo = self.env['sms.sms'].sudo().create([{'body': body, 'number': number} for number in sanitized_numbers])
         sms_api = SmsApi(self.env)
-        sent_sms_list = sms_api._send_sms_batch([{
-            'content': body,
-            'numbers': [{'number': sms_id.number, 'uuid': sms_id.uuid} for sms_id in new_sms_messages_sudo],
-        }], delivery_reports_url=url_join(self[0].get_base_url(), '/sms/status'))
+        sent_sms_list = sms_api._send_sms_batch(
+            [{
+                'content': body,
+                'numbers': [{'number': sms.number, 'uuid': sms.uuid} for sms in sms_sudo],
+            }],
+            delivery_reports_url=url_join(self[0].get_base_url(), '/sms/status')
+        )
 
         error_messages = {}
         if any(sent_sms.get('state') != 'success' for sent_sms in sent_sms_list):
             error_messages = sms_api._get_sms_api_error_messages()
 
         notification_messages = []
-        if invalid_numbers:
-            notification_messages.append(_('The following numbers are not correctly encoded: %s',
-                ', '.join(invalid_numbers)))
-
+        sms_uuid_to_number_map = {sms.uuid: sms.number for sms in sms_sudo}
         for sent_sms in sent_sms_list:
+            number = sms_uuid_to_number_map.get(sent_sms.get('uuid'))
             if sent_sms.get('state') == 'success':
-                notification_messages.append(
-                    _('Test SMS successfully sent to %s', sent_sms.get('res_id')))
-            elif sent_sms.get('state'):
-                notification_messages.append(
-                    _(
-                        "Test SMS could not be sent to %(destination)s: %(state)s",
-                        destination=sent_sms.get("res_id"),
-                        state=error_messages.get(sent_sms["state"], _("An error occurred.")),
-                    )
+                notification_messages.append(_('Test SMS successfully sent to %s', number))
+            else:
+                notification_messages.append(_(
+                    "Test SMS could not be sent to %(destination)s: %(state)s",
+                    destination=number,
+                    state=error_messages.get(sent_sms["state"], _("An error occurred.")),
+                ))
+        if invalid_numbers:
+            notification_messages.append(
+                _(
+                    "Test SMS skipped those numbers as they appear invalid: %(numbers)s",
+                    numbers=', '.join(invalid_numbers)
                 )
+            )
 
         if notification_messages:
             message_body = Markup(

--- a/addons/mass_mailing_sms/wizard/sms_composer.py
+++ b/addons/mass_mailing_sms/wizard/sms_composer.py
@@ -18,10 +18,10 @@ class SmsComposer(models.TransientModel):
     # Mass mode specific
     # ------------------------------------------------------------
 
-    def _get_unsubscribe_url(self, res_id, trace_code, number):
+    def _get_unsubscribe_url(self, mailing_id, trace_code):
         return werkzeug.urls.url_join(
             self.get_base_url(),
-            '/sms/%s/%s' % (self.mailing_id.id, trace_code)
+            '/sms/%s/%s' % (mailing_id, trace_code)
         )
 
     @api.model
@@ -47,7 +47,7 @@ class SmsComposer(models.TransientModel):
             trace_values['trace_status'] = 'cancel'
         else:
             if self.mass_sms_allow_unsubscribe:
-                stop_sms = self._get_unsubscribe_info(self._get_unsubscribe_url(record.id, trace_code, sms_values['number']))
+                stop_sms = self._get_unsubscribe_info(self._get_unsubscribe_url(self.mailing_id.id, trace_code))
                 sms_values['body'] = '%s\n%s' % (sms_values['body'] or '', stop_sms)
         return trace_values
 

--- a/addons/sms/static/src/components/sms_button/sms_button.js
+++ b/addons/sms/static/src/components/sms_button/sms_button.js
@@ -28,6 +28,7 @@ export class SendSMSButton extends Component {
                     default_res_id: this.props.record.resId,
                     default_number_field_name: this.props.name,
                     default_composition_mode: "comment",
+                    dialog_size: "medium",
                 },
             },
             {

--- a/addons/sms/static/src/components/sms_widget/fields_sms_widget.xml
+++ b/addons/sms/static/src/components/sms_widget/fields_sms_widget.xml
@@ -3,9 +3,9 @@
 <templates xml:space="preserve">
     <t t-name="sms.SmsWidget" t-inherit="mail.EmojisTextField" t-inherit-mode="primary">
         <xpath expr="/*[last()]/*[last()]" position="after">
-            <div class="o_sms_container">
-                <span class="text-muted o_sms_count">
-                    <t t-out="nbrChar"/> characters<t t-out="nbrCharExplanation"/>, fits in <t t-out="nbrSMS"/> SMS (<t t-out="encoding"/>)
+            <div class="o_sms_container mt-3">
+                <span class="text-muted o_sms_count" t-if="nbrChar > 0">
+                    <t t-out="nbrChar"/>/<t t-out="160 * nbrSMS" /> <t t-out="nbrCharExplanation" /> | <t t-out="nbrSMS"/> SMS (<t t-out="encoding"/>)
                     <a href="https://iap-services.odoo.com/iap/sms/pricing" target="_blank"
                         title="SMS Pricing" aria-label="SMS Pricing" class="fa fa-lg fa-info-circle"/>
                 </span>

--- a/addons/sms/wizard/sms_composer_views.xml
+++ b/addons/sms/wizard/sms_composer_views.xml
@@ -39,32 +39,35 @@
                         <field name="sanitized_numbers" invisible="1"/>
                         <field name="template_id" invisible="1"/>
 
-                        <label for="recipient_single_description" string="Recipient"
+                        <label for="recipient_single_description" string="To"
                             class="fw-bold"
                             invisible="not comment_single_recipient"/>
                         <div invisible="not comment_single_recipient">
-                            <field name="recipient_single_description" class="oe_inline" invisible="not recipient_single_description"/>
-                            <field name="recipient_single_number_itf" class="oe_inline" nolabel="1" onchange_on_keydown="True" placeholder="e.g. +1 415 555 0100"/>
+                            <field name="recipient_single_description" class="w-auto text-muted me-2" invisible="not recipient_single_description"/>
+                            <field name="recipient_single_number_itf" class="oe_inline border-bottom" nolabel="1" onchange_on_keydown="True" placeholder="e.g. +1 415 555 0100"/>
                         </div>
-                        <field name="body" widget="sms_widget" invisible="comment_single_recipient or recipient_single_valid"
-                            options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': 'res_model'}"/>
-                        <field name="body" widget="sms_widget" invisible="comment_single_recipient or not recipient_single_valid" default_focus="1"
-                            options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': 'res_model'}"/>
-                        <field name="body" widget="sms_widget" invisible="not comment_single_recipient"/>
-                        <field name="mass_keep_log" invisible="1"/>
                     </group>
+                        <field name="body" widget="sms_widget" invisible="comment_single_recipient or recipient_single_valid"
+                            options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': 'res_model'}"
+                            placeholder="Write a message..."/>
+                        <field name="body" widget="sms_widget" invisible="comment_single_recipient or not recipient_single_valid" default_focus="1"
+                            options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': 'res_model'}"
+                            placeholder="Write a message..."/>
+                        <field name="body" widget="sms_widget" invisible="not comment_single_recipient"
+                        placeholder="Write a message..."/>
+                        <field name="mass_keep_log" invisible="1"/>
                 </sheet>
                 <footer>
                     <!-- attrs doesn't work for 'disabled'-->
-                    <button string="Send SMS" type="object" class="oe_highlight" name="action_send_sms" data-hotkey="q"
+                    <button string="Send" type="object" class="oe_highlight" name="action_send_sms" data-hotkey="q"
                             invisible="composition_mode not in ('comment', 'numbers') or not recipient_single_valid"/>
-                    <button string="Send SMS" type="object" class="oe_highlight" name="action_send_sms" data-hotkey="q"
+                    <button string="Send" type="object" class="oe_highlight" name="action_send_sms" data-hotkey="q"
                             invisible="composition_mode not in ('comment', 'numbers') or recipient_single_valid" disabled='1'/>
                     <button string="Put in queue" type="object" class="oe_highlight" name="action_send_sms" data-hotkey="q"
                         invisible="composition_mode != 'mass'"/>
-                    <button string="Send Now" type="object" name="action_send_sms_mass_now" data-hotkey="w"
+                    <button string="Send now" type="object" name="action_send_sms_mass_now" data-hotkey="w"
                         invisible="composition_mode != 'mass'"/>
-                    <button string="Close" class="btn btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button string="Discard" class="btn btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>
         </field>

--- a/addons/web/static/src/views/fields/text/text_field.xml
+++ b/addons/web/static/src/views/fields/text/text_field.xml
@@ -26,7 +26,7 @@
                         record="props.record"
                     />
                     <button t-if="props.dynamicPlaceholder"
-                        class="btn m-0 py-0 px-2 fa fa-magic position-relative"
+                        class="btn m-0 py-2 px-2 fa fa-magic position-relative"
                         title="Insert Field"
                         t-on-click="onDynamicPlaceholderOpen"
                     />


### PR DESCRIPTION
In this task, several enhancements have been made for mass mailing SMS:

- Added opt-out link for test messages when mailing has unsubscribe links.
- Generate traces for test SMS flow.
- Add "is test" flag on traces.
- Displayed phone number in log notes instead of "none".
- Retained memory of the last used phone number in the testing popup.
- Removed hover effect for mailing lists.
- If "show in preferences" is disabled, displayed "mass mailing" instead of mailing list group.
- Removed extra page for unsubscribe error and implemented inline validation for unsubscribe error.
- Prevent reply_to and email_from  validation in mass_mailing_sms.
- Sms composer UI improvements.
- Unsubscribe page UI improvements.

Task-3996903
