### PR TITLE
[REF] web,*:  stop generating deprecated xpath

### DIFF
--- a/addons/calendar/static/src/views/calendar_form/calendar_quick_create.xml
+++ b/addons/calendar/static/src/views/calendar_form/calendar_quick_create.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="calendar.CalendarQuickCreateButtons" t-inherit="web.FormViewDialog.ToOne.buttons">
-        <xpath expr="//button[contains(@class, 'o_form_button_cancel')]" position="after">
+        <xpath expr="//button[hasclass('o_form_button_cancel')]" position="after">
             <button class="btn btn-link ms-auto" t-on-click="goToFullEvent">More Options</button>
         </xpath>
     </t>

--- a/addons/hr_holidays/static/src/views/view_dialog/form_view_dialog.xml
+++ b/addons/hr_holidays/static/src/views/view_dialog/form_view_dialog.xml
@@ -2,16 +2,16 @@
 <templates xml:space="preserve">
 
     <t t-name="hr_holidays.FormViewDialog.buttons" t-inherit="web.FormViewDialog.ToOne.buttons">
-        <xpath expr="//button[contains(@class, 'o_form_button_save')]" position="replace">
+        <xpath expr="//button[hasclass('o_form_button_save')]" position="replace">
             <button class="btn btn-primary o_form_button_save" t-if="!['validate1', 'validate', 'refuse'].includes(this.record.data.state)" t-on-click="saveButtonClicked" data-hotkey="q">Save</button>
         </xpath>
 
-        <xpath expr="//button[contains(@class, 'o_form_button_cancel')]" position="attributes">
+        <xpath expr="//button[hasclass('o_form_button_cancel')]" position="attributes">
             <attribute name="class" separator=" " remove="btn-secondary"/>
             <attribute name="t-attf-class" separator=" " add="{{ ['validate1', 'validate', 'refuse'].includes(this.record.data.state) ? 'btn-primary' : 'btn-secondary' }}"/>
         </xpath>
 
-        <xpath expr="//button[contains(@class, 'o_form_button_cancel')]" position="after">
+        <xpath expr="//button[hasclass('o_form_button_cancel')]" position="after">
             <button class="btn btn-secondary"
                     t-if="canCancel"
                     t-on-click="cancelRecord"

--- a/addons/hr_skills/static/src/fields/hr_skills_tags_list/hr_skills_tags_list.xml
+++ b/addons/hr_skills/static/src/fields/hr_skills_tags_list/hr_skills_tags_list.xml
@@ -2,11 +2,11 @@
 <templates xml:space="preserve">
 
     <t t-name="hr_skills.SkillsTagsList" t-inherit="web.TagsList">
-        <xpath expr='//span[contains(@class, "o_tag")]' position="attributes">
+        <xpath expr='//span[hasclass("o_tag")]' position="attributes">
             <attribute name="t-attf-class" add="{{ getTextStyle(tag) ? 'border border-2' : '' }}" separator=" "/>
             <attribute name="t-attf-style" add="{{ getTextStyle(tag) ? 'border-color: rgb(140, 140, 140) !important ;' : ''}}" separator=" "/>
         </xpath>
-        <xpath expr='//div[contains(@class, "o_tag_badge_text")]' position="attributes">
+        <xpath expr='//div[hasclass("o_tag_badge_text")]' position="attributes">
             <attribute name="t-attf-class" add="{{ getTextStyle(tag) ? 'fw-bold' : '' }}" separator=" "/>
         </xpath>
     </t>

--- a/addons/mail/static/src/views/web/fields/many2many_tags_email/many2many_tags_email.xml
+++ b/addons/mail/static/src/views/web/fields/many2many_tags_email/many2many_tags_email.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="FieldMany2ManyTagsEmailTagsList" t-inherit="web.TagsList" t-inherit-mode="primary">
-        <xpath expr="//span[contains(@class, 'o_tag')]" position="replace">
+        <xpath expr="//span[hasclass('o_tag')]" position="replace">
             <div t-if="tag.email" t-attf-class="badge rounded-pill dropdown o_tag o_tag_color_0 #{tag.email.indexOf('@') &lt; 0 ? 'o_tag_error' : ''}" t-att-data-color="tag.colorIndex" t-att-data-index="tag_index" t-att-data-id="tag.id" t-att-title="tag.text">
                 <span class="o_badge_text" t-att-title="tag.email"><t t-esc="tag.text"/></span>
                 <a t-if="!readonly &amp;&amp; tag.onDelete" t-on-click.stop.prevent="tag.onDelete" href="#" class="fa fa-times o_delete" title="Delete" aria-label="Delete"/>

--- a/addons/pos_hr/static/src/overrides/components/navbar/navbar.xml
+++ b/addons/pos_hr/static/src/overrides/components/navbar/navbar.xml
@@ -17,7 +17,7 @@
                 <i class="fa fa-fw fa-unlock"/>
             </button>
         </xpath>
-        <xpath expr="//Dropdown//div[contains(@class, 'pos-burger-menu-items')]" position="inside">
+        <xpath expr="//Dropdown//div[hasclass('pos-burger-menu-items')]" position="inside">
             <DropdownItem t-if="pos.config.module_pos_hr and ui.isSmall" onSelected="() => this.pos.showLoginScreen()">
                 Lock
             </DropdownItem>

--- a/addons/test_website/tests/test_menu.py
+++ b/addons/test_website/tests/test_menu.py
@@ -39,5 +39,5 @@ class TestWebsiteMenu(HttpCase):
         for record in records:
             record_url = f"{controller_url}{record.id}"
             tree = html.fromstring(self.url_open(record_url).content)
-            menu_link_el = tree.xpath(".//*[@id='top_menu']//a[@href='%s' and contains(@class, 'active')]" % record_url)
+            menu_link_el = tree.xpath(".//*[@id='top_menu']//a[@href='%s' and hasclass('active')]" % record_url)
             self.assertEqual(len(menu_link_el), 1, "The menu link related to the current record should be active")

--- a/addons/web/static/src/core/template_inheritance.js
+++ b/addons/web/static/src/core/template_inheritance.js
@@ -45,12 +45,23 @@ function getRoot(element) {
 }
 
 const HASCLASS_REGEXP = /hasclass\(([^)]*)\)/g;
+const CLASS_CONTAINS_REGEX = /contains\(@class.*\)/g;
 /**
  * @param {Element} operation
  * @returns {string}
  */
 function getXpath(operation) {
     const xpath = operation.getAttribute("expr");
+    if (odoo.debug) {
+        if (CLASS_CONTAINS_REGEX.test(xpath)) {
+            const parent = operation.closest("t[t-inherit]");
+            const templateName = parent.getAttribute("t-name") || parent.getAttribute("t-inherit");
+            console.warn(
+                `Error-prone use of @class in template "${templateName}" (or one of its inheritors).` +
+                " Use the hasclass(*classes) function to filter elements by their classes"
+            );
+        }
+    }
     // hasclass does not exist in XPath 1.0 but is a custom function defined server side (see _hasclass) usable in lxml.
     // Here we have to replace it by a complex condition (which is not nice).
     // Note: we assume that classes do not contain the 2 chars , and )

--- a/addons/web/static/src/views/view_dialogs/form_view_dialog.xml
+++ b/addons/web/static/src/views/view_dialogs/form_view_dialog.xml
@@ -16,14 +16,14 @@
   </t>
 
   <t t-name="web.FormViewDialog.ToMany.buttons" t-inherit="web.FormView.Buttons">
-    <xpath expr="//button[contains(@class, 'o_form_button_save')]" position="replace">
+    <xpath expr="//button[hasclass('o_form_button_save')]" position="replace">
       <button class="btn btn-primary o_form_button_save" t-on-click="saveButtonClicked" data-hotkey="c">Save &amp; Close</button>
       <button class="btn btn-primary o_form_button_save_new" t-on-click="() => this.saveButtonClicked({saveAndNew: true})" data-hotkey="n">Save &amp; New</button>
     </xpath>
   </t>
 
   <t t-name="web.FormViewDialog.ToOne.buttons" t-inherit="web.FormView.Buttons">
-    <xpath expr="//button[contains(@class, 'o_form_button_save')]" position="replace">
+    <xpath expr="//button[hasclass('o_form_button_save')]" position="replace">
       <button class="btn btn-primary o_form_button_save" t-on-click="saveButtonClicked" data-hotkey="c">Save &amp; Close</button>
     </xpath>
   </t>

--- a/addons/website/static/src/components/dialog/page_properties.xml
+++ b/addons/website/static/src/components/dialog/page_properties.xml
@@ -89,7 +89,7 @@
 </t>
 
 <t t-name="website.PagePropertiesDialogButtons" t-inherit="web.FormViewDialog.ToOne.buttons">
-    <xpath expr="//button[contains(@class, 'o_form_button_cancel')]" position="after">
+    <xpath expr="//button[hasclass('o_form_button_cancel')]" position="after">
         <button class="btn btn-link order-last ms-auto" t-on-click="props.clonePage"><i class="fa fa-fw fa-clone"/>Duplicate Page</button>
         <button class="btn btn-link order-last" t-on-click="props.deletePage"><i class="fa fa-fw fa-trash"/>Delete Page</button>
     </xpath>

--- a/addons/website/static/src/components/views/theme_preview.xml
+++ b/addons/website/static/src/components/views/theme_preview.xml
@@ -68,7 +68,7 @@
         <xpath expr="//t[@t-else]/Breadcrumbs" position="replace">
             <t t-call="website.ThemePreviewKanban.ControlPanel.BreadCrumbs"/>
         </xpath>
-        <xpath expr="//div[contains(@class,'o_control_panel_navigation')]" position="replace">
+        <xpath expr="//div[hasclass('o_control_panel_navigation')]" position="replace">
             <a class="btn btn-secondary align-self-center" t-on-click="this.close" aria-label="Close" data-tooltip="Close">
                 <i class="fa fa-times" role="img" aria-label="close"/>
             </a>

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -22,7 +22,7 @@ class TestSnippets(HttpCase):
         with MockRequest(self.env, website=self.env['website'].browse(1)):
             snippets_template = self.env['ir.ui.view'].render_public_asset('website.snippets')
         html_template = html.fromstring(snippets_template)
-        data_snippet_els = html_template.xpath("//*[snippets and not(contains(@class, 'd-none'))]//*[@data-oe-type='snippet']/*[@data-snippet]")
+        data_snippet_els = html_template.xpath("//*[snippets and not(hasclass('d-none'))]//*[@data-oe-type='snippet']/*[@data-snippet]")
         blacklist = [
             's_facebook_page',  # avoid call to external services (facebook.com)
             's_map',  # avoid call to maps.google.com


### PR DESCRIPTION
*= calendar, hr_holidays, hr_skills, im_livechat, mail, test_website, website

This commit will prevent using deprecated xpath.

Specifications:
`contains(@class...​` => `hasclass(...`

Enterprise PR: https://github.com/odoo/enterprise/pull/67145

Task - 3820162

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
