### PR TITLE
[FIX] sale_timesheet: fixed tour step with blur event problem in runbot

### DIFF
--- a/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
+++ b/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
@@ -38,7 +38,7 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
 }, {
     trigger: 'div[name="product_uom_qty"] input',
     content: "Add 10 hours as ordered quantity for this product.",
-    run: "edit 10 && click body",
+    run: "edit 10 && press Tab",
 }, {
     trigger: '.o_field_widget[name=price_subtotal]:contains(2,500.00)',
 }, {


### PR DESCRIPTION
Current Behaviour:

- Currently tour is written as enter the quantity and click on body to actuate a change/blur event so the price changes.
- If we click on body we lose focus on the list item we created and it becomes a table.
- Also we there is no concrete trigger that can be written to select the price field from the table.

Fix:

- Instead of clicking on body to actuate blur event we can use ```press Tab``` to actuate the same event thus solving the problem and not needing to adding additional step. Also it seems that a new method ```edit_blur``` may be released to mitigate the problem without pressing Tab ```(source: FW JS Team)```.

task-4072468