### PR TITLE
[FIX] mrp: fix components availability search

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -311,48 +311,30 @@ class MrpProduction(models.Model):
             production.location_src_id = production.picking_type_id.default_location_src_id.id or fallback_loc.id
             production.location_dest_id = production.picking_type_id.default_location_dest_id.id or fallback_loc.id
 
+    @api.model
     def _search_components_availability_state(self, operator, value):
-        def get_stock_moves(moves, state):
-            if state == 'available':
-                return moves.filtered(lambda m: m.forecast_availability == m.product_qty and not m.forecast_expected_date)
-            elif state == 'expected':
-                return moves.filtered(lambda m: m.forecast_availability == m.product_qty and m.forecast_expected_date and m.forecast_expected_date <= m.raw_material_production_id.date_start)
-            elif state == 'late':
-                return moves.filtered(lambda m: m.forecast_availability == m.product_qty and m.forecast_expected_date and m.forecast_expected_date > m.raw_material_production_id.date_start)
-            elif state == 'unavailable':
-                return moves.filtered(lambda m: m.forecast_availability < m.product_qty)
-            else:
-                raise UserError(_('Selection not supported.'))
-
-
-        if operator == '!=' and not value:
-            raise UserError(_('Operator not supported without a value.'))
-        elif operator == '=' and not value:
-            raw_stock_moves = self.env['stock.move'].search([
-                ('raw_material_production_id', '!=', False),
-                ('raw_material_production_id.state', 'in', ('cancel', 'done', 'draft'))])
-            return [('move_raw_ids', 'in', raw_stock_moves.ids)]
-
-        raw_stock_moves = self.env['stock.move'].search([
-            ('raw_material_production_id', '!=', False),
-            ('raw_material_production_id.state', 'not in', ('cancel', 'done', 'draft'))])
-        if operator == '=':
-            raw_stock_moves = get_stock_moves(raw_stock_moves, value)
-        elif operator == '!=':
-            raw_stock_moves = raw_stock_moves - get_stock_moves(raw_stock_moves, value)
-        elif operator == 'in':
-            search_raw_moves = self.env['stock.move']
-            for state in value:
-                search_raw_moves |= get_stock_moves(raw_stock_moves, state)
-            raw_stock_moves = search_raw_moves
-        elif operator == 'not in':
-            search_raw_moves = self.env['stock.move']
-            for state in value:
-                search_raw_moves |= raw_stock_moves - get_stock_moves(raw_stock_moves, state)
-            raw_stock_moves = search_raw_moves
-        else:
+        if operator not in ('=', '!=', 'in', 'not in'):
             raise UserError(_('Operation not supported'))
-        return [('move_raw_ids', 'in', raw_stock_moves.ids)]
+
+        states = ['available', 'expected', 'late', 'unavailable']
+        if operator in ('=', '!='):
+            value = [value]
+        if operator in ('not in', '!='):
+            value = filter(lambda state: state not in value, states)
+        if not all(state in states for state in value):
+            raise UserError(_('Selection not supported.'))
+
+        current_productions = self.search([('state', 'in', ('confirmed', 'progress', 'to_close'))])
+
+        productions_by_availability = dict.fromkeys(states, self.env['mrp.production'])
+        for production in current_productions:
+            productions_by_availability[production.components_availability_state] |= production
+
+        matching_production_ids = []
+        for state in value:
+            matching_production_ids.extend(productions_by_availability[state].ids)
+
+        return [('id', 'in', matching_production_ids)]
 
     @api.depends('state', 'reservation_state', 'date_start', 'move_raw_ids', 'move_raw_ids.forecast_availability', 'move_raw_ids.forecast_expected_date')
     def _compute_components_availability(self):

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -1775,6 +1775,12 @@ class TestMrpOrder(TestMrpCommon):
         self.assertEqual(mos.move_finished_ids.mapped('quantity'), [1] * 3)
 
     def test_components_availability(self):
+        def check_availability_state(state):
+            self.assertEqual(mo.components_availability_state, state)
+            MO = self.env['mrp.production']
+            self.assertIn(mo, MO.search([('components_availability_state', '=', state)]))
+            self.assertNotIn(mo, MO.search([('components_availability_state', '!=', state)]))
+
         self.bom_2.unlink()  # remove the kit bom of product_5
         now = fields.Datetime.now()
         mo_form = Form(self.env['mrp.production'])
@@ -1804,25 +1810,26 @@ class TestMrpOrder(TestMrpCommon):
 
         mo.invalidate_recordset(['components_availability', 'components_availability_state'])
         self.assertEqual(mo.components_availability, f'Exp {format_date(self.env, tommorrow)}')
-        self.assertEqual(mo.components_availability_state, 'late')
+        check_availability_state('late')
 
         mo.date_start = after_tommorrow
 
         self.assertEqual(mo.components_availability, f'Exp {format_date(self.env, tommorrow)}')
         self.assertEqual(mo.components_availability_state, 'expected')
+        check_availability_state('expected')
 
         (move1 | move2 | move3).picked = True
         (move1 | move2 | move3)._action_done()
 
         mo.invalidate_recordset(['components_availability', 'components_availability_state'])
         self.assertEqual(mo.components_availability, 'Available')
-        self.assertEqual(mo.components_availability_state, 'available')
+        check_availability_state('available')
 
         mo.action_assign()
 
         self.assertEqual(mo.reservation_state, 'assigned')
         self.assertEqual(mo.components_availability, 'Available')
-        self.assertEqual(mo.components_availability_state, 'available')
+        check_availability_state('available')
 
 
     def test_immediate_validate_6(self):


### PR DESCRIPTION
the search logic for productions by component availability is currently incorrect: it matches productions for which at least one bom line has the requested availability.

We align it with the compute method's logic

Note: at the current time we have to perform a search within the search method, which will hurt performance if we have many MO, but it is not possible to compute the domain without accessing the records because the relevant product fields are compute and non-searchable

opw-4055859
