### PR TITLE
[FIX] mrp: is_kits Multicompany

### DIFF
--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -45,7 +45,7 @@ class ProductTemplate(models.Model):
 
     @api.depends_context('company')
     def _compute_is_kits(self):
-        domain = [('company_id', 'in', [False] + self.env.companies.ids),
+        domain = [('company_id', 'in', [False, self.env.company.id]),
                   ('product_tmpl_id', 'in', self.ids),
                   ('active', '=', True),
                   ('type', '=', 'phantom')]
@@ -145,7 +145,7 @@ class ProductProduct(models.Model):
     @api.depends_context('company')
     def _compute_is_kits(self):
         domain = [
-            '&', ('company_id', 'in', [False] + self.env.companies.ids),
+            '&', ('company_id', 'in', [False, self.env.company.id]),
             '&', ('active', '=', True),
             '&', ('type', '=', 'phantom'),
             '|', ('product_id', 'in', self.ids),

--- a/addons/mrp/tests/test_multicompany.py
+++ b/addons/mrp/tests/test_multicompany.py
@@ -198,11 +198,15 @@ class TestMrpMulticompany(common.TransactionCase):
         template1 = product1.product_tmpl_id
         template2 = product2.product_tmpl_id
 
+        self.assertFalse(product1.with_context(allowed_company_ids=[self.company_b.id, self.company_a.id]).is_kits)
+        self.assertFalse(template1.with_context(allowed_company_ids=[self.company_b.id, self.company_a.id]).is_kits)
         self.assertTrue(product1.with_company(self.company_a).is_kits)
         self.assertTrue(template1.with_company(self.company_a).is_kits)
         self.assertFalse(product1.with_company(self.company_b).is_kits)
         self.assertFalse(template1.with_company(self.company_b).is_kits)
 
+        self.assertTrue(product2.with_context(allowed_company_ids=[self.company_b.id, self.company_a.id]).is_kits)
+        self.assertTrue(template2.with_context(allowed_company_ids=[self.company_b.id, self.company_a.id]).is_kits)
         self.assertTrue(product2.with_company(self.company_a).is_kits)
         self.assertTrue(template2.with_company(self.company_a).is_kits)
         self.assertTrue(product2.with_company(self.company_b).is_kits)


### PR DESCRIPTION
ammending https://github.com/odoo/odoo/pull/174006/commits/50c9c3d55a5ab2a023f6ff7fdbafa6b39cec5e4f to take into account env.company instead of companies

