### PR TITLE
[IMP] auth_ldap: Add function to test LDAP connection in LDAP Server configuration model

### DIFF
--- a/addons/auth_ldap/models/res_company_ldap.py
+++ b/addons/auth_ldap/models/res_company_ldap.py
@@ -244,3 +244,82 @@ class CompanyLDAP(models.Model):
         except ldap.LDAPError as e:
             _logger.error('An LDAP exception occurred: %s', e)
         return changed
+
+    def test_ldap_connection(self):
+        """
+        Test the LDAP connection using the current configuration.
+        """
+        conf = {
+            'ldap_server': self.ldap_server,
+            'ldap_server_port': self.ldap_server_port,
+            'ldap_binddn': self.ldap_binddn,
+            'ldap_password': self.ldap_password,
+            'ldap_base': self.ldap_base,
+            'ldap_tls': self.ldap_tls
+        }
+        try:
+            conn = self._connect(conf)
+            conn.simple_bind_s(to_text(self.ldap_binddn), to_text(self.ldap_password))
+            conn.unbind()
+            _logger.info("LDAP connection test successful for server %s at port %d.", self.ldap_server,
+                         self.ldap_server_port)
+            return {
+                'type': 'ir.actions.client',
+                'tag': 'display_notification',
+                'params': {
+                    'type': 'success',
+                    'title': _('Connection Test Successful!'),
+                    'message': _("Successfully connected to LDAP server at %(server)s:%(port)d", server=self.ldap_server, port=self.ldap_server_port),
+                    'sticky': False,
+                }
+            }
+        except ldap.SERVER_DOWN:
+            _logger.error("LDAP connection test failed: cannot contact LDAP server at %s:%d", self.ldap_server,
+                          self.ldap_server_port)
+            return {
+                'type': 'ir.actions.client',
+                'tag': 'display_notification',
+                'params': {
+                    'type': 'danger',
+                    'title': _('Connection Test Failed!'),
+                    'message': _("Cannot contact LDAP server at %(server)s:%(port)d", server=self.ldap_server, port=self.ldap_server_port),
+                    'sticky': False,
+                }
+            }
+        except ldap.INVALID_CREDENTIALS:
+            _logger.error("LDAP connection test failed: invalid credentials for bind DN %s", self.ldap_binddn)
+            return {
+                'type': 'ir.actions.client',
+                'tag': 'display_notification',
+                'params': {
+                    'type': 'danger',
+                    'title': _('Connection Test Failed!'),
+                    'message': _("Invalid credentials for bind DN %(binddn)s", binddn=self.ldap_binddn),
+                    'sticky': False,
+                }
+            }
+        except ldap.TIMEOUT:
+            _logger.error("LDAP connection test failed: connection to server %s at port %d timed out.",
+                          self.ldap_server, self.ldap_server_port)
+            return {
+                'type': 'ir.actions.client',
+                'tag': 'display_notification',
+                'params': {
+                    'type': 'danger',
+                    'title': _('Connection Test Failed!'),
+                    'message': _("Connection to LDAP server at %(server)s:%(port)d timed out", server=self.ldap_server, port=self.ldap_server_port),
+                    'sticky': False,
+                }
+            }
+        except ldap.LDAPError as e:
+            _logger.error('LDAP connection test failed: %s', e)
+            return {
+                'type': 'ir.actions.client',
+                'tag': 'display_notification',
+                'params': {
+                    'type': 'danger',
+                    'title': _('Connection Test Failed!'),
+                    'message': _("An error occurred: %(error)s", error=e),
+                    'sticky': False,
+                }
+            }

--- a/addons/auth_ldap/views/ldap_installer_views.xml
+++ b/addons/auth_ldap/views/ldap_installer_views.xml
@@ -7,28 +7,38 @@
             <field name="model">res.company.ldap</field>
             <field name="arch" type="xml">
                 <form string="LDAP Configuration">
-                    <group>
-                        <field name="company"/>
-                        <newline/>
-                        <group string="Server Information">
-                              <field name="ldap_server"/>
-                              <field name="ldap_server_port"/>
-                              <field name="ldap_tls"/>
+                    <header>
+                        <button name="test_ldap_connection" type="object" string="Test Connection" icon="fa-television" class="btn-primary"/>
+                    </header>
+                    <sheet>
+                        <group>
+                            <div class="oe_title">
+                                <label for="company"/>
+                                <h1>
+                                    <field name="company"/>
+                                </h1>
+                            </div>
+                            <newline/>
+                            <group string="Server Information">
+                                <field name="ldap_server"/>
+                                <field name="ldap_server_port"/>
+                                <field name="ldap_tls"/>
+                            </group>
+                            <group string="Login Information">
+                                <field name="ldap_binddn"/>
+                                <field name="ldap_password" password="True"/>
+                            </group>
+                            <group string="Process Parameter">
+                                <field name="ldap_base"/>
+                                <field name="ldap_filter"/>
+                                <field name="sequence"/>
+                            </group>
+                            <group string="User Information">
+                                <field name="create_user"/>
+                                <field name="user"/>
+                            </group>
                         </group>
-                        <group string="Login Information">
-                              <field name="ldap_binddn"/>
-                              <field name="ldap_password" password="True"/>
-                        </group>
-                        <group string="Process Parameter">
-                             <field name="ldap_base"/>
-                             <field name="ldap_filter"/>
-                             <field name="sequence"/>
-                        </group>
-                        <group string="User Information">
-                             <field name="create_user"/>
-                             <field name="user"/>
-                        </group>
-                    </group>
+                    </sheet>
                 </form>
             </field>
         </record>

--- a/doc/cla/individual/fasilwdr.md
+++ b/doc/cla/individual/fasilwdr.md
@@ -1,0 +1,11 @@
+India, 2024-07-22
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Fasil fasilwdr@hotmail.com https://github.com/fasilwdr


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Currently, administrators do not have a straightforward way to test LDAP server configurations within Odoo. This can lead to difficulties in diagnosing connection issues or invalid credentials, resulting in a time-consuming setup process.

**Current behavior before PR:**

- No built-in function to test LDAP server connectivity and authentication in the LDAP server configuration model.

- Administrators have to rely on external tools or guesswork to verify their LDAP configurations.

**Desired behavior after PR is merged:**

- A new function test_ldap_connection is added to the res.company.ldap model.

- Administrators can easily test LDAP server connectivity and authentication directly from the Odoo interface.

- The function provides clear and informative notifications about the success or failure of the connection test, including specific error messages for common issues like invalid credentials or server down.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr