### PR TITLE
[FIX] stock: fix traceback when the user deleted warehouse and creating new scrap

### DIFF
--- a/addons/stock/models/stock_scrap.py
+++ b/addons/stock/models/stock_scrap.py
@@ -61,7 +61,7 @@ class StockScrap(models.Model):
 
     @api.depends('company_id', 'picking_id')
     def _compute_location_id(self):
-        groups = self.env['stock.warehouse']._read_group(
+        groups = self.env['stock.warehouse'].with_context(active_test=False)._read_group(
             [('company_id', 'in', self.company_id.ids)], ['company_id'], ['lot_stock_id:array_agg'])
         locations_per_company = {
             company.id: lot_stock_ids[0] if lot_stock_ids else False


### PR DESCRIPTION
Currently, a traceback occurs when the user deletes a warehouse and tries to create a new scrap.

To reproduce this issue:

1) Install `stock` without demo data
2) Archive the `warehouse` from the stock configuration 
3) Now create a new `Scrap` from `Inventory/Operations`

Error:- 
```
KeyError: False
  File "odoo/http.py", line 2248, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1823, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1843, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1821, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1828, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2053, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 220, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 756, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 38, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 34, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 458, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/web/models/models.py", line 1006, in onchange
    todo = [
  File "addons/web/models/models.py", line 1009, in <listcomp>
    if field_name not in done and snapshot0.has_changed(field_name)
  File "addons/web/models/models.py", line 1122, in has_changed
    return self[field_name] != self.record[field_name]
  File "odoo/models.py", line 6610, in __getitem__
    return self._fields[key].__get__(self, self.env.registry[self._name])
  File "odoo/fields.py", line 2954, in __get__
    return super().__get__(records, owner)
  File "odoo/fields.py", line 1206, in __get__
    self.recompute(record)
  File "odoo/fields.py", line 1421, in recompute
    apply_except_missing(self.compute_value, recs)
  File "odoo/fields.py", line 1394, in apply_except_missing
    func(records)
  File "odoo/fields.py", line 1443, in compute_value
    records._compute_field_value(self)
  File "addons/mail/models/mail_thread.py", line 416, in _compute_field_value
    return super()._compute_field_value(field)
  File "odoo/models.py", line 4936, in _compute_field_value
    fields.determine(field.compute, self)
  File "odoo/fields.py", line 100, in determine
    return needle(*args)
  File "addons/mrp/models/stock_scrap.py", line 38, in _compute_location_id
    res = super(StockScrap, remaining_scrap)._compute_location_id()
  File "addons/stock/models/stock_scrap.py", line 74, in _compute_location_id
    scrap.location_id = locations_per_company[scrap.company_id.id]
```

When the user tries to create a new scrap without a warehouse a traceback occurs, because in the below lines `locations_per_company` is getting through the warehouse.

If there is no warehouse for that company the `locations_per_company` will be empty.
which leads to the above traceback when fetching a value from `locations_per_company`.

https://github.com/odoo/odoo/blob/0ac43fa3cffce83e88accda435f3315600af558a/addons/stock/models/stock_scrap.py#L64-L74

After applying this commit, it will resolve this issue by raising an usererror when there is no `locations_per_company`

sentry-5631303884

