### PR TITLE
[FIX] mail: chat/channels search results are uppercase on mobile

### DIFF
--- a/addons/mail/static/src/core/web/messaging_menu.xml
+++ b/addons/mail/static/src/core/web/messaging_menu.xml
@@ -16,7 +16,7 @@
 
 <t t-name="mail.MessagingMenu.content">
     <div t-att-class="`${discussSystray.contentClass} o-mail-MessagingMenu`">
-        <div class="o-mail-MessagingMenu-header d-flex" t-att-class="{'text-uppercase border-start-0 border-end-0': ui.isSmall, 'bg-view border-bottom': !ui.isSmall, 'd-flex flex-shrink-0': !env.inDiscussApp }">
+        <div class="o-mail-MessagingMenu-header d-flex" t-att-class="{'border-start-0 border-end-0': ui.isSmall, 'bg-view border-bottom': !ui.isSmall, 'd-flex flex-shrink-0': !env.inDiscussApp }">
             <t t-if="!ui.isSmall">
                 <button class="btn btn-link py-2 rounded-0" t-att-class="store.discuss.activeTab === 'main' ? 'fw-bold' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'main'">All</button>
                 <button class="btn btn-link py-2 rounded-0" t-att-class="store.discuss.activeTab === 'chat' ? 'fw-bold' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'chat'">Chats</button>


### PR DESCRIPTION
Before this commit, search results for chats and channels on mobile show up in uppercase.

This happens because of the class `text-uppercase` on a parent element.

This commit fixes the issue by removing said class on the parent element.

Before:
![image](https://github.com/user-attachments/assets/5ca6c781-4355-47ed-8feb-c846b92d5334)

After:
![image](https://github.com/user-attachments/assets/0ef299b8-e137-4d5a-89ad-6ff9f0268096)
