### PR TITLE
[FIX] mrp: add lot on additional finished product on locked MO

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -897,6 +897,8 @@ class MrpProduction(models.Model):
                     finished_move_lines.write({'lot_id': vals.get('lot_producing_id')})
                 if 'qty_producing' in vals:
                     finished_move.quantity = vals.get('qty_producing')
+                    if production.product_tracking == 'lot':
+                        finished_move.move_line_ids.lot_id = production.lot_producing_id
             if self._has_workorders() and not production.workorder_ids.operation_id and vals.get('date_start') and not vals.get('date_finished'):
                 new_date_start = fields.Datetime.to_datetime(vals.get('date_start'))
                 if not production.date_finished or new_date_start >= production.date_finished:


### PR DESCRIPTION
### Steps to reproduce:

- Create a product tracked by lot with a BOM
- Create and confirm an MO for 1 unit of that product
- Assign a producing lot via the [+] smart button
- Change the quantity producing to 2 and produce all
> Go on the Traceability Report an additional move_line associated to
your MO finished move was created and associated to the producing lot.
- Unlock the MO and change the quantity producing to 3
> Go on the Traceability Report an additional move_line associated to
your MO finished move was created and associated but the producing lot **is missing**

### Cause of the issue:

Changing the quantity producing on the MO and then marking the MO as done will trigger a call of the `_post_inventory` method. During this call the quantity of the finished move are adapted according to the quantity producing of the MO by these lines:
https://github.com/odoo/odoo/blob/4a388236ce49e03e3a32447f8fa6ed073a09126b/addons/mrp/models/mrp_production.py#L1700-L1702 The change of quantity will trigger a `_process_increase` of the qties of the finished move and will create an additional stock move line for the remaining qties:
https://github.com/odoo/odoo/blob/4a388236ce49e03e3a32447f8fa6ed073a09126b/addons/stock/models/stock_move.py#L2051-L2055 and the producing lot is added to this new line just after because of these lines:
https://github.com/odoo/odoo/blob/4a388236ce49e03e3a32447f8fa6ed073a09126b/addons/mrp/models/mrp_production.py#L1702-L1705 https://github.com/odoo/odoo/blob/f80094f43bcc464cc99fba6aa59f64659fe659b6/addons/mrp/models/mrp_production.py#L2780-L2784 By contrast, if you modify the quantity producing after the MO is marked as done, the quantity of the finished_move is modified dirrectly by the ovewrite of the `write` method of the `mrp_production` model: https://github.com/odoo/odoo/blob/4a388236ce49e03e3a32447f8fa6ed073a09126b/addons/mrp/models/mrp_production.py#L898-L899 This will also trigger a `_process_increase` but it will not add the `lot_id` to the new sml as in the `_post_inventory` call.

opw-4043539
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
