### PR TITLE
[FIX] l10n_gcc_invoice: display lists from right to left in Arabic

### DIFF
--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -451,7 +451,7 @@
                             <span t-field="o.narration"/>
                         </div>
                         <div class="col-6 text-right">
-                            <span t-field="o_sec.narration"/>
+                            <span dir="rtl" t-field="o_sec.narration"/>
                         </div>
                     </div>
                 </p>
@@ -461,7 +461,7 @@
                             <span t-field="o.fiscal_position_id.note"/>
                         </div>
                         <div class="col-6 text-right">
-                            <span t-field="o_sec.fiscal_position_id.note"/>
+                            <span dir="rtl" t-field="o_sec.fiscal_position_id.note"/>
                         </div>
                     </div>
                 </p>


### PR DESCRIPTION
### Steps to reproduce:
- Install the 'l10n_sa' module and switch to a saudi company
- Install the Arabic language
- Go in Accounting > Customers > Invoices and create a new one
- Add an internal note with a list (using /)
- Add a translation in arabic with the "EN" button
- Click Preview
- The points of the list appear in the middle of the page

### Cause:
The lists are not adapted to be displayed from right to left.

### Solution:
Add the option `dir="rtl"` in the span of the Arabic text to make the lists appear the right way.

opw-4043175
