### PR TITLE
[FIX] stock: enforce deterministic order on freed reservation

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -710,8 +710,8 @@ class StockMoveLine(models.Model):
             current_picking_first = lambda cand: (
                 cand.picking_id != self.move_id.picking_id,
                 -(cand.picking_id.scheduled_date or cand.move_id.date).timestamp()
-                if cand.picking_id or cand.move_id
-                else -cand.id,
+                if cand.picking_id or cand.move_id else 0,
+                -cand.id,
             )
             outdated_candidates = self.env['stock.move.line'].search(outdated_move_lines_domain).sorted(current_picking_first)
 

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -6153,3 +6153,35 @@ class StockMove(TransactionCase):
         ml.write({'product_uom_id': self.uom_unit.id})
         self.assertEqual(quant.reserved_quantity, 2)
         self.assertEqual(ml.product_uom_qty * self.uom_unit.ratio, 2)
+
+    def test_free_reservation(self):
+        """ Checks that the free_reservation uses the latest move line when the picking or date are equal.
+        """
+        self.env['stock.quant']._update_available_quantity(self.product, self.stock_location, 5)
+        # Create two moves using the all available quantity and reserve them
+        move_1, move_2 = self.env['stock.move'].create([{
+            'name': 'New move',
+            'product_id': self.product.id,
+            'product_uom_qty': qty,
+            'product_uom': self.product.uom_id.id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+        } for qty in [2, 3]])
+        (move_1 | move_2)._action_confirm()
+        (move_1 | move_2)._action_assign()
+
+        self.assertEqual(move_1.date, move_2.date)
+        self.assertEqual(move_1.state, 'assigned')
+        self.assertEqual(move_2.state, 'assigned')
+
+        # Create a scrap order, that will remove some on the available quantity
+        with Form(self.env['stock.scrap']) as scrap_form:
+            scrap_form.product_id = self.product
+            scrap_form.scrap_qty = 2
+            scrap_form.location_id = self.stock_location
+            scrap = scrap_form.save()
+        scrap.action_validate()
+
+        # Since both moves have the same date, ensure that the reservation is changed on the latest created
+        self.assertEqual(move_1.state, 'assigned')
+        self.assertEqual(move_2.state, 'partially_available')


### PR DESCRIPTION
Steps to reproduce:
- Create a product
- Update its quantity and set 4 in Stock
- Create two MO that consume each 2 units of that product with the same scheduled date
- Create a scrap order with 1 quantity of that product and validate it

Issue:
The unreserve will be done on the first MO.

When going through the candidate move lines in the `_free_reservation()`, we sort them depending on their picking, their date if they have a move, or their id if they don't.

The issue is that when their related move have an equal date, then the order becomes underministic. Now, always sort by their id as a last resort, so we have a consistent order no matter what.

opw-4046240

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
