### PR TITLE
[FIX] pos_restaurant: table translation from english to french

### DIFF
--- a/addons/pos_restaurant/i18n/fr.po
+++ b/addons/pos_restaurant/i18n/fr.po
@@ -1029,7 +1029,7 @@ msgstr "Basculer vers la vue de salle"
 #: model:ir.model.fields,field_description:pos_restaurant.field_pos_order__table_id
 #, python-format
 msgid "Table"
-msgstr "Tableau"
+msgstr "Table"
 
 #. module: pos_restaurant
 #: model:ir.model.fields,field_description:pos_restaurant.field_pos_config__module_pos_restaurant_appointment


### PR DESCRIPTION
In this commit:
================
Change the table translation from "TABLEAU" to "TABLE" when the user clicks on "Edit Plan" and tries to add a table.

task-4017059
