### PR TITLE
[FIX] hr_expense: compute on changing total_amount to 0

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -195,8 +195,8 @@ class HrExpense(models.Model):
             currency=currency or self.currency_id,
             product=self.product_id,
             taxes=self.tax_ids,
-            price_unit=price_unit or self.total_amount_company,
-            quantity=quantity or 1,
+            price_unit=price_unit or 0,
+            quantity=quantity if quantity is not None else 1,  # Allows 0 quantity
             account=self.account_id,
             analytic_distribution=self.analytic_distribution,
             extra_context={'force_price_include': True},
@@ -374,7 +374,7 @@ class HrExpense(models.Model):
     @api.onchange('total_amount')
     def _inverse_total_amount(self):
         for expense in self:
-            expense.unit_amount = expense.total_amount_company / expense.quantity
+            expense.unit_amount = expense.total_amount_company / (expense.quantity or 1)
 
     @api.constrains('payment_mode')
     def _check_payment_mode(self):

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -1473,3 +1473,28 @@ class TestExpenses(TestExpenseCommon):
         tax_lines = moves.line_ids.filtered(lambda line: line.tax_line_id == caba_tax)
         self.assertNotEqual(tax_lines.account_id, caba_transition_account, "The tax should not be on the transition account")
         self.assertEqual(tax_lines.tax_tag_ids, caba_tag, "The tax should still retrieve its tags")
+
+    def test_expense_set_total_amount_to_0(self):
+        """Checks that amount fields are correctly updating when setting total_amount to 0"""
+        expense = self.env['hr.expense'].create({
+            'name': 'Expense with amount',
+            'employee_id': self.expense_employee.id,
+            'product_id': self.product_c.id,
+            'total_amount': 100.0,
+            'tax_ids': self.tax_purchase_a.ids,
+        })
+        expense.total_amount = 0.0
+        self.assertTrue(expense.currency_id.is_zero(expense.amount_tax))
+        self.assertTrue(expense.company_currency_id.is_zero(expense.total_amount_company))
+
+    def test_expense_set_quantity_to_0(self):
+        """Checks that amount fields except for unit_amount are correctly updating when setting quantity to 0"""
+        expense = self.env['hr.expense'].create({
+            'name': 'Expense with amount',
+            'employee_id': self.expense_employee.id,
+            'product_id': self.product_b.id,
+            'quantity': 10
+        })
+        expense.quantity = 0
+        self.assertTrue(expense.currency_id.is_zero(expense.total_amount))
+        self.assertEqual(expense.company_currency_id.compare_amounts(expense.unit_amount, self.product_b.standard_price), 0)


### PR DESCRIPTION
### Steps to reproduce issue:

1. Create new Expense
2. Give a positive Total Amount, add a Tax and Save
3. Set Total Amount to 0
4. Tax Amount did not nullify
5. In the List view, Total Amount still has the previous value

### Explanation:

In `_convert_to_tax_base_line_dict`, `price_unit` is only passed if it has a strictly positive value, otherwise `total_amount_company` is used instead.
Since `total_amount_company` is computed using this method, it can never be reset to 0.
https://github.com/odoo/odoo/blob/72b84435d69d098d615284d84ef136e8bcd2aaa0/addons/hr_expense/models/hr_expense.py#L226-L232

### Suggested Fix:

The fallback to `total_amount_company` is unnecessary. For `quantity`, the fallback to 1 should only be observed if the quantity is not set. Correcting `_inverse_total_amount` to avoid division by 0.

opw-4049853