### PR TITLE
[IMP] todo: add deadlines to todo

### DIFF
--- a/addons/project/data/project_demo.xml
+++ b/addons/project/data/project_demo.xml
@@ -1244,6 +1244,7 @@ Send it ASAP, its urgent.</field>
             <field name="user_ids" eval="[Command.link(ref('base.user_admin')), Command.link(ref('base.user_demo'))]"/>
             <field name="project_id"/>
             <field name="name">Attend a project status meeting</field>
+            <field name="date_deadline" eval="(DateTime.today() + relativedelta(hours=5)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="description">Join the scheduled project status meeting to provide updates, discuss progress, and align with team members.</field>
             <field name="tag_ids" eval="[Command.set([ref('project_tags_15')])]"/>
         </record>
@@ -1251,6 +1252,7 @@ Send it ASAP, its urgent.</field>
             <field name="user_ids" eval="[Command.link(ref('base.user_admin'))]"/>
             <field name="project_id"/>
             <field name="name">Review and reply to emails</field>
+            <field name="date_deadline" eval="(DateTime.today() + relativedelta(hours=2)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="description">Spend time going through inbox, reviewing and replying to important emails to stay organized and maintain communication.</field>
             <field name="tag_ids" eval="[Command.set([ref('project_tags_10')])]"/>
         </record>
@@ -1260,6 +1262,7 @@ Send it ASAP, its urgent.</field>
             <field name="user_ids" eval="[Command.link(ref('base.user_admin')), Command.link(ref('base.user_demo'))]"/>
             <field name="project_id"/>
             <field name="name">Empty Trash Bins</field>
+            <field name="date_deadline" eval="(DateTime.today() + relativedelta(days=5)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="description">Take a few minutes to empty and replace the trash bins in the office. Keeping living space clean and odor-free.</field>
             <field name="tag_ids" eval="[Command.set([ref('project_tags_14')])]"/>
         </record>
@@ -1285,6 +1288,7 @@ Send it ASAP, its urgent.</field>
             <field name="user_ids" eval="[Command.link(ref('base.user_admin'))]"/>
             <field name="project_id"/>
             <field name="name">Research Investment Options</field>
+            <field name="date_deadline" eval="(DateTime.today() + relativedelta(days=60)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="description">Conduct thorough research on various investment options to make informed decisions about growing your financial portfolio.</field>
             <field name="tag_ids" eval="[Command.set([ref('project_tags_11')])]"/>
         </record>
@@ -1301,6 +1305,7 @@ Send it ASAP, its urgent.</field>
             <field name="user_ids" eval="[Command.link(ref('base.user_admin'))]"/>
             <field name="project_id"/>
             <field name="name">Attend a Local Event</field>
+            <field name="date_deadline" eval="(DateTime.today() - relativedelta(days=12)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="description">Participate in a local event to connect with the community</field>
             <field name="tag_ids" eval="[Command.set([ref('project_tags_12')])]"/>
         </record>

--- a/addons/project_todo/models/project_task.py
+++ b/addons/project_todo/models/project_task.py
@@ -66,5 +66,6 @@ class ProjectTask(models.Model):
             (self.env['ir.model.data']._xmlid_to_res_id("project_todo.project_task_view_todo_kanban"), "kanban"),
             (self.env['ir.model.data']._xmlid_to_res_id("project_todo.project_task_view_todo_tree"), "list"),
             (self.env['ir.model.data']._xmlid_to_res_id("project_todo.project_task_view_todo_form"), "form"),
+            (self.env['ir.model.data']._xmlid_to_res_id("project_todo.project_task_view_todo_calendar"), "calendar"),
             (self.env['ir.model.data']._xmlid_to_res_id("project_todo.project_task_view_todo_activity"), "activity"),
         ]

--- a/addons/project_todo/static/tests/mock_server/mock_models/project_task.js
+++ b/addons/project_todo/static/tests/mock_server/mock_models/project_task.js
@@ -6,6 +6,7 @@ export class ProjectTask extends projectModels.ProjectTask {
 
     company_id = fields.Many2one({ string: "Company", relation: "res.company" });
     tag_ids = fields.Many2many({ relation: "project.tags" });
+    date_deadline = fields.Datetime({ string: "Deadline" });
 
     _records = [
         {
@@ -13,6 +14,7 @@ export class ProjectTask extends projectModels.ProjectTask {
             name: "Todo 1",
             state: "01_in_progress",
             tag_ids: [1],
+            date_deadline: "2022-01-01 08:30:00",
         },
         {
             id: 2,
@@ -25,6 +27,7 @@ export class ProjectTask extends projectModels.ProjectTask {
             name: "Todo 3",
             state: "01_in_progress",
             tag_ids: [3, 2],
+            date_deadline: "2022-01-05 08:30:00",
         },
     ];
 }

--- a/addons/project_todo/static/tests/todo_calendar_view.test.js
+++ b/addons/project_todo/static/tests/todo_calendar_view.test.js
@@ -1,0 +1,54 @@
+import { expect, test, describe } from "@odoo/hoot";
+import { click, edit } from "@odoo/hoot-dom";
+import { contains, mountView, onRpc } from "@web/../tests/web_test_helpers";
+import { mockDate, animationFrame } from "@odoo/hoot-mock";
+
+import { defineTodoModels } from "./todo_test_helpers";
+import { ProjectTask } from "./mock_server/mock_models/project_task";
+
+describe.current.tags("desktop");
+defineTodoModels();
+
+test("test creation of todo from the calendar view", async () => {
+    mockDate("2022-01-03 12:00:00", +0);
+    onRpc("has_access", () => true);
+
+    ProjectTask._views = {
+        form: `
+            <form>
+                <field name="name"/>
+                <field name="date_deadline"/>
+            </form>
+        `,
+    };
+
+    await mountView({
+        resModel: "project.task",
+        type: "calendar",
+        arch: `
+            <calendar date_start="date_deadline" mode="month"
+                        js_class="project_task_calendar">
+                <field name="name"/>
+                <field name="priority" widget="priority"/>
+                <field name="tag_ids"/>
+            </calendar>
+        `,
+    });
+    expect(".fc-daygrid-event").toHaveCount(2, {
+        message: "The calendar view should have 2 todos with date_deadline set",
+    });
+
+    // click on today's cell to create a new todo
+    await contains(".fc-day-today").click();
+    await animationFrame();
+
+    expect(".o-calendar-quick-create").toBeVisible();
+    click("[name=title]");
+    edit("go running");
+    await contains(`.o-calendar-quick-create--create-btn`).click();
+    await animationFrame();
+
+    expect(".fc-daygrid-event").toHaveCount(3, {
+        message: "The calendar view should now have 3 todos with date_deadline set",
+    });
+});

--- a/addons/project_todo/views/project_task_views.xml
+++ b/addons/project_todo/views/project_task_views.xml
@@ -30,6 +30,7 @@
                         <t t-set="todoHasAssignees" t-value="record.user_ids.raw_value.length &gt; 1"/>
                         <div t-att-class="{'opacity-50': ['1_done', '1_canceled'].includes(record.state.raw_value)}">
                             <field name="name" class="fw-bolder fs-5" widget="name_with_subtask_count"/>
+                            <field t-if="record.date_deadline.raw_value" name="date_deadline" widget="remaining_days"/>
                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                             <field t-if="record.displayed_image_id.value" name="displayed_image_id" widget="attachment_image"/>
                         </div>
@@ -66,9 +67,10 @@
                 <field name="state" widget="todo_done_checkmark" nolabel="1"/>
                 <field name="name"/>
                 <field name="user_ids" optional="show" required="1" widget="many2many_avatar_user" options="{'no_quick_create': True}"/>
+                <field name="date_deadline" optional="show" widget="remaining_days"/>
+                <field name="activity_ids" optional="show" widget="list_activity"/>
                 <field name="tag_ids" optional="show" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
                 <field name="personal_stage_type_id" string="Stage" optional="hide"/>
-                <field name="activity_ids" optional="show" widget="list_activity"/>
             </list>
         </field>
     </record>
@@ -110,6 +112,10 @@
                                 placeholder="Assignees"/>
                         </group>
                         <group>
+                            <field name="date_deadline"
+                                decoration-danger="date_deadline &lt; current_date"/>
+                        </group>
+                        <group>
                             <field name="tag_ids"
                                 widget="many2many_tags"
                                 options="{'color_field': 'color', 'no_create_edit': True}"
@@ -133,6 +139,7 @@
             <form class="o_form_project_tasks">
                 <group>
                     <field name="name" string="To-do Title" placeholder="e.g. Send Invitations"/>
+                    <field name="date_deadline" decoration-danger="date_deadline &lt; current_date"/>
                 </group>
             </form>
         </field>
@@ -170,6 +177,24 @@
                     <button string="Discard" special="cancel"/>
                 </footer>
             </form>
+        </field>
+    </record>
+
+    <!-- Todo Calendar View -->
+    <record id="project_task_view_todo_calendar" model="ir.ui.view">
+        <field name="name">project.task.calendar</field>
+        <field name="model">project.task</field>
+        <field name="arch" type="xml">
+            <calendar string="To-dos"
+                      date_start="date_deadline" mode="month"
+                      color="personal_stage_type_id" hide_time="true"
+                      event_open_popup="true" quick_create="1" show_unusual_days="True"
+                      scales="day,week,month,year">
+                <field name="name"/>
+                <field name="priority" widget="priority"/>
+                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" invisible="not tag_ids"/>
+                <field name="personal_stage_id" string="Personal Stage" options="{'no_open': True}" invisible="not personal_stage_id"/>
+            </calendar>
         </field>
     </record>
 
@@ -212,6 +237,8 @@
                 <filter name="closed_tasks" string="Closed" domain="[('is_closed', '=', True)]"/>
                 <filter string="Closed On" name="closed_on" domain="[('is_closed', '=', True)]" date="date_last_stage_update"/>
                 <separator/>
+                <filter name="date_deadline" string="Deadline" domain="[('date_deadline', '!=', False)]" date="date_deadline"/>
+                <separator/>
                 <filter name="active_false" string="Archived" domain="[('active', '=', False)]"/>
                 <filter invisible="1" string="Late Activities" name="activities_overdue"
                         domain="[('my_activity_date_deadline', '&lt;', context_today().strftime('%Y-%m-%d'))]"
@@ -224,6 +251,7 @@
                     <filter string="Tags" name="tags" help="By assigned tags" context="{'group_by':'tag_ids'}"/>
                     <filter string="Assignees" name="user_ids" context="{'group_by': 'user_ids'}"/>
                     <filter string="Stage" name="stage" help="By personal stages" context="{'group_by':'personal_stage_type_id'}"/>
+                    <filter string="Deadline" name="deadline" context="{'group_by': 'date_deadline'}"/>
                 </group>
             </search>
         </field>
@@ -234,7 +262,7 @@
         <field name="name">To-dos</field>
         <field name="res_model">project.task</field>
         <field name="domain">[('user_ids', 'in', [uid]), ('project_id', '=', False), ('parent_id', '=', False)]</field>
-        <field name="view_mode">kanban,form,list,activity</field>
+        <field name="view_mode">kanban,form,list,calendar,activity</field>
         <field name="search_view_id" ref="project_task_view_todo_search"/>
         <field name="context">{'search_default_open_tasks': 1, 'list_view_ref': 'project_todo.project_task_view_todo_tree', 'default_project_id': False}</field>
         <field name="help" type="html">
@@ -262,6 +290,12 @@
     <record model="ir.actions.act_window.view" id="project_task_action_todo_tree_view">
         <field name="view_mode">list</field>
         <field name="view_id" ref="project_task_view_todo_tree"/>
+        <field name="act_window_id" ref="project_task_action_todo"/>
+    </record>
+
+    <record model="ir.actions.act_window.view" id="project_task_action_todo_calendar_view">
+        <field name="view_mode">calendar</field>
+        <field name="view_id" ref="project_task_view_todo_calendar"/>
         <field name="act_window_id" ref="project_task_action_todo"/>
     </record>
 


### PR DESCRIPTION
Prior to this commit, the todo module did not have deadline field enabled. This commit aims to add this field to the todos on the creation form, kanban card view, and list view. Additionally, a Calendar view is added for visualizing tasks with deadlines defined.

Tests are added to ensure the creation of a todo with deadline defined, as well as checking the list and form view of the todo with the deadline.

task: 3940457

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
