### PR TITLE
[IMP] mail: move member list code to discuss

### DIFF
--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -357,10 +357,6 @@ export class Thread extends Record {
         );
     }
 
-    get hasMemberList() {
-        return ["channel", "group"].includes(this.channel_type);
-    }
-
     get hasAttachmentPanel() {
         return this.model === "discuss.channel";
     }
@@ -521,14 +517,6 @@ export class Thread extends Record {
         return !this.messages.some((message) => !message.isEmpty);
     }
 
-    offlineMembers = Record.many("ChannelMember", {
-        /** @this {import("models").Thread} */
-        compute() {
-            return this.channelMembers.filter((member) => member.persona?.im_status !== "online");
-        },
-        sort: (m1, m2) => (m1.persona?.name < m2.persona?.name ? -1 : 1),
-    });
-
     get nonEmptyMessages() {
         return this.messages.filter((message) => !message.isEmpty);
     }
@@ -588,20 +576,6 @@ export class Thread extends Record {
             return res;
         },
     });
-
-    onlineMembers = Record.many("ChannelMember", {
-        /** @this {import("models").Thread} */
-        compute() {
-            return this.channelMembers.filter((member) => member.persona.im_status === "online");
-        },
-        sort(m1, m2) {
-            return this.store.Thread.sortOnlineMembers(m1, m2);
-        },
-    });
-
-    static sortOnlineMembers(m1, m2) {
-        return m1.persona.name?.localeCompare(m2.persona.name) || m1.id - m2.id;
-    }
 
     get unknownMembersCount() {
         return this.memberCount - this.channelMembers.length;

--- a/addons/mail/static/src/discuss/call/common/store_service_patch.js
+++ b/addons/mail/static/src/discuss/call/common/store_service_patch.js
@@ -33,5 +33,24 @@ const StorePatch = {
         super.onStarted(...arguments);
         this.rtc.start();
     },
+    sortOnlineMembers(m1, m2) {
+        const m1HasRtc = Boolean(m1.rtcSession);
+        const m2HasRtc = Boolean(m2.rtcSession);
+        if (m1HasRtc === m2HasRtc) {
+            /**
+             * If raisingHand is falsy, it gets an Infinity value so that when
+             * we sort by [oldest/lowest-value]-first, falsy values end up last.
+             */
+            const m1RaisingValue = m1.rtcSession?.raisingHand || Infinity;
+            const m2RaisingValue = m2.rtcSession?.raisingHand || Infinity;
+            if (m1HasRtc && m1RaisingValue !== m2RaisingValue) {
+                return m1RaisingValue - m2RaisingValue;
+            } else {
+                return super.sortOnlineMembers(m1, m2);
+            }
+        } else {
+            return m2HasRtc - m1HasRtc;
+        }
+    },
 };
 patch(Store.prototype, StorePatch);

--- a/addons/mail/static/src/discuss/call/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/call/common/thread_model_patch.js
@@ -3,28 +3,6 @@ import { Thread } from "@mail/core/common/thread_model";
 
 import { patch } from "@web/core/utils/patch";
 
-patch(Thread, {
-    sortOnlineMembers(m1, m2) {
-        const m1HasRtc = Boolean(m1.rtcSession);
-        const m2HasRtc = Boolean(m2.rtcSession);
-        if (m1HasRtc === m2HasRtc) {
-            /**
-             * If raisingHand is falsy, it gets an Infinity value so that when
-             * we sort by [oldest/lowest-value]-first, falsy values end up last.
-             */
-            const m1RaisingValue = m1.rtcSession?.raisingHand || Infinity;
-            const m2RaisingValue = m2.rtcSession?.raisingHand || Infinity;
-            if (m1HasRtc && m1RaisingValue !== m2RaisingValue) {
-                return m1RaisingValue - m2RaisingValue;
-            } else {
-                return super.sortOnlineMembers(m1, m2);
-            }
-        } else {
-            return m2HasRtc - m1HasRtc;
-        }
-    },
-});
-
 /** @type {import("models").Thread} */
 const ThreadPatch = {
     setup() {

--- a/addons/mail/static/src/discuss/core/common/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/common/@types/models.d.ts
@@ -1,0 +1,11 @@
+declare module "models" {
+    export interface Store {
+        sortOnlineMembers(m1: ChannelMember, m2: ChannelMember)
+    }
+
+    export interface Thread {
+        onlineMembers: ChannelMember[],
+        offlineMembers: ChannelMember[],
+        readonly hasMemberList: boolean,
+    }
+}

--- a/addons/mail/static/src/discuss/core/common/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/common/store_service_patch.js
@@ -1,0 +1,11 @@
+import { Store } from "@mail/model/store";
+import { patch } from "@web/core/utils/patch";
+
+/** @type {import("models").Store} */
+const storeServicePatch = {
+    sortOnlineMembers(m1, m2) {
+        return m1.persona.name?.localeCompare(m2.persona.name) || m1.id - m2.id;
+    },
+};
+
+patch(Store.prototype, storeServicePatch);


### PR DESCRIPTION
Some getters and fields related to `Member List` are defined in `core/common` while they are used in discuss only. So keeping them in `core` is useless.

This commit moves this code to `discuss` folder.

Also `sortOnlineMembers` has been moved to `Store`, so that this method is no longer static. New static methods cannot be augmented in models interface, so by it being initially defined in a patch would lead to lack of typing. This is undesirable for reducing programming errors.
Since the context of this method is not coupled to an instance of Thread, this has been moved to Store which is readily available for general-purpose methods that could be overridden.