### PR TITLE
[FIX] point_of_sale: prevent error on validation with customer note

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/customer_note_button/customer_note_button.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/customer_note_button/customer_note_button.js
@@ -32,7 +32,7 @@ export class OrderlineNoteButton extends Component {
         const oldNote = selectedOrderline.getNote();
         const notes = this.pos.models["pos.note"].getAll();
         let buttons;
-        if (this.props.label == _t("Internal Note")) {
+        if (this._isInternalNote()) {
             buttons = notes.map((note) => ({
                 label: note.name,
                 isSelected: selectedNote.split("\n").includes(note.name), // Check if the note is already selected
@@ -52,5 +52,8 @@ export class OrderlineNoteButton extends Component {
         }
 
         return { confirmed: typeof payload === "string", inputNote: payload, oldNote };
+    }
+    _isInternalNote() {
+        return this.props.label == _t("Internal Note");
     }
 }


### PR DESCRIPTION
Before this commit, validating an order in the PoS restaurant module with a customer note attached would result in a KeyError. This issue occurred because the customer note was incorrectly processed in the note history, leading to unexpected behavior.

Enterprise PR: https://github.com/odoo/enterprise/pull/67210

opw-4059220

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
