### PR TITLE
[FIX] stock : Compute reference when change picking_type_id

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -263,7 +263,7 @@ class StockMove(models.Model):
         for move in self:
             move.is_quantity_done_editable = move.product_id
 
-    @api.depends('picking_id', 'name')
+    @api.depends('picking_id', 'name', 'picking_id.name')
     def _compute_reference(self):
         for move in self:
             move.reference = move.picking_id.name if move.picking_id else move.name


### PR DESCRIPTION
### Steps to reproduce:
	- Install Inventory module
	- Create a move from any operation
	- Save this move and keep the reference > Change the operation type and save again
	- Navigate to Moves History
	- Search for the move with the old reference

### Current behavior before PR:
The move will be shown in the moves history with the old reference. This is happening because when changing the opertaion type it doesn't trigger the compute of the reference. https://github.com/odoo/odoo/blob/17.0/addons/stock/models/stock_move.py#L265

### Desired behavior after PR is merged:
We added the picking_id.name as a dependant field for the reference so when it is changed the computation method of the reference will be triggered to update the reference.

opw-4062591