### PR TITLE
[FIX] pos_hr: keep cashier after rehresh

### DIFF
--- a/addons/pos_hr/static/src/overrides/components/navbar/closing_popup/close_pos_popup.js
+++ b/addons/pos_hr/static/src/overrides/components/navbar/closing_popup/close_pos_popup.js
@@ -1,0 +1,10 @@
+/** @odoo-module */
+import { ClosePosPopup } from "@point_of_sale/app/navbar/closing_popup/closing_popup";
+import { patch } from "@web/core/utils/patch";
+
+patch(ClosePosPopup.prototype, {
+    async closeSession() {
+        sessionStorage.removeItem("connected_cashier");
+        super.closeSession();
+    },
+});

--- a/addons/pos_hr/static/src/overrides/models/pos_store.js
+++ b/addons/pos_hr/static/src/overrides/models/pos_store.js
@@ -7,7 +7,9 @@ patch(PosStore.prototype, {
     async setup() {
         await super.setup(...arguments);
         if (this.config.module_pos_hr) {
-            this.showTempScreen("LoginScreen");
+            if (!this.hasLoggedIn) {
+                this.showTempScreen("LoginScreen");
+            }
         }
     },
     async _processData(loadedData) {
@@ -15,13 +17,19 @@ patch(PosStore.prototype, {
         if (this.config.module_pos_hr) {
             this.employees = loadedData["hr.employee"];
             this.employee_by_id = loadedData["employee_by_id"];
-            this.reset_cashier();
+            const saved_cashier_id = sessionStorage.getItem("connected_cashier");
+            if (saved_cashier_id) {
+                this.set_cashier(this.employee_by_id[saved_cashier_id]);
+            } else {
+                this.reset_cashier();
+            }
         }
     },
     async after_load_server_data() {
         await super.after_load_server_data(...arguments);
         if (this.config.module_pos_hr) {
-            this.hasLoggedIn = !this.config.module_pos_hr;
+            const saved_cashier = sessionStorage.getItem("connected_cashier");
+            this.hasLoggedIn = saved_cashier ? true : false;
         }
     },
     reset_cashier() {
@@ -33,9 +41,11 @@ patch(PosStore.prototype, {
             pin: null,
             role: null,
         };
+        sessionStorage.removeItem("connected_cashier");
     },
     set_cashier(employee) {
         this.cashier = employee;
+        sessionStorage.setItem("connected_cashier", employee.id);
         const selectedOrder = this.get_order();
         if (selectedOrder && !selectedOrder.get_orderlines().length) {
             // Order without lines can be considered to be un-owned by any employee.

--- a/addons/pos_hr/static/tests/tours/PosHrTour.js
+++ b/addons/pos_hr/static/tests/tours/PosHrTour.js
@@ -90,3 +90,24 @@ registry.category("web_tour.tours").add("PosHrTour", {
             TicketScreen.nthRowContains(4, "Mitchell Admin", false),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("CashierStayLogged", {
+    test: true,
+    steps: () =>
+        [
+            PosHr.loginScreenIsShown(),
+            PosHr.clickLoginButton(),
+            SelectionPopup.isShown(),
+            SelectionPopup.hasSelectionItem("Pos Employee1"),
+            SelectionPopup.hasSelectionItem("Pos Employee2"),
+            SelectionPopup.hasSelectionItem("Mitchell Admin"),
+            SelectionPopup.clickItem("Mitchell Admin"),
+            PosHr.cashierNameIs("Mitchell Admin"),
+            PosHr.refreshPage(),
+            PosHr.cashierNameIs("Mitchell Admin"),
+            Chrome.clickMenuButton(),
+            PosHr.clickLockButton(),
+            PosHr.refreshPage(),
+            PosHr.loginScreenIsShown(),
+        ].flat(),
+});

--- a/addons/pos_hr/static/tests/tours/PosHrTourMethods.js
+++ b/addons/pos_hr/static/tests/tours/PosHrTourMethods.js
@@ -55,3 +55,14 @@ export function login(name, pin) {
     }
     return res;
 }
+
+export function refreshPage() {
+    return [
+        {
+            trigger: "body",
+            run: () => {
+                window.location.reload();
+            },
+        },
+    ];
+}

--- a/addons/pos_hr/tests/test_frontend.py
+++ b/addons/pos_hr/tests/test_frontend.py
@@ -61,3 +61,13 @@ class TestUi(TestPosHrHttpCommon):
             "PosHrTour",
             login="pos_admin",
         )
+
+    def test_cashier_stay_logged_in(self):
+        # open a session, the /pos/ui controller will redirect to it
+        self.main_pos_config.with_user(self.pos_admin).open_ui()
+
+        self.start_tour(
+            "/pos/ui?config_id=%d" % self.main_pos_config.id,
+            "CashierStayLogged",
+            login="pos_admin",
+        )


### PR DESCRIPTION
When refreshing the PoS when logged in with a cashier would disconnect the cashier.

Steps to reproduce:
-------------------
* Install pos_hr
* Log in as any cashier
* Refresh the page
> Observation: You are not logged in anymore

Why the fix:
------------
We save the current cashier_id in the session storage. This way when we
refresh the page we can get it back. We use the session storage instead
of local storage because it's specific to one tab.

opw-4005556
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
