### PR TITLE
[FIX] point_of_sale: correct discount amount display in reports

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1586,6 +1586,11 @@ class PosOrderLine(models.Model):
             )
         return base_line_vals_list
 
+    def _get_discount_amount(self):
+        self.ensure_one()
+        original_price = self.tax_ids.compute_all(self.price_unit, self.currency_id, self.qty, product=self.product_id, partner=self.order_id.partner_id)['total_included']
+        return original_price - self.price_subtotal_incl
+
 
 class PosOrderLineLot(models.Model):
     _name = "pos.pack.operation.lot"

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -2194,8 +2194,7 @@ class PosSession(models.Model):
     def get_total_discount(self):
         amount = 0
         for line in self.env['pos.order.line'].search([('order_id', 'in', self._get_closed_orders().ids), ('discount', '>', 0)]):
-            original_price = line.tax_ids.compute_all(line.price_unit, line.currency_id, line.qty, product=line.product_id, partner=line.order_id.partner_id)['total_included']
-            amount += original_price - line.price_subtotal_incl
+            amount += line._get_discount_amount()
 
         return amount
 

--- a/addons/point_of_sale/models/report_sale_details.py
+++ b/addons/point_of_sale/models/report_sale_details.py
@@ -261,13 +261,12 @@ class ReportSaleDetails(models.AbstractModel):
         for config in configs:
             config_names.append(config.name)
 
-        discount_number = 0
-        discount_amount = 0
+        discount_number = len(orders.filtered(lambda o: o.lines.filtered(lambda l: l.discount > 0)))
+        discount_amount = sum(l._get_discount_amount() for l in orders.lines.filtered(lambda l: l.discount > 0))
+
         invoiceList = []
         invoiceTotal = 0
         for session in sessions:
-            discount_number += len(session.order_ids.filtered(lambda o: o.lines.filtered(lambda l: l.discount > 0)))
-            discount_amount += session.get_total_discount()
             invoiceList.append({
                 'name': session.name,
                 'invoices': session._get_invoice_total_list(),

--- a/addons/point_of_sale/views/report_saledetails.xml
+++ b/addons/point_of_sale/views/report_saledetails.xml
@@ -336,7 +336,15 @@
                     </div>
                     <div class="row">
                         <div class="col-12">
-                            <strong>Amount of discounts</strong>: <span t-out="discount_amount">50.00</span>
+                            <strong>Amount of discounts</strong>:
+                            <span t-if="currency['position']">
+                                <span t-out="discount_amount" t-options="{'widget': 'float', 'precision': currency['precision']}">50.00</span>
+                                <span t-out='currency["symbol"]'>$</span>
+                            </span>
+                            <span t-else="">
+                                <span t-out='currency["symbol"]'>$</span>
+                                <span t-out="discount_amount" t-options="{'widget': 'float', 'precision': currency['precision']}">50.00</span>
+                            </span>
                         </div>
                     </div>
                     <br/>


### PR DESCRIPTION
Before this commit, the "discount amount" was not displayed as a monetary field in the sales report. Additionally, the discount amount calculation was limited to discounts applied within the entire session included in the report period. This meant that partial reports within a single session failed to include any discounts.

opw-4061831

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
