### PR TITLE
[PERF] bus, mail: only update presence when needed 

### DIFF
--- a/addons/bus/controllers/websocket.py
+++ b/addons/bus/controllers/websocket.py
@@ -3,7 +3,6 @@
 import json
 
 from odoo.http import Controller, request, route, SessionExpiredException
-from odoo.addons.base.models.assetsbundle import AssetsBundle
 from ..models.bus import channel_with_db
 from ..websocket import WebsocketConnectionHandler
 
@@ -28,22 +27,16 @@ class WebsocketController(Controller):
 
     @route('/websocket/peek_notifications', type='json', auth='public', cors='*')
     def peek_notifications(self, channels, last, is_first_poll=False):
-        if not all(isinstance(c, str) for c in channels):
-            raise ValueError("bus.Bus only string channels are allowed.")
         if is_first_poll:
             # Used to detect when the current session is expired.
             request.session['is_websocket_session'] = True
         elif 'is_websocket_session' not in request.session:
             raise SessionExpiredException()
-        channels = list(set(
-            channel_with_db(request.db, c)
-            for c in request.env['ir.websocket']._build_bus_channel_list(channels)
-        ))
-        last_known_notification_id = request.env['bus.bus'].sudo().search([], limit=1, order='id desc').id or 0
-        if last > last_known_notification_id:
-            last = 0
-        notifications = request.env['bus.bus']._poll(channels, last)
-        return {'channels': channels, 'notifications': notifications}
+        subscribe_data = request.env["ir.websocket"]._prepare_subscribe_data(channels, last)
+        subscribe_data["missed_presences"]._send_presence()
+        channels_with_db = [channel_with_db(request.db, c) for c in subscribe_data["channels"]]
+        notifications = request.env["bus.bus"]._poll(channels_with_db, subscribe_data["last"])
+        return {"channels": channels_with_db, "notifications": notifications}
 
     @route('/websocket/update_bus_presence', type='json', auth='public', cors='*')
     def update_bus_presence(self, inactivity_period, im_status_ids_by_model):
@@ -51,6 +44,10 @@ class WebsocketController(Controller):
             raise SessionExpiredException()
         request.env['ir.websocket']._update_bus_presence(int(inactivity_period), im_status_ids_by_model)
         return {}
+
+    @route("/websocket/on_closed", type="json", auth="public", cors="*")
+    def on_websocket_closed(self):
+        request.env["ir.websocket"]._on_websocket_closed(request.httprequest.cookies)
 
     @route('/bus/websocket_worker_bundle', type='http', auth='public', cors='*')
     def get_websocket_worker_bundle(self, v=None):  # pylint: disable=unused-argument

--- a/addons/bus/models/bus_presence.py
+++ b/addons/bus/models/bus_presence.py
@@ -6,12 +6,14 @@ from psycopg2 import OperationalError
 
 from odoo import api, fields, models
 from odoo import tools
+from odoo.osv import expression
 from odoo.service.model import PG_CONCURRENCY_ERRORS_TO_RETRY
 from odoo.tools.misc import DEFAULT_SERVER_DATETIME_FORMAT
 
 UPDATE_PRESENCE_DELAY = 60
 DISCONNECTION_TIMER = UPDATE_PRESENCE_DELAY + 5
 AWAY_TIMER = 1800  # 30 minutes
+PRESENCE_OUTDATED_TIMER = 12 * 60 * 60  # 12 hours
 
 
 class BusPresence(models.Model):
@@ -33,6 +35,24 @@ class BusPresence(models.Model):
     def init(self):
         self.env.cr.execute("CREATE UNIQUE INDEX IF NOT EXISTS bus_presence_user_unique ON %s (user_id) WHERE user_id IS NOT NULL" % self._table)
 
+    def create(self, values):
+        presences = super().create(values)
+        presences._invalidate_im_status()
+        presences._send_presence()
+        return presences
+
+    def write(self, values):
+        status_by_user = {presence._get_identity_field_name(): presence.status for presence in self}
+        result = super().write(values)
+        updated = self.filtered(lambda p: status_by_user[p._get_identity_field_name()] != p.status)
+        updated._invalidate_im_status()
+        updated._send_presence()
+        return result
+
+    def unlink(self):
+        self._send_presence("offline")
+        return super().unlink()
+
     @api.model
     def update_presence(self, inactivity_period, identity_field, identity_value):
         """ Updates the last_poll and last_presence of the current user
@@ -53,24 +73,68 @@ class BusPresence(models.Model):
                 return self.env.cr.rollback()
             raise
 
+    def _get_bus_target(self):
+        self.ensure_one()
+        return self.env.ref("base.group_user")
+
+    def _get_identity_field_name(self):
+        self.ensure_one()
+        return "user_id" if self.user_id else None
+
+    def _get_identity_data(self):
+        self.ensure_one()
+        return {"partner_id": self.user_id.partner_id.id} if self.user_id else None
+
     @api.model
     def _update_presence(self, inactivity_period, identity_field, identity_value):
-        presence = self.search([(identity_field, '=', identity_value)], limit=1)
-        # compute last_presence timestamp
-        last_presence = datetime.datetime.now() - datetime.timedelta(milliseconds=inactivity_period)
+        presence = self.search([(identity_field, "=", identity_value)])
         values = {
-            'last_poll': time.strftime(DEFAULT_SERVER_DATETIME_FORMAT),
+            "last_poll": time.strftime(DEFAULT_SERVER_DATETIME_FORMAT),
+            "last_presence": datetime.datetime.now() - datetime.timedelta(milliseconds=inactivity_period),
+            "status": "away" if inactivity_period > AWAY_TIMER * 1000 else "online",
         }
-        # update the presence or a create a new one
-        if not presence:  # create a new presence for the user
+        if not presence:
             values[identity_field] = identity_value
-            values['last_presence'] = last_presence
-            self.create(values)
-        else:  # update the last_presence if necessary, and write values
-            if presence.last_presence < last_presence:
-                values['last_presence'] = last_presence
+            presence = self.create(values)
+        else:
             presence.write(values)
+
+    def _invalidate_im_status(self):
+        self.user_id.invalidate_recordset(["im_status"])
+        self.user_id.partner_id.invalidate_recordset(["im_status"])
+
+    def _send_presence(self, im_status=None):
+        """Send notification related to bus presence update.
+
+        :param im_status: 'online', 'away' or 'offline'
+        """
+        notifications = []
+        for presence in self:
+            identity_data = presence._get_identity_data()
+            target = presence._get_bus_target()
+            if identity_data and target:
+                notifications.append(
+                    (
+                        (target, "presence"),
+                        "bus.bus/im_status_updated",
+                        {"im_status": im_status or presence.status, **identity_data},
+                    )
+                )
+        self.env["bus.bus"]._sendmany(notifications)
 
     @api.autovacuum
     def _gc_bus_presence(self):
-        self.search([('user_id.active', '=', False)]).unlink()
+        domain = expression.OR(
+            [
+                [("user_id.active", "=", False)],
+                [("status", "=", "offline")],
+                [
+                    (
+                        "last_poll",
+                        "<",
+                        datetime.datetime.now() - datetime.timedelta(seconds=PRESENCE_OUTDATED_TIMER),
+                    )
+                ],
+            ]
+        )
+        self.search(domain).unlink()

--- a/addons/bus/models/ir_websocket.py
+++ b/addons/bus/models/ir_websocket.py
@@ -1,5 +1,9 @@
+from datetime import datetime, timedelta
+
 from odoo import models
 from odoo.http import request, SessionExpiredException
+from odoo.tools import OrderedSet
+from odoo.osv import expression
 from odoo.service import security
 from ..models.bus import dispatch
 from ..websocket import wsrequest
@@ -18,6 +22,39 @@ class IrWebsocket(models.AbstractModel):
             )]
         return im_status
 
+    def _get_missed_presences_identity_domains(self, presence_channels):
+        """
+        Return a list of domains that will be combined with `expression.OR` to
+        find presences related to `presence_channels`. This is used to find
+        missed presences when subscribing to presence channels.
+        :param typing.List[typing.Tuple[recordset, str]] presence_channels: The
+            presence channels the user subscribed to.
+        """
+        partners = self.env["res.partner"].browse(
+            [p.id for p, _ in presence_channels if isinstance(p, self.pool["res.partner"])]
+        )
+        # sudo: res.partner - can acess users of partner channels to find
+        # their presences as those channels were already verified during
+        # `_build_bus_channel_list`.
+        return [[("user_id", "in", partners.with_context(active_test=False).sudo().user_ids.ids)]]
+
+    def _build_presence_channel_list(self, presences):
+        """
+        Return the list of presences to subscribe to.
+        :param typing.List[typing.Tuple[str, int]] presences: The presence
+            list sent by the client where the first element is the model
+            name and the second is the record id.
+        """
+        channels = []
+        if self.env.user and self.env.user._is_internal():
+            channels.extend(
+                (partner, "presence")
+                for partner in self.env["res.partner"]
+                .with_context(active_test=False)
+                .search([("id", "in", [int(p[1]) for p in presences if p[0] == "res.partner"])])
+            )
+        return channels
+
     def _build_bus_channel_list(self, channels):
         """
             Return the list of channels to subscribe to. Override this
@@ -28,18 +65,58 @@ class IrWebsocket(models.AbstractModel):
         """
         req = request or wsrequest
         channels.append('broadcast')
+        channels.extend(self.env.user.groups_id)
         if req.session.uid:
             channels.append(self.env.user.partner_id)
         return channels
 
-    def _subscribe(self, data):
-        if not all(isinstance(c, str) for c in data['channels']):
+    def _prepare_subscribe_data(self, channels, last):
+        """
+        Parse the data sent by the client and return the list of channels,
+        missed presences and the last known notification id. This will be used
+        both by the websocket controller and the websocket request class when
+        the `subscribe` event is received.
+        :param typing.List[str] channels: List of channels to subscribe to sent
+            by the client.
+        :param int last: Last known notification sent by the client.
+        :return:
+            A dict containing the following keys:
+            - channels (set of str): The list of channels to subscribe to.
+            - last (int): The last known notification id.
+            - missed_presences (odoo.models.Recordset): The missed presences.
+        :raise ValueError: If the list of channels is not a list of strings.
+        """
+        if not all(isinstance(c, str) for c in channels):
             raise ValueError("bus.Bus only string channels are allowed.")
-        last_known_notification_id = self.env['bus.bus'].sudo().search([], limit=1, order='id desc').id or 0
-        if data['last'] > last_known_notification_id:
-            data['last'] = 0
-        channels = set(self._build_bus_channel_list(data['channels']))
-        dispatch.subscribe(channels, data['last'], self.env.registry.db_name, wsrequest.ws)
+        # sudo - bus.bus: reading non-sensitive last bus id.
+        last = 0 if last > self.env["bus.bus"].sudo()._bus_last_id() else last
+        str_presence_channels = {
+            c for c in channels if isinstance(c, str) and c.startswith("odoo-presence-")
+        }
+        presence_channels = self._build_presence_channel_list(
+            [tuple(c.replace("odoo-presence-", "").split("_")) for c in str_presence_channels]
+        )
+        # There is a gap between a subscription client side (which is debounced)
+        # and the actual subcription thus presences can be missed. Send a
+        # notification to avoid missing presences during a subscription.
+        domain = expression.AND(
+            [
+                [("last_poll", ">", datetime.now() - timedelta(seconds=2))],
+                expression.OR(self._get_missed_presences_identity_domains(presence_channels)),
+            ]
+        )
+        # sudo: bus.presence: can access presences linked to presence channels.
+        missed_presences = self.env["bus.presence"].sudo().search(domain)
+        all_channels = OrderedSet(presence_channels)
+        all_channels.update(
+            self._build_bus_channel_list([c for c in channels if c not in str_presence_channels])
+        )
+        return {"channels": all_channels, "last": last, "missed_presences": missed_presences}
+
+    def _subscribe(self, og_data):
+        data = self._prepare_subscribe_data(og_data["channels"], og_data["last"])
+        dispatch.subscribe(data["channels"], data["last"], self.env.registry.db_name, wsrequest.ws)
+        data["missed_presences"]._send_presence()
 
     def _update_bus_presence(self, inactivity_period, im_status_ids_by_model):
         if self.env.user and not self.env.user._is_public():
@@ -48,9 +125,10 @@ class IrWebsocket(models.AbstractModel):
                 identity_field='user_id',
                 identity_value=self.env.uid
             )
-            im_status_notification = self._get_im_status(im_status_ids_by_model)
-            if im_status_notification:
-                self.env['bus.bus']._sendone(self.env.user.partner_id, 'mail.record/insert', im_status_notification)
+
+    def _on_websocket_closed(self, cookies):
+        if self.env.user and not self.env.user._is_public():
+            self.env["bus.presence"].search([("user_id", "=", self.env.uid)]).unlink()
 
     @classmethod
     def _authenticate(cls):

--- a/addons/bus/models/res_partner.py
+++ b/addons/bus/models/res_partner.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from odoo import api, fields, models
-from odoo.addons.bus.models.bus_presence import AWAY_TIMER
-from odoo.addons.bus.models.bus_presence import DISCONNECTION_TIMER
+from odoo import fields, models
 
 
 class ResPartner(models.Model):
@@ -11,19 +9,14 @@ class ResPartner(models.Model):
     im_status = fields.Char('IM Status', compute='_compute_im_status')
 
     def _compute_im_status(self):
-        self.env.cr.execute("""
-            SELECT
-                U.partner_id as id,
-                CASE WHEN max(B.last_poll) IS NULL THEN 'offline'
-                    WHEN age(now() AT TIME ZONE 'UTC', max(B.last_poll)) > interval %s THEN 'offline'
-                    WHEN age(now() AT TIME ZONE 'UTC', max(B.last_presence)) > interval %s THEN 'away'
-                    ELSE 'online'
-                END as status
-            FROM bus_presence B
-            RIGHT JOIN res_users U ON B.user_id = U.id
-            WHERE U.partner_id IN %s AND U.active = 't'
-         GROUP BY U.partner_id
-        """, ("%s seconds" % DISCONNECTION_TIMER, "%s seconds" % AWAY_TIMER, tuple(self.ids)))
-        res = dict(((status['id'], status['status']) for status in self.env.cr.dictfetchall()))
+        status_by_partner = {}
+        for presence in self.env["bus.presence"].search([("user_id", "in", self.user_ids.ids)]):
+            partner = presence.user_id.partner_id
+            if (
+                status_by_partner.get(partner, "offline") == "offline"
+                or presence.status == "online"
+            ):
+                status_by_partner[partner] = presence.status
         for partner in self:
-            partner.im_status = res.get(partner.id, 'im_partner')  # if not found, it is a partner, useful to avoid to refresh status in js
+            default_status = "offline" if partner.user_ids else "im_partner"
+            partner.im_status = status_by_partner.get(partner, default_status)

--- a/addons/bus/static/src/im_status_service.js
+++ b/addons/bus/static/src/im_status_service.js
@@ -2,48 +2,60 @@
 
 import { browser } from "@web/core/browser/browser";
 import { registry } from "@web/core/registry";
-import { timings } from "@bus/misc";
+import { session } from "@web/session";
 
+export const AWAY_DELAY = 30 * 60 * 1000; // 30 minutes
+export const FIRST_UPDATE_DELAY = 500;
 export const UPDATE_BUS_PRESENCE_DELAY = 60000;
+
 /**
  * This service updates periodically the user presence in order for the
  * im_status to be up to date.
- *
- * In order to receive bus notifications related to im_status, one must
- * register model/ids to monitor to this service.
  */
 export const imStatusService = {
-    dependencies: ["bus_service", "multi_tab", "presence"],
+    dependencies: ["bus_service", "multi_tab", "presence", "user"],
 
-    start(env, { bus_service, multi_tab, presence }) {
-        const imStatusModelToIds = {};
-        let updateBusPresenceTimeout;
-        const throttledUpdateBusPresence = timings.throttle(function updateBusPresence() {
-            clearTimeout(updateBusPresenceTimeout);
+    start(env, { bus_service, multi_tab, presence, user }) {
+        let lastSentInactivity;
+        let becomeAwayTimeout;
+
+        const updateBusPresence = () => {
+            lastSentInactivity = presence.getInactivityPeriod();
+            startAwayTimeout();
             if (!multi_tab.isOnMainTab()) {
                 return;
             }
-            const now = new Date().getTime();
             bus_service.send("update_presence", {
-                inactivity_period: now - presence.getLastPresence(),
-                im_status_ids_by_model: { ...imStatusModelToIds },
+                inactivity_period: lastSentInactivity,
+                im_status_ids_by_model: {},
             });
-            updateBusPresenceTimeout = browser.setTimeout(
-                throttledUpdateBusPresence,
-                UPDATE_BUS_PRESENCE_DELAY
-            );
-        }, UPDATE_BUS_PRESENCE_DELAY);
+        };
+        this.updateBusPresence = updateBusPresence;
 
-        bus_service.addEventListener("connect", () => {
-            // wait for im_status model/ids to be registered before starting.
-            browser.setTimeout(throttledUpdateBusPresence, 250);
+        const startAwayTimeout = () => {
+            clearTimeout(becomeAwayTimeout);
+            const awayTime = AWAY_DELAY - lastSentInactivity;
+            if (awayTime > 0) {
+                becomeAwayTimeout = browser.setTimeout(() => updateBusPresence(), awayTime);
+            }
+        };
+
+        bus_service.addEventListener("connect", () => updateBusPresence(), { once: true });
+        bus_service.subscribe("bus.bus/im_status_updated", async ({ partner_id, im_status }) => {
+            if (session.is_public || !partner_id || partner_id !== user.partnerId) {
+                return;
+            }
+            const isOnline = presence.getInactivityPeriod() < AWAY_DELAY;
+            if (im_status === "offline" || (im_status === "away" && isOnline)) {
+                this.updateBusPresence();
+            }
         });
-        multi_tab.bus.addEventListener("become_main_tab", throttledUpdateBusPresence);
-        bus_service.addEventListener("reconnect", throttledUpdateBusPresence);
-        multi_tab.bus.addEventListener("no_longer_main_tab", () =>
-            clearTimeout(updateBusPresenceTimeout)
-        );
-        bus_service.addEventListener("disconnect", () => clearTimeout(updateBusPresenceTimeout));
+        presence.bus.addEventListener("presence", () => {
+            if (lastSentInactivity >= AWAY_DELAY) {
+                this.updateBusPresence();
+            }
+            startAwayTimeout();
+        });
 
         return {
             /**
@@ -52,24 +64,19 @@ export const imStatusService = {
              * through the bus. Overwrite registration if already
              * present.
              *
+             * @deprecated
              * @param {string} model model related to the given ids.
              * @param {Number[]} ids ids whose im_status should be
              * monitored.
              */
-            registerToImStatus(model, ids) {
-                if (!ids.length) {
-                    return this.unregisterFromImStatus(model);
-                }
-                imStatusModelToIds[model] = ids;
-            },
+            registerToImStatus(model, ids) {},
             /**
              * Unregister model from im_status notifications.
              *
+             * @deprecated
              * @param {string} model model to unregister.
              */
-            unregisterFromImStatus(model) {
-                delete imStatusModelToIds[model];
-            },
+            unregisterFromImStatus(model) {},
         };
     },
 };

--- a/addons/bus/static/src/workers/websocket_worker.js
+++ b/addons/bus/static/src/workers/websocket_worker.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { debounce } from "@bus/workers/websocket_worker_utils";
+import { debounce, Deferred } from "@bus/workers/websocket_worker_utils";
 
 /**
  * Type of events that can be sent from the worker to its clients.
@@ -34,7 +34,7 @@ export const WEBSOCKET_CLOSE_CODES = Object.freeze({
 });
 // Should be incremented on every worker update in order to force
 // update of the worker in browser cache.
-export const WORKER_VERSION = "1.0.7";
+export const WORKER_VERSION = "1.0.8";
 const MAXIMUM_RECONNECT_DELAY = 60000;
 
 /**
@@ -62,10 +62,11 @@ export class WebsocketWorker {
         this.isDebug = false;
         this.isReconnecting = false;
         this.lastChannelSubscription = null;
+        this.firstSubscribeDeferred = new Deferred();
         this.lastNotificationId = 0;
         this.messageWaitQueue = [];
         this._forceUpdateChannels = debounce(this._forceUpdateChannels, 300);
-        this._updateChannels = debounce(this._updateChannels, 0);
+        this._debouncedUpdateChannels = debounce(this._updateChannels, 300);
 
         this._onWebsocketClose = this._onWebsocketClose.bind(this);
         this._onWebsocketError = this._onWebsocketError.bind(this);
@@ -162,7 +163,7 @@ export class WebsocketWorker {
         if (!clientChannels.includes(channel)) {
             clientChannels.push(channel);
             this.channelsByClient.set(client, clientChannels);
-            this._updateChannels();
+            this._debouncedUpdateChannels();
         }
     }
 
@@ -181,7 +182,7 @@ export class WebsocketWorker {
         const channelIndex = clientChannels.indexOf(channel);
         if (channelIndex !== -1) {
             clientChannels.splice(channelIndex, 1);
-            this._updateChannels();
+            this._debouncedUpdateChannels();
         }
     }
 
@@ -206,7 +207,7 @@ export class WebsocketWorker {
         this.isDebug = Object.values(this.debugModeByClient).some(
             (debugValue) => debugValue !== ""
         );
-        this._updateChannels();
+        this._debouncedUpdateChannels();
     }
 
     /**
@@ -308,6 +309,7 @@ export class WebsocketWorker {
             );
         }
         this.lastChannelSubscription = null;
+        this.firstSubscribeDeferred = new Deferred();
         if (this.isReconnecting) {
             // Connection was not established but the close event was
             // triggered anyway. Let the onWebsocketError method handle
@@ -374,13 +376,15 @@ export class WebsocketWorker {
                 "color: #c6e; font-weight: bold;"
             );
         }
-        this._updateChannels();
-        this.messageWaitQueue.forEach((msg) => this.websocket.send(msg));
-        this.messageWaitQueue = [];
         this.broadcast(this.isReconnecting ? "reconnect" : "connect");
+        this._debouncedUpdateChannels();
         this.connectRetryDelay = this.INITIAL_RECONNECT_DELAY;
         this.connectTimeout = null;
         this.isReconnecting = false;
+        this.firstSubscribeDeferred.then(() => {
+            this.messageWaitQueue.forEach((msg) => this.websocket.send(msg));
+            this.messageWaitQueue = [];
+        });
     }
 
     /**
@@ -404,9 +408,20 @@ export class WebsocketWorker {
     _sendToServer(message) {
         const payload = JSON.stringify(message);
         if (!this._isWebsocketConnected()) {
-            this.messageWaitQueue.push(payload);
+            if (message["event_name"] === "subscribe") {
+                this.messageWaitQueue = this.messageWaitQueue.filter(
+                    (msg) => JSON.parse(msg).event_name !== "subscribe"
+                );
+                this.messageWaitQueue.unshift(payload);
+            } else {
+                this.messageWaitQueue.push(payload);
+            }
         } else {
-            this.websocket.send(payload);
+            if (message["event_name"] === "subscribe") {
+                this.websocket.send(payload);
+            } else {
+                this.firstSubscribeDeferred.then(() => this.websocket.send(payload));
+            }
         }
     }
 
@@ -469,6 +484,7 @@ export class WebsocketWorker {
                 event_name: "subscribe",
                 data: { channels: allTabsChannels, last: this.lastNotificationId },
             });
+            this.firstSubscribeDeferred.resolve();
         }
     }
 }

--- a/addons/bus/static/src/workers/websocket_worker_utils.js
+++ b/addons/bus/static/src/workers/websocket_worker_utils.js
@@ -27,3 +27,18 @@ export function debounce(func, wait, immediate) {
         }
     };
 }
+
+/**
+ * Deferred is basically a resolvable/rejectable extension of Promise.
+ */
+export class Deferred extends Promise {
+    constructor() {
+        let resolve;
+        let reject;
+        const prom = new Promise((res, rej) => {
+            resolve = res;
+            reject = rej;
+        });
+        return Object.assign(prom, { resolve, reject });
+    }
+}

--- a/addons/bus/static/tests/bus_tests.js
+++ b/addons/bus/static/tests/bus_tests.js
@@ -1,4 +1,4 @@
-/** @odoo-module **/
+/** @odoo-module alias=@bus/../tests/bus_tests default=false */
 
 import { addBusServicesToRegistry } from "@bus/../tests/helpers/test_utils";
 import { startServer } from "@bus/../tests/helpers/mock_python_environment";
@@ -14,7 +14,9 @@ import { busParametersService } from "@bus/bus_parameters_service";
 import { WEBSOCKET_CLOSE_CODES } from "@bus/workers/websocket_worker";
 
 import { makeTestEnv } from "@web/../tests/helpers/mock_env";
-import { makeDeferred, patchWithCleanup } from "@web/../tests/helpers/utils";
+import { makeDeferred, nextTick, patchWithCleanup } from "@web/../tests/helpers/utils";
+import { assertSteps, click, contains, step } from "@web/../tests/utils";
+import { createWebClient } from "@web/../tests/webclient/helpers";
 import { browser } from "@web/core/browser/browser";
 import { session } from "@web/session";
 
@@ -60,7 +62,7 @@ QUnit.test("notifications still received after disconnect/reconnect", async () =
     const pyEnv = await startServer();
     const env = await makeTestEnv({ activateMockServer: true });
     env.services["bus_service"].addChannel("lambda");
-    await Promise.all([waitForBusEvent(env, "connect"), waitForChannels(["lambda"])]);
+    await Promise.all([waitForBusEvent(env, "connect"), waitUntilSubscribe("lambda")]);
     pyEnv["bus.bus"]._sendone("lambda", "notifType", "beta");
     await waitNotifications([env, "notifType", "beta"]);
     pyEnv.simulateConnectionLost(WEBSOCKET_CLOSE_CODES.ABNORMAL_CLOSURE);
@@ -142,7 +144,7 @@ QUnit.test("channel management from multiple tabs", async (assert) => {
     const firstTabEnv = await makeTestEnv({ activateMockServer: true });
     const secTabEnv = await makeTestEnv({ activateMockServer: true });
     firstTabEnv.services["bus_service"].addChannel("channel1");
-    await waitForChannels(["channel1"]);
+    await waitUntilSubscribe("channel1");
     // this should not trigger a subscription since the channel1 was
     // aleady known.
     secTabEnv.services["bus_service"].addChannel("channel1");
@@ -199,7 +201,7 @@ QUnit.test("Last notification id is passed to the worker on service start", asyn
         ["lambda", "notifType", "beta"],
         ["lambda", "notifType", "beta"],
     ]);
-    await waitForBusEvent(env1, "notification");
+    await waitNotifications([env1, "notifType", "beta"], [env1, "notifType", "beta"]);
     updateLastNotificationDeferred = makeDeferred();
     const env2 = await makeTestEnv();
     await env2.services["bus_service"].start();
@@ -266,7 +268,7 @@ QUnit.test("WebSocket connects with URL corresponding to given serverURL", async
     const env = await makeTestEnv();
     env.services["bus_service"].start();
     await websocketCreatedDeferred;
-    assert.verifySteps([`${serverURL.replace("http", "ws")}/websocket`]);
+    assert.verifySteps([`${serverURL.replace("http", "ws")}/websocket?version=undefined`]);
 });
 
 QUnit.test("Disconnect on offline, re-connect on online", async () => {
@@ -293,15 +295,8 @@ QUnit.test("No disconnect on change offline/online when bus inactive", async () 
 
 QUnit.test("Can reconnect after late close event", async (assert) => {
     addBusServicesToRegistry();
-    let subscribeSent = 0;
     const closeDeferred = makeDeferred();
-    const worker = patchWebsocketWorkerWithCleanup({
-        _sendToServer({ event_name }) {
-            if (event_name === "subscribe") {
-                subscribeSent++;
-            }
-        },
-    });
+    const worker = patchWebsocketWorkerWithCleanup();
     const pyEnv = await startServer();
     const env = await makeTestEnv();
     env.services["bus_service"].start();
@@ -335,8 +330,6 @@ QUnit.test("Can reconnect after late close event", async (assert) => {
     pyEnv.simulateConnectionLost(WEBSOCKET_CLOSE_CODES.KEEP_ALIVE_TIMEOUT);
     await waitForBusEvent(env, "reconnecting");
     await waitForBusEvent(env, "reconnect");
-    // 3 connections were opened, so 3 subscriptions are expected.
-    assert.strictEqual(subscribeSent, 3);
 });
 
 QUnit.test("Fallback on simple worker when shared worker failed to initialize", async (assert) => {
@@ -390,4 +383,138 @@ QUnit.test("subscribe to single notification", async (assert) => {
     });
     await messageReceivedDeferred;
     assert.verifySteps(["message"]);
+});
+
+QUnit.test("do not reconnect when worker version is outdated", async () => {
+    await startServer();
+    addBusServicesToRegistry();
+    const worker = patchWebsocketWorkerWithCleanup();
+    const env = await makeTestEnv({ activateMockServer: true });
+    env.services["bus_service"].addEventListener("connect", () => step("connect"));
+    env.services["bus_service"].addEventListener("reconnect", () => step("reconnect"));
+    env.services["bus_service"].addEventListener("disconnect", () => step("disconnect"));
+    env.services["bus_service"].start();
+    await assertSteps(["connect"]);
+    worker.websocket.close(WEBSOCKET_CLOSE_CODES.ABNORMAL_CLOSURE);
+    await assertSteps(["disconnect", "reconnect"]);
+    patchWithCleanup(console, { warn: (message) => step(message) });
+    worker.websocket.close(WEBSOCKET_CLOSE_CODES.CLEAN, "OUTDATED_VERSION");
+    await assertSteps(["Worker deactivated due to an outdated version.", "disconnect"]);
+    env.services["bus_service"].start();
+    env.services["bus_service"].send("hello", "world");
+    await nextTick();
+    await assertSteps([]);
+});
+
+QUnit.test("reconnect on demande after clean close code", async () => {
+    await startServer();
+    addBusServicesToRegistry();
+    const worker = patchWebsocketWorkerWithCleanup();
+    const env = await makeTestEnv({ activateMockServer: true });
+    env.services["bus_service"].addEventListener("connect", () => step("connect"));
+    env.services["bus_service"].addEventListener("reconnect", () => step("reconnect"));
+    env.services["bus_service"].addEventListener("disconnect", () => step("disconnect"));
+    env.services["bus_service"].start();
+    await assertSteps(["connect"]);
+    worker.websocket.close(WEBSOCKET_CLOSE_CODES.ABNORMAL_CLOSURE);
+    await assertSteps(["disconnect", "reconnect"]);
+    worker.websocket.close(WEBSOCKET_CLOSE_CODES.CLEAN);
+    await assertSteps(["disconnect"]);
+    env.services["bus_service"].start();
+    await assertSteps(["connect"]);
+});
+
+QUnit.test("remove from main tab candidates when version is outdated", async (assert) => {
+    await startServer();
+    addBusServicesToRegistry();
+    const worker = patchWebsocketWorkerWithCleanup();
+    const env = await makeTestEnv({ activateMockServer: true });
+    patchWithCleanup(console, { warn: (message) => step(message) });
+    env.services["bus_service"].addEventListener("connect", () => step("connect"));
+    env.services["bus_service"].addEventListener("disconnect", () => step("disconnect"));
+    env.services["bus_service"].start();
+    await assertSteps(["connect"]);
+    patchWithCleanup(env.services.multi_tab, { isOnMainTab: () => true });
+    assert.ok(env.services["multi_tab"].isOnMainTab());
+    env.services.multi_tab.bus.addEventListener("no_longer_main_tab", () =>
+        step("no_longer_main_tab")
+    );
+    worker.websocket.close(WEBSOCKET_CLOSE_CODES.CLEAN, "OUTDATED_VERSION");
+    await assertSteps([
+        "Worker deactivated due to an outdated version.",
+        "disconnect",
+        "no_longer_main_tab",
+    ]);
+});
+
+QUnit.test("show notification when version is outdated", async () => {
+    await startServer();
+    addBusServicesToRegistry();
+    const worker = patchWebsocketWorkerWithCleanup();
+    const { env } = await createWebClient({});
+    patchWithCleanup(console, { warn: (message) => step(message) });
+    patchWithCleanup(browser.location, { reload: () => step("reload") });
+    env.services["bus_service"].addEventListener("connect", () => step("connect"));
+    env.services["bus_service"].addEventListener("disconnect", () => step("disconnect"));
+    env.services["bus_service"].start();
+    await assertSteps(["connect"]);
+    worker.websocket.close(WEBSOCKET_CLOSE_CODES.CLEAN, "OUTDATED_VERSION");
+    await assertSteps(["Worker deactivated due to an outdated version.", "disconnect"]);
+    await contains(".o_notification", {
+        text: "Save your work and refresh to get the latest updates and avoid potential issues.",
+    });
+    await click(".o_notification_buttons .btn-primary", { text: "Refresh" });
+    await assertSteps(["reload"]);
+});
+
+QUnit.test("subscribe message is sent first", async () => {
+    await startServer();
+    addBusServicesToRegistry();
+    const worker = patchWebsocketWorkerWithCleanup();
+    const ogSocket = window.WebSocket;
+    patchWithCleanup(window, {
+        WebSocket: function () {
+            const ws = new ogSocket(...arguments);
+            ws.send = (message) => step(JSON.parse(message).event_name);
+            return ws;
+        },
+    });
+    const env = await makeTestEnv({ activateMockServer: true });
+    env.services.bus_service.start();
+    await assertSteps(["subscribe"]);
+    env.services.bus_service.send("some_event");
+    await assertSteps(["some_event"]);
+    worker.websocket.close(WEBSOCKET_CLOSE_CODES.CLEAN);
+    env.services.bus_service.send("some_event");
+    env.services.bus_service.send("some_other_event");
+    env.services.bus_service.addChannel("channel_1");
+    await assertSteps([]);
+    env.services.bus_service.start();
+    await assertSteps(["subscribe", "some_event", "some_other_event"]);
+});
+
+QUnit.test("subscribe message is sent first", async () => {
+    await startServer();
+    addBusServicesToRegistry();
+    const worker = patchWebsocketWorkerWithCleanup();
+    const ogSocket = window.WebSocket;
+    patchWithCleanup(window, {
+        WebSocket: function () {
+            const ws = new ogSocket(...arguments);
+            ws.send = (message) => step(JSON.parse(message).event_name);
+            return ws;
+        },
+    });
+    const env = await makeTestEnv({ activateMockServer: true });
+    env.services.bus_service.start();
+    await assertSteps(["subscribe"]);
+    env.services.bus_service.send("some_event");
+    await assertSteps(["some_event"]);
+    worker.websocket.close(WEBSOCKET_CLOSE_CODES.CLEAN);
+    env.services.bus_service.send("some_event");
+    env.services.bus_service.send("some_other_event");
+    env.services.bus_service.addChannel("channel_1");
+    await assertSteps([]);
+    env.services.bus_service.start();
+    await assertSteps(["subscribe", "some_event", "some_other_event"]);
 });

--- a/addons/bus/static/tests/helpers/mock_websocket.js
+++ b/addons/bus/static/tests/helpers/mock_websocket.js
@@ -64,6 +64,7 @@ class WorkerMock extends SharedWorkerMock {
 }
 
 let websocketWorker;
+QUnit.testDone(() => (websocketWorker = null));
 /**
  * @param {*} params Parameters used to patch the websocket worker.
  * @returns {WebsocketWorker} Instance of the worker which will run during the

--- a/addons/bus/static/tests/im_status_tests.js
+++ b/addons/bus/static/tests/im_status_tests.js
@@ -1,0 +1,160 @@
+/* @odoo-module */
+
+import { startServer } from "@bus/../tests/helpers/mock_python_environment";
+import { patchWebsocketWorkerWithCleanup } from "@bus/../tests/helpers/mock_websocket";
+import { addBusServicesToRegistry } from "@bus/../tests/helpers/test_utils";
+import { waitUntilSubscribe } from "@bus/../tests/helpers/websocket_event_deferred";
+import { AWAY_DELAY as ACTUAL_AWAY_DELAY, imStatusService } from "@bus/im_status_service";
+import { makeTestEnv } from "@web/../tests/helpers/mock_env";
+import { mockTimeout, nextTick, patchWithCleanup } from "@web/../tests/helpers/utils";
+import { registerCleanup } from "@web/../tests/helpers/cleanup";
+import { assertSteps, step } from "@web/../tests/utils";
+import { browser } from "@web/core/browser/browser";
+import { registry } from "@web/core/registry";
+import { session } from "@web/session";
+
+// Delays can slighly differ since time is not frozen. Let's tolerate 1000ms
+// of difference.
+const TOLERANCE = 1000;
+const AWAY_DELAY = ACTUAL_AWAY_DELAY + TOLERANCE;
+function assertAlmostEqual(a, b) {
+    QUnit.assert.ok(Math.abs(a - b) < TOLERANCE, `${a} and ${b} should be almost equal`);
+}
+
+QUnit.module("IM status", {
+    async beforeEach() {
+        addBusServicesToRegistry();
+        patchWebsocketWorkerWithCleanup();
+        registry.category("services").add("im_status", imStatusService);
+        const pyEnv = await startServer();
+        patchWithCleanup(session, { partner_id: pyEnv.currentPartner.id });
+        registry.category("mock_server").add("res.users/has_group", (route, args) => {
+            return args[0] === "base.group_public";
+        });
+        registerCleanup(() => registry.category("mock_server").remove("res.users/has_group"));
+    },
+});
+
+QUnit.test(
+    "update presence if IM status changes to offline while this device is online",
+    async () => {
+        const pyEnv = await startServer();
+        const env = await makeTestEnv({ activateMockServer: true });
+        patchWithCleanup(env.services.bus_service, { send: (type) => step(type) });
+        env.services.bus_service.start();
+        await waitUntilSubscribe();
+        await assertSteps(["update_presence"]);
+        pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "bus.bus/im_status_updated", {
+            im_status: "offline",
+            partner_id: pyEnv.currentPartner.id,
+        });
+        await assertSteps(["update_presence"]);
+    }
+);
+
+QUnit.test("update presence if IM status changes to away while this device is online", async () => {
+    const pyEnv = await startServer();
+    const env = await makeTestEnv({ activateMockServer: true });
+    patchWithCleanup(env.services.bus_service, { send: (type) => step(type) });
+    patchWithCleanup(env.services.presence, { getLastPresence: () => new Date().getTime() });
+    env.services.bus_service.addEventListener("connect", () => step("connect"), { once: true });
+    env.services.bus_service.start();
+    await assertSteps(["connect"]);
+    await assertSteps(["update_presence"]);
+    pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "bus.bus/im_status_updated", {
+        im_status: "away",
+        partner_id: pyEnv.currentPartner.id,
+    });
+    await assertSteps(["update_presence"]);
+});
+
+QUnit.test(
+    "do not update presence if IM status changes to away while this device is away",
+    async () => {
+        const pyEnv = await startServer();
+        const env = await makeTestEnv({ activateMockServer: true });
+        patchWithCleanup(env.services.bus_service, { send: (type) => step(type) });
+        patchWithCleanup(env.services.presence, {
+            getLastPresence: () => new Date().getTime() - AWAY_DELAY,
+        });
+        env.services.bus_service.addEventListener("connect", () => step("connect"), { once: true });
+        env.services.bus_service.start();
+        await assertSteps(["connect"]);
+        await assertSteps(["update_presence"]);
+        pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "bus.bus/im_status_updated", {
+            im_status: "away",
+            partner_id: pyEnv.currentPartner.id,
+        });
+        await nextTick();
+        await assertSteps([]);
+    }
+);
+
+QUnit.test("do not update presence if other user's IM status changes to away", async () => {
+    const pyEnv = await startServer();
+    const env = await makeTestEnv({ activateMockServer: true });
+    patchWithCleanup(env.services.bus_service, { send: (type) => step(type) });
+    patchWithCleanup(env.services.presence, { getLastPresence: () => new Date().getTime() });
+    env.services.bus_service.addEventListener("connect", () => step("connect"), { once: true });
+    env.services.bus_service.start();
+    await assertSteps(["connect"]);
+    await assertSteps(["update_presence"]);
+    pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "bus.bus/im_status_updated", {
+        im_status: "away",
+        partner_id: pyEnv.publicPartnerId,
+    });
+    await nextTick();
+    await assertSteps([]);
+});
+
+QUnit.test("update presence when user comes back from away", async () => {
+    const env = await makeTestEnv();
+    patchWithCleanup(env.services.bus_service, {
+        send: (type, payload) => {
+            if (type === "update_presence") {
+                assertAlmostEqual(expectedInactivityPeriod, payload.inactivity_period);
+                step("update_presence");
+            }
+        },
+    });
+    patchWithCleanup(env.services.presence, {
+        getLastPresence: () => new Date().getTime() - AWAY_DELAY,
+    });
+    let expectedInactivityPeriod = AWAY_DELAY;
+    env.services.bus_service.addEventListener("connect", () => step("connect"), { once: true });
+    env.services.bus_service.start();
+    await assertSteps(["connect"]);
+    await assertSteps(["update_presence"]);
+    const event = new StorageEvent("storage", {
+        key: "presence.lastPresence",
+        newValue: new Date().getTime(),
+    });
+    patchWithCleanup(env.services.presence, { getLastPresence: () => new Date().getTime() });
+    expectedInactivityPeriod = 0;
+    browser.dispatchEvent(event);
+    await assertSteps(["update_presence"]);
+});
+
+QUnit.test("update presence when user status changes to away", async () => {
+    const { advanceTime } = mockTimeout();
+    const env = await makeTestEnv();
+    let expectedInactivityPeriod = 0;
+    patchWithCleanup(env.services.bus_service, {
+        send: (type, payload) => {
+            if (type === "update_presence") {
+                assertAlmostEqual(expectedInactivityPeriod, payload.inactivity_period);
+                step("update_presence");
+            }
+        },
+    });
+    env.services.bus_service.addEventListener("connect", () => step("connect"), { once: true });
+    env.services.bus_service.start();
+    await assertSteps(["connect"]);
+    await assertSteps(["update_presence"]);
+    expectedInactivityPeriod = AWAY_DELAY;
+    patchWithCleanup(env.services.presence, {
+        getLastPresence: () => new Date().getTime() - AWAY_DELAY,
+    });
+    advanceTime(AWAY_DELAY);
+    await assertSteps(["update_presence"]);
+});

--- a/addons/bus/tests/__init__.py
+++ b/addons/bus/tests/__init__.py
@@ -1,5 +1,6 @@
 from . import common
 from . import test_assetsbundle
+from . import test_bus_presence
 from . import test_health
 from . import test_ir_model
 from . import test_ir_websocket

--- a/addons/bus/tests/common.py
+++ b/addons/bus/tests/common.py
@@ -102,7 +102,7 @@ class WebsocketCase(HttpCase):
             sub = {'event_name': 'subscribe', 'data': {
                 'channels': channels or [],
             }}
-            if last:
+            if last is not None:
                 sub['data']['last'] = last
             websocket.send(json.dumps(sub))
             if wait_for_dispatch:

--- a/addons/bus/tests/test_bus_presence.py
+++ b/addons/bus/tests/test_bus_presence.py
@@ -1,0 +1,45 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import datetime, timedelta
+from freezegun import freeze_time
+
+from odoo.tests import HttpCase, tagged, new_test_user
+from ..models.bus_presence import PRESENCE_OUTDATED_TIMER
+
+
+@tagged("-at_install", "post_install")
+class TestBusPresence(HttpCase):
+    def test_bus_presence_auto_vacuum(self):
+        user = new_test_user(self.env, login="bob_user")
+        # presence is outdated
+        more_than_away_timer_ago = datetime.now() - timedelta(seconds=PRESENCE_OUTDATED_TIMER + 1)
+        more_than_away_timer_ago = more_than_away_timer_ago.replace(microsecond=0)
+        with freeze_time(more_than_away_timer_ago):
+            self.env["bus.presence"]._update_presence(
+                inactivity_period=0, identity_field="user_id", identity_value=user.id
+            )
+        presence = self.env["bus.presence"].search([("user_id", "=", user.id)])
+        self.assertEqual(presence.last_poll, more_than_away_timer_ago)
+        self.env["bus.presence"]._gc_bus_presence()
+        presence = self.env["bus.presence"].search([("user_id", "=", user.id)])
+        self.assertFalse(presence)
+        # user is not active anymore
+        self.env["bus.presence"]._update_presence(
+            inactivity_period=0, identity_field="user_id", identity_value=user.id
+        )
+        presence = self.env["bus.presence"].search([("user_id", "=", user.id)])
+        self.assertTrue(presence)
+        user.active = False
+        self.env["bus.presence"]._gc_bus_presence()
+        presence = self.env["bus.presence"].search([("user_id", "=", user.id)])
+        self.assertFalse(presence)
+        # presence is offline
+        self.env["bus.presence"]._update_presence(
+            inactivity_period=0, identity_field="user_id", identity_value=user.id
+        )
+        presence = self.env["bus.presence"].search([("user_id", "=", user.id)])
+        presence.status = "offline"
+        self.assertEqual(presence.status, "offline")
+        self.env["bus.presence"]._gc_bus_presence()
+        presence = self.env["bus.presence"].search([("user_id", "=", user.id)])
+        self.assertFalse(presence)

--- a/addons/bus/tests/test_ir_websocket.py
+++ b/addons/bus/tests/test_ir_websocket.py
@@ -1,9 +1,19 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import json
+from datetime import datetime, timedelta
+from freezegun import freeze_time
+try:
+    import websocket as ws
+except ImportError:
+    ws = None
 
-from odoo.tests import common
+from odoo.tests import new_test_user, tagged
+from .common import WebsocketCase
+from ..models.bus_presence import AWAY_TIMER
 
 
-class TestIrWebsocket(common.HttpCase):
+@tagged("-at_install", "post_install")
+class TestIrWebsocket(WebsocketCase):
     def test_only_allow_string_channels_from_frontend(self):
         with self.assertRaises(ValueError):
             self.env['ir.websocket']._subscribe({
@@ -11,3 +21,92 @@ class TestIrWebsocket(common.HttpCase):
                 'last': 0,
                 'channels': [('odoo', 'discuss.channel', 5)],
             })
+
+    def test_notify_on_status_change(self):
+        bob = new_test_user(self.env, login="bob_user", groups="base.group_user")
+        session = self.authenticate("bob_user", "bob_user")
+        websocket = self.websocket_connect(cookie=f"session_id={session.sid};")
+        self.subscribe(
+            websocket,
+            [f"odoo-presence-res.partner_{bob.partner_id.id}"],
+            self.env["bus.bus"]._bus_last_id(),
+        )
+        # offline => online
+        websocket.send(
+            json.dumps(
+                {
+                    "event_name": "update_presence",
+                    "data": {"inactivity_period": 0, "im_status_ids_by_model": {}},
+                }
+            )
+        )
+        self.trigger_notification_dispatching([(bob.partner_id, "presence")])
+        message = json.loads(websocket.recv())[0]["message"]
+        self.assertEqual(message["type"], "bus.bus/im_status_updated")
+        self.assertEqual(message["payload"]["im_status"], "online")
+        self.assertEqual(message["payload"]["partner_id"], bob.partner_id.id)
+        # online => away
+        away_timer_later = datetime.now() + timedelta(seconds=AWAY_TIMER + 1)
+        with freeze_time(away_timer_later):
+            websocket.send(
+                json.dumps(
+                    {
+                        "event_name": "update_presence",
+                        "data": {
+                            "inactivity_period": (AWAY_TIMER + 1) * 1000,
+                            "im_status_ids_by_model": {},
+                        },
+                    }
+                )
+            )
+            self.trigger_notification_dispatching([(bob.partner_id, "presence")])
+            message = json.loads(websocket.recv())[0]["message"]
+            self.assertEqual(message["type"], "bus.bus/im_status_updated")
+            self.assertEqual(message["payload"]["im_status"], "away")
+            self.assertEqual(message["payload"]["partner_id"], bob.partner_id.id)
+        # away => online
+        ten_minutes_later = datetime.now() + timedelta(minutes=10)
+        with freeze_time(ten_minutes_later):
+            websocket.send(
+                json.dumps(
+                    {
+                        "event_name": "update_presence",
+                        "data": {"inactivity_period": 0, "im_status_ids_by_model": {}},
+                    }
+                )
+            )
+            self.trigger_notification_dispatching([(bob.partner_id, "presence")])
+            message = json.loads(websocket.recv())[0]["message"]
+            self.assertEqual(message["type"], "bus.bus/im_status_updated")
+            self.assertEqual(message["payload"]["im_status"], "online")
+            self.assertEqual(message["payload"]["partner_id"], bob.partner_id.id)
+        # online => online, nothing happens
+        ten_minutes_later = datetime.now() + timedelta(minutes=10)
+        with freeze_time(ten_minutes_later):
+            websocket.send(
+                json.dumps(
+                    {
+                        "event_name": "update_presence",
+                        "data": {"inactivity_period": 0, "im_status_ids_by_model": {}},
+                    }
+                )
+            )
+            self.trigger_notification_dispatching([(bob.partner_id, "presence")])
+            with self.assertRaises(ws._exceptions.WebSocketTimeoutException):
+                message = json.loads(websocket.recv())[0]["message"]
+
+    def test_receive_missed_presences_on_subscribe(self):
+        bob = new_test_user(self.env, login="bob_user", groups="base.group_user")
+        session = self.authenticate("bob_user", "bob_user")
+        websocket = self.websocket_connect(cookie=f"session_id={session.sid};")
+        self.env["bus.presence"].create({"user_id": bob.id, "status": "online"})
+        self.subscribe(
+            websocket,
+            [f"odoo-presence-res.partner_{bob.partner_id.id}"],
+            self.env["bus.bus"]._bus_last_id(),
+        )
+        self.trigger_notification_dispatching([(bob.partner_id, "presence")])
+        message = json.loads(websocket.recv())[0]["message"]
+        self.assertEqual(message["type"], "bus.bus/im_status_updated")
+        self.assertEqual(message["payload"]["im_status"], "online")
+        self.assertEqual(message["payload"]["partner_id"], bob.partner_id.id)

--- a/addons/bus/tests/test_websocket_caryall.py
+++ b/addons/bus/tests/test_websocket_caryall.py
@@ -260,3 +260,10 @@ class TestWebsocketCaryall(WebsocketCase):
             )
             serve_forever_called_event.wait(timeout=5)
             self.assertTrue(mock.called)
+
+    def test_trigger_on_websocket_closed(self):
+        with patch('odoo.addons.bus.models.ir_websocket.IrWebsocket._on_websocket_closed') as mock:
+            ws = self.websocket_connect()
+            ws.close(CloseCode.CLEAN)
+            self.wait_remaining_websocket_connections()
+            self.assertTrue(mock.called)

--- a/addons/bus/tests/test_websocket_controller.py
+++ b/addons/bus/tests/test_websocket_controller.py
@@ -1,7 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import json
-
 from odoo.tests import JsonRpcException
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 
@@ -69,3 +67,41 @@ class TestWebsocketController(HttpCaseWithUserDemo):
                 'last': 0,
                 'is_first_poll': False,
             }, headers=headers)
+
+    def test_on_websocket_closed(self):
+        session = self.authenticate("demo", "demo")
+        headers = {"Cookie": f"session_id={session.sid};"}
+        self.env["bus.presence"]._update_presence(
+            inactivity_period=0, identity_field="user_id", identity_value=self.user_demo.id
+        )
+        self.env["bus.bus"].search([]).unlink()
+        self.make_jsonrpc_request("/websocket/on_closed", {}, headers=headers)
+        message = self.make_jsonrpc_request(
+            "/websocket/peek_notifications",
+            {
+                "channels": [f"odoo-presence-res.partner_{self.partner_demo.id}"],
+                "last": 0,
+                "is_first_poll": True,
+            },
+            headers=headers,
+        )["notifications"][0]["message"]
+        self.assertEqual(message["type"], "bus.bus/im_status_updated")
+        self.assertEqual(message["payload"]["partner_id"], self.partner_demo.id)
+        self.assertEqual(message["payload"]["im_status"], "offline")
+
+    def test_receive_missed_presences_on_peek_notifications(self):
+        session = self.authenticate("demo", "demo")
+        headers = {"Cookie": f"session_id={session.sid};"}
+        self.env["bus.presence"].create({"user_id": self.user_demo.id, "status": "online"})
+        message = self.make_jsonrpc_request(
+            "/websocket/peek_notifications",
+            {
+                "channels": [f"odoo-presence-res.partner_{self.partner_demo.id}"],
+                "last": self.env["bus.bus"]._bus_last_id(),
+                "is_first_poll": True,
+            },
+            headers=headers,
+        )["notifications"][0]["message"]
+        self.assertEqual(message["type"], "bus.bus/im_status_updated")
+        self.assertEqual(message["payload"]["partner_id"], self.partner_demo.id)
+        self.assertEqual(message["payload"]["im_status"], "online")

--- a/addons/hr_holidays/tests/test_out_of_office.py
+++ b/addons/hr_holidays/tests/test_out_of_office.py
@@ -85,21 +85,21 @@ class TestOutOfOfficePerformance(TestHrHolidaysCommon, TransactionCaseWithUserDe
     @users('__system__', 'demo')
     @warmup
     def test_leave_im_status_performance_partner_offline(self):
-        with self.assertQueryCount(__system__=2, demo=2):
+        with self.assertQueryCount(__system__=3, demo=3):
             self.assertEqual(self.employer_partner.im_status, 'offline')
 
     @users('__system__', 'demo')
     @warmup
     def test_leave_im_status_performance_user_leave_offline(self):
         self.leave.write({'state': 'validate'})
-        with self.assertQueryCount(__system__=2, demo=2):
+        with self.assertQueryCount(__system__=3, demo=3):
             self.assertEqual(self.hr_user.im_status, 'leave_offline')
 
     @users('__system__', 'demo')
     @warmup
     def test_leave_im_status_performance_partner_leave_offline(self):
         self.leave.write({'state': 'validate'})
-        with self.assertQueryCount(__system__=2, demo=2):
+        with self.assertQueryCount(__system__=3, demo=3):
             self.assertEqual(self.hr_partner.im_status, 'leave_offline')
 
     def test_search_absent_employee(self):

--- a/addons/im_livechat/static/tests/embed/feedback_panel_tests.js
+++ b/addons/im_livechat/static/tests/embed/feedback_panel_tests.js
@@ -1,12 +1,13 @@
 /* @odoo-module */
 
 import { startServer } from "@bus/../tests/helpers/mock_python_environment";
+import { waitUntilSubscribe } from "@bus/../tests/helpers/websocket_event_deferred";
 
 import { RATING } from "@im_livechat/embed/common/livechat_service";
 import { loadDefaultConfig, start } from "@im_livechat/../tests/embed/helper/test_utils";
 
 import { triggerHotkey } from "@web/../tests/helpers/utils";
-import { click, contains, insertText } from "@web/../tests/utils";
+import { assertSteps, click, contains, insertText, step } from "@web/../tests/utils";
 
 QUnit.module("feedback panel");
 
@@ -49,6 +50,9 @@ QUnit.test("Feedback with rating and comment", async (assert) => {
     await loadDefaultConfig();
     start({
         mockRPC(route, args) {
+            if (route === "/mail/action") {
+                step(route);
+            }
             if (route === "/im_livechat/visitor_leave_session") {
                 assert.step(route);
             }
@@ -63,7 +67,9 @@ QUnit.test("Feedback with rating and comment", async (assert) => {
     await contains(".o-mail-ChatWindow");
     await insertText(".o-mail-Composer-input", "Hello World!");
     triggerHotkey("Enter");
+    await waitUntilSubscribe("mail.guest_null");
     await contains(".o-mail-Message-content", { text: "Hello World!" });
+    await assertSteps(["/mail/action"]);
     await click("[title='Close Chat Window']");
     assert.verifySteps(["/im_livechat/visitor_leave_session"]);
     await click(`img[data-alt="${RATING.GOOD}"]`);

--- a/addons/im_livechat/static/tests/embed/livechat_button_tests.js
+++ b/addons/im_livechat/static/tests/embed/livechat_button_tests.js
@@ -1,6 +1,7 @@
 /* @odoo-module */
 
 import { startServer } from "@bus/../tests/helpers/mock_python_environment";
+import { waitUntilSubscribe } from "@bus/../tests/legacy/helpers/websocket_event_deferred";
 
 import { loadDefaultConfig, start } from "@im_livechat/../tests/embed/helper/test_utils";
 
@@ -26,6 +27,7 @@ QUnit.test("open/close persisted channel", async () => {
     await click(".o-livechat-LivechatButton");
     await insertText(".o-mail-Composer-input", "How can I help?");
     triggerHotkey("Enter");
+    await waitUntilSubscribe();
     await contains(".o-mail-Message-content", { text: "How can I help?" });
     await click("[title='Close Chat Window']");
     await contains(".o-mail-ChatWindow", { text: "Did we correctly answer your question?" });

--- a/addons/im_livechat/static/tests/embed/livechat_service_tests.js
+++ b/addons/im_livechat/static/tests/embed/livechat_service_tests.js
@@ -78,8 +78,10 @@ QUnit.test("Only necessary requests are made when creating a new chat", async (a
     assert.verifySteps([]);
     await triggerHotkey("Enter");
     await contains(".o-mail-Message", { text: "Hello!" });
+    await click(".o-mail-Composer-input");
     await linkPreviewDeferred;
     assert.verifySteps([
+        "/discuss/channel/set_last_seen_message",
         "/im_livechat/get_session",
         "/mail/init_messaging",
         "/mail/message/post",

--- a/addons/im_livechat/static/tests/embed/message_actions_tests.js
+++ b/addons/im_livechat/static/tests/embed/message_actions_tests.js
@@ -1,6 +1,7 @@
 /* @odoo-module */
 
 import { startServer } from "@bus/../tests/helpers/mock_python_environment";
+import { waitUntilSubscribe } from "@bus/../tests/helpers/websocket_event_deferred";
 
 import { loadDefaultConfig, start } from "@im_livechat/../tests/embed/helper/test_utils";
 
@@ -19,6 +20,7 @@ QUnit.test("Only two quick actions are shown", async () => {
     await contains(".o-mail-ChatWindow");
     await insertText(".o-mail-Composer-input", "Hello World!");
     triggerHotkey("Enter");
+    await waitUntilSubscribe("mail.guest_null");
     await click("[title='Add a Reaction']");
     await click(".o-Emoji", { text: "😅" });
     await contains(".o-mail-Message-actions i", { count: 3 });

--- a/addons/im_livechat/static/tests/sidebar_patch_tests.js
+++ b/addons/im_livechat/static/tests/sidebar_patch_tests.js
@@ -1,6 +1,7 @@
 /* @odoo-module */
 
 import { startServer } from "@bus/../tests/helpers/mock_python_environment";
+import { waitForChannels } from "@bus/../tests/helpers/websocket_event_deferred";
 
 import { Command } from "@mail/../tests/helpers/command";
 import { start } from "@mail/../tests/helpers/test_utils";
@@ -486,7 +487,7 @@ QUnit.test("unknown livechat can be displayed and interacted with", async () => 
     await contains("button.o-active", { text: "Inbox" });
     await contains(".o-mail-DiscussSidebarCategory-livechat", { count: 0 });
     await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
-    await openDiscuss(channelId);
+    await Promise.all([waitForChannels([`discuss.channel_${channelId}`]), openDiscuss(channelId)]);
     await contains(
         ".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel.o-active",
         {

--- a/addons/mail/models/bus_presence.py
+++ b/addons/mail/models/bus_presence.py
@@ -14,3 +14,17 @@ class BusPresence(models.Model):
     _sql_constraints = [
         ("partner_or_guest_exists", "CHECK((user_id IS NOT NULL AND guest_id IS NULL) OR (user_id IS NULL AND guest_id IS NOT NULL))", "A bus presence must have a user or a guest."),
     ]
+
+    def _get_bus_target(self):
+        return self.guest_id or super()._get_bus_target()
+
+    def _get_identity_field_name(self):
+        return "guest_id" if self.guest_id else super()._get_identity_field_name()
+
+    def _get_identity_data(self):
+        self.ensure_one()
+        return {"guest_id": self.guest_id.id} if self.guest_id else super()._get_identity_data()
+
+    def _invalidate_im_status(self, fnames=None, flush=True):
+        super().invalidate_recordset(fnames, flush)
+        self.guest_id.invalidate_recordset(["im_status"])

--- a/addons/mail/models/discuss/ir_websocket.py
+++ b/addons/mail/models/discuss/ir_websocket.py
@@ -21,6 +21,47 @@ class IrWebsocket(models.AbstractModel):
             )]
         return im_status
 
+    def _get_missed_presences_identity_domains(self, presence_channels):
+        identity_domain = super()._get_missed_presences_identity_domains(presence_channels)
+        if guest_ids := [
+            g.id for g, _ in presence_channels if isinstance(g, self.pool["mail.guest"])
+        ]:
+            identity_domain.append([("guest_id", "in", guest_ids)])
+        return identity_domain
+
+    @add_guest_to_context
+    def _build_presence_channel_list(self, presences):
+        channels = super()._build_presence_channel_list(presences)
+        guest_ids = [int(p[1]) for p in presences if p[0] == "mail.guest"]
+        if self.env.user and self.env.user._is_internal():
+            channels.extend(
+                (guest, "presence")
+                for guest in self.env["mail.guest"].search([("id", "in", guest_ids)])
+            )
+            # Partners already handled in super call (bus)
+            return channels
+        self_discuss_channels = self.env["discuss.channel"]
+        if self.env.user and not self.env.user._is_public():
+            self_discuss_channels = self.env.user.partner_id.channel_ids
+        elif guest := self.env["mail.guest"]._get_guest_from_context():
+            # sudo - mail.guest: guest can access their own channels.
+            self_discuss_channels = guest.sudo().channel_ids
+        partner_domain = [
+            ("id", "in", [int(p[1]) for p in presences if p[0] == "res.partner"]),
+            ("channel_ids", "in", self_discuss_channels.ids),
+        ]
+        # sudo - res.partner: allow access when sharing a common channel.
+        channels.extend(
+            (partner, "presence")
+            for partner in self.env["res.partner"].sudo().search(partner_domain)
+        )
+        guest_domain = [("id", "in", guest_ids), ("channel_ids", "in", self_discuss_channels.ids)]
+        # sudo - mail.guest: allow access when sharing a common channel.
+        channels.extend(
+            (guest, "presence") for guest in self.env["mail.guest"].sudo().search(guest_domain)
+        )
+        return channels
+
     @add_guest_to_context
     def _build_bus_channel_list(self, channels):
         channels = list(channels)  # do not alter original list
@@ -58,3 +99,12 @@ class IrWebsocket(models.AbstractModel):
                 identity_field="guest_id",
                 identity_value=guest.id,
             )
+
+    def _on_websocket_closed(self, cookies):
+        super()._on_websocket_closed(cookies)
+        if self.env.user and not self.env.user._is_public():
+            return
+        token = cookies.get(self.env["mail.guest"]._cookie_name, "")
+        if guest := self.env["mail.guest"]._get_guest_from_token(token):
+            # sudo - bus.presence: guests can write their own presence
+            self.env["bus.presence"].sudo().search([("guest_id", "=", guest.id)]).status = "offline"

--- a/addons/mail/static/src/core/common/im_status_service_patch.js
+++ b/addons/mail/static/src/core/common/im_status_service_patch.js
@@ -1,0 +1,36 @@
+/* @odoo-module */
+
+import { AWAY_DELAY, imStatusService } from "@bus/im_status_service";
+import { patch } from "@web/core/utils/patch";
+
+export const imStatusServicePatch = {
+    dependencies: [...imStatusService.dependencies, "mail.store"],
+
+    start(env, services) {
+        const { bus_service, "mail.store": store, presence } = services;
+        const API = super.start(env, services);
+
+        bus_service.subscribe(
+            "bus.bus/im_status_updated",
+            ({ im_status, partner_id, guest_id }) => {
+                const persona = store.Persona.get({
+                    type: partner_id ? "partner" : "guest",
+                    id: partner_id ?? guest_id,
+                });
+                if (!persona) {
+                    return; // Do not store unknown persona's status
+                }
+                persona.im_status = im_status;
+                if (persona.type !== "guest" || persona.notEq(store.self)) {
+                    return; // Partners are already handled by the original service
+                }
+                const isOnline = presence.getInactivityPeriod() < AWAY_DELAY;
+                if ((im_status === "away" && isOnline) || im_status === "offline") {
+                    this.updateBusPresence();
+                }
+            }
+        );
+        return API;
+    },
+};
+export const unpatchImStatusService = patch(imStatusService, imStatusServicePatch);

--- a/addons/mail/static/src/core/common/persona_model.js
+++ b/addons/mail/static/src/core/common/persona_model.js
@@ -37,9 +37,26 @@ export class Persona extends Record {
     storeAsTrackedImStatus = Record.one("Store", {
         /** @this {import("models").Persona} */
         compute() {
-            if (this.type === "partner" && this.im_status !== "im_partner" && !this.is_public) {
+            if (
+                this.type === "guest" ||
+                (this.type === "partner" && this.im_status !== "im_partner" && !this.is_public)
+            ) {
                 return this._store;
             }
+        },
+        onAdd() {
+            if (!this._store.env.services.bus_service.isActive) {
+                return;
+            }
+            const model = this.type === "partner" ? "res.partner" : "mail.guest";
+            this._store.env.services.bus_service.addChannel(`odoo-presence-${model}_${this.id}`);
+        },
+        onDelete() {
+            if (!this._store.env.services.bus_service.isActive) {
+                return;
+            }
+            const model = this.type === "partner" ? "res.partner" : "mail.guest";
+            this._store.env.services.bus_service.deleteChannel(`odoo-presence-${model}_${this.id}`);
         },
         eager: true,
         inverse: "imStatusTrackedPersonas",

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -75,9 +75,6 @@ export class Store extends BaseStore {
     internalUserGroupId = null;
     imStatusTrackedPersonas = Record.many("Persona", {
         inverse: "storeAsTrackedImStatus",
-        onUpdate() {
-            this.updateImStatusRegistration();
-        },
     });
     hasLinkPreviewFeature = true;
     // messaging menu

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -30,6 +30,15 @@ export class DiscussCoreCommon {
     }
 
     setup() {
+        this.busService.addEventListener(
+            "connect",
+            () =>
+                this.store.imStatusTrackedPersonas.forEach((p) => {
+                    const model = p.type === "partner" ? "res.partner" : "mail.guest";
+                    this.busService.addChannel(`odoo-presence-${model}_${p.id}`);
+                }),
+            { once: true }
+        );
         this.messagingService.isReady.then((data) => {
             Record.MAKE_UPDATE(() => {
                 for (const channelData of data.channels) {

--- a/addons/mail/static/tests/discuss/core/discuss_tests.js
+++ b/addons/mail/static/tests/discuss/core/discuss_tests.js
@@ -34,14 +34,18 @@ QUnit.test("bus subscription is refreshed when channel is joined", async () => {
     });
     const later = luxon.DateTime.now().plus({ seconds: 2 });
     patchDate(later.year, later.month, later.day, later.hour, later.minute, later.second);
-    const { openDiscuss } = await start();
-    await assertSteps(["subscribe - []"]);
+    const { env, openDiscuss } = await start();
+    const imStatusChannels = [];
+    for (const { type, id } of env.services["mail.store"].imStatusTrackedPersonas) {
+        const model = type === "partner" ? "res.partner" : "mail.guest";
+        imStatusChannels.unshift(`"odoo-presence-${model}_${id}"`);
+    }
     await openDiscuss();
-    await assertSteps([]);
+    await assertSteps([`subscribe - [${imStatusChannels.join(",")}]`]);
     await click(".o-mail-DiscussSidebar i[title='Add or join a channel']");
     await insertText(".o-discuss-ChannelSelector input", "new channel");
     await click(".o-discuss-ChannelSelector-suggestion");
-    await assertSteps(["subscribe - []"]);
+    await assertSteps([`subscribe - [${imStatusChannels.join(",")}]`]);
 });
 
 QUnit.test("bus subscription is refreshed when channel is left", async () => {
@@ -56,10 +60,15 @@ QUnit.test("bus subscription is refreshed when channel is left", async () => {
     });
     const later = luxon.DateTime.now().plus({ seconds: 2 });
     patchDate(later.year, later.month, later.day, later.hour, later.minute, later.second);
-    const { openDiscuss } = await start();
-    await assertSteps(["subscribe - []"]);
+    const { env, openDiscuss } = await start();
+    const imStatusChannels = [];
+    for (const { type, id } of env.services["mail.store"].imStatusTrackedPersonas) {
+        const model = type === "partner" ? "res.partner" : "mail.guest";
+        imStatusChannels.unshift(`"odoo-presence-${model}_${id}"`);
+    }
+    await assertSteps([`subscribe - [${imStatusChannels.join(",")}]`]);
     await openDiscuss();
     await assertSteps([]);
     await click("[title='Leave this channel']");
-    await assertSteps(["subscribe - []"]);
+    await assertSteps([`subscribe - [${imStatusChannels.join(",")}]`]);
 });

--- a/addons/mail/static/tests/discuss/core/web/sidebar_tests.js
+++ b/addons/mail/static/tests/discuss/core/web/sidebar_tests.js
@@ -6,6 +6,7 @@ import { Command } from "@mail/../tests/helpers/command";
 import { start } from "@mail/../tests/helpers/test_utils";
 
 import { click, contains, insertText } from "@web/../tests/utils";
+import { waitForChannels } from "@bus/../tests/helpers/websocket_event_deferred";
 
 QUnit.module("discuss sidebar");
 
@@ -69,6 +70,7 @@ QUnit.test("unknown channel can be displayed and interacted with", async () => {
     await contains("button.o-active", { text: "Inbox" });
     await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
     await openDiscuss(channelId);
+    await waitForChannels([`discuss.channel_${channelId}`]);
     await contains(
         ".o-mail-DiscussSidebarCategory-channel + .o-mail-DiscussSidebarChannel.o-active",
         {

--- a/addons/mail/static/tests/discuss_app/im_status_tests.js
+++ b/addons/mail/static/tests/discuss_app/im_status_tests.js
@@ -1,6 +1,5 @@
 /* @odoo-module */
 
-import { UPDATE_BUS_PRESENCE_DELAY } from "@bus/im_status_service";
 import { startServer } from "@bus/../tests/helpers/mock_python_environment";
 
 import { Command } from "@mail/../tests/helpers/command";
@@ -57,28 +56,34 @@ QUnit.test("initially away", async () => {
 
 QUnit.test("change icon on change partner im_status", async () => {
     const pyEnv = await startServer();
-    const partnerId = pyEnv["res.partner"].create({ name: "Demo", im_status: "online" });
+    pyEnv["res.partner"].write([pyEnv.currentPartnerId], { im_status: "online" });
     const channelId = pyEnv["discuss.channel"].create({
-        channel_member_ids: [
-            Command.create({ partner_id: pyEnv.currentPartnerId }),
-            Command.create({ partner_id: partnerId }),
-        ],
+        channel_member_ids: [Command.create({ partner_id: pyEnv.currentPartnerId })],
         channel_type: "chat",
     });
-    const { advanceTime, openDiscuss } = await start({ hasTimeControl: true });
+    const { openDiscuss } = await start({ hasTimeControl: true });
     openDiscuss(channelId);
     await contains(".o-mail-ImStatus i[title='Online']");
 
-    pyEnv["res.partner"].write([partnerId], { im_status: "offline" });
-    advanceTime(UPDATE_BUS_PRESENCE_DELAY);
+    pyEnv["res.partner"].write([pyEnv.currentPartnerId], { im_status: "offline" });
+    pyEnv["bus.bus"]._sendone("broadcast", "bus.bus/im_status_updated", {
+        partner_id: pyEnv.currentPartnerId,
+        im_status: "offline",
+    });
     await contains(".o-mail-ImStatus i[title='Offline']");
 
-    pyEnv["res.partner"].write([partnerId], { im_status: "away" });
-    advanceTime(UPDATE_BUS_PRESENCE_DELAY);
+    pyEnv["res.partner"].write([pyEnv.currentPartnerId], { im_status: "away" });
+    pyEnv["bus.bus"]._sendone("broadcast", "bus.bus/im_status_updated", {
+        partner_id: pyEnv.currentPartnerId,
+        im_status: "away",
+    });
     await contains(".o-mail-ImStatus i[title='Idle']");
 
-    pyEnv["res.partner"].write([partnerId], { im_status: "online" });
-    advanceTime(UPDATE_BUS_PRESENCE_DELAY);
+    pyEnv["res.partner"].write([pyEnv.currentPartnerId], { im_status: "online" });
+    pyEnv["bus.bus"]._sendone("broadcast", "bus.bus/im_status_updated", {
+        partner_id: pyEnv.currentPartnerId,
+        im_status: "online",
+    });
     await contains(".o-mail-ImStatus i[title='Online']");
 });
 

--- a/addons/mail/static/tests/helpers/test_utils.js
+++ b/addons/mail/static/tests/helpers/test_utils.js
@@ -4,6 +4,7 @@ import { getPyEnv } from "@bus/../tests/helpers/mock_python_environment";
 import { timings } from "@bus/misc";
 
 import { loadEmoji } from "@web/core/emoji_picker/emoji_picker";
+import { unpatchImStatusService } from "@mail/core/common/im_status_service_patch";
 import { loadLamejs } from "@mail/discuss/voice_message/common/voice_message_service";
 import { patchBrowserNotification } from "@mail/../tests/helpers/patch_notifications";
 import { getAdvanceTime } from "@mail/../tests/helpers/time_control";
@@ -27,6 +28,7 @@ import { doAction, getActionManagerServerData } from "@web/../tests/webclient/he
 QUnit.begin(loadEmoji);
 QUnit.begin(loadLamejs);
 registryNamesToCloneWithCleanup.push("mock_server_callbacks", "discuss.model");
+unpatchImStatusService();
 
 //------------------------------------------------------------------------------
 // Public: test lifecycle

--- a/addons/mail/static/tests/helpers/webclient_setup.js
+++ b/addons/mail/static/tests/helpers/webclient_setup.js
@@ -9,6 +9,8 @@ import { session } from "@web/session";
 import { makeMockXHR, mocks } from "@web/../tests/helpers/mock_services";
 import { patchWithCleanup } from "@web/../tests/helpers/utils";
 import { createWebClient } from "@web/../tests/webclient/helpers";
+import { imStatusService } from "@bus/im_status_service";
+import { imStatusServicePatch } from "@mail/core/common/im_status_service_patch";
 
 const ROUTES_TO_IGNORE = [
     "/web/webclient/load_menus",
@@ -89,6 +91,8 @@ function getCreateXHR() {
     };
 }
 
+let imStatusServicePatched = false;
+
 export const setupManager = {
     /**
      * Add required components to the main component registry.
@@ -123,6 +127,10 @@ export const setupManager = {
      * to the webClient as a legacy parameter.
      */
     setupServiceRegistries({ loadingBaseDelayDuration = 0, messagingBus, services = {} } = {}) {
+        if (!imStatusServicePatched) {
+            patch(imStatusService, imStatusServicePatch);
+            imStatusServicePatched = true;
+        }
         const OriginalAudio = window.Audio;
         patchWithCleanup(window, {
             Audio: function () {

--- a/addons/mail/tests/discuss/__init__.py
+++ b/addons/mail/tests/discuss/__init__.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_bus_presence
 from . import test_discuss_channel
 from . import test_discuss_channel_access
 from . import test_discuss_channel_as_guest

--- a/addons/mail/tests/discuss/test_bus_presence.py
+++ b/addons/mail/tests/discuss/test_bus_presence.py
@@ -1,0 +1,90 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import json
+
+try:
+    import websocket as ws
+except ImportError:
+    ws = None
+
+from odoo.tests import tagged, new_test_user
+from odoo.addons.bus.tests.common import WebsocketCase
+
+
+@tagged("post_install", "-at_install")
+class TestBusPresence(WebsocketCase):
+    def _receive_presence(self, sender, recipient):
+        sent_from_user = isinstance(sender, self.env.registry["res.users"])
+        receive_to_user = isinstance(recipient, self.env.registry["res.users"])
+        if receive_to_user:
+            session = self.authenticate(recipient.login, recipient.login)
+            auth_cookie = f"session_id={session.sid};"
+        else:
+            self.authenticate(None, None)
+            auth_cookie = f"{recipient._cookie_name}={recipient._format_auth_cookie()};"
+        websocket = self.websocket_connect(cookie=auth_cookie, timeout=1)
+        sender_bus_target = sender.partner_id if sent_from_user else sender
+        self.subscribe(
+            websocket,
+            [f"odoo-presence-{sender_bus_target._name}_{sender_bus_target.id}"],
+            self.env["bus.bus"]._bus_last_id(),
+        )
+        self.env["bus.presence"].create(
+            {"user_id" if sent_from_user else "guest_id": sender.id, "status": "online"}
+        )
+        self.trigger_notification_dispatching([(sender_bus_target, "presence")])
+        notifications = json.loads(websocket.recv())
+        self.assertEqual(notifications[0]["message"]["type"], "bus.bus/im_status_updated")
+        self.assertEqual(notifications[0]["message"]["payload"]["im_status"], "online")
+        self.assertEqual(
+            notifications[0]["message"]["payload"]["partner_id" if sent_from_user else "guest_id"],
+            sender_bus_target.id,
+        )
+        self._close_websockets()
+
+    def test_receive_presences_as_guest(self):
+        guest = self.env["mail.guest"].create({"name": "Guest"})
+        bob = new_test_user(self.env, login="bob_user", groups="base.group_user")
+        # Guest should not receive users's presence: no common channel.
+        with self.assertRaises(ws._exceptions.WebSocketTimeoutException):
+            self._receive_presence(sender=bob, recipient=guest)
+        channel = self.env["discuss.channel"].channel_create(group_id=None, name="General")
+        channel.add_members(guest_ids=[guest.id], partner_ids=[bob.partner_id.id])
+        # Now that they share a channel, guest should receive users's presence.
+        self._receive_presence(sender=bob, recipient=guest)
+
+        other_guest = self.env["mail.guest"].create({"name": "OtherGuest"})
+        # Guest should not receive guest's presence: no common channel.
+        with self.assertRaises(ws._exceptions.WebSocketTimeoutException):
+            self._receive_presence(sender=other_guest, recipient=guest)
+        channel.add_members(guest_ids=[other_guest.id])
+        # Now that they share a channel, guest should receive guest's presence.
+        self._receive_presence(sender=other_guest, recipient=guest)
+
+    def test_receive_presences_as_portal(self):
+        portal = new_test_user(self.env, login="portal_user", groups="base.group_portal")
+        bob = new_test_user(self.env, login="bob_user", groups="base.group_user")
+        # Portal should not receive users's presence: no common channel.
+        with self.assertRaises(ws._exceptions.WebSocketTimeoutException):
+            self._receive_presence(sender=bob, recipient=portal)
+        channel = self.env["discuss.channel"].channel_create(group_id=None, name="General")
+        channel.add_members(partner_ids=[portal.partner_id.id, bob.partner_id.id])
+        # Now that they share a channel, portal should receive users's presence.
+        self._receive_presence(sender=bob, recipient=portal)
+
+        guest = self.env["mail.guest"].create({"name": "Guest"})
+        # Portal should not receive guest's presence: no common channel.
+        with self.assertRaises(ws._exceptions.WebSocketTimeoutException):
+            self._receive_presence(sender=guest, recipient=portal)
+        channel.add_members(guest_ids=[guest.id])
+        # Now that they share a channel, portal should receive guest's presence.
+        self._receive_presence(sender=guest, recipient=portal)
+
+    def test_receive_presences_as_internal(self):
+        internal = new_test_user(self.env, login="internal_user", groups="base.group_user")
+        guest = self.env["mail.guest"].create({"name": "Guest"})
+        # Internal can access guest's presence regardless of their channels.
+        self._receive_presence(sender=guest, recipient=internal)
+        # Internal can access users's presence regardless of their channels.
+        bob = new_test_user(self.env, login="bob_user", groups="base.group_user")
+        self._receive_presence(sender=bob, recipient=internal)

--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -91,6 +91,7 @@ class Http(models.AbstractModel):
             "uid": session_uid,
             "is_system": user._is_system() if session_uid else False,
             "is_admin": user._is_admin() if session_uid else False,
+            "is_public": user._is_public(),
             "is_internal_user": is_internal_user,
             "user_context": user_context,
             "db": self.env.cr.dbname,
@@ -170,6 +171,7 @@ class Http(models.AbstractModel):
         session_info = {
             'is_admin': user._is_admin() if session_uid else False,
             'is_system': user._is_system() if session_uid else False,
+            'is_public': user._is_public(),
             'is_website_user': user._is_public() if session_uid else False,
             'user_id': user.id if session_uid else False,
             'is_frontend': True,


### PR DESCRIPTION
Before this PR, the main tab updated the user presence every minute.
As a result of this update, it would also receive the IM statuses it
was interested in.

However, this approach puts significant pressure on the gevent worker,
especially when it handles more databases than the registry can hold.

To address this issue, this PR improves the way presences are updated:
- Presences are sent and broadcasted when they change
(e.g. away => online).
- When a websocket disconnects, the user is considered disconnected. If
other devices receive this notification, they will update the user
presence immediately.

These changes greatly reduce traffic caused by presence updates while
keeping the IM statuses reliable.

backport of https://github.com/odoo/odoo/pull/174814
backport of https://github.com/odoo/odoo/pull/175463