### PR TITLE
[FIX] pos_sale: create downpayment line for unique tax combination

### DIFF
--- a/addons/pos_sale/static/tests/helpers/ProductScreenTourMethods.js
+++ b/addons/pos_sale/static/tests/helpers/ProductScreenTourMethods.js
@@ -11,7 +11,7 @@ export function clickQuotationButton() {
 export function clickSave() {
     return [
         {
-            content: 'Click on Save button',
+            content: "Click on Save button",
             trigger: '.control-button:contains("Save")',
         },
     ];
@@ -62,19 +62,40 @@ export function downPaymentFirstOrder() {
 }
 
 export function checkCustomerNotes(note) {
-        return [
-            {
-                content: `check customer notes`,
-                trigger: `.customer-note:contains(${note})`,
-            }
-        ];
+    return [
+        {
+            content: `check customer notes`,
+            trigger: `.customer-note:contains(${note})`,
+        },
+    ];
 }
 
 export function checkOrdersListEmpty() {
     return [
         {
-            content: 'Check that the orders list is empty',
-            trigger: 'body:not(:has(.order-row))',
-        }
+            content: "Check that the orders list is empty",
+            trigger: "body:not(:has(.order-row))",
+        },
+    ];
+}
+
+export function downPayment20PercentFirstOrder() {
+    return [
+        {
+            content: `select order`,
+            trigger: `.order-row .col.name:first`,
+        },
+        {
+            content: `click on select the order`,
+            trigger: `.selection-item:contains('Apply a down payment (percentage)')`,
+        },
+        {
+            content: `click on +10 button`,
+            trigger: `div.numpad.row button.col:contains("+20")`,
+        },
+        {
+            content: `click on ok button`,
+            trigger: `.button.confirm`,
+        },
     ];
 }

--- a/addons/pos_sale/static/tests/tours/PosSaleTour.js
+++ b/addons/pos_sale/static/tests/tours/PosSaleTour.js
@@ -137,12 +137,11 @@ registry.category("web_tour.tours").add("PosSettleOrder3", {
         ].flat(),
 });
 
-registry
-    .category("web_tour.tours")
-    .add('PosSettleOrderNotGroupable', {
-        test: true,
-        url: '/pos/ui',
-        steps: () => [
+registry.category("web_tour.tours").add("PosSettleOrderNotGroupable", {
+    test: true,
+    url: "/pos/ui",
+    steps: () =>
+        [
             ProductScreen.confirmOpeningPopup(),
             ProductScreen.clickQuotationButton(),
             ProductScreen.selectFirstOrder(),
@@ -150,71 +149,91 @@ registry
             ProductScreen.selectedOrderlineHas("Product A", "0.50"),
             ProductScreen.checkOrderlinesNumber(4),
         ].flat(),
-    });
+});
 
-registry
-    .category("web_tour.tours")
-    .add('PosSettleOrderWithNote', {
-        test: true,
-        url: '/pos/ui',
-        steps: () => [
+registry.category("web_tour.tours").add("PosSettleOrderWithNote", {
+    test: true,
+    url: "/pos/ui",
+    steps: () =>
+        [
             ProductScreen.confirmOpeningPopup(),
             ProductScreen.clickQuotationButton(),
             ProductScreen.selectFirstOrder(),
             ProductScreen.checkCustomerNotes("Customer note 2--Customer note 3"),
             ProductScreen.clickPayButton(),
-            PaymentScreen.clickPaymentMethod('Bank'),
+            PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickValidate(),
             ReceiptScreen.checkCustomerNotes("Customer note 2--Customer note 3"),
             ReceiptScreen.clickNextOrder(),
-
         ].flat(),
-    });
-
-registry
-.category("web_tour.tours")
-.add('PosSettleAndInvoiceOrder', {
-    test: true,
-    url: '/pos/ui',
-    steps: () => [
-        ProductScreen.confirmOpeningPopup(),
-        ProductScreen.clickQuotationButton(),
-        ProductScreen.selectFirstOrder(),
-        ProductScreen.clickPayButton(),
-        PaymentScreen.clickPaymentMethod("Bank"),
-        PaymentScreen.clickInvoiceButton(),
-        PaymentScreen.clickValidate(),
-    ].flat(),
 });
 
-registry
-    .category("web_tour.tours")
-    .add('PosQuotationSaving', {
-        test: true,
-        url: '/pos/ui',
-        steps: () => [
-            ProductScreen.confirmOpeningPopup(),
-            ProductScreen.clickQuotationButton(),
-            ProductScreen.selectFirstOrder(),
-            ProductScreen.selectedOrderlineHas('Product', '4.00', '40.00'),
-            ProductScreen.clickSave(),
-        ].flat(),
-    });
-
-registry
-    .category("web_tour.tours")
-    .add('PosOrderDoesNotRemainInList', {
-        test: true,
-        url: '/pos/ui',
-        steps: () => [
+registry.category("web_tour.tours").add("PosSettleAndInvoiceOrder", {
+    test: true,
+    url: "/pos/ui",
+    steps: () =>
+        [
             ProductScreen.confirmOpeningPopup(),
             ProductScreen.clickQuotationButton(),
             ProductScreen.selectFirstOrder(),
             ProductScreen.clickPayButton(),
-            PaymentScreen.clickPaymentMethod('Bank'),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickInvoiceButton(),
+            PaymentScreen.clickValidate(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("PosQuotationSaving", {
+    test: true,
+    url: "/pos/ui",
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.clickQuotationButton(),
+            ProductScreen.selectFirstOrder(),
+            ProductScreen.selectedOrderlineHas("Product", "4.00", "40.00"),
+            ProductScreen.clickSave(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("PosOrderDoesNotRemainInList", {
+    test: true,
+    url: "/pos/ui",
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.clickQuotationButton(),
+            ProductScreen.selectFirstOrder(),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickValidate(),
             ReceiptScreen.clickNextOrder(),
             ProductScreen.clickQuotationButton(),
             ProductScreen.checkOrdersListEmpty(),
         ].flat(),
-    });
+});
+
+registry.category("web_tour.tours").add("PoSDownPaymentLinesPerTax", {
+    test: true,
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.clickQuotationButton(),
+            ProductScreen.downPayment20PercentFirstOrder(),
+            Order.hasLine({
+                productName: "Down Payment",
+                quantity: "1.0",
+                price: "2.20",
+            }),
+            Order.hasLine({
+                productName: "Down Payment",
+                quantity: "1.0",
+                price: "1.00",
+            }),
+            Order.hasLine({
+                productName: "Down Payment",
+                quantity: "1.0",
+                price: "3.00",
+            }),
+        ].flat(),
+});


### PR DESCRIPTION
When importing a sale in PoS and doing a downpayment there was only one downpayment line created. And because of this the taxes where not always correct. If you do a 100% downpayment you would end up with negative untaxed amount on the invoice.

Steps to reproduce:
-------------------
* Create 2 taxes, A and B with 5% and 10%
* Create 2 products, A and B. Assign the 2 taxes to the products
* Create a sale order with the 2 products
* Open the sale order in PoS and make a downpayment for it
> Observation: There is only one downpayment line when it should have 2.

Why the fix:
------------
If you do the same flow in the sales app, you get 2 downpayment lines. We do this to allign the behavior in sales and PoS. For each unique tax combination we compute what part of the total downpayment should be assigned to it. Then we make sure that the taxes are assigned to the line and that the line has the right value.

opw-3999047
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr