### PR TITLE
[FIX] point_of_sale: display an error popup if a payment line value has more precision than the rounding precision

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -6175,8 +6175,8 @@ msgstr ""
 #: code:addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js:0
 #, python-format
 msgid ""
-"The amount of your payment lines must be rounded to validate the "
-"transaction."
+"The amount of your payment lines must be rounded to validate the transaction.\n"
+"The rounding precision is %s so you should set %s or %s as payment amount instead of %s."
 msgstr ""
 
 #. module: point_of_sale

--- a/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
@@ -9,6 +9,7 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
     const Registries = require('point_of_sale.Registries');
     const { isConnectionError } = require('point_of_sale.utils');
     const utils = require('web.utils');
+    const round_pr = utils.round_precision;
 
     class PaymentScreen extends PosComponent {
         setup() {
@@ -81,6 +82,10 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
         }
         addNewPaymentLine({ detail: paymentMethod }) {
             // original function: click_paymentmethods
+            if(!this.env.pos.get_order().check_paymentlines_rounding()) {
+                this._display_popup_error_paymentlines_rounding();
+                return false;
+            }
             let result = this.currentOrder.add_paymentline(paymentMethod);
             if (result){
                 NumberBuffer.reset();
@@ -92,6 +97,36 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
                     body: this.env._t('There is already an electronic payment in progress.'),
                 });
                 return false;
+            }
+        }
+        _display_popup_error_paymentlines_rounding() {
+            if(this.env.pos.config.cash_rounding) {
+                const orderlines = this.paymentLines;
+                const cash_rounding = this.env.pos.cash_rounding[0].rounding;
+                const default_rounding = this.env.pos.currency.rounding;
+                for(var id in orderlines) {
+                    var line = orderlines[id];
+                    var diff = round_pr(round_pr(line.amount, cash_rounding) - round_pr(line.amount, default_rounding), default_rounding);
+
+                    if(diff && (line.payment_method.is_cash_count || !this.env.pos.config.only_round_cash_method)) {
+                        const upper_amount = round_pr(round_pr(line.amount, default_rounding) + cash_rounding / 2, cash_rounding)
+                        const lower_amount = round_pr(round_pr(line.amount, default_rounding) - cash_rounding / 2, cash_rounding)
+                        this.showPopup("ErrorPopup", {
+                            title: this.env._t("Rounding error in payment lines"),
+                            body: _.str.sprintf(
+                                this.env._t(
+                                    "The amount of your payment lines must be rounded to validate the transaction.\n" +
+                                    "The rounding precision is %s so you should set %s or %s as payment amount instead of %s."
+                                ),
+                                cash_rounding.toFixed(this.env.pos.currency.decimal_places),
+                                lower_amount.toFixed(this.env.pos.currency.decimal_places),
+                                upper_amount.toFixed(this.env.pos.currency.decimal_places),
+                                line.amount.toFixed(this.env.pos.currency.decimal_places)
+                            ),
+                        });
+                        return;
+                    }
+                }
             }
         }
         _updateSelectedPaymentline() {
@@ -174,10 +209,7 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
         async validateOrder(isForceValidate) {
             if(this.env.pos.config.cash_rounding) {
                 if(!this.env.pos.get_order().check_paymentlines_rounding()) {
-                    this.showPopup('ErrorPopup', {
-                        title: this.env._t('Rounding error in payment lines'),
-                        body: this.env._t("The amount of your payment lines must be rounded to validate the transaction."),
-                    });
+                    this._display_popup_error_paymentlines_rounding();
                     return;
                 }
             }

--- a/addons/point_of_sale/static/tests/tours/PaymentScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/PaymentScreen.tour.js
@@ -2,6 +2,7 @@ odoo.define('point_of_sale.tour.PaymentScreen', function (require) {
     'use strict';
 
     const { Chrome } = require('point_of_sale.tour.ChromeTourMethods');
+    const { ErrorPopup } = require('point_of_sale.tour.ErrorPopupTourMethods');
     const { ProductScreen } = require('point_of_sale.tour.ProductScreenTourMethods');
     const { PaymentScreen } = require('point_of_sale.tour.PaymentScreenTourMethods');
     const { ReceiptScreen } = require('point_of_sale.tour.ReceiptScreenTourMethods');
@@ -249,4 +250,25 @@ odoo.define('point_of_sale.tour.PaymentScreen', function (require) {
 
     Tour.register('PaymentScreenTotalDueWithOverPayment', { test: true, url: '/pos/ui' }, getSteps());
 
+    startSteps();
+
+    ProductScreen.do.confirmOpeningPopup();
+    ProductScreen.do.clickHomeCategory();
+    ProductScreen.exec.addOrderline('Magnetic Board', '1');
+    ProductScreen.do.clickPayButton();
+
+    // Check the popup error is shown when selecting another payment method
+    PaymentScreen.check.totalIs('1.90');
+    PaymentScreen.do.clickPaymentMethod('Cash');
+    PaymentScreen.do.pressNumpad('1 .');
+    PaymentScreen.check.selectedPaymentlineHas('Cash', '1.00');
+    PaymentScreen.do.pressNumpad('2 4');
+    PaymentScreen.check.selectedPaymentlineHas('Cash', '1.24');
+    PaymentScreen.do.clickPaymentMethod('Bank');
+    ErrorPopup.check.isShown();
+    ErrorPopup.check.messageBodyContains(  // Verify the value displayed are as expected
+        'The rounding precision is 0.10 so you should set 1.20 or 1.30 as payment amount instead of 1.24.'
+    );
+
+    Tour.register('CashRoundingPayment', { test: true, url: '/pos/ui' }, getSteps());
 });

--- a/addons/point_of_sale/static/tests/tours/helpers/ErrorPopupTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/ErrorPopupTourMethods.js
@@ -24,6 +24,15 @@ odoo.define('point_of_sale.tour.ErrorPopupTourMethods', function (require) {
                 },
             ];
         }
+
+        messageBodyContains(text) {
+            return [
+                {
+                    content: `check '${text}' is in the body of the popup`,
+                    trigger: `.modal-dialog .popup-error .body:contains(${text})`,
+                }
+            ];
+        }
     }
 
     return createTourMethods('ErrorPopup', Do, Check);

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1104,3 +1104,23 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'FiscalPositionTwoTaxIncluded', login="accountman")
+
+    def test_cash_rounding_payment(self):
+        """Verify than an error popup is shown if the payment value is more precise than the rounding method"""
+        rounding_method = self.env['account.cash.rounding'].create({
+            'name': 'Down 0.10',
+            'rounding': 0.10,
+            'strategy': 'add_invoice_line',
+            'profit_account_id': self.company_data['default_account_revenue'].copy().id,
+            'loss_account_id': self.company_data['default_account_expense'].copy().id,
+            'rounding_method': 'DOWN',
+        })
+
+        self.main_pos_config.write({
+            'cash_rounding': True,
+            'only_round_cash_method': False,
+            'rounding_method': rounding_method.id,
+        })
+
+        self.main_pos_config.open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'CashRoundingPayment', login="accountman")


### PR DESCRIPTION
Current behavior:
When a cashier enter a payment value with more precision than the rounding precision (eg. rounding=0.10 and payment value=1.25), he just cannot proceed to the payment.

Steps to reproduce:
- Install "Point of Sale" app
- Go to the settings and enable the cash rounding
- Go the shop settings and enable the cash rounding and create a down rounding method with a precision of 0.10
- Start a shop session, select a product and go to the payment screen
- Select a payment method and write a number on the numpad so that the value goes up to the cent (eg. 1.25)
- Select another payment method to pay the rest

Solution:
With this commit, an error popup will be displayed explaining why the cashier cannot proceed the payment and what he could change to authorize the payment. This popup should appear when selecting another payment method and when validating the payment.

opw-3992018


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
