### PR TITLE
[FIX] stock: merge extra moves created for push

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -868,6 +868,8 @@ class StockMove(models.Model):
         ]
         if self.env['ir.config_parameter'].sudo().get_param('stock.merge_only_same_date'):
             fields.append('date')
+        if self.env.context.get('merge_extra'):
+            fields.pop(fields.index('procure_method'))
         if not self.env['ir.config_parameter'].sudo().get_param('stock.merge_ignore_date_deadline'):
             fields.append('date_deadline')
         return fields
@@ -1712,7 +1714,7 @@ class StockMove(models.Model):
             extra_move_vals = self._prepare_extra_move_vals(extra_move_quantity)
             extra_move = self.copy(default=extra_move_vals).with_context(avoid_putaway_rules=True)
 
-            merge_into_self = all(self[field] == extra_move[field] for field in self._prepare_merge_moves_distinct_fields())
+            merge_into_self = all(self[field] == extra_move[field] for field in self.with_context(merge_extra=True)._prepare_merge_moves_distinct_fields())
 
             if merge_into_self:
                 extra_move = extra_move._action_confirm(merge_into=self)


### PR DESCRIPTION
### Steps to reproduce:

- Enable Multi-Steps route in the settings
- Inventory > Configuration > Warehouse Management > Warehouses
- Set you warehouse on 3 steps delivery
- Inventory > Configuration > Warehouse Management > Operations Types
- "show_detailed Operations" on the Pick and Pack picking types
- Create and confirm an SO for 1 unit of a consumable product
- On Detailed Op. of the pick move set the quantity done to 2 > validate
- On Detailed Op. of the pack move set the quantity done to 2 > validate

**> A new move with a demand of 1 and a quantity done of 0 has been added to the "Operation" tab**

### Cause of the issue:

When a move is registered with a `quantity_done` exceeding the demand, an extra move is created to trigger push rules for the additional quantities during the `_action_done` of the move:
https://github.com/odoo/odoo/blob/9daefd0bc9b724e0721dbcb51e522da8636ebef6/addons/stock/models/stock_move.py#L1741 https://github.com/odoo/odoo/blob/9daefd0bc9b724e0721dbcb51e522da8636ebef6/addons/stock/models/stock_move.py#L1695-L1701 During this call, the extra move will be confirmed and merged to the original move if it is found suitable to do so (determined by the `_prepare_merge_moves_distinct_fields` method):
https://github.com/odoo/odoo/blob/9daefd0bc9b724e0721dbcb51e522da8636ebef6/addons/stock/models/stock_move.py#L1715-L1719 For the pick move, this is the case since the `procure_method` of the extra move and of the pick move are both 'make_to_stock'. However, for the pack move, the extra_move will be `make_to_order` and the moves will be set not to be merged by the`_prepare_merge_moves_distinct_fields` call.

### Note/Fix:

The issue is not reproducible from 17.0 onwards thanks to the stockpocalypse which added a contextual 'move_extra' argument to treat this use case differently:
https://github.com/odoo/odoo/blob/242613600215f8adb05283feda5c303e5541b90d/addons/stock/models/stock_move.py#L985-L986 https://github.com/odoo/odoo/blob/242613600215f8adb05283feda5c303e5541b90d/addons/stock/models/stock_move.py#L1801-L1802 This part of the change does not rely on the new stock implementations and can therefore be backported to 15.0. This is our proposition. On the other hand, we do not apply the other part of the change: https://github.com/odoo/odoo/blob/242613600215f8adb05283feda5c303e5541b90d/addons/stock/models/stock_move.py#L961-L967 current:
https://github.com/odoo/odoo/blob/c5852cf68302b7bffe42af5237acbd97ca81a02f/addons/stock/models/stock_move.py#L853 as this would avoid the update of the demand of the move by the extra_move (makes sense in 17.0) but does not in 15.0/16.0 because of the stockpocalypse.

opw-4063134
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
