### PR TITLE
[I18N] mass_mailing: Change placeholder to neutral

### DIFF
--- a/addons/mass_mailing/i18n/ru.po
+++ b/addons/mass_mailing/i18n/ru.po
@@ -3024,7 +3024,7 @@ msgstr "например, новостная рассылка для клиен�
 #. module: mass_mailing
 #: model_terms:ir.ui.view,arch_db:mass_mailing.mailing_contact_view_form
 msgid "e.g. John Smith"
-msgstr "напр., Степан Бандера"
+msgstr "напр., Иван Иванов"
 
 #. module: mass_mailing
 #: model_terms:ir.ui.view,arch_db:mass_mailing.view_mail_mass_mailing_form


### PR DESCRIPTION
Степан Бандера is national hero according to laws of current Ukraine and criminal according to laws of Soviet Ukraine.
His name has nothing to do in Russian translation. So I switched to neutral Иван Иванов (Ivan Ivanov).

In 15.0 branch I already submitted patch via transifex.

Ping: @mart-e 