### PR TITLE
[FIX] account: avatax preceding amount traceback

### DIFF
--- a/addons/account/static/src/components/tax_totals/tax_totals.xml
+++ b/addons/account/static/src/components/tax_totals/tax_totals.xml
@@ -51,15 +51,16 @@
                             <span t-att-name="subtotal['name']" style="white-space: nowrap; font-weight: bold;" t-out="subtotal['formatted_amount']"/>
                         </td>
                     </tr>
-
-                    <t t-foreach="totals.groups_by_subtotal[subtotal['name']]" t-as="taxGroup" t-key="taxGroup.group_key">
-                        <TaxGroupComponent
-                            currency="currency"
-                            taxGroup="taxGroup"
-                            isReadonly="readonly"
-                            onChangeTaxGroup.bind="_onChangeTaxValueByTaxGroup"
-                            invalidate.bind="invalidate"
-                        />
+                    <t t-if="subtotal['name'] in totals.groups_by_subtotal">
+                        <t t-foreach="totals.groups_by_subtotal[subtotal['name']]" t-as="taxGroup" t-key="taxGroup.group_key">
+                            <TaxGroupComponent
+                                currency="currency"
+                                taxGroup="taxGroup"
+                                isReadonly="readonly"
+                                onChangeTaxGroup.bind="_onChangeTaxValueByTaxGroup"
+                                invalidate.bind="invalidate"
+                            />
+                        </t>
                     </t>
                 </t>
 


### PR DESCRIPTION
Description of the issue this commit addresses:

When using a preceding amount on a tax group for which a tax is in the avatax "Automatic Tax Mapping (AvaTax)" fiscal position, when the fiscal position is applied on a move which uses a tax of that tax group, it becomes impossible to see the invoices lines.

---

Steps to reproduce:

1. Set up AvaTax in Accounting settings
2. Make sure that the “Use AvaTax API” field is checked for the fiscal position named “Automatic Tax Mapping (AvaTax)”
3. Go to “Tax Groups” and for the record called “Tax 15%”, add anything to the field called “Preceding Subtotal”
4. Go to the Product Category called “All” and choose any selection for the field called “AvaTax Category”
5. Make a Sale Order and add any product. Make sure that the tax is the default 15% tax
6. Click on the “Other Info” tab and choose “Automatic Tax Mapping (AvaTax)”
7. Confirm the Sale Order then try to navigate back to the “Order Lines” tab
8. An error is raised.

---

Desired behavior after this commit is merged:

No traceback appears.

---

Details on the fix:

The error was thrown because the tax grouping was conflicting with the tax subtotals. The template tried to render a non existant value. Encasing that element in a t-if fixes the issue.

---

opw-3984546

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr