### PR TITLE
[IMP] bus, mail: Recover ongoing video calls when tab is closed 

### DIFF
--- a/addons/bus/static/src/multi_tab_service.js
+++ b/addons/bus/static/src/multi_tab_service.js
@@ -24,6 +24,11 @@ let multiTabId = 0;
 export const multiTabService = {
     start() {
         const bus = new EventBus();
+        let broadcastChannel = null;
+        if (browser.BroadcastChannel) {
+            broadcastChannel = new browser.BroadcastChannel("multi.tab.service");
+            broadcastChannel.onmessage = ({ data }) => bus.trigger(data.type, data.payload);
+        }
 
         // CONSTANTS
         const TAB_HEARTBEAT_PERIOD = 10000; // 10 seconds
@@ -34,7 +39,6 @@ export const multiTabService = {
         const PRIVATE_LOCAL_STORAGE_KEYS = ["main", "heartbeat"];
 
         // PROPERTIES
-        let _isOnMainTab = false;
         let lastHeartbeat = 0;
         let heartbeatTimeout;
         const sanitizedOrigin = location.origin.replace(/:\/{0,2}/g, "_");
@@ -60,7 +64,7 @@ export const multiTabService = {
         }
 
         function startElection() {
-            if (_isOnMainTab) {
+            if (isOnMainTab()) {
                 return;
             }
             // Check who's next.
@@ -80,8 +84,7 @@ export const multiTabService = {
                 // We're next in queue. Electing as main.
                 lastHeartbeat = now;
                 setItemInStorage("heartbeat", lastHeartbeat);
-                setItemInStorage("main", true);
-                _isOnMainTab = true;
+                setItemInStorage("main", tabId);
                 bus.trigger("become_main_tab");
                 // Removing main peer from queue.
                 delete lastPresenceByTab[newMain];
@@ -98,7 +101,7 @@ export const multiTabService = {
                 startElection();
                 heartbeatValue = getItemFromStorage("heartbeat", 0);
             }
-            if (_isOnMainTab) {
+            if (isOnMainTab()) {
                 // Walk through all tabs and kill old ones.
                 const cleanedTabs = {};
                 for (const [tabId, lastPresence] of Object.entries(lastPresenceByTab)) {
@@ -109,7 +112,6 @@ export const multiTabService = {
                 if (heartbeatValue !== lastHeartbeat) {
                     // Someone else is also main...
                     // It should not happen, except in some race condition situation.
-                    _isOnMainTab = false;
                     lastHeartbeat = 0;
                     lastPresenceByTab[tabId] = now;
                     setItemInStorage("lastPresenceByTab", lastPresenceByTab);
@@ -124,7 +126,7 @@ export const multiTabService = {
                 lastPresenceByTab[tabId] = now;
                 setItemInStorage("lastPresenceByTab", lastPresenceByTab);
             }
-            const hbPeriod = _isOnMainTab ? MAIN_TAB_HEARTBEAT_PERIOD : TAB_HEARTBEAT_PERIOD;
+            const hbPeriod = isOnMainTab() ? MAIN_TAB_HEARTBEAT_PERIOD : TAB_HEARTBEAT_PERIOD;
             heartbeatTimeout = browser.setTimeout(heartbeat, hbPeriod);
         }
 
@@ -155,11 +157,19 @@ export const multiTabService = {
             setItemInStorage("lastPresenceByTab", lastPresenceByTab);
 
             // Unload main.
-            if (_isOnMainTab) {
-                _isOnMainTab = false;
+            if (isOnMainTab()) {
                 bus.trigger("no_longer_main_tab");
                 browser.localStorage.removeItem(generateLocalStorageKey("main"));
             }
+        }
+
+        /**
+         * Determine whether or not this tab is the main one.
+         *
+         * @returns {boolean}
+         */
+        function isOnMainTab() {
+            return getItemFromStorage("main") === tabId;
         }
 
         browser.addEventListener("pagehide", unregister);
@@ -177,16 +187,9 @@ export const multiTabService = {
 
         return {
             bus,
+            isOnMainTab,
             get currentTabId() {
                 return tabId;
-            },
-            /**
-             * Determine whether or not this tab is the main one.
-             *
-             * @returns {boolean}
-             */
-            isOnMainTab() {
-                return _isOnMainTab;
             },
             /**
              * Get value shared between all the tabs.
@@ -223,6 +226,12 @@ export const multiTabService = {
              * be able to become the main tab.
              */
             unregister: unregister,
+            broadcast(type, payload, delay = 0) {
+                broadcastChannel?.postMessage({ type, payload, delay });
+            },
+            subscribe(type, callback) {
+                bus.addEventListener(type, ({ detail }) => callback(detail));
+            },
         };
     },
 };

--- a/addons/mail/controllers/discuss/rtc.py
+++ b/addons/mail/controllers/discuss/rtc.py
@@ -78,7 +78,7 @@ class RtcController(http.Controller):
 
     @http.route("/mail/rtc/channel/leave_call", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
-    def channel_call_leave(self, channel_id):
+    def channel_call_leave(self, channel_id, recovery_ts=None):
         """Disconnects the current user from a rtc call and clears any invitation sent to that user on this channel
         :param int channel_id: id of the channel from which to disconnect
         """
@@ -87,6 +87,8 @@ class RtcController(http.Controller):
             raise NotFound()
         # sudo: discuss.channel.rtc.session - member of current user can leave call
         member.sudo()._rtc_leave_call()
+        if recovery_ts:
+            member._bus_send("discuss.rtc/recover", {"channel_id": channel_id, "recovery_ts": recovery_ts})
 
     @http.route("/mail/rtc/channel/cancel_call_invitation", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context

--- a/addons/mail/static/tests/legacy/web/fields/m2x_avatar_user_tests.js
+++ b/addons/mail/static/tests/legacy/web/fields/m2x_avatar_user_tests.js
@@ -30,6 +30,8 @@ const fakeMultiTab = {
             },
             setSharedValue(key, value) {},
             removeSharedValue(key) {},
+            broadcast(type, payload, delay = 0) {},
+            subscribe(type, callback) {},
         };
     },
 };


### PR DESCRIPTION
**Current behavior before PR:**
Closing a browser tab with an ongoing video call terminates it.

**Desired behavior after PR is merged:**
If another available browser exists, it will attempt to recover the call.

Task-3244140

[ENTERPRISE PR](https://github.com/odoo/enterprise/pull/67181)