### PR TITLE
[FIX] loyalty: Description does not update when tags update.

### DIFF
--- a/addons/loyalty/models/loyalty_reward.py
+++ b/addons/loyalty/models/loyalty_reward.py
@@ -179,7 +179,7 @@ class LoyaltyReward(models.Model):
             ('reward_product_tag_id.product_ids', operator, value)
         ]
 
-    @api.depends('reward_type', 'reward_product_id', 'discount_mode',
+    @api.depends('reward_type', 'reward_product_id', 'discount_mode', 'reward_product_tag_id',
                  'discount', 'currency_id', 'discount_applicability', 'all_discount_product_ids')
     def _compute_description(self):
         for reward in self:

--- a/addons/loyalty/tests/test_loyalty.py
+++ b/addons/loyalty/tests/test_loyalty.py
@@ -184,3 +184,36 @@ class TestLoyalty(TransactionCase):
         loyalty_program.action_archive()
         # Make sure that the main product didn't get archived
         self.assertTrue(product.active)
+
+    def test_card_description_on_tag_change(self):
+        product_tag = self.env['product.tag'].create({'name': 'Multiple Products'})
+        product1 = self.env['product.product'].create({
+            'name': 'Test Product',
+            'detailed_type': 'consu',
+            'list_price': 20.0,
+            'product_tag_ids': product_tag,
+        })
+        self.env['product.product'].create({
+            'name': 'Test Product 2',
+            'detailed_type': 'consu',
+            'list_price': 30.0,
+            'product_tag_ids': product_tag,
+        })
+        reward = self.env['loyalty.reward'].create({
+            'program_id': self.program.id,
+            'reward_type': 'product',
+            'reward_product_id': product1.id,
+        })
+        reward_description_single_product = reward.description
+        reward.reward_product_tag_id = product_tag
+        reward_description_product_tag = reward.description
+        self.assertNotEqual(
+            reward_description_single_product,
+            reward_description_product_tag,
+            "Reward description should be changed after adding a tag"
+        )
+        self.assertEqual(
+            reward_description_product_tag,
+            "Free Product - [Test Product, Test Product 2]",
+            "Reward description for reward with tag should be 'Free Product - [Test Product, Test Product 2]'"
+        )


### PR DESCRIPTION
Steps:

- Create a loyalty program with reward_type product
- add a tag in product_tag field which is linked to multiple products

Issue:

- Description is not updated

Cause:

- The compute_reward_description is not called when tag is updated

Fix:

- added product_tag in depends for the _compute_reward_description

opw-4039914

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
