### PR TITLE
[FIX] hw_drivers: wrong printer connection type for windows IoT

### DIFF
--- a/addons/hw_drivers/iot_handlers/interfaces/PrinterInterface_W.py
+++ b/addons/hw_drivers/iot_handlers/interfaces/PrinterInterface_W.py
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import logging
 import win32print
 
 from odoo.addons.hw_drivers.interface import Interface
+
+_logger = logging.getLogger(__name__)
+
 
 class PrinterInterface(Interface):
     _loop_delay = 30
@@ -16,9 +20,20 @@ class PrinterInterface(Interface):
         for printer in printers:
             identifier = printer[2]
             handle_printer = win32print.OpenPrinter(identifier)
-            win32print.GetPrinter(handle_printer, 2)
+            # The value "2" is the level of detail we want to get from the printer, see:
+            # https://learn.microsoft.com/en-us/windows/win32/printdocs/getprinter#parameters
+            printer_details = win32print.GetPrinter(handle_printer, 2)
+            printer_port = None
+            if printer_details:
+                # see: https://learn.microsoft.com/en-us/windows/win32/printdocs/printer-info-2#members
+                printer_port = printer_details.get('pPortName')
+            if printer_port is None:
+                _logger.warning('Printer "%s" has no port name. Used dummy port', identifier)
+                printer_port = 'IOT_DUMMY_PORT'
+
             printer_devices[identifier] = {
                 'identifier': identifier,
                 'printer_handle': handle_printer,
+                'port': printer_port,
             }
         return printer_devices


### PR DESCRIPTION
Before this commit:
Any printer connected to a windows IoT was always set to "network" connection type. Apart from wrong information on odoo's backend, it also create issues as the backend filter network printer with the same name to appear only once, see: https://github.com/odoo/enterprise/blob/221a94164b558bc997328331c48cbc1213b895d2/iot/controllers/main.py#L109-L112 So if 2 USB printer of the same model are plugged to 2 distinct windows IoT, only one of them would appear with no way to print to the one missing (apart from renaming the printer to avoid printer name clash).

After this commit:
Determine the type of connection based on the printer port.

Additionally, virtual printers (like "Microsoft Print to PDF") are now discarded to avoid triggering dialog boxes prompts which will block the printing operation process

opw-3801703