### PR TITLE
[FIX] auth_signup: prevent error when duplicating multiple users

### DIFF
--- a/addons/auth_signup/models/res_users.py
+++ b/addons/auth_signup/models/res_users.py
@@ -346,9 +346,8 @@ class ResUsers(models.Model):
                     users_with_email.partner_id.with_context(create_user=True).signup_cancel()
         return users
 
-    def copy(self, default=None):
-        self.ensure_one()
+    def copy_data(self, default=None):
         if not default or not default.get('email'):
             # avoid sending email to the user we are duplicating
             self = self.with_context(no_reset_password=True)
-        return super().copy(default=default)
+        return super().copy_data(default=default)

--- a/addons/auth_signup/tests/test_auth_signup.py
+++ b/addons/auth_signup/tests/test_auth_signup.py
@@ -64,3 +64,33 @@ class TestAuthSignupFlow(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
 
         with self.assertRaises(AccessError):
             partner.with_user(user.id).signup_url
+
+    def test_users_multiple_copy_data(self):
+        partners = self.env['res.partner'].create([
+            {'name': 'Jagdish Bhagat', 'email': 'jagdish@example.com'},
+            {'name': 'Deepak Kalal', 'email': 'deepak@example.com'},
+            {'name': 'Puneet Superstar', 'email': 'puneet@example.com'},
+        ])
+
+        users = self.env['res.users'].create([
+            {'name': "Jagdish Bhagat", 'login': "jagdish_bhagat", 'partner_id': partners[0].id},
+            {'name': "Deepak Kalal", 'login': "deepak_kalal", 'partner_id': partners[1].id},
+            {'name': "Puneet Superstar", 'login': "puneet_superstar", 'partner_id': partners[2].id},
+        ])
+
+        updated_mail = {
+            'email': 'carry@example.com',
+        }
+
+        duplicate_user_1, duplicate_user_2 = (users[0] + users[1]).copy()
+        duplicate_user_3 = users[2].copy(default=updated_mail)
+
+        self.assertEqual(duplicate_user_1.name, users[0].name + ' (copy)')
+        self.assertEqual(duplicate_user_2.name, users[1].name + ' (copy)')
+
+        self.assertEqual(duplicate_user_1.login, users[0].login + ' (copy)')
+        self.assertEqual(duplicate_user_2.login, users[1].login + ' (copy)')
+
+        self.assertFalse(duplicate_user_1.email)
+        self.assertFalse(duplicate_user_2.email)
+        self.assertTrue(duplicate_user_3.email)


### PR DESCRIPTION
When we try to duplicate users in the Users section, this error occurs.

Steps to reproduce:
- Install the ``auth_signup`` module
- Go to users and select ``Mitchell Admin`` and ``Marc Demo``
- Now duplicate both of them

Traceback: 
``ValueError: Expected singleton: res.users(2, 6)``

This error occurs at [1], where we are receiving multiple values in ``self``.

This commit will fix the above error by changing the method name from ``copy`` to ``copy_data``.

[1]- https://github.com/odoo/odoo/blob/0a52ad52b1a17f2732f92a5e24ec0814d929329b/addons/auth_signup/models/res_users.py#L348

sentry-5635211309

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
