### PR TITLE
[FIX] web: added `fullscreen` in size props of `Dialog` component

### DIFF
--- a/addons/web/static/src/core/dialog/dialog.js
+++ b/addons/web/static/src/core/dialog/dialog.js
@@ -34,7 +34,7 @@ Dialog.props = {
     fullscreen: { type: Boolean, optional: true },
     footer: { type: Boolean, optional: true },
     header: { type: Boolean, optional: true },
-    size: { type: String, optional: true, validate: (s) => ["sm", "md", "lg", "xl"].includes(s) },
+    size: { type: String, optional: true, validate: (s) => ["sm", "md", "lg", "xl", "fullscreen"].includes(s) },
     technical: { type: Boolean, optional: true },
     title: { type: String, optional: true },
     modalRef: { type: Function, optional: true },


### PR DESCRIPTION
Previously, setting the `size` prop to `fullscreen` in the `Dialog` component caused an error in debug mode, as the `fullscreen` utility class from Bootstrap was not included in the props.

This commit resolves the issue by allowing the `fullscreen` option in the `size` props, ensuring compatibility with Bootstrap's utility classes.

