### PR TITLE
[IMP] microsoft_calendar: improve event link addition in microsoft calendar

### DIFF
--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -47,7 +47,7 @@ class Meeting(models.Model):
     def _get_microsoft_synced_fields(self):
         return {'name', 'description', 'allday', 'start', 'date_end', 'stop',
                 'user_id', 'privacy',
-                'attendee_ids', 'alarm_ids', 'location', 'show_as', 'active'}
+                'attendee_ids', 'alarm_ids', 'location', 'show_as', 'active', 'videocall_location'}
 
     @api.model
     def _restart_microsoft_sync(self):
@@ -520,6 +520,12 @@ class Meeting(models.Model):
 
         if 'location' in fields_to_sync:
             values['location'] = {'displayName': self.location or ''}
+
+        if not self.location and 'videocall_location' in fields_to_sync and self._need_video_call():
+            values['isOnlineMeeting'] = True
+            values['onlineMeetingProvider'] = 'teamsForBusiness'
+        else:
+            values['isOnlineMeeting'] = False
 
         if 'alarm_ids' in fields_to_sync:
             alarm_id = self.alarm_ids.filtered(lambda a: a.alarm_type == 'notification')[:1]

--- a/addons/microsoft_calendar/models/microsoft_sync.py
+++ b/addons/microsoft_calendar/models/microsoft_sync.py
@@ -506,3 +506,11 @@ class MicrosoftSync(models.AbstractModel):
         the appropriate user accordingly.
         """
         raise NotImplementedError()
+
+    def _need_video_call(self):
+        """
+        Implement this method to return True if the event needs a video call
+        :return: bool
+        """
+        self.ensure_one()
+        return True

--- a/addons/microsoft_calendar/tests/test_update_events.py
+++ b/addons/microsoft_calendar/tests/test_update_events.py
@@ -68,7 +68,7 @@ class TestUpdateEvents(TestCommon):
         self.assertTrue(res)
         mock_patch.assert_called_once_with(
             self.simple_event.microsoft_id,
-            {"subject": "my new simple event"},
+            {"subject": "my new simple event", "isOnlineMeeting": False},
             token=mock_get_token(self.organizer_user),
             timeout=ANY,
         )
@@ -92,7 +92,7 @@ class TestUpdateEvents(TestCommon):
         self.assertTrue(res)
         mock_patch.assert_called_once_with(
             self.simple_event.microsoft_id,
-            {"subject": "my new simple event"},
+            {"subject": "my new simple event", "isOnlineMeeting": False},
             token=mock_get_token(self.organizer_user),
             timeout=ANY,
         )


### PR DESCRIPTION
Before this PR:
When synchronizing the calendar with Microsoft and creating a new event, no link was generated.

After this PR:
A link is now generated when an event is synchronized with the Microsoft calendar.

task-4016268


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
