### PR TITLE
[IMP] purchase,purchase_requisition,rating,repair: simplify kanban archs

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -313,76 +313,40 @@
                                         <field name="name" nolabel="1"  invisible="not display_type"/>
                                 </form>
                                 <kanban class="o_kanban_mobile">
-                                     <field name="name"/>
-                                     <field name="product_id"/>
-                                     <field name="product_qty"/>
-                                     <field name="product_uom" groups="uom.group_uom"/>
-                                     <field name="price_subtotal"/>
-                                     <field name="price_tax"/>
-                                     <field name="price_total"/>
-                                     <field name="price_unit"/>
-                                     <field name="discount"/>
                                      <field name="display_type"/>
-                                     <field name="taxes_id"/>
                                      <field name="tax_calculation_rounding_method"/>
                                      <templates>
-                                         <t t-name="kanban-box">
-                                             <div t-attf-class="oe_kanban_card oe_kanban_global_click {{ record.display_type.raw_value ? 'o_is_' + record.display_type.raw_value : '' }}">
-                                                 <t t-if="!record.display_type.raw_value">
-                                                     <div class="row">
-                                                         <div class="col-8">
-                                                             <strong>
-                                                                 <span t-esc="record.product_id.value"/>
-                                                             </strong>
-                                                         </div>
-                                                         <div class="col-4">
-                                                             <strong>
-                                                                 <span>
-                                                                     Tax excl.: <t t-esc="record.price_subtotal.value" class="float-end text-end"/>
-                                                                 </span>
-                                                             </strong>
-                                                         </div>
-                                                     </div>
-                                                     <div class="row">
-                                                         <div class="col-8 text-muted">
-                                                             <span>
-                                                                 Quantity:
-                                                                 <t t-esc="record.product_qty.value"/>
-                                                                 <small> <t t-esc="record.product_uom.value" groups="uom.group_uom"/></small>
-                                                             </span>
-                                                         </div>
-                                                         <div class="col-4" t-if="record.tax_calculation_rounding_method.raw_value === 'round_per_line'">
-                                                             <strong>
-                                                                <span>
-                                                                    Tax incl.: <t t-esc="record.price_total.value"/>
-                                                                </span>
-                                                             </strong>
-                                                         </div>
-                                                     </div>
-                                                     <div class="row">
-                                                         <div class="col-12 text-muted">
-                                                             <span>
-                                                                 Unit Price:
-                                                                 <field name="price_unit"/>
-                                                             </span>
-                                                         </div>
-                                                     </div>
-                                                     <div class="row" t-if="record.discount.raw_value">
-                                                         <div class="col-12 text-muted">
-                                                            <span>
-                                                                Discount: <t t-out="record.discount.value"/>%
-                                                            </span>
-                                                         </div>
-                                                     </div>
-                                                 </t>
-                                                 <div
-                                                     t-elif="record.display_type.raw_value === 'line_section' || record.display_type.raw_value === 'line_note'"
-                                                     class="row">
-                                                     <div class="col-12">
-                                                         <span t-esc="record.name.value"/>
-                                                     </div>
-                                                 </div>
-                                             </div>
+                                         <t t-name="kanban-card">
+                                            <t t-if="!record.display_type.raw_value">
+                                                <div class="row">
+                                                    <field name="product_id" class="fw-bold col-8"/>
+                                                    <span class="fw-bold col-4">
+                                                        Tax excl.: <field name="price_subtotal" class="float-end"/>
+                                                    </span>
+                                                </div>
+                                                <div class="row">
+                                                    <span class="col-8 text-muted">
+                                                        Quantity:
+                                                        <field name="product_qty" />
+                                                        <field name="product_uom" groups="uom.group_uom" class="small"/>
+                                                    </span>
+                                                    <span class="fw-bold col-4" t-if="record.tax_calculation_rounding_method.raw_value === 'round_per_line'">
+                                                        Tax incl.: <field name="price_total" />
+                                                    </span>
+                                                </div>
+                                                <span class="text-muted">
+                                                    Unit Price:
+                                                    <field name="price_unit" />
+                                                </span>
+                                                <span class="text-muted" t-if="record.discount.raw_value">
+                                                    Discount: <field name="discount" />%
+                                                </span>
+                                            </t>
+                                            <div t-elif="record.display_type.raw_value === 'line_section' || record.display_type.raw_value === 'line_note'">
+                                                <div t-attf-class="{{record.display_type.raw_value === 'line_section' ? 'fw-bold' : 'fst-italic' }}">
+                                                    <field name="name" />
+                                                </div>
+                                            </div>
                                          </t>
                                      </templates>
                                  </kanban>
@@ -506,34 +470,23 @@
             <field name="model">purchase.order</field>
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile" js_class="purchase_dashboard_kanban" sample="1" quick_create="false">
-                    <field name="name"/>
-                    <field name="partner_id" readonly="1"/>
-                    <field name="amount_total"/>
-                    <field name="state"/>
                     <field name="date_order"/>
-                    <field name="currency_id" readonly="1"/>
-                    <field name="activity_state"/>
+                    <field name="currency_id"/>
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="oe_kanban_card oe_kanban_global_click">
-                                <div class="o_kanban_record_top mb16">
-                                    <field name="priority" widget="priority"/>
-                                    <div class="o_kanban_record_headings ms-1">
-                                        <strong class="o_kanban_record_title"><span><t t-esc="record.partner_id.value"/></span></strong>
-                                    </div>
-                                    <strong><field name="amount_total" widget="monetary"/></strong>
-                                </div>
-                                <div class="o_kanban_record_bottom">
-                                    <div class="oe_kanban_bottom_left">
-                                        <span><t t-esc="record.name.value"/> <t t-esc="record.date_order.value and record.date_order.value.split(' ')[0] or False"/></span>
-                                        <field name="activity_ids" widget="kanban_activity"/>
-                                    </div>
-                                    <div class="oe_kanban_bottom_right">
-                                        <field name="state" widget="label_selection" options="{'classes': {'draft': 'default', 'cancel': 'default', 'done': 'success', 'approved': 'warning'}}"/>
-                                    </div>
-                                </div>
+                        <t t-name="kanban-card">
+                            <div class="d-flex mb-3">
+                                <field name="priority" widget="priority" class="mt-1 me-1"/>
+                                <field name="partner_id" class="fw-bolder fs-5"/>
+                                <field name="amount_total" widget="monetary" class="fw-bolder ms-auto"/>
                             </div>
+                            <footer class="fs-6 pt-0">
+                                <div class="d-flex">
+                                    <field name="name" class="me-1"/> <t t-esc="record.date_order.value and record.date_order.value.split(' ')[0] or False"/>
+                                    <field name="activity_ids" widget="kanban_activity" class="ms-1"/>
+                                </div>
+                                <field name="state" widget="label_selection" options="{'classes': {'draft': 'default', 'cancel': 'default', 'done': 'success', 'approved': 'warning'}}" class="ms-auto"/>
+                            </footer>
                         </t>
                     </templates>
                 </kanban>

--- a/addons/purchase_requisition/views/purchase_requisition_views.xml
+++ b/addons/purchase_requisition/views/purchase_requisition_views.xml
@@ -143,31 +143,17 @@
         <field name="model">purchase.requisition</field>
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile" sample="1">
-                <field name="name"/>
-                <field name="state"/>
-                <field name="user_id"/>
-                <field name="requisition_type"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_card oe_kanban_global_click">
-                            <div class="o_kanban_record_top">
-                                <div class="o_kanban_record_headings mt4">
-                                    <strong class="o_kanban_record_title"><span><field name="name"/></span></strong>
-                                </div>
-                                <field name="state" widget="label_selection" options="{'classes': {'draft': 'default', 'done': 'success', 'close': 'danger'}}" readonly="1"/>
-                            </div>
-                            <div class="o_kanban_record_body">
-                                <span class="text-muted"><field name="requisition_type"/></span>
-                            </div>
-                            <div class="o_kanban_record_bottom">
-                                <div class="oe_kanban_bottom_left">
-                                    <field name="vendor_id"/>
-                                </div>
-                                <div class="oe_kanban_bottom_right">
-                                    <field name="user_id" widget="many2one_avatar_user"/>
-                                </div>
-                            </div>
+                    <t t-name="kanban-card">
+                        <div class="d-flex mb-1">
+                            <field name="name" class="fw-bolder fs-5"/>
+                            <field name="state" widget="label_selection" options="{'classes': {'draft': 'default', 'done': 'success', 'close': 'danger'}}" readonly="1" class="ms-auto"/>
                         </div>
+                        <field name="requisition_type" class="text-muted"/>
+                        <footer class="fs-6">
+                            <field name="vendor_id"/>
+                            <field name="user_id" widget="many2one_avatar_user" class="ms-auto"/>
+                        </footer>
                     </t>
                 </templates>
             </kanban>

--- a/addons/rating/static/src/scss/rating_rating_views.scss
+++ b/addons/rating/static/src/scss/rating_rating_views.scss
@@ -2,12 +2,4 @@
     .o_kanban_record {
         width: 350px;
     }
-
-    .o_rating_kanban_left {
-        min-width: 80px;
-
-        .o_rating_value {
-            font-size: 4rem;
-        }
-    }
 }

--- a/addons/rating/views/rating_rating_views.xml
+++ b/addons/rating/views/rating_rating_views.xml
@@ -86,48 +86,32 @@
             <field name="model">rating.rating</field>
             <field name="arch" type="xml">
                 <kanban create="false" sample="1">
-                    <field name="rating"/>
-                    <field name="res_name"/>
-                    <field name="feedback"/>
-                    <field name="partner_id"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div class="oe_kanban_global_click d-flex align-items-center justify-content-center">
-                                <div class="row oe_kanban_details">
-                                    <div class="col-4 my-auto">
-                                        <field name="rating_image" widget="image" class="bg-view" />
-                                    </div>
-                                    <div class="col-8 ps-1">
-                                        <strong>
-                                            <field name="rated_partner_name"/>
-                                        </strong>
-                                        <ul>
-                                            <li t-if="record.partner_id.value">
-                                                <span class="o_text_overflow">
-                                                    by
-                                                    <span t-att-title="record.partner_id.value">
-                                                        <field name="partner_id" />
-                                                    </span>
-                                                </span>
-                                            </li>
-                                            <li>
-                                                <span class="o_text_overflow">
-                                                    for
-                                                    <a type="object" name="action_open_rated_object" t-att-title="record.res_name.raw_value">
-                                                        <field name="res_name" />
-                                                    </a>
-                                                </span>
-                                            </li>
-                                            <li>
-                                                on <field name="create_date" />
-                                            </li>
-                                            <li t-if="record.feedback.raw_value" class="o_text_overflow" t-att-title="record.feedback.raw_value">
-                                                <field name="feedback"/>
-                                            </li>
-                                        </ul>
+                        <t t-name="kanban-card" class="row g-0">
+                            <aside class="col-4 my-auto align-self-center">
+                                <field name="rating_image" widget="image" class="bg-view ms-3" />
+                            </aside>
+                            <main class="col ps-2">
+                                <field name="rated_partner_name" class="fw-bolder"/>
+                                <div t-if="record.partner_id.value" class="text-truncate">
+                                    by
+                                    <span t-att-title="record.partner_id.value">
+                                        <field name="partner_id" />
+                                    </span>
                                 </div>
+                                <span class="text-truncate">
+                                    for
+                                    <a type="object" name="action_open_rated_object" t-att-title="record.res_name.raw_value">
+                                        <field name="res_name" />
+                                    </a>
+                                </span>
+                                <div>
+                                    on <field name="create_date" />
                                 </div>
-                            </div>
+                                <span class="text-truncate" t-att-title="record.feedback.raw_value">
+                                    <field name="feedback"/>
+                                </span>
+                            </main>
                         </t>
                     </templates>
                 </kanban>
@@ -141,53 +125,38 @@
             <field name="arch" type="xml">
                 <kanban create="false" class="o_rating_rating_kanban">
                     <field name="rating"/>
-                    <field name="res_name"/>
-                    <field name="feedback"/>
-                    <field name="partner_id"/>
                     <templates>
-                        <t t-name="kanban-box">
+                        <t t-name="kanban-card" class="row g-0">
                             <t t-set="val_stars" t-value="Math.round(record.rating.raw_value * 10) / 10"/>
                             <t t-set="val_integer" t-value="Math.floor(val_stars)"/>
                             <t t-set="val_decimal" t-value="val_stars - val_integer"/>
                             <t t-set="empty_star" t-value="5 - (val_integer + Math.ceil(val_decimal))"/>
-                            <div class="oe_kanban_card oe_kanban_global_click">
-                                <div class="d-flex flex-row">
-                                    <div class="o_rating_kanban_left me-3">
-                                        <h1 class="o_rating_value text-center text-primary" t-esc="val_stars"/>
-                                        <i t-foreach="[...Array(val_integer).keys()]" t-as="num"  t-key="num"
-                                           class="fa fa-star"
-                                           aria-label="A star"
-                                           role="img"/>
-                                        <i t-if="val_decimal"
-                                           class="fa fa-star-half-o"
-                                           aria-label="Half a star"
-                                           role="img"/>
-                                        <i t-foreach="[...Array(empty_star).keys()]" t-as="num" t-key="num"
-                                           class="fa fa-star text-black-25"
-                                           aria-label="A star"
-                                           role="img"/>
-                                    </div>
-                                    <div>
-                                        <div class="o_kanban_card_header">
-                                            <div class="o_kanban_card_header_title">
-                                                <span class="fw-bold"><field name="partner_id"/></span>
-                                            </div>
-                                        </div>
-                                        <div class="o_kanban_card_content mt0 d-flex flex-column">
-                                            <span>
-                                                <i class="fa fa-folder me-2" aria-label="Open folder"></i>
-                                                <a type="object" name="action_open_rated_object" t-att-title="record.res_name.raw_value">
-                                                    <field name="res_name" />
-                                                </a>
-                                            </span>
-                                            <span><i class="fa fa-clock-o me-2" aria-label="Create date"/> <field name="create_date" /></span>
-                                            <div class="d-flex mt-2">
-                                                <span t-esc="record.feedback.raw_value"/>
-                                            </div>
-                                        </div>
-                                    </div>
-                                 </div>
-                             </div>
+                            <aside class="col-3 me-2">
+                                <div class="display-3 fw-bold text-center text-primary mb-2" t-esc="val_stars"/>
+                                <i t-foreach="[...Array(val_integer).keys()]" t-as="num"  t-key="num"
+                                    class="fa fa-star"
+                                    aria-label="A star"
+                                    role="img"/>
+                                <i t-if="val_decimal"
+                                    class="fa fa-star-half-o"
+                                    aria-label="Half a star"
+                                    role="img"/>
+                                <i t-foreach="[...Array(empty_star).keys()]" t-as="num" t-key="num"
+                                    class="fa fa-star text-black-25"
+                                    aria-label="A star"
+                                    role="img"/>
+                            </aside>
+                            <main class="col">
+                                <field name="partner_id" class="fw-bold fs-5"/>
+                                <div class="mt0">
+                                    <i class="fa fa-folder me-2" aria-label="Open folder"></i>
+                                    <a type="object" name="action_open_rated_object" t-att-title="record.res_name.raw_value">
+                                        <field name="res_name" />
+                                    </a>
+                                    <div><i class="fa fa-clock-o me-2" aria-label="Create date"/> <field name="create_date" /></div>
+                                    <field name="feedback" class="mt-2"/>
+                                </div>
+                            </main>
                         </t>
                     </templates>
                 </kanban>

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -201,34 +201,18 @@
         <field name="model">repair.order</field>
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile" sample="1" quick_create="false">
-                <field name="company_id" invisible="1"/>
-                <field name="name"/>
-                <field name="product_id"/>
-                <field name="partner_id"/>
-                <field name="state"/>
-                <field name="activity_state"/>
                 <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_card oe_kanban_global_click">
-                            <div class="row mb4">
-                                <div class="col-6">
-                                    <strong><span><t t-esc="record.name.value"/></span></strong>
-                                </div>
-                                <div class="col-6 text-end">
-                                    <field name="state" widget="label_selection" options="{'classes': {'draft': 'info', 'cancel': 'danger', 'done': 'success', 'under_repair': 'secondary'}}"/>
-                                </div>
+                    <t t-name="kanban-card">
+                        <div class="row">
+                            <field name="name" class="col-6 fw-bolder mb-1"/>
+                            <field name="state" class="col-6 text-end mb-1" widget="label_selection" options="{'classes': {'draft': 'info', 'cancel': 'danger', 'done': 'success', 'under_repair': 'secondary'}}"/>
+                            <div class="col-6 text-muted">
+                                <field name="product_id" />
+                                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                             </div>
-                            <div class="row">
-                                <div class="col-6 text-muted">
-                                    <span><t t-esc="record.product_id.value"/></span>
-                                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
-                                </div>
-                                <div class="col-6">
-                                    <span class="float-end">
-                                        <field name="partner_id"/>
-                                    </span>
-                                </div>
+                            <div class="col-6">
+                                <field name="partner_id" class="float-end"/>
                             </div>
                         </div>
                     </t>

--- a/addons/resource_mail/static/tests/many2one_avatar_resource.test.js
+++ b/addons/resource_mail/static/tests/many2one_avatar_resource.test.js
@@ -98,11 +98,9 @@ test("many2one_avatar_resource widget in kanban view", async () => {
     await openKanbanView("resource.task", {
         arch: `<kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="display_name"/>
-                            <field name="resource_id" widget="many2one_avatar_resource"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="display_name"/>
+                        <field name="resource_id" widget="many2one_avatar_resource"/>
                     </t>
                 </templates>
             </kanban>`,

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -952,7 +952,7 @@ stepUtils.autoExpandMoreButtons(),
     run: "click",
 }, {
     isActive: ["mobile"],
-    trigger: '.o_kanban_record .o_kanban_record_title:contains("the_flow.vendor")',
+    trigger: '.o_kanban_record:contains("the_flow.vendor")',
     content: _t('Select the generated request for quotation'),
     tooltipPosition: 'bottom',
     run: "click",


### PR DESCRIPTION
In this commit we have simplified the kanban arch for the purchase, purchase_requisition,rating,repair and resource_mail modules.the goal is to simplify them, make them easier to read and use bootstrap utility classnames.

- Previously, we used kanban-box, but now we are using kanban-card instead.
- Deprecated oe_kanban_global_click and oe_kanban_global_click_edit.
- More use of <field/> tags
- Removed the oe_kanban_colorpicker class and replaced it with the kanban_color_picker widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- kanban_image from rendering context, is deprecated so we use <field name="..." widget="image"/> instead
- kanban_color, kanban_getcolor and kanban_getcolorname are deprecated use new attribute highlight_color="color_field_name" on root node
- oe_kanban_colorpicker is deprecated, use kanban_color_picker widget instead

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
