### PR TITLE
[IMP] account: allow to register a payment on draft invoices

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4519,6 +4519,15 @@ class AccountMove(models.Model):
                 })
 
     def action_register_payment(self):
+        if any(m.state != 'posted' for m in self):
+            raise UserError(_("You can only register payment for posted journal entries."))
+        return self.action_force_register_payment()
+
+    def action_force_register_payment(self):
+        if any(m.payment_state not in ('not_paid', 'partial') for m in self):
+            raise UserError(_("You can only register payments for (partially) unpaid documents."))
+        if any(m.move_type == 'entry' for m in self):
+            raise UserError(_("You cannot register payments for miscellaneous entries."))
         return self.line_ids.action_register_payment()
 
     def action_duplicate(self):

--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -779,13 +779,6 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         ])
 
     def test_register_payment_constraints(self):
-        # Test to register a payment for a draft journal entry.
-        self.out_invoice_1.button_draft()
-        with self.assertRaises(UserError), self.cr.savepoint():
-            self.env['account.payment.register']\
-                .with_context(active_model='account.move', active_ids=self.out_invoice_1.ids)\
-                .create({})
-
         # Test to register a payment for an already fully reconciled journal entry.
         self.env['account.payment.register']\
             .with_context(active_model='account.move', active_ids=self.out_invoice_2.ids)\

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1864,6 +1864,19 @@ if records:
             </field>
         </record>
 
+        <record model="ir.actions.server" id="action_move_force_register_payment">
+            <field name="name">Pay</field>
+            <field name="model_id" ref="account.model_account_move"/>
+            <field name="groups_id" eval="[(4, ref('account.group_account_invoice'))]"/>
+            <field name="binding_model_id" ref="account.model_account_move" />
+            <field name="state">code</field>
+            <field name="binding_view_types">list,form</field>
+            <field name="code">
+if records:
+    action = records.action_force_register_payment()
+            </field>
+        </record>
+
         <record model="ir.actions.server" id="action_check_hash_integrity">
             <field name="name">Data Inalterability Check</field>
             <field name="model_id" ref="account.model_res_company"/>

--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -407,19 +407,6 @@
             </field>
         </record>
 
-        <record id="action_account_invoice_from_list" model="ir.actions.server">
-            <field name="name">Register Payment</field>
-            <field name="groups_id" eval="[(4, ref('account.group_account_invoice'))]"/>
-            <field name="model_id" ref="account.model_account_move"/>
-            <field name="binding_model_id" ref="account.model_account_move"/>
-            <field name="binding_view_types">list</field>
-            <field name="state">code</field>
-            <field name="code">
-                if records:
-                    action = records.action_register_payment()
-            </field>
-        </record>
-
         <!-- Action confirm_payments for multi -->
         <record id="action_account_confirm_payments" model="ir.actions.server">
             <field name="name">Post Payments</field>

--- a/addons/account/wizard/account_payment_register_views.xml
+++ b/addons/account/wizard/account_payment_register_views.xml
@@ -81,7 +81,7 @@
                             <label for="payment_difference"/>
                             <div>
                                 <field name="payment_difference"/>
-                                <field name="payment_difference_handling" widget="radio" nolabel="1"/>
+                                <field name="payment_difference_handling" widget="radio" nolabel="1" invisible="is_register_payment_on_draft"/>
                                 <div invisible="hide_writeoff_section or payment_difference_handling == 'open'">
                                     <label for="writeoff_account_id" string="Post Difference In" class="oe_edit_only"/>
                                     <field name="writeoff_account_id"


### PR DESCRIPTION
It is now possible to register payments on draft invoices through a button hidden in the cog menu as it is considered advanced use.

task-id 3979071
