### PR TITLE
[FIX] repair: validate when product reserved quantity all

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -285,13 +285,13 @@ class Repair(models.Model):
             ('location_id', '=', self.location_id.id),
             ('lot_id', '=', self.lot_id.id),
             ('owner_id', '=', self.partner_id.id),
-        ]).mapped('quantity'))
+        ]).mapped('available_quantity'))
         available_qty_noown = sum(self.env['stock.quant'].search([
             ('product_id', '=', self.product_id.id),
             ('location_id', '=', self.location_id.id),
             ('lot_id', '=', self.lot_id.id),
             ('owner_id', '=', False),
-        ]).mapped('quantity'))
+        ]).mapped('available_quantity'))
         repair_qty = self.product_uom._compute_quantity(self.product_qty, self.product_id.uom_id)
         for available_qty in [available_qty_owner, available_qty_noown]:
             if float_compare(available_qty, repair_qty, precision_digits=precision) >= 0:


### PR DESCRIPTION
Product A, quantity in stock = 1,
sale product A -> picking out assigned
create repair order with product A, there is still stock in stock but all reserved. We need warning this case when validate with available_quantity (quantity - reserved quantity) instead quantity

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
