### PR TITLE
[FIX] website_sale_stock: add product name in payment error

### DIFF
--- a/addons/website_sale_stock/i18n/website_sale_stock.pot
+++ b/addons/website_sale_stock/i18n/website_sale_stock.pot
@@ -264,8 +264,16 @@ msgstr ""
 
 #. module: website_sale_stock
 #. odoo-python
-#: code:addons/website_sale_stock/models/sale_order.py:0
 #: code:addons/website_sale_stock/models/sale_order_line.py:0
+#, python-format
+msgid ""
+"You ask for %(desired_qty)s %(product_name)s but only %(new_qty)s is "
+"available"
+msgstr ""
+
+#. module: website_sale_stock
+#. odoo-python
+#: code:addons/website_sale_stock/models/sale_order.py:0
 #, python-format
 msgid "You ask for %(desired_qty)s products but only %(new_qty)s is available"
 msgstr ""

--- a/addons/website_sale_stock/models/sale_order_line.py
+++ b/addons/website_sale_stock/models/sale_order_line.py
@@ -9,8 +9,8 @@ class SaleOrderLine(models.Model):
     def _set_shop_warning_stock(self, desired_qty, new_qty):
         self.ensure_one()
         self.shop_warning = _(
-            'You ask for %(desired_qty)s products but only %(new_qty)s is available',
-            desired_qty=desired_qty, new_qty=new_qty
+            'You ask for %(desired_qty)s %(product_name)s but only %(new_qty)s is available',
+            desired_qty=desired_qty, product_name=self.product_id.name, new_qty=new_qty
         )
         return self.shop_warning
 


### PR DESCRIPTION
__Current behavior before commit:__
When you check out your cart with a product not in the stock anymore you have an error message. There is no product name in this message so if you have multiple products in your cart you don't know which one to remove.

__Description of the fix:__
Add the product name in the error message, so it's easy to identify which product to remove of the cart.
The warning method is linked to sale.order.line so we can access to the product directly.

__Steps to reproduce the issue:__
- add products to your cart
- remove one or many products of the stock
- try to validate your payment

opw-4016059 (upgrade issues)
