### PR TITLE
[FIX] l10n_lu: use correct format for translated tax line

### DIFF
--- a/addons/l10n_lu/i18n_extra/de.po
+++ b/addons/l10n_lu/i18n_extra/de.po
@@ -1613,7 +1613,7 @@ msgid ""
 "767 - Supply of goods for which the purchaser is liable for the payment of "
 "VAT - base"
 msgstr ""
-"767 -Vom Erwerber als Steuerschuldner zu erklärende Lieferungen - Besteuerungsgrundlage"
+"767 - Vom Erwerber als Steuerschuldner zu erklärende Lieferungen - Besteuerungsgrundlage"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax
@@ -1621,7 +1621,7 @@ msgid ""
 "768 - Supply of goods for which the purchaser is liable for the payment of "
 "VAT - tax"
 msgstr ""
-"768 -Vom Erwerber als Steuerschuldner zu erklärende Lieferungen - MwSt."
+"768 - Vom Erwerber als Steuerschuldner zu erklärende Lieferungen - MwSt."
 
 #. module: l10n_lu
 #: model:account.tax.template,name:l10n_lu.lu_2015_tax_FB-PA-8


### PR DESCRIPTION
Issue
----

The german translation for some tax lines for Luxembourg have the wrong format. This makes the line get ignored when generating a XML report.

Steps
----

 - Install `l10n_lu`.
 - Change the fiscal country to Luxembourg.
 - Go to Accounting -> Tax Report.
 - Choose Tax Report (LU) from the Report button above.
 - Generate a XML report.
 - The XML report doesn't have the `767` & `768` codes.

Cause
----

Corresponding tax lines are mis-formated.

opw-4053595