### PR TITLE
[REF] web_tour: remove consumeEvent in tour step

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_service.js
+++ b/addons/web_tour/static/src/tour_service/tour_service.js
@@ -41,7 +41,6 @@ import { TourInteractive } from "./tour_interactive";
  * @property {boolean} [in_modal] When true, check that trigger node is present in the last visible .modal.
  * @property {number} [timeout] By default, when the trigger node isn't found after 10000 milliseconds, it throws an error.
  * You can change this value to lengthen or shorten the time before the error occurs [ms].
- * @property {string} [consumeEvent] Only in manual mode (onboarding tour). It's the event we want the customer to do.
  * @property {string} [title]
 
  * @typedef {"manual" | "auto"} TourMode
@@ -61,7 +60,6 @@ function checkTourStepKeyValues(tourStep) {
         run: { type: [String, Function], optional: true },
         in_modal: { type: Boolean, optional: true },
         timeout: { type: Number, optional: true },
-        consumeEvent: { type: String, optional: true },
         title: { type: String, optional: true },
         debugHelp: { type: String, optional: true },
         noPrepend: { type: Boolean, optional: true },

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -129,7 +129,6 @@ function changePaddingSize(direction) {
     return {
         trigger: `:iframe .oe_overlay.o_draggable.o_we_overlay_sticky.oe_active .o_handle.${paddingDirection}`,
         content: markup(_t("<b>Slide</b> this button to change the %s padding", direction)),
-        consumeEvent: 'mousedown',
         position: position,
         run: "click",
     };


### PR DESCRIPTION
From b2b2576691750c0444d8871f95b733bec07ae45d,
consumeEvent in no longer used in interactive Tour. Then, it's removed from tour API.

task~3974087

https://github.com/odoo/enterprise/pull/67265

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr