### PR TITLE
[PERF] pos_loyalty: optimize product addition to orders

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/loyalty.js
+++ b/addons/pos_loyalty/static/src/overrides/models/loyalty.js
@@ -660,8 +660,7 @@ patch(Order.prototype, {
         }
 
         // Check if the reward line is part of the rule
-        const valid_product_ids = rule.valid_product_ids.map((p) => p.id);
-        if (!(rule.any_product || valid_product_ids.includes(line.reward_product_id))) {
+        if (!(rule.any_product || rule.validProductIds.has(line.reward_product_id))) {
             return false;
         }
 
@@ -772,10 +771,7 @@ patch(Order.prototype, {
                 }
                 for (const rule of program.rule_ids) {
                     // Skip lines to which the rule doesn't apply.
-                    if (
-                        rule.any_product ||
-                        rule.valid_product_ids.find((p) => p.id === line.product.id)
-                    ) {
+                    if (rule.any_product || rule.validProductIds.has(line.product.id)) {
                         if (!linesPerRule[rule.id]) {
                             linesPerRule[rule.id] = [];
                         }
@@ -814,14 +810,12 @@ patch(Order.prototype, {
                 const qtyPerProduct = {};
                 let orderedProductPaid = 0;
                 for (const line of orderLines) {
-                    const valid_product_ids = rule.valid_product_ids.map((p) => p.id);
-
                     if (
                         ((!line.reward_product_id &&
-                            (rule.any_product || valid_product_ids.includes(line.product.id))) ||
+                            (rule.any_product || rule.validProductIds.has(line.product.id))) ||
                             (line.reward_product_id &&
                                 (rule.any_product ||
-                                    valid_product_ids.includes(line.reward_product_id)))) &&
+                                    rule.validProductIds.has(line.reward_product_id)))) &&
                         !line.ignoreLoyaltyPoints({ program })
                     ) {
                         if (line.is_reward_line) {
@@ -872,10 +866,9 @@ patch(Order.prototype, {
                         );
                     } else if (rule.reward_point_mode === "money") {
                         for (const line of orderLines) {
-                            const valid_product_ids = rule.valid_product_ids.map((p) => p.id);
                             if (
                                 line.is_reward_line ||
-                                !valid_product_ids.includes(line.product.id) ||
+                                !rule.validProductIds.has(line.product.id) ||
                                 line.get_quantity() <= 0 ||
                                 line.ignoreLoyaltyPoints({ program })
                             ) {
@@ -942,7 +935,7 @@ patch(Order.prototype, {
     _computeNItems(rule) {
         return this._get_regular_order_lines().reduce((nItems, line) => {
             let increment = 0;
-            if (rule.any_product || rule.valid_product_ids.find((p) => p.id === line.product.id)) {
+            if (rule.any_product || rule.validProductIds.has(line.product.id)) {
                 increment = line.get_quantity();
             }
             return nItems + increment;
@@ -1396,8 +1389,7 @@ patch(Order.prototype, {
     _isRewardProductPartOfRules(reward, product) {
         return (
             reward.program_id.rule_ids.filter(
-                (rule) =>
-                    rule.any_product || rule.valid_product_ids.find((p) => p.id === product.id)
+                (rule) => rule.any_product || rule.validProductIds.has(product.id)
             ).length > 0
         );
     },
@@ -1451,10 +1443,7 @@ patch(Order.prototype, {
                 let factor = 0;
                 let orderPoints = 0;
                 for (const rule of appliedRules) {
-                    if (
-                        rule.any_product ||
-                        rule.valid_product_ids.find((p) => p.id === product.id)
-                    ) {
+                    if (rule.any_product || rule.validProductIds.has(product.id)) {
                         if (rule.reward_point_mode === "order") {
                             orderPoints += rule.reward_point_amount;
                         } else if (rule.reward_point_mode === "money") {

--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -225,12 +225,15 @@ patch(PosStore.prototype, {
         this.partnerId2CouponIds = {};
 
         for (const reward of this.models["loyalty.reward"].getAll()) {
-            reward.all_discount_product_ids = new Set(reward.all_discount_product_ids);
+            reward.all_discount_product_ids = new Set(reward.raw.all_discount_product_ids);
         }
 
-        for (const reward of this.models["loyalty.reward"].getAll()) {
-            this.compute_discount_product_ids(reward, this.models["product.product"].getAll());
-        }
+        this.computeDiscountProductIdsForAllRewards(this.models["product.product"].getAll());
+
+        this.models["product.product"].addEventListener(
+            "create",
+            this.computeDiscountProductIdsForAllRewards.bind(this)
+        );
 
         for (const program of this.models["loyalty.program"].getAll()) {
             if (program.date_to) {
@@ -239,6 +242,16 @@ patch(PosStore.prototype, {
             if (program.date_from) {
                 program.date_from = DateTime.fromISO(program.date_from);
             }
+        }
+
+        for (const rule of this.models["loyalty.rule"].getAll()) {
+            rule.validProductIds = new Set(rule.raw.valid_product_ids);
+        }
+    },
+
+    computeDiscountProductIdsForAllRewards(products) {
+        for (const reward of this.models["loyalty.reward"].getAll()) {
+            this.compute_discount_product_ids(reward, products);
         }
     },
 

--- a/addons/pos_loyalty/static/tests/unit/utils.js
+++ b/addons/pos_loyalty/static/tests/unit/utils.js
@@ -8,6 +8,7 @@ patch(MockPosData.prototype, {
         const data = super.data;
         data.models["loyalty.reward"] = { fields: {}, records: [] };
         data.models["loyalty.program"] = { fields: {}, records: [] };
+        data.models["loyalty.rule"] = { fields: {}, records: [] };
         return data;
     },
 });


### PR DESCRIPTION
Before this commit, adding products to an order in databases with a large number of products in `valid_product_ids` could take several seconds. This fix addresses the issue by utilizing a set to store the IDs, significantly speeding up the search process.

opw-4075527

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
