### PR TITLE
[FIX] web: prevent crash in web_read_group with date groupby and limit

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -239,9 +239,10 @@ class Base(models.AbstractModel):
         if not groups:
             length = 0
         elif limit and len(groups) == limit:
+            annoted_groupby = self._read_group_get_annoted_groupby(groupby, lazy=lazy)
             length = limit + len(self._read_group(
                 domain,
-                groupby=groupby if not lazy else [groupby[0]],
+                groupby=annoted_groupby.values(),
                 offset=limit,
             ))
 

--- a/addons/web/tests/__init__.py
+++ b/addons/web/tests/__init__.py
@@ -17,6 +17,7 @@ from . import test_assets
 from . import test_assets_xml
 from . import test_login
 from . import test_web_search_read
+from . import test_web_read_group
 from . import test_domain
 from . import test_translate
 from . import test_web_redirect

--- a/addons/web/tests/test_web_read_group.py
+++ b/addons/web/tests/test_web_read_group.py
@@ -1,0 +1,20 @@
+from odoo import fields
+from odoo.tests import common
+
+
+@common.tagged('post_install', '-at_install')
+class TestWebReadGroup(common.TransactionCase):
+
+    def test_web_read_group_with_date_groupby_and_limit(self):
+        first, second = self.env["res.partner"].create([
+            {
+                "name": "first",
+                "date": fields.Date.to_date("2021-06-01")
+            },
+            {
+                "name": "second",
+                "date": fields.Date.to_date("2021-07-01")
+            }
+        ])
+        groups = self.env["res.partner"].web_read_group([["id", "in", [first.id, second.id]]], [], groupby=["date"], limit=1)
+        self.assertEqual(groups["length"], 2)

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2630,6 +2630,25 @@ class BaseModel(metaclass=MetaModel):
                 row['__domain'] = expression.AND([row['__domain'], [(fullname, '=', row[fullname])]])
 
     @api.model
+    def _read_group_get_annoted_groupby(self, groupby, lazy):
+        groupby = [groupby] if isinstance(groupby, str) else groupby
+        lazy_groupby = groupby[:1] if lazy else groupby
+
+        annoted_groupby = {}  # Key as the name in the result, value as the explicit groupby specification
+        for group_spec in lazy_groupby:
+            field_name, property_name, granularity = parse_read_group_spec(group_spec)
+            if field_name not in self._fields:
+                raise ValueError(f"Invalid field {field_name!r} on model {self._name!r}")
+            field = self._fields[field_name]
+            if property_name and field.type != 'properties':
+                raise ValueError(f"Property name {property_name!r} has to be used on a property field.")
+            if field.type in ('date', 'datetime'):
+                annoted_groupby[group_spec] = f"{field_name}:{granularity or 'month'}"
+            else:
+                annoted_groupby[group_spec] = group_spec
+        return annoted_groupby
+
+    @api.model
     def read_group(self, domain, fields, groupby, offset=0, limit=None, orderby=False, lazy=True):
         """Get the list of records in list view grouped by the given ``groupby`` fields.
 
@@ -2675,18 +2694,7 @@ class BaseModel(metaclass=MetaModel):
         # - Modify `groupby` default value 'month' into specifique groupby specification
         # - Modify `fields` into aggregates specification of _read_group
         # - Modify the order to be compatible with the _read_group specification
-        annoted_groupby = {}  # Key as the name in the result, value as the explicit groupby specification
-        for group_spec in lazy_groupby:
-            field_name, property_name, granularity = parse_read_group_spec(group_spec)
-            if field_name not in self._fields:
-                raise ValueError(f"Invalid field {field_name!r} on model {self._name!r}")
-            field = self._fields[field_name]
-            if property_name and field.type != 'properties':
-                raise ValueError(f"Property name {property_name!r} has to be used on a property field.")
-            if field.type in ('date', 'datetime'):
-                annoted_groupby[group_spec] = f"{field_name}:{granularity or 'month'}"
-            else:
-                annoted_groupby[group_spec] = group_spec
+        annoted_groupby = self._read_group_get_annoted_groupby(groupby, lazy=lazy)
 
         annoted_aggregates = {  # Key as the name in the result, value as the explicit aggregate specification
             f"{lazy_groupby[0].split(':')[0]}_count" if lazy and len(lazy_groupby) == 1 else '__count': '__count',


### PR DESCRIPTION
Steps to reproduce
==================

- Edit a kanban view so that the default_group_by is a date field
- Go to that view
- Open studio

=> Granularity not set on a date(time) field

Cause of the issue
==================

`web_read_group` is called with a limit of 1

First a call to `read_group` is made

Then in order to return the total number of groups when the limit is reached, a call to _read_group is made.

Inside `read_group`, there is a compatibility layer that notably add a default month granularity to date(time) fields.

This isn't the case inside `_read_group`, which causes a crash

Solution
========

Extract the compatibility layer related to the groupby from `read_group`
and use that for both methods

opw-4051657