### PR TITLE
[FIX] html_editor: shape rounded and circle are exclusive

### DIFF
--- a/addons/html_editor/static/src/main/media/image_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_plugin.js
@@ -202,8 +202,21 @@ export class ImagePlugin extends Plugin {
 
         switch (command) {
             case "SHAPE_ROUNDED":
+            case "SHAPE_CIRCLE": {
+                const selectedImg = this.getSelectedImage();
+                if (!selectedImg) {
+                    return;
+                }
+                const mutuallyExclusiveShapes = {
+                    SHAPE_ROUNDED: "rounded-circle",
+                    SHAPE_CIRCLE: "rounded",
+                };
+                selectedImg.classList.remove(mutuallyExclusiveShapes[command]);
+                selectedImg.classList.toggle(commandToClassNameDict[command]);
+                this.dispatch("ADD_STEP");
+                break;
+            }
             case "SHAPE_SHADOW":
-            case "SHAPE_CIRCLE":
             case "SHAPE_THUMBNAIL": {
                 const selectedImg = this.getSelectedImage();
                 if (!selectedImg) {

--- a/addons/html_editor/static/tests/image.test.js
+++ b/addons/html_editor/static/tests/image.test.js
@@ -59,6 +59,39 @@ test("can shape an image", async () => {
     expect(img).toHaveClass("img-thumbnail");
 });
 
+test("shape_circle and shape_rounded are mutually exclusive", async () => {
+    await setupEditor(`
+        <img src="${base64Img}">
+    `);
+    const img = queryOne("img");
+    click(img);
+    await waitFor(".o-we-toolbar");
+
+    const buttons = {};
+    for (const buttonName of ["shape_rounded", "shape_circle", "shape_shadow", "shape_thumbnail"]) {
+        buttons[buttonName] = `.o-we-toolbar button[name='${buttonName}']`;
+    }
+
+    click(buttons["shape_rounded"]);
+    await animationFrame();
+    expect(buttons["shape_rounded"]).toHaveClass("active");
+    expect(img).toHaveClass("rounded");
+
+    click(buttons["shape_circle"]);
+    await animationFrame();
+    expect(buttons["shape_circle"]).toHaveClass("active");
+    expect(img).toHaveClass("rounded-circle");
+    expect(buttons["shape_rounded"]).not.toHaveClass("active");
+    expect(img).not.toHaveClass("rounded");
+
+    click(buttons["shape_rounded"]);
+    await animationFrame();
+    expect(buttons["shape_rounded"]).toHaveClass("active");
+    expect(img).toHaveClass("rounded");
+    expect(buttons["shape_circle"]).not.toHaveClass("active");
+    expect(img).not.toHaveClass("rounded-circle");
+});
+
 test("can undo a shape", async () => {
     const { editor } = await setupEditor(`
         <img src="${base64Img}">


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Commands `SHAPE_ROUNDED` and `SHAPE_CIRCLE` could be applied simultaneously, causing each command to cancel the effect of other.

**Desired behavior after PR is merged:**

Commands `SHAPE_ROUNDED` and `SHAPE_CIRCLE`  are mutually exclusive.

task-4072949