### PR TITLE
[FIX] project: allow customer edition in portal subtasks subview

### DIFF
--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -206,7 +206,7 @@
                                         column_invisible="not parent.allow_milestones"
                                         invisible="not allow_milestones"/>
                                     <field name="company_id" column_invisible="True"/>
-                                    <field name="partner_id" options="{'no_open': True, 'no_create': True, 'no_edit': True}" optional="hide" invisible="not project_id"/>
+                                    <field name="partner_id" options="{'no_open': True, 'no_create': True, 'no_edit': True}" optional="hide"/>
                                     <field name="user_ids" column_invisible="True" />
                                     <field name="portal_user_names" string="Assignees" optional="show"/>
                                     <field name="date_deadline" invisible="state in ['1_done', '1_canceled']" decoration-danger="date_deadline &lt; current_date" optional="show"/>


### PR DESCRIPTION
Steps:
- Login as portal, and to to a task form, page sub-tasks.
- Make Customer column visible.
- Add a line and try to edit that field.

Issue:
You can't. But after saving, you can.

Cause:
The new record doesn't have a project (it will be given to it on save). Yet this PR odoo#111335 added the condition
that it should be invisible if no project.
The reason why it caused no issue in 16.3 (where it was merged) was that there was a default project in `child_ids`'s context.

Solution:
In this case, the condition is not needed. Subtasks always have a project : private tasks can't have subtasks and deleting project field on a non-private task's subtask will actually give it its parent project. So the solution is simple: remove the condition.

task-3713729




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
