### PR TITLE
[FIX] point_of_sale: ensure capture of a new orders with same reference

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -958,7 +958,7 @@ class PosOrder(models.Model):
                 existing_draft_order = self.env['pos.order'].search(['&', ('id', '=', order['data']['server_id']), ('state', '=', 'draft')], limit=1)
 
                 # if there is no draft order, skip processing this order
-                if not existing_draft_order:
+                if not existing_draft_order and draft:
                     continue
 
             if not existing_draft_order:


### PR DESCRIPTION
In the POS Restaurant module, there was an issue where an order could be missed in the backend if a draft order, opened by a cashier on one device, was paid for on another device. Subsequently, if the cashier added more products to the order and completed the payment, the receipt would be printed, but the backend would fail to record the updated order. This fix ensures that an updated order with the same reference is captured in the backend if its content has changed, preventing data loss and ensuring consistency across devices.

opw-4067875

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
