### PR TITLE
[DRAFT][FIX] stock: Preserve delivery slip description format

### DIFF
--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -242,7 +242,7 @@
             <td>
                 <span t-esc="aggregated_lines[line]['name']"/>
                 <p t-if="aggregated_lines[line]['description']">
-                    <span t-esc="aggregated_lines[line]['description']"/>
+                    <span t-esc="aggregated_lines[line]['description']" t-options="{'widget': 'text'}"/>
                 </p>
             </td>
             <td class="text-center" name="move_line_aggregated_qty_ordered">


### PR DESCRIPTION
Steps to reproduce:
- Edit any product's 'Description for delivery orders' (inventory tab)
- Create a delivery for this product (or confirm sale order to create one automatically)
- Print delivery slip (Correct formatting)
- Validate delivery
- Print delivery slip once more (Description loses linebreaks)

This is only for looks, but it's a document the end user will see so there are concerns about it looking unprofessional.

This formatting error is due to us not being able to use a field element after remaking the order lines to group related products in python.

opw-4040127

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
