### PR TITLE
[IMP] core: route's max_content_length as a callable

### DIFF
--- a/addons/web/controllers/dataset.py
+++ b/addons/web/controllers/dataset.py
@@ -16,10 +16,10 @@ _logger = logging.getLogger(__name__)
 
 class DataSet(http.Controller):
 
-    def _call_kw_readonly(self, registry, request):
+    def _call_kw_readonly(self):
         params = request.get_json_data()['params']
         try:
-            model_class = registry[params['model']]
+            model_class = request.registry[params['model']]
         except KeyError as e:
             raise NotFound() from e
         method_name = params['method']

--- a/addons/web/controllers/home.py
+++ b/addons/web/controllers/home.py
@@ -34,7 +34,7 @@ class Home(http.Controller):
             return request.redirect_query('/web/login_successful', query=request.params)
         return request.redirect_query('/odoo', query=request.params)
 
-    def _web_client_readonly(self, registry, request):
+    def _web_client_readonly(self):
         return False
 
     # ideally, this route should be `auth="user"` but that don't work in non-monodb mode.

--- a/odoo/addons/test_http/controllers.py
+++ b/odoo/addons/test_http/controllers.py
@@ -32,6 +32,9 @@ class TestHttp(http.Controller):
     def _readonly(self):
         return str2bool(request.httprequest.args.get('readonly', True))
 
+    def _max_content_length_1kiB(self):
+        return 1024
+
     # =====================================================
     # Greeting
     # =====================================================
@@ -120,7 +123,8 @@ class TestHttp(http.Controller):
         })
 
     @http.route('/test_http/<model("test_http.galaxy"):galaxy>/setname',
-                methods=['GET', 'POST'], type='http', auth='user', readonly=_readonly)
+                methods=['GET', 'POST'], type='http', auth='user', readonly=_readonly,
+                max_content_length=_max_content_length_1kiB)
     def galaxy_set_name(self, galaxy, name, readonly=True):
         galaxy.name = name
         return galaxy.name

--- a/odoo/addons/test_http/controllers.py
+++ b/odoo/addons/test_http/controllers.py
@@ -9,7 +9,7 @@ from psycopg2 import OperationalError
 from odoo import http
 from odoo.exceptions import AccessError, UserError
 from odoo.http import request
-from odoo.tools import replace_exceptions
+from odoo.tools import replace_exceptions, str2bool
 
 from odoo.addons.web.controllers.utils import ensure_db
 
@@ -29,32 +29,27 @@ class SerializationFailureError(OperationalError):
 
 
 class TestHttp(http.Controller):
+    def _readonly(self):
+        return str2bool(request.httprequest.args.get('readonly', True))
 
     # =====================================================
     # Greeting
     # =====================================================
+
     @http.route(['/test_http/greeting', '/test_http/greeting-none'], type='http', auth='none')
     def greeting_none(self):
         return "Tek'ma'te"
 
-    @http.route('/test_http/greeting-public', type='http', auth='public', readonly=True)
-    def greeting_public(self):
+    @http.route('/test_http/greeting-public', type='http', auth='public', readonly=_readonly)
+    def greeting_public(self, readonly=True):
         assert request.env.user, "ORM should be initialized"
+        assert request.env.cr.readonly == str2bool(readonly)
         return "Tek'ma'te"
 
-    @http.route('/test_http/greeting-user', type='http', auth='user', readonly=True)
-    def greeting_user(self):
+    @http.route('/test_http/greeting-user', type='http', auth='user', readonly=_readonly)
+    def greeting_user(self, readonly=True):
         assert request.env.user, "ORM should be initialized"
-        return "Tek'ma'te"
-
-    @http.route('/test_http/greeting-public-rw', type='http', auth='public')
-    def greeting_public_rw(self):
-        assert request.env.user, "ORM should be initialized"
-        return "Tek'ma'te"
-
-    @http.route('/test_http/greeting-user-rw', type='http', auth='user')
-    def greeting_user_rw(self):
-        assert request.env.user, "ORM should be initialized"
+        assert request.env.cr.readonly == str2bool(readonly)
         return "Tek'ma'te"
 
     @http.route('/test_http/wsgi_environ', type='http', auth='none')
@@ -124,13 +119,9 @@ class TestHttp(http.Controller):
             ]),
         })
 
-    @http.route('/test_http/<model("test_http.galaxy"):galaxy>/setname-rw', methods=['GET', 'POST'], type='http', auth='user')
-    def galaxy_set_name_rw(self, galaxy, name):
-        galaxy.name = name
-        return galaxy.name
-
-    @http.route('/test_http/<model("test_http.galaxy"):galaxy>/setname-ro', methods=['GET', 'POST'], type='http', auth='user', readonly=True)
-    def galaxy_set_name_ro(self, galaxy, name):
+    @http.route('/test_http/<model("test_http.galaxy"):galaxy>/setname',
+                methods=['GET', 'POST'], type='http', auth='user', readonly=_readonly)
+    def galaxy_set_name(self, galaxy, name, readonly=True):
         galaxy.name = name
         return galaxy.name
 

--- a/odoo/addons/test_http/tests/test_device.py
+++ b/odoo/addons/test_http/tests/test_device.py
@@ -79,7 +79,7 @@ class TestDevice(TestHttpBase):
 
     def test_detection_device_no_readonly(self):
         session = self.authenticate(self.user_admin.login, self.user_admin.login)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw')
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0')
 
         devices, logs = self.get_devices_logs(self.user_admin)
         self.assertEqual(len(devices), 1)
@@ -88,7 +88,7 @@ class TestDevice(TestHttpBase):
 
     def test_detection_user_public(self):
         self.authenticate(None, None)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw')
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0')
 
         devices, logs = self.get_devices_logs()
         self.assertEqual(len(devices), 0)
@@ -103,7 +103,7 @@ class TestDevice(TestHttpBase):
         self.assertEqual(len(logs), 1)
         self.assertEqual(len(session._trace), 1)
 
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw')
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0')
 
         devices, logs = self.get_devices_logs(self.user_admin)
         self.assertEqual(len(devices), 1)
@@ -112,7 +112,7 @@ class TestDevice(TestHttpBase):
 
     def test_detection_device_according_to_time(self):
         session = self.authenticate(self.user_admin.login, self.user_admin.login)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw')
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0')
 
         devices, logs = self.get_devices_logs(self.user_admin)
         self.assertEqual(len(devices), 1)
@@ -120,7 +120,7 @@ class TestDevice(TestHttpBase):
         self.assertEqual(len(session._trace), 1)
         self.assertEqual(self.info_trace(session._trace[0])['elapsed_time'], 0)
 
-        self.hit('2024-01-01 08:30:00', '/test_http/greeting-public-rw')
+        self.hit('2024-01-01 08:30:00', '/test_http/greeting-public?readonly=0')
 
         devices, logs = self.get_devices_logs(self.user_admin)
         self.assertEqual(len(devices), 1)
@@ -128,7 +128,7 @@ class TestDevice(TestHttpBase):
         self.assertEqual(len(session._trace), 1)
         self.assertEqual(self.info_trace(session._trace[0])['elapsed_time'], 0)  # No trace update (< 3600 sec)
 
-        self.hit('2024-01-01 09:00:00', '/test_http/greeting-public-rw')
+        self.hit('2024-01-01 09:00:00', '/test_http/greeting-public?readonly=0')
 
         devices, logs = self.get_devices_logs(self.user_admin)
         self.assertEqual(len(devices), 1)
@@ -136,7 +136,7 @@ class TestDevice(TestHttpBase):
         self.assertEqual(len(session._trace), 1)
         self.assertEqual(self.info_trace(session._trace[0])['elapsed_time'], 3600)
 
-        self.hit('2024-01-01 10:00:00', '/test_http/greeting-public-rw')
+        self.hit('2024-01-01 10:00:00', '/test_http/greeting-public?readonly=0')
 
         devices, logs = self.get_devices_logs(self.user_admin)
         self.assertEqual(len(devices), 1)
@@ -147,7 +147,7 @@ class TestDevice(TestHttpBase):
     def test_detection_device_according_to_useragent(self):
         session = self.authenticate(self.user_admin.login, self.user_admin.login)
 
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw', headers={'User-Agent': USER_AGENT_linux_chrome})
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_chrome})
 
         devices, logs = self.get_devices_logs(self.user_admin)
         self.assertEqual(len(devices), 1)
@@ -156,7 +156,7 @@ class TestDevice(TestHttpBase):
         self.assertEqual(self.info_trace(session._trace[0])['platform'], 'linux')
         self.assertEqual(self.info_trace(session._trace[0])['browser'], 'chrome')
 
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw', headers={'User-Agent': USER_AGENT_linux_firefox})
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_firefox})
 
         devices, logs = self.get_devices_logs(self.user_admin)
         self.assertEqual(len(devices), 2)
@@ -167,14 +167,14 @@ class TestDevice(TestHttpBase):
 
     def test_detection_device_according_to_ipaddress(self):
         session = self.authenticate(self.user_admin.login, self.user_admin.login)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw')
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0')
 
         devices, logs = self.get_devices_logs(self.user_admin)
         self.assertEqual(len(devices), 1)
         self.assertEqual(len(logs), 1)
         self.assertEqual(len(session._trace), 1)
 
-        self.hit('2024-01-01 08:00:01', '/test_http/greeting-public-rw', ip=TEST_IP)
+        self.hit('2024-01-01 08:00:01', '/test_http/greeting-public?readonly=0', ip=TEST_IP)
 
         devices, logs = self.get_devices_logs(self.user_admin)
         self.assertEqual(len(devices), 1)
@@ -188,9 +188,9 @@ class TestDevice(TestHttpBase):
 
     def test_detection_usurpation_sid(self):
         session = self.authenticate(self.user_internal.login, self.user_internal.login)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-user-rw')
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-user?readonly=0')
 
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-user-rw', headers={'session_id': session.sid}, ip=TEST_IP)
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-user?readonly=0', headers={'session_id': session.sid}, ip=TEST_IP)
         devices, logs = self.get_devices_logs(self.user_internal)
         self.assertEqual(len(devices), 1)
         self.assertEqual(len(logs), 2)
@@ -198,25 +198,25 @@ class TestDevice(TestHttpBase):
 
     def test_detection_devices_according_to_time_useragent(self):
         self.authenticate(self.user_admin.login, self.user_admin.login)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw', headers={'User-Agent': USER_AGENT_linux_chrome})
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_chrome})
         self.assertEqual(len(self.user_admin.device_ids), 1)
 
-        self.hit('2024-01-01 09:00:00', '/test_http/greeting-public-rw', headers={'User-Agent': USER_AGENT_linux_chrome})
+        self.hit('2024-01-01 09:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_chrome})
         self.assertEqual(len(self.user_admin.device_ids), 1)
 
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw', headers={'User-Agent': USER_AGENT_linux_firefox})
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_firefox})
         self.assertEqual(len(self.user_admin.device_ids), 2)
 
-        self.hit('2024-01-01 09:00:00', '/test_http/greeting-public-rw', headers={'User-Agent': USER_AGENT_linux_firefox})
+        self.hit('2024-01-01 09:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_firefox})
         self.assertEqual(len(self.user_admin.device_ids), 2)
 
     def test_detection_devices_according_to_user_or_admin(self):
         self.authenticate(self.user_admin.login, self.user_admin.login)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw')
-        self.hit('2024-01-01 09:00:00', '/test_http/greeting-public-rw')
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0')
+        self.hit('2024-01-01 09:00:00', '/test_http/greeting-public?readonly=0')
         self.authenticate(self.user_internal.login, self.user_internal.login)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw')
-        self.hit('2024-01-01 09:00:00', '/test_http/greeting-public-rw')
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0')
+        self.hit('2024-01-01 09:00:00', '/test_http/greeting-public?readonly=0')
 
         devices, logs = self.get_devices_logs()
         self.assertEqual(len(devices), 2)
@@ -231,8 +231,8 @@ class TestDevice(TestHttpBase):
 
     def test_differentiate_computer_and_mobile(self):
         self.authenticate(self.user_admin.login, self.user_admin.login)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw', headers={'User-Agent': USER_AGENT_linux_chrome})
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw', headers={'User-Agent': USER_AGENT_android_chrome})
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_chrome})
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_android_chrome})
 
         devices, logs = self.get_devices_logs(self.user_admin)
         self.assertEqual(len(devices), 2)
@@ -245,9 +245,9 @@ class TestDevice(TestHttpBase):
 
     def test_retrieve_linked_ip_addresses(self):
         self.authenticate(self.user_admin.login, self.user_admin.login)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw', ip='193.0.3.43')
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw', ip='192.0.2.42')
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw', ip='191.0.1.41')
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', ip='193.0.3.43')
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', ip='192.0.2.42')
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', ip='191.0.1.41')
 
         devices, _ = self.get_devices_logs(self.user_admin)
         self.assertEqual(len(devices), 1)
@@ -257,9 +257,9 @@ class TestDevice(TestHttpBase):
 
     def test_retrieve_linked_ip_addresses_according_to_devices(self):
         self.authenticate(self.user_admin.login, self.user_admin.login)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw', headers={'User-Agent': USER_AGENT_linux_chrome}, ip='193.0.3.43')
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw', headers={'User-Agent': USER_AGENT_linux_chrome}, ip='192.0.2.42')
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw', headers={'User-Agent': USER_AGENT_linux_firefox}, ip='191.0.1.41')
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_chrome}, ip='193.0.3.43')
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_chrome}, ip='192.0.2.42')
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_firefox}, ip='191.0.1.41')
 
         devices, _ = self.get_devices_logs(self.user_admin)
         self.assertEqual(len(devices), 2)
@@ -280,7 +280,7 @@ class TestDevice(TestHttpBase):
             wants to block his device (and therefore its session).
         """
         self.authenticate(self.user_internal.login, self.user_internal.login)
-        res = self.hit('2024-01-01 08:00:00', '/test_http/greeting-user-rw')
+        res = self.hit('2024-01-01 08:00:00', '/test_http/greeting-user?readonly=0')
         self.assertNotIn('/web/login', res.url)
 
         user_internal_device = self.user_internal.device_ids
@@ -289,26 +289,26 @@ class TestDevice(TestHttpBase):
 
         user_internal_device._revoke()
 
-        res = self.hit('2024-01-01 08:00:01', '/test_http/greeting-user-rw')
+        res = self.hit('2024-01-01 08:00:01', '/test_http/greeting-user?readonly=0')
         self.assertIn('/web/login', res.url)
 
     def test_deletion_invalidate_sid(self):
         session = self.authenticate(self.user_internal.login, self.user_internal.login)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-user-rw')
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-user?readonly=0')
 
         self.user_internal.device_ids._revoke()
 
-        res = self.hit('2024-01-01 08:00:00', '/test_http/greeting-user-rw', headers={'session_id': session.sid})
+        res = self.hit('2024-01-01 08:00:00', '/test_http/greeting-user?readonly=0', headers={'session_id': session.sid})
         self.assertIn('/web/login', res.url)
 
     def test_deletion_specific_device(self):
         self.authenticate(self.user_admin.login, self.user_admin.login)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-user-rw', headers={'User-Agent': USER_AGENT_linux_chrome})
-        self.hit('2024-01-01 09:00:00', '/test_http/greeting-user-rw', headers={'User-Agent': USER_AGENT_linux_chrome})
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-user?readonly=0', headers={'User-Agent': USER_AGENT_linux_chrome})
+        self.hit('2024-01-01 09:00:00', '/test_http/greeting-user?readonly=0', headers={'User-Agent': USER_AGENT_linux_chrome})
         self.authenticate(self.user_admin.login, self.user_admin.login)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-user-rw', headers={'User-Agent': USER_AGENT_linux_chrome})
-        self.hit('2024-01-01 09:00:00', '/test_http/greeting-user-rw', headers={'User-Agent': USER_AGENT_linux_chrome})
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-user-rw', headers={'User-Agent': USER_AGENT_linux_firefox})
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-user?readonly=0', headers={'User-Agent': USER_AGENT_linux_chrome})
+        self.hit('2024-01-01 09:00:00', '/test_http/greeting-user?readonly=0', headers={'User-Agent': USER_AGENT_linux_chrome})
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-user?readonly=0', headers={'User-Agent': USER_AGENT_linux_firefox})
 
         devices, logs = self.get_devices_logs(self.user_admin)
         self.assertEqual(len(devices), 3)
@@ -317,7 +317,7 @@ class TestDevice(TestHttpBase):
 
         self.user_admin.device_ids.filtered(lambda device: 'firefox' in device.browser)._revoke()
 
-        res = self.hit('2024-01-01 08:00:30', '/test_http/greeting-user-rw', headers={'User-Agent': USER_AGENT_linux_firefox})
+        res = self.hit('2024-01-01 08:00:30', '/test_http/greeting-user?readonly=0', headers={'User-Agent': USER_AGENT_linux_firefox})
         self.assertIn('/web/login', res.url)
 
     # --------------------
@@ -331,7 +331,7 @@ class TestDevice(TestHttpBase):
             are no changes in the session itself.
         """
         session = self.authenticate(None, None)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw')
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0')
 
         # As we don't have a uid in the session, we shouldn't go through
         # the session check and therefore we won't go through the device update.

--- a/odoo/addons/test_http/tests/test_models.py
+++ b/odoo/addons/test_http/tests/test_models.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import html
+from http import HTTPStatus
 
 import odoo
 from odoo.tests import tagged
@@ -104,3 +105,9 @@ class TestHttpModels(TestHttpBase):
             [rec.msg % rec.args for rec in capture_sql_db.records],
             [Like('bad query:...UPDATE "test_http_galaxy"...ERROR: cannot execute UPDATE in a read-only transaction')],
         )
+
+    def test_models5_max_upload_too_large(self):
+        res = self.url_open('/test_http/1/setname', {
+            'name': "too much data" * 1000  # 1.3kB
+        })
+        self.assertEqual(res.status_code, HTTPStatus.REQUEST_ENTITY_TOO_LARGE)

--- a/odoo/addons/test_http/tests/test_models.py
+++ b/odoo/addons/test_http/tests/test_models.py
@@ -72,7 +72,7 @@ class TestHttpModels(TestHttpBase):
 
 
         milky_way.invalidate_recordset()
-        res = self.url_open(f'/test_http/{milky_way.id}/setname-rw', {
+        res = self.url_open(f'/test_http/{milky_way.id}/setname?readonly=0', {
             'name': "Wilky May",
             'csrf_token': odoo.http.Request.csrf_token(self),
         })
@@ -88,7 +88,7 @@ class TestHttpModels(TestHttpBase):
 
         with self.assertLogs('odoo.http', 'WARNING') as capture_http,\
              self.assertLogs('odoo.sql_db', 'WARNING') as capture_sql_db:
-            res = self.url_open(f'/test_http/{milky_way.id}/setname-ro', {
+            res = self.url_open(f'/test_http/{milky_way.id}/setname?readonly=1', {
                 'name': "Wilky May",
                 'csrf_token': odoo.http.Request.csrf_token(self),
             })

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -2027,7 +2027,10 @@ class Dispatcher(ABC):
             werkzeug.exceptions.abort(Response(status=204))
 
         if 'max_content_length' in routing:
-            self.request.httprequest.max_content_length = routing['max_content_length']
+            max_content_length = routing['max_content_length']
+            if callable(max_content_length):
+                max_content_length = max_content_length(rule.endpoint.func.__self__)
+            self.request.httprequest.max_content_length = max_content_length
 
     @abstractmethod
     def dispatch(self, endpoint, args):

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1899,7 +1899,7 @@ class Request:
         self._set_request_dispatcher(rule)
         readonly = rule.endpoint.routing['readonly']
         if callable(readonly):
-            readonly = readonly(rule.endpoint.func.__self__, self.registry, request)
+            readonly = readonly(rule.endpoint.func.__self__)
         return self._transactioning(
             functools.partial(self._serve_ir_http, rule, args),
             readonly=readonly,


### PR DESCRIPTION
**[IMP] core: route's max_content_length as a callable**

The `max_content_length` argument of `@http.route` was only taking a int
or None (=no limit). In case no argument was given, it defaulted to
checking (at runtime) the value of the `web.max_file_upload_size` ICP.

Applications (e.g. Documents) can wish to use another non-final limit, a
limit that is determined at runtime.

In this work we enrich the scope of the `max_content_length` argument to
accept a controller method that takes no argument and that return an int
or None. That returned value will be used as limit.

Task-4014623

---

**[FIX] core: readonly callable get request via proxy**

Calling the readonly callable passing both a request and a registry
object is useless: both objects can be retrieved via odoo.http.request
and odoo.http.request.registry.

