### PR TITLE
[REM] website: remove leftover from website_twitter

### DIFF
--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -156,7 +156,6 @@
                     t-image-preview="/website/static/src/img/snippets_previews/s_instagram_preview.jpg">
                     <keywords>social media, ig, feed</keywords>
                 </t>
-                <t id="twitter_favorite_tweets_hook"/>
                 <!-- TODO: remove 'snippet_google_map_hook', it does not seem to be used -->
                 <t id="snippet_google_map_hook"/>
                 <t t-set="google_maps_api_key" t-value="request.env['website'].get_current_website().google_maps_api_key"/>


### PR DESCRIPTION
[Commit b2355d0c] removed the `website_twitter` module, but one line was left in `snippets.xml`.

[Commit b2355d0c]: https://github.com/odoo/odoo/commit/b2355d0cddf1f82017d8d0af523de44136f56c5a

task-4008369