### PR TITLE
[FIX] web: tests - more precise memory logs

### DIFF
--- a/addons/web/static/tests/_framework/module_set.hoot.js
+++ b/addons/web/static/tests/_framework/module_set.hoot.js
@@ -361,36 +361,34 @@ const runTests = async () => {
  * @param {number} [testCount]
  */
 const __gcAndLogMemory = (label, testCount) => {
-    const canRunGc = typeof window.gc === "function";
-    if (canRunGc) {
-        // Cleanup last retained textarea
-        const textarea = document.createElement("textarea");
-        document.body.appendChild(textarea);
-        textarea.value = "aaa";
-        textarea.focus();
-        textarea.remove();
-
-        // Run garbage collection
-        window.gc();
+    if (typeof window.gc !== "function") {
+        return;
     }
 
-    const { memory } = window.performance;
-    if (memory) {
-        // Log memory usage
-        const logs = [
-            `[MEMINFO] ${label}${canRunGc ? " (after GC)" : ""}`,
-            "- used:",
-            memory.usedJSHeapSize,
-            "- total:",
-            memory.totalJSHeapSize,
-            "- limit:",
-            memory.jsHeapSizeLimit,
-        ];
-        if (Number.isInteger(testCount)) {
-            logs.push("- tests:", testCount);
-        }
-        console.log(...logs);
+    // Cleanup last retained textarea
+    const textarea = document.createElement("textarea");
+    document.body.appendChild(textarea);
+    textarea.value = "aaa";
+    textarea.focus();
+    textarea.remove();
+
+    // Run garbage collection
+    window.gc();
+
+    // Log memory usage
+    const logs = [
+        `[MEMINFO] ${label} (after GC)`,
+        "- used:",
+        window.performance.memory.usedJSHeapSize,
+        "- total:",
+        window.performance.memory.totalJSHeapSize,
+        "- limit:",
+        window.performance.memory.jsHeapSizeLimit,
+    ];
+    if (Number.isInteger(testCount)) {
+        logs.push("- tests:", testCount);
     }
+    console.log(...logs);
 };
 
 /** @extends {ModuleLoader} */

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1130,14 +1130,14 @@ class ChromeBrowser:
             '--user-data-dir': user_data_dir,
             '--window-size': window_size,
             '--no-first-run': '',
-            # '--enable-precise-memory-info': '',  # uncomment to debug memory leaks in unit tests
-            # FIXME: these next flag is temporarily uncommented to allow client
+            # FIXME: these next 2 flags are temporarily uncommented to allow client
             # code to manually run garbage collection. This is done as currently
             # the Chrome unit test process doesn't have access to its available
             # memory, so it cannot run the GC efficiently and may run out of memory
             # and crash. These should be re-commented when the process is correctly
             # configured.
-            '--js-flags': '--expose-gc',  # uncomment to debug memory leaks in unit tests
+            '--enable-precise-memory-info': '',
+            '--js-flags': '--expose-gc',
         }
         if headless:
             switches.update(headless_switches)


### PR DESCRIPTION
This commit does 2 things:

- memory information logs (i.e. [MEMINFO]) were always logged, even when running JS unit tests in the browser manually. This was polluting the console with information that is available either way in the "memory" tab. Now these logs only appear when the garbage collector is exposed (i.e. when running unit tests through test_js.py);

- since the "enable-precise-memory-info" flag wasn't applied, these memory logs were always displaying the same info accross multiple calls. This has been fixed by also checking that flag for all builds, along with the previously exposed "gc" flag.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
