### PR TITLE
[FIX] base: make the New password field visible

### DIFF
--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -40,7 +40,7 @@
                 <tree string="Users" editable="bottom" create="false" delete="false">
                     <field name="user_id" column_invisible="True"/> <!-- required field, needed when updating the password -->
                     <field name="user_login" force_save="1"/>
-                    <field name="new_passwd" password="True" width="20px"/>
+                    <field name="new_passwd" password="True"/>
                 </tree>
             </field>
         </record>


### PR DESCRIPTION
Steps to Reproduce : 
 - Go to Settings->User->Select an user
 - Click on the action menu and `Change Password`

Expected Behavior :
The `New Password` field should be clearly visible.

Task-4072410
