### PR TITLE
[FIX] phone_validation: monkey patch phone validatino

### DIFF
--- a/addons/phone_validation/lib/phonenumbers_patch/__init__.py
+++ b/addons/phone_validation/lib/phonenumbers_patch/__init__.py
@@ -63,6 +63,10 @@ else:
         # https://github.com/daviddrysdale/python-phonenumbers/blob/v8.13.36/python/phonenumbers/data/region_CO.py
         phonenumbers.phonemetadata.PhoneMetadata.register_region_loader('CO', _local_load_region)
 
+    if parse_version(phonenumbers.__version__) < parse_version('8.13.31'):
+        # https://github.com/daviddrysdale/python-phonenumbers/blob/v8.13.40/python/phonenumbers/data/region_KE.py
+        phonenumbers.phonemetadata.PhoneMetadata.register_region_loader('KE', _local_load_region)
+
     # MONKEY PATCHING phonemetadata to fix Brazilian phonenumbers following 2016 changes
     def _hook_load_region(code):
         if parse_version(phonenumbers.__version__) < parse_version('8.13.39'):

--- a/addons/phone_validation/lib/phonenumbers_patch/region_KE.py
+++ b/addons/phone_validation/lib/phonenumbers_patch/region_KE.py
@@ -1,0 +1,15 @@
+"""Auto-generated file, do not edit by hand. KE metadata"""
+from ..phonemetadata import NumberFormat, PhoneNumberDesc, PhoneMetadata
+
+PHONE_METADATA_KE = PhoneMetadata(id='KE', country_code=254, international_prefix='000',
+    general_desc=PhoneNumberDesc(national_number_pattern='(?:[17]\\d\\d|900)\\d{6}|(?:2|80)0\\d{6,7}|[4-6]\\d{6,8}', possible_length=(7, 8, 9, 10)),
+    fixed_line=PhoneNumberDesc(national_number_pattern='(?:4[245]|5[1-79]|6[01457-9])\\d{5,7}|(?:4[136]|5[08]|62)\\d{7}|(?:[24]0|66)\\d{6,7}', example_number='202012345', possible_length=(7, 8, 9)),
+    mobile=PhoneNumberDesc(national_number_pattern='(?:1(?:0[0-8]|1[0-7]|2[014]|30)|7\\d\\d)\\d{6}', example_number='712123456', possible_length=(9,)),
+    toll_free=PhoneNumberDesc(national_number_pattern='800[02-8]\\d{5,6}', example_number='800223456', possible_length=(9, 10)),
+    premium_rate=PhoneNumberDesc(national_number_pattern='900[02-9]\\d{5}', example_number='900223456', possible_length=(9,)),
+    national_prefix='0',
+    national_prefix_for_parsing='0',
+    number_format=[NumberFormat(pattern='(\\d{2})(\\d{5,7})', format='\\1 \\2', leading_digits_pattern=['[24-6]'], national_prefix_formatting_rule='0\\1'),
+        NumberFormat(pattern='(\\d{3})(\\d{6})', format='\\1 \\2', leading_digits_pattern=['[17]'], national_prefix_formatting_rule='0\\1'),
+        NumberFormat(pattern='(\\d{3})(\\d{3})(\\d{3,4})', format='\\1 \\2 \\3', leading_digits_pattern=['[89]'], national_prefix_formatting_rule='0\\1')],
+    mobile_number_portable_region=True)

--- a/addons/phone_validation/tests/test_phonenumbers_patch.py
+++ b/addons/phone_validation/tests/test_phonenumbers_patch.py
@@ -132,6 +132,23 @@ class TestPhonenumbersPatch(BaseCase):
         )
         self._assert_parsing_phonenumbers(parse_test_lines_MU)
 
+    def test_region_KE_monkey_patch(self):
+        """Makes sure that patch for kenyan phone numbers work"""
+        gt_KE_number = 711123456  # what national number we expect after parsing
+        gt_KE_code = 254  # what country code we expect after parsing
+
+        parse_test_lines_KE = (
+            self.PhoneInputOutputLine("+254711123456", gt_national_number=gt_KE_number, gt_country_code=gt_KE_code),
+            self.PhoneInputOutputLine("+254 711 123 456", gt_national_number=gt_KE_number, gt_country_code=gt_KE_code),
+            self.PhoneInputOutputLine("+254-711-123-456", gt_national_number=gt_KE_number, gt_country_code=gt_KE_code),
+            self.PhoneInputOutputLine("+254 711/123/456", gt_national_number=gt_KE_number, gt_country_code=gt_KE_code),
+            self.PhoneInputOutputLine("0711123456", region="KE", gt_national_number=gt_KE_number, gt_country_code=gt_KE_code),
+            self.PhoneInputOutputLine("0711 123 456", region="KE", gt_national_number=gt_KE_number, gt_country_code=gt_KE_code),
+            self.PhoneInputOutputLine("0711-123-456", region="KE", gt_national_number=gt_KE_number, gt_country_code=gt_KE_code),
+            self.PhoneInputOutputLine("0711/123/456", region="KE", gt_national_number=gt_KE_number, gt_country_code=gt_KE_code),
+        )
+        self._assert_parsing_phonenumbers(parse_test_lines_KE)
+
     def test_region_PA_monkey_patch(self):
         """Makes sure that patch for Panama's phone numbers work"""
         parse_test_lines_PA = (


### PR DESCRIPTION
When the user adds a Kenyan phone number, it is not correctly parsed by the phonenumbers library, resulting in a user error while sending a WhatsApp message to that number.

Steps to produce:
- Add a Kenyan phone number (e.g., '+254114627044').
- Try to send WhatsApp messages using this phone number.
- This will throw an Invalid number error.

Problem:
when `phonenumbers` python library is used in odoo for parsing phone numbers, versions below `8.13.31` have problem with parsing some Kenyian numbers because they aren't updated, therefore they can't identify prefix and throw an error.

task-3994165

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
