### PR TITLE
[FIX] pos_loyalty: allow adding zero points

### DIFF
--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -683,7 +683,8 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
                         program_id: program.id,
                         coupon_id: coupon.id,
                         barcode: pa.barcode,
-                        appliedRules: pointsForProgramsCountedRules[program.id]
+                        appliedRules: pointsForProgramsCountedRules[program.id],
+                        giftCardId: pa.giftCardId
                     };
                 }
             }

--- a/addons/pos_loyalty/static/src/tours/GiftCardProgramTours.js
+++ b/addons/pos_loyalty/static/src/tours/GiftCardProgramTours.js
@@ -82,3 +82,16 @@ PosLoyalty.do.enterCode("044123456");
 PosLoyalty.check.orderTotalIs("50.00");
 ProductScreen.check.checkTaxAmount("-6.52");
 Tour.register("PosLoyaltyGiftCardTaxes", { test: true }, getSteps());
+
+startSteps();
+ProductScreen.do.confirmOpeningPopup();
+ProductScreen.do.clickHomeCategory();
+ProductScreen.do.clickDisplayedProduct('Gift Card');
+TextInputPopup.check.isShown();
+TextInputPopup.do.inputText('044123456');
+TextInputPopup.do.clickConfirm();
+PosLoyalty.check.orderTotalIs('0.00');
+ProductScreen.do.pressNumpad("Price 5");
+PosLoyalty.check.orderTotalIs('5.00');
+PosLoyalty.exec.finalizeOrder('Cash', '5');
+Tour.register("PosLoyaltyGiftCardNoPoints", { test: true }, getSteps());

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -2011,3 +2011,21 @@ class TestUi(TestPointOfSaleHttpCommon):
             login="accountman",
         )
         self.main_pos_config.current_session_id.close_session_from_ui()
+
+    def test_gift_card_no_points(self):
+        self.env['loyalty.program'].search([]).write({'active': False})
+        self.env.ref('loyalty.gift_card_product_50').write({'active': True})
+
+        gift_card_program = self.create_programs([('arbitrary_name', 'gift_card')])['arbitrary_name']
+        self.main_pos_config.write({'gift_card_settings': 'scan_use'})
+        self.env["loyalty.generate.wizard"].with_context(
+            {"active_id": gift_card_program.id}
+        ).create({"coupon_qty": 1, 'points_granted': 0}).generate_coupons()
+        gift_card_program.coupon_ids.code = '044123456'
+
+        self.main_pos_config.open_ui()
+        self.start_tour(
+            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "PosLoyaltyGiftCardNoPoints",
+            login="accountman",
+        )


### PR DESCRIPTION
Problem:
For a gift card with 0 points which have its price changed a popup error is displayed saying the gift card has already been sold

Steps to reproduce:
- Install "point_of_sale" app and "pos_loyalty" module
- Select "Scan existing cards" in the promotions settings
- Generate a gift card with a value of 0.00 $ and copy its code
- Start a shop session
- Select the gift card product and enter the code
- Change the price of the gift card (must be an integer < 10)
- Proceed to the payment
- See the popup error

Cause:
As the gift card has no points, `couponPointChanges` stays empty. But when the price is modified, `couponPointChanges` is updated but has no giftCardId so the error is triggered (see `validateOrder` in PaymentScreen.js). There is no issue if the price is > 10 or is not an integer because `_updatePrograms` is called after each click on the numpad and `changesPerProgram` gets the values of `couponPointChanges` which are the saved in `oldChanges` which is modified by getting the values of `pointsAdded` which has `giftCardId` so `couponPointChanges` get the `giftCardId`

opw-3909019


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
