### PR TITLE
[FIX] lunch: provide origin information on lunch alerts

### DIFF
--- a/addons/lunch/models/lunch_alert.py
+++ b/addons/lunch/models/lunch_alert.py
@@ -195,6 +195,8 @@ class LunchAlert(models.Model):
         partners = self.env['lunch.order'].search(order_domain).user_id.partner_id
         if partners:
             self.env['mail.thread'].message_notify(
+                model=self._name,
+                res_id=self.id,
                 body=self.message,
                 partner_ids=partners.ids,
                 subject=_('Your Lunch Order'),


### PR DESCRIPTION
Steps to reproduce:
- My user > Preferences
- Set notifications to 'Handle in Odoo'
- Lunch > Configuration > Alerts
- Add all locations to any alert
- Debug mode > Scheduled Action
- Manually run your alert

An error occurs when trying to access the message thread because none
was given. It is expected for messages of type user_notification not to
have a thread, but this is never checked on the js side of things. This
is because we assume information on the origin should be passed when
sending the notification, which in this case we did not provide.

opw-4057887

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
