### PR TITLE
[FIX] mrp: wo button column width

### DIFF
--- a/addons/mrp/static/src/views/fields/mrp_workorder_one2many.js
+++ b/addons/mrp/static/src/views/fields/mrp_workorder_one2many.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
 import { registry } from "@web/core/registry";
+import { listView } from "@web/views/list/list_view";
 import { AutoColumnWidthListRenderer } from "@stock/views/list/auto_column_width_list_renderer";
 import { X2ManyField, x2ManyField } from "@web/views/fields/x2many/x2many_field";
 
@@ -15,3 +16,10 @@ export const mrpWorkorderX2ManyField = {
 };
 
 registry.category("fields").add("mrp_workorder_one2many", mrpWorkorderX2ManyField);
+
+export const mrpWorkorderListView = {
+    ...listView,
+    Renderer: AutoColumnWidthListRenderer,
+};
+
+registry.category("views").add("mrp_workorder_list_view", mrpWorkorderListView);

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -61,7 +61,7 @@
         <field name="model">mrp.workorder</field>
         <field name="priority" eval="100"/>
         <field name="arch" type="xml">
-            <tree editable="bottom" multi_edit="1">
+            <tree editable="bottom" js_class="mrp_workorder_list_view" multi_edit="1">
                 <field name="consumption" column_invisible="True"/>
                 <field name="company_id" column_invisible="True"/>
                 <field name="is_produced" column_invisible="True"/>


### PR DESCRIPTION
Since https://github.com/odoo/odoo/commit/3d9a6acaa73229408093ecc7c29cd9538450c0e7, the width of the wo buttons columns is not correct when pressing start/pause (overlapping with the dropdown menu).
![image](https://github.com/user-attachments/assets/904f5406-cc03-42c7-abd8-d080f3b1ba88)

This is due to the removal of the useEffect that now do not recompute the size of the columns each time one is added/modified).

This commits adds the modified AutocolumnWidthRenderer to the editable tree view of work orders.

task-id: 4074770


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
