### PR TITLE
[FIX] web_editor: output raw html when using html widget on non html …

### DIFF
--- a/addons/web_editor/static/src/js/backend/html_field.js
+++ b/addons/web_editor/static/src/js/backend/html_field.js
@@ -20,6 +20,7 @@ import { toInline } from '@web_editor/js/backend/convert_inline';
 import { getBundle, loadBundle } from '@web/core/assets';
 import {
     Component,
+    markup,
     useRef,
     useState,
     onWillStart,
@@ -35,6 +36,8 @@ import { uniqueId } from '@web/core/utils/functions';
 import '@web/views/fields/html/html_field';
 
 let stripHistoryIds;
+
+const Markup = markup().constructor;
 
 export class HtmlField extends Component {
     static template = "web_editor.HtmlField";
@@ -178,7 +181,8 @@ export class HtmlField extends Component {
         return this.props.record.fields[this.props.name].translate;
     }
     get markupValue () {
-        return this.props.record.data[this.props.name];
+        const value = this.props.record.data[this.props.name];
+        return value instanceof Markup ? value : markup(value)
     }
     get showIframe () {
         return (this.sandboxedPreview && !this.state.showCodeView) || (this.props.readonly && this.props.cssReadonlyAssetId);

--- a/addons/web_editor/static/tests/html_field_tests.js
+++ b/addons/web_editor/static/tests/html_field_tests.js
@@ -248,6 +248,28 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
         assert.strictEqual(editable.innerHTML, `<p>first</p>`);
     });
 
+    QUnit.test("output raw html on non html type field", async (assert) => {
+        serverData.models.partner.fields.txt.type = "text";
+        serverData.models.partner.records = [
+            { id: 1, txt: "<p>first</p>" },
+        ];
+
+        await makeView({
+            type: "form",
+            resId: 1,
+            resModel: "partner",
+            serverData,
+            arch: `
+            <form>
+                <field name="txt" widget="html" readonly="1"/>
+            </form>`,
+        });
+
+        assert.strictEqual(
+            target.querySelector("[name=txt] .o_readonly").textContent,
+            "first"
+        );
+    });
 
     QUnit.module('Sandboxed Preview');
 


### PR DESCRIPTION
…field

Steps to reproduce
==================

- Go to sales
- Open a quotation
- Using the debug tools, edit the view so that the x2many name field uses the html widget: `widget="html"` instead of the section_and_note_text widget

=> In readonly mode, the html tags are displayed as is

Cause of the issue
==================

Since the field is not of type html,
`this.props.record.data[this.props.name]` isn't wrapped in a markup instance.

This means that the output of `t-out="markupValue"` is the escaped html value

Solution
========

If the value isn't already a markup, wrap it in one.

opw-4061739