### PR TITLE
[FIX] mail: Banner should not hide the chatter actions

### DIFF
--- a/addons/mail/static/src/chatter/web/chatter.xml
+++ b/addons/mail/static/src/chatter/web/chatter.xml
@@ -88,6 +88,7 @@
                 <SuggestedRecipientsList t-if="state.composerType !== 'note' and toRecipientsText" styleString="'margin-left:48px;'" thread="state.thread" onSuggestedRecipientAdded.bind="onSuggestedRecipientAdded"/>
                 <Composer composer="state.thread.composer" autofocus="true" className="state.composerType === 'message' ? '' : 'pt-4'" mode="'extended'" onPostCallback.bind="onPostCallback" dropzoneRef="rootRef" type="state.composerType" t-key="props.threadId"/>
             </t>
+            <JumpToPresentBanner t-if="!state.isSearchOpen" jumpToPresent="jumpToPresent" order="'desc'"/>
         </div>
         <div class="o-mail-Chatter-content">
             <div t-if="state.isSearchOpen" class="o-mail-Chatter-search">

--- a/addons/mail/static/src/chatter/web/chatter_patch.js
+++ b/addons/mail/static/src/chatter/web/chatter_patch.js
@@ -8,7 +8,7 @@ import { RecipientList } from "@mail/core/web/recipient_list";
 import { SearchMessagesPanel } from "@mail/core/common/search_messages_panel";
 import { useAttachmentUploader } from "@mail/core/common/attachment_uploader_hook";
 import { useDropzone } from "@mail/core/common/dropzone_hook";
-import { useHover, useMessageHighlight } from "@mail/utils/common/hooks";
+import { useHover, useMessageHighlight, useJumpToPresent } from "@mail/utils/common/hooks";
 
 import { markup, useEffect } from "@odoo/owl";
 
@@ -71,6 +71,7 @@ Object.assign(Chatter.defaultProps, {
 patch(Chatter.prototype, {
     setup() {
         this.messageHighlight = useMessageHighlight();
+        this.jumpToPresent = useJumpToPresent();
         super.setup(...arguments);
         this.orm = useService("orm");
         this.mailPopoutService = useService("mail.popout");
@@ -165,7 +166,11 @@ patch(Chatter.prototype, {
     },
 
     get childSubEnv() {
-        return { ...super.childSubEnv, messageHighlight: this.messageHighlight };
+        return {
+            ...super.childSubEnv,
+            messageHighlight: this.messageHighlight,
+            jumpToPresent: this.jumpToPresent,
+        };
     },
 
     get followerButtonLabel() {

--- a/addons/mail/static/src/chatter/web_portal/chatter.js
+++ b/addons/mail/static/src/chatter/web_portal/chatter.js
@@ -1,4 +1,5 @@
 import { Composer } from "@mail/core/common/composer";
+import { JumpToPresentBanner } from "@mail/core/common/jump_to_present_banner";
 import { Thread } from "@mail/core/common/thread";
 
 import {
@@ -20,7 +21,7 @@ import { useThrottleForAnimation } from "@web/core/utils/timing";
  */
 export class Chatter extends Component {
     static template = "mail.Chatter";
-    static components = { Thread, Composer };
+    static components = { Thread, Composer, JumpToPresentBanner };
     static props = ["threadId?", "threadModel"];
     static defaultProps = { threadId: false };
 

--- a/addons/mail/static/src/core/common/jump_to_present_banner.js
+++ b/addons/mail/static/src/core/common/jump_to_present_banner.js
@@ -1,0 +1,6 @@
+import { Component } from "@odoo/owl";
+
+export class JumpToPresentBanner extends Component {
+    static template = "mail.JumpToPresentBanner";
+    static props = ["jumpToPresent", "order"];
+}

--- a/addons/mail/static/src/core/common/jump_to_present_banner.xml
+++ b/addons/mail/static/src/core/common/jump_to_present_banner.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="mail.JumpToPresentBanner">
+        <span t-if="props.jumpToPresent.showBanner"
+            t-att-class="{'m-0 px-4 top-0': env.inChatter,}"
+            class="o-mail-Thread-banner o-mail-Thread-bannerHover d-flex d-print-none
+            justify-content-between alert alert-primary border-0 rounded-0 mb-0 py-1
+            cursor-pointer shadow-sm small fw-bold"
+            t-on-click="props.jumpToPresent.jump"
+        >
+            <span>You're viewing older messages</span>
+            <span>Jump to Present
+                <i class="ms-2 fa" t-att-class="{ 'fa-caret-up': props.order !== 'asc', 'fa-caret-down': props.order === 'asc' }"/>
+            </span>
+        </span>
+    </t>
+</templates>

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -2,8 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.Thread">
-    <t t-if="env.inChatter" t-call="mail.Thread.jumpPresent"/> <!-- chatter has its own scrollable, this ensures proper sticky showing -->
-    <t t-else="" t-call="mail.Thread.jumpUnread"/>
+    <t t-if="!env.inChatter" t-call="mail.Thread.jumpUnread"/>
     <div class="o-mail-Thread position-relative flex-grow-1 d-flex flex-column overflow-auto" t-att-class="{ 'pb-4':  props.showJumpPresent and !state.showJumpPresent, 'px-3': !env.inChatter and !props.isInChatWindow }" t-ref="messages" tabindex="-1">
         <t t-if="!props.thread.isEmpty or props.thread.loadOlder or props.thread.hasLoadingFailed" name="content">
             <div class="d-flex flex-column position-relative flex-grow-1" t-att-class="{'justify-content-end': !env.inChatter and props.thread.model !== 'mail.box'}">
@@ -56,16 +55,7 @@
             </div>
         </t>
     </div>
-    <t t-if="!env.inChatter" t-call="mail.Thread.jumpPresent"/>
-</t>
-
-<t t-name="mail.Thread.jumpPresent">
-    <span t-if="props.showJumpPresent and state.showJumpPresent" t-att-class="{
-        'm-0 px-4 position-sticky top-0': env.inChatter,
-    }" class="o-mail-Thread-banner o-mail-Thread-bannerHover d-flex d-print-none justify-content-between alert alert-secondary border-0 rounded-0 mb-0 py-1 cursor-pointer shadow-sm small fw-bold" t-on-click="() => this.jumpToPresent()">
-        <span>You're viewing older messages</span>
-        <span>Jump to Present<i class="ms-2 fa" t-att-class="{ 'fa-caret-up': props.order !== 'asc', 'fa-caret-down': props.order === 'asc' }"/></span>
-    </span>
+    <JumpToPresentBanner t-if="!env.inChatter and jumpToPresent" jumpToPresent="jumpToPresent" order="props.order"/>
 </t>
 
 <t t-name="mail.Thread.jumpUnread">

--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -471,3 +471,22 @@ export const useMovable = makeDraggableHook({
         return { top, left };
     },
 });
+
+export function useJumpToPresent() {
+    const state = useState({
+        current: null,
+        showBanner: null,
+        update(stateShow, current) {
+            state.current = current;
+            state.showBanner = stateShow;
+        },
+        async jump() {
+            state.current.messageHighlight?.clearHighlight();
+            await state.current.props.thread.loadAround();
+            state.current.props.thread.loadNewer = false;
+            state.current.props.thread.scrollTop = "bottom";
+            state.current.state.showJumpPresent = false;
+        },
+    });
+    return state;
+}

--- a/addons/mail/static/tests/discuss_app/jump_to_present.test.js
+++ b/addons/mail/static/tests/discuss_app/jump_to_present.test.js
@@ -75,11 +75,11 @@ test("Basic jump to present when scrolling to outdated messages (chatter, DESC)"
     await click(".o-mail-Thread-banner", {
         text: "You're viewing older messagesJump to Present",
     });
+    await contains(".o-mail-Chatter", { scroll: 0 });
     await contains(".o-mail-Thread-banner", {
         count: 0,
         text: "You're viewing older messagesJump to Present",
     });
-    await contains(".o-mail-Chatter", { scroll: 0 });
 });
 
 test("Jump to old reply should prompt jump to present", async () => {


### PR DESCRIPTION
**Current behavior before PR:**

When scrolling down on the chatter, the 'Jump to present' banner hides the chatter actions.

**Desired behavior after PR is merged:**

the issues was resolved by fixing the potions of banner, now scrolling down on the chatter,the 'Jump to present' banner it displayed below chatter actions

task-3930968

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
