### PR TITLE
[FIX] sale_management: enable discounts before running tests

### DIFF
--- a/addons/sale/tests/test_sale_prices.py
+++ b/addons/sale/tests/test_sale_prices.py
@@ -19,8 +19,8 @@ class TestSalePrices(SaleCommon):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.discount = 10  # %
         cls._enable_discounts()
+        cls.discount = 10  # %
 
         # Needed when run without demo data
         #   s.t. taxes creation doesn't fail

--- a/addons/sale_management/tests/test_sale_order.py
+++ b/addons/sale_management/tests/test_sale_order.py
@@ -17,6 +17,7 @@ class TestSaleOrder(SaleManagementCommon):
         # some variables to ease asserts in tests
         cls.pub_product_price = 100.0
         cls.pl_product_price = 80.0
+        cls._enable_discounts()
         cls.tpl_discount = 10.0
         cls.pl_discount = (cls.pub_product_price - cls.pl_product_price) * 100 / cls.pub_product_price
         cls.merged_discount = 100.0 - (100.0 - cls.pl_discount) * (100.0 - cls.tpl_discount) / 100.0


### PR DESCRIPTION
After commit 73b80be7649746f739fbd924c94a0410d6660659, 
a check was added if discount was enabled before applying it 
some tests were failing, because the setting was not enabled 
So now we make sure the setting is enabled before running the tests

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
