### PR TITLE
[FIX] stock: don't use seq in `stock.location`

### DIFF
--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -17,7 +17,7 @@ class Location(models.Model):
     _description = "Inventory Locations"
     _parent_name = "location_id"
     _parent_store = True
-    _order = 'sequence, complete_name, id'
+    _order = 'complete_name, id'
     _rec_name = 'complete_name'
     _rec_names_search = ['complete_name', 'barcode']
     _check_company_auto = True
@@ -96,7 +96,7 @@ class Location(models.Model):
     incoming_move_line_ids = fields.One2many('stock.move.line', 'location_dest_id') # used to compute weight
     net_weight = fields.Float('Net Weight', compute="_compute_weight")
     forecast_weight = fields.Float('Forecasted Weight', compute="_compute_weight")
-    sequence = fields.Integer(string="Sequence", related='warehouse_id.sequence', store=True)
+    sequence = fields.Integer(string="Sequence", related='warehouse_id.sequence', store=True)  # to delete in master, not used
     is_empty = fields.Boolean('Is Empty', compute='_compute_is_empty', search='_search_is_empty')
 
     _sql_constraints = [('barcode_company_uniq', 'unique (barcode,company_id)', 'The barcode for a location must be unique per company!'),


### PR DESCRIPTION
The sequence field was added to `stock_location` for incorrect reasons. Because of this, the field has no value and results in potentially incorrect ordering of the locations (e.g. in field dropdown) and also potentially results in unexpected ordering since ordering by `complete_name` typically results in easier grouping by location > sublocation, e.g.:

parent
parent > child 1
parent > child 1 > subchild 1
parent > child 2
parent > child 2 > subchild 2

Task: 4013661

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
