### PR TITLE
[DRAFT][FIX] base: allow merge of company properties without company

### DIFF
--- a/odoo/addons/base/wizard/base_partner_merge.py
+++ b/odoo/addons/base/wizard/base_partner_merge.py
@@ -229,6 +229,7 @@ class MergePartnerAutomatic(models.TransientModel):
              WHERE _ip2.res_id = %(destination_id)s
              AND _ip2.fields_id = _ip1.fields_id
              AND _ip2.company_id = _ip1.company_id
+             OR (_ip2.company_id IS NULL AND _ip1.company_id IS NULL)
         )""", params)
 
     def _get_summable_fields(self):


### PR DESCRIPTION
Steps to reproduce:
- Install Invoicing and Contacts
- Settings > Enable Sales credit limit
- On any contact, remove company
- Invoicing tab > Set Partner limit
- Duplicate contact
- Debug mode > Company properties
- Remove company from credit limit of partners
- Try to merge those 2 contacts

Error "(4215, 0, res.partner,39) already exists". This is because the NOT EXISTS clause in the SQL query meant to prevent the operation does not take into account that in SQL, NULL = NULL evaluates to False.

Credit limit is used here but this seems to happen with any ir_property on the merge, as long as both partners have set that property.

opw-4031904

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
