### PR TITLE
[REF] html_editor: split unbreakable into two concepts

### DIFF
--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -1,4 +1,4 @@
-import { isUnbreakable, paragraphRelatedElements } from "../utils/dom_info";
+import { paragraphRelatedElements } from "../utils/dom_info";
 import { Plugin } from "../plugin";
 import { closestBlock, isBlock } from "../utils/blocks";
 import { unwrapContents } from "../utils/dom";
@@ -314,7 +314,7 @@ export class ClipboardPlugin extends Plugin {
                 // Break line by inserting new paragraph and
                 // remove current paragraph's bottom margin.
                 const p = closestElement(selection.anchorNode, "p");
-                if (isUnbreakable(closestBlock(selection.anchorNode))) {
+                if (this.shared.isUnsplittable(closestBlock(selection.anchorNode))) {
                     this.dispatch("INSERT_LINEBREAK");
                 } else {
                     const [pBefore] = this.shared.splitBlock();

--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -15,7 +15,6 @@ import {
     isProtecting,
     isSelfClosingElement,
     isShrunkBlock,
-    isUnbreakable,
     paragraphRelatedElements,
 } from "../utils/dom_info";
 import { closestElement, descendants } from "../utils/dom_traversal";
@@ -24,7 +23,7 @@ import { DIRECTIONS, childNodeIndex, rightPos } from "../utils/position";
 
 export class DomPlugin extends Plugin {
     static name = "dom";
-    static dependencies = ["selection", "split"];
+    static dependencies = ["selection", "split", "delete"];
     static shared = ["domInsert", "copyAttributes"];
     static resources = () => ({
         powerboxCommands: {
@@ -223,7 +222,7 @@ export class DomPlugin extends Plugin {
         // If all the Html have been isolated, We force a split of the parent element
         // to have the need new line in the final result
         if (!container.hasChildNodes()) {
-            if (isUnbreakable(closestBlock(currentNode.nextSibling))) {
+            if (this.shared.isUnsplittable(closestBlock(currentNode.nextSibling))) {
                 this.dispatch("INSERT_LINEBREAK_NODE", {
                     targetNode: currentNode.nextSibling,
                     targetOffset: 0,
@@ -251,7 +250,7 @@ export class DomPlugin extends Plugin {
                     (!allowsParagraphRelatedElements(currentNode.parentElement) ||
                         currentNode.parentElement.nodeName === "LI")
                 ) {
-                    if (isUnbreakable(currentNode.parentElement)) {
+                    if (this.shared.isUnsplittable(currentNode.parentElement)) {
                         // If we have to insert a table, we cannot afford to unwrap it
                         // we need to search for a more suitable spot to put the table in
                         if (nodeToInsert.nodeName === "TABLE") {
@@ -485,7 +484,7 @@ export class DomPlugin extends Plugin {
     shouldBeMerged(node) {
         return (
             areSimilarElements(node, node.previousSibling) &&
-            !isUnbreakable(node) &&
+            !this.shared.isUnmergeable(node) &&
             !isEditorTab(node) &&
             !(
                 node.attributes?.length === 1 &&

--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -2,7 +2,7 @@ import { Plugin } from "../plugin";
 import { isBlock } from "../utils/blocks";
 import { hasAnyNodesColor } from "@html_editor/utils/color";
 import { unwrapContents } from "../utils/dom";
-import { isUnbreakable, isVisibleTextNode, isZWS } from "../utils/dom_info";
+import { isVisibleTextNode, isZWS } from "../utils/dom_info";
 import { closestElement } from "../utils/dom_traversal";
 import { FONT_SIZE_CLASSES, formatsSpecs } from "../utils/formatting";
 import { DIRECTIONS } from "../utils/position";
@@ -155,7 +155,7 @@ export class FormatPlugin extends Plugin {
             .getTraversedNodes()
             .filter((n) => n.nodeType === Node.TEXT_NODE);
         const isFormatted = formatsSpecs[format].isFormatted;
-        return selectedNodes.length && selectedNodes.some((n) => isFormatted(n, this.editable));
+        return selectedNodes.some((n) => isFormatted(n, this.editable));
     }
     /**
      * Return true if the current selection on the editable appears as the
@@ -241,8 +241,7 @@ export class FormatPlugin extends Plugin {
             while (
                 parentNode &&
                 !isBlock(parentNode) &&
-                !isUnbreakable(parentNode) &&
-                !isUnbreakable(currentNode) &&
+                !this.shared.isUnsplittable(parentNode) &&
                 (parentNode.classList.length === 0 ||
                     [...parentNode.classList].every((cls) => FONT_SIZE_CLASSES.includes(cls)))
             ) {

--- a/addons/html_editor/static/src/core/split_plugin.js
+++ b/addons/html_editor/static/src/core/split_plugin.js
@@ -29,7 +29,6 @@ export class SplitPlugin extends Plugin {
             // "Unbreakable" is a legacy term that means unsplittable and
             // unmergeable.
             (element) => element.classList.contains("oe_unbreakable"),
-            (element) => element.hasAttribute("t"),
             (element) => ["DIV", "SECTION"].includes(element.tagName),
         ],
         onBeforeInput: p.onBeforeInput.bind(p),

--- a/addons/html_editor/static/src/core/split_plugin.js
+++ b/addons/html_editor/static/src/core/split_plugin.js
@@ -1,7 +1,7 @@
 import { Plugin } from "../plugin";
 import { isBlock } from "../utils/blocks";
 import { fillEmpty } from "../utils/dom";
-import { isUnbreakable, isVisible } from "../utils/dom_info";
+import { isVisible } from "../utils/dom_info";
 import { prepareUpdate } from "../utils/dom_state";
 import { childNodes, closestElement, firstLeaf, lastLeaf } from "../utils/dom_traversal";
 import { DIRECTIONS, childNodeIndex } from "../utils/position";
@@ -16,10 +16,22 @@ export class SplitPlugin extends Plugin {
         "splitAroundUntil",
         "splitTextNode",
         "splitSelection",
+        "isUnsplittable",
     ];
     static resources = (p) => ({
-        // @todo: get rules from separate plugins, get rid of isUnbreakable
-        unsplittable: (block) => isUnbreakable(block),
+        isUnsplittable: [
+            // An unremovable element is also unmergeable (as merging two
+            // elements results in removing one of them).
+            // An unmergeable element is unsplittable and vice-versa (as
+            // split and merge are reverse operations from one another).
+            // Therefore, unremovable nodes are also unsplittable.
+            (element) => p.resources.isUnremovable?.some((predicate) => predicate(element)),
+            // "Unbreakable" is a legacy term that means unsplittable and
+            // unmergeable.
+            (element) => element.classList.contains("oe_unbreakable"),
+            (element) => element.hasAttribute("t"),
+            (element) => ["DIV", "SECTION"].includes(element.tagName),
+        ],
         onBeforeInput: p.onBeforeInput.bind(p),
     });
 
@@ -87,6 +99,10 @@ export class SplitPlugin extends Plugin {
     splitElementBlock({ targetNode, targetOffset, blockToSplit }) {
         // If the block is unsplittable, insert a line break instead.
         if (this.isUnsplittable(blockToSplit)) {
+            // @todo: t-if, t-else etc are not blocks, but they are
+            // unsplittable.  The check must be done from the targetNode up to
+            // the block for unsplittables. There are apparently no tests for
+            // this.
             this.dispatch("INSERT_LINEBREAK_ELEMENT", { targetNode, targetOffset });
             return [undefined, undefined];
         }
@@ -115,11 +131,11 @@ export class SplitPlugin extends Plugin {
         return [beforeElement, afterElement];
     }
 
-    // @todo: t-if, t-else etc are not blocks, but they are unsplittable.
-    // The check must be done from the targetNode up to the block for unsplittables
-    // There are apparently no tests for this.
-    isUnsplittable(block) {
-        return this.resources.unsplittable.some((callback) => callback(block));
+    isUnsplittable(node) {
+        return (
+            node.nodeType === Node.ELEMENT_NODE &&
+            this.resources.isUnsplittable.some((predicate) => predicate(node))
+        );
     }
 
     /**

--- a/addons/html_editor/static/src/core/zws_plugin.js
+++ b/addons/html_editor/static/src/core/zws_plugin.js
@@ -55,8 +55,7 @@ export class ZwsPlugin extends Plugin {
             this.cleanZWS(element);
             return;
         }
-        // @todo phoenix: consider making the delete plugin export isUnremovable instead?
-        if (this.resources.unremovables.some((predicate) => predicate(element))) {
+        if (this.resources.isUnremovable.some((predicate) => predicate(element))) {
             return;
         }
         if (element.classList.length) {

--- a/addons/html_editor/static/src/main/column_plugin.js
+++ b/addons/html_editor/static/src/main/column_plugin.js
@@ -32,7 +32,7 @@ export class ColumnPlugin extends Plugin {
     static name = "column";
     static dependencies = ["selection"];
     static resources = () => ({
-        unremovables: isUnremovableColumn,
+        isUnremovable: isUnremovableColumn,
         powerboxCommands: [
             {
                 name: _t("2 columns"),

--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -290,7 +290,7 @@ export class FontPlugin extends Plugin {
         // Detect if cursor is at the start of the editable (collapsed range).
         const rangeIsCollapsed = startContainer === endContainer && startOffset === endOffset;
         if (rangeIsCollapsed) {
-            const isUnremovable = this.resources.unremovables.some((predicate) =>
+            const isUnremovable = this.resources.isUnremovable.some((predicate) =>
                 predicate(closestHandledElement)
             );
             if (

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -32,7 +32,9 @@ export class TablePlugin extends Plugin {
         handle_tab: { callback: p.handleTab.bind(p), sequence: 20 },
         handle_shift_tab: { callback: p.handleShiftTab.bind(p), sequence: 20 },
         handle_delete_range: { callback: p.handleDeleteRange.bind(p) },
-        unremovables: isUnremovableTableComponent,
+        isUnremovable: isUnremovableTableComponent,
+        isUnsplittable: (element) =>
+            element.tagName === "TABLE" || tableInnerComponents.has(element.tagName),
         onSelectionChange: p.updateSelectionTable.bind(p),
     });
 

--- a/addons/html_editor/static/src/others/qweb_plugin.js
+++ b/addons/html_editor/static/src/others/qweb_plugin.js
@@ -2,6 +2,12 @@ import { Plugin } from "@html_editor/plugin";
 import { closestElement } from "@html_editor/utils/dom_traversal";
 import { QWebPicker } from "./qweb_picker";
 
+const isUnsplittableQWebElement = (element) =>
+    element.tagName === "T" ||
+    ["t-field", "t-if", "t-elif", "t-else", "t-foreach", "t-value", "t-esc", "t-out", "t-raw"].some(
+        (attr) => element.getAttribute(attr)
+    );
+
 export class QWebPlugin extends Plugin {
     static name = "qweb";
     static dependencies = ["overlay", "selection"];
@@ -9,6 +15,8 @@ export class QWebPlugin extends Plugin {
     static resources = (p) => ({
         onSelectionChange: p.onSelectionChange.bind(p),
         is_mutation_record_savable: p.isMutationRecordSavable.bind(p),
+        isUnremovable: (element) => element.getAttribute("t-set") || element.getAttribute("t-call"),
+        isUnsplittable: isUnsplittableQWebElement,
     });
 
     setup() {

--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -1,5 +1,5 @@
 import { closestBlock, isBlock } from "./blocks";
-import { ancestors, closestElement, firstLeaf, lastLeaf } from "./dom_traversal";
+import { closestElement, firstLeaf, lastLeaf } from "./dom_traversal";
 import { DIRECTIONS, nodeSize } from "./position";
 
 export function isEmpty(el) {
@@ -271,55 +271,6 @@ export const isNotEditableNode = (node) =>
     node.getAttribute &&
     node.getAttribute("contenteditable") &&
     node.getAttribute("contenteditable").toLowerCase() === "false";
-
-export function isUnbreakable(node) {
-    if (!node || node.nodeType === Node.TEXT_NODE) {
-        return false;
-    }
-    if (node.nodeType !== Node.ELEMENT_NODE) {
-        return true;
-    }
-    return (
-        isUnremovable(node) || // An unremovable node is always unbreakable.
-        // @todo @phoenix: move the specific part in a proper plugin.
-        ["TABLE", "THEAD", "TBODY", "TFOOT", "TR", "TH", "TD", "SECTION", "DIV"].includes(
-            node.tagName
-        ) ||
-        node.hasAttribute("t") ||
-        (node.nodeType === Node.ELEMENT_NODE &&
-            (node.nodeName === "T" ||
-                node.getAttribute("t-if") ||
-                node.getAttribute("t-esc") ||
-                node.getAttribute("t-elif") ||
-                node.getAttribute("t-else") ||
-                node.getAttribute("t-foreach") ||
-                node.getAttribute("t-value") ||
-                node.getAttribute("t-out") ||
-                node.getAttribute("t-raw"))) ||
-        node.getAttribute("t-field") ||
-        node.classList.contains("oe_unbreakable")
-    );
-}
-
-// @todo @phoenix: adapt .oid parts
-export function isUnremovable(node) {
-    return (
-        (node.nodeType !== Node.ELEMENT_NODE && node.nodeType !== Node.TEXT_NODE) ||
-        node.oid === "root" ||
-        // @todo @phoenix: move the specific part in a proper plugin.
-        (node.nodeType === Node.ELEMENT_NODE &&
-            (node.classList.contains("o_editable") ||
-                node.getAttribute("t-set") ||
-                node.getAttribute("t-call"))) ||
-        (node.classList && node.classList.contains("oe_unremovable")) ||
-        (node.nodeName === "SPAN" &&
-            node.parentElement &&
-            node.parentElement.getAttribute("data-oe-type") === "monetary") ||
-        (node.ownerDocument &&
-            node.ownerDocument.defaultWindow &&
-            !ancestors(node).find((ancestor) => ancestor.oid === "root")) // Node is in DOM but not in editable.
-    );
-}
 
 const iconTags = ["I", "SPAN"];
 // @todo @phoenix: move the specific part in a proper plugin.

--- a/addons/html_editor/static/tests/format/font_size.test.js
+++ b/addons/html_editor/static/tests/format/font_size.test.js
@@ -3,6 +3,8 @@ import { testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { strong } from "../_helpers/tags";
 import { setFontSize } from "../_helpers/user_actions";
+import { Plugin } from "@html_editor/plugin";
+import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
 
 test("should change the font size of a few characters", async () => {
     await testEditor({
@@ -153,10 +155,16 @@ test("should apply font size in unbreakable span with class", async () => {
 });
 
 test("should apply font size in unbreakable span without class", async () => {
+    class AddUnsplittableRulePlugin extends Plugin {
+        static resources = () => ({
+            isUnsplittable: (element) => element.getAttribute("t") === "unbreakable",
+        });
+    }
     await testEditor({
         contentBefore: `<h1><span t="unbreakable">some [text]</span></h1>`,
         stepFunction: setFontSize("18px"),
         contentAfter: `<h1><span t="unbreakable">some <span style="font-size: 18px;">[text]</span></span></h1>`,
+        config: { Plugins: [...MAIN_PLUGINS, AddUnsplittableRulePlugin] },
     });
 });
 

--- a/addons/html_editor/static/tests/unbreakable/delete.test.js
+++ b/addons/html_editor/static/tests/unbreakable/delete.test.js
@@ -452,9 +452,9 @@ describe("list", () => {
         test("should not outdent while nested within a list item if the list is unbreakable", async () => {
             // Only one LI.
             await testEditor({
-                contentBefore: '<p>abc</p><ol t="1"><li>[]def</li></ol>',
+                contentBefore: '<p>abc</p><ol class="oe_unbreakable"><li>[]def</li></ol>',
                 stepFunction: deleteBackward,
-                contentAfter: '<p>abc</p><ol t="1"><li>[]def</li></ol>',
+                contentAfter: '<p>abc</p><ol class="oe_unbreakable"><li>[]def</li></ol>',
             });
             // First LI.
             // await testEditor({


### PR DESCRIPTION
An "unbreakable" element means that:
- it cannot be split into two elements (e.g. pressing enter inside a block splits it into two, unless it is unbreakable), AND
- it cannot be merged with another element (e.g. when deleting content across two blocks, they get merged into one, unless one of them is unbreakable).

This double meaning concept often leads to confusion, and for this reason this commit splits it into two different self-explanatory concepts: "unsplittable" and "unmergeable".

Moreover, the rules for an element to be considered "unsplittable" or "unmergeable" are distributed among the concerned plugins, similarly to what is done to "unremovable" elements.

