### PR TITLE
[IMP] web_tour: log ignored step in onboarding

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_interactive.js
+++ b/addons/web_tour/static/src/tour_service/tour_interactive.js
@@ -71,6 +71,13 @@ export class TourInteractive {
         }
 
         this.currentAction = this.actions.at(this.currentActionIndex);
+
+        if (this.currentAction.event === "warn") {
+            console.warn(`Step '${this.currentAction.anchor}' ignored because no 'run'`);
+            this.currentActionIndex++;
+            this.play();
+        }
+
         if (!isActive({ isActive: this.currentAction.isActive }, "manual")) {
             this.currentActionIndex++;
             this.play();
@@ -198,7 +205,11 @@ export class TourInteractive {
     getSubActions(step) {
         const actions = [];
         if (!step.run || typeof step.run === "function") {
-            return [];
+            actions.push({
+                event: "warn",
+                anchor: step.trigger,
+            });
+            return actions;
         }
 
         for (const todo of step.run.split("&&")) {

--- a/addons/web_tour/static/tests/tour_service.test.js
+++ b/addons/web_tour/static/tests/tour_service.test.js
@@ -1157,7 +1157,6 @@ test("Tour started by the URL", async () => {
         state = useState({ bool: true });
         static components = {};
         static template = xml`
-            <button class="fool w-100" t-on-click="() => { state.bool = true; }">You fool</button>
             <button class="foo w-100" t-if="state.bool" t-on-click="() => { state.bool = false; }">Foo</button>
             <button class="bar w-100" t-if="!state.bool">Bar</button>
         `;
@@ -1172,7 +1171,39 @@ test("Tour started by the URL", async () => {
     await animationFrame();
     expect(".o_tour_pointer").toHaveCount(1);
 
-    await contains("button.fool").click();
+    await contains("button.bar").click();
+    await animationFrame();
+    expect(".o_tour_pointer").toHaveCount(0);
+
+});
+
+test("Log a warning if step ignored", async () => {
+    patchWithCleanup(console, {
+        warn: (msg) => expect.step(msg),
+    });
+
+    registry.category("web_tour.tours").add("tour1", {
+        sequence: 10,
+        steps: () => [
+            { trigger: "button.foo", run: "click" },
+            { trigger: "button.bar" },
+            { trigger: "button.bar", run: "click" },
+        ],
+    });
+
+    class Dummy extends Component {
+        static props = ["*"];
+        state = useState({ bool: true });
+        static components = {};
+        static template = xml`
+            <button class="foo w-100" t-if="state.bool" t-on-click="() => { state.bool = false; }">Foo</button>
+            <button class="bar w-100" t-if="!state.bool">Bar</button>
+        `;
+    }
+
+    await mountWithCleanup(Dummy);
+
+    getService("tour_service").startTour("tour1", { mode: "manual" });
     await animationFrame();
     expect(".o_tour_pointer").toHaveCount(1);
 
@@ -1183,4 +1214,6 @@ test("Tour started by the URL", async () => {
     await contains("button.bar").click();
     await animationFrame();
     expect(".o_tour_pointer").toHaveCount(0);
+
+    expect.verifySteps(["Step 'button.bar' ignored because no 'run'"]);
 });


### PR DESCRIPTION
Now, when a step has no run or a function in the run, instead of of just ignoring the step in the tour_interactive, it will be log with a warn in the console. Like that we don't lose the information.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
