### PR TITLE
[FIX] web_editor: not able to create link as an image

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
@@ -95,6 +95,11 @@ const Link = Widget.extend({
             } else {
                 this.data.originalHTML = linkNode.innerHTML;
             }
+            const imgEl = linkNode.querySelector('IMG');
+            if (imgEl) {
+                this.data.isImage = true;
+                this.needLabel = false;
+            }
             this.data.url = this.$link.attr('href') || '';
         } else {
             this.data.content = this.data.content ? this.data.content.replace(/[ \t\r\n]+/g, ' ') : '';
@@ -491,7 +496,7 @@ const Link = Widget.extend({
      */
     _updateLinkContent($link, linkInfos, { force = false } = {}) {
         if (force || (this._setLinkContent && (linkInfos.content !== this.data.originalText || linkInfos.url !== this.data.url))) {
-            if (linkInfos.content === this.data.originalText) {
+            if (linkInfos.content === this.data.originalText || this.data.isImage) {
                 $link.html(this.data.originalHTML);
             } else if (linkInfos.content && linkInfos.content.length) {
                 $link.text(linkInfos.content);


### PR DESCRIPTION
**Behaviour before PR:**

When we try to add a link on an image through dialog box, image gets hidden and url is added as a link label instead.

**Behaviour after PR:**

Now, link can be added to the image without vanishing the image.

task-4049730




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
