### PR TITLE
[IMP] website: redesign `s_process_steps` snippet

### DIFF
--- a/addons/website/static/src/snippets/s_process_steps/002.scss
+++ b/addons/website/static/src/snippets/s_process_steps/002.scss
@@ -1,0 +1,53 @@
+.s_process_steps[data-vcss='002']  {
+    $process-step-number-size: 5rem;
+
+    .s_process_step {
+        .s_process_step_number {
+            width: $process-step-number-size;
+            height: $process-step-number-size;
+
+            // It is possible to add icons or images with the "/" command
+            img {
+                // Note that we use contain and not cover. For "full images"
+                // (like a photo which is a rectangle with colors on the edges),
+                // cover would be better. But for "image icons", contain is a
+                // better fit (as we want the full icon to be visible). Also
+                // in the case of "photos", the user has to be possibility to
+                // crop the image to a square, that way it would act as cover.
+                object-fit: contain;
+            }
+        }
+
+        .s_process_step_connector {
+            height: $process-step-number-size;
+            width: calc(100% - #{$process-step-number-size});
+            left: calc(50% + #{$process-step-number-size / 2});
+
+            path {
+                stroke: $border-color;
+                fill: transparent;
+            }
+        }
+
+        &:last-child .s_process_step_connector {
+            display: none;
+        }
+    }
+
+    &.s_process_steps_connector_curved_arrow {
+        .s_process_step:nth-child(odd) .s_process_step_connector {
+            transform: scale(1, -1);
+        }
+    }
+
+    .s_process_steps_arrow_head path {
+        fill: map-get($grays, '600');
+        stroke: transparent;
+    }
+
+    @include media-breakpoint-down(lg) {
+        .s_process_step_connector {
+            display: none;
+        }
+    }
+}

--- a/addons/website/static/src/snippets/s_process_steps/options.js
+++ b/addons/website/static/src/snippets/s_process_steps/options.js
@@ -108,9 +108,9 @@ options.registry.StepsConnector = options.Class.extend({
             const stepPaddingTop = this._getClassSuffixedInteger(stepsEls[i], 'pt');
             const nextStepPaddingTop = this._getClassSuffixedInteger(stepsEls[i + 1], 'pt');
 
-            connectorEl.style.left = `calc(50% + ${stepMainElementRect.width / 2}px)`;
+            connectorEl.style.left = `calc(50% + ${stepMainElementRect.width / 2}px + 16px)`;
             connectorEl.style.height = `${stepMainElementRect.height}px`;
-            connectorEl.style.width = `calc(${100 * (stepSize / 2 + nextStepOffset + nextStepSize / 2) / stepSize}% - ${stepMainElementRect.width / 2}px - ${nextStepMainElementRect.width / 2}px)`;
+            connectorEl.style.width = `calc(${100 * (stepSize / 2 + nextStepOffset + nextStepSize / 2) / stepSize}% - ${stepMainElementRect.width / 2}px - ${nextStepMainElementRect.width / 2}px - 32px)`;
 
             const isTheLastColOfRow = nbBootstrapCols <
                 colsInRow + stepSize + stepOffset + nextStepSize + nextStepOffset;
@@ -147,7 +147,7 @@ options.registry.StepsConnector = options.Class.extend({
      * @returns {object}
      */
     _getStepMainElementRect(stepEl) {
-        const iconEl = stepEl.querySelector(".s_process_step_icon > *");
+        const iconEl = stepEl.querySelector(".s_process_step_number");
         if (iconEl) {
             return iconEl.getBoundingClientRect();
         }

--- a/addons/website/static/tests/tours/media_dialog.js
+++ b/addons/website/static/tests/tours/media_dialog.js
@@ -82,28 +82,27 @@ wTourUtils.registerWebsitePreviewTour('website_media_dialog_icons', {
     edition: true,
 }, () => [
     ...wTourUtils.dragNDrop({
-        id: 's_process_steps',
-        name: 'Steps',
-        groupName: "Content",
+        id: 's_social_media',
+        name: 'Social Media',
     }),
     {
         content: "Open MediaDialog from a snippet icon",
-        trigger: ':iframe .s_process_steps .fa-unlock-alt',
+        trigger: ':iframe .s_social_media .fa-instagram',
         run: "dblclick",
     },
     {
         content: "Pick the same icon",
-        trigger: '.o_select_media_dialog .o_we_attachment_selected.fa-unlock-alt',
+        trigger: '.o_select_media_dialog .o_we_attachment_selected.fa-instagram',
         run: "click",
     },
     {
         content: "Check if the icon remains the same",
-        trigger: ':iframe .s_process_steps .fa-unlock-alt',
+        trigger: ':iframe .s_social_media .fa-instagram',
         run: () => null, // it's a check
     },
     {
         content: "Open MediaDialog again",
-        trigger: ':iframe .s_process_steps .fa-unlock-alt',
+        trigger: ':iframe .s_social_media .fa-instagram',
         run: "dblclick",
     },
     {
@@ -113,7 +112,7 @@ wTourUtils.registerWebsitePreviewTour('website_media_dialog_icons', {
     },
     {
         content: "Check if the icon remains the same",
-        trigger: ':iframe .s_process_steps .fa-unlock-alt',
+        trigger: ':iframe .s_social_media .fa-instagram',
         run: () => null, // it's a check
     },
     ...wTourUtils.clickOnSave()

--- a/addons/website/views/snippets/s_process_steps.xml
+++ b/addons/website/views/snippets/s_process_steps.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <template name="Steps" id="s_process_steps">
-    <section class="s_process_steps pt24 pb24 s_process_steps_connector_line" data-vcss="001">
+    <section class="s_process_steps pt72 pb72 s_process_steps_connector_line" data-vcss="002" data-vxml="002">
         <svg class="s_process_step_svg_defs position-absolute">
             <defs>
                 <marker class="s_process_steps_arrow_head" markerWidth="15" markerHeight="10" refX="6" refY="6" orient="auto">
@@ -11,53 +11,54 @@
             </defs>
         </svg>
         <div class="container">
+            <h2 class="mb-4 text-center h3-fs">Our process in four easy steps</h2>
             <div class="row g-0">
-                <div class="col-lg-3 s_process_step pt24 pb24">
-                    <svg class="s_process_step_connector" viewBox="0 0 100 20" preserveAspectRatio="none">
+                <div class="col-lg-3 s_process_step position-relative pt24 pb24">
+                    <svg class="s_process_step_connector position-absolute z-index-1" viewBox="0 0 100 20" preserveAspectRatio="none">
                         <path d="M 0 10 L 100 10" vector-effect="non-scaling-stroke"/>
                     </svg>
-                    <div class="s_process_step_icon">
-                        <i class="fa fa-shopping-basket fa-2x mx-auto rounded-circle bg-o-color-1"/>
+                    <div class="s_process_step_number d-flex align-items-center justify-content-center mx-auto rounded-circle bg-primary-light" data-name="Step Number">
+                        <h3 class="mb-0 text-primary text-center">1</h3>
                     </div>
-                    <div class="s_process_step_content">
-                        <h2>Add to cart</h2>
-                        <p>Let your customers follow <br/>and understand your process.</p>
+                    <div class="s_process_step_content mt-3 px-3 text-center">
+                        <h3 class="h4-fs">Add to cart</h3>
+                        <p>Let your customers understand your process.</p>
                     </div>
                 </div>
-                <div class="col-lg-3 s_process_step pt24 pb24">
-                    <svg class="s_process_step_connector" viewBox="0 0 100 20" preserveAspectRatio="none">
+                <div class="col-lg-3 s_process_step position-relative pt24 pb24">
+                    <svg class="s_process_step_connector position-absolute z-index-1" viewBox="0 0 100 20" preserveAspectRatio="none">
                         <path d="M 0 10 L 100 10" vector-effect="non-scaling-stroke"/>
                     </svg>
-                    <div class="s_process_step_icon">
-                        <i class="fa fa-unlock-alt fa-2x mx-auto rounded-circle bg-o-color-5"/>
+                    <div class="s_process_step_number d-flex align-items-center justify-content-center mx-auto rounded-circle bg-primary-light" data-name="Step Number">
+                        <h3 class="mb-0 text-primary text-center">2</h3>
                     </div>
-                    <div class="s_process_step_content">
-                        <h2>Sign in</h2>
-                        <p>Click on the icon to adapt it <br/>to your purpose.</p>
+                    <div class="s_process_step_content mt-3 px-3 text-center">
+                        <h3 class="h4-fs">Sign in</h3>
+                        <p>Click on the number to adapt it to your purpose.</p>
                     </div>
                 </div>
-                <div class="col-lg-3 s_process_step pt24 pb24">
-                    <svg class="s_process_step_connector" viewBox="0 0 100 20" preserveAspectRatio="none">
+                <div class="col-lg-3 s_process_step position-relative pt24 pb24">
+                    <svg class="s_process_step_connector position-absolute z-index-1" viewBox="0 0 100 20" preserveAspectRatio="none">
                         <path d="M 0 10 L 100 10" vector-effect="non-scaling-stroke"/>
                     </svg>
-                    <div class="s_process_step_icon">
-                        <i class="fa fa-paypal fa-2x mx-auto rounded-circle bg-o-color-2"/>
+                    <div class="s_process_step_number d-flex align-items-center justify-content-center mx-auto rounded-circle bg-primary-light" data-name="Step Number">
+                        <h3 class="mb-0 text-primary text-center">3</h3>
                     </div>
-                    <div class="s_process_step_content">
-                        <h2>Pay</h2>
-                        <p>Duplicate blocks <br/>to add more steps.</p>
+                    <div class="s_process_step_content mt-3 px-3 text-center">
+                        <h3 class="h4-fs">Pay</h3>
+                        <p>Duplicate blocks to add more steps.</p>
                     </div>
                 </div>
-                <div class="col-lg-3 s_process_step pt24 pb24">
-                    <svg class="s_process_step_connector" viewBox="0 0 100 20" preserveAspectRatio="none">
+                <div class="col-lg-3 s_process_step position-relative pt24 pb24">
+                    <svg class="s_process_step_connector position-absolute z-index-1" viewBox="0 0 100 20" preserveAspectRatio="none">
                         <path d="M 0 10 L 100 10" vector-effect="non-scaling-stroke"/>
                     </svg>
-                    <div class="s_process_step_icon">
-                        <i class="fa fa-plane fa-2x mx-auto rounded-circle bg-o-color-3"/>
+                    <div class="s_process_step_number d-flex align-items-center justify-content-center mx-auto rounded-circle bg-primary-light" data-name="Step Number">
+                        <h3 class="mb-0 text-primary text-center">4</h3>
                     </div>
-                    <div class="s_process_step_content">
-                        <h2>Get Delivered</h2>
-                        <p>Select and delete blocks <br/>to remove some steps.</p>
+                    <div class="s_process_step_content mt-3 px-3 text-center">
+                        <h3 class="h4-fs">Get Delivered</h3>
+                        <p>Select and delete blocks to remove some steps.</p>
                     </div>
                 </div>
             </div>
@@ -83,6 +84,13 @@
                     data-css-property="stroke" data-change-color="true"/>
             </we-row>
         </div>
+        <t t-call="website.snippet_options_background_options">
+            <t t-set="selector" t-value="'.s_process_step .s_process_step_number'"/>
+            <t t-set="with_colors" t-value="True"/>
+            <t t-set="with_images" t-value="False"/>
+            <t t-set="with_color_combinations" t-value="False"/>
+            <t t-set="with_gradients" t-value="True"/>
+        </t>
     </xpath>
 </template>
 
@@ -97,6 +105,14 @@
     <field name="name">Process steps 001 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
     <field name="path">website/static/src/snippets/s_process_steps/001.scss</field>
+    <field name="active" eval="False"/>
+</record>
+
+<record id="website.s_process_steps_002_scss" model="ir.asset">
+    <field name="name">Process steps 002 SCSS</field>
+    <field name="bundle">web.assets_frontend</field>
+    <field name="path">website/static/src/snippets/s_process_steps/002.scss</field>
+    <field name="active" eval="True"/>
 </record>
 
 </odoo>


### PR DESCRIPTION
The goal of this PR is to improve the visual design of the default `s_process_steps` snippet.

| Before | After |
|--------|--------|
| <img width="1424" alt="Screenshot 2024-07-23 at 11 45 09" src="https://github.com/user-attachments/assets/aa431b21-019f-4e43-af2a-6ca69d361de8"> | <img width="1438" alt="Screenshot 2024-07-23 at 11 45 22" src="https://github.com/user-attachments/assets/43c646eb-5df9-4afa-a241-48180fd29f6f"> | 

Requires:
- https://github.com/odoo/design-themes/pull/840

task-3672430

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
