### PR TITLE
[FIX] account: Avoid null in account payment method

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -375,8 +375,6 @@ class AccountPayment(models.Model):
                 pay.payment_method_id = pay.payment_method_id
             elif available_payment_methods:
                 pay.payment_method_id = available_payment_methods[0]._origin
-            else:
-                pay.payment_method_id = False
 
     @api.depends('payment_type',
                  'journal_id.inbound_payment_method_ids',


### PR DESCRIPTION
The compute of `account_payment.payment_method_id` sets the value to False when the linked journal has no inbound/outbound payment methods: https://github.com/odoo/odoo/blob/14.0/addons/account/models/account_payment.py#L363

This causes the check here to fail:
https://github.com/odoo/odoo/blob/14.0/addons/account/models/account_payment.py#L571

In 13.0, the field was required, but not a computed one. What happens is that before upgrading, the `account_payment` would have a `payment_method_id` that isn't in the linked journal. When upgrading to 14.0 the introduced compute method would nullify the field, causing the error.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
