### PR TITLE
[IMP] sale, *: simplify kanban archs

### DIFF
--- a/addons/crm/views/crm_team_member_views.xml
+++ b/addons/crm/views/crm_team_member_views.xml
@@ -20,12 +20,14 @@
         <field name="model">crm.team.member</field>
         <field name="inherit_id" ref="sales_team.crm_team_member_view_kanban"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[hasclass('oe_kanban_details')]" position="after">
-                <field name="assignment_enabled" invisible="1"/>
-                <field name="assignment_optout" invisible="1"/>
+            <field name="active" position="after">
+                <field name="assignment_enabled"/>
+                <field name="assignment_optout"/>
+                <field name="assignment_max"/>
+            </field>
+            <xpath expr="//main" position="after">
                 <div class="o_member_assignment"
                         invisible="not assignment_enabled or assignment_optout">
-                    <field name="assignment_max" invisible="1"/>
                     <field name="lead_month_count" widget="gauge"
                         options="{'max_field': 'assignment_max'}"
                         invisible="assignment_max == 0"/>

--- a/addons/sale/static/tests/sales_team_dashboard_tests.js
+++ b/addons/sale/static/tests/sales_team_dashboard_tests.js
@@ -29,8 +29,8 @@ QUnit.module("Sales Team Dashboard", {
     },
 });
 
-QUnit.test("edit target with several o_kanban_primary_bottom divs", async (assert) => {
-    assert.expect(4);
+QUnit.test("edit progressbar target", async (assert) => {
+    assert.expect(3);
 
     const fakeActionService = {
         start: () => ({
@@ -59,10 +59,8 @@ QUnit.test("edit target with several o_kanban_primary_bottom divs", async (asser
             <kanban>
                 <field name="invoiced_target"/>
                 <templates>
-                    <div t-name="kanban-box" class="container o_kanban_card_content">
+                    <div t-name="kanban-card">
                         <field name="invoiced" widget="sales_team_progressbar" options="{'current_value': 'invoiced', 'max_value': 'invoiced_target', 'editable': true, 'edit_max_value': true}"/>
-                        <div class="col-12 o_kanban_primary_bottom"/>
-                        <div class="col-12 o_kanban_primary_bottom bottom_block"/>
                     </div>
                 </templates>
             </kanban>`,
@@ -83,7 +81,6 @@ QUnit.test("edit target with several o_kanban_primary_bottom divs", async (asser
         target,
         ".o_field_sales_team_progressbar:contains(Click to define an invoicing target)"
     );
-    assert.containsN(target, ".o_kanban_primary_bottom", 2);
     assert.containsNone(target, ".o_progressbar input");
 
     await click(target, ".sale_progressbar_form_link"); // should trigger a do_action

--- a/addons/sale/views/sale_order_line_views.xml
+++ b/addons/sale/views/sale_order_line_views.xml
@@ -118,14 +118,8 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div class="oe_kanban_content oe_kanban_global_click">
-                            <div class="row">
-                                <div class="col-12">
-                                <field name="display_name"/>
-                                </div>
-                            </div>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="display_name"/>
                     </t>
                 </templates>
             </kanban>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -70,42 +70,25 @@
         <field name="model">sale.order</field>
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile" sample="1" quick_create="false">
-                <field name="name"/>
-                <field name="partner_id"/>
-                <field name="amount_total"/>
-                <field name="date_order"/>
-                <field name="state"/>
                 <field name="currency_id"/>
-                <field name="activity_state"/>
                 <progressbar field="activity_state"
                     colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_card oe_kanban_global_click">
-                            <div class="o_kanban_record_top mb16">
-                                <div class="o_kanban_record_headings mt4">
-                                    <strong class="o_kanban_record_title">
-                                        <span t-out="record.partner_id.value"/>
-                                    </strong>
-                                </div>
-                                <strong>
-                                    <field name="amount_total" widget="monetary"/>
-                                </strong>
-                            </div>
-                            <div class="o_kanban_record_bottom">
-                                <div class="oe_kanban_bottom_left text-muted">
-                                    <span>
-                                        <t t-out="record.name.value"/> <t t-out="record.date_order.value"/>
-                                    </span>
-                                    <field name="activity_ids" widget="kanban_activity"/>
-                                </div>
-                                <div class="oe_kanban_bottom_right">
-                                    <field name="state"
-                                        widget="label_selection"
-                                        options="{'classes': {'draft': 'info', 'cancel': 'default', 'sale': 'success'}}"/>
-                                </div>
-                            </div>
+                    <t t-name="kanban-card">
+                        <div class="d-flex mb-2">
+                            <field name="partner_id" class="fw-bolder fs-5" />
+                            <field name="amount_total" widget="monetary" class="fw-bolder ms-auto"/>
                         </div>
+                        <footer class="fs-6">
+                            <div class="d-flex text-muted">
+                                <field name="name"/>
+                                <field name="date_order" class="ms-1"/>
+                                <field name="activity_ids" widget="kanban_activity" class="ms-2"/>
+                            </div>
+                            <field name="state"
+                                widget="label_selection"
+                                options="{'classes': {'draft': 'info', 'cancel': 'default', 'sale': 'success'}}" class="ms-auto"/>
+                        </footer>
                     </t>
                 </templates>
             </kanban>
@@ -643,19 +626,8 @@
                                 <field name="company_id" column_invisible="True"/>
                             </tree>
                             <kanban class="o_kanban_mobile">
-                                <field name="name"/>
-                                <field name="product_id"/>
-                                <field name="product_uom_qty"/>
-                                <field name="product_uom"/>
                                 <field name="price_subtotal"/>
-                                <field name="price_total"/>
-                                <field name="price_tax"/>
-                                <field name="price_total"/>
-                                <field name="price_unit"/>
                                 <field name="display_type"/>
-                                <field name="tax_id"/>
-                                <field name="company_id"/>
-                                <field name="tax_calculation_rounding_method"/>
                                 <field name="currency_id"/>
                                 <control>
                                     <create name="add_product_control" string="Add product"/>
@@ -668,58 +640,47 @@
                                             class="btn-secondary"/>
                                 </control>
                                 <templates>
-                                    <t t-name="kanban-box">
-                                        <div t-attf-class="oe_kanban_card oe_kanban_global_click ps-0 pe-0 {{ record.display_type.raw_value ? 'o_is_' + record.display_type.raw_value : '' }}">
-                                            <t t-if="!record.display_type.raw_value">
-                                                <div class="row g-0">
-                                                    <div class="col-2 p-1">
-                                                        <img t-att-src="kanban_image('product.product', 'image_128', record.product_id.raw_value)" t-att-title="record.product_id.value" t-att-alt="record.product_id.value" style="max-width: 100%;"/>
-                                                    </div>
-                                                    <div class="col-10">
-                                                        <div class="row">
-                                                            <div class="col">
-                                                                <span class="fa fa-exclamation-triangle text-warning me-1"
-                                                                    title="This product is archived"
-                                                                    invisible="state not in ['draft', 'sent'] or not is_product_archived"
-                                                                />
-                                                                <strong t-out="record.product_id.value" />
-                                                            </div>
-                                                            <div class="col-auto">
-                                                                <t t-set="line_price" t-value="record.price_subtotal.value"/>
-                                                                <strong class="float-end text-end pe-1" t-out="line_price" widget="monetary"/>
-                                                            </div>
-                                                        </div>
-                                                        <div class="row">
-                                                            <div class="col-12 text-muted">
-                                                                Quantity:
-                                                                <t t-out="record.product_uom_qty.value"/> <t t-out="record.product_uom.value"/>
-                                                            </div>
-                                                        </div>
-                                                        <div class="row">
-                                                            <div class="col text-muted">
-                                                                Unit Price:
-                                                                <t t-out="record.price_unit.value"/>
-                                                            </div>
-                                                        </div>
-                                                        <t t-if="record.discount?.raw_value">
-                                                            <div class="row">
-                                                                <div class="col-12 text-muted">
-                                                                    Discount:
-                                                                    <t t-out="record.discount.value"/>%
-                                                                </div>
-                                                            </div>
-                                                        </t>
-                                                    </div>
-                                                </div>
-                                            </t>
-                                            <t t-if="record.display_type.raw_value === 'line_section' || record.display_type.raw_value === 'line_note'">
+                                    <t t-name="kanban-card" class="row g-0 ps-0 pe-0">
+                                        <t t-if="!record.display_type.raw_value">
+                                            <aside class="col-2 p-1">
+                                                <span t-att-title="record.product_id.value">
+                                                    <field name="product_id" widget="image" options="{'preview_image': 'image_128', 'img_class': 'object-fit-contain w-100'}"/>
+                                                </span>
+                                            </aside>
+                                            <main class="col">
                                                 <div class="row">
-                                                    <div class="col-12">
-                                                        <t t-out="record.name.value"/>
+                                                    <div class="col">
+                                                        <span class="fa fa-exclamation-triangle text-warning me-1"
+                                                            title="This product is archived"
+                                                            invisible="state not in ['draft', 'sent'] or not is_product_archived"
+                                                        />
+                                                        <field name="product_id" class="fw-bold"/>
+                                                    </div>
+                                                    <div class="col-auto">
+                                                        <field name="price_subtotal" class="fw-bolder float-end pe-1" widget="monetary"/>
                                                     </div>
                                                 </div>
-                                            </t>
-                                        </div>
+                                                <div class="text-muted">
+                                                    Quantity:
+                                                    <field name="product_uom_qty"/> <field name="product_uom"/>
+                                                </div>
+                                                <div class="text-muted">
+                                                    Unit Price:
+                                                    <field name="price_unit"/>
+                                                </div>
+                                                <t t-if="record.discount?.raw_value">
+                                                    <div class="text-muted">
+                                                        Discount:
+                                                        <field name="discount"/>%
+                                                    </div>
+                                                </t>
+                                            </main>
+                                        </t>
+                                        <t t-if="record.display_type.raw_value === 'line_section' || record.display_type.raw_value === 'line_note'">
+                                            <div t-attf-class="{{record.display_type.raw_value === 'line_section' ? 'fw-bold' : 'fst-italic' }}">
+                                                <field name="name"/>
+                                            </div>
+                                        </t>
                                     </t>
                                 </templates>
                             </kanban>

--- a/addons/sale_management/views/sale_order_views.xml
+++ b/addons/sale_management/views/sale_order_views.xml
@@ -25,47 +25,25 @@
                             </group>
                         </form>
                         <kanban class="o_kanban_mobile">
-                            <field name="product_id"/>
-                            <field name="quantity"/>
-                            <field name="uom_id" groups="uom.group_uom"/>
-                            <field name="price_unit"/>
                             <field name="is_present" />
                             <templates>
-                                <t t-name="kanban-box">
-                                    <div class="oe_kanban_card oe_kanban_global_click">
-                                        <div class="row">
-                                            <div class="col-10">
-                                                <strong>
-                                                    <span>
-                                                        <t t-out="record.product_id.value"/>
-                                                    </span>
-                                                </strong>
-                                            </div>
-                                            <div class="col-2">
-                                                <button name="button_add_to_order"
-                                                    class="btn btn-link oe_link fa fa-shopping-cart"
-                                                    title="Add to order lines"
-                                                    type="object"
-                                                    invisible="is_present"/>
-                                            </div>
-                                        </div>
-                                        <div class="row">
-                                            <div class="col-12 text-muted">
-                                                <span>
-                                                    Quantity:
-                                                    <t t-out="record.quantity.value"/>
-                                                    <t t-out="record.uom_id.value" groups="uom.group_uom"/>
-                                                </span>
-                                            </div>
-                                        </div>
-                                        <div class="row">
-                                            <div class="col-12 text-muted">
-                                                <span>
-                                                    Unit Price:
-                                                    <t t-out="record.price_unit.value"/>
-                                                </span>
-                                            </div>
-                                        </div>
+                                <t t-name="kanban-card">
+                                    <div class="row">
+                                        <field name="product_id" class="col-10 fw-bolder"/>
+                                        <button name="button_add_to_order"
+                                            class="col-2 btn btn-link oe_link fa fa-shopping-cart"
+                                            title="Add to order lines"
+                                            type="object"
+                                            invisible="is_present"/>
+                                    </div>
+                                    <div class="text-muted">
+                                        Quantity:
+                                        <field name="quantity"/>
+                                        <field name="uom_id" groups="uom.group_uom"/>
+                                    </div>
+                                    <div class="text-muted">
+                                        Unit Price:
+                                        <field name="price_unit"/>
                                     </div>
                                 </t>
                             </templates>

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -39,34 +39,24 @@
                             <field name="cost_currency_id" column_invisible="True"/>
                         </tree>
                         <kanban class="o_kanban_mobile">
-                            <field name="employee_id"/>
-                            <field name="sale_line_id"/>
-                            <field name="existing_employee_ids"/>
-                            <field name="partner_id"/>
                             <field name="currency_id"/>
                             <templates>
-                                <t t-name="kanban-box">
-                                    <div t-attf-class="oe_kanban_card oe_kanban_global_click">
-                                        <div class="row">
-                                            <div class="col-8 d-flex">
-                                                <field name="employee_id" widget="many2one_avatar_employee"/>
-                                                <strong><span class="ps-1"><t t-esc="record.employee_id.value"/></span></strong>
-                                            </div>
-                                            <div class="col-4 float-end text-end">
-                                                <b>Unit Price: </b>
-                                                <field name="price_unit" widget="monetary" force_save="1" options="{'currency_field': 'currency_id'}"/>
-                                            </div>
+                                <t t-name="kanban-card">
+                                    <div class="row">
+                                        <div class="col-8 d-flex">
+                                            <field name="employee_id" widget="many2one_avatar_employee"/>
+                                            <field name="employee_id" class="fw-bold ps-1"/>
                                         </div>
-                                        <div class="row">
-                                            <div class="col-8 text-muted">
-                                                <span><t t-esc="record.sale_line_id.value"/></span>
-                                            </div>
-                                            <div class="col-4">
-                                                <span class="float-end text-end">
-                                                    <b>Daily Cost: </b>
-                                                    <field name="display_cost" widget="monetary" options="{'currency_field': 'currency_id'}"/>
-                                                </span>
-                                            </div>
+                                        <div class="col-4 float-end text-end">
+                                            <b>Unit Price: </b>
+                                            <field name="price_unit" widget="monetary" force_save="1" options="{'currency_field': 'currency_id'}"/>
+                                        </div>
+                                    </div>
+                                    <div class="row">
+                                        <field name="sale_line_id" class="col-8 text-muted"/>
+                                        <div class="col-4 float-end text-end">
+                                            <b>Daily Cost: </b>
+                                            <field name="display_cost" widget="monetary" options="{'currency_field': 'currency_id'}"/>
                                         </div>
                                     </div>
                                 </t>

--- a/addons/sales_team/static/src/scss/crm_team_views.scss
+++ b/addons/sales_team/static/src/scss/crm_team_views.scss
@@ -8,11 +8,6 @@
     .o_kanban_group:not(.o_column_folded) {
         min-height: 100px;
     }
-    .o_kanban_record {
-        &:not(.o_kanban_ghost){
-            min-height: 100px;
-        }
-    }
     .ribbon {
         --Ribbon-wrapper-width: 6rem;
     }

--- a/addons/sales_team/views/crm_team_member_views.xml
+++ b/addons/sales_team/views/crm_team_member_views.xml
@@ -50,27 +50,20 @@
                 sample="1"
                 default_group_by="crm_team_id"
                 class="o_crm_team_member_kanban">
-                <field name="user_id"/>
                 <field name="active"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div class="oe_kanban_card oe_kanban_global_click">
-                            <div class="ribbon ribbon-top-right" invisible="active">
-                                <span class="text-bg-danger">Archived</span>
+                    <t t-name="kanban-card" class="flex-row mb-3">
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
+                        <aside>
+                            <field name="user_id" widget="image" options="{'preview_image': 'avatar_128'}" class="o_image_64_cover" alt="Avatar"/>
+                        </aside>
+                        <main class="ms-3">
+                            <field name="user_id" class="fw-bold fs-5"/>
+                            <a type="open" class="nav-link p-0"><field name="crm_team_id"/></a>
+                            <div class="d-flex align-items-baseline text-break">
+                                <i class="fa fa-envelope me-1" role="img" aria-label="Email" title="Email"/><field name="email"/>
                             </div>
-                            <div class="o_kanban_card_content d-flex">
-                                <div>
-                                    <img t-att-src="kanban_image('res.users', 'avatar_128', record.user_id.raw_value)" class="o_kanban_image o_image_64_cover" alt="Avatar"/>
-                                </div>
-                                <div class="oe_kanban_details d-flex flex-column ms-3">
-                                    <strong class="o_kanban_record_title oe_partner_heading"><field name="user_id"/></strong>
-                                    <a type="open" class="nav-link p-0"><field name="crm_team_id"/></a>
-                                    <div class="d-flex align-items-baseline text-break">
-                                        <i class="fa fa-envelope me-1" role="img" aria-label="Email" title="Email"/><field name="email"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        </main>
                     </t>
                 </templates>
             </kanban>

--- a/addons/sales_team/views/crm_team_views.xml
+++ b/addons/sales_team/views/crm_team_views.xml
@@ -55,26 +55,17 @@
                             <field name="member_ids" mode="kanban"
                                 class="w-100">
                                 <kanban>
-                                    <field name="id"/>
-                                    <field name="name"/>
-                                    <field name="email"/>
-                                    <field name="avatar_128"/>
                                     <templates>
-                                        <t t-name="kanban-box">
-                                            <div class="oe_kanban_card oe_kanban_global_click">
-                                                <div class="o_kanban_card_content d-flex">
-                                                    <div>
-                                                        <img t-att-src="kanban_image('res.users', 'avatar_128', record.id.raw_value)"
-                                                            class="o_kanban_image o_image_64_cover" alt="Avatar"/>
-                                                    </div>
-                                                    <div class="oe_kanban_details d-flex flex-column ms-3">
-                                                        <strong class="o_kanban_record_title oe_partner_heading"><field name="name"/></strong>
-                                                        <div class="d-flex align-items-baseline text-break">
-                                                            <i class="fa fa-envelope me-1" role="img" aria-label="Email" title="Email"/><field name="email"/>
-                                                        </div>
-                                                    </div>
+                                        <t t-name="kanban-card" class="flex-row">
+                                            <aside>
+                                                <field name="avatar_128" widget="image" class="o_image_64_cover" alt="Avatar"/>
+                                            </aside>
+                                            <main class="ms-3">
+                                                <field name="name" class="fw-bold fs-5"/>
+                                                <div class="d-flex align-items-baseline text-break">
+                                                    <i class="fa fa-envelope me-1" role="img" aria-label="Email" title="Email"/><field name="email"/>
                                                 </div>
-                                            </div>
+                                            </main>
                                         </t>
                                     </templates>
                                 </kanban>
@@ -117,16 +108,10 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile" sample="1">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_content oe_kanban_global_click">
-                            <div class="row">
-                                <div class="col-6">
-                                    <strong><field name="name"/></strong>
-                                </div>
-                                <div class="col-6">
-                                    <span class="float-end"><field name="user_id"/></span>
-                                </div>
-                            </div>
+                    <t t-name="kanban-card" class="row g-0">
+                        <field name="name" class="col-6 fw-bold"/>
+                        <div class="col-6">
+                            <field name="user_id" class="float-end"/>
                         </div>
                     </t>
                 </templates>

--- a/addons/sms/static/tests/web/sms_button.test.js
+++ b/addons/sms/static/tests/web/sms_button.test.js
@@ -115,10 +115,9 @@ test(
                         <field name="mobile" widget="phone"/>
                         <field name="partner_ids">
                         <kanban>
-                            <field name="display_name"/>
                             <templates>
-                                <t t-name="kanban-box">
-                                    <div><t t-esc="record.display_name"/></div>
+                                <t t-name="kanban-card">
+                                    <field name="display_name"/>
                                 </t>
                             </templates>
                         </kanban>

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -792,7 +792,7 @@ stepUtils.autoExpandMoreButtons(),
 },
 {
     isActive: ["mobile"],
-    trigger: '.o_field_widget[name=order_line] .oe_kanban_card:contains(the_flow.product)',
+    trigger: '.o_field_widget[name=order_line] .o_kanban_record:contains(the_flow.product)',
 },
 {
     isActive: ["mobile"],
@@ -1076,7 +1076,7 @@ stepUtils.autoExpandMoreButtons(),
 },
 {
     isActive: ["mobile"],
-    trigger: ".o_kanban_record .o_kanban_record_title:contains('the_flow.customer')",
+    trigger: ".o_kanban_record:contains('the_flow.customer')",
     content: _t("Go to the last sale order"),
     tooltipPosition: "bottom",
     run: "click",


### PR DESCRIPTION
*crm,sale_management,sale_timesheet,sales_team,sms In this commit we have simplified the kanban arch for the sale and their related modules.the goal is to simplify them, make them easier to read and use bootstrap utility classnames.

- Previously, we used kanban-box, but now we are using kanban-card instead.
- Deprecated oe_kanban_global_click and oe_kanban_global_click_edit.
- More use of <field/> tags
- Removed the oe_kanban_colorpicker class and replaced it with the kanban_color_picker widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- kanban_image from rendering context, is deprecated so we use <field name="..." widget="image"/> instead
- kanban_color, kanban_getcolor and kanban_getcolorname are deprecated use new attribute highlight_color="color_field_name" on root node

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
