### PR TITLE
[FIX] website_event: resolve online event filter issue

### DIFF
--- a/addons/website_event/i18n/website_event.pot
+++ b/addons/website_event/i18n/website_event.pot
@@ -765,6 +765,11 @@ msgid "Online"
 msgstr ""
 
 #. module: website_event
+#: model_terms:ir.ui.view,arch_db:website_event.event_location
+msgid "Online Events"
+msgstr ""
+
+#. module: website_event
 #: model_terms:ir.ui.view,arch_db:website_event.event_description_full
 msgid "Organizer"
 msgstr ""

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -117,7 +117,11 @@
         <li class="nav-item dropdown mr-2 my-1">
             <a href="#" role="button" class="btn dropdown-toggle" data-toggle="dropdown">
                 <i class="fa fa-map-marker"/>
-                <t t-if="current_country" t-esc="current_country.name"/>
+                <t t-if="searches['country'] == 'online'">
+                    <t t-set="online_event_text">Online Events</t>
+                    <t t-out="online_event_text"/>
+                </t>
+                <t t-elif="current_country" t-esc="current_country.name"/>
                 <t t-else="">All countries</t>
             </a>
             <div class="dropdown-menu">


### PR DESCRIPTION
Steps to Reproduce
===================
- Open the event page.
- Switch on the country filter.
- select the online event from that.
- The filter is applied but in a dropdown, it is still showing the All countries.

After this commit
==================
This PR addresses the issue and now when we select the online filter online event will be there in a dropdown also.

Task-4058244