### PR TITLE
[FIX] Add new group translate in redex_order

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -72,7 +72,7 @@ regex_alphanumeric = re.compile(r'^[a-z0-9_]+$')
 regex_order = re.compile(r'''
     ^
     (\s*
-        (?P<term>((?P<field>[a-z0-9_]+|"[a-z0-9_]+")(\.(?P<property>[a-z0-9_]+))?(:(?P<func>[a-z_]+))?))
+        (?P<term>((?P<field>[a-z0-9_]+|"[a-z0-9_]+")(\.(?P<property>[a-z0-9_]+))?(\->>'(?P<translate>[a-z0-9_]+)')?(:(?P<func>[a-z_]+))?))
         (\s+(?P<direction>desc|asc))?
         (\s+(?P<nulls>nulls\ first|nulls\ last))?
         \s*


### PR DESCRIPTION
[FIX] Added in redex_order new group translate to possible to order by language code in jsonb fields like SELECT name FROM res_partner ORDER BY name->>'bg_BG';

Description of the issue/feature this PR addresses: In tree and kamban views to be possible to sort with language orient order, for users will be move conformable if order be in native language

Current behavior before PR: When add in tree view option default_order="name->>'bg_BG'" return error """Invalid Operation

Invalid "order" specified (name-->>'bg_BG' ASC). A valid "order" specification is a comma-separated list of valid field names (optionally followed by asc/desc for the direction)"""

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
