### PR TITLE
[FIX] mrp,stock: allow scrapping of kits again

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -337,7 +337,8 @@ class StockMoveLine(models.Model):
 
         move_to_recompute_state = self.env['stock.move']
         for move_line in mls:
-            if move_line.state == 'done':
+            if move_line.state == 'done' or (move_line.state == 'draft' and move_line.move_id.scrapped):
+                # Scrapped moves are created with their move lines, even in draft. Should not reserve in this case.
                 continue
             location = move_line.location_id
             product = move_line.product_id


### PR DESCRIPTION
Steps to reproduce:
- Create a kit with two components
- Set some quantity for both components
- Create a scrap order for the kit and validate it

Issue:
Instead of the expected moves for each component of the kit, a single move with the kit itself will be done.

This happens because [1] added a recomputation of the move's state on move line creation. But since scrap moves are created in draft with their move line, it triggers the recompute, setting it always as "assigned", regardless of the actual stock.

This is problematic, as then it won't go through the `action_explode()`, splitting the kit move into its components moves.

[1] 61095af1b3eaa66fe4d514bfe150c07d66554d32

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
