### PR TITLE
[IMP] website: allow bypassing iframe redirect in debug mode

### DIFF
--- a/addons/website/i18n/website.pot
+++ b/addons/website/i18n/website.pot
@@ -10855,6 +10855,14 @@ msgstr ""
 
 #. module: website
 #. odoo-javascript
+#: code:addons/website/static/src/client_actions/website_preview/website_preview.js:0
+#, python-format
+msgid ""
+"Bypass redirect (I know what I'm doing)"
+msgstr ""
+
+#. module: website
+#. odoo-javascript
 #: code:addons/website/static/src/components/translator/translator.xml:0
 #, python-format
 msgid "You are about to enter the translation mode."

--- a/addons/website/static/src/client_actions/website_preview/website_preview.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.js
@@ -67,17 +67,28 @@ export class WebsitePreview extends Component {
                 // URL (event if it wasn't, it wouldn't be an issue as those are
                 // really considered as the same domain, the user will share the
                 // same session and CORS errors won't be a thing in such a case)
-                this.dialogService.add(WebsiteDialog, {
-                    title: this.env._t("Redirecting..."),
-                    body: sprintf(this.env._t(
-                        "You are about to be redirected to the domain configured for your website ( %s ). " +
-                        "This is necessary to edit or view your website from the Website app. You might need to log back in."
-                    ), this.websiteDomain),
-                    showSecondaryButton: false,
-                }, {
-                    onClose: () => {
-                         window.location.href = `${this.websiteDomain}/web#action=website.website_preview&path=${encodedPath}&website_id=${encodeURIComponent(this.websiteId)}`;
-                    }
+                let redirect = true;
+                await new Promise(resolve => {
+                    this.dialogService.add(WebsiteDialog, {
+                        title: this.env._t("Redirecting..."),
+                        body: sprintf(this.env._t(
+                            "You are about to be redirected to the domain configured for your website ( %s ). " +
+                            "This is necessary to edit or view your website from the Website app. You might need to log back in."
+                        ), this.websiteDomain),
+                        showSecondaryButton: !!this.env.debug && !this.websiteService.hasMultiWebsites,
+                        secondaryTitle: this.env._t("Bypass redirect (I know what I'm doing)"),
+                        secondaryClick: () => redirect = false,
+                    }, {
+                        onClose: () => {
+                            if (!redirect) {
+                                this.initialUrl = "/";
+                                resolve();
+                                return;
+                            }
+                            window.location.href = `${this.websiteDomain}/web#action=website.website_preview&path=${encodedPath}&website_id=${encodeURIComponent(this.websiteId)}`;
+                            resolve();
+                        }
+                    });
                 });
             } else {
                 this.initialUrl = `/website/force/${encodeURIComponent(this.websiteId)}?path=${encodedPath}`;


### PR DESCRIPTION
This commit is an answer to a demand from our support team.

Prior to 16.0 [1], the support could log into a customer's database using *.odoo.com, and by going to the homepage, they could edit the website.

However, with 16.0 and the website in iframe, this was no longer possible as the iframe redirects the top window to the domain of the website.

This is because we use `/website/force` to set the correct websiteId in the session. Ensuring that the user is not viewing the wrong website. However, `/website/force` redirects if a domain is set, which would lead to CORS errors within the iframe.

This commit introduces a bypass when in debug mode and multi website is not enabled.

The feature would not work properly if multi website is enabled and could end up with trying to select website 1 but still seeing website 2.

[1]: https://github.com/odoo/odoo/commit/fed0e69c27e9c9109dedb154cbda3b2d2be5251a

task-4069779
