### PR TITLE
[FIX] sale_purchase_{stock, inter_company_rules}: transfer custom attribute values on SO

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -204,8 +204,7 @@ class StockMove(models.Model):
         self.write({'created_purchase_line_id': False})
 
     def _get_upstream_documents_and_responsibles(self, visited):
-        if self.created_purchase_line_id and self.created_purchase_line_id.state not in ('done', 'cancel') \
-                and (self.created_purchase_line_id.state != 'draft' or self._context.get('include_draft_documents')):
+        if self.created_purchase_line_id and self.created_purchase_line_id.state not in ('draft', 'done', 'cancel'):
             return [(self.created_purchase_line_id.order_id, self.created_purchase_line_id.order_id.user_id, visited)]
         elif self.purchase_line_id and self.purchase_line_id.state not in ('done', 'cancel'):
             return[(self.purchase_line_id.order_id, self.purchase_line_id.order_id.user_id, visited)]

--- a/addons/sale_purchase_stock/models/purchase_order.py
+++ b/addons/sale_purchase_stock/models/purchase_order.py
@@ -13,3 +13,13 @@ class PurchaseOrder(models.Model):
 
     def _get_sale_orders(self):
         return super(PurchaseOrder, self)._get_sale_orders() | self.order_line.move_dest_ids.group_id.sale_id | self.order_line.move_ids.move_dest_ids.group_id.sale_id
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = 'purchase.order.line'
+
+    @api.model
+    def _prepare_purchase_order_line_from_procurement(self, product_id, product_qty, product_uom, company_id, values, po):
+        res = super()._prepare_purchase_order_line_from_procurement(product_id, product_qty, product_uom, company_id, values, po)
+        res['sale_line_id'] = values.get('move_dest_ids', self.env['stock.move']).sale_line_id.id
+        return res

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -189,7 +189,7 @@ class SaleOrder(models.Model):
         for sale_order in self:
             if sale_order.state == 'sale' and sale_order.order_line:
                 sale_order_lines_quantities = {order_line: (order_line.product_uom_qty, 0) for order_line in sale_order.order_line}
-                documents = self.env['stock.picking'].with_context(include_draft_documents=True)._log_activity_get_documents(sale_order_lines_quantities, 'move_ids', 'UP')
+                documents = self.env['stock.picking']._log_activity_get_documents(sale_order_lines_quantities, 'move_ids', 'UP')
         self.picking_ids.filtered(lambda p: p.state != 'done').action_cancel()
         if documents:
             filtered_documents = {}

--- a/addons/stock_dropshipping/models/purchase.py
+++ b/addons/stock_dropshipping/models/purchase.py
@@ -42,5 +42,5 @@ class PurchaseOrderLine(models.Model):
     @api.model
     def _prepare_purchase_order_line_from_procurement(self, product_id, product_qty, product_uom, company_id, values, po):
         res = super()._prepare_purchase_order_line_from_procurement(product_id, product_qty, product_uom, company_id, values, po)
-        res['sale_line_id'] = values.get('sale_line_id', False)
+        res['sale_line_id'] = values.get('sale_line_id', res.get('sale_line_id', False))
         return res


### PR DESCRIPTION
### Steps to reproduce:

Have 2 companies: CO1 and CO2

- In the setting, enable Multi-Step Routes and Inter-Company Transactions
- With CO1 and CO, enable Synchronize Sales and Purchase Order 
- Go to Inventory > Configuration > Warehouse Management > Routes
- Unarchive the MTO Route
- With CO1 create a route with a buy action and destination CO1/stock
- With CO2 create a route with a manufacture action 
- Go to Inventory > Configuration > Products > Attributes
- Create a product attribute with a value that "is_custom"
- Create a storable product P with using MTO and tour CO1 and CO2 routes
- Set CO2 as a vendor for the product
- With CO1, create a SO for 1 unit of your product P
- a popup asks you for a custom product attribute value, write "test"
- Confirm the SO > Automatically creates a PO (w/ description)
- Confirm the PO > Automatically create an SO in CO2 (w/ description)
- Confirm the SO in CO2 > Automatically create an MO

#### Issue:
#### The custom description is missing on the final MO.

#### Note:
If you were to create an SO directly in CO2 for 1 unit of P, the custom description associated with the custom attribute value would be present on the associated MO.

### Cause of the issue:

The MO is created by a procurement generated from the SOL during the call of the `_action_launch_stock_rule` method:
https://github.com/odoo/odoo/blob/055184ea033e7068ce33c92390c73ae39b2db259/addons/sale_stock/models/sale_order_line.py#L345 The custom description that will appear on the MO and containing the informations related to the custom attribute values is generated here: https://github.com/odoo/odoo/blob/055184ea033e7068ce33c92390c73ae39b2db259/addons/sale_stock/models/sale_order_line.py#L267 However, this method will return an empty string because the `product_custom_attribute_value_ids` is absent from our SOL https://github.com/odoo/odoo/blob/055184ea033e7068ce33c92390c73ae39b2db259/addons/sale/models/sale_order_line.py#L338-L347 On the other hand, this `product_custom_attribute_value_ids` was set and is still existing on the original SO that started the flow in CO1. The reason that it is not present anymore on the last SO is because this SOL field has no equivalent on the `purchase.order.line` model and the information was therefore forgotten on the MO and has not been transferred directly from the PO of CO1 to the SO of CO2.

### Fix:

We rely on the `sale_line_id` field of the `purchase.order.line` model in order to determine the original SOL of the final SOL and update the `product_custom_attribute_value_ids` accordingly.

### Note:

As a side effect of our change in `sale_purchase_stock` linking our sol to the pol via the procurement commit 63ef74b can be reverted since the message is already automatically posted (the message is now written by the user who cancelled the SO rather than Odoobot).

opw-3998861
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
