### PR TITLE
[FIX] maintenance: put a duplicated maintenance request in first stage

### DIFF
--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -330,7 +330,7 @@ class MaintenanceRequest(models.Model):
             schedule_date = self.schedule_date or fields.Datetime.now()
             schedule_date += relativedelta(**{f"{self.repeat_unit}s": self.repeat_interval})
             if self.repeat_type == 'forever' or schedule_date.date() <= self.repeat_until:
-                self.copy({'schedule_date': schedule_date})
+                self.copy({'schedule_date': schedule_date, 'stage_id': self._default_stage().id})
         res = super(MaintenanceRequest, self).write(vals)
         if vals.get('owner_user_id') or vals.get('user_id'):
             self._add_followers()


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a maintenance request:
   - repeat_type: forever,
   - Maintenance Type: preventive,
   - recurring_maintenance: True,
   
- Move this request to the 'done' stage.

Problem:
A new maintenance request is duplicated but with the same last stage of
this maintenance request

opw-4060845
