### PR TITLE
[FIX] stock: split order reservation

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -923,7 +923,7 @@ class StockPicking(models.Model):
             if picking.state not in ('confirmed', 'waiting', 'assigned'):
                 picking.show_check_availability = False
                 continue
-            if all(m.picked for m in picking.move_ids):
+            if all(m.picked or m.product_uom_qty == m.quantity for m in picking.move_ids):
                 picking.show_check_availability = False
                 continue
             picking.show_check_availability = any(


### PR DESCRIPTION
With This Commit :
-----------------------------------
- When creating an advanced back-order by splitting the transfer,
  the quantity now updates correctly to reflect the available quantity,
  and product availability is displayed as 'Available'.
- The 'Check Availability' button was still appearing because the condition
  for its visibility.
- This commit adds the necessary condition to the computation,
  ensuring the 'Check Availability' button is displayed correctly based on
  the product's availability status.

Task-id : 4070486
