### PR TITLE
[FIX] hr_holidays: timeoff is accrued on carryover date.

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -820,6 +820,7 @@ class HolidaysAllocation(models.Model):
         self.number_of_days_display = 0.0
         self.number_of_hours_display = 0.0
         self.number_of_days = 0.0
+        self.already_accrued = False
         date_to = min(self.date_to, date.today()) if self.date_to else False
         self._process_accrual_plans(date_to)
 

--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -7,6 +7,7 @@ import pytz
 
 from collections import defaultdict
 from datetime import date, datetime, time
+from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models
 from odoo.exceptions import ValidationError
@@ -592,6 +593,12 @@ class HolidaysType(models.Model):
             carryover_date = False
             if carryover_policy in ['maximum', 'lost']:
                 carryover_date = allocation._get_carryover_date(target_date)
+                # If carry over date == target date, then add 1 year to carry over date.
+                # Rational: for example if carry over date = 01/01 this year and target date = 01/01 this year,
+                # then any accrued days on 01/01 this year will have their carry over date 01/01 next year
+                # and not 01/01 this year.
+                if carryover_date == target_date:
+                    carryover_date += relativedelta(years=1)
 
             expiration_dates.extend([expiration_date, carryover_date])
             expiration_dates_per_allocation[allocation]['expiration_date'] = expiration_date


### PR DESCRIPTION
In an accrual plan, all the days should be accrued on the accrual date. However some days are accrued on the carryover date and the rest of the days are accrued on the accrual date.

An extension to this issue: The days are accrued first and then the carryover policy is applied. So if the carryover policy is set to 'None. Accrued time reset to 0', any days that are accrued on the carryover date will be lost. This also means that when the carryover policy on a milestone is set to 'None. Accrued time reset to 0' and the accrual date is the same as the carryover date of the accrual plan, the number of accrued days is always zero.

Steps to reproduce:
 - Create an accrual plan. Set the carryover date as July 1st.
 - Create a milestone:
	* Set the number of accrued days to 10.
	* Set the accrual frequency as `Yearly` and the accrual date as January 1st.
	* Set the carryover policy `all time off carried over`
 - Create an allocation. Set the start date as 01/01/2024. Set the accrual plan as the one created above.
 - Use future allocations to see the number of allocated days on 01/01/2025. It should be 10.
 - Use future allocations to see the number of allocated days on 01/07/2025. It should be still 10. Instead it will be 15. 5 days were accrued on the carryover date because half of the accrual period (half a year) has passed.

Steps to reproduce the extension of the issue:
 - Create an accrual plan. Set the carryover date to 01/01
 - Create a milestone:
   * Set the number of accrued days to 10.
   * Set the accrual frequency as `Yearly` and the accrual date to 01/01.
 - Create an allocation. Set the start date to 01/01/2024. Set the accrual plan to the one created above.
 - Use future allocations to see the number of days accrued on 01/01/2025. It should be 10. However, It will be 0.

task-4060330
