### PR TITLE
[FIX] pos_sale: Handle special characters in partner name search

### DIFF
--- a/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_control_panel/sale_order_management_control_panel.js
+++ b/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_control_panel/sale_order_management_control_panel.js
@@ -30,7 +30,7 @@ export class SaleOrderManagementControlPanel extends Component {
 
         const currentPartner = this.pos.get_order().get_partner();
         if (currentPartner) {
-            this.pos.orderManagement.searchString = currentPartner.name;
+            this.pos.orderManagement.searchString = `"${currentPartner.name}"`;
         }
         this.saleOrderFetcher.setSearchDomain(this._computeDomain());
     }
@@ -96,10 +96,18 @@ export class SaleOrderManagementControlPanel extends Component {
             return domain;
         }
 
-        const searchConditions = this.pos.orderManagement.searchString.split(/[,&]\s*/);
+        let searchConditions;
+        let isQuoted = false;
+        if (input.startsWith('"') && input.endsWith('"')) {
+            searchConditions = [input.slice(1, -1)];
+            isQuoted = true;
+        } else {
+            searchConditions = input.split(/[,&]\s*/);
+        }
+
         if (searchConditions.length === 1) {
             const cond = searchConditions[0].split(/:\s*/);
-            if (cond.length === 1) {
+            if (cond.length === 1 || isQuoted) {
                 domain = domain.concat(Array(this.searchFields.length - 1).fill("|"));
                 domain = domain.concat(
                     this.searchFields.map((field) => [field, "ilike", `%${cond[0]}%`])


### PR DESCRIPTION
Before this commit, searching for a sale order with a partner name containing special characters (e.g., &) would fail to correctly filter the sale orders. This commit ensures that partner names with special characters are properly handled, allowing for accurate sale order searches.

opw-4062365

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
