### PR TITLE
[FIX] sale_project : Create AA when adding service product

### DIFF
--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -170,10 +170,17 @@ class SaleOrderLine(models.Model):
 
     def _timesheet_create_project_prepare_values(self):
         """Generate project values"""
+        account = self.order_id.analytic_account_id
+        if not account:
+            service_products = self.order_id.order_line.product_id.filtered(
+                lambda p: p.type == 'service' and p.default_code)
+            default_code = service_products.default_code if len(service_products) == 1 else None
+            self.order_id._create_analytic_account(prefix=default_code)
+            account = self.order_id.analytic_account_id
         # create the project or duplicate one
         return {
             'name': '%s - %s' % (self.order_id.client_order_ref, self.order_id.name) if self.order_id.client_order_ref else self.order_id.name,
-            'analytic_account_id': self.order_id.analytic_account_id.id,
+            'analytic_account_id': account.id,
             'partner_id': self.order_id.partner_id.id,
             'sale_line_id': self.id,
             'active': True,

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -810,3 +810,26 @@ class TestSaleProject(TestSaleProjectCommon):
         })
         action = sale_order_2.action_view_task()
         self.assertEqual(action["context"]["default_project_id"], self.project_global.id)
+
+    def test_creating_AA_when_adding_service_to_confirmed_so(self):
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'partner_invoice_id': self.partner.id,
+            'partner_shipping_id': self.partner.id,
+        })
+
+        self.env['sale.order.line'].create({
+            'product_id': self.product_a.id,
+            'product_uom_qty': 1,
+            'order_id': sale_order.id,
+        })
+
+        sale_order.action_confirm()
+
+        self.env['sale.order.line'].create({
+            'product_id': self.product_order_service4.id,
+            'product_uom_qty': 1,
+            'order_id': sale_order.id,
+        })
+
+        self.assertTrue(sale_order.analytic_account_id)


### PR DESCRIPTION
### Steps to reproduce:
	- Install Sale and Project modules
	- Create a Service product that creates a project when ordered
	- Create a SO with a non-service product and confirm it
	- Add a SOL with a service product
	- Navigate to the created project settings and check AA

### Current behavior before PR:
No AA is generated for the project when adding a SOL with a service product to a confirmed SO. This issue has been introduced after this commit https://github.com/odoo/odoo/pull/154934/commits/ffb3fe1b81a41b6462fd6eaae837f8e806da0d51 as it is now generating AA only when we confirm the SO 'action_confirm' so if you are confirming the SO with no service products it won't generate an AA so self.order_id.analytic_account_id will be false and when add a service product and preparing the values to create its project
https://github.com/odoo/odoo/blob/saas-17.2/addons/sale_project/models/sale_order_line.py#L176 there will be no AA in SO

### Desired behavior after PR is merged:
with reverting this diff https://github.com/odoo/odoo/pull/154934/commits/ffb3fe1b81a41b6462fd6eaae837f8e806da0d51#diff-54515e6934b8a75befb26b76cc09b04f898281f6fcfc3f32ac4b1afdd17004b2 we are no checking before creating the project if we have a service product in the SO and there is not AA already generated we will create it before creating the project.

opw-4045976