### PR TITLE
[IMP] point_of_sale: group orderlines by product categories

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -195,6 +195,8 @@ class PosConfig(models.Model):
         string='Closing Entry by product',
         help="Display the breakdown of sales lines by product in the automatically generated closing entry.")
     order_edit_tracking = fields.Boolean(string="Track orders edits", help="Store edited orders in the backend", default=False)
+    orderlines_sequence_in_cart_by_category = fields.Boolean(string="Order cart by category's sequence", default=False,
+        help="When active, orderlines will be sorted based on product category and sequence in the product screen's order cart.")
 
     @api.model
     def _load_pos_data_domain(self, data):

--- a/addons/point_of_sale/models/res_config_settings.py
+++ b/addons/point_of_sale/models/res_config_settings.py
@@ -115,6 +115,7 @@ class ResConfigSettings(models.TransientModel):
     pos_module_pos_sms = fields.Boolean(related="pos_config_id.module_pos_sms", readonly=False)
     pos_is_closing_entry_by_product = fields.Boolean(related='pos_config_id.is_closing_entry_by_product', readonly=False)
     pos_order_edit_tracking = fields.Boolean(related="pos_config_id.order_edit_tracking", readonly=False)
+    pos_orderlines_sequence_in_cart_by_category = fields.Boolean(related='pos_config_id.orderlines_sequence_in_cart_by_category', readonly=False)
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.OrderSummary">
-      <OrderWidget lines="currentOrder.lines" t-slot-scope="scope" class="'bg-light'"
+      <OrderWidget lines="currentOrder.getSortedOrderlines()" t-slot-scope="scope" class="'bg-light'"
           total="env.utils.formatCurrency(currentOrder.get_total_with_tax())"
           tax="!env.utils.floatIsZero(currentOrder.get_total_tax()) and env.utils.formatCurrency(currentOrder.get_total_tax()) or ''">
           <t t-set="line" t-value="scope.line" />

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -157,6 +157,9 @@
                             <setting id="margin_and_cost" string="Show margins &amp; costs" help="Show margins &amp; costs on product information">
                                 <field name="pos_is_margins_costs_accessible_to_every_user"/>
                             </setting>
+                            <setting id="orderlines_seq_cart" string="Sort cart by category" help="Group items in the cart according to their category">
+                                <field name="pos_orderlines_sequence_in_cart_by_category"/>
+                            </setting>
                         </block>
                         <block title="Accounting" id="pos_accounting_section">
                             <setting id="default_sales_tax_setting" title="This tax is applied to any new product created in the catalog." documentation="/applications/finance/accounting/taxation/taxes/default_taxes.html">

--- a/addons/pos_loyalty/static/src/overrides/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_order.js
@@ -1388,4 +1388,33 @@ patch(PosOrder.prototype, {
             return super.removeOrderline(lineToRemove);
         }
     },
+    getSortedOrderlines() {
+        const lines = super.getSortedOrderlines();
+        if (this.config.orderlines_sequence_in_cart_by_category && this.lines.length) {
+            const rewardLines = [];
+            const resultLines = [];
+
+            lines.forEach((line) => {
+                if (line.is_reward_line) {
+                    rewardLines.push(line);
+                } else {
+                    resultLines.push(line);
+                }
+            });
+
+            rewardLines.forEach((line) => {
+                if (line.reward_id.reward_type === "discount") {
+                    resultLines.splice(resultLines.length, 0, line);
+                } else if (line.reward_id.reward_type === "product") {
+                    const rewardProductIndex = resultLines.findIndex(
+                        (rewardLine) =>
+                            line.reward_id?.reward_product_id?.id === rewardLine.product_id.id
+                    );
+                    resultLines.splice(rewardProductIndex + 1, 0, line);
+                }
+            });
+            return resultLines;
+        }
+        return lines;
+    },
 });

--- a/addons/pos_loyalty/static/src/overrides/models/pos_order_line.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_order_line.js
@@ -87,4 +87,10 @@ patch(PosOrderline.prototype, {
             "fst-italic": this.is_reward_line,
         };
     },
+    getDisplayData() {
+        if (!this.order_id) {
+            return;
+        }
+        return super.getDisplayData();
+    },
 });


### PR DESCRIPTION
In this commit:
===============
Orderlines will now be added under their respective POS product categories. This enhancement organizes orderlines by categories instead of listing them directly below.

task- 4069597
