### PR TITLE
[FIX] purchase_stock: properly set final location in manual PO

### DIFF
--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -229,6 +229,12 @@ class PurchaseOrder(models.Model):
             return self.dest_address_id.property_stock_customer.id
         return self.picking_type_id.default_location_dest_id.id
 
+    def _get_final_location_record(self):
+        self.ensure_one()
+        if self.dest_address_id and self.picking_type_id.code == 'dropship':
+            return self.dest_address_id.property_stock_customer
+        return self.picking_type_id.warehouse_id.lot_stock_id
+
     @api.model
     def _get_picking_type(self, company_id):
         picking_type = self.env['stock.picking.type'].search([('code', '=', 'incoming'), ('warehouse_id.company_id', '=', company_id)])

--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -271,7 +271,7 @@ class PurchaseOrderLine(models.Model):
         self._check_orderpoint_picking_type()
         product = self.product_id.with_context(lang=self.order_id.dest_address_id.lang or self.env.user.lang)
         location_dest = self.env['stock.location'].browse(self.order_id._get_destination_location())
-        location_final = self.location_final_id
+        location_final = self.location_final_id or self.order_id._get_final_location_record()
         if location_final and location_final._child_of(location_dest):
             location_dest = location_final
         date_planned = self.date_planned or self.order_id.date_planned


### PR DESCRIPTION
Problem
---
Using the default 2 steps receipt routes (input -> stock), when we manually create and confirm a purchase order for a storable product, the incoming products are not being taken into account for the stock forecast

Steps
---
* install purchase, mrp, sales_management
* In the setting enable multi-step routes, and configure the main warehouse to use the 2 step route.
* create a product P: 
   * storable 
   * has a supplier line 
   * route = buy
* create a corresponding 0,0 auto buy reordering rule.
* create a purchase order for 10 P, confirm it. 
  * => the forecast for the reordering rule is still 0
* create a SO for 10 P and confirm it
  * => a new RFQ is wrongly generated

Cause
---
Previously, when using multi step routes, creating a purchase order would create a move for every step of the route, and the destination of the last move of the chain was the main stock.
But as of 11e69870db1c49d9a6af79ffd263e4e162b34b6b, we create moves one step at a time, and use `location_final_id` to keep track of the eventual destination.
However, in purchase when creating the moves for a manual PO, we do not set this location. So the forecast doesn't take the move into account, as its destination is not the stock but the input.

opw-4033857
