### PR TITLE
[FIX] pos*: prevent error when creating a contact

### DIFF
--- a/addons/l10n_ar_pos/static/src/overrides/components/partner_list/partner_list.js
+++ b/addons/l10n_ar_pos/static/src/overrides/components/partner_list/partner_list.js
@@ -7,13 +7,17 @@ patch(PartnerList.prototype, {
     newPartnerDefaults() {
         const newPartner = super.newPartnerDefaults(...arguments);
         if (this.pos.isArgentineanCompany()) {
-            newPartner.l10n_latam_identification_type_id = this.pos.models[
-                "l10n_latam.identification.type"
-            ].get(this.pos["l10n_latam.identification.type"][0].id);
+            if (this.pos["l10n_latam.identification.type"].length > 0) {
+                newPartner.l10n_latam_identification_type_id = this.pos.models[
+                    "l10n_latam.identification.type"
+                ].get(this.pos["l10n_latam.identification.type"][0].id);
+            }
 
-            newPartner.l10n_ar_afip_responsibility_type_id = this.pos.models[
-                "l10n_ar.afip.responsibility.type"
-            ].get(this.pos["l10n_ar.afip.responsibility.type"][0].id);
+            if (this.pos["l10n_ar.afip.responsibility.type"].length > 0) {
+                newPartner.l10n_ar_afip_responsibility_type_id = this.pos.models[
+                    "l10n_ar.afip.responsibility.type"
+                ].get(this.pos["l10n_ar.afip.responsibility.type"][0].id);
+            }
         }
         return newPartner;
     },

--- a/addons/l10n_pe_pos/static/src/overrides/components/partner_list/partner_list.js
+++ b/addons/l10n_pe_pos/static/src/overrides/components/partner_list/partner_list.js
@@ -7,13 +7,19 @@ patch(PartnerList.prototype, {
     newPartnerDefaults() {
         const newPartner = super.newPartnerDefaults(...arguments);
         if (this.pos.isPeruvianCompany()) {
-            newPartner.city_id = this.pos.models["res.city"].get(this.pos["res.city"][0].id);
-            newPartner.l10n_latam_identification_type_id = this.pos.models[
-                "l10n_latam.identification.type"
-            ].get(this.pos["l10n_latam.identification.type"][0].id);
-            newPartner.l10n_pe_district = this.pos.models["l10n_pe.res.city.district"].get(
-                this.pos["l10n_pe.res.city.district"][0].id
-            );
+            if (this.pos["res.city"].length > 0) {
+                newPartner.city_id = this.pos.models["res.city"].get(this.pos["res.city"][0].id);
+            }
+            if (this.pos["l10n_latam.identification.type"].length > 0) {
+                newPartner.l10n_latam_identification_type_id = this.pos.models[
+                    "l10n_latam.identification.type"
+                ].get(this.pos["l10n_latam.identification.type"][0].id);
+            }
+            if (this.pos["l10n_pe.res.city.district"].length > 0) {
+                newPartner.l10n_pe_district = this.pos.models["l10n_pe.res.city.district"].get(
+                    this.pos["l10n_pe.res.city.district"][0].id
+                );
+            }
         }
         return newPartner;
     },


### PR DESCRIPTION
Before this commit, attempting to create a new contact without any identification type available in the database would result in an error. This commit ensures that a new contact can be created even when no identification types are present.

Enterprise PR: https://github.com/odoo/enterprise/pull/67328

opw-4068907

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
