### PR TITLE
[FIX] base: allow const_eval to return const vals in python 3.12

### DIFF
--- a/odoo/addons/base/tests/test_base.py
+++ b/odoo/addons/base/tests/test_base.py
@@ -20,6 +20,8 @@ class TestSafeEval(BaseCase):
         expected = (1, {"a": {2.5}}, [None, u"foo"])
         actual = const_eval('(1, {"a": {2.5}}, [None, u"foo"])')
         self.assertEqual(actual, expected)
+        # Test RETURN_CONST
+        self.assertEqual(const_eval('10'), 10)
 
     def test_expr(self):
         # NB: True and False are names in Python 2 not consts

--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -100,6 +100,8 @@ _CONST_OPCODES = set(to_opcodes([
     'COPY', 'SWAP',
     # Added in 3.11 https://docs.python.org/3/whatsnew/3.11.html#new-opcodes
     'RESUME',
+    # 3.12 https://docs.python.org/3/whatsnew/3.12.html#cpython-bytecode-changes
+    'RETURN_CONST',
 ])) - _BLACKLIST
 
 # operations which are both binary and inplace, same order as in doc'
@@ -124,7 +126,6 @@ _EXPR_OPCODES = _CONST_OPCODES.union(to_opcodes([
     'GEN_START',  # added in 3.10 but already removed from 3.11.
     # Added in 3.11, replacing all BINARY_* and INPLACE_*
     'BINARY_OP',
-    'RETURN_CONST',
     'BINARY_SLICE',
 ])) - _BLACKLIST
 
@@ -171,7 +172,7 @@ _SAFE_OPCODES = _EXPR_OPCODES.union(to_opcodes([
     'PUSH_EXC_INFO',
     'NOP',
     'FORMAT_VALUE', 'BUILD_STRING',
-    # 3.12 https://docs.python.org/3/whatsnew/3.12.html#new-opcodes
+    # 3.12 https://docs.python.org/3/whatsnew/3.12.html#cpython-bytecode-changes
     'END_FOR',
     'LOAD_FAST_AND_CLEAR', 'LOAD_FAST_CHECK',
     'POP_JUMP_IF_NOT_NONE', 'POP_JUMP_IF_NONE',


### PR DESCRIPTION
63a80c14f62e2a96e0a5dc9b33d1cf8c9e7a4b9a added support for safe_eval in python 3.12. However this added RETURN_CONST in _SAFE_OPCODES instead of _CONST_OPCODES. This stopped const_eval from returning const values.

closes #174045

Task-4067772