### PR TITLE
[FIX] mail: public channel fetching and real-time messaging

### DIFF
--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -186,6 +186,12 @@ export class Store extends BaseStore {
         if (ev.target.closest(".o_channel_redirect") && model && id) {
             ev.preventDefault();
             const thread = this.Thread.insert({ model, id });
+            if (!thread.is_pinned) {
+                this.env.services["mail.thread"].fetchChannel(id).then(() => {
+                    this.env.services["mail.thread"].open(thread);
+                });
+                return true;
+            }
             this.env.services["mail.thread"].open(thread);
             return true;
         } else if (ev.target.closest(".o_mail_redirect") && id) {

--- a/addons/mail/static/src/core/web/thread_service_patch.js
+++ b/addons/mail/static/src/core/web/thread_service_patch.js
@@ -189,6 +189,9 @@ patch(ThreadService.prototype, {
     },
     /** @override */
     open(thread, replaceNewMessageChatWindow, options) {
+        if (thread.model === "discuss.channel") {
+            this.store.env.services["bus_service"].addChannel(thread.busChannel);
+        }
         if (!this.store.discuss.isActive && !this.ui.isSmall) {
             this._openChatWindow(thread, replaceNewMessageChatWindow, options);
             return;
@@ -229,7 +232,11 @@ patch(ThreadService.prototype, {
         }
         super.unpin(...arguments);
     },
-    _openChatWindow(thread, replaceNewMessageChatWindow, { autofocus = true, openMessagingMenuOnClose } = {}) {
+    _openChatWindow(
+        thread,
+        replaceNewMessageChatWindow,
+        { autofocus = true, openMessagingMenuOnClose } = {}
+    ) {
         const chatWindow = this.store.ChatWindow.insert(
             assignDefined(
                 {

--- a/addons/mail/static/tests/discuss/core/discuss_tests.js
+++ b/addons/mail/static/tests/discuss/core/discuss_tests.js
@@ -35,17 +35,22 @@ QUnit.test("bus subscription is refreshed when channel is joined", async () => {
     const later = luxon.DateTime.now().plus({ seconds: 2 });
     patchDate(later.year, later.month, later.day, later.hour, later.minute, later.second);
     const { env, openDiscuss } = await start();
-    const imStatusChannels = [];
+    const expectedSubscribes = [];
     for (const { type, id } of env.services["mail.store"].imStatusTrackedPersonas) {
         const model = type === "partner" ? "res.partner" : "mail.guest";
-        imStatusChannels.unshift(`"odoo-presence-${model}_${id}"`);
+        expectedSubscribes.unshift(`"odoo-presence-${model}_${id}"`);
     }
     await openDiscuss();
-    await assertSteps([`subscribe - [${imStatusChannels.join(",")}]`]);
+    await assertSteps([`subscribe - [${expectedSubscribes.join(",")}]`]);
     await click(".o-mail-DiscussSidebar i[title='Add or join a channel']");
     await insertText(".o-discuss-ChannelSelector input", "new channel");
     await click(".o-discuss-ChannelSelector-suggestion");
-    await assertSteps([`subscribe - [${imStatusChannels.join(",")}]`]);
+    const [newChannel] = pyEnv["discuss.channel"].searchRead([["name", "=", "new channel"]]);
+    expectedSubscribes.unshift(`"discuss.channel_${newChannel.id}"`);
+    await assertSteps([
+        `subscribe - [${expectedSubscribes.join(",")}]`,
+        `subscribe - [${expectedSubscribes.join(",")}]`, // 1 is enough. The 2 comes from technical details (1: from channel_join, 2: from channel open), 2nd covers shadowing
+    ]);
 });
 
 QUnit.test("bus subscription is refreshed when channel is left", async () => {

--- a/addons/mail/static/tests/helpers/mock_server/models/discuss_channel.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/discuss_channel.js
@@ -511,7 +511,8 @@ patch(MockServer.prototype, {
                 fold_state: foldState,
                 is_minimized: foldState !== "closed",
             };
-            this.pyEnv["discuss.channel.member"].write([memberOfCurrentUser.id], vals);
+            memberOfCurrentUser &&
+                this.pyEnv["discuss.channel.member"].write([memberOfCurrentUser.id], vals);
             this.pyEnv["bus.bus"]._sendone(this.pyEnv.currentPartner, "discuss.Thread/fold_state", {
                 foldStateCount: state_count,
                 id: channel.id,

--- a/addons/mail/static/tests/thread/thread_tests.js
+++ b/addons/mail/static/tests/thread/thread_tests.js
@@ -8,6 +8,7 @@ import { start } from "@mail/../tests/helpers/test_utils";
 import { config as transitionConfig } from "@web/core/transition";
 import { makeDeferred, nextTick, patchWithCleanup } from "@web/../tests/helpers/utils";
 import {
+    assertSteps,
     click,
     contains,
     createFile,
@@ -15,8 +16,10 @@ import {
     focus,
     insertText,
     scroll,
+    step,
     triggerEvents,
 } from "@web/../tests/utils";
+import { patchWebsocketWorkerWithCleanup } from "@bus/../tests/helpers/mock_websocket";
 
 QUnit.module("thread");
 
@@ -426,6 +429,43 @@ QUnit.test(
         await contains(".o-mail-ChatWindow .o-mail-Thread", { scroll: 0 });
     }
 );
+
+QUnit.test("can join public channel from channel mention link", async () => {
+    const pyEnv = await startServer();
+    const userId = pyEnv["res.users"].create({ name: "Demo" });
+    const partnerId = pyEnv["res.partner"].create({
+        name: "Demo",
+        user_ids: [userId],
+    });
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "Channel",
+        channel_member_ids: [Command.create({ partner_id: partnerId })],
+        channel_type: "channel",
+        group_public_id: false,
+    });
+    pyEnv["mail.message"].create({
+        model: "res.partner",
+        message_type: "comment",
+        body: `<p><a class="o_channel_redirect" href="#" data-oe-model="discuss.channel" data-oe-id="${channelId}">#Channel</a></p>`, // simulated channel mention in message
+        author_id: partnerId,
+        res_id: partnerId,
+    });
+    patchWebsocketWorkerWithCleanup({
+        _sendToServer({ event_name, data }) {
+            if (event_name === "subscribe") {
+                const channels = data.channels.filter((subscription) =>
+                    subscription.startsWith("discuss.channel_")
+                );
+                step(`subscribe - [${channels.join(",")}]`);
+            }
+        },
+    });
+    const { openFormView } = await start();
+    await openFormView("res.partner", partnerId);
+    await click(".o-mail-Message-body a", { text: "#Channel" });
+    await contains(".o-mail-ChatWindow-header", { text: "Channel" });
+    await assertSteps([`subscribe - [discuss.channel_${channelId}]`]);
+});
 
 QUnit.test("show empty placeholder when thread contains no message", async () => {
     const pyEnv = await startServer();


### PR DESCRIPTION
**Current behavior before PR:**

Public channels were not being fetched when users clicked channel mentions,
causing chat window title to display "New message" instead of their actual names.
Additionally, bus channels were not added every time when
threads were opened, preventing real-time messaging in some cases.

**Desired behavior after PR is merged:**

Implemented channel fetching on mention clicks and added bus channel
subscription when opening threads, enabling proper channel name display
and real-time messaging functionality.



Task:[3899453](https://www.odoo.com/odoo/project/1519/tasks/3899453)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr