### PR TITLE
[FIX] sale: show downpayments in sale report

### DIFF
--- a/addons/sale/report/sale_report.py
+++ b/addons/sale/report/sale_report.py
@@ -106,12 +106,12 @@ class SaleReport(models.Model):
                 * {self._case_value_or_one('currency_table.rate')}
                 ) ELSE 0
             END AS price_subtotal,
-            CASE WHEN l.product_id IS NOT NULL THEN SUM(l.untaxed_amount_to_invoice
+            CASE WHEN l.product_id IS NOT NULL OR l.is_downpayment THEN SUM(l.untaxed_amount_to_invoice
                 / {self._case_value_or_one('s.currency_rate')}
                 * {self._case_value_or_one('currency_table.rate')}
                 ) ELSE 0
             END AS untaxed_amount_to_invoice,
-            CASE WHEN l.product_id IS NOT NULL THEN SUM(l.untaxed_amount_invoiced
+            CASE WHEN l.product_id IS NOT NULL OR l.is_downpayment THEN SUM(l.untaxed_amount_invoiced
                 / {self._case_value_or_one('s.currency_rate')}
                 * {self._case_value_or_one('currency_table.rate')}
                 ) ELSE 0
@@ -209,6 +209,7 @@ class SaleReport(models.Model):
             partner.industry_id,
             partner.state_id,
             partner.zip,
+            l.is_downpayment,
             l.discount,
             s.id,
             currency_table.rate"""

--- a/addons/sale/tests/test_sale_report.py
+++ b/addons/sale/tests/test_sale_report.py
@@ -4,6 +4,7 @@
 from odoo import fields
 from odoo.fields import Command
 from odoo.tests import tagged
+from odoo.tools.float_utils import float_compare
 
 from odoo.addons.sale.tests.common import SaleCommon
 
@@ -128,3 +129,30 @@ class TestSaleReportCurrencyRate(SaleCommon):
 
         price_total = sum(report_lines.mapped('price_total'))
         self.assertAlmostEqual(price_total, expected_reported_amount)
+
+    def test_sale_report_with_downpayment(self):
+        """Checks that downpayment lines are used in the calculation of amounts invoiced and to invoice"""
+        order = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [Command.create({
+                'product_id': self.product.id,
+            })]
+        })
+        order.action_confirm()
+
+        downpayment = self.env['sale.advance.payment.inv'].with_context(active_ids=order.ids).create({
+            'advance_payment_method': 'fixed',
+            'fixed_amount': 200
+        })
+        downpayment.create_invoices()
+        order.invoice_ids.action_post()
+        order.order_line.flush_recordset()
+
+        amount_line = self.env['sale.report'].read_group(
+            [('order_reference', '=', f'sale.order,{order.id}')],
+            ['untaxed_amount_to_invoice:sum', 'untaxed_amount_invoiced:sum'],
+            []
+        )[0]
+
+        self.assertEqual(float_compare(amount_line['untaxed_amount_invoiced'], 200, order.currency_id.rounding), 0)
+        self.assertEqual(float_compare(amount_line['untaxed_amount_to_invoice'], self.product.lst_price - 200, order.currency_id.rounding), 0)


### PR DESCRIPTION
### Steps to reproduce the issue:

1. Create a Sales Order
2. Create an Invoice with a Down Payment
3. Go to Sales>Reporting>Sales in Pivot View
4. Activate "Untaxed Amount To Invoice" or "Untaxed Amount Invoiced" in the Measures
5. Look for the Sales Order
6. The Down Payment is not calculated

### Explanation:

In commit odoo/odoo@9aa52dd6418e5881adc2d96d15d062b55d6150c5, the Down Payment product was removed and Down Payment lines no longer have a `product_id`. In `sale.report`, most values are only calculated if this field, `product_id`, has a value. This includes `untaxed_amount_to_invoice` and `untaxed_amount_invoiced`.

### Fix reasoning:

`is_downpayment` field filters Down Payment lines, it can be used to add them in the calculation of selected columns in the report.

opw-4033003