### PR TITLE
[IMP] calendar: consistent deletion handling for recurring events

### DIFF
--- a/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_controller.js
+++ b/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_controller.js
@@ -128,7 +128,7 @@ export class AttendeeCalendarController extends CalendarController {
             },
             {
                 onClose: () => {
-                    location.reload();
+                    this.model.load();
                 },
             }
         );

--- a/addons/calendar/static/src/views/list_view/calendar_list_controller.js
+++ b/addons/calendar/static/src/views/list_view/calendar_list_controller.js
@@ -1,0 +1,30 @@
+/** @odoo-module **/
+
+import { useService } from "@web/core/utils/hooks";
+import { ListController } from "@web/views/list/list_controller";
+import { useAskRecurrenceUpdatePolicy } from "@calendar/views/ask_recurrence_update_policy_hook";
+
+export class CaledarListController extends ListController {
+    setup() {
+        super.setup();
+        this.orm = useService("orm");
+        this.askRecurrenceUpdatePolicy = useAskRecurrenceUpdatePolicy();
+    }
+
+    /**
+     * Deletes selected records with handling for recurring events.
+     */
+    async onDeleteSelectedRecords() {
+        const selectedRecords = this.model.root.selection;
+        let recurrenceUpdate = false;
+        if (selectedRecords.length == 1 && selectedRecords[0]?.data.recurrency) {
+            recurrenceUpdate = await this.askRecurrenceUpdatePolicy();
+            if (recurrenceUpdate) {
+                await this.orm.call(this.model.root.resModel, "action_mass_archive", [[selectedRecords[0]?.resId], recurrenceUpdate]);
+                this.model.load();
+            }
+        } else {
+            super.onDeleteSelectedRecords(...arguments);
+        }
+    }
+}

--- a/addons/calendar/static/src/views/list_view/calendar_list_view.js
+++ b/addons/calendar/static/src/views/list_view/calendar_list_view.js
@@ -1,6 +1,7 @@
 import { listView } from "@web/views/list/list_view";
 import { registry } from "@web/core/registry";
 import { user } from "@web/core/user";
+import { CaledarListController } from "./calendar_list_controller";
 
 export class CalendarListModel extends listView.Model {
     setup(params, { action, dialog, notification, rpc, user, view, company }) {
@@ -31,6 +32,7 @@ export class CalendarListModel extends listView.Model {
 export const CalendarListView = {
     ...listView,
     Model: CalendarListModel,
+    Controller: CaledarListController,
 };
 
 function _mockGetCalendarPartnerIds(params) {


### PR DESCRIPTION
Before this commit, deleting recurring events from the calendar view would display a dialog with options on how to handle the deletion of recurring events. However, this behavior was inconsistent in the form view and the list view, where deleting a recurring event would simply delete the event without showing any dialog.

This commit ensures consistent behavior across the calendar, form, and list views by adding a recurring event deletion dialog in both the form and list views. This dialog provides options for how users want to handle the deletion of recurring events, matching the functionality in the calendar view.

task-4063288
