### PR TITLE
[16.0][FIX] calendar: Avoid sending more emails than necessary at events

### DIFF
--- a/addons/calendar/models/calendar_attendee.py
+++ b/addons/calendar/models/calendar_attendee.py
@@ -140,7 +140,6 @@ class Attendee(models.Model):
                     email_layout_xmlid='mail.mail_notification_light',
                     attachment_ids=attachment_values,
                     force_send=force_send,
-                    message_type='auto_comment',
                 )
 
     def _should_notify_attendee(self):


### PR DESCRIPTION
Avoid sending more emails than necessary at events

We want to make sure that in all mails sent from the calendar event, the recipients are only the ones we want and avoid sending them to 'indirect' followers. 

Examples use case:
- Subtype Notes with Default checked.
- Several Attendees set (including several users).
- Each invitation email must be sent only to the corresponding attendee, no one else.
- Each event reminder email must reach only the corresponding attendee, no one else.

Example use case in runbot v16 **before** this change.
![ejemplo-antes](https://github.com/user-attachments/assets/f3987730-324f-4699-9e10-f8226cf92657)

Example use case **after** this change.
![ejemplo-despues](https://github.com/user-attachments/assets/f4eb797e-cd06-4fac-8561-479fd51406aa)

@Tecnativa TT50302

Ping @pedrobaeza and @carlosdauden 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr