### PR TITLE
[FIX] account_audit_trail: allow merging partners

### DIFF
--- a/addons/account_audit_trail/models/__init__.py
+++ b/addons/account_audit_trail/models/__init__.py
@@ -5,5 +5,6 @@ from . import account_bank_statement_line
 from . import account_move
 from . import mail_message
 from . import mail_tracking_value
+from . import merge_partner_automatic
 from . import res_company
 from . import res_config_settings

--- a/addons/account_audit_trail/models/mail_message.py
+++ b/addons/account_audit_trail/models/mail_message.py
@@ -7,6 +7,8 @@ from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.osv.expression import OR
 
+bypass_token = object()
+
 
 class Message(models.Model):
     _inherit = 'mail.message'
@@ -171,6 +173,8 @@ class Message(models.Model):
 
     @api.ondelete(at_uninstall=True)
     def _except_audit_log(self):
+        if self.env.context.get('bypass_audit') is bypass_token:
+            return
         for message in self:
             if message.show_audit_log and not (
                 message.account_audit_log_move_id

--- a/addons/account_audit_trail/models/merge_partner_automatic.py
+++ b/addons/account_audit_trail/models/merge_partner_automatic.py
@@ -1,0 +1,9 @@
+from odoo import models
+from .mail_message import bypass_token
+
+
+class MergePartnerAutomatic(models.TransientModel):
+    _inherit = 'base.partner.merge.automatic.wizard'
+
+    def _update_reference_fields(self, src_partners, dst_partner):
+        return super(MergePartnerAutomatic, self.with_context(bypass_audit=bypass_token))._update_reference_fields(src_partners, dst_partner)


### PR DESCRIPTION
When the audit trail feature was enabled, it was impossible to merge the partners.
Since we don't lose any information, we allow that action specifically.

Because it should never be allowed in non controlled settings, we use a python token so that the context key cannot be used with RPC calls.
