### PR TITLE
[FIX] hr_calendar: traceback when partner is unavailable

### DIFF
--- a/addons/hr_calendar/models/calendar_event.py
+++ b/addons/hr_calendar/models/calendar_event.py
@@ -23,6 +23,9 @@ class CalendarEvent(models.Model):
         # Event without start and stop are skipped, except all day event: their interval is computed
         # based on company calendar's interval.
         for event, event_interval in event_intervals.items():
+            if not event_interval._items:
+                event.unavailable_partner_ids = []
+                continue
             start = event_interval._items[0][0]
             stop = event_interval._items[0][1]
             schedule_by_partner = event.partner_ids._get_schedule(start, stop, merge=False)


### PR DESCRIPTION
Version:
- Master

Issue:
- Creating a partner event throws a traceback error when the partner is unavailable.

Solution:
- Added a condition to handle cases where the partner is unavailable, preventing the error.

task-4069110

