### PR TITLE
[FIX] web_editor: fix double background options for quotes carousel

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2378,6 +2378,21 @@ var SnippetsMenu = Widget.extend({
                 $style[0].dataset.dropIn = dropInPatch.join(', ');
             }
 
+            // Fix in stable: carousel options are excluded from the background
+            // background options, then specific options exists for those
+            // carousel. The specific options includes the Quotes Carousel
+            // but the Quotes Carousel is not excluded from the default options
+            // and this lead to the options confusing each other enabling each
+            // others widgets and displaying conflicted infos. So exclude
+            // the quotes carousel from the default options.
+            if (
+                exclude &&
+                exclude.includes(", .s_carousel_wrapper") &&
+                !exclude.includes(", .s_quotes_carousel_wrapper")
+            ) {
+                exclude += ", .s_quotes_carousel_wrapper";
+            }
+
             // Fix in stable: we have removed the option for setting the
             // background color for snippets in the footer. However, this should
             // not affect the snippets in the "All pages" popup which is also


### PR DESCRIPTION
Commit [1] introduced specific background options for carousel and excluded them from the default background options which targets almost all sections.

However, it did not exclude the quotes carousel, while still targeting it for the specific options. This leads to 2 background options being displayed and conflicting each other by enabling each other's widgets, displaying the wrong colors, etc.

This commit fixes this in stable by checking if the exclude selector contained the `s_carousel_wrapper` class but not the `s_quotes_carousel_wrapper` class, and adding it in such cases.

Steps to reproduce:
- Drop a "Quotes" block => 2 background options are displayed

[1]: https://github.com/odoo/odoo/commit/bb0cd4d5c82a9c2311f8c45ced0e9fdc0397d292

task-4074604