### PR TITLE
[FIX] payment: remove upi support in stripe

### DIFF
--- a/addons/payment/data/payment_provider_data.xml
+++ b/addons/payment/data/payment_provider_data.xml
@@ -380,7 +380,6 @@
                          ref('payment.payment_method_revolut_pay'),
                          ref('payment.payment_method_sepa_direct_debit'),
                          ref('payment.payment_method_sofort'),
-                         ref('payment.payment_method_upi'),
                          ref('payment.payment_method_wechat_pay'),
                          ref('payment.payment_method_zip'),
                      ])]"


### PR DESCRIPTION
Steps to reproduce:
- Configure stripe and enable UPI payment method.
- In e-commerce, add a product to the cart.
- Go to checkout and select UPI.

Issue:
On selecting UPI, we get `Cannot display the payment form` error.

Cause:
Our current integration with Stripe does not support UPI as a payment method. Our setup only supports payment methods activated in the Stripe account, and UPI is not listed there. As a result, the Stripe API does not recognize the `upi` code and throws an error.

Fix:
Remove the support for UPI as a payment method from the stripe.

opw-4014898
