### PR TITLE
[FIX] web: remove flicker when changing datetime

### DIFF
--- a/addons/web/static/src/core/datetime/datetimepicker_service.js
+++ b/addons/web/static/src/core/datetime/datetimepicker_service.js
@@ -84,7 +84,6 @@ export const datetimePickerService = {
                         return;
                     }
 
-                    lastInitialProps = null; // Next pickerProps are considered final
                     inputsChanged = ensureArray(pickerProps.value).map(() => false);
 
                     hookParams.onApply?.(pickerProps.value);
@@ -467,16 +466,19 @@ export const datetimePickerService = {
                                 editableInputs++;
                             }
                         }
-                        const calendarIconGroupEl = getInput(0)?.parentElement
-                            .querySelector(".input-group-text .fa-calendar")?.parentElement;
+                        const calendarIconGroupEl = getInput(0)?.parentElement.querySelector(
+                            ".input-group-text .fa-calendar"
+                        )?.parentElement;
                         if (calendarIconGroupEl) {
                             // TODO: Remove this line and the `pe-none` class
                             // from templates in master
                             calendarIconGroupEl.classList.remove("pe-none");
                             calendarIconGroupEl.classList.add("cursor-pointer");
-                            cleanups.push(addListener(calendarIconGroupEl, "click", () => {
-                                openPicker(0);
-                            }));
+                            cleanups.push(
+                                addListener(calendarIconGroupEl, "click", () => {
+                                    openPicker(0);
+                                })
+                            );
                         }
                         if (!editableInputs && popover.isOpen) {
                             saveAndClose();


### PR DESCRIPTION
Before this PR, when selecting a new date in a date(time)_field, the value would first be reset before performing the "onchange" call, resulting in a flicker (selected value -> null -> new value after onchange).

Now, the value is not reset and is simply left as selected when performing the onchange call, as to not trigger any flicker.

Part of task [3471424](https://www.odoo.com/odoo/333/tasks/3471424)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
