### PR TITLE
[IMP] account{,edi_ubl_cii}: autopost of bills for trusted vendors

### DIFF
--- a/addons/account/__manifest__.py
+++ b/addons/account/__manifest__.py
@@ -25,6 +25,7 @@ You could use this simplified accounting in case you work with an (external) acc
         'data/onboarding_data.xml',
         'views/account_payment_view.xml',
         'wizard/account_automatic_entry_wizard_views.xml',
+        'wizard/account_autopost_bills_wizard.xml',
         'wizard/account_unreconcile_view.xml',
         'wizard/account_move_reversal_view.xml',
         'wizard/account_resequence_views.xml',

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -228,6 +228,9 @@ class ResCompany(models.Model):
     # Audit trail
     check_account_audit_trail = fields.Boolean(string='Audit Trail')
 
+    # Autopost Wizard
+    autopost_bills = fields.Boolean(string='Auto-validate bills', default=True)
+
     def _get_company_root_delegated_field_names(self):
         return super()._get_company_root_delegated_field_names() + [
             'fiscalyear_last_day',

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -607,6 +607,13 @@ class ResPartner(models.Model):
     # amount of their generated incoming/outgoing account moves
     supplier_rank = fields.Integer(default=0, copy=False)
     customer_rank = fields.Integer(default=0, copy=False)
+    autopost_bills = fields.Selection(
+        selection=[('always', 'Always'), ('ask', 'Ask after 3 validations without edits'), ('never', 'Never')],
+        string='Auto-post bills',
+        help="Automatically post bills for this trusted partner",
+        default='ask',
+        required=True,
+    )
 
     # Technical field holding the amount partners that share the same account number as any set on this partner.
     duplicated_bank_account_partners_count = fields.Integer(

--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -222,6 +222,9 @@ class ResConfigSettings(models.TransientModel):
     # Audit trail
     check_account_audit_trail = fields.Boolean(string='Audit Trail', related='company_id.check_account_audit_trail', readonly=False)
 
+    # Autopost of bills
+    autopost_bills = fields.Boolean(related='company_id.autopost_bills', readonly=False)
+
     @api.depends('country_code')
     def _compute_is_account_peppol_eligible(self):
         # we want to show Peppol settings only to customers that are eligible for Peppol,

--- a/addons/account/security/ir.model.access.csv
+++ b/addons/account/security/ir.model.access.csv
@@ -115,6 +115,7 @@ access_account_payment,account.payment,model_account_payment,account.group_accou
 
 access_account_payment_register,access.account.payment.register,model_account_payment_register,account.group_account_invoice,1,1,1,0
 access_account_automatic_entry_wizard,access.account.automatic.entry.wizard,model_account_automatic_entry_wizard,account.group_account_user,1,1,1,0
+access_account_autopost_bills_wizard,access.account.autopost.bills.wizard,model_account_autopost_bills_wizard,account.group_account_invoice,1,1,1,0
 access_account_unreconcile,access.account.unreconcile,model_account_unreconcile,account.group_account_user,1,1,1,0
 access_account_resequence,access.account.resequence.wizard,model_account_resequence_wizard,account.group_account_manager,1,1,1,0
 access_validate_account_move,access.validate.account.move,model_validate_account_move,account.group_account_invoice,1,1,1,0

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -225,9 +225,10 @@
                                     <field name="credit_limit" class="oe_inline" invisible="not use_partner_credit_limit"/>
                                 </div>
                             </group>
-                            <group groups="base.group_no_one">
-                                <field name="ignore_abnormal_invoice_amount"/>
-                                <field name="ignore_abnormal_invoice_date"/>
+                            <group name='accounting_automation' string='Automation'>
+                                <field name="autopost_bills" groups="account.group_account_invoice,account.group_account_readonly"/>
+                                <field name="ignore_abnormal_invoice_amount" groups="base.group_no_one"/>
+                                <field name="ignore_abnormal_invoice_date" groups="base.group_no_one"/>
                             </group>
                         </group>
                     </page>

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -224,6 +224,9 @@
                             <setting id="show_purchase_receipts" help="Activate to create purchase receipt">
                                 <field name="group_show_purchase_receipts"/>
                             </setting>
+                            <setting id="autopost_bills" help="After importing three bills for a vendor without making changes, Odoo will suggest automatically validating future bills. You can toggle this feature at any time in the vendor's profile.">
+                                <field name="autopost_bills"/>
+                            </setting>
                         </block>
                         <block title="Vendor Payments" id="print_vendor_checks_setting_container">
                             <setting id="print_checks" groups="account.group_account_user" string="Checks" company_dependent="1" help="Print checks to pay your vendors"

--- a/addons/account/wizard/__init__.py
+++ b/addons/account/wizard/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import account_automatic_entry_wizard
+from . import account_autopost_bills_wizard
 from . import account_unreconcile
 from . import account_validate_account_move
 from . import account_move_reversal

--- a/addons/account/wizard/account_autopost_bills_wizard.py
+++ b/addons/account/wizard/account_autopost_bills_wizard.py
@@ -1,0 +1,22 @@
+from odoo import models, fields
+
+
+class AutoPostBillsWizard(models.TransientModel):
+    _name = "account.autopost.bills.wizard"
+    _description = "Autopost Bills Wizard"
+
+    partner_id = fields.Many2one("res.partner")
+    partner_name = fields.Char(related="partner_id.name")
+    nb_unmodified_bills = fields.Integer("Number of bills previously unmodified from this partner")
+
+    def action_automate_partner(self):
+        for wizard in self:
+            wizard.partner_id.autopost_bills = 'always'
+
+    def action_ask_later(self):
+        for wizard in self:
+            wizard.partner_id.autopost_bills = 'ask'
+
+    def action_never_automate_partner(self):
+        for wizard in self:
+            wizard.partner_id.autopost_bills = 'never'

--- a/addons/account/wizard/account_autopost_bills_wizard.xml
+++ b/addons/account/wizard/account_autopost_bills_wizard.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="autopost_bills_wizard" model="ir.ui.view">
+            <field name="name">Autopost Bills</field>
+            <field name="model">account.autopost.bills.wizard</field>
+            <field name="arch" type="xml">
+                <form string="Autopost Bills">
+                    <p>Hey there !</p>
+                    <p>
+                        It looks like you've successfully validated the last
+                        <b>
+                            <field name="nb_unmodified_bills" readonly="True" class="oe_inline" invisible="nb_unmodified_bills &gt; 9"/>
+                            <span invisible="nb_unmodified_bills &lt; 10">10+</span>
+                        </b>
+                        bills for <b><field name="partner_name"/></b> without making any corrections.
+                    </p>
+                    <p>Want to make your life even easier and automate bill validation from this vendor ?</p>
+
+                    <p class="text-muted">
+                        <i class="fa fa-lightbulb-o" role="img"/>
+                        Don't worry, you can always change this setting later on the vendor's form.
+                        You also have the option to disable the feature for all vendors in the accounting settings.
+                    </p>
+
+                    <footer>
+                        <button class="btn-primary" type="object" name="action_automate_partner">Activate auto-validation</button>
+                        <button class="btn-secondary" type="object" name="action_ask_later">Ask me later</button>
+                        <button class="btn-secondary" type="object" name="action_never_automate_partner">Never for this vendor</button>
+                    </footer>
+                </form>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/account/wizard/account_validate_account_move.py
+++ b/addons/account/wizard/account_validate_account_move.py
@@ -61,4 +61,6 @@ class ValidateAccountMove(models.TransientModel):
         if self.force_post:
             self.move_ids.auto_post = 'no'
         self.move_ids._post(not self.force_post)
+        if autopost_bills_wizard := self.move_ids._show_autopost_bills_wizard():
+            return autopost_bills_wizard
         return {'type': 'ir.actions.act_window_close'}

--- a/addons/account_edi_ubl_cii/tests/__init__.py
+++ b/addons/account_edi_ubl_cii/tests/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 
+from . import test_autopost_bills
 from . import test_partner_peppol_fields
 from . import test_ubl_cii

--- a/addons/account_edi_ubl_cii/tests/test_autopost_bills.py
+++ b/addons/account_edi_ubl_cii/tests/test_autopost_bills.py
@@ -1,0 +1,135 @@
+import base64
+from datetime import datetime
+
+from odoo import fields
+from odoo.tests import tagged
+from odoo.tools import file_open
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged('post_install', '-at_install')
+class TestAutoPostBills(AccountTestInvoicingCommon):
+
+    def import_facturx(self, filename='facturx_out_invoice.xml'):
+        self.env.cr._now = datetime.now()  # reset transaction's NOW, otherwise all move will have the same create_date
+        with file_open(f"account_edi_ubl_cii/tests/test_files/{filename}", 'rb', filter_ext=('.xml',)) as file:
+            attachment = self.env['ir.attachment'].create({
+                'name': 'test_file.xml',
+                'datas': base64.encodebytes(file.read()),
+            })
+            return self.company_data['default_journal_purchase'].with_context(disable_abnormal_invoice_detection=False)._create_document_from_attachment(attachment.id)
+
+    def assert_wizard(self, post_result, expected_nb_bills):
+        self.assertEqual(post_result.get('res_model'), 'account.autopost.bills.wizard')
+        wizard = self.env[post_result.get('res_model')].browse(post_result.get('res_id'))
+        self.assertEqual(wizard.nb_unmodified_bills, expected_nb_bills)
+        return wizard
+
+    def test_autopost_bills(self):
+        """
+        When invoices from a same vendor are input thrice in a row without changing anything,
+        so for invoice coming from OCR or e-Invoicing, we should show a banner to the user
+        and allow him to automatically post future invoices from this vendor.
+        - If there is a significant difference (see abnormal_amount), don't autopost and show the banner !
+        - Not applicable to hashed journals
+        """
+        # Create 1st bill ever for this partner, should NOT show popup
+        move = self.import_facturx()
+        autopost_bills_wizard = move.action_post()
+        self.assertFalse(autopost_bills_wizard)
+        self.assertFalse(move.is_manually_modified)
+
+        # Create 2nd bill without changes for this partner, should NOT show popup
+        move = self.import_facturx()
+        autopost_bills_wizard = move.action_post()
+        self.assertFalse(autopost_bills_wizard)
+        self.assertFalse(move.is_manually_modified)
+
+        # Create 3rd bill without changes for this partner, should show popup on posting
+        move = self.import_facturx()
+        autopost_bills_wizard = move.action_post()
+        self.assertFalse(move.is_manually_modified)
+        wizard = self.assert_wizard(autopost_bills_wizard, 3)
+        wizard.action_ask_later()  # Nothing changes, we should still show the popup
+
+        # Create 4th bill without changes for this partner, should show popup on posting
+        move = self.import_facturx()
+        autopost_bills_wizard = move.action_post()
+        self.assertFalse(move.is_manually_modified)
+        wizard = self.assert_wizard(autopost_bills_wizard, 4)
+        wizard.action_ask_later()  # Nothing changes, we should still show the popup
+
+        # Create 5th bill with changes, should NOT show popup on posting
+        move = self.import_facturx()
+        move.invoice_date_due = fields.Date.today()
+        autopost_bills_wizard = move.action_post()
+        self.assertFalse(autopost_bills_wizard)
+        self.assertTrue(move.is_manually_modified)
+
+        # Create again 3 bills without any changes
+        for _ in range(3):
+            move = self.import_facturx()
+            autopost_bills_wizard = move.action_post()
+        wizard = self.assert_wizard(autopost_bills_wizard, 3)
+        wizard.action_automate_partner()
+
+        # Create 4th bill without changes with automation enabled => should automatically post, no popup
+        move = self.import_facturx()
+        self.assertEqual(move.state, 'posted')
+
+        # Reset
+        move.partner_id.autopost_bills = 'ask'
+
+        # Create 5th bill without changes, should show popup on posting
+        move = self.import_facturx()
+        autopost_bills_wizard = move.action_post()
+        wizard = self.assert_wizard(autopost_bills_wizard, 5)
+        wizard.action_never_automate_partner()
+
+        # Create 6th bill without changes, should not show popup, and move should stay in draft
+        move = self.import_facturx()
+        self.assertEqual(move.state, 'draft')
+        autopost_bills_wizard = move.action_post()
+        self.assertFalse(autopost_bills_wizard)
+
+        # Reset
+        move.partner_id.autopost_bills = 'ask'
+
+        # Create 7th bill without changes, should show popup on posting
+        move = self.import_facturx()
+        autopost_bills_wizard = move.action_post()
+        wizard = self.assert_wizard(autopost_bills_wizard, 7)
+        wizard.action_ask_later()
+
+        # Deactivate the feature fully from the settings
+        # => Should never show popup, nor autopost (even if partner is on 'always')
+        move.company_id.autopost_bills = False
+        move.partner_id.autopost_bills = 'always'
+        move = self.import_facturx()
+        self.assertEqual(move.state, 'draft')
+        autopost_bills_wizard = move.action_post()
+        self.assertFalse(autopost_bills_wizard)
+
+        # Reset
+        move.company_id.autopost_bills = True
+        move.partner_id.autopost_bills = 'always'
+
+        # If there is a significant difference (see abnormal_amount), don't autopost even if 'always' is set
+        for _ in range(10):  # See test_unexpected_invoice
+            move = self.import_facturx()  # automatically posted
+            self.assertEqual(move.state, "posted")
+
+        move = self.import_facturx(filename='facturx_out_invoice_abnormal.xml')  # amounts * 100 here, a bit abnormal...
+        self.assertEqual(move.state, "draft")  # even if partner's autopost is always
+        res = move.action_post()
+        self.assertEqual(res.get('res_model'), 'validate.account.move')
+        wizard = self.env[res.get('res_model')].browse(res.get('res_id'))
+        self.assertEqual(wizard.move_ids, move)
+
+        # Not applicable to hashed journals
+        self.company_data['default_journal_purchase'].restrict_mode_hash_table = True
+        move = self.import_facturx()
+        self.assertEqual(move.state, "draft")
+        res = move.action_post()
+        self.assertFalse(res)

--- a/addons/account_edi_ubl_cii/tests/test_files/facturx_out_invoice.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/facturx_out_invoice.xml
@@ -1,0 +1,214 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+  <rsm:ExchangedDocumentContext>
+    <ram:GuidelineSpecifiedDocumentContextParameter>
+      <ram:ID>urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended</ram:ID>
+    </ram:GuidelineSpecifiedDocumentContextParameter>
+  </rsm:ExchangedDocumentContext>
+  <rsm:ExchangedDocument>
+    <ram:ID>INV/2017/01/0002</ram:ID>
+    <ram:TypeCode>380</ram:TypeCode>
+    <ram:IssueDateTime>
+      <udt:DateTimeString format="102">20170101</udt:DateTimeString>
+    </ram:IssueDateTime>
+    <ram:IncludedNote>
+      <ram:Content>test narration</ram:Content>
+    </ram:IncludedNote>
+  </rsm:ExchangedDocument>
+  <rsm:SupplyChainTradeTransaction>
+    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>1</ram:LineID>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:Name>product_a</ram:Name>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:GrossPriceProductTradePrice>
+          <ram:ChargeAmount>990.00</ram:ChargeAmount>
+          <ram:AppliedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>false</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:ActualAmount>99.00</ram:ActualAmount>
+          </ram:AppliedTradeAllowanceCharge>
+        </ram:GrossPriceProductTradePrice>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>891.00</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="DZN">2.0</ram:BilledQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>21.0</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>1782.00</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>2</ram:LineID>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:Name>product_b</ram:Name>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:GrossPriceProductTradePrice>
+          <ram:ChargeAmount>100.00</ram:ChargeAmount>
+        </ram:GrossPriceProductTradePrice>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>100.00</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="C62">10.0</ram:BilledQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>12.0</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>1000.00</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>3</ram:LineID>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:Name>product_b</ram:Name>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:GrossPriceProductTradePrice>
+          <ram:ChargeAmount>100.00</ram:ChargeAmount>
+        </ram:GrossPriceProductTradePrice>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>100.00</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="C62">-1.0</ram:BilledQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>12.0</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>-100.00</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+    <ram:ApplicableHeaderTradeAgreement>
+      <ram:BuyerReference>ref_partner_2</ram:BuyerReference>
+      <ram:SellerTradeParty>
+        <ram:Name>partner_1</ram:Name>
+        <ram:DefinedTradeContact>
+          <ram:PersonName>partner_1</ram:PersonName>
+          <ram:TelephoneUniversalCommunication>
+            <ram:CompleteNumber>+1 (650) 555-0111</ram:CompleteNumber>
+          </ram:TelephoneUniversalCommunication>
+          <ram:EmailURIUniversalCommunication>
+            <ram:URIID schemeID="SMTP">partner1@yourcompany.com</ram:URIID>
+          </ram:EmailURIUniversalCommunication>
+        </ram:DefinedTradeContact>
+        <ram:PostalTradeAddress>
+          <ram:PostcodeCode>75000</ram:PostcodeCode>
+          <ram:LineOne>Rue Jean Jaurès, 42</ram:LineOne>
+          <ram:CityName>Paris</ram:CityName>
+          <ram:CountryID>FR</ram:CountryID>
+        </ram:PostalTradeAddress>
+        <ram:SpecifiedTaxRegistration>
+          <ram:ID schemeID="VA">FR05677404089</ram:ID>
+        </ram:SpecifiedTaxRegistration>
+      </ram:SellerTradeParty>
+      <ram:BuyerTradeParty>
+        <ram:Name>partner_2</ram:Name>
+        <ram:DefinedTradeContact>
+          <ram:PersonName>partner_2</ram:PersonName>
+        </ram:DefinedTradeContact>
+        <ram:PostalTradeAddress>
+          <ram:PostcodeCode>52330</ram:PostcodeCode>
+          <ram:LineOne>Rue Charles de Gaulle</ram:LineOne>
+          <ram:CityName>Colombey-les-Deux-Églises</ram:CityName>
+          <ram:CountryID>FR</ram:CountryID>
+        </ram:PostalTradeAddress>
+        <ram:SpecifiedTaxRegistration>
+          <ram:ID schemeID="VA">FR35562153452</ram:ID>
+        </ram:SpecifiedTaxRegistration>
+      </ram:BuyerTradeParty>
+      <ram:BuyerOrderReferencedDocument>
+        <ram:IssuerAssignedID>INV/2017/01/0002: INV/2017/01/0002</ram:IssuerAssignedID>
+      </ram:BuyerOrderReferencedDocument>
+    </ram:ApplicableHeaderTradeAgreement>
+    <ram:ApplicableHeaderTradeDelivery>
+      <ram:ShipToTradeParty>
+        <ram:Name>partner_2</ram:Name>
+        <ram:DefinedTradeContact>
+          <ram:PersonName>partner_2</ram:PersonName>
+        </ram:DefinedTradeContact>
+        <ram:PostalTradeAddress>
+          <ram:PostcodeCode>52330</ram:PostcodeCode>
+          <ram:LineOne>Rue Charles de Gaulle</ram:LineOne>
+          <ram:CityName>Colombey-les-Deux-Églises</ram:CityName>
+          <ram:CountryID>FR</ram:CountryID>
+        </ram:PostalTradeAddress>
+      </ram:ShipToTradeParty>
+      <ram:ActualDeliverySupplyChainEvent>
+        <ram:OccurrenceDateTime>
+          <udt:DateTimeString format="102">20170101</udt:DateTimeString>
+        </ram:OccurrenceDateTime>
+      </ram:ActualDeliverySupplyChainEvent>
+    </ram:ApplicableHeaderTradeDelivery>
+    <ram:ApplicableHeaderTradeSettlement>
+      <ram:PaymentReference>INV/2017/01/0002</ram:PaymentReference>
+      <ram:InvoiceCurrencyCode>USD</ram:InvoiceCurrencyCode>
+      <ram:SpecifiedTradeSettlementPaymentMeans>
+        <ram:TypeCode>42</ram:TypeCode>
+        <ram:PayeePartyCreditorFinancialAccount>
+          <ram:ProprietaryID>FR15001559627230</ram:ProprietaryID>
+        </ram:PayeePartyCreditorFinancialAccount>
+      </ram:SpecifiedTradeSettlementPaymentMeans>
+      <ram:ApplicableTradeTax>
+        <ram:CalculatedAmount>374.22</ram:CalculatedAmount>
+        <ram:TypeCode>VAT</ram:TypeCode>
+        <ram:BasisAmount>1782.00</ram:BasisAmount>
+        <ram:CategoryCode>S</ram:CategoryCode>
+        <ram:DueDateTypeCode>5</ram:DueDateTypeCode>
+        <ram:RateApplicablePercent>21.0</ram:RateApplicablePercent>
+      </ram:ApplicableTradeTax>
+      <ram:ApplicableTradeTax>
+        <ram:CalculatedAmount>108.00</ram:CalculatedAmount>
+        <ram:TypeCode>VAT</ram:TypeCode>
+        <ram:BasisAmount>900.00</ram:BasisAmount>
+        <ram:CategoryCode>S</ram:CategoryCode>
+        <ram:DueDateTypeCode>5</ram:DueDateTypeCode>
+        <ram:RateApplicablePercent>12.0</ram:RateApplicablePercent>
+      </ram:ApplicableTradeTax>
+      <ram:SpecifiedTradePaymentTerms>
+        <ram:Description>30% Advance End of Following Month</ram:Description>
+        <ram:DueDateDateTime>
+          <udt:DateTimeString format="102">20170228</udt:DateTimeString>
+        </ram:DueDateDateTime>
+      </ram:SpecifiedTradePaymentTerms>
+      <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        <ram:LineTotalAmount>2682.00</ram:LineTotalAmount>
+        <ram:TaxBasisTotalAmount>2682.00</ram:TaxBasisTotalAmount>
+        <ram:TaxTotalAmount currencyID="USD">482.22</ram:TaxTotalAmount>
+        <ram:GrandTotalAmount>3164.22</ram:GrandTotalAmount>
+        <ram:TotalPrepaidAmount>0.00</ram:TotalPrepaidAmount>
+        <ram:DuePayableAmount>3164.22</ram:DuePayableAmount>
+      </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+    </ram:ApplicableHeaderTradeSettlement>
+  </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>

--- a/addons/account_edi_ubl_cii/tests/test_files/facturx_out_invoice_abnormal.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/facturx_out_invoice_abnormal.xml
@@ -1,0 +1,217 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<rsm:CrossIndustryInvoice
+        xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+        xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+        xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+    <rsm:ExchangedDocumentContext>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+            <ram:ID>urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+    </rsm:ExchangedDocumentContext>
+    <rsm:ExchangedDocument>
+        <ram:ID>INV/2017/01/0002</ram:ID>
+        <ram:TypeCode>380</ram:TypeCode>
+        <ram:IssueDateTime>
+            <udt:DateTimeString format="102">20170101</udt:DateTimeString>
+        </ram:IssueDateTime>
+        <ram:IncludedNote>
+            <ram:Content>test narration</ram:Content>
+        </ram:IncludedNote>
+    </rsm:ExchangedDocument>
+    <rsm:SupplyChainTradeTransaction>
+        <ram:IncludedSupplyChainTradeLineItem>
+            <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>1</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+            <ram:SpecifiedTradeProduct>
+                <ram:Name>product_a</ram:Name>
+            </ram:SpecifiedTradeProduct>
+            <ram:SpecifiedLineTradeAgreement>
+                <ram:GrossPriceProductTradePrice>
+                    <ram:ChargeAmount>99000.00</ram:ChargeAmount>
+                    <ram:AppliedTradeAllowanceCharge>
+                        <ram:ChargeIndicator>
+                            <udt:Indicator>false</udt:Indicator>
+                        </ram:ChargeIndicator>
+                        <ram:ActualAmount>9900.00</ram:ActualAmount>
+                    </ram:AppliedTradeAllowanceCharge>
+                </ram:GrossPriceProductTradePrice>
+                <ram:NetPriceProductTradePrice>
+                    <ram:ChargeAmount>89100.00</ram:ChargeAmount>
+                </ram:NetPriceProductTradePrice>
+            </ram:SpecifiedLineTradeAgreement>
+            <ram:SpecifiedLineTradeDelivery>
+                <ram:BilledQuantity unitCode="DZN">2.0</ram:BilledQuantity>
+            </ram:SpecifiedLineTradeDelivery>
+            <ram:SpecifiedLineTradeSettlement>
+                <ram:ApplicableTradeTax>
+                    <ram:TypeCode>VAT</ram:TypeCode>
+                    <ram:CategoryCode>S</ram:CategoryCode>
+                    <ram:RateApplicablePercent>21.0</ram:RateApplicablePercent>
+                </ram:ApplicableTradeTax>
+                <ram:SpecifiedTradeSettlementLineMonetarySummation>
+                    <ram:LineTotalAmount>178200.00</ram:LineTotalAmount>
+                </ram:SpecifiedTradeSettlementLineMonetarySummation>
+            </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+        <ram:IncludedSupplyChainTradeLineItem>
+            <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>2</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+            <ram:SpecifiedTradeProduct>
+                <ram:Name>product_b</ram:Name>
+            </ram:SpecifiedTradeProduct>
+            <ram:SpecifiedLineTradeAgreement>
+                <ram:GrossPriceProductTradePrice>
+                    <ram:ChargeAmount>10000.00</ram:ChargeAmount>
+                </ram:GrossPriceProductTradePrice>
+                <ram:NetPriceProductTradePrice>
+                    <ram:ChargeAmount>10000.00</ram:ChargeAmount>
+                </ram:NetPriceProductTradePrice>
+            </ram:SpecifiedLineTradeAgreement>
+            <ram:SpecifiedLineTradeDelivery>
+                <ram:BilledQuantity unitCode="C62">10.0</ram:BilledQuantity>
+            </ram:SpecifiedLineTradeDelivery>
+            <ram:SpecifiedLineTradeSettlement>
+                <ram:ApplicableTradeTax>
+                    <ram:TypeCode>VAT</ram:TypeCode>
+                    <ram:CategoryCode>S</ram:CategoryCode>
+                    <ram:RateApplicablePercent>12.0</ram:RateApplicablePercent>
+                </ram:ApplicableTradeTax>
+                <ram:SpecifiedTradeSettlementLineMonetarySummation>
+                    <ram:LineTotalAmount>100000.00</ram:LineTotalAmount>
+                </ram:SpecifiedTradeSettlementLineMonetarySummation>
+            </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+        <ram:IncludedSupplyChainTradeLineItem>
+            <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>3</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+            <ram:SpecifiedTradeProduct>
+                <ram:Name>product_b</ram:Name>
+            </ram:SpecifiedTradeProduct>
+            <ram:SpecifiedLineTradeAgreement>
+                <ram:GrossPriceProductTradePrice>
+                    <ram:ChargeAmount>10000.00</ram:ChargeAmount>
+                </ram:GrossPriceProductTradePrice>
+                <ram:NetPriceProductTradePrice>
+                    <ram:ChargeAmount>10000.00</ram:ChargeAmount>
+                </ram:NetPriceProductTradePrice>
+            </ram:SpecifiedLineTradeAgreement>
+            <ram:SpecifiedLineTradeDelivery>
+                <ram:BilledQuantity unitCode="C62">-1.0</ram:BilledQuantity>
+            </ram:SpecifiedLineTradeDelivery>
+            <ram:SpecifiedLineTradeSettlement>
+                <ram:ApplicableTradeTax>
+                    <ram:TypeCode>VAT</ram:TypeCode>
+                    <ram:CategoryCode>S</ram:CategoryCode>
+                    <ram:RateApplicablePercent>12.0</ram:RateApplicablePercent>
+                </ram:ApplicableTradeTax>
+                <ram:SpecifiedTradeSettlementLineMonetarySummation>
+                    <ram:LineTotalAmount>-10000.00</ram:LineTotalAmount>
+                </ram:SpecifiedTradeSettlementLineMonetarySummation>
+            </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+        <ram:ApplicableHeaderTradeAgreement>
+            <ram:BuyerReference>ref_partner_2</ram:BuyerReference>
+            <ram:SellerTradeParty>
+                <ram:Name>partner_1</ram:Name>
+                <ram:DefinedTradeContact>
+                    <ram:PersonName>partner_1</ram:PersonName>
+                    <ram:TelephoneUniversalCommunication>
+                        <ram:CompleteNumber>+1 (650) 555-0111</ram:CompleteNumber>
+                    </ram:TelephoneUniversalCommunication>
+                    <ram:EmailURIUniversalCommunication>
+                        <ram:URIID schemeID="SMTP">partner1@yourcompany.com</ram:URIID>
+                    </ram:EmailURIUniversalCommunication>
+                </ram:DefinedTradeContact>
+                <ram:PostalTradeAddress>
+                    <ram:PostcodeCode>75000</ram:PostcodeCode>
+                    <ram:LineOne>Rue Jean Jaurès, 42</ram:LineOne>
+                    <ram:CityName>Paris</ram:CityName>
+                    <ram:CountryID>FR</ram:CountryID>
+                </ram:PostalTradeAddress>
+                <ram:SpecifiedTaxRegistration>
+                    <ram:ID schemeID="VA">FR05677404089</ram:ID>
+                </ram:SpecifiedTaxRegistration>
+            </ram:SellerTradeParty>
+            <ram:BuyerTradeParty>
+                <ram:Name>partner_2</ram:Name>
+                <ram:DefinedTradeContact>
+                    <ram:PersonName>partner_2</ram:PersonName>
+                </ram:DefinedTradeContact>
+                <ram:PostalTradeAddress>
+                    <ram:PostcodeCode>52330</ram:PostcodeCode>
+                    <ram:LineOne>Rue Charles de Gaulle</ram:LineOne>
+                    <ram:CityName>Colombey-les-Deux-Églises</ram:CityName>
+                    <ram:CountryID>FR</ram:CountryID>
+                </ram:PostalTradeAddress>
+                <ram:SpecifiedTaxRegistration>
+                    <ram:ID schemeID="VA">FR35562153452</ram:ID>
+                </ram:SpecifiedTaxRegistration>
+            </ram:BuyerTradeParty>
+            <ram:BuyerOrderReferencedDocument>
+                <ram:IssuerAssignedID>INV/2017/01/0002: INV/2017/01/0002</ram:IssuerAssignedID>
+            </ram:BuyerOrderReferencedDocument>
+        </ram:ApplicableHeaderTradeAgreement>
+        <ram:ApplicableHeaderTradeDelivery>
+            <ram:ShipToTradeParty>
+                <ram:Name>partner_2</ram:Name>
+                <ram:DefinedTradeContact>
+                    <ram:PersonName>partner_2</ram:PersonName>
+                </ram:DefinedTradeContact>
+                <ram:PostalTradeAddress>
+                    <ram:PostcodeCode>52330</ram:PostcodeCode>
+                    <ram:LineOne>Rue Charles de Gaulle</ram:LineOne>
+                    <ram:CityName>Colombey-les-Deux-Églises</ram:CityName>
+                    <ram:CountryID>FR</ram:CountryID>
+                </ram:PostalTradeAddress>
+            </ram:ShipToTradeParty>
+            <ram:ActualDeliverySupplyChainEvent>
+                <ram:OccurrenceDateTime>
+                    <udt:DateTimeString format="102">20170101</udt:DateTimeString>
+                </ram:OccurrenceDateTime>
+            </ram:ActualDeliverySupplyChainEvent>
+        </ram:ApplicableHeaderTradeDelivery>
+        <ram:ApplicableHeaderTradeSettlement>
+            <ram:PaymentReference>INV/2017/01/0002</ram:PaymentReference>
+            <ram:InvoiceCurrencyCode>USD</ram:InvoiceCurrencyCode>
+            <ram:SpecifiedTradeSettlementPaymentMeans>
+                <ram:TypeCode>42</ram:TypeCode>
+                <ram:PayeePartyCreditorFinancialAccount>
+                    <ram:ProprietaryID>FR15001559627230</ram:ProprietaryID>
+                </ram:PayeePartyCreditorFinancialAccount>
+            </ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:ApplicableTradeTax>
+                <ram:CalculatedAmount>37400.22</ram:CalculatedAmount>
+                <ram:TypeCode>VAT</ram:TypeCode>
+                <ram:BasisAmount>178200.00</ram:BasisAmount>
+                <ram:CategoryCode>S</ram:CategoryCode>
+                <ram:DueDateTypeCode>5</ram:DueDateTypeCode>
+                <ram:RateApplicablePercent>21.0</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:ApplicableTradeTax>
+                <ram:CalculatedAmount>10800.00</ram:CalculatedAmount>
+                <ram:TypeCode>VAT</ram:TypeCode>
+                <ram:BasisAmount>90000.00</ram:BasisAmount>
+                <ram:CategoryCode>S</ram:CategoryCode>
+                <ram:DueDateTypeCode>5</ram:DueDateTypeCode>
+                <ram:RateApplicablePercent>12.0</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradePaymentTerms>
+                <ram:Description>30% Advance End of Following Month</ram:Description>
+                <ram:DueDateDateTime>
+                    <udt:DateTimeString format="102">20170228</udt:DateTimeString>
+                </ram:DueDateDateTime>
+            </ram:SpecifiedTradePaymentTerms>
+            <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+                <ram:LineTotalAmount>268200.00</ram:LineTotalAmount>
+                <ram:TaxBasisTotalAmount>268200.00</ram:TaxBasisTotalAmount>
+                <ram:TaxTotalAmount currencyID="USD">48200.22</ram:TaxTotalAmount>
+                <ram:GrandTotalAmount>316400.22</ram:GrandTotalAmount>
+                <ram:TotalPrepaidAmount>0.00</ram:TotalPrepaidAmount>
+                <ram:DuePayableAmount>316400.22</ram:DuePayableAmount>
+            </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+    </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>


### PR DESCRIPTION
Purpose
-------

The idea is to automate a bit more the post of bills for vendor in which you trust, i.e. vendor with invoices well recognized by OCR or invoices xml

Spec
----

- When invoices from a same vendor are input twice in a row without changing anything, so for invoice coming from OCR or e-Invoicing, we should show a banner to the user and allow him to input automatically invoice from this vendor for the next ones

- There should be a checkbox on the partner form to enable/disable this autopost feature at any time

- If there is a significant difference (see abnormal_amount), don't autopost and show the banner

- Not applicable to hashed invoices

task-id 3958958

Community PR: https://github.com/odoo/odoo/pull/174540
Enterprise PR: https://github.com/odoo/enterprise/pull/67788
Upgrade PR: https://github.com/odoo/upgrade/pull/6356