### PR TITLE
[FIX] website_links: keep text-box open in select2 no matches

### DIFF
--- a/addons/website_links/static/src/js/website_links.js
+++ b/addons/website_links/static/src/js/website_links.js
@@ -49,6 +49,7 @@ var SelectBox = publicWidget.Widget.extend({
         this.$el.select2({
             placeholder: self.placeholder,
             allowClear: true,
+            formatNoMatches: false,
             createSearchChoice: function (term) {
                 if (self._objectExists(term)) {
                     return null;


### PR DESCRIPTION
**Before this PR:**
In link tracker form, if there is no campaign/medium/source, 'No matches found' message is directly displayed and the text-box for input disappears quickly.

**Specifications:**
We need to keep the input text-box open to be able to create new records on the fly.

**Technical Reason:**
defined 'formatNoMatches' as false to keep text-box open.

**After this PR:**
Text-box for input will remain open and will not disappear.

Task-4065969

