### PR TITLE
[FIX] web: hide save and discard buttons

### DIFF
--- a/addons/web/static/src/views/fields/ace/ace_field.js
+++ b/addons/web/static/src/views/fields/ace/ace_field.js
@@ -60,6 +60,7 @@ export class AceField extends Component {
                 await this.props.record.update({ [this.props.name]: this.editedValue });
             }
             this.isDirty = false;
+            this.props.record.model.bus.trigger("FIELD_IS_DIRTY", false);
         }
     }
 }

--- a/addons/web/static/tests/views/fields/ace_editor_field_tests.js
+++ b/addons/web/static/tests/views/fields/ace_editor_field_tests.js
@@ -259,4 +259,32 @@ QUnit.module("Fields", (hooks) => {
         await click(target, ".o_form_button_save");
         assert.verifySteps(['web_save: [[1],{"foo":"a"}]']);
     });
+
+    QUnit.test("Save and Discard buttons will become invisible after saving", async (assert) => {
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            resId: 1,
+            serverData,
+            arch: `
+                <form>
+                    <field name="display_name" />
+                    <field name="foo" widget="code" />
+                </form>`,
+        });
+
+        const textArea = target.querySelector(".ace_editor textarea");
+        await click(textArea);
+        textArea.focus();
+        textArea.value = "a";
+        await triggerEvent(textArea, null, "input", {});
+        assert.containsOnce(target, ".o_form_status_indicator_buttons");
+        assert.doesNotHaveClass(
+            target.querySelector(".o_form_status_indicator_buttons"),
+            "invisible"
+        );
+        await click(target, ".o_form_button_save");
+        assert.containsOnce(target, ".o_form_status_indicator_buttons");
+        assert.hasClass(target.querySelector(".o_form_status_indicator_buttons"), "invisible");
+    });
 });


### PR DESCRIPTION
**Steps to reproduce this issue:**

- Go to views (Settings -> Technical -> User Interface -> Views).
- Edit something and click the Save/Discard button.
- Notice that the Save and Discard buttons remain visible.

**Current behavior before PR:**

The state `fieldIsDirty` remains true after clicking the Save/Discard button because the `FIELD_IS_DIRTY` event defined in the `useBus` hook is not triggered in `commitChanges`.

**Desired behavior after PR is merged:**

The Save and Discard buttons hide successfully when not needed.

task-3948043

