### PR TITLE
[FIX] hr_skills: skills_tour tour

### DIFF
--- a/addons/hr_skills/static/tests/tours/skills_tour.js
+++ b/addons/hr_skills/static/tests/tours/skills_tour.js
@@ -115,6 +115,10 @@ registry.category("web_tour.tours").add('hr_skills_tour', {
         run: "click",
     },
     {
+        content: "Wait the new skill is completely saved. Ensure also the modal is closed before open a new one.",
+        trigger: "body:not(:has(.modal))",
+    },
+    {
         content: "Check if item is added",
         trigger: ".o_data_row td.o_data_cell:contains('Fortunate Son')",
     },
@@ -124,7 +128,11 @@ registry.category("web_tour.tours").add('hr_skills_tour', {
         run: "click",
     },
     {
-        content: "Select a song", // "Music" should be already selected
+        content: "Music should be already selected",
+        trigger: ".modal:contains(select skills) .o_field_widget[name=skill_id] input:value(Fortunate Son)",
+    },
+    {
+        content: "Select a song",
         trigger: ".modal:contains(select skills) .o_field_widget[name='skill_id'] input",
         run: "edit Mary",
     },
@@ -147,6 +155,10 @@ registry.category("web_tour.tours").add('hr_skills_tour', {
         content: "Save new skill",
         trigger: ".modal:contains(select skills) .o_form_button_save:contains(save & close)",
         run: "click",
+    },
+    {
+        content: "Wait the new skill is completely saved",
+        trigger: "body:not(:has(.modal))",
     },
     {
         content: "Check if item is added",


### PR DESCRIPTION
In this commit, we add a step in the tour which allows you to check that the modal is closed before opening another one. This allows you to avoid looking for a value in the previous modal. In a tour, we do not necessarily expect a change between each stage. So, if the element is found in the DOM without a mutation, the tour continues.
It is therefore always better to add steps which ensure that the modals are closed, that the forms are saved,...

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
