### PR TITLE
[IMP] l10n_mx_edi: Add new cfdi line for local tax

### DIFF
--- a/addons/l10n_mx/models/account_tax.py
+++ b/addons/l10n_mx/models/account_tax.py
@@ -20,6 +20,7 @@ class AccountTax(models.Model):
             ('isr', "ISR"),
             ('iva', "IVA"),
             ('ieps', "IEPS"),
+            ('local', "Local"),
         ],
         string="SAT Tax Type",
         compute="_compute_l10n_mx_tax_type",


### PR DESCRIPTION
[IMP] l10n_mx_edi: Add new cfdi line for local tax

Local taxes are created by states in MX. Each state can have a different % of each tax. Some of the industries that need those taxes are: Construction, Tourism, and certain services industries. Those taxes are distributed in a different node with new attributes in the XML.

We are adding new line for local taxes grouped by tax_group

task-id#4033949

enterprise-pr#https://github.com/odoo/enterprise/pull/67261

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr