### PR TITLE
[IMP] hw_posbox_homepage: better logging page

### DIFF
--- a/addons/hw_posbox_homepage/controllers/__init__.py
+++ b/addons/hw_posbox_homepage/controllers/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import main
+from . import logging

--- a/addons/hw_posbox_homepage/controllers/logging.py
+++ b/addons/hw_posbox_homepage/controllers/logging.py
@@ -1,0 +1,151 @@
+
+import functools
+import logging
+import platform
+import re
+
+from .main import jinja_env
+
+from odoo import http, tools
+from odoo.addons.hw_drivers.tools import helpers
+from odoo.addons.hw_drivers.server_logger import check_and_update_odoo_config_log_to_server_option, get_odoo_config_log_to_server_option
+from odoo.http import request
+
+LOGGING_HTML = jinja_env.get_template('logging.jinja2')
+LOGGING_TABLE_HTML = jinja_env.get_template('logging_table.jinja2')
+
+LOGGING_TABLE_PRIORITY = ('odoo', 'werkzeug', 'websocket')
+LOGGING_TABLE_WHITELIST = {'root', r'odoo\.addons', r'odoo\.addons\.hw_drivers', r'odoo\.addons\.hw_drivers\..*', *LOGGING_TABLE_PRIORITY}
+
+class LoggerNode:
+    def __init__(self, logger_name:str, logger: logging.Logger) -> None:
+        self.logger_name = logger_name
+        self.logger = logger
+        self.children = []
+        self.parent = None
+
+    @property
+    def is_level_parent(self):
+        return self.logger.getEffectiveLevel() == logging.NOTSET
+
+    @property
+    def level_str(self):
+        return logging.getLevelName(self.logger.level).lower()
+
+    @property
+    def is_level_inherited(self):
+        return self.logger.level == logging.NOTSET
+
+    @property
+    def level_efficient_str(self):
+        return logging.getLevelName(self.logger.getEffectiveLevel()).lower()
+
+    @property
+    @functools.lru_cache()
+    def exists(self):
+        # Non-existing loggers will be `logging.PlaceHolder` instances
+        return isinstance(self.logger, logging.Logger)
+
+    @property
+    @functools.lru_cache()
+    def logger__name__(self):
+        i = self.logger_name.rfind('.', 0, len(self.logger_name) - 1)
+        if i == -1:
+            return self.logger_name
+        return self.logger_name[i + 1:]
+    
+    @property
+    @functools.lru_cache()
+    def available_levels(self):
+        ret = ['debug', 'info', 'warning', 'error']
+        if self.logger_name != 'root':
+            ret = ['parent'] + ret
+        return ret
+
+    def add_child(self, child: 'LoggerNode', parent: 'LoggerNode'=None):
+        child.parent = parent
+        self.children.append(child)
+
+def _save_odoo_config_file(should_save=True):
+    if not should_save:
+        return
+    with helpers.writable():
+        tools.config.save()
+
+class IoTTechnicalLogging(http.Controller):
+    @http.route('/technical/logging', type='http', auth='none', csrf=False)
+    def logging(self, **post):
+        if request.httprequest.method == 'POST':
+            new_should_send_logs_to_server = post.get('log-to-server') == 'on' # we use .get() as if the HTML checkbox is unchecked, no value is given in the POST request
+
+            _save_odoo_config_file(
+                check_and_update_odoo_config_log_to_server_option(
+                    new_should_send_logs_to_server
+                )
+            )
+
+        return jinja_env.get_template('logging.jinja2').render({
+            'os': platform.system(),
+            'ip': helpers.get_ip(),
+            'is_log_to_server_activated': get_odoo_config_log_to_server_option(),
+        })
+
+    @classmethod
+    def _update_logger_level(cls, logger_name, new_level):
+        # Checks
+        assert new_level in {'debug', 'info', 'warning', 'error', 'parent'}, f"Invalid level '{new_level}'"
+        assert cls._is_authorised_logger(logger_name), f"Logger '{logger_name}' is not authorised to modify"
+        if logger_name == 'root':
+            logger_name = ''  # change it as previosuly use this name for root logger
+        assert logger_name == '' or logger_name in logging.Logger.manager.loggerDict, f"Logger '{logger_name}' does not exist"
+        is_new_level_parent = new_level == 'parent'
+        if logger_name == '':
+            assert not is_new_level_parent, "Cannot set root logger to parent level"
+        real_new_level = logging.NOTSET if is_new_level_parent else new_level.upper()
+
+        # Change the level of the logger dynamically first
+        logging.getLogger(logger_name).setLevel(real_new_level)
+
+
+        # Edit odoo config file to persist the changes
+        # `tools.config[ODOO_CONFIG_NAME_LOG_HANDLER]` value is a list of `<logger.name>:<LEVEL>`
+        # e.g:[':INFO', 'werkzeug:CRITICAL', 'odoo.fields:WARNING']`
+
+        # 1) Have a version of all loggers, without the modified one
+        log_handlers_without_logger = [
+            log_handler for log_handler in tools.config['log_handler'] if not log_handler.startswith(logger_name+':')
+        ]
+        # 2) Add the modified logger to the list. If it is parent level, then it will simply not be in the list
+        if not is_new_level_parent:
+            log_handlers_without_logger.append(f'{logger_name}:{real_new_level}')
+        tools.config['log_handler'] = log_handlers_without_logger
+        _save_odoo_config_file()
+
+    @staticmethod
+    def _is_authorised_logger(logger_name):
+        return any(re.fullmatch(pattern, logger_name) for pattern in LOGGING_TABLE_WHITELIST)
+
+    @http.route('/technical/logging/logging-table', type='http', auth='none', csrf=False)
+    def logging_table(self, **logger_name_new_level_dict):
+        if request.httprequest.method == 'POST':
+            self._update_logger_level(*logger_name_new_level_dict.popitem())
+        return jinja_env.get_template('logging_table.jinja2').render(log_tree=self._get_logger_tree())
+
+    def _get_logger_tree(self):
+        loggers = list(logging.Logger.manager.loggerDict.items())
+        # apply whitelist
+        loggers = [(name, logger) for name, logger in loggers if self._is_authorised_logger(name)]
+        # sort by priority
+        loggers = sorted(loggers, key=lambda x: (not x[0].startswith(LOGGING_TABLE_PRIORITY), x[0]))
+
+        root = LoggerNode('root', logging.root)
+        all_nodes = {}
+        for logger_name, logger in loggers:
+            all_nodes[logger_name] = node = LoggerNode(logger_name, logger)
+            i = logger_name.rfind('.', 0, len(logger_name) - 1)  # same formula used in `logging`
+            if i == -1:
+                parent = root
+            else:
+                parent = all_nodes[logger_name[:i]]
+            parent.add_child(node, parent)
+        return root

--- a/addons/hw_posbox_homepage/controllers/main.py
+++ b/addons/hw_posbox_homepage/controllers/main.py
@@ -12,13 +12,13 @@ import subprocess
 import sys
 import threading
 
-from odoo import http, service, tools
-from odoo.http import Response, request
+from odoo import http, service
+from odoo.http import Response
 from odoo.modules.module import get_resource_path
 from odoo.addons.hw_drivers.connection_manager import connection_manager
 from odoo.addons.hw_drivers.main import iot_devices
 from odoo.addons.hw_drivers.tools import helpers
-from odoo.addons.hw_drivers.server_logger import check_and_update_odoo_config_log_to_server_option, close_server_log_sender_handler, get_odoo_config_log_to_server_option
+from odoo.addons.hw_drivers.server_logger import close_server_log_sender_handler
 from odoo.addons.web.controllers.home import Home
 
 _logger = logging.getLogger(__name__)
@@ -111,46 +111,8 @@ class IoTboxHomepage(Home):
         else:
             return homepage_template.render(self.get_homepage_data())
 
-    @http.route('/list_handlers', type='http', auth='none', website=True, csrf=False, save_session=False)
-    def list_handlers(self, **post):
-        AVAILABLE_LOG_LEVELS = ('debug', 'info', 'warning', 'error')
-        if request.httprequest.method == 'POST':
-            need_config_save = False  # If the config file needed to be saved at the end
-
-            # Check and update "send logs to server"
-            need_config_save |= check_and_update_odoo_config_log_to_server_option(
-                post.get('log-to-server') == 'on' # we use .get() as if the HTML checkbox is unchecked, no value is given in the POST request
-            )
-
-            # Check and update logging levels
-            IOT_LOGGING_PREFIX = 'iot-logging-'
-            INTERFACE_PREFIX = 'interface-'
-            DRIVER_PREFIX = 'driver-'
-            AVAILABLE_LOG_LEVELS_WITH_PARENT = AVAILABLE_LOG_LEVELS + ('parent',)
-            for post_request_key, log_level_or_parent in post.items():
-                if not post_request_key.startswith(IOT_LOGGING_PREFIX):
-                    # probably a new post request payload argument not related to logging
-                    continue
-                post_request_key = post_request_key[len(IOT_LOGGING_PREFIX):]
-
-                if post_request_key == 'root':
-                    need_config_save |= self._update_logger_level('', log_level_or_parent, AVAILABLE_LOG_LEVELS)
-                elif post_request_key == 'odoo':
-                    need_config_save |= self._update_logger_level('odoo', log_level_or_parent, AVAILABLE_LOG_LEVELS)
-                    need_config_save |= self._update_logger_level('werkzeug', log_level_or_parent if log_level_or_parent != 'debug' else 'info', AVAILABLE_LOG_LEVELS)
-                elif post_request_key.startswith(INTERFACE_PREFIX):
-                    logger_name = post_request_key[len(INTERFACE_PREFIX):]
-                    need_config_save |= self._update_logger_level(logger_name, log_level_or_parent, AVAILABLE_LOG_LEVELS_WITH_PARENT, 'interfaces')
-                elif post_request_key.startswith(DRIVER_PREFIX):
-                    logger_name = post_request_key[len(DRIVER_PREFIX):]
-                    need_config_save |= self._update_logger_level(logger_name, log_level_or_parent, AVAILABLE_LOG_LEVELS_WITH_PARENT, 'drivers')
-                else:
-                    _logger.warning('Unhandled iot logger: %s', post_request_key)
-
-            # Update and save the config file (in case of IoT box reset)
-            if need_config_save:
-                with helpers.writable():
-                    tools.config.save()
+    @http.route('/list_handlers', type='http', auth='none', website=True, csrf=False)
+    def list_handlers(self):
         drivers_list = helpers.list_file_by_os(get_resource_path('hw_drivers', 'iot_handlers', 'drivers'))
         interfaces_list = helpers.list_file_by_os(get_resource_path('hw_drivers', 'iot_handlers', 'interfaces'))
         return handler_list_template.render({
@@ -159,13 +121,6 @@ class IoTboxHomepage(Home):
             'drivers_list': drivers_list,
             'interfaces_list': interfaces_list,
             'server': helpers.get_odoo_server_url(),
-            'is_log_to_server_activated': get_odoo_config_log_to_server_option(),
-            'root_logger_log_level': self._get_logger_effective_level_str(logging.getLogger()),
-            'odoo_current_log_level': self._get_logger_effective_level_str(logging.getLogger('odoo')),
-            'recommended_log_level': 'warning',
-            'available_log_levels': AVAILABLE_LOG_LEVELS,
-            'drivers_logger_info': self._get_iot_handlers_logger(drivers_list, 'drivers'),
-            'interfaces_logger_info': self._get_iot_handlers_logger(interfaces_list, 'interfaces'),
         })
 
     @http.route('/load_iot_handlers', type='http', auth='none', website=True)
@@ -430,107 +385,3 @@ class IoTboxHomepage(Home):
         except Exception as e:
             _logger.error('An error encountered : %s ', e)
             return str(e)
-
-    def _get_logger_effective_level_str(self, logger):
-        return logging.getLevelName(logger.getEffectiveLevel()).lower()
-
-    def _get_iot_handler_logger(self, handler_name, handler_folder_name):
-        """
-        Get Odoo Iot logger given an IoT handler name
-        :param handler_name: name of the IoT handler
-        :param handler_folder_name: IoT handler folder name (interfaces or drivers)
-        :return: logger if any, False otherwise
-        """
-        odoo_addon_handler_path = helpers.compute_iot_handlers_addon_name(handler_folder_name, handler_name)
-        return odoo_addon_handler_path in logging.Logger.manager.loggerDict.keys() and \
-               logging.getLogger(odoo_addon_handler_path)
-
-    def _update_logger_level(self, logger_name, new_level, available_log_levels, handler_folder=False):
-        """
-        Update (if necessary) Odoo's configuration and logger to the given logger_name to the given level.
-        The responsibility of saving the config file is not managed here.
-        :param logger_name: name of the logging logger to change level
-        :param new_level: new log level to set for this logger
-        :param available_log_levels: iterable of logs levels allowed (for initial check)
-        :param handler_folder: optional string of the IoT handler folder name ('interfaces' or 'drivers')
-        :return: wherever some changes were performed or not on the config
-        """
-        if new_level not in available_log_levels:
-            _logger.warning('Unknown level to set on logger %s: %s', logger_name, new_level)
-            return False
-
-        if handler_folder:
-            logger = self._get_iot_handler_logger(logger_name, handler_folder)
-            if not logger:
-                _logger.warning('Unable to change log level for logger %s as logger missing', logger_name)
-                return False
-            logger_name = logger.name
-
-        ODOO_TOOL_CONFIG_HANDLER_NAME = 'log_handler'
-        LOG_HANDLERS = tools.config[ODOO_TOOL_CONFIG_HANDLER_NAME]
-        LOGGER_PREFIX = logger_name + ':'
-        IS_NEW_LEVEL_PARENT = new_level == 'parent'
-
-        if not IS_NEW_LEVEL_PARENT:
-            intended_to_find = LOGGER_PREFIX + new_level.upper()
-            if intended_to_find in LOG_HANDLERS:
-                # There is nothing to do, the entry is already inside
-                return False
-
-        # We remove every occurrence for the given logger
-        log_handlers_without_logger = [
-            log_handler for log_handler in LOG_HANDLERS if not log_handler.startswith(LOGGER_PREFIX)
-        ]
-
-        if IS_NEW_LEVEL_PARENT:
-            # We must check that there is no existing entries using this logger (whatever the level)
-            if len(log_handlers_without_logger) == len(LOG_HANDLERS):
-                return False
-
-        # We add if necessary new logger entry
-        # If it is "parent" it means we want it to inherit from the parent logger.
-        # In order to do this we have to make sure that no entries for the logger exists in the
-        # `log_handler` (which is the case at this point as long as we don't re-add an entry)
-        tools.config[ODOO_TOOL_CONFIG_HANDLER_NAME] = log_handlers_without_logger
-        new_level_upper_case = new_level.upper()
-        if not IS_NEW_LEVEL_PARENT:
-            new_entry = [LOGGER_PREFIX + new_level_upper_case]
-            tools.config[ODOO_TOOL_CONFIG_HANDLER_NAME] += new_entry
-            _logger.debug('Adding to odoo config log_handler: %s', new_entry)
-
-        # Update the logger dynamically
-        real_new_level = logging.NOTSET if IS_NEW_LEVEL_PARENT else new_level_upper_case
-        _logger.debug('Change logger %s level to %s', logger_name, real_new_level)
-        logging.getLogger(logger_name).setLevel(real_new_level)
-        return True
-
-    def _get_iot_handlers_logger(self, handlers_name, iot_handler_folder_name):
-        """
-        :param handlers_name: List of IoT handler string to search the loggers of
-        :param iot_handler_folder_name: name of the handler folder ('interfaces' or 'drivers')
-        :return:
-        {
-            <iot_handler_name_1> : {
-                'level': <logger_level_1>,
-                'is_using_parent_level': <logger_use_parent_level_or_not_1>,
-                'parent_name': <logger_parent_name_1>,
-            },
-            ...
-        }
-        """
-        handlers_loggers_level = dict()
-        for handler_name in handlers_name:
-            handler_logger = self._get_iot_handler_logger(handler_name, iot_handler_folder_name)
-            if not handler_logger:
-                # Might happen if the file didn't define a logger (or not init yet)
-                handlers_loggers_level[handler_name] = False
-                _logger.debug('Unable to find logger for handler %s', handler_name)
-                continue
-            logger_parent = handler_logger.parent
-            handlers_loggers_level[handler_name] = {
-                'level': self._get_logger_effective_level_str(handler_logger),
-                'is_using_parent_level': handler_logger.level == logging.NOTSET,
-                'parent_name': logger_parent.name,
-                'parent_level': self._get_logger_effective_level_str(logger_parent),
-            }
-        return handlers_loggers_level

--- a/addons/hw_posbox_homepage/views/handler_list.html
+++ b/addons/hw_posbox_homepage/views/handler_list.html
@@ -23,106 +23,28 @@
     </script>
 {% endblock %}
 {% block content %}
-    <h2 class="text-center text-green">Logging</h2>
-    <form method="post">
-        <input type="checkbox" id="log-to-server" name="log-to-server" {{ "checked" if is_log_to_server_activated }} />
-        <label for="log-to-server">IoT logs automatically send to server logs</label>
-        <div style="text-align: left;display:block;">
-            <label for="iot-logging-root">Root log level (Current value: {{root_logger_log_level}}):</label>
-            <select name="iot-logging-root" id="iot-logging-root">
-            {% for log_level in available_log_levels %}
-                <option value="{{ log_level }}" {{ "selected" if log_level == root_logger_log_level }}>
-                    {{ log_level | capitalize }} {{ "(Recommended)" if log_level == recommended_log_level }}
-                </option>
-            {% endfor %}
-            </select>
-
-            <label for="iot-logging-odoo">Odoo log level (Current value: {{odoo_current_log_level}}):</label>
-            <select name="iot-logging-odoo" id="iot-logging-odoo">
-            {% for log_level in available_log_levels %}
-                <option value="{{ log_level }}" {{ "selected" if log_level == odoo_current_log_level }}>
-                    {{ log_level | capitalize }} {{ "(Recommended)" if log_level == recommended_log_level }}
-                </option>
-            {% endfor %}
-            </select>
-        </div>
-
-        <h2 class="text-center text-green">Interfaces list</h2>
-        <table align="center" width="80%" cellpadding="3">
-            <tr>
-                <th>Name</th>
-                <th>Log Level</th>
-            </tr>
-            {% for interface in interfaces_list -%}
-                <tr>
-                    <td>{{ interface }}</td>
-                    <td>
-                        {% set interface_logger_info = interfaces_logger_info[interface] %}
-                        {% if interface_logger_info != False %}
-                            <select name="iot-logging-interface-{{interface}}">
-                                <option value="parent" {{ "selected" if interface_logger_info.is_using_parent_level }}>
-                                    Same as {{ interface_logger_info.parent_name | capitalize }} ({{ interface_logger_info.parent_level | capitalize }})
-                                </option>
-                                <option style="font-size: 1pt; background-color: black;" disabled>&nbsp;</option>
-                                {% for log_level in available_log_levels %}
-                                <option value="{{ log_level }}" {{ "selected" if not interface_logger_info.is_using_parent_level and log_level == interface_logger_info.level }}>
-                                    {{ log_level | capitalize }}
-                                </option>
-                                {% endfor %}
-                            </select>
-                        {% else %}
-                            <span class="font-small">Logger uninitialised</span>
-                        {% endif %}
-                    </td>
-                </tr>
-            {%- endfor %}
-        </table>
-
-        <h2 class="text-center text-green">Drivers list</h2>
-        <table align="center" width="80%" cellpadding="3">
-            <tr>
-                <th>Name</th>
-                <th>Log Level</th>
-            </tr>
-            {% for driver in drivers_list -%}
-                <tr>
-                    <td>{{ driver }}</td>
-                    <td>
-                        {% set driver_logger_info = drivers_logger_info[driver] %}
-                        {% if driver_logger_info != False %}
-                            <select name="iot-logging-driver-{{driver}}">
-                                <option value="parent" {{ "selected" if driver_logger_info.is_using_parent_level }}>
-                                    Same as {{ driver_logger_info.parent_name | capitalize }} ({{ driver_logger_info.parent_level | capitalize }})
-                                </option>
-                                <option style="font-size: 1pt; background-color: black;" disabled>&nbsp;</option>
-                                {% for log_level in available_log_levels %}
-                                <option value="{{ log_level }}" {{ "selected" if not driver_logger_info.is_using_parent_level and log_level == driver_logger_info.level }}>
-                                    {{ log_level | capitalize }}
-                                </option>
-                                {% endfor %}
-                            </select>
-                        {% else %}
-                            <span class="font-small">Logger uninitialised</span>
-                        {% endif %}
-                    </td>
-                </tr>
-            {%- endfor %}
-        </table>
-
-        <div style="margin-top: 20px;" class="text-center">
-            {% if server %}
-                <a id="load_handler_btn" class="btn" href='/load_iot_handlers'>Load handlers</a>
-            {% endif %}
-            <input class="btn" type="submit" value="Update Logs Configuration"/>
-        </div>
-    </form>
+    <h2 class="text-center text-green">Interfaces list</h2>
+    <table align="center" width="50%" cellpadding="3">
+        {% for interfaces in interfaces_list -%}
+            <tr><td>{{ interfaces }}</td></tr>
+        {%- endfor %}
+    </table>
+    <h2 class="text-center text-green">Drivers list</h2>
+    <table align="center" width="50%" cellpadding="3">
+        {% for driver in drivers_list -%}
+            <tr><td>{{ driver }}</td></tr>
+        {%- endfor %}
+    </table>
     {% if server %}
-        <div class="text-center font-small" style="margin: 10px auto;">
-            You can clear the handlers configuration
-            <form style="display: inline-block;margin-left: 4px;" action='/handlers_clear'>
-                <input class="btn btn-sm" type="submit" value="Clear"/>
-            </form>
-        </div>
+    <div style="margin-top: 20px;" class="text-center">
+        <a id="load_handler_btn" class="btn" href='/load_iot_handlers'>Load handlers</a>
+    </div>
+    <div class="text-center font-small" style="margin: 10px auto;">
+        You can clear the handlers configuration
+        <form style="display: inline-block;margin-left: 4px;" action='/handlers_clear'>
+            <input class="btn btn-sm" type="submit" value="Clear"/>
+        </form>
+    </div>
     {% endif %}
     {{ loading_block_ui('Loading Handlers') }}
 {% endblock %}

--- a/addons/hw_posbox_homepage/views/logging.jinja2
+++ b/addons/hw_posbox_homepage/views/logging.jinja2
@@ -1,0 +1,30 @@
+
+{% extends "layout.html" %}
+
+{% block content %}
+<h2>Logging</h2>
+<h3>Log Files</h3>
+<a class="btn" href="/hw_drivers/download_logs">Download log file</a>
+{% if os == 'Linux' %}
+    {#
+    Don't use a normal link as if use with :8069 it will not work as the route is served by nginx, see:
+    https://github.com/odoo/odoo/pull/165765/files
+    #}
+    <a class="btn" targer="_blank" href="http://{{ip}}/odoo-logs/">Logs Folder</a>
+{% endif %}
+
+<h3>Log Level Table</h3>
+<p>
+    This tool allows you to adjust the level of detail in the IoT log file.<br>
+    It will <b>NOT</b> change the behavior of the IoT, only the amount of information that is store in the log file while the IoT runs.<br>
+    Used for debugging/troubleshooting purposes, should be used with caution.
+</p>
+<iframe src="/technical/logging/logging-table" style="width: 100%; height: 300px; border: none;"></iframe>
+
+<h3>Other configuration</h3>
+<form method="POST">
+    <input type="checkbox" id="log-to-server" name="log-to-server" {{ "checked" if is_log_to_server_activated }} onchange="this.form.submit()"  />
+    <label for="log-to-server">IoT logs automatically send to server logs</label>
+</form>
+
+{% endblock %}

--- a/addons/hw_posbox_homepage/views/logging_table.jinja2
+++ b/addons/hw_posbox_homepage/views/logging_table.jinja2
@@ -1,0 +1,131 @@
+<html>
+<head>
+  <style>
+    table {
+      width: 100%;
+    }
+    thead {
+      background-color: #f0f0f0;
+      color: #333;
+      position: sticky;
+      top: 0;
+      z-index: 1; /* Ensure the header stays above the table rows */
+    }
+    thead th {
+      border-bottom: 2px solid #a3a3a3;
+    }
+    tbody th, td {
+      padding: 8px;
+      text-align: left;
+      border-bottom: 1px solid #ddd;
+    }
+    tbody tr:nth-child(even) {
+      background-color: #f2f2f2;
+    }
+    tbody tr:nth-child(odd) {
+      background-color: #ffffff;
+    }
+    tbody tr:hover {
+      background-color: #d8d8d8;
+    }
+    .log-level-debug {
+      color: blue;
+    }
+    .log-level-info {
+      color: green;
+    }
+    .log-level-warning {
+      color: orange;
+    }
+    .log-level-error {
+      color: red;
+    }
+    .log-level-critical {
+      color: darkred;
+    }
+    select {
+      padding: 8px;
+      border: 1px solid #ddd;
+      border-radius: 4px;
+      background-color: #f9f9f9;
+      font-size: 16px;
+      color: #333;
+    }
+  </style>
+  <script>
+    function loggingSelectChange(element, loggerName) {
+      element.name = loggerName;
+      element.form.submit();
+    }
+  </script>
+</head>
+<body>
+{% macro render_log_level_row(log_node, tree_level) -%}
+  {% set log_level_color = {
+    'debug': 'log-level-debug',
+      'info': 'log-level-info',
+      'warning': 'log-level-warning',
+      'error': 'log-level-error',
+      'critical': 'log-level-critical',
+  } %}
+  <tr>
+    <td style="opacity: {{ '0.6' if not log_node.exists else '1' }}; padding-left: {{ 8 + tree_level * 5 }}px;" 
+    {% if not log_node.exists %}
+      colspan="3"
+      title="Logger uninitialised for the python module: {{ log_node.logger_name }}"
+    {% else %}
+      title="Full name: {{ log_node.logger_name }}"
+    {% endif %}
+    >
+      {{ log_node.logger__name__ }}</td>
+    {% if log_node.exists %}
+      <td class="{{ log_level_color[log_node.level_efficient_str] }}"
+      {% if log_node.is_level_inherited %}
+        title="Inherited from parent logger: {{ log_node.parent.logger__name__ }}"
+      {% endif %}
+      >
+      {% if log_node.is_level_inherited %}
+        <i>
+      {% endif %}
+      {{ log_node.level_efficient_str }}
+      {% if log_node.is_level_inherited %}
+        </i>
+      {% endif %}
+      </td>
+      <td>
+      <select class="logging-selection" onchange="loggingSelectChange(this, '{{ log_node.logger_name }}')" >
+        {% for level in log_node.available_levels %}
+          <option value="{{ level }}" 
+          {% if log_node.is_level_inherited and level == 'parent' or not log_node.is_level_inherited and level == log_node.level_efficient_str %}
+            selected
+          {% endif %}
+          >
+            {{ level }}
+          </option>
+        {% endfor %}
+      </select>
+      </td>
+    {% endif %}
+  </tr>
+  
+  {% for child in log_node.children %}
+      {{ render_log_level_row(child, tree_level + 1) }}
+  {% endfor %}
+{%- endmacro %}
+
+<form method="POST">
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th><th>Level</th><th>Change</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{ render_log_level_row(log_tree, 0) }}
+    </tbody>
+  </table>
+</form>
+
+
+</body>
+</html>


### PR DESCRIPTION
[IMP] hw_posbox_homepage: better logging page

Improve the IoT logging by having a dedicate page rather than sharing the "Handlers List" page which was not meant for this.

We partially reverted/clean these 2 PR:
 - https://github.com/odoo/odoo/pull/134174
 - https://github.com/odoo/odoo/pull/150920

Also include a button now to download the logs from the IoT itself.
IoT-box only: added a button to browse the IoT logs folder (see: https://github.com/odoo/odoo/pull/165765) which is the only way to download logs which are older than today

Preview:
![image](https://github.com/user-attachments/assets/26e9998f-b09c-4d03-9d67-8c16849636e9)
