### PR TITLE
[FIX] stock: broken storage location link

### DIFF
--- a/addons/stock/views/res_config_settings_views.xml
+++ b/addons/stock/views/res_config_settings_views.xml
@@ -113,7 +113,7 @@
                                     </div>
                                 </div>
                             </setting>
-                            <setting id="manage_product_packaging" title="Manage product packagings (e.g. pack of 6 bottles, box of 10 pieces)" help="Manage product packagings (e.g. pack of 6 bottles, box of 10 pieces)" documentation="/applications/inventory_and_mrp/inventory/management/products/usage.html#packaging">
+                            <setting id="manage_product_packaging" title="Packagings" help="Manage product packagings (e.g. pack of 6 bottles, box of 10 pieces)" documentation="/applications/inventory_and_mrp/inventory/product_management/product_tracking/packaging.html">
                                 <field name="group_stock_packaging"/>
                                 <div class="content-group">
                                     <div class="mt8" invisible="not group_stock_packaging">
@@ -145,7 +145,7 @@
                             </setting>
                         </block>
                         <block title="Warehouse" name="warehouse_setting_container">
-                            <setting id="track_product_location" help="Track product location in your warehouse" documentation="/applications/inventory_and_mrp/inventory/management/warehouses/warehouses_locations.html" title="Store products in specific locations of your warehouse (e.g. bins, racks) and to track inventory accordingly.">
+                            <setting id="track_product_location" help="Track product location in your warehouse" documentation="/applications/inventory_and_mrp/inventory/warehouses_storage/inventory_management/use_locations.html" title="Store products in specific locations of your warehouse (e.g. bins, racks) and to track inventory accordingly.">
                                 <field name="group_stock_multi_locations"/>
                                 <div class="content-group">
                                     <div class="mt8" invisible="not group_stock_multi_locations">


### PR DESCRIPTION
Update links to Packaging and Storage Location documentation on Inventory > Settings > Configuration page
