### PR TITLE
[IMP] discuss: call ui improvements (step 1)

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call.js
+++ b/addons/mail/static/src/discuss/call/common/call.js
@@ -16,6 +16,7 @@ import {
 import { browser } from "@web/core/browser/browser";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
+import { ResizablePanel } from "@web/core/resizable_panel/resizable_panel";
 
 /**
  * @typedef CardData
@@ -32,7 +33,7 @@ import { useService } from "@web/core/utils/hooks";
  * @extends {Component<Props, Env>}
  */
 export class Call extends Component {
-    static components = { CallActionList, CallParticipantCard, PttAdBanner };
+    static components = { CallActionList, CallParticipantCard, PttAdBanner, ResizablePanel };
     static props = ["thread", "compact?"];
     static template = "discuss.Call";
 
@@ -67,6 +68,14 @@ export class Call extends Component {
         useExternalListener(browser, "fullscreenchange", this.onFullScreenChange);
     }
 
+    get classNames() {
+        return `o-discuss-Call user-select-none d-flex ${
+            this.state.isFullscreen ? "fixed-top vw-100 vh-100" : ""
+        } ${this.minimized ? "o-minimized" : ""} ${this.resizable ? "o-resizable" : ""} ${
+            !this.state.isFullscreen ? "position-relative" : ""
+        }`;
+    }
+
     get isActiveCall() {
         return Boolean(this.props.thread.eq(this.rtc.state?.channel));
     }
@@ -79,6 +88,10 @@ export class Call extends Component {
             return true;
         }
         return false;
+    }
+
+    get resizable() {
+        return this.env.inDiscussApp && !this.props.compact && !this.state.isFullscreen;
     }
 
     /** @returns {CardData[]} */

--- a/addons/mail/static/src/discuss/call/common/call.scss
+++ b/addons/mail/static/src/discuss/call/common/call.scss
@@ -11,6 +11,11 @@
         height: 20%; // ensures that the view returns to the right height when resized
         min-height: #{"max(20%, 130px)"};
     }
+
+    &.o-resizable {
+        height: 100%;
+        max-height: 500px;
+    }
 }
 
 .o-discuss-Call-main {

--- a/addons/mail/static/src/discuss/call/common/call.xml
+++ b/addons/mail/static/src/discuss/call/common/call.xml
@@ -3,52 +3,61 @@
 
     <t t-name="discuss.Call">
         <PttAdBanner/>
-        <div class="o-discuss-Call user-select-none d-flex" t-att-class="{'o-fullscreen fixed-top vw-100 vh-100': state.isFullscreen, 'o-minimized': minimized, 'position-relative': !state.isFullscreen }">
-            <div class="o-discuss-Call-main d-flex flex-grow-1 flex-column align-items-center justify-content-center position-relative overflow-auto" t-on-mouseleave="onMouseleaveMain">
-                <div
-                    class="o-discuss-Call-mainCards d-flex align-items-center overflow-hidden h-100 w-100 flex-wrap justify-content-center"
-                    t-attf-style="--height:{{state.tileHeight}}px; --width:{{state.tileWidth}}px;"
-                    t-on-click="() => this.showOverlay()"
-                    t-on-mousemove="onMousemoveMain"
-                    t-ref="grid"
-                >
-                    <CallParticipantCard t-foreach="visibleMainCards" t-as="cardData" t-key="cardData.key"
-                        cardData="cardData"
-                        className="'o-discuss-Call-mainCardStyle'"
-                        minimized="minimized"
-                        thread="props.thread"
-                    />
-                </div>
-
-                <!-- Buttons -->
-                <t t-if="hasSidebarButton">
-                    <i t-if="state.sidebar" class="o-discuss-Call-sidebarToggler p-2 fs-5 cursor-pointer position-absolute oi oi-arrow-right" title="Hide sidebar" t-on-click="() => this.state.sidebar = false"/>
-                    <i t-else="" class="o-discuss-Call-sidebarToggler p-2 fs-5 cursor-pointer position-absolute oi oi-arrow-left" title="Show sidebar" t-on-click="() => this.state.sidebar = true"/>
-                </t>
-                <div t-if="state.overlay or !isControllerFloating" class="o-discuss-Call-overlay d-flex justify-content-center w-100 pb-1" t-att-class="{ 'o-isFloating position-absolute bottom-0 pb-3': isControllerFloating }">
-                    <div t-on-mousemove="onMousemoveOverlay">
-                        <CallActionList thread="props.thread" compact="props.compact" fullscreen="{ isActive: state.isFullscreen, enter: () => this.enterFullScreen(), exit: () => this.exitFullScreen() }"/>
-                    </div>
-                </div>
-                <div t-if="hasCallNotifications" class="position-absolute d-flex flex-column-reverse start-0 bottom-0" t-att-class="{ 'ps-5 pb-5': state.isFullscreen, 'ps-2 pb-2': !state.isFullscreen }">
-                    <span class="text-bg-800 shadow-lg rounded-1 m-1" t-att-class="{ 'p-4 fs-4': state.isFullscreen, 'p-2': !state.isFullscreen }" t-foreach="rtc.notifications.values()" t-as="notification" t-key="notification.id" t-esc="notification.text"/>
-                </div>
+        <ResizablePanel class="classNames" t-if="resizable" handleSide="'bottom'">
+            <t t-call="discuss.Call.content"/>
+        </ResizablePanel>
+        <t t-else="">
+            <div t-att-class="classNames">
+                <t t-call="discuss.Call.content"/>
             </div>
-            <div t-if="state.sidebar and props.thread.activeRtcSession" class="o-discuss-Call-sidebar d-flex align-items-center h-100 flex-column">
-                <CallParticipantCard t-foreach="visibleCards" t-as="cardData" t-key="cardData.key"
+        </t>
+    </t>
+
+    <t t-name="discuss.Call.content">
+        <div class="o-discuss-Call-main d-flex flex-grow-1 flex-column align-items-center justify-content-center position-relative overflow-auto" t-on-mouseleave="onMouseleaveMain">
+            <div
+                class="o-discuss-Call-mainCards d-flex align-items-center overflow-hidden h-100 w-100 flex-wrap justify-content-center"
+                t-attf-style="--height:{{state.tileHeight}}px; --width:{{state.tileWidth}}px;"
+                t-on-click="() => this.showOverlay()"
+                t-on-mousemove="onMousemoveMain"
+                t-ref="grid"
+            >
+                <CallParticipantCard t-foreach="visibleMainCards" t-as="cardData" t-key="cardData.key"
                     cardData="cardData"
-                    className="'o-discuss-Call-sidebarCard w-100'"
+                    className="'o-discuss-Call-mainCardStyle'"
+                    minimized="minimized"
                     thread="props.thread"
                 />
             </div>
-            <CallParticipantCard
-                t-if="props.thread.videoCount > 0 and state.insetCard"
-                cardData="state.insetCard"
-                className="'o-discuss-Call-mainCardStyle'"
+
+            <!-- Buttons -->
+            <t t-if="hasSidebarButton">
+                <i t-if="state.sidebar" class="o-discuss-Call-sidebarToggler p-2 fs-5 cursor-pointer position-absolute oi oi-arrow-right" title="Hide sidebar" t-on-click="() => this.state.sidebar = false"/>
+                <i t-else="" class="o-discuss-Call-sidebarToggler p-2 fs-5 cursor-pointer position-absolute oi oi-arrow-left" title="Show sidebar" t-on-click="() => this.state.sidebar = true"/>
+            </t>
+            <div t-if="state.overlay or !isControllerFloating" class="o-discuss-Call-overlay d-flex justify-content-center w-100 pb-1" t-att-class="{ 'o-isFloating position-absolute bottom-0 pb-3': isControllerFloating }">
+                <div t-on-mousemove="onMousemoveOverlay">
+                    <CallActionList thread="props.thread" compact="props.compact" fullscreen="{ isActive: state.isFullscreen, enter: () => this.enterFullScreen(), exit: () => this.exitFullScreen() }"/>
+                </div>
+            </div>
+            <div t-if="hasCallNotifications" class="position-absolute d-flex flex-column-reverse start-0 bottom-0" t-att-class="{ 'ps-5 pb-5': state.isFullscreen, 'ps-2 pb-2': !state.isFullscreen }">
+                <span class="text-bg-800 shadow-lg rounded-1 m-1" t-att-class="{ 'p-4 fs-4': state.isFullscreen, 'p-2': !state.isFullscreen }" t-foreach="rtc.notifications.values()" t-as="notification" t-key="notification.id" t-esc="notification.text"/>
+            </div>
+        </div>
+        <div t-if="state.sidebar and props.thread.activeRtcSession" class="o-discuss-Call-sidebar d-flex align-items-center flex-column">
+            <CallParticipantCard t-foreach="visibleCards" t-as="cardData" t-key="cardData.key"
+                cardData="cardData"
+                className="'o-discuss-Call-sidebarCard w-100'"
                 thread="props.thread"
-                inset.bind="setInset"
             />
         </div>
+        <CallParticipantCard
+            t-if="props.thread.videoCount > 0 and state.insetCard"
+            cardData="state.insetCard"
+            className="'o-discuss-Call-mainCardStyle'"
+            thread="props.thread"
+            inset.bind="setInset"
+        />
     </t>
 
 </templates>

--- a/addons/web/static/src/core/resizable_panel/resizable_panel.scss
+++ b/addons/web/static/src/core/resizable_panel/resizable_panel.scss
@@ -1,10 +1,17 @@
 .o_resizable_panel {
     max-width: 100vw;
+    max-height: 100vh;
     flex-grow: 0;
 }
 
 .o_resizable_panel_handle {
-    cursor: col-resize;
     z-index: 10;
-    width: 5px;
+    &.o_resizable_panel_handle_x {
+        cursor: col-resize;
+        width: 5px;
+    }
+    &.o_resizable_panel_handle_y {
+        cursor: row-resize;
+        height: 5px;
+    }
 }

--- a/addons/web/static/src/core/resizable_panel/resizable_panel.xml
+++ b/addons/web/static/src/core/resizable_panel/resizable_panel.xml
@@ -2,10 +2,15 @@
 <templates>
 
     <t t-name="web_studio.ResizablePanel">
-        <div class="o_resizable_panel d-flex flex-column" t-att-class="class" t-ref="containerRef">
+        <div class="o_resizable_panel" t-att-class="class" t-ref="containerRef">
             <t t-slot="default" />
             <div
-                class="o_resizable_panel_handle position-absolute top-0 bottom-0 end-0" t-att-class="props.handleSide === 'start' ? 'start-0' : 'end-0'"
+                class="o_resizable_panel_handle position-absolute" t-att-class="{
+                    'o_resizable_panel_handle o_resizable_panel_handle_y start-0 end-0 top-0': props.handleSide === 'top',
+                    'o_resizable_panel_handle o_resizable_panel_handle_y start-0 end-0 bottom-0': props.handleSide === 'bottom',
+                    'o_resizable_panel_handle o_resizable_panel_handle_x start-0 top-0 bottom-0': props.handleSide === 'start',
+                    'o_resizable_panel_handle o_resizable_panel_handle_x end-0 top-0 bottom-0': props.handleSide === 'end',
+                }"
                 t-ref="handleRef"
             ></div>
         </div>


### PR DESCRIPTION
This commit adds the possibility to resize the ResizablePanel vertically.
This is a preparation for the new UI of the Call view.

Making the call panel in discuss resizable when it is not in fullscreen.

Part of call ui improvements, including:
1. Making the call panel resizable when it is not in fullscreen.
2. Making it possible to collapse the call panel when in chatwindow.
3. Make use of the sidepanel for the call when in Discuss.
4. UI improvements and cleanup.

![动画](https://github.com/user-attachments/assets/61e6ecf3-8dbf-458d-a527-c39cc4cb4fa3)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
