### PR TITLE
[IMP] stock, *: simplify kanban archs

### DIFF
--- a/addons/product_expiry/views/production_lot_views.xml
+++ b/addons/product_expiry/views/production_lot_views.xml
@@ -58,14 +58,15 @@
         <field name="model">stock.lot</field>
         <field name="inherit_id" ref="stock.view_production_lot_kanban"/>
         <field name="arch" type="xml">
-            <xpath expr="//strong[hasclass('o_kanban_record_title')]" position="after">
-                <field name="product_qty" invisible="1"/>
-                <field name="product_expiry_alert" invisible="1"/>
-                <field name="expiration_date" invisible="1"/>
+            <xpath expr="//templates" position="before">
+                <field name="product_qty"/>
+                <field name="product_expiry_alert"/>
+            </xpath>
+            <xpath expr="//field[@name='name']" position="after">
                 <span title="Alert" class="fa fa-exclamation-triangle text-danger ms-2" invisible="product_qty &lt;= 0 or not product_expiry_alert or not expiration_date"/>
                 <field name="alert_date" widget='remaining_days' class="ms-2"/>
             </xpath>
-            <xpath expr="//div[@name='product_name']" position="after">
+            <xpath expr="//field[@name='product_id']" position="after">
                 <div invisible="not expiration_date">
                     <div>
                         <label for="expiration_date">Expiration: </label>

--- a/addons/stock/views/stock_lot_views.xml
+++ b/addons/stock/views/stock_lot_views.xml
@@ -83,29 +83,12 @@
         <field name="model">stock.lot</field>
         <field name="arch" type="xml">
             <kanban group_create="false" group_delete="false">
-                <field name="name"/>
-                <field name="ref"/>
-                <field name="product_id"/>
-                <field name="create_date"/>
-                <field name="company_id" groups="base.group_multi_company"/>
-                <field name="last_delivery_partner_id"/>
-                <field name="lot_properties"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div class="oe_kanban_global_click">
-                            <div class="oe_kanban_details">
-                                <strong class="o_kanban_record_title">
-                                    <field name="name"/>
-                                </strong>
-                                <div name="product_name">
-                                    <small><field name="product_id"/></small>
-                                </div>
-                                <div>
-                                    <field name="lot_properties" widget="properties"/>
-                                </div>
-                            </div>
-                            <field name="activity_ids" widget="kanban_activity"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="name" class="fw-bolder fs-5"/>
+                        <field name="product_id" class="small"/>
+                        <field name="lot_properties" widget="properties"/>
+                        <field name="activity_ids" widget="kanban_activity"/>
                     </t>
                 </templates>
             </kanban>

--- a/addons/stock/views/stock_move_line_views.xml
+++ b/addons/stock/views/stock_move_line_views.xml
@@ -165,39 +165,28 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_card oe_kanban_global_click">
-                            <field name="picking_id" invisible="1"/>
-                            <div class="row">
-                                <div class="col-6">
-                                    <field name="reference"/>
-                                </div>
-                                <div class="col-6 text-end">
-                                    <field name="date"/>
-                                </div>
+                    <t t-name="kanban-card">
+                        <div class="row">
+                            <field name="reference" class="col-6"/>
+                            <field name="date" class="col-6 text-end"/>
+                        </div>
+                        <field name="product_id" class="fw-bolder"/>
+                        <div groups="stock.group_stock_multi_locations">
+                            <field name="location_id"/>
+                            →
+                            <field name="location_dest_id"/>
+                        </div>
+                        <div groups="stock.group_production_lot" invisible="not lot_id and not lot_name">
+                            Lot/SN:
+                            <field name="lot_id" invisible="not lot_id and lot_name"/>
+                            <field name="lot_name" invisible="lot_id or not lot_name"/>
+                        </div>
+                        <div class="row">
+                            <div class="col-6">
+                                <field name="quantity" string="Quantity"/>
+                                <field name="product_uom_id" string="Unit of Measure" groups="uom.group_uom"/>
                             </div>
-                            <div>
-                                <strong><field name="product_id"/></strong>
-                            </div>
-                            <div groups="stock.group_stock_multi_locations">
-                                <field name="location_id"/>
-                                →
-                                <field name="location_dest_id"/>
-                            </div>
-                            <div groups="stock.group_production_lot" invisible="not lot_id and not lot_name">
-                                Lot/SN:
-                                <field name="lot_id" invisible="not lot_id and lot_name"/>
-                                <field name="lot_name" invisible="lot_id or not lot_name"/>
-                            </div>
-                            <div class="row">
-                                <div class="col-6">
-                                    <field name="quantity" string="Quantity"/>
-                                    <field name="product_uom_id" string="Unit of Measure" groups="uom.group_uom"/>
-                                </div>
-                                <div class="col-6 text-end">
-                                    <field name="state" widget="label_selection" options="{'classes': {'draft': 'default', 'cancel': 'danger', 'waiting': 'warning', 'confirmed': 'warning', 'done': 'success'}}"/>
-                                </div>
-                            </div>
+                            <field class="col-6 text-end" name="state" widget="label_selection" options="{'classes': {'draft': 'default', 'cancel': 'danger', 'waiting': 'warning', 'confirmed': 'warning', 'done': 'success'}}"/>
                         </div>
                     </t>
                 </templates>

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -96,39 +96,20 @@
             <field name="priority">10</field>
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile">
-                    <field name="product_id"/>
-                    <field name="show_details_visible"/>
-                    <field name="product_uom_qty"/>
                     <field name="product_qty" readonly="1" force_save="0"/>
-                    <field name="quantity"/>
                     <field name="is_inventory"/>
-                    <field name="state"/>
-                    <field name="name"/>
-                    <field name="product_uom"/>
-                    <field name="location_id"/>
-                    <field name="location_dest_id"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="oe_kanban_global_click">
-                                <div class="o_kanban_record_top">
-                                    <div class="o_kanban_record_headings">
-                                        <strong class="o_kanban_record_title"><span><field name="product_id" readonly="state == 'done'"/></span></strong>
-                                    </div>
-                                </div>
-                                <div class="o_kanban_record_body">
-                                    <div invisible="not is_inventory">
-                                        <span>Initial Demand <field name="product_uom_qty" readonly="state == 'done'"/></span><br/>
-                                        <span>Quantity <field name="quantity"/></span>
-                                    </div>
-                                    <div invisible="is_inventory">
-                                        <span>
-                                            Quantity <field name="quantity"/> /
-                                            <field name="product_uom_qty" readonly="state != 'draft'"/>
-                                            <field name="product_uom" groups="uom.group_uom" class="ms-1"/>
-                                        </span>
-                                    </div>
-                                </div>
+                        <t t-name="kanban-card">
+                            <field name="product_id" readonly="state == 'done'" class="fw-bold fs-5"/>
+                            <div invisible="not is_inventory">
+                                <span>Initial Demand <field name="product_uom_qty" readonly="state == 'done'"/></span><br/>
+                                <span>Quantity <field name="quantity"/></span>
                             </div>
+                            <span invisible="is_inventory">
+                                Quantity <field name="quantity"/> /
+                                <field name="product_uom_qty" readonly="state != 'draft'"/>
+                                <field name="product_uom" groups="uom.group_uom" class="ms-1"/>
+                            </span>
                         </t>
                     </templates>
                 </kanban>

--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -5,29 +5,16 @@
         <field name="model">stock.warehouse.orderpoint</field>
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
-                <field name="name"/>
-                <field name="product_id"/>
-                <field name="trigger"/>
-                <field name="product_min_qty"/>
-                <field name="product_max_qty"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_global_click">
-                            <div class="o_kanban_record_top">
-                                <div class="o_kanban_record_headings">
-                                    <strong class="o_kanban_record_title"><t t-esc="record.name.value"/></strong>
-                                </div>
-                                <span class="badge rounded-pill"><strong>Min qty:</strong><t t-esc="record.product_min_qty.value"/></span>
-                            </div>
-                            <div class="o_kanban_record_bottom">
-                                <div class="oe_kanban_bottom_left">
-                                    <span><t t-esc="record.product_id.value"/></span>
-                                </div>
-                                <div class="oe_kanban_bottom_right">
-                                    <span class="badge rounded-pill"><strong>Max qty:</strong><t t-esc="record.product_max_qty.value"/></span>
-                                </div>
-                            </div>
+                    <t t-name="kanban-card">
+                        <div class="d-flex">
+                            <field name="name" class="fw-bold fs-5 mb-1"/>
+                            <span class="badge rounded-pill ms-auto mt-1"><strong>Min qty:</strong><field name="product_min_qty"/></span>
                         </div>
+                        <footer class="fs-6 pt-0">
+                            <field name="product_id"/>
+                            <span class="badge rounded-pill ms-auto"><strong>Max qty:</strong><field name="product_max_qty"/></span>
+                        </footer>
                     </t>
                 </templates>
             </kanban>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -35,40 +35,28 @@
             <field name="model">stock.picking</field>
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile" sample="1">
-                    <field name="name"/>
-                    <field name="partner_id"/>
-                    <field name="location_dest_id"/>
                     <field name="scheduled_date"/>
-                    <field name="activity_state"/>
                     <field name="picking_type_id"/>
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="oe_kanban_card oe_kanban_global_click">
-                                <div class="o_kanban_record_top mb8">
-                                    <field name="priority" widget="priority"/>
-                                    <div class="o_kanban_record_headings ms-1">
-                                        <strong class="o_kanban_record_title"><span><t t-esc="record.name.value"/></span></strong>
-                                    </div>
-                                    <strong>
-                                            <field name="state" widget="label_selection" options="{'classes': {'draft': 'default', 'cancel': 'danger', 'waiting': 'warning', 'confirmed': 'warning', 'done': 'success'}}"/>
-                                    </strong>
-                                </div>
-                                <div class="o_kanban_record_body">
-                                    <field name="picking_properties" widget="properties"/>
-                                </div>
-                                <div class="o_kanban_record_bottom">
-                                    <div class="oe_kanban_bottom_left">
-                                        <t t-esc="record.partner_id.value"/>
-                                        <field name="activity_ids" widget="kanban_activity"/>
-                                        <field name="json_popover" nolabel="1" widget="stock_rescheduling_popover" invisible="not json_popover"/>
-                                    </div>
-                                    <div class="oe_kanban_bottom_right">
-                                        <t t-esc="record.scheduled_date.value and record.scheduled_date.value.split(' ')[0] or False"/>
-                                        <field name="user_id" widget="many2one_avatar_user" invisible="not user_id" readonly="state in ['cancel', 'done']"/>
-                                    </div>
-                                </div>
+                        <t t-name="kanban-card">
+                            <div class="d-flex mb-1">
+                                <field name="priority" widget="priority" class="pt-1"/>
+                                <field name="name" class="fw-bold fs-5 ms-1"/>
+                                <field name="state" widget="label_selection" options="{'classes': {'draft': 'default', 'cancel': 'danger', 'waiting': 'warning', 'confirmed': 'warning', 'done': 'success'}}" class="ms-auto"/>
                             </div>
+                            <field name="picking_properties" widget="properties"/>
+                            <footer class="fs-6 pt-0">
+                                <div class="d-flex">
+                                    <field name="partner_id"/>
+                                    <field name="activity_ids" widget="kanban_activity"/>
+                                    <field name="json_popover" nolabel="1" widget="stock_rescheduling_popover" invisible="not json_popover"/>
+                                </div>
+                                <div class="d-flex ms-auto mt-1 align-items-center">
+                                    <t t-esc="record.scheduled_date.value and record.scheduled_date.value.split(' ')[0] or False"/>
+                                    <field name="user_id" widget="many2one_avatar_user" invisible="not user_id" readonly="state in ['cancel', 'done']" class="ms-1"/>
+                                </div>
+                            </footer>
                         </t>
                     </templates>
                 </kanban>

--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -298,26 +298,12 @@
                         </list>
                         <kanban class="o_kanban_mobile">
                             <templates>
-                                <t t-name="kanban-box">
-                                    <div class="oe_kanban_global_click">
-                                        <div class="o_kanban_card_content">
-                                            <div class="row">
-                                                <div class="col-12">
-                                                    <strong><field name="product_id"/></strong>
-                                                </div>
-                                            </div>
-                                            <div class="row">
-                                                <div class="col-12">
-                                                    <field name="lot_id"/>
-                                                </div>
-                                            </div>
-                                            <div class="row">
-                                                <div class="col-12">
-                                                    <field name="quantity"/>
-                                                    <field class="mx-2" name="product_uom_id" groups="uom.group_uom"/>
-                                                </div>
-                                            </div>
-                                        </div>
+                                <t t-name="kanban-card">
+                                    <field name="product_id" class="fw-bold"/>
+                                    <field name="lot_id"/>
+                                    <div class="d-flex">
+                                        <field name="quantity"/>
+                                        <field class="mx-2" name="product_uom_id" groups="uom.group_uom"/>
                                     </div>
                                 </t>
                             </templates>
@@ -348,18 +334,9 @@
         <field name="arch" type="xml">
             <kanban sample="1" group_create="0">
                 <templates>
-                <field name="name"/>
-                    <t t-name="kanban-box">
-                        <div class="oe_kanban_global_click">
-                            <div class="o_kanban_record_top mb0">
-                                <div class="col-6">
-                                    <strong class="o_kanban_record_title"><field name="name"/></strong>
-                                </div>
-                                <div class="col-6">
-                                    <field name="package_type_id"/>
-                                </div>
-                            </div>
-                        </div>
+                    <t t-name="kanban-card" class="row g-0">
+                        <field name="name" class="col-6 fw-bold fs-5"/>
+                        <field name="package_type_id" class="col-6"/>
                     </t>
                 </templates>
             </kanban>

--- a/addons/stock/views/stock_scrap_views.xml
+++ b/addons/stock/views/stock_scrap_views.xml
@@ -84,32 +84,19 @@
             <field name="model">stock.scrap</field>
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile" sample="1">
-                    <field name="name"/>
-                    <field name="product_id"/>
-                    <field name="date_done"/>
-                    <field name="scrap_qty"/>
-                    <field name="state"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div class="oe_kanban_global_click">
-                                <div class="row mb4">
-                                    <strong class="col-6">
-                                        <span t-esc="record.name.value"/>
-                                    </strong>
-                                    <strong t-if="record.date_done.value" class="col-6 text-end">
-                                        <i class="fa fa-clock-o" role="img" aria-label="Date" title="Date"/><span t-esc="record.date_done.value"/>
-                                    </strong>
-                                    <div class="col-12">
-                                        <span t-esc="record.product_id.value"/>
-                                    </div>
-                                    <div class="col-6">
-                                        <span t-esc="record.scrap_qty.value"/>
-                                    </div>
-                                    <div class="col-6">
-                                        <span class="float-end badge text-bg-secondary">
-                                            <field name="state"/>
-                                        </span>
-                                    </div>
+                        <t t-name="kanban-card">
+                            <div class="row">
+                                <field name="name" class="col-6 fw-bolder"/>
+                                <div class="col-6 fw-bolder text-end">
+                                    <i class="fa fa-clock-o" role="img" aria-label="Date" title="Date"/><field name="date_done"/>
+                                </div>
+                            </div>
+                            <field name="product_id"/>
+                            <div class="row">
+                                <field name="scrap_qty" class="col-6"/>
+                                <div class="col-6">
+                                    <field name="state" class="float-end badge text-bg-secondary"/>
                                 </div>
                             </div>
                         </t>

--- a/addons/stock/wizard/stock_package_destination_views.xml
+++ b/addons/stock/wizard/stock_package_destination_views.xml
@@ -17,26 +17,13 @@
                             <field name="lot_id" groups="stock.group_production_lot"/>
                         </list>
                         <kanban>
-                            <field name="product_id"/>
-                            <field name="quantity"/>
-                            <field name="location_dest_id"/>
                             <templates>
-                                <t t-name="kanban-box">
-                                    <div class="container o_kanban_card_content">
-                                        <div class="row">
-                                            <div class="col-6 o_kanban_primary_left">
-                                                <field name="product_id"/>
-                                            </div>
-                                            <div class="col-6 o_kanban_primary_right">
-                                                <field name="quantity" String="quantity"/>
-                                            </div>
-                                        </div>
-                                        <div class="row">
-                                            <div class="col-12">
-                                                <field name="location_dest_id"/>
-                                            </div>
-                                        </div>
+                                <t t-name="kanban-card">
+                                    <div class="row">
+                                        <field name="product_id" class="col-6"/>
+                                        <field name="quantity" class="col-6" String="quantity"/>
                                     </div>
+                                    <field name="location_dest_id"/>
                                 </t>
                             </templates>
                         </kanban>

--- a/addons/stock_fleet/views/stock_picking_batch.xml
+++ b/addons/stock_fleet/views/stock_picking_batch.xml
@@ -109,19 +109,15 @@
         <field name="inherit_id" ref="stock_picking_batch.stock_picking_batch_kanban"/>
         <field name="arch" type="xml">
             <data>
-                <xpath expr="//templates/t/div/div[2]" position="replace">
-                    <div class="o_kanban_record_bottom">
-                        <div class="col">
-                            <div><field name="dock_id"/></div>
-                            <div class="col">
-                                <field name="state" widget="state_selection" class="ms-auto float-start" style="padding-top: 4px; margin-right: 6px"/>
-                                <field name="scheduled_date" readonly="state in ['cancel', 'done']"/>
-                            </div>
+                <xpath expr="//footer" position="replace">
+                    <footer class="fs-6 pt-0">
+                        <field name="dock_id"/>
+                        <div>
+                            <field name="state" widget="state_selection" class="float-start pt-1 me-1"/>
+                            <field name="scheduled_date" readonly="state in ['cancel', 'done']"/>
                         </div>
-                        <div class="oe_kanban_bottom_right">
-                            <field name="user_id" widget="many2one_avatar_user" readonly="state not in ['draft', 'in_progress']"/>
-                        </div>
-                    </div>
+                        <field name="user_id" widget="many2one_avatar_user" readonly="state not in ['draft', 'in_progress']" class="ms-auto"/>
+                    </footer>
                 </xpath>
             </data>
         </field>

--- a/addons/stock_landed_costs/views/stock_landed_cost_views.xml
+++ b/addons/stock_landed_costs/views/stock_landed_cost_views.xml
@@ -154,29 +154,19 @@
             <field name="model">stock.landed.cost</field>
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile">
-                    <field name="name"/>
-                    <field name="date"/>
-                    <field name="state"/>
-                    <field name="account_journal_id"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div class="oe_kanban_global_click">
-                                <div class="row mb4">
-                                    <strong class="col-6">
-                                        <span t-esc="record.name.value"/>
-                                    </strong>
-                                    <div class="col-6">
-                                        <span class="float-end badge text-bg-secondary">
-                                            <field name="state"/>
-                                        </span>
-                                    </div>
-                                    <div class="col-6">
-                                        <i class="fa fa-clock-o" title="Date" role="img" aria-label="Date"/><span t-esc="record.date.value"/>
-                                    </div>
-                                    <div class="col-6 text-end">
-                                        <field name="account_journal_id" readonly="state == 'done'"/>
-                                    </div>
+                        <t t-name="kanban-card">
+                            <div class="row mb-1">
+                                <field name="name" class="col-6 fw-bolder"/>
+                                <div class="col-6">
+                                    <field name="state" class="float-end badge text-bg-secondary"/>
                                 </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-6">
+                                    <i class="fa fa-clock-o" title="Date" role="img" aria-label="Date"/><field name="date"/>
+                                </div>
+                                <field name="account_journal_id" class="col-6 text-end" readonly="state == 'done'"/>
                             </div>
                         </t>
                     </templates>

--- a/addons/stock_picking_batch/views/stock_picking_batch_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_batch_views.xml
@@ -150,29 +150,20 @@
         <field name="model">stock.picking.batch</field>
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile" sample="1">
-                <field name="name"/>
-                <field name="user_id"/>
-                <field name="state"/>
+                <field name="company_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_global_click">
-                            <div class="o_kanban_record_top mb16">
-                                <div class="o_kanban_record_headings">
-                                    <strong class="o_kanban_record_title"><field name="name"/></strong>
-                                </div>
-                                <field name="state" widget="label_selection"/>
-                            </div>
-                            <div class="o_kanban_record_bottom">
-                                <div class="oe_kanban_bottom_left">
-                                    <field name="picking_type_id" readonly="state != 'draft'"/>
-                                </div>
-                                <div class="oe_kanban_bottom_right">
-                                    <field name="scheduled_date" readonly="state in ['cancel', 'done']"/>
-                                    <field name="company_id" invisible="1"/>
-                                    <field name="user_id" widget="many2one_avatar_user" readonly="state not in ['draft', 'in_progress']"/>
-                                </div>
-                            </div>
+                    <t t-name="kanban-card">
+                        <div class="d-flex mb-4">
+                            <field name="name" class="fw-bolder fs-5"/>
+                            <field name="state" widget="label_selection" class="ms-auto"/>
                         </div>
+                        <footer class="fs-6 pt-0">
+                            <field name="picking_type_id" readonly="state != 'draft'"/>
+                            <div class="d-flex">
+                                <field name="scheduled_date" readonly="state in ['cancel', 'done']"/>
+                                <field name="user_id" widget="many2one_avatar_user" readonly="state not in ['draft', 'in_progress']"/>
+                            </div>
+                        </footer>
                     </t>
                 </templates>
             </kanban>


### PR DESCRIPTION
*product_expiry,stock_fleet,stock_landed_costs,stock_picking_batch
In this commit we have simplified the kanban arch for the stock and their related modules.the goal is to simplify them, make them easier to read and use bootstrap utility classnames.

- Previously, we used kanban-box, but now we are using kanban-card instead.
- Deprecated oe_kanban_global_click and oe_kanban_global_click_edit.
- More use of <field/> tags
- Removed the oe_kanban_colorpicker class and replaced it with the kanban_color_picker widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- kanban_image from rendering context, is deprecated so we use <field name="..." widget="image"/> instead
- kanban_color, kanban_getcolor and kanban_getcolorname are deprecated use new attribute highlight_color="color_field_name" on root node

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
