### PR TITLE
[FIX] web: Hoot - properly check isInDOM

### DIFF
--- a/addons/web/static/lib/hoot-dom/helpers/dom.js
+++ b/addons/web/static/lib/hoot-dom/helpers/dom.js
@@ -1344,24 +1344,7 @@ export function isFocusable(target, options) {
  *  isInDOM(document.createElement("div")); // false
  */
 export function isInDOM(target) {
-    target = ensureElement(target);
-    if (!target) {
-        return false;
-    }
-    const frame = getParentFrame(target);
-    if (frame) {
-        return isInDOM(frame);
-    }
-    while (target) {
-        if (target === document) {
-            return true;
-        }
-        target = target.parentNode;
-        if (target?.host) {
-            target = target.host.parentNode;
-        }
-    }
-    return false;
+    return ensureElement(target)?.isConnected;
 }
 
 /**

--- a/addons/web/static/lib/hoot/tests/hoot-dom/dom.test.js
+++ b/addons/web/static/lib/hoot/tests/hoot-dom/dom.test.js
@@ -12,6 +12,7 @@ import {
     isEditable,
     isEventTarget,
     isFocusable,
+    isInDOM,
     isVisible,
     queryAll,
     queryAllRects,
@@ -282,6 +283,30 @@ describe.tags("ui")(parseUrl(import.meta.url), () => {
 
         expect(isFocusable("input:first")).toBe(true);
         expect(isFocusable("li:first")).toBe(false);
+    });
+
+    test("isInDom", async () => {
+        await mountOnFixture(FULL_HTML_TEMPLATE);
+        await waitForIframes();
+
+        expect(isInDOM(document)).toBe(true);
+        expect(isInDOM(document.body)).toBe(true);
+        expect(isInDOM(document.head)).toBe(true);
+        expect(isInDOM(document.documentElement)).toBe(true);
+
+        const form = queryOne`form`;
+        expect(isInDOM(form)).toBe(true);
+
+        form.remove();
+
+        expect(isInDOM(form)).toBe(false);
+
+        const paragraph = queryOne`:iframe p`;
+        expect(isInDOM(paragraph)).toBe(true);
+
+        paragraph.remove();
+
+        expect(isInDOM(paragraph)).toBe(false);
     });
 
     test("isDisplayed", async () => {


### PR DESCRIPTION
This commit ensures that the `isInDOM` helper function in Hoot actually checks that the given target is connected to a document.

The previous implementation was naïve and only relied on the presence of a parent element. This was incomplete as there are some cases where a node is connected to a document element without having a `parentNode`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
