### PR TITLE
[IMP] mail: parent_id only on channels

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -711,7 +711,7 @@ class Channel(models.Model):
             ]).id
 
     def _get_allowed_message_post_params(self):
-        return super()._get_allowed_message_post_params() | {"special_mentions"}
+        return super()._get_allowed_message_post_params() | {"special_mentions", "parent_id"}
 
     @api.returns('mail.message', lambda value: value.id)
     def message_post(self, *, message_type='notification', **kwargs):

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2064,7 +2064,7 @@ class MailThread(models.AbstractModel):
     # ------------------------------------------------------------
 
     def _get_allowed_message_post_params(self):
-        return {"attachment_ids", "body", "message_type", "partner_ids", "subtype_xmlid", "parent_id"}
+        return {"attachment_ids", "body", "message_type", "partner_ids", "subtype_xmlid"}
 
     @api.returns('mail.message', lambda value: value.id)
     def message_post(self, *,

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -604,10 +604,9 @@ export async function mail_message_post(request) {
         "message_type",
         "partner_ids",
         "subtype_xmlid",
-        "parent_id",
     ];
     if (thread_model === "discuss.channel") {
-        allowedParams.push("special_mentions");
+        allowedParams.push("parent_id", "special_mentions");
     }
     for (const allowedParam of allowedParams) {
         if (post_data[allowedParam] !== undefined) {


### PR DESCRIPTION
Parent_id as an allowed message post params is specific to the channels. This commit moves it to `discuss.channel` model.

