### PR TITLE
[FIX] web: pass context when duplicating records from list view

### DIFF
--- a/addons/web/static/src/model/relational_model/dynamic_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_list.js
@@ -215,7 +215,9 @@ export class DynamicList extends DataPoint {
             resIds = await this.getResIds(true);
         }
 
-        const duplicated = await this.model.orm.call(this.resModel, "copy_multi", [resIds]);
+        const duplicated = await this.model.orm.call(this.resModel, "copy_multi", [resIds], {
+            context: this.context,
+        });
         if (resIds.length > duplicated.length) {
             this.model.notification.add(_t("Some records could not be duplicated"), {
                 title: _t("Warning"),

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -5997,6 +5997,31 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, "tbody td.o_list_record_selector", 3, "should have 3 records");
     });
 
+    QUnit.test("Duplicate one record and verify context key", async function (assert) {
+        await makeView({
+            type: "list",
+            resModel: "foo",
+            serverData,
+            actionMenus: {},
+            arch: '<tree><field name="foo"/></tree>',
+            mockRPC(route, args) {
+                if (args.method === "copy_multi") {
+                    assert.step("duplicate");
+                    const { context } = args.kwargs;
+                    assert.strictEqual(context.ctx_key, "ctx_val");
+                }
+            },
+            context: {
+                ctx_key: "ctx_val",
+            },
+        });
+
+        await click(target.querySelector("tbody td.o_list_record_selector:first-child input"));
+        await toggleActionMenu(target);
+        await toggleMenuItem(target, "Duplicate");
+        assert.verifySteps(["duplicate"]);
+    });
+
     QUnit.test("custom delete confirmation dialog", async (assert) => {
         const listView = registry.category("views").get("list");
         class CautiousController extends listView.Controller {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- i found that context is never passed in [_duplicateRecords()](https://github.com/odoo/odoo/blob/bd922d14051e5cf09628ad20087d5a78c6588919/addons/web/static/src/model/relational_model/dynamic_list.js#L210) function for list views, when making 'orm' calls from js side, while it is passed in [duplicate](https://github.com/odoo/odoo/blob/bd922d14051e5cf09628ad20087d5a78c6588919/addons/web/static/src/model/relational_model/record.js#L191) function of record.js, which is called when duplicating record from form view.

**use case:**
- In `sale_renting` module, There is difference in the result, when a `sale_order` is duplcated from form view(duplicated properly) and when it is duplicated from list view(unexpected result). When duplicating a sale_order, its lines are also being duplicated, and at that time [_compute_is_rental](https://github.com/odoo/enterprise/blob/10006504139abc706ccdb00f71c16846414731eb/sale_renting/models/sale_order_line.py#L56) is being computed, which relies on context key `in_rental_app`. 'in_rental_app' is set in the related action yet was not available when duplicating the sale_order from list view (which resulted in unexpected behaviour).

Current behavior before PR:
- Context is not passed when duplicating Records from list view.

Desired behavior after PR is merged:
- Context is passed when duplicating Records from list view.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
