### PR TITLE
[REF] *: remove obsolete isActive auto in tours

### DIFF
--- a/addons/account/static/src/js/tours/account.js
+++ b/addons/account/static/src/js/tours/account.js
@@ -32,7 +32,6 @@ registry.category("web_tour.tours").add('account_tour', {
     ...accountTourSteps.onboarding(),
     ...accountTourSteps.newInvoice(),
     {
-        isActive: ["auto"],
         trigger: "[name=move_type] [raw-value=out_invoice]",
     },
     {
@@ -46,7 +45,6 @@ registry.category("web_tour.tours").add('account_tour', {
         run: "edit Test",
     }, 
     {
-        isActive: ["auto"],
         trigger: "[name=move_type] [raw-value=out_invoice]",
     },
     {
@@ -56,7 +54,6 @@ registry.category("web_tour.tours").add('account_tour', {
         run: "click",
     }, 
     {
-        isActive: ["auto"],
         trigger: "[name=move_type] [raw-value=out_invoice]",
     },
     {
@@ -66,7 +63,6 @@ registry.category("web_tour.tours").add('account_tour', {
         run: "click",
     }, 
     {
-        isActive: ["auto"],
         trigger: "[name=move_type] [raw-value=out_invoice]",
     },
     {
@@ -75,7 +71,6 @@ registry.category("web_tour.tours").add('account_tour', {
         run: "click",
     },
     {
-        isActive: ["auto"],
         trigger: "[name=move_type] [raw-value=out_invoice]",
     },
     {
@@ -85,7 +80,6 @@ registry.category("web_tour.tours").add('account_tour', {
         run: "edit Test",
     },
     {
-        isActive: ["auto"],
         trigger: "[name=move_type] [raw-value=out_invoice]",
     },
     {
@@ -96,7 +90,6 @@ registry.category("web_tour.tours").add('account_tour', {
     },
     ...stepUtils.saveForm(),
     {
-        isActive: ["auto"],
         trigger: "button.o_form_button_create",
     },
     {
@@ -105,7 +98,6 @@ registry.category("web_tour.tours").add('account_tour', {
         run: "click",
     },
     {
-        isActive: ["auto"],
         trigger: "[name=move_type] [raw-value=out_invoice]",
     },
     {
@@ -115,7 +107,6 @@ registry.category("web_tour.tours").add('account_tour', {
         run: "click",
     },
     {
-        isActive: ["auto"],
         trigger: "div.modal-dialog",
     },
     {
@@ -142,7 +133,6 @@ registry.category("web_tour.tours").add('account_tour', {
         run: "click",
     }, 
     {
-        isActive: ["auto"],
         trigger: "[name=move_type] [raw-value=out_invoice], [name=move_type][raw-value=out_invoice]",
     },
     {
@@ -152,7 +142,6 @@ registry.category("web_tour.tours").add('account_tour', {
         run: "click",
     }, 
     {
-        isActive: ["auto"],
         trigger: "[name=move_type] [raw-value=out_invoice]",
     },
     {
@@ -163,7 +152,6 @@ registry.category("web_tour.tours").add('account_tour', {
         run: "click",
     },
     {
-        isActive: ["auto"],
         trigger: "body:has(.o_form_saved)",
     },
     {

--- a/addons/crm/static/src/js/tours/crm.js
+++ b/addons/crm/static/src/js/tours/crm.js
@@ -24,7 +24,6 @@ registry.category("web_tour.tours").add('crm_tour', {
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_opportunity_kanban",
 },
 {
@@ -49,7 +48,6 @@ registry.category("web_tour.tours").add('crm_tour', {
     run: "click",
 }, 
 {
-    isActive: ["auto"],
     trigger: ".o_opportunity_kanban",
 },
 {
@@ -59,7 +57,6 @@ registry.category("web_tour.tours").add('crm_tour', {
     run: "drag_and_drop(.o_opportunity_kanban .o_kanban_group:eq(2))",
 }, 
 {
-    isActive: ["auto"],
     trigger: ".o_opportunity_kanban",
 },
 {
@@ -70,7 +67,6 @@ registry.category("web_tour.tours").add('crm_tour', {
     run: "click",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_opportunity_kanban",
 },
 {
@@ -91,7 +87,6 @@ registry.category("web_tour.tours").add('crm_tour', {
     run: "drag_and_drop(.o_opportunity_kanban .o_kanban_group:eq(3))",
 },
 {
-    isActive: ["auto"],
     trigger: ".o_opportunity_kanban",
 },
 {

--- a/addons/hr_holidays/static/src/tours/hr_holidays_tour.js
+++ b/addons/hr_holidays/static/src/tours/hr_holidays_tour.js
@@ -94,7 +94,6 @@ registry.category("web_tour.tours").add("hr_holidays_tour", {
             run: "click",
         },
         {
-            isActive: ["auto"],
             trigger: `tr.o_data_row:first:not(:has(button[name="action_approve"])),table tbody:not(tr.o_data_row)`,
             content: "Verify leave is approved",
         },

--- a/addons/hr_recruitment/static/src/js/tours/hr_recruitment.js
+++ b/addons/hr_recruitment/static/src/js/tours/hr_recruitment.js
@@ -29,7 +29,6 @@ registry.category("web_tour.tours").add('hr_recruitment_tour',{
     run: "click",
 }, 
 {
-    isActive: ["auto"],
     trigger: ".o_hr_job_simple_form",
 },
 {
@@ -39,7 +38,6 @@ registry.category("web_tour.tours").add('hr_recruitment_tour',{
     run: "click",
 }, 
 {
-    isActive: ["auto"],
     trigger: '.o_hr_job_simple_form',
 },
 {
@@ -59,7 +57,6 @@ registry.category("web_tour.tours").add('hr_recruitment_tour',{
     run: "click",
 }, 
 {
-    isActive: ["auto"],
     trigger: ".o_kanban_applicant",
 },
 {
@@ -69,7 +66,6 @@ registry.category("web_tour.tours").add('hr_recruitment_tour',{
     run: "click",
 }, 
 {
-    isActive: ["auto"],
     trigger: ".o_hr_recruitment_kanban",
 },
 {
@@ -79,7 +75,6 @@ registry.category("web_tour.tours").add('hr_recruitment_tour',{
     run: "click",
 }, 
 {
-    isActive: ["auto"],
     trigger: ".o_kanban_applicant",
 },
 {
@@ -89,7 +84,6 @@ registry.category("web_tour.tours").add('hr_recruitment_tour',{
     run: "drag_and_drop(.o_kanban_group:eq(1))",
 }, 
 {
-    isActive: ["auto"],
     trigger: ".o_kanban_applicant",
 },
 {
@@ -99,7 +93,6 @@ registry.category("web_tour.tours").add('hr_recruitment_tour',{
     run: "click",
 }, 
 {
-    isActive: ["auto"],
     trigger: ".o_applicant_form",
 },
 {
@@ -109,7 +102,6 @@ registry.category("web_tour.tours").add('hr_recruitment_tour',{
     run: "click",
 }, 
 {
-    isActive: ["auto"],
     trigger: ".o_applicant_form",
 },
 {
@@ -119,7 +111,6 @@ registry.category("web_tour.tours").add('hr_recruitment_tour',{
     run: "click",
 }, 
 {
-    isActive: ["auto"],
     trigger: ".o_applicant_form",
 },
 {
@@ -129,7 +120,6 @@ registry.category("web_tour.tours").add('hr_recruitment_tour',{
     run: "click",
 }, 
 {
-    isActive: ["auto"],
     trigger: ".o_applicant_form",
 },
 {
@@ -139,7 +129,6 @@ registry.category("web_tour.tours").add('hr_recruitment_tour',{
     run: "click",
 }, 
 {
-    isActive: ["auto"],
     trigger: ".o_hr_employee_form_view",
 },
 {

--- a/addons/mail/static/tests/tours/discuss_channel_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_tour.js
@@ -25,7 +25,6 @@ registry.category("web_tour.tours").add("discuss_channel_tour", {
             run: `edit SomeChannel_${new Date().getTime()}`,
         },
         {
-            isActive: ["auto"],
             trigger: ".o-discuss-ChannelSelector-suggestion",
         },
         {
@@ -91,7 +90,6 @@ registry.category("web_tour.tours").add("discuss_channel_tour", {
             run: "click",
         },
         {
-            isActive: ["auto"],
             trigger: ".o-discuss-ChannelSelector",
         },
     ],

--- a/addons/mass_mailing/static/src/js/tours/mass_mailing_tour.js
+++ b/addons/mass_mailing/static/src/js/tours/mass_mailing_tour.js
@@ -25,7 +25,6 @@
         run: "click",
     },
     {
-        isActive: ["auto"],
         trigger: ".o_mass_mailing_mailing_tree",
     },
     {

--- a/addons/project/static/src/js/tours/project.js
+++ b/addons/project/static/src/js/tours/project.js
@@ -24,7 +24,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "click",
 }, 
 {
-    isActive: ["auto"],
     trigger: ".o_project_kanban",
 },
 {
@@ -54,7 +53,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "click",
 }, 
 {
-    isActive: ["auto"],
     trigger: ".o_kanban_group",
 },
 {
@@ -69,7 +67,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "click",
 }, 
 {
-    isActive: ["auto"],
     trigger: ".o_kanban_group:eq(1)",
 },
 {
@@ -79,7 +76,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "click",
 }, 
 {
-    isActive: ["auto"],
     trigger: ".o_kanban_project_tasks",
 },
 {
@@ -89,7 +85,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "edit Test",
 }, 
 {
-    isActive: ["auto"],
     trigger: ".o_kanban_project_tasks",
 },
 {
@@ -99,7 +94,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "click",
 }, 
 {
-    isActive: ["auto"],
     trigger: ".o_kanban_project_tasks",
 },
 {
@@ -109,7 +103,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "drag_and_drop(.o_kanban_group:eq(1))",
 }, 
 {
-    isActive: ["auto"],
     trigger: ".o_kanban_project_tasks",
 },
 {
@@ -119,7 +112,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "click",
 }, 
 {
-    isActive: ["auto"],
     trigger: ".o_form_project_tasks",
 },
 {
@@ -129,7 +121,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "click",
 }, 
 {
-    isActive: ["auto"],
     trigger: ".o_form_project_tasks",
 },
 {
@@ -139,7 +130,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "click",
 }, 
 {
-    isActive: ["auto"],
     trigger: ".o_form_project_tasks",
 },
 {
@@ -148,11 +138,6 @@ registry.category("web_tour.tours").add('project_tour', {
     position: "bottom",
     run: "click",
 }, 
-{
-    trigger: ".o_form_project_tasks",
-    isActive: ["auto"],
-},
-
 {
     trigger: ".o_form_project_tasks",
 },
@@ -165,7 +150,6 @@ registry.category("web_tour.tours").add('project_tour', {
 
 {
     trigger: ".o_form_project_tasks",
-    isActive: ["auto"],
 },
 {
     trigger: ".o_field_widget[name='user_ids'] input",
@@ -199,7 +183,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "edit New Sub-task",
 }, 
 {
-    isActive: ["auto"],
     trigger: ".o_form_project_tasks .o_form_dirty",
 },
 {
@@ -210,7 +193,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "click",
 }, 
 {
-    isActive: ["auto"],
     trigger: ".o_form_project_tasks",
 },
 {
@@ -225,7 +207,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "click",
 }, 
 {
-    isActive: ["auto"],
     trigger: ".o_widget_subtask_kanban_list .subtask_list",
 },
 {
@@ -235,7 +216,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "click",
 }, 
 {
-    isActive: ["auto"],
     trigger: ".subtask_create_input",
 },
 {
@@ -250,7 +230,6 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "click",
 }, 
 {
-    isActive: ["auto"],
     trigger: ".dropdown-menu",
 },
 {

--- a/addons/purchase/static/src/js/tours/purchase.js
+++ b/addons/purchase/static/src/js/tours/purchase.js
@@ -31,7 +31,6 @@ registry.category("web_tour.tours").add("purchase_tour", {
             run: "click",
         },
         {
-            isActive: ["auto"],
             trigger: ".o_purchase_order",
         },
         {
@@ -41,7 +40,6 @@ registry.category("web_tour.tours").add("purchase_tour", {
             run: "click",
         },
         {
-            isActive: ["auto"],
             trigger: ".o_purchase_order",
         },
         {
@@ -57,7 +55,6 @@ registry.category("web_tour.tours").add("purchase_tour", {
             run: "click",
         },
         {
-            isActive: ["auto"],
             trigger: ".o_field_many2one[name='partner_id'] .o_external_button",
         },
         {
@@ -67,7 +64,6 @@ registry.category("web_tour.tours").add("purchase_tour", {
             run: "click",
         },
         {
-            isActive: ["auto"],
             trigger: ".o_purchase_order",
         },
         {
@@ -90,11 +86,9 @@ registry.category("web_tour.tours").add("purchase_tour", {
             run: "click",
         },
         {
-            isActive: ["auto"],
             trigger: '.o_form_editable textarea[name="name"].product_creation_success',
         },
         {
-            isActive: ["auto"],
             trigger: ".o_purchase_order",
         },
         {
@@ -104,7 +98,7 @@ registry.category("web_tour.tours").add("purchase_tour", {
             run: "edit 12.0",
         },
         {
-            isActive: ["auto", "mobile"],
+            isActive: ["mobile"],
             trigger: ".o_statusbar_buttons .o_arrow_button_current[name='action_rfq_send']",
         },
         ...stepUtils.statusbarButtonsSteps(
@@ -116,7 +110,6 @@ registry.category("web_tour.tours").add("purchase_tour", {
             run: "edit agrolait@example.com",
         },
         {
-            isActive: ["auto"],
             trigger: ".modal-footer button[name='action_send_mail']",
         },
         {
@@ -126,7 +119,6 @@ registry.category("web_tour.tours").add("purchase_tour", {
             run: "click",
         },
         {
-            isActive: ["auto"],
             trigger: ".o_purchase_order",
         },
         {

--- a/addons/sale/static/src/js/tours/sale.js
+++ b/addons/sale/static/src/js/tours/sale.js
@@ -27,7 +27,6 @@ registry.category("web_tour.tours").add("sale_tour", {
             run: "click",
         },
         {
-            isActive: ["auto"],
             trigger: ".o_sale_order",
         },
         {
@@ -37,7 +36,6 @@ registry.category("web_tour.tours").add("sale_tour", {
             run: "click",
         },
         {
-            isActive: ["auto"],
             trigger: ".o_sale_order",
         },
         {
@@ -59,7 +57,6 @@ registry.category("web_tour.tours").add("sale_tour", {
             run: "click",
         },
         {
-            isActive: ["auto"],
             trigger: ".o_sale_order",
         },
         {
@@ -88,11 +85,9 @@ registry.category("web_tour.tours").add("sale_tour", {
             run: "click",
         },
         {
-            isActive: ["auto"],
             trigger: ".o_field_text[name='name'] textarea:value(DESK0001)",
         },
         {
-            isActive: ["auto"],
             trigger: ".oi-arrow-right", // Wait for product creation
         },
         {
@@ -107,7 +102,7 @@ registry.category("web_tour.tours").add("sale_tour", {
             run: "click",
         },
         {
-            isActive: ["auto", "mobile"],
+            isActive: ["mobile"],
             trigger: ".o_statusbar_buttons button[name='action_quotation_send']",
         },
         ...stepUtils.statusbarButtonsSteps(

--- a/addons/survey/static/src/js/tours/survey_tour.js
+++ b/addons/survey/static/src/js/tours/survey_tour.js
@@ -29,7 +29,6 @@ registry.category("web_tour.tours").add('survey_tour', {
     run: "click",
 }, 
 {
-    isActive: ["auto"],
     trigger: '.js_question-wrapper span:contains("How frequently")',
 },
 {
@@ -39,7 +38,6 @@ registry.category("web_tour.tours").add('survey_tour', {
     run: "click",
 }, 
 {
-    isActive: ["auto"],
     trigger: '.js_question-wrapper span:contains("How many")',
 },
 {
@@ -49,7 +47,6 @@ registry.category("web_tour.tours").add('survey_tour', {
     run: "click",
 }, 
 {
-    isActive: ["auto"],
     trigger: '.js_question-wrapper span:contains("How likely")',
 },
 {

--- a/addons/web_tour/static/src/tour_service/tour_utils.js
+++ b/addons/web_tour/static/src/tour_service/tour_utils.js
@@ -138,7 +138,7 @@ export const stepUtils = {
         const steps = [];
         if (trigger) {
             steps.push({
-                isActive: ["auto", "mobile"],
+                isActive: ["mobile"],
                 trigger,
             });
         }
@@ -219,7 +219,6 @@ export const stepUtils = {
                 run: "click",
             },
             {
-                isActive: ["auto"],
                 content: "wait for save completion",
                 trigger: ".o_form_readonly, .o_form_saved",
             },
@@ -240,7 +239,6 @@ export const stepUtils = {
                 run: "click",
             },
             {
-                isActive: ["auto"],
                 content: "wait for cancellation to complete",
                 trigger:
                     ".o_view_controller.o_list_view, .o_form_view > div > div > .o_form_readonly, .o_form_view > div > div > .o_form_saved",

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -184,7 +184,6 @@ function clickOnEditAndWaitEditMode(position = "bottom") {
         position: position,
         run: "click",
     }, {
-        isActive: ["auto"], // Checking step only for automated tests
         content: "Check that we are in edit mode",
         trigger: ".o_website_preview.editor_enable.editor_has_snippets",
     }];
@@ -208,7 +207,6 @@ function clickOnEditAndWaitEditModeInTranslatedPage(position = "bottom") {
         position: position,
         run: "click",
     }, {
-        isActive: ["auto"], // Checking step only for automated tests
         content: "Check that we are in edit mode",
         trigger: ".o_website_preview.editor_enable.editor_has_snippets",
     }];
@@ -261,7 +259,6 @@ function clickOnSave(position = "bottom", timeout) {
             run: "click",
         },
         {
-            isActive: ["auto"], // Just making sure save is finished in automatic tests
             trigger: ":iframe body:not(.editor_enable)",
             noPrepend: true,
             timeout: timeout,
@@ -411,7 +408,6 @@ function registerWebsitePreviewTour(name, options, steps) {
             // of course.
             if (options.edition) {
                 tourSteps.unshift({
-                    isActive: ["auto"],
                     content: "Wait for the edit mode to be started",
                     trigger: ".o_website_preview.editor_enable.editor_has_snippets",
                     timeout: 30000,

--- a/addons/website/static/tests/tours/snippet_background_edition.js
+++ b/addons/website/static/tests/tours/snippet_background_edition.js
@@ -46,7 +46,6 @@ function addCheck(steps, checkX, checkNoX, xType, noSwitch = false) {
     }
     if (!selectorCheckX && selectorCheckNoX) {
         steps.push({
-            isActive: ["auto"],
             trigger: selectorCheckNoX,
         });
     }

--- a/addons/website_blog/static/src/js/tours/website_blog.js
+++ b/addons/website_blog/static/src/js/tours/website_blog.js
@@ -24,7 +24,6 @@
         run: "edit Test",
     },
     {
-        isActive: ["auto"],
         trigger: 'div.o_field_widget[name="blog_id"]',
     },
     {
@@ -41,7 +40,6 @@
         run: "click",
     },
     {
-        isActive: ["auto"],
         trigger: "#oe_snippets.o_loaded",
         timeout: 15000,
     },
@@ -52,7 +50,6 @@
         run: "editor Test",
     },
     {
-        isActive: ["auto"],
         trigger: `:iframe #wrap h1[data-oe-expression="blog_post.name"]:not(:contains(''))`,
     },
     {
@@ -84,7 +81,6 @@
         run: "click",
     },
     {
-        isActive: ["auto"],
         trigger: ".o_website_preview.o_is_mobile",
     },
     {
@@ -94,7 +90,6 @@
         run: "click",
     },
     {
-        isActive: ["auto"],
         trigger: ":iframe body:not(.editor_enable)",
     },
     {
@@ -103,7 +98,6 @@
         content: markup(_t("<b>Publish your blog post</b> to make it visible to your visitors.")),
         run: "click",
     }, {
-        isActive: ["auto"],
         trigger: '.o_menu_systray_item a:contains("Published")',
     }
 ]);

--- a/addons/website_event/static/tests/tours/website_event.js
+++ b/addons/website_event/static/tests/tours/website_event.js
@@ -37,7 +37,6 @@
         }
     },
     {
-        isActive: ["auto"],
         trigger: `.modal-dialog input[type=text]:not(:value(""))`,
     },
     {

--- a/addons/website_forum/static/src/js/tours/website_forum.js
+++ b/addons/website_forum/static/src/js/tours/website_forum.js
@@ -17,7 +17,6 @@
         run: "edit Test",
     },
     {
-        isActive: ["auto"],
         trigger: `input[name=post_name]:not(:empty)`,
     },
     {
@@ -27,7 +26,6 @@
         run: "editor Test",
     },
     {
-        isActive: ["auto"],
         trigger: `.note-editable p:not(:contains(/^<br>$/))`,
     },
     {
@@ -40,7 +38,6 @@
         run: "edit Test",
     },
     {
-        isActive: ["auto"],
         trigger: `input[id=s2id_autogen2]:not(:contains(Tags))`,
     },
     {
@@ -66,7 +63,6 @@
         run: "editor Test",
     },
     {
-        isActive: ["auto"],
         trigger: `.note-editable p:not(:contains(/^<br>$/))`,
     },
     {
@@ -84,7 +80,6 @@
         position: "right",
         run: "click",
     }, {
-        isActive: ["auto"],
         content: "Check edit button is there",
         trigger: "a:contains('Edit your answer')",
     }]);

--- a/addons/website_sale/static/src/js/tours/website_sale_shop.js
+++ b/addons/website_sale/static/src/js/tours/website_sale_shop.js
@@ -11,7 +11,6 @@
     },
     () => [
     {
-        isActive: ["auto"],
         trigger: ":iframe .js_sale",
     },
     {
@@ -36,7 +35,6 @@
         run: "click",
     },
     {
-        isActive: ["auto"],
         trigger: "#oe_snippets.o_loaded",
     },
     {
@@ -47,7 +45,6 @@
         timeout: 30000,
     },
     {
-        isActive: ["auto"],
         trigger: ":iframe .product_price .o_dirty .oe_currency_value:not(:contains(/^1.00$/))",
     },
     {
@@ -64,7 +61,6 @@
     },
     wTourUtils.goBackToBlocks(),
     {
-        isActive: ["auto"],
         trigger: "body:not(.modal-open)",
     },
     {
@@ -83,7 +79,6 @@
         run: "click",
     },
     {
-        isActive: ["auto"],
         trigger: ":iframe body:not(.editor_enable)",
     },
     {

--- a/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
+++ b/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
@@ -31,7 +31,6 @@
     },
         tourUtils.goToCart({quantity: 2}),
     {
-        isActive: ["auto"],
         trigger:
             '#cart_products div:has(a>h6:contains("Storage Box Test")) input.js_quantity:value(2)',
     },
@@ -85,7 +84,6 @@
         run: "click",
     },
     {
-        isActive: ["auto"],
         trigger: 'h3:contains("Delivery address")',
     },
     {
@@ -137,7 +135,6 @@
         run: "click",
     },
     {
-        isActive: ["auto"],
         trigger: 'h3:contains("Billing address")',
     },
     {
@@ -176,7 +173,6 @@
         run: "click",
     },
     {
-        isActive: ["auto"],
         trigger:
             'input[name="o_payment_radio"][data-payment-method-code="wire_transfer"]:checked',
     },
@@ -210,7 +206,6 @@
     },
     // Sign in as admin change config auth_signup -> b2b, sale_show_tax -> total and Logout
     {
-        isActive: ["auto"],
         trigger: ".o_header_standard:not(.o_transitioning)",
     },
     {
@@ -248,7 +243,6 @@
         run: "click"
     },
     {
-        isActive: ["auto"],
         trigger: ".o_frontend_to_backend_nav", // Check if the user is connected
     },
     {
@@ -299,7 +293,6 @@
     },
         tourUtils.goToCart({quantity: 2}),
         {
-            isActive: ["auto"],
             trigger:
                 '#cart_products div:has(a>h6:contains("Storage Box Test")) input.js_quantity:value(2)',
         },
@@ -372,7 +365,6 @@
         run: "click",
     },
     {
-        isActive: ["auto"],
         trigger: 'input[name="o_payment_radio"][data-payment-method-code="wire_transfer"]:checked',
     },
     {
@@ -381,7 +373,6 @@
         run: "click",
     },
     {
-        isActive: ["auto"],
         trigger: '.oe_cart .oe_website_sale_tx_status',
     },
     {
@@ -390,7 +381,6 @@
         run: "click",
     },
     {
-        isActive: ["auto"],
         trigger: "header#top li.dropdown .js_usermenu.show",
     },
     {
@@ -401,7 +391,6 @@
 
     // enable extra step on website checkout and check extra step on checkout process
     {
-        isActive: ["auto"],
         trigger: ".o_header_standard:not(.o_transitioning)",
     },
     {
@@ -444,7 +433,6 @@
         url: '/shop/cart',
         steps: () => [
     {
-        isActive: ["auto"],
         trigger: '.o_wizard:contains("Extra Info")',
     },
     {


### PR DESCRIPTION
Since interactive tours no longer take into account steps that do not have a run, isActive: ["auto"] for steps that do not have a run are no longer useful.

https://github.com/odoo/enterprise/pull/67195