### PR TITLE
[FIX] l10n_fr_fec: export fec with sub companies

### DIFF
--- a/addons/l10n_fr_fec/tests/test_wizard.py
+++ b/addons/l10n_fr_fec/tests/test_wizard.py
@@ -113,3 +113,63 @@ class TestAccountFrFec(AccountTestInvoicingCommon):
         self.wizard.generate_fec()
         content = base64.b64decode(self.wizard.fec_data).decode()
         self.assertEqual(self.expected_report, content)
+
+    def test_fec_sub_companies(self):
+        """When exporting FEC, data from child companies should be included"""
+        main_company = self.env.company
+        branch_a, branch_b = self.env['res.company'].create([
+            {
+                'name': 'Branch A',
+                'country_id': main_company.country_id.id,
+                'parent_id': main_company.id,
+            }, {
+                'name': 'Branch B',
+                'country_id': main_company.country_id.id,
+                'parent_id': main_company.id
+            }
+        ])
+        branch_a1 = self.env['res.company'].create({
+            'name': 'Branch A1',
+            'country_id': main_company.country_id.id,
+            'parent_id': branch_a.id,
+        })
+
+        self.cr.precommit.run()  # load the COA
+        all_companies = (main_company + branch_a + branch_a1 + branch_b)
+
+        for i, company in enumerate(all_companies, start=1):
+            self.init_invoice('out_invoice', invoice_date=self.today, post=True, amounts=[i * 100], company=company)
+
+        self.env.flush_all()
+
+        expected_content = self.expected_report + (
+            "\r\n"
+            "INV|Customer Invoices|INV/2021/00002|20210502|707100|Goods for resale (or group) A|||-|20210502|test line|0,00| 000000000000100,00|||20210502|-000000000000100,00|EUR\r\n"
+            f"INV|Customer Invoices|INV/2021/00002|20210502|411100|Customers - Sales of goods or services|{self.partner_a.id}|partner_a|-|20210502|INV/2021/00002| 000000000000100,00|0,00|||20210502| 000000000000100,00|EUR\r\n"
+            "INV|Customer Invoices|INV/2021/00003|20210502|707100|Goods for resale (or group) A|||-|20210502|test line|0,00| 000000000000200,00|||20210502|-000000000000200,00|EUR\r\n"
+            f"INV|Customer Invoices|INV/2021/00003|20210502|411100|Customers - Sales of goods or services|{self.partner_a.id}|partner_a|-|20210502|INV/2021/00003| 000000000000200,00|0,00|||20210502| 000000000000200,00|EUR\r\n"
+            "INV|Customer Invoices|INV/2021/00004|20210502|707100|Goods for resale (or group) A|||-|20210502|test line|0,00| 000000000000300,00|||20210502|-000000000000300,00|EUR\r\n"
+            f"INV|Customer Invoices|INV/2021/00004|20210502|411100|Customers - Sales of goods or services|{self.partner_a.id}|partner_a|-|20210502|INV/2021/00004| 000000000000300,00|0,00|||20210502| 000000000000300,00|EUR\r\n"
+            "INV|Customer Invoices|INV/2021/00005|20210502|707100|Goods for resale (or group) A|||-|20210502|test line|0,00| 000000000000400,00|||20210502|-000000000000400,00|EUR\r\n"
+            f"INV|Customer Invoices|INV/2021/00005|20210502|411100|Customers - Sales of goods or services|{self.partner_a.id}|partner_a|-|20210502|INV/2021/00005| 000000000000400,00|0,00|||20210502| 000000000000400,00|EUR"
+        )
+
+        self.wizard.generate_fec()
+        content = base64.b64decode(self.wizard.fec_data).decode()
+        self.assertEqual(expected_content, content)
+
+        # Select only parent company
+        self.env.user.write({
+            'company_ids': [Command.set(main_company.ids)],
+            'company_id': main_company.id,
+        })
+
+        expected_content = self.expected_report + (
+            "\r\n"
+            "INV|Customer Invoices|INV/2021/00002|20210502|707100|Goods for resale (or group) A|||-|20210502|test line|0,00| 000000000000100,00|||20210502|-000000000000100,00|EUR\r\n"
+            f"INV|Customer Invoices|INV/2021/00002|20210502|411100|Customers - Sales of goods or services|{self.partner_a.id}|partner_a|-|20210502|INV/2021/00002| 000000000000100,00|0,00|||20210502| 000000000000100,00|EUR"
+        )
+
+        self.wizard.generate_fec()
+        content = base64.b64decode(self.wizard.fec_data).decode()
+        self.assertEqual(expected_content, content)

--- a/addons/l10n_fr_fec/wizard/account_fr_fec.py
+++ b/addons/l10n_fr_fec/wizard/account_fr_fec.py
@@ -34,8 +34,9 @@ class AccountFrFec(models.TransientModel):
             self.export_type = 'official'
 
     def _get_where_query(self):
-        where_params = {'company_id': self.env.company.id}
-        where_query = "am.company_id = %(company_id)s\n"
+        accessible_branches = self.env.company._accessible_branches()
+        where_params = {'company_ids': tuple(accessible_branches.ids)}
+        where_query = "am.company_id IN %(company_ids)s\n"
         # For official report: only use posted entries
         if self.export_type == "official":
             where_query += "AND am.state = 'posted'\n"


### PR DESCRIPTION
When exporting fec file, data from child companies
should be included in the file.

opw-4014583
