### PR TITLE
[FIX] base: set current company display currency if not it available in record

### DIFF
--- a/odoo/addons/base/models/ir_qweb_fields.py
+++ b/odoo/addons/base/models/ir_qweb_fields.py
@@ -509,7 +509,7 @@ class MonetaryConverter(models.AbstractModel):
             fields = record._fields.items()
             currency_fields = [k for k, v in fields if v.type == 'many2one' and v.comodel_name == 'res.currency']
             if currency_fields:
-                options['display_currency'] = record[currency_fields[0]]
+                options['display_currency'] = record[currency_fields[0]] or self.env.company.currency_id
         if 'date' not in options:
             options['date'] = record._context.get('date')
         if 'company_id' not in options:


### PR DESCRIPTION
Currently, an exception is generated when the user tries to save the "statement" report in Studio.

Steps to produce an error:
- Create DB without a demo and install 'web_studio' and 'account_reports' 
- Open Accounting and click on studio icon 
- Click Reports > Remove values from searchbar > Open "STATEMENT" report
- edit anything > Click on save >>> Error generated

This is because line [1] tries to get the display currency from the record (which is the "currency_id" field), but since without demo we do not have any record in account statement, it tries to get value from 'NewId' and no value is available in field 'currency_id'.

This commit will fix the above issue by setting the current company currency as display currency if not currency available in record.

[1] - https://github.com/odoo/odoo/blob/d1f20d6b71203e6bb4b428ae1bcbb0b76e739f51/odoo/addons/base/models/ir_qweb_fields.py#L512

sentry-5639835599
