### PR TITLE
[FIX] loyalty: resolve validation error for loyalty description

### DIFF
--- a/addons/loyalty/models/loyalty_reward.py
+++ b/addons/loyalty/models/loyalty_reward.py
@@ -50,7 +50,14 @@ class LoyaltyReward(models.Model):
     company_id = fields.Many2one(related='program_id.company_id', store=True)
     currency_id = fields.Many2one(related='program_id.currency_id')
 
-    description = fields.Char(compute='_compute_description', readonly=False, store=True, translate=True)
+    description = fields.Char(
+        translate=True,
+        compute='_compute_description',
+        precompute=True,
+        store=True,
+        readonly=False,
+        required=True,
+    )
 
     reward_type = fields.Selection([
         ('product', 'Free Product'),


### PR DESCRIPTION
**Steps:**
- Create a new Discount and loyalty program.
- Keep the program type as Buy X Get Y / any other program
- In the rewards pop-up, leave the 'description on the product' empty and click on 'save & close'.
- Try to save the loyalty program. Validation error appears.

**Cause:**
- This occurs because the description is used to set the name of the discount product, but if it's empty, the write method will not get the proper values hence resulting in error.

**Fix:**
- Making the description field required because it is used for all programs and exclusively used to compute value of discount product. Also pre-computing this field because for data created on the fly, the description should be computed before inserting the record in the database, so that the compute is triggered.

**Upgrade PR**: https://github.com/odoo/upgrade/pull/6313

**Affected Version:** master
**opw**-4032798