### PR TITLE
[IMP] *: add v18 digest tips

### DIFF
--- a/addons/account/data/digest_data.xml
+++ b/addons/account/data/digest_data.xml
@@ -19,5 +19,18 @@
 </div>
             </field>
         </record>
+
+        <record id="digest_tip_account_1" model="digest.tip">
+            <field name="name">Tip: Stop chasing the Documents you need</field>
+            <field name="sequence">3100</field>
+            <field name="group_id" ref="account.group_account_invoice"/>
+            <field name="tip_description" type="html">
+<div>
+    <p class="tip_title">Tip: Stop chasing the Documents you need</p>
+    <p class="tip_content">Missing a document for a banking statement? Use the Documents apps to request it and let the owner upload it at the right place.</p>
+    <img src="https://download.odoocdn.com/digests/account/static/src/img/18-invoice-request-document.gif" width="540" class="illustration_border"/>
+</div>
+            </field>
+        </record>
     </data>
 </odoo>

--- a/addons/base_automation/__manifest__.py
+++ b/addons/base_automation/__manifest__.py
@@ -15,10 +15,11 @@ Use automation rules to automatically trigger actions for various screens.
 Sales Team, or an opportunity which still has status pending after 14 days might
 trigger an automatic reminder email.
     """,
-    'depends': ['base', 'resource', 'mail', 'sms'],
+    'depends': ['base', 'digest', 'resource', 'mail', 'sms'],
     'data': [
         'security/ir.model.access.csv',
         'data/base_automation_data.xml',
+        'data/digest_data.xml',
         'views/ir_actions_server_views.xml',
         'views/base_automation_views.xml',
     ],

--- a/addons/base_automation/data/digest_data.xml
+++ b/addons/base_automation/data/digest_data.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='utf-8'?>
+<odoo>
+    <data>
+        <record id="digest_tip_base_automation_0" model="digest.tip">
+            <field name="name">Tip: Automate everything with Automation Rules</field>
+            <field name="sequence">3700</field>
+            <field name="group_id" ref="base.group_system"/>
+            <field name="tip_description" type="html">
+<div>
+    <p class="tip_title">Tip: Automate everything with Automation Rules</p>
+    <p class="tip_content">Send an email when an object changes state, archive records after a month of inactivity or remind yourself to follow-up on tasks when a specific tag is added.<br/>With Automation Rules, you can automate any workflow.</p>
+    <img src="https://download.odoocdn.com/digests/base_automation/static/src/img/18-automation-rules.gif" width="540" class="illustration_border"/>
+</div>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/crm/data/digest_data.xml
+++ b/addons/crm/data/digest_data.xml
@@ -86,5 +86,29 @@
 </div>
             </field>
         </record>
+        <record id="digest_tip_crm_6" model="digest.tip">
+            <field name="name">Tip: Identify Bottlenecks at a glance</field>
+            <field name="sequence">3600</field>
+            <field name="group_id" ref="sales_team.group_sale_salesman"/>
+            <field name="tip_description" type="html">
+<div>
+    <p class="tip_title">Tip: Identify Bottlenecks at a glance</p>
+    <p class="tip_content">Check the Stage Tracker of Leads to identify bottlenecks in your Sales process.</p>
+    <img src="https://download.odoocdn.com/digests/crm/static/src/img/18-lead-stage-bottleneck.png" width="540" class="illustration_border"/>
+</div>
+            </field>
+        </record>
+        <record id="digest_tip_crm_7" model="digest.tip">
+            <field name="name">Tip: Turn Sales Forecasting into Child's Play</field>
+            <field name="sequence">4400</field>
+            <field name="group_id" ref="sales_team.group_sale_salesman"/>
+            <field name="tip_description" type="html">
+<div>
+    <p class="tip_title">Tip: Turn Sales Forecasting into Child's Play</p>
+    <p class="tip_content">Use the CRM Forecast Kanban to easily define when Opportunities are expected to be won.</p>
+    <img src="https://download.odoocdn.com/digests/crm/static/src/img/18-opportunity-forecast.gif" width="540" class="illustration_border"/>
+</div>
+            </field>
+        </record>
     </data>
 </odoo>

--- a/addons/digest/data/digest_tips_data.xml
+++ b/addons/digest/data/digest_tips_data.xml
@@ -72,5 +72,29 @@ Follow a project / sales team to keep track of this project's tasks / this team'
 </div>
             </field>
         </record>
+        <record id="digest_tip_digest_5" model="digest.tip">
+            <field name="name">Tip: Join the Dark Side</field>
+            <field name="sequence">3300</field>
+            <field name="group_id" ref="base.group_user"/>
+            <field name="tip_description" type="html">
+<div>
+    <p class="tip_title">Tip: Join the Dark Side</p>
+    <p class="tip_content">Feeling eye strain? Give your eyes a break by switching to Dark Mode.</p>
+    <img src="https://download.odoocdn.com/digests/digest/static/src/img/18-web-dark-theme.gif" width="540" class="illustration_border"/>
+</div>
+            </field>
+        </record>
+        <record id="digest_tip_digest_6" model="digest.tip">
+            <field name="name">Tip: Personalize your Home Menu</field>
+            <field name="sequence">3800</field>
+            <field name="group_id" ref="base.group_user"/>
+            <field name="tip_description" type="html">
+<div>
+    <p class="tip_title">Tip: Personalize your Home Menu</p>
+    <p class="tip_content">Click and hold on a Menu Item to reorder your Apps to your liking.</p>
+    <img src="https://download.odoocdn.com/digests/digest/static/src/img/18-web-app-order.gif" width="540" class="illustration_border"/>
+</div>
+            </field>
+        </record>
     </data>
 </odoo>

--- a/addons/hr/__manifest__.py
+++ b/addons/hr/__manifest__.py
@@ -13,6 +13,7 @@
     ],
     'depends': [
         'base_setup',
+        'digest',
         'phone_validation',
         'resource_mail',
         'web',
@@ -20,6 +21,7 @@
     'data': [
         'security/hr_security.xml',
         'security/ir.model.access.csv',
+        'data/digest_data.xml',
         'data/report_paperformat.xml',
         'wizard/hr_departure_wizard_views.xml',
         'wizard/mail_activity_schedule_views.xml',

--- a/addons/hr/data/digest_data.xml
+++ b/addons/hr/data/digest_data.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='utf-8'?>
+<odoo>
+    <data>
+        <record id="digest_tip_hr_0" model="digest.tip">
+            <field name="name">Tip: Where's Bryan?</field>
+            <field name="sequence">3500</field>
+            <field name="group_id" ref="hr.group_hr_manager"/>
+            <field name="tip_description" type="html">
+<div>
+    <p class="tip_title">Tip: Where's Bryan?</p>
+    <p class="tip_content">Activate Remote Work to let Employees specify where they are working from.</p>
+    <img src="https://download.odoocdn.com/digests/hr/static/src/img/18-hr-work-location.gif" width="540" class="illustration_border"/>
+</div>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -569,7 +569,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
 
     def test_leave_with_public_holiday_other_company(self):
         other_company = self.env['res.company'].create({
-            'name': 'Test Company',
+            'name': 'Test Company 2',
         })
         # Create a public holiday for the second company
         p_leave = self.env['resource.calendar.leaves'].create({

--- a/addons/hr_work_entry_holidays/tests/test_performance.py
+++ b/addons/hr_work_entry_holidays/tests/test_performance.py
@@ -32,7 +32,7 @@ class TestWorkEntryHolidaysPerformance(TestWorkEntryHolidaysBase):
         self.richard_emp.generate_work_entries(date(2018, 1, 1), date(2018, 1, 2))
         leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
 
-        with self.assertQueryCount(__system__=114, admin=115):  # com 96/97
+        with self.assertQueryCount(__system__=117, admin=118):  # com 96/97
             leave.action_validate()
         leave.action_refuse()
 

--- a/addons/project/data/digest_data.xml
+++ b/addons/project/data/digest_data.xml
@@ -39,5 +39,31 @@
 </div>
             </field>
         </record>
+
+        <record id="digest_tip_project_2" model="digest.tip">
+            <field name="name">Tip: Your Own Personal Kanban</field>
+            <field name="sequence">3200</field>
+            <field name="group_id" ref="project.group_project_user"/>
+            <field name="tip_description" type="html">
+<div>
+    <p class="tip_title">Tip: Your Own Personal Kanban</p>
+    <p class="tip_content">Use personal stages to organize your tasks and create your own workflow.</p>
+    <img src="https://download.odoocdn.com/digests/project/static/src/img/18-project-personal-stages.gif" width="540" class="illustration_border"/>
+</div>
+            </field>
+        </record>
+
+        <record id="digest_tip_project_3" model="digest.tip">
+            <field name="name">Tip: Project-Specific Fields</field>
+            <field name="sequence">3900</field>
+            <field name="group_id" ref="project.group_project_manager"/>
+            <field name="tip_description" type="html">
+<div>
+    <p class="tip_title">Tip: Project-Specific Fields</p>
+    <p class="tip_content">Add project-specific property fields on tasks to customize your project management process.</p>
+    <img src="https://download.odoocdn.com/digests/project/static/src/img/18-project-property-fields.gif" width="540" class="illustration_border"/>
+</div>
+            </field>
+        </record>
     </data>
 </odoo>

--- a/addons/stock/data/digest_data.xml
+++ b/addons/stock/data/digest_data.xml
@@ -22,5 +22,17 @@
 </div>
             </field>
         </record>
+        <record id="digest_tip_stock_1" model="digest.tip">
+            <field name="name">Tip: Monitor Lot details</field>
+            <field name="sequence">4000</field>
+            <field name="group_id" ref="stock.group_stock_user"/>
+            <field name="tip_description" type="html">
+<div>
+    <p class="tip_title">Tip: Monitor Lot details</p>
+    <p class="tip_content">Store and retrieve information regarding every Lot/Serial Number (condition, product info, ...).</p>
+    <img src="https://download.odoocdn.com/digests/stock/static/src/img/18-stock-property-fields.gif" width="540" class="illustration_border"/>
+</div>
+            </field>
+        </record>
     </data>
 </odoo>


### PR DESCRIPTION
Add more digest tips to showcase the new features added for v18.
Tips sequence numbers going from 3100 to 4400.

Technical:
Had to slightly change the name of a company in the hr_holidays tests
to be different from the base test company declared in the module common test file.
Adding the digest module as dependency to the hr module loads helpdesk before hr_holidays.
An helpdesk team is thus created each time a company is created and using the same company
name generates the same mail alias which breaks the alias unicity check.

Same thing happens in the hr_work_entry_holidays tests, the modules loading order has slightly changed
following the addition of the digest dependency in hr. This causes a slight increase in the query count
when testing the validation of a leave.
Ideally those tests should become post_install in order to be more deterministic.

Related: https://github.com/odoo/enterprise/pull/67244

Task-3762938

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
