### PR TITLE
[FIX] website_sale: Sendcloud refresh delivery points

### DIFF
--- a/addons/website_sale/static/src/js/website_sale_delivery.js
+++ b/addons/website_sale/static/src/js/website_sale_delivery.js
@@ -365,12 +365,16 @@ publicWidget.registry.websiteSaleDelivery = publicWidget.Widget.extend({
         if (radio.checked && !this._shouldDisplayPickupLocations(ev) && !this.forceClickCarrier) {
             return;
         }
-        this.forceClickCarrier = false;
 
         this._disablePayButton();
         this._showLoading(radio);
         radio.checked = true;
-        await this._onClickShowLocations(ev);
+        if (this.forceClickCarrier){
+            await this._onClickRemoveLocation(ev);
+            this.forceClickCarrier = false;
+        } else {
+            await this._onClickShowLocations(ev);
+        }
         await this._handleCarrierUpdateResult(radio);
         this._disablePayButtonNoPickupPoint(ev);
     },


### PR DESCRIPTION
Steps to reproduce:
- Install Sendcloud/fedex and configure them with delivery points
- Puchase an item on the website and stop before payment
- Select the Sendcloud shipping method and pick a delivery point
- Edit customer Address and comeback to the payment page

Bug:
delivery point is still selected

Fix:
remove delivery point on reload (which also refreshes the list)

opw-3916395