### PR TITLE
[FIX] base: prevent putting filter and defaut out of reach

### DIFF
--- a/odoo/addons/base/models/ir_default.py
+++ b/odoo/addons/base/models/ir_default.py
@@ -39,7 +39,9 @@ class IrDefault(models.Model):
     def write(self, vals):
         if self:
             self.clear_caches()
-        return super(IrDefault, self).write(vals)
+        new_default = super().write(vals)
+        self.check_access_rule('write')
+        return new_default
 
     def unlink(self):
         if self:

--- a/odoo/addons/base/models/ir_filters.py
+++ b/odoo/addons/base/models/ir_filters.py
@@ -31,6 +31,11 @@ class IrFilters(models.Model):
         self._cr.execute("SELECT model, name FROM ir_model ORDER BY name")
         return self._cr.fetchall()
 
+    def write(self, vals):
+        new_filter = super().write(vals)
+        self.check_access_rule('write')
+        return new_filter
+
     def copy(self, default=None):
         self.ensure_one()
         default = dict(default or {}, name=_('%s (copy)', self.name))


### PR DESCRIPTION
This fix add a verification check to ir.filter and ir.default. This aims at preventing user to put such record out of their own reach

This behaviour is usually valid in Odoo, however in this case, it is not normal that the user cannot delete the filter and default that he created himself.

