### PR TITLE
[IMP] sale, sale_management: easier template inheritance

### DIFF
--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -159,7 +159,7 @@
                             </div>
 
                             <t t-if="not sale_order.is_expired and sale_order.state in ['draft', 'sent']">
-                                <div t-if="sale_order.amount_undiscounted - sale_order.amount_untaxed &gt; 0.01" class="list-group-item flex-grow-1">
+                                <div t-if="sale_order.amount_undiscounted - sale_order.amount_untaxed &gt; 0.01" class="list-group-item flex-grow-1" name="sale_order_advantage">
                                     <small><b class="text-muted">Your advantage</b></small>
                                     <small>
                                         <b t-field="sale_order.amount_undiscounted"
@@ -194,7 +194,7 @@
                 <div id="quote_content" class="col-12 col-lg-8 col-xxl-9 mt-5 mt-lg-0">
 
                     <!-- modal relative to the actions sign and pay -->
-                    <div role="dialog" class="modal fade" id="modalaccept">
+                    <div role="dialog" class="modal fade" id="modalaccept" name="sale_order_modal_sign_and_pay">
                         <div class="modal-dialog" t-if="sale_order._has_to_be_signed()">
                             <form id="accept" method="POST" t-att-data-order-id="sale_order.id" t-att-data-token="sale_order.access_token" class="js_accept_json modal-content js_website_submit_form">
                                 <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
@@ -217,7 +217,7 @@
                             </form>
                         </div>
 
-                        <div class="modal-dialog" t-if="not sale_order._has_to_be_signed() and sale_order._has_to_be_paid()">
+                        <div class="modal-dialog" t-if="not sale_order._has_to_be_signed() and sale_order._has_to_be_paid()" name="sale_order_modal_validate">
                             <div class="modal-content">
                                 <header class="modal-header">
                                     <h4 class="modal-title">Validate Order</h4>
@@ -349,7 +349,7 @@
                     </div>
 
                     <!-- bottom actions -->
-                    <div t-if="sale_order._has_to_be_signed() or sale_order._has_to_be_paid()" class="d-flex justify-content-center gap-1 d-print-none">
+                    <div t-if="sale_order._has_to_be_signed() or sale_order._has_to_be_paid()" class="d-flex justify-content-center gap-1 d-print-none" name="sale_order_actions">
 
                         <t t-if="sale_order._has_to_be_signed()">
                             <div class="col-sm-auto mt8">
@@ -646,7 +646,7 @@
     </template>
 
     <template id="sale_order_portal_content_totals_table">
-        <table class="table table-sm">
+        <table class="table table-sm" name="sale_order_totals_table">
             <t t-set="tax_totals" t-value="sale_order.tax_totals"/>
             <t t-call="#{sale_order._get_name_tax_totals_view()}"/>
         </table>

--- a/addons/sale_management/views/sale_portal_templates.xml
+++ b/addons/sale_management/views/sale_portal_templates.xml
@@ -32,28 +32,28 @@
                 <section>
                     <h3>Options</h3>
                     <t t-set="display_discount" t-value="True in [option.discount > 0 for option in sale_order.sale_order_option_ids]"/>
-                    <table class="table table-sm">
+                    <table class="table table-sm" name="sale_order_options_table">
                         <thead>
                             <tr>
-                                <th class="text-start">Product</th>
-                                <th t-if="display_discount" class="text-end">Disc.%
+                                <th class="text-start" name="th_option_product_name">Product</th>
+                                <th t-if="display_discount" class="text-end" name="th_option_discount">Disc.%
                                 </th>
-                                <th class="text-end">Unit Price</th>
-                                <th t-if="sale_order._can_be_edited_on_portal() and report_type == 'html'"></th>
+                                <th class="text-end" name="th_option_unit_price">Unit Price</th>
+                                <th t-if="sale_order._can_be_edited_on_portal() and report_type == 'html'" name="th_option_add_button"></th>
                             </tr>
                         </thead>
                         <tbody>
                             <tr t-foreach="sale_order.sale_order_option_ids" t-as="option">
                                 <t t-if="not option.is_present">
-                                    <td>
+                                    <td name="td_option_product_name">
                                         <div t-field="option.name"/>
                                     </td>
-                                    <td t-if="display_discount" class="text-end">
+                                    <td t-if="display_discount" class="text-end" name="td_option_discount">
                                         <strong t-if="option.discount" class="text-info">
                                             <t t-out="((option.discount % 1) and '%s' or '%d') % option.discount"/>%
                                         </strong>
                                     </td>
-                                    <td>
+                                    <td name="td_option_unit_price">
                                         <strong class="text-end">
                                             <div t-field="option.price_unit"
                                                 t-options='{"widget": "monetary", "display_currency": sale_order.currency_id}'
@@ -64,7 +64,7 @@
                                             </div>
                                         </strong>
                                     </td>
-                                    <td class="text-end" t-if="sale_order._can_be_edited_on_portal() and report_type == 'html'">
+                                    <td class="text-end" t-if="sale_order._can_be_edited_on_portal() and report_type == 'html'" name="td_option_add_button">
                                         <a t-att-data-option-id="option.id" href="#" class="mb8 js_add_optional_products d-print-none" aria-label="Add to cart" title="Add to cart">
                                             <span class="btn btn-secondary">Add to order</span>
                                         </a>


### PR DESCRIPTION
It's not rare for customizations to be requested in the Sales portal tables, e.g. to modify the way discounts are shown, to hide specific sections, etc.

This commit introduces several name attributes on (arbitrarily) important elements to make such inheritance easier and avoid xpath of this kind:
```xml
<!-- give a neame to the freaking optional products table -->
<xpath expr="//table[hasclass('table-sm')]/tbody/tr/t/td/../../../.." position="attributes">
  <attribute name="name">table_optional_products</attribute>
</xpath>
```

Inspired by dev at Task-3957129 (PS-Tech)
