### PR TITLE
[FIX] account: hide Upload button in journal entries

### DIFF
--- a/addons/account/static/src/components/bills_upload/bills_upload.js
+++ b/addons/account/static/src/components/bills_upload/bills_upload.js
@@ -139,6 +139,7 @@ export class AccountMoveListController extends ListController {
     setup() {
         super.setup();
         this.account_move_service = useService("account_move");
+        this.showUploadButton = this.props.context.default_move_type !== 'entry' || 'active_id' in this.props.context;
     }
 
     async onDeleteSelectedRecords() {
@@ -174,7 +175,12 @@ AccountMoveUploadKanbanRenderer.components = {
     AccountDropZone,
 };
 
-export class AccountMoveUploadKanbanController extends KanbanController {}
+export class AccountMoveUploadKanbanController extends KanbanController {
+    setup() {
+        super.setup();
+        this.showUploadButton = this.props.context.default_move_type !== 'entry' || 'active_id' in this.props.context;
+    }
+}
 AccountMoveUploadKanbanController.components = {
     ...KanbanController.components,
     AccountFileUploader,

--- a/addons/account/static/src/components/bills_upload/bills_upload.xml
+++ b/addons/account/static/src/components/bills_upload/bills_upload.xml
@@ -52,13 +52,13 @@
 
     <t t-name="account.ListView.Buttons" t-inherit="web.ListView.Buttons" t-inherit-mode="primary">
         <xpath expr="//div[hasclass('o_list_buttons')]" position="inside">
-            <t t-call="account.AccountViewUploadButton"/>
+            <t t-if="showUploadButton" t-call="account.AccountViewUploadButton"/>
         </xpath>
     </t>
 
     <t t-name="account.KanbanView.Buttons" t-inherit="web.KanbanView.Buttons" t-inherit-mode="primary">
         <xpath expr="//div[hasclass('o_cp_buttons')]" position="inside">
-            <t t-call="account.AccountViewUploadButton"/>
+            <t t-if="showUploadButton" t-call="account.AccountViewUploadButton"/>
         </xpath>
     </t>
 


### PR DESCRIPTION
To replicate the issue:
1. Go to Accounting app
2. Click on the Accounting menu => Journal Entries
3. Click the button Upload
4. After selecting a file, an error is raise, saying that "The journal in which to upload the invoice is not specified."

Cause:
In the view for Journal Entries, there isn't a particular journal associated with it, so there is no definition the journal in which the document should be uploaded. Before 17.0, the document was uploaded to a default journal. Without a default journal, the error is raised. This renders the button useless in this view, as it will always raise an error after the user has selected a file to upload.

Fix:
The button should not be shown in the Journal Entries view (through Accounting => Journal Entries). But if the user is in a specific journal (for example, navigating from Accounting Dashboard => Miscellaneous Operations), the button should be shown.

To do so, the account move list and kanban controllers in bills_upload check if the default move type is 'entry', and if so, whether there is an active id in the context. This allows differentiating between the specific journals or the general Journal Entries view.

opw-4029227
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
