### PR TITLE
[FIX] mrp: avoid changing the consumed qty

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -304,6 +304,12 @@ class StockMove(models.Model):
             new_qty = float_round((mo.qty_producing - mo.qty_produced) * self.unit_factor, precision_rounding=self.product_uom.rounding)
             self.quantity = new_qty
 
+    @api.onchange('quantity', 'product_uom', 'picked')
+    def _onchange_quantity(self):
+        if self.raw_material_production_id and not self.manual_consumption and self.picked and self.product_uom and \
+           float_compare(self.product_uom_qty, self.quantity, precision_rounding=self.product_uom.rounding) != 0:
+            self.manual_consumption = True
+
     @api.model
     def default_get(self, fields_list):
         defaults = super(StockMove, self).default_get(fields_list)


### PR DESCRIPTION
Backport of [1]

The commit says:
> The issue does not appear in 17.0 because, thanks to commit [5bb0f96](https://github.com/odoo/odoo/commit/5bb0f96f1973fa7e19b6701944b4a29577f3314f):
The `manual_consumption` field of the stock moves related to a
manufacturing order is set to be True as soon as the quantity is changed
because of these lines:
https://github.com/odoo/odoo/blob/9a11717c17b860ec2f1b2e228517c0d3945c474a/addons/mrp/static/src/widgets/mrp_consumed.js#L25-L27

But, if the user changes that quantity through the detailed
operations, nothing will write on `manual_consumption`. As a result,
the user then ticks the _Consumed_ box, sets a producing qty and...
The bug is back: the consumed qty of the components will be updated.

In the above use case, if [1] is applied, when the user ticks the
box, it will trigger the onchange and flag `manual_consumption`.

[1] https://github.com/odoo/odoo/commit/8aa7800fdf52b765b2b08b33aed1b963ff141401

OPW-4048258