### PR TITLE
[FIX] mail: prevent race condition when searching messages rapidly

### DIFF
--- a/addons/mail/static/src/core/common/message_search_hook.js
+++ b/addons/mail/static/src/core/common/message_search_hook.js
@@ -21,7 +21,7 @@ export function searchHighlight(searchTerm, target) {
         // Special handling for '
         // Note: browsers use XPath 1.0, so uses concat() rather than ||
         const split = term.toLowerCase().split("'");
-        let lowercase = split.map(s => `'${s}'`).join(', "\'", ');
+        let lowercase = split.map((s) => `'${s}'`).join(', "\'", ');
         let uppercase = lowercase.toUpperCase();
         if (split.length > 1) {
             lowercase = `concat(${lowercase})`;
@@ -72,9 +72,13 @@ export function useMessageSearch(thread) {
         async search(before = false) {
             if (this.searchTerm) {
                 this.searching = true;
-                const { count, loadMore, messages } = await sequential(() =>
+                const data = await sequential(() =>
                     threadService.search(this.searchTerm, this.thread, before)
                 );
+                if (!data) {
+                    return;
+                }
+                const { count, loadMore, messages } = data;
                 this.searched = true;
                 this.searching = false;
                 this.count = count;


### PR DESCRIPTION
**Current behavior before PR:**

When initiating searches quickly in discuss channels or chatter, overlapping
requests can occur before previous searches finish. This race condition leads to
errors and causes issues with destructuring properties like count, loadMore, and
messages.( see:  [Discuss](https://www.awesomescreenshot.com/video/29801496?key=44057f8e37a2f394f20e8fc790f80537))

**Desired behavior after PR is merged:**

This commit updates the `useMessageSearch` hook to handle simultaneous requests
more robustly by checking that search results are defined before processing
them. This prevents errors and improves stability during rapid searches.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
