### PR TITLE
[FIX] hr_holidays: correct computation of new record

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -217,7 +217,8 @@ class HolidaysAllocation(models.Model):
         employee_days_per_allocation = self.employee_id._get_consumed_leaves(self.holiday_status_id, date_from, ignore_future=True)[0]
         for allocation in self:
             allocation.max_leaves = allocation.number_of_hours_display if allocation.type_request_unit == 'hour' else allocation.number_of_days
-            allocation.leaves_taken = employee_days_per_allocation[allocation.employee_id][allocation.holiday_status_id][allocation]['leaves_taken']
+            origin = allocation._origin
+            allocation.leaves_taken = employee_days_per_allocation[origin.employee_id][origin.holiday_status_id][origin]['leaves_taken']
 
     @api.depends('number_of_days')
     def _compute_number_of_days_display(self):
@@ -569,11 +570,13 @@ class HolidaysAllocation(models.Model):
                 and (not self.nextcall or self.nextcall <= accrual_date)):
             return 0
 
-        fake_allocation = self.env['hr.leave.allocation'].new(origin=self)
+        fake_allocation = self.env['hr.leave.allocation'].with_context(default_date_from=accrual_date).new(origin=self)
         fake_allocation.sudo()._process_accrual_plans(accrual_date, log=False)
         if self.type_request_unit in ['hour']:
             return float_round(fake_allocation.number_of_hours_display - self.number_of_hours_display, precision_digits=2)
-        return round((fake_allocation.number_of_days - self.number_of_days), 2)
+        res = round((fake_allocation.number_of_days - self.number_of_days), 2)
+        self._invalidate_cache()
+        return res
 
     ####################################################
     # ORM Overrides methods

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -1867,3 +1867,67 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             })
 
             self.assertEqual(allocation.lastcall, datetime.date(2017, 12, 5))
+
+    def test_future_accural_time_with_leaves_taken_in_the_past(self):
+        leave_type = self.env['hr.leave.type'].create({
+            'name': 'Test Leave Type',
+            'time_type': 'leave',
+            'requires_allocation': 'yes',
+            'allocation_validation_type': 'no',
+        })
+        accrual_plan = self.env['hr.leave.accrual.plan'].create({
+            'name': 'Accrual Plan For Test',
+            'accrued_gain_time': 'start',
+            'carryover_date': 'year_start',
+            'level_ids': [(0, 0, {
+                'start_count': 1,
+                'start_type': 'day',
+                'added_value': 1,
+                'added_value_type': 'day',
+                'frequency': 'daily',
+                'cap_accrued_time': True,
+                'maximum_leave': 10
+            })],
+        })
+
+        def get_reamining_leaves(*args):
+            return leave_type.get_allocation_data(self.employee_emp, datetime.date(*args))[self.employee_emp][0][1][
+                'remaining_leaves']
+
+        with freeze_time("2024-03-01"):
+            # Simulate creating an allocation from frontend interface
+            with Form(self.env['hr.leave.allocation']) as f:
+                f.allocation_type = "accrual"
+                f.accrual_plan_id = accrual_plan
+                f.employee_ids.add(self.employee_emp)
+                f.holiday_status_id = leave_type
+                f.date_from = '2024-02-01'
+                f.name = "Accrual allocation for employee"
+
+            allocation = f.record
+            allocation.action_validate()
+            self.assertEqual(get_reamining_leaves(2024, 3, 1), 10, "The cap is reached, no more leaves should be accrued")
+
+            leave = self.env['hr.leave'].create({
+                'name': 'leave',
+                'employee_id': self.employee_emp.id,
+                'holiday_status_id': leave_type.id,
+                'request_date_from': '2024-02-26',
+                'request_date_to': '2024-03-01',
+            })
+            leave.action_validate()
+            self.assertEqual(get_reamining_leaves(2024, 3, 1), 5, "5 day should be deduced from the allocation")
+            self.assertEqual(get_reamining_leaves(2024, 3, 3), 7, "2 days should be added to the accrual allocation")
+            self.assertEqual(get_reamining_leaves(2024, 3, 3), 7, "Function return result should persist")
+            self.assertEqual(get_reamining_leaves(2024, 3, 10), 10, "Accrual allocation should be capped at 10")
+
+            leave = self.env['hr.leave'].create({
+                'name': 'leave',
+                'employee_id': self.employee_emp.id,
+                'holiday_status_id': leave_type.id,
+                'request_date_from': '2024-03-04',
+                'request_date_to': '2024-03-08',
+            })
+            leave.action_validate()
+            self.assertEqual(get_reamining_leaves(2024, 3, 4), 3, "5 days should be deduced from the allocation and a new day should be accrued")
+            self.assertEqual(get_reamining_leaves(2024, 3, 11), 10, "Accrual allocation should be capped at 10")


### PR DESCRIPTION
To reproduce the bug, follow these steps:

1. Create a new time off type.
2. Create a new accrual plan.
3. Set the "Accrued Gain Time" field to “At the start of the accrual period.”
4. Create a new milestone with a cap.
5. Create a new allocation set its type to accrual then link it to our accrual plan.
6. Set the start date in the past so that the accrued days reach the cap.
7. Create a new leave in the past related to the allocation.
8. Check your balance for a future date in the Time Off app.

Normally, with accrual allocation, we should see the allocation increase. The problem here is that in the future, the
allocation decreases.

This issue arises due to the way the `leaves_taken` field is computed.

https://github.com/odoo/odoo/blob/08a4b9d78addeefde24b189f0066540e0dcee4c4/addons/hr_holidays/models/hr_leave_allocation.py#L215-L220

The value is retrieved from a default dictionary, which is processed based on existing records in the database. When we
attempt to fetch the value using a new instance that only exists in memory, the key returns the default value of 0.

Additionally, if we modify step 7 to set the leave in the future, the accrual value caps out at a level below the
intended maximum. In some cases, if the data-fetching function is called with the same parameters consecutively, we
receive different outputs.

These issues arise because the new record persists as a cache. When we retrieve a new record with the same origin as a
previous call, we receive the previously processed data. This also leads to a problem with recursion in the function
`_get_future_leaves_on`. This commit addresses and resolves these issues.

opw-4040882