### PR TITLE
[FIX] hr_expense: hr_expense_test_tour fail

### DIFF
--- a/addons/hr_expense/static/tests/tours/expense_upload_tours.js
+++ b/addons/hr_expense/static/tests/tours/expense_upload_tours.js
@@ -47,13 +47,15 @@ odoo.define('hr_expense.tests.tours', function (require) {
             }
         },
         {
-            content: "Check Create Report Button and click on it",
-            trigger: ".btn-secondary:contains(\"Create Report\")",
-        },
-        {
-            trigger: '.fa-cloud-upload',
-            content: 'Save the new report',
-            run: 'click',
+            content: "Check Create Report Button, but not click on it",
+            trigger: "button.o_switch_view.o_kanban.active",
+            run() {
+                const button = Array.from(document.querySelectorAll('.btn-secondary'))
+                    .filter(element => element.textContent.includes('Create Report'));
+                if(!button) {
+                    console.error('Missing Create Report button in My Expenses to Report > Kanban View');
+                }
+            }
         },
         {
             content: "Go to Reporting",


### PR DESCRIPTION
Since #169396, the hr_expense_test_tour is failing on community nightly runs as the "save the new report" step does not succeed without demo.

runbot-70701

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
