### PR TITLE
[FIX] im_livechat: Fix error when opening Messages systray menu

### DIFF
--- a/addons/im_livechat/models/mail_message.py
+++ b/addons/im_livechat/models/mail_message.py
@@ -29,8 +29,9 @@ class MailMessage(models.Model):
                         'id': message_sudo.author_id.id,
                         'user_livechat_username': message_sudo.author_id.user_livechat_username,
                     }
+                # sudo: chatbot.script.step - members of a channel can access the current chatbot step
                 if mail_channel.chatbot_current_step_id \
-                        and message_sudo.author_id == mail_channel.chatbot_current_step_id.chatbot_script_id.operator_partner_id:
+                        and message_sudo.author_id == mail_channel.chatbot_current_step_id.sudo().chatbot_script_id.operator_partner_id:
                     chatbot_message_id = self.env['chatbot.message'].sudo().search([
                         ('mail_message_id', '=', message_sudo.id)], limit=1)
                     if chatbot_message_id.script_step_id:

--- a/addons/im_livechat/tests/chatbot_common.py
+++ b/addons/im_livechat/tests/chatbot_common.py
@@ -140,6 +140,6 @@ class ChatbotCase(common.TransactionCase):
             cls.env['chatbot.message'].search([
                 ('mail_message_id', '=', mail_message.id)
             ], limit=1).user_script_answer_id = chatbot_script_answer.id
-
-        next_step = mail_channel.chatbot_current_step_id._process_answer(mail_channel, mail_message.body)
+        # sudo: chatbot.script.step - members of a channel can access the current chatbot step
+        next_step = mail_channel.chatbot_current_step_id.sudo()._process_answer(mail_channel, mail_message.body)
         next_step._process_step(mail_channel)

--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -2,11 +2,12 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import Command
-from odoo.tests.common import users, tagged, TransactionCase
+from odoo.tests.common import users, tagged
+from odoo.addons.im_livechat.tests.chatbot_common import ChatbotCase
 
 
 @tagged('post_install', '-at_install')
-class TestImLivechatMessage(TransactionCase):
+class TestImLivechatMessage(ChatbotCase):
     def setUp(self):
         super().setUp()
         self.users = self.env['res.users'].create([
@@ -21,6 +22,55 @@ class TestImLivechatMessage(TransactionCase):
             },
             {'name': 'test1', 'login': 'test1', 'email': 'test1@example.com'},
         ])
+
+    @users('emp')
+    def test_chatbot_message_format(self):
+        user = self.env.user
+        channel_info = self.livechat_channel.with_user(user)._open_livechat_mail_channel(
+            anonymous_name='Test Chatbot',
+            previous_operator_id=self.chatbot_script.operator_partner_id.id,
+            chatbot_script=self.chatbot_script,
+            user_id=user.id
+        )
+        mail_channel = self.env['mail.channel'].browse(channel_info['id'])
+        self._post_answer_and_trigger_next_step(
+            mail_channel,
+            self.step_dispatch_buy_software.name,
+            chatbot_script_answer=self.step_dispatch_buy_software
+        )
+        chatbot_message = mail_channel.chatbot_message_ids.mail_message_id[-1:]
+        self.assertEqual(chatbot_message.message_format(), [{
+            'id': chatbot_message.id,
+            'body': '<p>Can you give us your email please?</p>',
+            'date': chatbot_message.date,
+            'message_type': 'comment',
+            'subtype_id': (self.env.ref('mail.mt_comment').id, 'Discussions'),
+            'subject': False,
+            'model': 'mail.channel',
+            'res_id': mail_channel.id,
+            'record_name': 'Testing Bot',
+            'starred_partner_ids': [],
+            'author': {
+                'id': self.chatbot_script.operator_partner_id.id,
+                'name': 'Testing Bot'
+            },
+            'guestAuthor': [('clear',)],
+            'notifications': [],
+            'attachment_ids': [],
+            'trackingValues': [],
+            'linkPreviews': [],
+            'messageReactionGroups': [],
+            'chatbot_script_step_id': self.step_email.id,
+            'needaction_partner_ids': [],
+            'history_partner_ids': [],
+            'is_note': False,
+            'is_discussion': True,
+            'subtype_description': False,
+            'is_notification': False,
+            'recipients': [],
+            'module_icon': '/mail/static/description/icon.png',
+            'sms_ids': []
+        }])
 
     @users('emp')
     def test_message_format(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- After an internal user (without Live Chat application access) interacted with chatbot from website, he will not be able to click on the Messages icon on the top-right menu anymore:
![image](https://github.com/user-attachments/assets/a8b96c5f-b409-4a35-8c79-90f7cf97b09c)
- Cause: Internal user without Live Chat application access cannot read on model `chatbot.script.step`, so when system calls `mail_channel.chatbot_current_step_id`, security error occurs.
- Solution: Use `sudo` on `mail_channel` variable to avoid security error.

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
