### PR TITLE
[FIX] pos_loyalty: Exempt specific fields from auto-loading

### DIFF
--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -27,8 +27,14 @@ function mapObj(obj, fn) {
 
 const RELATION_TYPES = new Set(["many2many", "many2one", "one2many"]);
 const X2MANY_TYPES = new Set(["many2many", "one2many"]);
-const EXEMPTED_AUTOMATIC_LOAD = ["pos.session", "pos.config"];
 const AVAILABLE_EVENT = ["create", "update", "delete"];
+export const CONFIG = {
+    exemptedAutomaticLoad: [(field) => ["pos.session", "pos.config"].includes(field.relation)],
+};
+
+function isFieldExemptedAutoLoad(field) {
+    return CONFIG.exemptedAutomaticLoad.some((condition) => condition(field));
+}
 
 function processModelDefs(modelDefs) {
     modelDefs = clone(modelDefs);
@@ -758,14 +764,13 @@ export function createRelatedModels(modelDefs, modelClasses = {}, indexes = {}) 
                                     const toConnect = records[field.relation].get(id);
                                     if (toConnect) {
                                         connect(field, recorded, toConnect);
-                                    } else if (
-                                        this[field.relation] &&
-                                        !EXEMPTED_AUTOMATIC_LOAD.includes(field.relation)
-                                    ) {
-                                        if (!missingRecords[field.relation]) {
-                                            missingRecords[field.relation] = new Set([id]);
-                                        } else {
-                                            missingRecords[field.relation].add(id);
+                                    } else if (this[field.relation]) {
+                                        if (!isFieldExemptedAutoLoad(field)) {
+                                            if (!missingRecords[field.relation]) {
+                                                missingRecords[field.relation] = new Set([id]);
+                                            } else {
+                                                missingRecords[field.relation].add(id);
+                                            }
                                         }
                                         const key = `${field.relation}_${id}`;
                                         if (!missingFields[key]) {
@@ -783,14 +788,13 @@ export function createRelatedModels(modelDefs, modelClasses = {}, indexes = {}) 
                             const toConnect = records[field.relation].get(id);
                             if (toConnect) {
                                 connect(field, recorded, toConnect);
-                            } else if (
-                                this[field.relation] &&
-                                !EXEMPTED_AUTOMATIC_LOAD.includes(field.relation)
-                            ) {
-                                if (!missingRecords[field.relation]) {
-                                    missingRecords[field.relation] = new Set([id]);
-                                } else {
-                                    missingRecords[field.relation].add(id);
+                            } else if (this[field.relation]) {
+                                if (!isFieldExemptedAutoLoad(field)) {
+                                    if (!missingRecords[field.relation]) {
+                                        missingRecords[field.relation] = new Set([id]);
+                                    } else {
+                                        missingRecords[field.relation].add(id);
+                                    }
                                 }
                                 const key = `${field.relation}_${id}`;
                                 if (!missingFields[key]) {

--- a/addons/pos_loyalty/static/src/overrides/models/related_models.js
+++ b/addons/pos_loyalty/static/src/overrides/models/related_models.js
@@ -1,0 +1,8 @@
+/* @odoo-module */
+
+import { CONFIG } from "@point_of_sale/app/models/related_models";
+
+CONFIG.exemptedAutomaticLoad.push(
+    (field) => field.model === "loyalty.reward" && field.name === "all_discount_product_ids",
+    (field) => field.model === "loyalty.rule" && field.name === "valid_product_ids"
+);


### PR DESCRIPTION
Before this commit, databases with a large number of products would load all products in `all_discount_product_ids` of rewards and `valid_product_ids` of rules due to automatic loading of missing products. This commit exempts these fields from being automatically loaded.

opw-4061504

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
