### PR TITLE
[FIX] gamification: call message_notify method from 'mail.thread'

### DIFF
--- a/addons/gamification/models/goal.py
+++ b/addons/gamification/models/goal.py
@@ -221,7 +221,9 @@ class Goal(models.Model):
 
         # generate a reminder report
         body_html = self.env.ref('gamification.email_template_goal_reminder')._render_field('body_html', self.ids, compute_lang=True)[self.id]
-        self.message_notify(
+        self.env['mail.thread'].message_notify(
+            model=self._name,
+            res_id=self.id,
             body=body_html,
             partner_ids=[self.user_id.partner_id.id],
             subtype_xmlid='mail.mt_comment',


### PR DESCRIPTION
At [1], we are using the ``message_notify`` method in the ``goal.py`` file but forgot to inherit from ``mail.thread``, where this method is defined.

Traceback: 
``AttributeError: 'gamification.goal' object has no attribute 'message_notify'``

This commit will fix the above error by calling the ``message_notify`` method from the correct file.

[1]- https://github.com/odoo/odoo/blob/718bc95bd3bdbac1603310dafc054936935364e2/addons/gamification/models/goal.py#L224

sentry-5634399280


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
