### PR TITLE
[IMP] point_of_sale: make pos modals pop up on mobile

### DIFF
--- a/addons/point_of_sale/static/src/app/pos_app.scss
+++ b/addons/point_of_sale/static/src/app/pos_app.scss
@@ -72,17 +72,29 @@ input::-webkit-inner-spin-button {
 
 @media screen and (max-width: 575px) {
     .pos .modal-dialog{
+        margin: 0;
         max-height: 90vh;
     }
     .pos .modal-content{
         max-height: 90vh;
+        border-radius: 1rem 1rem 0 0;
+        animation: popUp 0.2s ease-in-out forwards;
     }
     .pos .modal-body{
-        overflow: scroll;
+        overflow: auto;
     }
     .modal-dialog-centered {
-        display: flex;
-        align-items: end !important;
-        min-height: subtract(100%, $modal-dialog-margin * 2);
+        position: fixed;
+        inset: auto 0 0 0;
+        min-height: unset;
+    }
+}
+
+@keyframes popUp {
+    0% {
+        transform: translateY(100%);
+    }
+    100% {
+        transform: translateY(0);
     }
 }


### PR DESCRIPTION
modify the `<Dialog/>` pos overrides to pop from the bottom on mobile/small screens

### Before
<img width="386" alt="Screenshot 2024-07-24 at 3 46 06 PM" src="https://github.com/user-attachments/assets/aed40353-95e7-44cb-ad15-de0ad2568ad5">


### After
<img width="386" alt="Screenshot 2024-07-25 at 10 51 42 AM" src="https://github.com/user-attachments/assets/633e187f-53d1-4e4d-89cd-827afce3e91e">