### PR TITLE
[FIX] portal: fixed skip_to_content_tour step

### DIFF
--- a/addons/portal/static/tests/tours/skip_to_content.js
+++ b/addons/portal/static/tests/tours/skip_to_content.js
@@ -13,7 +13,7 @@ registry.category("web_tour.tours").add("skip_to_content", {
             content: "Check if we have been redirected to #wrap",
             trigger: "body",
             run: () => {
-                if (!window.location.href.endsWith("/#wrap")) {
+                if (!window.location.href.endsWith("#wrap")) {
                     console.error("We should be on #wrap.");
                 }
             }


### PR DESCRIPTION
Reason for failure:

- Here the tour fails because here in the run we check the href we placed on the ```Skip to content``` link/button to end with ```/#wrap```.

- But when we place a href in anchor tag it redirects them exactly to the specified url. Here in we don't redirect to a page rather a specific component/area within the page using # before id of the HTML element.

- Here in href we give ```#wrap``` which would redirect to /my#wrap but check and expect something like this /my/#wrap.

task-4070472