### PR TITLE
[FIX] hr_expense: test_expense_manager_can_always_set_employee tour

### DIFF
--- a/addons/hr_expense/static/tests/tours/expense_form_tours.js
+++ b/addons/hr_expense/static/tests/tours/expense_form_tours.js
@@ -26,10 +26,7 @@ registry.category("web_tour.tours").add('create_expense_no_employee_access_tour'
     {
         content: "Delete default search",
         trigger: 'input#employee_id_0',
-        run() {
-            const dropdown = document.querySelector('input#employee_id_0');
-            dropdown.value = '';
-        }
+        run: "clear",
     },
     {
         content: "Select test expense employee",
@@ -38,8 +35,12 @@ registry.category("web_tour.tours").add('create_expense_no_employee_access_tour'
     },
     {
         content: "Save",
-        trigger: '.o_form_button_save',
+        trigger: ".o_form_button_save:enabled",
         run: 'click',
+    },
+    {
+        content: "wait until the form is saved",
+        trigger: "body .o_form_saved",
     },
     {
         content: "Exit form",

--- a/addons/web_tour/static/src/tour_service/tour_utils.js
+++ b/addons/web_tour/static/src/tour_service/tour_utils.js
@@ -70,7 +70,7 @@ export const stepUtils = {
     showAppsMenuItem() {
         return {
             isActive: ["auto", "community"],
-            trigger: ".o_navbar_apps_menu button",
+            trigger: ".o_navbar_apps_menu button:enabled",
             position: "bottom",
             run: "click",
         };


### PR DESCRIPTION
In this commit, we fix the test_expense_manager_can_always_set_employee tour. As explained in the error message, it's preferable to add :enabled pseudo selector to a button to ensure it is enabled before to click on it.
It's also preferable to ensure the form is well saved before to continue the tour.