### PR TITLE
[FIX] web: deactivate debug mode

### DIFF
--- a/addons/web/static/src/core/debug/debug_menu_items.js
+++ b/addons/web/static/src/core/debug/debug_menu_items.js
@@ -9,7 +9,7 @@ function activateAssetsDebugging({ env }) {
         type: "item",
         description: _t("Activate Assets Debugging"),
         callback: () => {
-            browser.location.search = "?debug=assets";
+            router.pushState({ debug: "assets" }, { reload: true });
         },
         sequence: 410,
     };
@@ -20,7 +20,7 @@ function activateTestsAssetsDebugging({ env }) {
         type: "item",
         description: _t("Activate Tests Assets Debugging"),
         callback: () => {
-            browser.location.search = "?debug=assets,tests";
+            router.pushState({ debug: "assets,tests" }, { reload: true });
         },
         sequence: 420,
     };
@@ -57,7 +57,7 @@ function leaveDebugMode() {
         type: "item",
         description: _t("Leave the Developer Tools"),
         callback: () => {
-            router.pushState({ debug: undefined }, { reload: true });
+            router.pushState({ debug: 0 }, { reload: true });
         },
         sequence: 450,
     };

--- a/addons/web/static/src/core/debug/debug_providers.js
+++ b/addons/web/static/src/core/debug/debug_providers.js
@@ -20,7 +20,7 @@ commandProviderRegistry.add("debug", {
             }
             result.push({
                 action() {
-                    router.pushState({ debug: undefined }, { reload: true });
+                    router.pushState({ debug: 0 }, { reload: true });
                 },
                 category: "debug",
                 name: _t("Deactivate debug mode"),

--- a/addons/web/static/src/webclient/settings_form_view/widgets/res_config_dev_tool.xml
+++ b/addons/web/static/src/webclient/settings_form_view/widgets/res_config_dev_tool.xml
@@ -8,7 +8,7 @@
                         <a t-if="!isDebug" class="d-block" t-on-click="() => this.activateDebug(1)" href="#">Activate the developer mode</a>
                         <a t-if="!isAssets" class="d-block" t-on-click="() => this.activateDebug('assets')" href="#">Activate the developer mode (with assets)</a>
                         <a t-if="!isTests" class="d-block" t-on-click="() => this.activateDebug('assets,tests')" href="#">Activate the developer mode (with tests assets)</a>
-                        <a t-if="isDebug" class="d-block" t-on-click="() => this.activateDebug()" href="#">Deactivate the developer mode</a>
+                        <a t-if="isDebug" class="d-block" t-on-click="() => this.activateDebug(0)" href="#">Deactivate the developer mode</a>
                         <a t-if="isDebug and !isDemoDataActive" t-on-click.prevent="onClickForceDemo" class="o_web_settings_force_demo" href="#">Load demo data</a>
                 </Setting>
             </SettingsBlock>

--- a/addons/web/static/tests/webclient/settings_form_view/res_config_dev_tool.test.js
+++ b/addons/web/static/tests/webclient/settings_form_view/res_config_dev_tool.test.js
@@ -156,6 +156,6 @@ test("Activate the developer modeddd (with tests assets)", async () => {
 
     await click("a:contains('Deactivate the developer mode')");
     await tick();
-    expect(router.current).toEqual({ cids: 1 });
+    expect(router.current).toEqual({ cids: 1, debug: 0 });
     expect.verifySteps(["location reload"]);
 });


### PR DESCRIPTION
Before this commit, when debug mode was activated, and we wanted to deactivate (by the debug menu, the command pallet or the settings links), the debug mode wasn't completely and correctly deactivated. The debug mode was removed from the URL and the debug menu wasn't accessible anymore, but not everything was deactivated. For instance : the settings were still there (Translations, Gamification Tools and Technical), the link tracker app is still visible, all the user technical rights and extra rights are still shown.

The issue occurs, because we just remove it from the URL (to setting the debug to `undefined`); this will remove the debug menu, but won't deactivate correctly the debug mode. To deactivate correctly the debug mode, the debug should be set to `0`;

Note that, this commit will also solve a minor issue, that when activate the assets debugging, or test assets debugging from the debug menu, the rest of the query string was lost. This could lead to some errors, when reloading do to lost information.

opw-4042335
opw-4047116
