### PR TITLE
[FIX] l10n_fi: new taxes not updated

### DIFF
--- a/addons/l10n_fi/__manifest__.py
+++ b/addons/l10n_fi/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Finnish Localization",
-    "version": "13.0.1",
+    "version": "13.0.2",
     "author": "Avoin.Systems, "
               "Tawasta, "
               "Vizucom, "

--- a/addons/l10n_fi/migrations/13.0.2/post-migrate_update_taxes.py
+++ b/addons/l10n_fi/migrations/13.0.2/post-migrate_update_taxes.py
@@ -1,0 +1,7 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.account.models.chart_template import update_taxes_from_templates
+
+
+def migrate(cr, version):
+    update_taxes_from_templates(cr, 'l10n_fi.fi_chart_template')


### PR DESCRIPTION
This commit ammends a previous one in which new taxes were added but not the necessary system to update them into existing databases.

Those new taxes have only been merged in 15.0 so this commit won't be FW.

---

task-4010731
related PR: [odoo/171414](https://github.com/odoo/odoo/pull/171414)

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
