### PR TITLE
[FIX] html_editor: reintroduce translate button for Html field

### DIFF
--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -13,6 +13,7 @@ import { useBus, useService } from "@web/core/utils/hooks";
 import { useRecordObserver } from "@web/model/relational_model/utils";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
 import { HtmlViewer } from "./html_viewer";
+import { TranslationButton } from "@web/views/fields/translation_button";
 
 /**
  * Check whether the current value contains nodes that would break
@@ -48,6 +49,7 @@ export class HtmlField extends Component {
     static components = {
         Wysiwyg,
         HtmlViewer,
+        TranslationButton,
     };
 
     setup() {
@@ -105,6 +107,11 @@ export class HtmlField extends Component {
         // @todo @phoenix maybe remove containsComplexHTML and alway use sandboxedPreview options
         return this.props.sandboxedPreview || this.state.containsComplexHTML;
     }
+
+    get isTranslatable() {
+        return this.props.record.fields[this.props.name].translate;
+    }
+
     async updateValue(value) {
         this.lastValue = value;
         this.isDirty = false;

--- a/addons/html_editor/static/src/fields/html_field.scss
+++ b/addons/html_editor/static/src/fields/html_field.scss
@@ -1,3 +1,25 @@
 textarea.o_codeview {
     min-height: 400px;
 }
+
+.note-editable {
+    padding: 4px;
+}
+
+div.o_field_html {
+    span.o_field_translate {
+        font-size: 15px;
+        position: absolute;
+        right: 5px;
+        top: 5px;
+    }
+
+    .o_show_codeview span.o_field_translate {
+        right: 40px;
+    }
+
+    .o_field_translate .note-editable {
+        padding-right: 40px;
+    }
+}
+

--- a/addons/html_editor/static/src/fields/html_field.xml
+++ b/addons/html_editor/static/src/fields/html_field.xml
@@ -6,7 +6,7 @@
                 cssAssetId="props.cssReadonlyAssetId"
                 hasFullHtml="sandboxedPreview"/>
         </t>
-        <div t-else="" class="h-100">
+        <div t-else="" class="h-100" t-att-class="{'o_show_codeview': state.showCodeView, 'o_field_translate': isTranslatable}">
             <t t-if="state.showCodeView">
                 <textarea t-ref="codeView" class="o_codeview" t-att-value="this.value" t-on-change="onChange"/>
             </t>
@@ -14,9 +14,15 @@
                 <Wysiwyg
                     config="this.getConfig()"
                     onLoad.bind="onEditorLoad"
-                    contentClass="'note-editable p-1'"
+                    contentClass="'note-editable'"
                     onBlur.bind="onBlur"
                     t-key="wysiwygKey"/>
+            </t>
+            <t t-if="isTranslatable">
+                <TranslationButton
+                    fieldName="props.name"
+                    record="props.record"
+                />
             </t>
         </div>
         <div t-if="state.showCodeView || (sandboxedPreview and !props.readonly)" t-ref="codeViewButton" id="codeview-btn-group" class="btn-group" t-on-click="toggleCodeView">

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -21,6 +21,7 @@ import {
     mountView,
     onRpc,
     patchWithCleanup,
+    serverState,
 } from "@web/../tests/web_test_helpers";
 import { assets } from "@web/core/assets";
 import { browser } from "@web/core/browser/browser";
@@ -1767,5 +1768,37 @@ describe("save image", () => {
         expect(img.getAttribute("src")).toBe("/test_image_url.png?access_token=12345");
         expect(img.classList.contains("o_b64_image_to_save")).not.toBe(true);
         expect.verifySteps(["add_data: partner 1", "generate_access_token: 123"]);
+    });
+});
+
+describe("translatable", () => {
+    test("should display translate button when html field is translatable", async () => {
+        Partner._fields.txt = fields.Html({ string: "txt", translate: true });
+        serverState.lang = "en_US";
+        serverState.multiLang = true;
+
+        await mountView({
+            type: "form",
+            resModel: "partner",
+            resId: 1,
+            arch: /* xml */ `
+                <form string="Partner">
+                    <sheet>
+                        <group>
+                            <field name="txt" widget="html"/>
+                        </group>
+                    </sheet>
+                </form>`,
+        });
+
+        expect(".o_field_html .btn.o_field_translate").not.toBeVisible();
+
+        // Focus on the editable to make the translate button visible
+        await contains(".odoo-editor-editable").click();
+        expect(".o_field_html .btn.o_field_translate").toBeVisible();
+
+        // Click away to remove focus
+        await contains(".o_form_label").click();
+        expect(".o_field_html .btn.o_field_translate").not.toBeVisible();
     });
 });


### PR DESCRIPTION
When the html field is translatable, a button should be displayed to allow the user to include translations for the different installed languages.

The Html field implementation has been changed from the one in the web_editor addon to the one in the new html_editor addon [1], in which the translation button was not included (most likely due to an oversight). This commit reintroduces such button.

[1]: https://github.com/odoo/odoo/commit/97117e70a1766ad24f5ec14ffef303127d56b76b
