### PR TITLE
[FIX] l10n_fr_invoice_addr: fix legal invoice elements not appearing

### DIFF
--- a/addons/l10n_fr_invoice_addr/views/report_invoice.xml
+++ b/addons/l10n_fr_invoice_addr/views/report_invoice.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="report_invoice_document" inherit_id="sale.report_invoice_document_inherit_sale">
+        <xpath expr="//t[@t-set='information_block']/div[@name='shipping_address_block']" position="attributes">
+            <attribute name="groups"/>
+            <attribute name="t-if">(o.l10n_fr_is_company_french and o.move_type.startswith('out_')) or o.env.user.has_group('sale.group_delivery_invoice_address')</attribute>
+        </xpath>
+
         <xpath expr="//address" position="after">
             <div class="mb-3" t-if="o.l10n_fr_is_company_french and o.partner_id.commercial_partner_id.siret">
                 SIRET: <t t-esc="o.partner_id.commercial_partner_id.siret"/>


### PR DESCRIPTION
Steps to reproduce:
- Install `l10n_fr_invoice_addr`
- Switch to a french company
- In the "Settings" application, go to "Sales > Quotations & Orders"
- Check "Customer Addresses" off
- Go to an invoice with a shipping address distinct from the customer's
- Click "Preview", the shipping address won't be here

See: #172497

task-4066670