### PR TITLE
[FIX] stock: lot quick create in stock move popup

### DIFF
--- a/addons/stock/static/src/widgets/stock_pick_from.js
+++ b/addons/stock/static/src/widgets/stock_pick_from.js
@@ -41,7 +41,6 @@ export const stockPickFrom = {
         // dependencies to build the quant display name
         { name: "location_id", type: "relation" },
         { name: "location_dest_id", type: "relation" },
-        { name: "lot_id", type: "relation" },
         { name: "package_id", type: "relation" },
         { name: "owner_id", type: "relation" },
     ],


### PR DESCRIPTION
Steps:
- enable lots & serials
- enable 'Use Existing ones' in operation type 'Receipts'
- create a product A tracked by lot
- create a receipt operation, add product A, add quantity, mark as todo
- open burger menu, add a new lot number, select 'Create' (not 'Create and edit...')

Issue:
`default_product_id` missing in the context because of `getFieldContext` in utils.js filtering it out.
Due to that, Odoo will open a new popup as if we selected 'Create and edit...'.

Fix:
Remove the lot line in pick_from.js, it is not needed and there's another lot_id in the xml to use.

opw-4064895

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
