### PR TITLE
[REV] project: set default value of analytic plan in the project config setting

### DIFF
--- a/addons/hr_timesheet/tests/test_timesheet.py
+++ b/addons/hr_timesheet/tests/test_timesheet.py
@@ -705,7 +705,7 @@ class TestTimesheet(TestCommonTimesheet):
         self.assertEqual(self.task1.progress, 100, 'The percentage of allocated hours should be 100%.')
 
     def test_analytic_plan_setting(self):
-        self.env['ir.config_parameter'].set_param('analytic.project_plan', 1)
+        self.env['ir.config_parameter'].set_param('analytic.analytic_plan_projects', 1)
         project_1 = self.env['project.project'].create({
             'name': "Project with plan setting 1",
             'allow_timesheets': True,
@@ -713,7 +713,7 @@ class TestTimesheet(TestCommonTimesheet):
         })
         self.assertEqual(project_1.analytic_account_id.plan_id.id, 1)
 
-        self.env['ir.config_parameter'].set_param('analytic.project_plan', 2)
+        self.env['ir.config_parameter'].set_param('analytic.analytic_plan_projects', 2)
         project_2 = self.env['project.project'].create({
             'name': "Project with plan setting 2",
             'allow_timesheets': True,

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -900,7 +900,7 @@ class Project(models.Model):
     @api.model
     def _create_analytic_account_from_values(self, values):
         company = self.env['res.company'].browse(values.get('company_id', False))
-        project_plan_id = int(self.env['ir.config_parameter'].sudo().get_param('analytic.project_plan'))
+        project_plan_id = int(self.env['ir.config_parameter'].sudo().get_param('analytic.analytic_plan_projects'))
 
         if not project_plan_id:
             project_plan, _other_plans = self.env['account.analytic.plan']._get_all_plans()

--- a/addons/project/models/res_config_settings.py
+++ b/addons/project/models/res_config_settings.py
@@ -18,7 +18,7 @@ class ResConfigSettings(models.TransientModel):
     analytic_plan_id = fields.Many2one(
         comodel_name='account.analytic.plan',
         string="Analytic Plan",
-        config_parameter="analytic.project_plan",
+        config_parameter="analytic.analytic_plan_projects",
     )
 
     @api.model


### PR DESCRIPTION
[REV] project: set default value of analytic plan in the project config setting

This reverts commit https://github.com/odoo/odoo/commit/a2c51c6ad9ae80e6d4edc5de96811edd56df7a7c because the
`analytic.project_plan` should not be altered since that field is used
to find the column auto-generated in `account.analytic.line` model by
`analytic.plan`.

opw-4051817
