### PR TITLE
[FIX] l10n_latam_check: received third party check not "on hand"

### DIFF
--- a/addons/l10n_latam_check/views/account_payment_view.xml
+++ b/addons/l10n_latam_check/views/account_payment_view.xml
@@ -40,7 +40,7 @@
                 <separator/>
                 <filter string="Checks on hand" name="checks_on_hand"
                     domain="[('state', '=', 'posted'),
-                                ('l10n_latam_check_current_journal_id.inbound_payment_method_line_ids.payment_method_id.code', '=', 'in_third_party_checks')]"/>
+                                ('l10n_latam_check_current_journal_id.inbound_payment_method_line_ids.payment_method_id.code', 'in', ['new_third_party_checks', 'in_third_party_checks'])]"/>
             </filter>
             <filter name="journal" position="after">
                 <filter name="groupby_third_party_check_current_journal"


### PR DESCRIPTION
Version: 16

Description of the issue/feature this PR addresses:

A third party check received in a customer payment with journal with type "Cash" and Incoming payment method "New Third Party Checks" is not on hand in menu "Accounting / Customers / Third Party Checks" if journal doesn't has "Existing Third Party Checks" incoming payment method.

Steps to reproduce:

1) Log in with admin on runbot odoo enterprise 16 instance and install l10n_latam_check (Third Party and Deferred/Electronic Checks Management) module.

2) Go to "Accounting / Configuration /Accounting / Journals" and create a new journal of type "Cash" and add incoming payment method "New Third Party Checks".
![image](https://github.com/user-attachments/assets/a600542a-8e35-473a-b5a6-66b6d6cbc15b)

3) Create a new customer payment with journal created on step 2 and "New Third Party Checks" payment method and confirm.
![image](https://github.com/user-attachments/assets/4036ef78-03d1-4993-aa66-a49ae7174069)

4) Go to menu Third Party Checks and the check received on step 3 is not on hand.
![image](https://github.com/user-attachments/assets/84fe2ffb-3ce4-42df-9cd6-c31dd81c84dd)


Current behavior before PR:

A third party check received in a customer payment with journal with type "Cash" and Incoming payment method "New Third Party Checks" is not on hand on tree view in "Accounting / Customers / Third Party Checks" if the journal doesn't has "Existing Third Party Checks" incoming payment method.

Desired behavior after PR is merged:

A third party check received in a customer payment with journal with type "Cash" and Incoming payment method "New Third Party Checks" is on hand on tree view in "Accounting / Customers / Third Party Checks" if the journal doesn't has "Existing Third Party Checks" incoming payment method.

Ticket Adhoc side: 77887
Task Latam side: 1234


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
