### PR TITLE
[FIX] w_crm_partner_assign, w_customer: fix slug to avoid redirect

### DIFF
--- a/addons/website_crm_partner_assign/controllers/main.py
+++ b/addons/website_crm_partner_assign/controllers/main.py
@@ -188,7 +188,8 @@ class WebsiteCrmPartnerAssign(WebsitePartnerPage, GoogleMap):
     _references_per_page = 40
 
     def _get_gmap_domains(self, **kw):
-        domains = super()._get_gmap_domains(**kw)
+        if kw.get('dom', '') != "website_crm_partner_assign.partners":
+            return super()._get_gmap_domains(**kw)
         current_grade = kw.get('current_grade')
         current_country = kw.get('current_country')
 
@@ -202,8 +203,7 @@ class WebsiteCrmPartnerAssign(WebsitePartnerPage, GoogleMap):
         if current_grade:
             domain += [('grade_id', '=', int(current_grade))]
 
-        domains['website_crm_partner_assign.partners'] = domain
-        return domains
+        return domain
 
     def sitemap_partners(env, rule, qs):
         if not qs or qs.lower() in '/partners':
@@ -331,7 +331,6 @@ class WebsiteCrmPartnerAssign(WebsitePartnerPage, GoogleMap):
             offset=pager['offset'], limit=self._references_per_page)
         partners = partner_ids.sudo()
 
-        google_map_partner_ids = ','.join(str(p.id) for p in partners)
         google_maps_api_key = request.website.google_maps_api_key
 
         values = {
@@ -341,7 +340,6 @@ class WebsiteCrmPartnerAssign(WebsitePartnerPage, GoogleMap):
             'grades': grades,
             'current_grade': grade,
             'partners': partners,
-            'google_map_partner_ids': google_map_partner_ids,
             'pager': pager,
             'searches': post,
             'search_path': "%s" % werkzeug.urls.url_encode(post),

--- a/addons/website_customer/controllers/main.py
+++ b/addons/website_customer/controllers/main.py
@@ -15,7 +15,9 @@ class WebsiteCustomer(GoogleMap):
     _references_per_page = 20
 
     def _get_gmap_domains(self, **kw):
-        domains = super()._get_gmap_domains(**kw)
+        if kw.get('dom', '') != "website_customer.customers":
+            return super()._get_gmap_domains(**kw)
+
         current_industry = kw.get('current_industry')
         current_country = kw.get('current_country')
 
@@ -27,8 +29,7 @@ class WebsiteCustomer(GoogleMap):
         if current_industry and current_industry != '0':
             domain += [('industry_id', '=', int(current_industry))]
 
-        domains['website_customer.customers'] = domain
-        return domains
+        return domain
 
     def sitemap_industry(env, rule, qs):
         if not qs or qs.lower() in '/customers':
@@ -132,7 +133,6 @@ class WebsiteCustomer(GoogleMap):
         )
 
         partners = Partner.sudo().search(domain, offset=pager['offset'], limit=self._references_per_page)
-        google_map_partner_ids = ','.join(str(it) for it in partners.ids)
         google_maps_api_key = request.website.google_maps_api_key
 
         tags = Tag.search([('website_published', '=', True), ('partner_ids', 'in', partners.ids)], order='classname, name ASC')
@@ -146,7 +146,6 @@ class WebsiteCustomer(GoogleMap):
             'current_industry_id': industry.id if industry else 0,
             'current_industry': industry or False,
             'partners': partners,
-            'google_map_partner_ids': google_map_partner_ids,
             'pager': pager,
             'post': post,
             'search_path': "?%s" % werkzeug.urls.url_encode(post),

--- a/addons/website_google_map/controllers/main.py
+++ b/addons/website_google_map/controllers/main.py
@@ -25,7 +25,7 @@ class GoogleMap(http.Controller):
     '''
 
     def _get_gmap_domains(self, **kw):
-        return {}
+        return [(0, '=', 1)]
 
     @http.route(['/google_map'], type='http', auth="public", website=True, sitemap=False)
     def google_map(self, *arg, **post):
@@ -38,7 +38,7 @@ class GoogleMap(http.Controller):
                     clean_ids.append(int(partner_id))
             domain += [("id", "in", clean_ids), ('is_company', '=', True)]
         elif post.get('dom'):
-            domain = self._get_gmap_domains(**post).get(post['dom'], [])
+            domain = self._get_gmap_domains(**post)
 
         limit = post.get('limit') and int(post['limit']) or 80
 


### PR DESCRIPTION
Use slugs in the country switcher to avoid extra redirects. Remove old, useless code related to google_map_partner_ids for Google Maps since we now use `dom`.
Compute `dom` only for the current expected `dom´ to avoid conflicts. For example, if one controller uses grade as an integer and another as a slug, it could cause issues.
