### PR TITLE
[FIX] web_tour: fix url from tour dialog

### DIFF
--- a/addons/web_tour/static/src/debug/tour_dialog_component.js
+++ b/addons/web_tour/static/src/debug/tour_dialog_component.js
@@ -56,7 +56,9 @@ export default class ToursDialog extends Component {
      * @param {MouseEvent} ev
      */
     _copyUrlTour(ev) {
-        navigator.clipboard.writeText(`${browser.location.origin}?tour=${ev.target.dataset.name}`);
+        navigator.clipboard.writeText(
+            `${browser.location.origin}/odoo?tour=${ev.target.dataset.name}`
+        );
         this.notification.add(_t("Url copied to clipboard"), { type: "info" });
     }
 }


### PR DESCRIPTION
The url given in the tour dialog was giving an url to the frontend and the tour was not executed.
Now, the url is the one to the backend.

Task-ID: 4072309

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
