### PR TITLE
[FIX] stock: allow check available qty in strict locations

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -307,9 +307,13 @@ class Product(models.Model):
         # this optimizes [('location_id', 'child_of', locations.ids)]
         # by avoiding the ORM to search for children locations and injecting a
         # lot of location ids into the main query
-        paths_domain = expression.OR([[('parent_path', '=like', loc.parent_path + '%')] for loc in locations])
-        loc_domain = [('location_id', 'any', paths_domain)]
-        dest_loc_domain = [('location_dest_id', 'any', paths_domain)]
+        if self.env.context.get('strict'):
+            loc_domain = [('location_id', 'in', locations.ids)]
+            dest_loc_domain = [('location_dest_id', 'in', locations.ids)]
+        else:
+            paths_domain = expression.OR([[('parent_path', '=like', loc.parent_path + '%')] for loc in locations])
+            loc_domain = [('location_id', 'any', paths_domain)]
+            dest_loc_domain = [('location_dest_id', 'any', paths_domain)]
 
         return (
             loc_domain,

--- a/addons/stock/models/stock_scrap.py
+++ b/addons/stock/models/stock_scrap.py
@@ -187,7 +187,8 @@ class StockScrap(models.Model):
             location=self.location_id.id,
             lot_id=self.lot_id.id,
             package_id=self.package_id.id,
-            owner_id=self.owner_id.id
+            owner_id=self.owner_id.id,
+            strict=True,
         ).product_id.qty_available
         scrap_qty = self.product_uom_id._compute_quantity(self.scrap_qty, self.product_id.uom_id)
         return float_compare(available_qty, scrap_qty, precision_digits=precision) >= 0

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -5140,6 +5140,23 @@ class StockMove(TransactionCase):
         self.assertFalse(quant_scrap.reserved_quantity)
         self.assertFalse(quant_scrap.quantity)
 
+    def test_scrap_12_qty_in_sublocation(self):
+        """ Checks that if a product is only available in a sublocation, then trying to validate a scrap order from a
+            parent location should trigger the insufficient quantity warning.
+        """
+        # 10 units are available in Stock/Shelf, none in Stock directly
+        subloc = self.stock_location.child_ids[0]
+        self.env['stock.quant']._update_available_quantity(self.product, subloc, 10)
+
+        with Form(self.env['stock.scrap']) as scrap_form:
+            scrap_form.product_id = self.product
+            scrap_form.scrap_qty = 5
+            scrap_form.location_id = self.stock_location
+            scrap = scrap_form.save()
+
+        warning = scrap.action_validate()
+        self.assertEqual(warning.get('res_model'), 'stock.warn.insufficient.qty.scrap', "Should trigger the warning as no qty in location")
+
     def test_in_date_1(self):
         """ Check that moving a tracked quant keeps the incoming date.
         """


### PR DESCRIPTION
Steps to reproduce:
- Create a product and set a quantity in a sublocation of Stock
- Create a scrap order for that product
- Set location as Stock (NOT the sublocation)
- Validate the scrap order

Issue:
The insufficient quantity warning doesn't trigger anymore.

The change made in [1] allowed the scrap orders to properly handle kits. To do that, it uses the product qty_available directly as it correctly handles kit components. But since we're not using the strict mode of `_gather()` anymore, it will also look for child locations quantities, which isn't what we want for scrap orders.

Added a context key to enable a strict location lookup for qty_available and uses it for scrap orders.

[1] a196f947c829fde08d3ddf79b6c4f5a42a1217cd

opw-4055721

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
