### PR TITLE
[FIX] web: Hoot - properly filter module addons

### DIFF
--- a/addons/web/static/tests/_framework/module_set.hoot.js
+++ b/addons/web/static/tests/_framework/module_set.hoot.js
@@ -84,14 +84,16 @@ const defineModuleSet = async (entryPoints, additionalAddons) => {
             additionalAddons.add(getAddonName(entryPoint));
         }
         const addons = await fetchDependencies(additionalAddons);
-        const joinedAddons = [...addons].sort().join(",");
-        const filter = (path) => joinedAddons.includes(getAddonName(path));
+        const filter = (path) => addons.has(getAddonName(path));
+
         // Module names are cached for each configuration of addons
+        const joinedAddons = [...addons].sort().join(",");
         if (!moduleNamesCache[joinedAddons]) {
             moduleNamesCache[joinedAddons] = sortedModuleNames.filter(
                 (name) => !name.endsWith(TEST_SUFFIX) && filter(name)
             );
         }
+
         moduleSet.filter = filter;
         moduleSet.moduleNames = moduleNamesCache[joinedAddons];
     }


### PR DESCRIPTION
Before this PR, to filter modules that a module set required, the addon name was searched within the list of allowed addons *stringified and joined* with a simple call to "includes", which means that a partial match with an addon's name would allow the module to be started.

This has been fixed by checking that the full addon's name appears in the list of allowed addons.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
