### PR TITLE
[FIX] product: set a default for the sequence

### DIFF
--- a/addons/product/models/product_attribute.py
+++ b/addons/product/models/product_attribute.py
@@ -17,7 +17,7 @@ class ProductAttribute(models.Model):
 
     name = fields.Char('Attribute', required=True, translate=True)
     value_ids = fields.One2many('product.attribute.value', 'attribute_id', 'Values', copy=True)
-    sequence = fields.Integer('Sequence', help="Determine the display order", index=True)
+    sequence = fields.Integer('Sequence', help="Determine the display order", index=True, default=20)
     attribute_line_ids = fields.One2many('product.template.attribute.line', 'attribute_id', 'Lines')
     create_variant = fields.Selection([
         ('always', 'Instantly'),


### PR DESCRIPTION
Problem
---
The `sequence` field of product attributes has no default, This causes ordering bugs in the frontend when using handles.

Steps
---
* go to product attributes list view
* move the last element to the top (to ensure a full reordering)
* create a new product attribute *PA* > go back to the list view 
  * => it appears at the bottom of the list 
  * => its sequence appears to be 0 to the frontend but is actually NULL
* move it one place up 
  * => *PA* and the item after it now have the sequence numbers 0, 1
* refresh 
  * => the two last items move to the top, crisscrossing with the previous 2 first items which also have sequence 0, 1

Cause
---
The frontend always assume click-and-drag sortable lists are already sorted, but this assumption is wrong when we have a record with a NULL `sequence`, because it will appears at the end of the ORDERBY SQL query but be converted to 0 frontend-side.

opw-3937263