### PR TITLE
[FIX] account_debit_note: remove unnecessary assignment of refund_sequence field

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -806,10 +806,6 @@ class AccountJournal(models.Model):
             if not vals['code']:
                 raise UserError(_("Cannot generate an unused journal code. Please change the name for journal %s.", vals['name']))
 
-        # === Fill missing refund_sequence ===
-        if 'refund_sequence' not in vals:
-            vals['refund_sequence'] = vals['type'] in ('sale', 'purchase')
-
         # === Fill missing alias name for sale / purchase, to force alias creation ===
         if journal_type in {'sale', 'purchase'}:
             if 'alias_name' not in vals:


### PR DESCRIPTION
- Updated the refund_sequence field decorator from `@onchange` to `@depends` and adjusted the compute function accordingly in the below PR.
- Consequently, the assignment of the refund_sequence field in the _fill_missing_values method is no longer required.

Related PR-https://github.com/odoo/odoo/pull/168844