### PR TITLE
[WIP][IMP] *: Allow three way fiscal positions

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2049,7 +2049,7 @@ class AccountMove(models.Model):
     def _compute_tax_country_id(self):
         foreign_vat_records = self.filtered(lambda r: r.fiscal_position_id.foreign_vat)
         for fiscal_position_id, record_group in groupby(foreign_vat_records, key=lambda r: r.fiscal_position_id):
-            self.env['account.move'].concat(*record_group).tax_country_id = fiscal_position_id.country_id
+            self.env['account.move'].concat(*record_group).tax_country_id = fiscal_position_id.delivery_country_id
         for company_id, record_group in groupby((self-foreign_vat_records), key=lambda r: r.company_id):
             self.env['account.move'].concat(*record_group).tax_country_id = company_id.account_fiscal_country_id
 

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -32,8 +32,8 @@ class AccountFiscalPosition(models.Model):
     auto_apply = fields.Boolean(string='Detect Automatically', help="Apply automatically this fiscal position.")
     vat_required = fields.Boolean(string='VAT required', help="Apply only if partner has a VAT number.")
     company_country_id = fields.Many2one(string="Company Country", related='company_id.account_fiscal_country_id')
-    country_id = fields.Many2one('res.country', string='Country',
-        help="Apply only if delivery country matches.")
+    country_id = fields.Many2one('res.country', string='Fiscal Country',
+        help="Country from which's taxes are available for the fiscal position mapping.")
     country_group_id = fields.Many2one('res.country.group', string='Country Group',
         help="Apply only if delivery country matches the group.")
     state_ids = fields.Many2many('res.country.state', string='Federal States')

--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -116,7 +116,7 @@ class ResConfigSettings(models.TransientModel):
     module_currency_rate_live = fields.Boolean(string="Automatic Currency Rates")
     module_account_intrastat = fields.Boolean(string='Intrastat')
     module_product_margin = fields.Boolean(string="Allow Product Margin")
-    module_l10n_eu_oss = fields.Boolean(string="EU Intra-community Distance Selling")
+    module_l10n_eu_oss = fields.Boolean(string="EU Intra-community Distance Selling (OSS)")
     module_account_taxcloud = fields.Boolean(string="Account TaxCloud")
     module_account_invoice_extract = fields.Boolean(string="Bill Digitalization")
     module_snailmail_account = fields.Boolean(string="Snailmail")

--- a/addons/fiscal_position_three_way/__init__.py
+++ b/addons/fiscal_position_three_way/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/fiscal_position_three_way/__manifest__.py
+++ b/addons/fiscal_position_three_way/__manifest__.py
@@ -1,0 +1,29 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'Three way fiscal positions',
+    'version': '1.0',
+    'category': 'Accounting',
+    'summary': 'Three way fiscal positions',
+    'description': """
+        Fiscal positions enhancement module which allows the user to configure three way fiscal positions
+        This can be useful for companies having warehouse out of their fiscal country which export goods.
+
+        Example:
+            - Company is in Belgium - company_id.country_id
+            - Warehouse is in France - country_id
+            - Customer is in Germany - delivery_country_id
+
+        In this case, the company will have to pay the VAT in France and the customer will have to pay the VAT in Germany.
+        All this while allowing the product's taxes to remain Belgian taxes.
+""",
+    'depends': [
+        'account',
+        'base_vat',
+    ],
+    'data': [
+        'views/fiscal_position.xml',
+    ],
+    'installable': True,
+    'application': False,
+    'license': 'LGPL-3',
+}

--- a/addons/fiscal_position_three_way/models/__init__.py
+++ b/addons/fiscal_position_three_way/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_fiscal_position
+from . import account_move

--- a/addons/fiscal_position_three_way/models/account_fiscal_position.py
+++ b/addons/fiscal_position_three_way/models/account_fiscal_position.py
@@ -1,0 +1,158 @@
+from odoo import api, models, fields, _
+from odoo.exceptions import ValidationError
+
+
+class AccountFiscalPosition(models.Model):
+    _inherit = "account.fiscal.position"
+
+    delivery_country_id = fields.Many2one("res.country", string="Delivery Country", help="Apply only if delivery country matches.")
+
+    @api.model
+    def create(self, vals):
+        vals = self.adjust_vals_delivery_country_id(vals)
+        vals = self.adjust_vals_country_id(vals)
+        return super().create(vals)
+
+    def write(self, vals):
+        vals = self.adjust_vals_delivery_country_id(vals)
+        vals = self.adjust_vals_country_id(vals)
+        return super().write(vals)
+
+    def adjust_vals_delivery_country_id(self, vals):
+        country_id = self.country_id or vals.get('country_id')
+        delivery_country_id = self.delivery_country_id or vals.get('delivery_country_id')
+        if not delivery_country_id and country_id:
+            vals['delivery_country_id'] = country_id
+        return vals
+
+    def adjust_vals_country_id(self, vals):
+        foreign_vat = vals.get('foreign_vat')
+        country_group_id = vals.get('country_group_id')
+        if foreign_vat and country_group_id and not (self.delivery_country_id or vals.get('delivery_country_id')):
+            vals['delivery_country_id'] = self.env['res.country.group'].browse(country_group_id).country_ids.filtered(lambda c: c.code == foreign_vat[:2].upper()).id or False
+        if not (self.country_id or vals.get('country_id')) and vals.get('delivery_country_id'):
+            vals['country_id'] = vals['delivery_country_id']
+        return vals
+
+    @api.depends('foreign_vat', 'country_id')
+    def _compute_foreign_vat_header_mode(self):
+        for record in self:
+            if not record.foreign_vat or not (record.country_id or record.delivery_country_id):
+                record.foreign_vat_header_mode = None
+                continue
+
+            if self.env['account.tax'].search([('country_id', '=', record.country_id.id)], limit=1) and self.env['account.tax'].search([('country_id', '=', record.delivery_country_id.id)], limit=1):
+                record.foreign_vat_header_mode = None
+            elif self.env['account.tax.template'].search([('chart_template_id.country_id', '=', record.country_id.id)], limit=1) and self.env['account.tax.template'].search([('chart_template_id.country_id', '=', record.delivery_country_id.id)], limit=1):
+                record.foreign_vat_header_mode = 'templates_found'
+            else:
+                record.foreign_vat_header_mode = 'no_template'
+
+    def action_create_foreign_taxes(self):
+        self.ensure_one()
+        self.env['account.tax.template']._try_instantiating_foreign_taxes(self.country_id, self.company_id)
+        self.env['account.tax.template']._try_instantiating_foreign_taxes(self.delivery_country_id, self.company_id)
+
+    @api.constrains('country_id', 'country_group_id', 'delivery_country_id', 'state_ids', 'foreign_vat')
+    def _validate_foreign_vat_country(self):
+        for record in self:
+            if record.foreign_vat:
+                if record.country_id == record.company_id.account_fiscal_country_id:
+                    if record.foreign_vat == record.company_id.vat:
+                        raise ValidationError(_("You cannot create a fiscal position within your fiscal country with the same VAT number as the main one set on your company."))
+
+                    if not record.state_ids:
+                        if record.company_id.account_fiscal_country_id.state_ids:
+                            raise ValidationError(_("You cannot create a fiscal position with a foreign VAT within your fiscal country without assigning it a state."))
+                        else:
+                            raise ValidationError(_("You cannot create a fiscal position with a foreign VAT within your fiscal country."))
+                if record.country_group_id and record.delivery_country_id:
+                    if record.delivery_country_id not in record.country_group_id.country_ids:
+                        raise ValidationError(_("You cannot create a fiscal position with a country outside of the selected country group."))
+
+                similar_fpos_domain = [
+                    ('foreign_vat', '!=', False),
+                    ('company_id', '=', record.company_id.id),
+                    ('id', '!=', record.id),
+                ]
+
+                if record.country_group_id:
+                    foreign_vat_country = self.country_group_id.country_ids.filtered(lambda c: c.code == record.foreign_vat[:2].upper())
+                    if not foreign_vat_country:
+                        raise ValidationError(_("The country code of the foreign VAT number does not match any country in the group."))
+                    similar_fpos_domain += [('country_group_id', '=', record.country_group_id.id), ('country_id', '=', foreign_vat_country.id)]
+                elif record.delivery_country_id:
+                    similar_fpos_domain += [('delivery_country_id', '=', record.delivery_country_id.id), ('country_group_id', '=', False), ('country_id', '=', record.country_id.id)]
+
+                if record.state_ids:
+                    similar_fpos_domain.append(('state_ids', 'in', record.state_ids.ids))
+                else:
+                    similar_fpos_domain.append(('state_ids', '=', False))
+
+                similar_fpos_count = self.env['account.fiscal.position'].search_count(similar_fpos_domain)
+                if similar_fpos_count:
+                    raise ValidationError(_("A fiscal position with a foreign VAT already exists in this region."))
+
+    @api.onchange('country_id')
+    def _onchange_country_id(self):
+        return
+
+    @api.onchange('delivery_country_id')
+    def _onchange_delivery_country_id(self):
+        if self.delivery_country_id:
+            self.zip_from = self.zip_to = False
+            self.state_ids = [(5,)]
+            self.states_count = len(self.delivery_country_id.state_ids)
+
+    @api.model
+    def _get_fpos_by_region(self, country_id=False, state_id=False, zipcode=False, vat_required=False):
+        if not country_id:
+            return False
+        base_domain = [
+            ('auto_apply', '=', True),
+            ('vat_required', '=', vat_required),
+            ('company_id', 'in', [self.env.company.id, False]),
+        ]
+        null_state_dom = state_domain = [('state_ids', '=', False)]
+        null_zip_dom = zip_domain = [('zip_from', '=', False), ('zip_to', '=', False)]
+        null_country_dom = [('delivery_country_id', '=', False), ('country_group_id', '=', False)]
+
+        if zipcode:
+            zip_domain = [('zip_from', '<=', zipcode), ('zip_to', '>=', zipcode)]
+
+        if state_id:
+            state_domain = [('state_ids', '=', state_id)]
+
+        domain_country = base_domain + [('delivery_country_id', '=', country_id)]
+        domain_group = base_domain + [('country_group_id.country_ids', '=', country_id)]
+
+        # Build domain to search records with exact matching criteria
+        fpos = self.search(domain_country + state_domain + zip_domain, limit=1)
+        # return records that fit the most the criteria, and fallback on less specific fiscal positions if any can be found
+        if not fpos and state_id:
+            fpos = self.search(domain_country + null_state_dom + zip_domain, limit=1)
+        if not fpos and zipcode:
+            fpos = self.search(domain_country + state_domain + null_zip_dom, limit=1)
+        if not fpos and state_id and zipcode:
+            fpos = self.search(domain_country + null_state_dom + null_zip_dom, limit=1)
+
+        # fallback: country group with no state/zip range
+        if not fpos:
+            fpos = self.search(domain_group + null_state_dom + null_zip_dom, limit=1)
+
+        if not fpos:
+            # Fallback on catchall (no country, no group)
+            fpos = self.search(base_domain + null_country_dom, limit=1)
+        return fpos
+
+
+class AccountFiscalPositionTax(models.Model):
+    _inherit = 'account.fiscal.position.tax'
+
+    tax_report_id = fields.Many2one('account.tax', string='Tax to Report')
+
+    @api.onchange('tax_dest_id')
+    def _onchange_tax_report_id(self):
+        for record in self:
+            if not record.tax_report_id and record.tax_dest_id and record.position_id.country_id == record.position_id.delivery_country_id:
+                record.tax_report_id = record.tax_dest_id

--- a/addons/fiscal_position_three_way/models/account_move.py
+++ b/addons/fiscal_position_three_way/models/account_move.py
@@ -1,0 +1,21 @@
+from odoo import api, models, _
+from odoo.exceptions import ValidationError
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    @api.constrains('line_ids', 'fiscal_position_id', 'company_id')
+    def _validate_taxes_country(self):
+        """ By playing with the fiscal position in the form view, it is possible to keep taxes on the invoices from
+        a different country than the one allowed by the fiscal country or the fiscal position.
+        This contrains ensure such account.move cannot be kept, as they could generate inconsistencies in the reports.
+        """
+        self._compute_tax_country_id()  # We need to ensure this field has been computed, as we use it in our check
+        for record in self:
+            amls = record.line_ids
+            impacted_countries = amls.tax_ids.country_id | amls.tax_line_id.country_id
+            if impacted_countries and impacted_countries != record.tax_country_id:
+                if record.fiscal_position_id and impacted_countries != record.fiscal_position_id.delivery_country_id:
+                    raise ValidationError(_("This entry contains taxes that are not compatible with your fiscal position. Check the country set in fiscal position and in your tax configuration."))
+                raise ValidationError(_("This entry contains one or more taxes that are incompatible with your fiscal country. Check company fiscal country in the settings and tax country in taxes configuration."))

--- a/addons/fiscal_position_three_way/views/fiscal_position.xml
+++ b/addons/fiscal_position_three_way/views/fiscal_position.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_account_position_form" model="ir.ui.view">
+        <field name="name">account.fiscal.position.form.inherit</field>
+        <field name="model">account.fiscal.position</field>
+        <field name="inherit_id" ref="account.view_account_position_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='country_group_id']" position="attributes">
+                <attribute name="string">Delivery Country Group</attribute>
+                <attribute name="attrs">{'invisible': [('auto_apply', '=', False)]}</attribute>
+                <attribute name="options">{'no_open': True, 'no_create': True}</attribute>
+            </xpath>
+            <xpath expr="//field[@name='country_id']" position="replace">
+                <field name="delivery_country_id"
+                    attrs="{'invisible': [('auto_apply', '=', False)]}"
+                    options="{'no_open': True, 'no_create': True}"/>
+            </xpath>
+            <xpath expr="//field[@name='foreign_vat']" position="after">
+                <field name="country_id" string="Fiscal Country" attrs="{'required': [('foreign_vat', '!=', False)]}"/>
+            </xpath>
+
+            <xpath expr="//field[@name='tax_dest_id']" position="before">
+                <field name="tax_report_id"
+                    domain="[
+                        ('type_tax_use', '!=', 'none'),
+                        ('country_id', '=', parent.country_id if parent.foreign_vat else parent.company_country_id),
+                        '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)
+                    ]"
+                    context="{'append_type_to_tax_name': True}"
+                    attrs="{'required': [('tax_dest_id', '!=', False)]}"
+                />
+            </xpath>
+            <xpath expr="//field[@name='tax_dest_id']" position="attributes">
+                <attribute name="attrs">{'required': [('tax_report_id', '!=', False)]}</attribute>
+                <attribute name="domain">
+                    [
+                        ('type_tax_use', '!=', 'none'),
+                        ('country_id', '=', parent.delivery_country_id if parent.foreign_vat else parent.company_country_id),
+                        '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)
+                    ]
+                </attribute>
+                <attribute name="context">{'append_type_to_tax_name': True}</attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
*: account, fiscal_position_three_way

----

Description of the issue this commit addresses:

Some companies export goods from warehouses outside of their fiscal country. It is currently not possible to use the "Detect Automatically" feature of the fiscal positions for them as the country they need to set to get the right tax mapping is not the country that needs to be detected for the auto apply.

---

Desired behavior after this commit is merged:

This commit allows users upon the installation of the new module to split the country of the tax mapping and the country of the auto apply. They are named "Fiscal Country" and "Delivery Country" and it grants companies the ability to have a working flow without starting from scratch if they need such a behavior.

---

task-4066525

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
