### PR TITLE
[IMP] web: searchbar subitems have a load more button.

### DIFF
--- a/addons/web/static/src/search/search_bar/search_bar.xml
+++ b/addons/web/static/src/search/search_bar/search_bar.xml
@@ -90,6 +90,7 @@
                     </t>
                     <a href="#" t-on-click.prevent="" t-att-class="{'ps-3 pe-2 text-truncate': item.isFieldProperty }" t-att-title="item.title">
                         <t t-if="item.isAddCustomFilterButton"><span class="text-action">Add Custom Filter</span></t>
+                        <t t-elif="item.loadMore"><span class="text-action"><t t-esc="item.label"/></span></t>
                         <t t-elif="item.isChild">
                             <t t-esc="item.label"/>
                         </t>

--- a/addons/web/static/tests/search/search_bar.test.js
+++ b/addons/web/static/tests/search/search_bar.test.js
@@ -10,6 +10,7 @@ import {
     queryAllTexts,
     queryAllValues,
     queryFirst,
+    queryLast,
     queryOne,
 } from "@odoo/hoot-dom";
 import { Deferred, animationFrame, mockDate, mockTimeZone } from "@odoo/hoot-mock";
@@ -689,7 +690,7 @@ test("check kwargs of a rpc call with a domain", async () => {
             kwargs: {
                 args: [["bool", "=", true]],
                 context: { lang: "en", uid: 7, tz: "taht", allowed_company_ids: [1] },
-                limit: 8,
+                limit: 8 + 1,
                 operator: "ilike",
                 name: "F",
             },
@@ -1749,4 +1750,51 @@ test(`quoted search term performs a name_search with operator = for subitems`, a
     await editSearch(`"First record"`);
     await contains(".o_expand").click();
     expect(".o_searchview_autocomplete li.o_menu_item.o_indent").toHaveText("First record");
+});
+
+test("subitems have a load more item if there is more records available", async () => {
+    for (let i = 0; i < 20; i++) {
+        Partner._records.push({
+            id: 100 + i,
+            name: `Home Depot ${i}`,
+        });
+    }
+    await mountWithSearch(SearchBar, {
+        resModel: "partner",
+        searchMenuTypes: [],
+        searchViewId: false,
+        searchViewArch: `
+            <search>
+                <field name="company"/>
+            </search>
+        `,
+    });
+    await editSearch("Home");
+    await contains(".o_expand").click();
+    await expect(".o_searchview_autocomplete li.o_menu_item.o_indent").toHaveCount(8 + 1);
+    await expect(queryLast(".o_searchview_autocomplete li.o_menu_item.o_indent")).toHaveText(
+        "Load more"
+    );
+    await contains(queryLast(".o_searchview_autocomplete li.o_menu_item.o_indent")).click();
+    await expect(".o_searchview_autocomplete li.o_menu_item.o_indent").toHaveCount(8 + 8 + 1);
+    await expect(queryLast(".o_searchview_autocomplete li.o_menu_item.o_indent")).toHaveText(
+        "Load more"
+    );
+});
+
+test("subitems do not have a load more item if there is no more records available", async () => {
+    await mountWithSearch(SearchBar, {
+        resModel: "partner",
+        searchMenuTypes: [],
+        searchViewId: false,
+        searchViewArch: `
+            <search>
+                <field name="company"/>
+            </search>
+        `,
+    });
+    await editSearch("home");
+    await contains(".o_expand").click();
+    await expect(".o_searchview_autocomplete li.o_menu_item.o_indent").toHaveCount(1);
+    await expect(".o_searchview_autocomplete li.o_menu_item.o_indent").toHaveText("(no result)");
 });


### PR DESCRIPTION
With relationship in the search bar autocomplete, the system loads a limit of 8 subitems.
This task adds a load more button when there are more available records.
It will always add the default limit (8) on each click.

task ID 3821281