### PR TITLE
[FIX] website: fix race condition on all snippets drop test

### DIFF
--- a/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
+++ b/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
@@ -41,7 +41,7 @@ for (const snippet of snippetsNames) {
     const snippetSteps = [{
         content: `Drop ${snippet} snippet [${n}/${snippetsNames.length}]`,
         trigger: `#oe_snippets .oe_snippet:has( > [data-snippet='${snippet}']) .oe_snippet_thumbnail`,
-        run: "drag_and_drop_native iframe #wrap",
+        run: "drag_and_drop_native iframe #wrap", 
     }, {
         content: `Edit ${snippet} snippet`,
         trigger: `iframe #wrap.o_editable [data-snippet='${snippet}']${isModal ? ' .modal.show' : ''}`,


### PR DESCRIPTION
A race condition appears since version 16.3 (1) and on all versions since then. Each time it's on a different snippet, but always on the same step (`Edit XXX snippet`). It seems to be because the drop happens before the dropzones have had time to show, meaning that the snippet never appears in the DOM.

runbot-72198 (master)
runbot-71794 (17.2)
runbot-71532 (17.2)
runbot-71245 (17.2)
runbot-70553 (master)
runbot-70298 (17.3)
runbot-69982 (17.3)
runbot-68980 (16.3)
runbot-68967 (17.0)
runbot-68966 (17.0)
runbot-68952 (17.2)
runbot-68055 (17.2)