### PR TITLE
[FIX] website: undo class name translation that removed carousel next icon in Dutch

### DIFF
--- a/addons/website/i18n/nl.po
+++ b/addons/website/i18n/nl.po
@@ -1125,7 +1125,7 @@ msgid ""
 "<span class=\"carousel-control-next-icon\"/>\n"
 "                <span class=\"visually-hidden\">Next</span>"
 msgstr ""
-"<span class=\"carrousel-control-next-icon\"/>\n"
+"<span class=\"carousel-control-next-icon\"/>\n"
 "                <span class=\"visually-hidden\">Volgende</span>"
 
 #. module: website

--- a/doc/cla/individual/Daniel-H123.md
+++ b/doc/cla/individual/Daniel-H123.md
@@ -1,0 +1,11 @@
+Netherlands, 22-7-2024
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Daniel 78355193+daniel-h123@users.noreply.github.com https://github.com/Daniel-H123


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Carousel icon doesn't display icon for next button due to a translated class name.

Current behavior before PR:
On my site the carousel doesn't display the right next icon. It's because the html served contains the wrong class.

On my site the carousel still doesn't display the icon, but this has to be the fix. I believe my site is using a cached version, since the aria label also doesn't change when choosing another language. Would appreciate it if someone can test if this actually solves it.

```html
<a class="carousel-control-next o_not_editable o_we_no_overlay" data-bs-slide="next" role="img" aria-label="Volgende" title="Volgende" href="{unique}">
    <span class="carrousel-control-next-icon"></span>
    <span class="visually-hidden o_default_snippet_text">Volgende</span>
</a>
```
Desired behavior after PR is merged:
```html
<a class="carousel-control-next o_not_editable o_we_no_overlay" data-bs-slide="next" role="img" aria-label="Volgende" title="Volgende" href="{unique}">
    <span class="carousel-control-next-icon"></span>
    <span class="visually-hidden o_default_snippet_text">Volgende</span>
</a>
```



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
