### PR TITLE
[IMP] html_editor, project: add link preview new feature

### DIFF
--- a/addons/html_editor/controllers/main.py
+++ b/addons/html_editor/controllers/main.py
@@ -15,6 +15,7 @@ from odoo.http import request
 from odoo.tools.mimetypes import guess_mimetype
 from odoo.tools.misc import file_open
 from odoo.addons.iap.tools import iap_tools
+from odoo.addons.mail.tools import link_preview
 
 from ..models.ir_attachment import SUPPORTED_IMAGE_MIMETYPES
 
@@ -546,3 +547,42 @@ class HTML_Editor(http.Controller):
         bus_data.update({'model_name': model_name, 'field_name': field_name, 'res_id': res_id})
         request.env['bus.bus']._sendone(channel, 'editor_collaboration', bus_data)
 
+    @http.route('/html_editor/link_preview_external', type="json", auth="public", methods=['POST'])
+    def link_preview_metadata(self, preview_url):
+        return link_preview.get_link_preview_from_url(preview_url)
+
+    @http.route('/html_editor/link_preview_internal', type="json", auth="user", methods=['POST'])
+    def link_preview_metadata_internal(self, preview_url):
+        try:
+            Actions = request.env['ir.actions.actions']
+            context = dict(request.env.context)
+            words = preview_url.strip('/').split('/')
+
+            record_id = int(words.pop())
+            action_name = words.pop()
+            action = Actions.sudo().search([('path', '=', action_name)])
+            if not action:
+                return {'error_msg': _("Action %s not found, link preview is not available, please check your url is correct", action_name)}
+            action_type = action.type
+            if action_type != 'ir.actions.act_window':
+                return {'other_error_msg': _("Action %s is not a window action, link preview is not available", action_name)}
+            action = request.env[action_type].browse(action.id)
+
+            model = request.env[action.res_model].with_context(context)
+            record = model.browse(record_id)
+
+            result = {}
+            if 'description' in record:
+                result['description'] = record.description
+
+            if 'link_preview_name' in record:
+                result['link_preview_name'] = record.link_preview_name
+            elif 'display_name' in record:
+                result['display_name'] = record.display_name
+
+            return result
+        except (MissingError) as e:
+            return {'error_msg': _("Link preview is not available because %s, please check if your url is correct", str(e))}
+        # catch all other exceptions and return the error message to display in the console but not blocking the flow
+        except Exception as e:  # noqa: BLE001
+            return {'other_error_msg': str(e)}

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -2,14 +2,16 @@
 
     <t t-name="html_editor.linkPopover">
         <div class="o-we-linkpopover d-flex bg-white overflow-auto shadow">
-            <div t-if="state.editing" class="m-1 container-fluid d-flex vertical-center" t-ref="editing-wrapper">
-                <div class="col m-1" data-prevent-closing-overlay="true">
-                    <div class="input-group">
-                        <input class="o_we_label_link m-1" t-model="state.label" placeholder="Type your link label"/>
-                        <input class="o_we_href_input_link m-1" t-model="state.url" placeholder="Type your URL" t-on-keydown="onKeydownEnter"/>
+            <div t-if="state.editing" class="container-fluid d-flex vertical-center p-2" t-ref="editing-wrapper"  data-prevent-closing-overlay="true">
+                <div class="col p-2" style="max-width: 250px;">
+                    <div class="input-group mb-1">
+                        <input class="o_we_label_link form-control form-control-sm" t-model="state.label" title="Label" placeholder="Type your link label"/>
+                    </div>
+                    <div class="input-group mb-1">
+                        <input class="o_we_href_input_link form-control form-control-sm" t-model="state.url" title="URL" placeholder="Type your URL" t-on-keydown="onKeydownEnter"/>
                     </div>
                     <div class="input-group" t-on-change="onChangeClasses">
-                        <select name="link_type" class="form-select" t-on-change="(ev)=>this.state.type = ev.target.value">
+                        <select name="link_type" class="form-select form-select-sm" t-att-class="{'mb-1': state.type !==  ''}" t-on-change="(ev)=>this.state.type = ev.target.value">
                             <t t-foreach="this.colorsData" t-as="colorData" t-key="colorData.type">
                                 <t t-if="colorData.type !== 'custom'">
                                     <option t-att-value="colorData.type" t-att-selected="state.type === colorData.type" t-attf-class="o_btn_preview dropdown-item">
@@ -18,15 +20,15 @@
                                 </t>
                             </t>
                         </select>
-                        <div t-if="state.type !== 'custom' and state.type !==  ''" class="input-group md-3">
-                                <select name="link_style_size" class="form-select link-style" t-on-change="(ev)=>this.state.buttonSize = ev.target.value">
+                        <div t-if="state.type !== 'custom' and state.type !==  ''" class="input-group mb-1">
+                                <select name="link_style_size" class="form-select form-select-sm link-style" t-on-change="(ev)=>this.state.buttonSize = ev.target.value">
                                     <t t-foreach="this.buttonSizesData" t-as="buttonSizesData" t-key="buttonSizesData.size">
                                         <option t-att-value="buttonSizesData.size" t-att-selected="state.buttonSize === buttonSizesData.size">
                                             <span t-esc="buttonSizesData.label"/>
                                         </option>
                                     </t>
                                 </select>
-                                <select name="link_style_shape" class="form-select link-style" t-on-change="(ev)=>this.state.buttonStyle = ev.target.value">
+                                <select name="link_style_shape" class="form-select form-select-sm link-style ms-1" t-on-change="(ev)=>this.state.buttonStyle = ev.target.value">
                                     <t t-foreach="this.buttonStylesData" t-as="buttonStylesData" t-key="buttonStylesData.style">
                                         <option t-att-value="buttonStylesData.style" t-att-selected="state.buttonStyle === buttonStylesData.style">
                                             <span t-esc="buttonStylesData.label"/>
@@ -34,46 +36,66 @@
                                     </t>
                                 </select>
                         </div>
-                        <div>
-                            <button class="o_we_apply_link btn btn-primary m-1" t-on-click="onClickApply">Apply</button>
-                        </div>
+                        <button class="o_we_apply_link btn btn-sm btn-primary" t-att-class="{'mx-1': state.type ===  ''}" t-on-click="onClickApply">Apply</button>
                     </div>
                 </div>
 
-                <div class="col o_link_dialog_preview">
-                    <div class="text-center">
+                <div class="col o_link_dialog_preview" style="max-width: 125px;border-left: 1px solid #DEE2E6;">
+                    <div class="text-center p-2">
                         <label>Preview</label>
-                        <div style="overflow-x: auto; max-width: 100%; max-height: 200px;">
-                            <a href="#" t-if="state.url" id="link-preview" aria-label="Preview" title="Preview" t-attf-class="{{state.classes}}">
+                        <div style="max-width: 100px; max-height: 200px;" class="text-truncate">
+                            <a href="#" t-if="state.url" id="link-preview" aria-label="Preview" title="Preview" t-attf-class="{{state.classes}} text-truncate" style="max-width: 90px;">
                                 <t t-esc="state.label or state.url"/>
                             </a>
                         </div>
                     </div>
                 </div>
             </div>
-            <div t-else="" class="d-flex">
-                <span class="me-2 o_we_preview_favicon">
-                    <i t-if="!state.previewImg" t-attf-class="fa {{state.faIcon}}"></i>
-                    <img t-if="state.previewImg" t-attf-src="{{state.imgSrc}}" class="align-baseline"></img>
-                </span>
-                <div class="w-100">
+            <div t-else="" style="max-width: 260px; min-width: 200px;" data-prevent-closing-overlay="true">
+                <div class="d-flex flex-column p-2">
                     <div class="d-flex">
-                        <a href="#" target="_blank" t-attf-href="{{state.url}}" class="o_we_url_link fw-bold flex-grow-1 text-truncate" title="Open in a new tab">
-                            <t t-esc="state.urlTitle"/>
-                        </a>
-                        <a href="#" class="mx-1 o_we_copy_link text-dark" t-on-click="onClickCopy" title="Copy Link">
-                            <i class="fa fa-clone"></i>
-                        </a>
-                        <a href="#" class="mx-1 o_we_edit_link text-dark" t-on-click="onClickEdit" title="Edit Link">
-                            <i class="fa fa-edit"></i>
-                        </a>
-                        <a href="#" class="ms-1 o_we_remove_link text-dark" t-on-click="onClickRemove" title="Remove Link">
-                            <i class="fa fa-chain-broken"></i>
-                        </a>
+                        <span class="o_we_preview_favicon" style="width: 16px;">
+                            <i t-if="!state.previewIcon" t-attf-class="fa fa-fw {{state.faIcon}}"></i>
+                            <img t-else="" t-attf-src="{{state.iconSrc}}" class="align-content-center"></img>
+                        </span>
+                        <div class="ms-1 w-100">
+                            <div class="d-flex">
+                                <a href="#" target="_blank" t-attf-href="{{state.url}}" class="o_we_url_link fw-bold flex-grow-1 text-truncate" style="max-width: 160px;" t-attf-title="{{state.urlTitle}}">
+                                    <t t-esc="state.urlTitle"/>
+                                </a>
+                                <a href="#" class="mx-1 o_we_copy_link text-dark" t-on-click="onClickCopy" title="Copy Link">
+                                    <i class="fa fa-clone"></i>
+                                </a>
+                                <a href="#" class="mx-1 o_we_edit_link text-dark" t-on-click="onClickEdit" title="Edit Link">
+                                    <i class="fa fa-edit"></i>
+                                </a>
+                                <a href="#" class="ms-1 o_we_remove_link text-dark" t-on-click="onClickRemove" title="Remove Link">
+                                    <i class="fa fa-chain-broken"></i>
+                                </a>
+                            </div>
+                            <div t-if="state.urlTitle and state.url and state.urlTitle !== state.url" class="text-truncate" style="max-width: 200px; font-size: 12px;">
+                                <span t-attf-class="o_we_full_url text-muted o_we_webkit_box" t-attf-title="{{state.url}}">
+                                    <t t-esc="state.url || 'No URL specified'"/>
+                                </span>
+                            </div>
+                        </div>
                     </div>
-                    <a t-if="state.showFullUrl" href="#" target="_blank" t-attf-href="{{state.url}}" t-attf-class="o_we_full_url mt-1 text-muted o_we_webkit_box" title="Open in a new tab">
-                        <t t-esc="state.url || 'No URL specified'"/>
-                    </a>
+                    <div t-if="state.imgSrc" class="o_extra_info_card" style="align-self: center; max-width: 235px">
+                            <a href="#" target="_blank" t-attf-href="{{state.url}}" title="Open in a new tab">
+                                <img t-att-src="state.imgSrc" class="img-fluid mb-1" style="max-width: 230; max-height: 100%;"/>
+                            </a>
+                    </div>
+                    <div t-if="state.urlDescription" class="d-flex">
+                        <i class="fa fa-align-right align-content-center"></i>
+                        <span class="ms-1 o_we_description_link_preview" style="display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 2; font-size: 12px;color: gray; overflow: hidden;" t-attf-title="{{state.urlDescription}}">
+                            <t t-esc="state.urlDescription"/>
+                        </span>
+                    </div>
+                </div>
+                <div t-if="state.urlTitle and ((state.url === state.label and state.urlTitle !== state.label ) || (state.url === state.label+'/' and state.urlTitle !== state.label+'/'))" class="d-flex align-items-baseline" style="background-color: var(--primary);">
+                    <i class="fa fa-magic fa-fw m-1" style="color: var(--o-cc1-btn-primary-text);"></i>
+                    <span class="me-2 flex-grow-1" style="color: var(--o-cc1-btn-primary-text);font-size: smaller;">Replace URL with its title?</span>
+                    <button class=" btn btn-sm btn-primary o_we_replace_title_btn" style="margin: 1px;font-size: smaller;" t-on-click="onClickReplaceTitle">Yes</button>
                 </div>
             </div>
         </div>

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -299,6 +299,7 @@ class Task(models.Model):
             ! Set the task a high priority\n
             Make sure to use the right format and order e.g. Improve the configuration screen #feature #v16 @Mitchell !""",
     )
+    link_preview_name = fields.Char(compute='_compute_link_preview_name', export_string_translation=False)
 
     _sql_constraints = [
         ('recurring_task_has_no_parent', 'CHECK (NOT (recurring_task IS TRUE AND parent_id IS NOT NULL))', "A subtask cannot be recurrent."),
@@ -778,6 +779,13 @@ class Task(models.Model):
                     if match.group(group):
                         extract_data(task)
                 task.name = task.display_name.strip()
+
+    def _compute_link_preview_name(self):
+        for task in self:
+            link_preview_name = task.display_name
+            if task.project_id:
+                link_preview_name += f' | {task.project_id.sudo().name}'
+            task.link_preview_name = link_preview_name
 
     def copy_data(self, default=None):
         default = dict(default or {})


### PR DESCRIPTION
Description
-----------------
This commit introduces the new feature to preview link elements upon
clicking and assigns customized link titles for project.task.

Implementation
-----------------
External Links: The preview metadata for external links is retrieved
using an existing method from the mail module. If the external link is
pointing to an image, we display it in the preview popover and title it
with the link label.

Internal Links: To display customized titles for internal links, a
computed field named link_preview_name is introduced. This allows
displaying titles in a format specific to the model, such as
"TaskName | ProjectName" for tasks within projects. The
link_preview_name field is model-specific and is determined by the
preferred data representation for the preview. In cases where
link_preview_name is not defined, the system falls back to display_name,
and subsequently to name, or ultimately uses the webpage's title if none
of these fields are available.

When the displayed link label differs from the preview title, a banner
is displayed at the bottom of the preview indicating the change to the
preview title.

Error Handling
-----------------
The approach to error handling is designed to ensure that the preview
functionality does not interrupt the user flow.

External Links: If metadata retrieval fails for an external link, the
preview is removed, and only the favicon along with the URL is displayed

Internal Links: For internal links, specific errors such as value or
index errors indicate incorrect record links, triggering a warning
notification. Other types of errors are logged to the front-end console
without raising an exception in the controller, to prevent any
disruption to the user interface.


task-3678777

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
