### PR TITLE
[FIX] mrp_account: no currency in work center analytic account

### DIFF
--- a/addons/mrp_account/models/mrp_workorder.py
+++ b/addons/mrp_account/models/mrp_workorder.py
@@ -61,7 +61,8 @@ class MrpWorkorder(models.Model):
                     wo_to_link_mo_analytic_line += wo
                     mo_analytic_line_vals_list.append(wo._prepare_analytic_line_values(mo_account, hours, value))
             if wc_account and wc_account != mo_account:
-                is_zero = float_is_zero(value, precision_rounding=wc_account.currency_id.rounding)
+                wc_currency = wc_account.currency_id or wo.company_id.currency_id
+                is_zero = float_is_zero(value, precision_rounding=wc_currency.rounding)
                 if wo.wc_analytic_account_line_id:
                     wo.wc_analytic_account_line_id.write({
                         'unit_amount': hours,


### PR DESCRIPTION
Problem: If there is no company set on the analytic account for a work center, then an error occurs when adding a work order with that work center to a manufacturing order. The error occurs because there is no company assigned to the analytic account, so there is no currency set.

Purpose: Should be able to add a work order to a manufacturing order when the analytic account associated with the work center doesn't have an associated company.

Steps to Reproduce on Runbot:

1. Create a new analytic account and remove the company
2. Navigate to a work center and set the analytic account from the previous step
3. Create a manufacturing order
4. Add a work order with the work center from the previous step and save

opw-4036375

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
