### PR TITLE
[FIX] mrp: correct backorder MOs with create_backorder setting

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -2018,7 +2018,7 @@ class MrpProduction(models.Model):
         else:
             productions_not_to_backorder = self
             productions_to_backorder = self.env['mrp.production']
-
+        productions_not_to_backorder = productions_not_to_backorder.with_context(no_procurement=True)
         self.workorder_ids.button_finish()
 
         backorders = productions_to_backorder and productions_to_backorder._split_productions()
@@ -2145,21 +2145,19 @@ class MrpProduction(models.Model):
 
         quantity_issues = self._get_quantity_produced_issues()
         if quantity_issues:
-            prods_auto_backorder = [prod for prod in quantity_issues if prod.picking_type_id.create_backorder == "always"]
-            if prods_auto_backorder:
-                auto_backorders = self.env['mrp.production.backorder'].create({
-                    "mrp_production_backorder_line_ids": [Command.create({
-                            'mrp_production_id': prod.id,
-                            'to_backorder': True,
-                        }) for prod in prods_auto_backorder
-                    ],
-                })
-                return auto_backorders.action_backorder()
-            ask_backorder = [prod for prod in quantity_issues if prod.picking_type_id.create_backorder == "ask"]
-            if ask_backorder:
-                return self._action_generate_backorder_wizard(ask_backorder)
-            else:
-                return True
+            mo_ids_always = []  # we need to pass the mo.ids in a context, so collect them to avoid looping through the list twice
+            mos_ask = []  # we need to pass a list of mo records to the backorder wizard, so collect records
+            for mo in quantity_issues:
+                if mo.picking_type_id.create_backorder == "always":
+                    mo_ids_always.append(mo.id)
+                elif mo.picking_type_id.create_backorder == "ask":
+                    mos_ask.append(mo)
+            if mos_ask:
+                # any "never" MOs will be passed to the wizard, but not considered for being backorder-able, always backorder mos are hack forced via context
+                return self.with_context(always_backorder_mo_ids=mo_ids_always)._action_generate_backorder_wizard(mos_ask)
+            elif mo_ids_always:
+                # we have to pass all the MOs that the nevers/no issue MOs are also passed to be "mark done" without a backorder
+                return self.with_context(skip_backorder=True, mo_ids_to_backorder=mo_ids_always).button_mark_done()
         return True
 
     def _button_mark_done_sanity_checks(self):

--- a/addons/mrp/tests/test_backorder.py
+++ b/addons/mrp/tests/test_backorder.py
@@ -661,17 +661,25 @@ class TestMrpProductionBackorder(TestMrpCommon):
         self.assertFalse(last_move.quantity)
 
     def test_auto_generate_backorder(self):
+        """
+        Test that when the create_backorder is set to "always", the backorder
+        is automatically created. Due to the complexity of how backorders work,
+        check that "priority" is correctly disabled as part of the expected
+        "done" values that are written to the original MO.
+        """
         mo = self.env['mrp.production'].create({
             'product_qty': 10,
             'bom_id': self.bom_1.id,
+            'priority': '1',
         })
         mo.picking_type_id.create_backorder = "always"
         mo.action_confirm()
         with Form(mo) as mo_form:
             mo_form.qty_producing = 3.0
         mo = mo_form.save()
+        self.assertEqual(mo.priority, '1')
         mo.button_mark_done()
-        self.assertRecordValues(mo, [{'state': 'done', 'qty_produced': 3.0, 'mrp_production_backorder_count': 2}])
+        self.assertRecordValues(mo, [{'state': 'done', 'qty_produced': 3.0, 'mrp_production_backorder_count': 2, 'priority': '0'}])
         backorder = mo.procurement_group_id.mrp_production_ids - mo
         self.assertEqual(backorder.product_qty, 7.0)
 
@@ -680,6 +688,177 @@ class TestMrpProductionBackorder(TestMrpCommon):
         backorder = backorder_form.save()
         backorder.button_mark_done()
         self.assertRecordValues(backorder, [{'state': 'done', 'qty_produced': 7.0, 'mrp_production_backorder_count': 2}])
+
+    def test_generate_backorder_multi_type(self):
+        """
+        Test that when there are 2 MOs with different manufacture operation types
+        with different create_backorder values, then marking both as done at the
+        same time works as expected:
+        - Always + Ask (backorder=yes) => both are correctly backordered
+        - Always + Never => only the always is backordered without wizard popping up
+        - Ask (backorder=yes) + Never => only the ask is backordered
+        - Always + Ask (backorder=no) => only the always is backordered
+        - Ask (backorder=no) + Never => neither is backordered
+        In every case, we also include a MO Produce All (i.e. `qty_producing` untouched, so all produced)
+        and a fully produced (i.e. `qty_producing`=`product_qty`) to ensure they are always correctly passed
+        as MOs that are done, but not backordered (i.e. their priority should be removed when done)
+        """
+        product_qty = 10.0  # for MOs with no backorder, qty_produced = product_qty
+        qty_produced = 3.0  # for MOs where qty_produced < product_qty
+
+        def create_mo(picking_type_id=False):
+            return self.env['mrp.production'].create({
+            'product_qty': product_qty,
+            'bom_id': self.bom_1.id,
+            'priority': '1',
+            'picking_type_id': picking_type_id or self.warehouse.manu_type_id.id,
+        })
+        picking_type_always = self.warehouse.manu_type_id.copy({'name': "Always BO", 'sequence_code': "always", 'create_backorder': "always"})
+        picking_type_ask = self.warehouse.manu_type_id.copy({'name': "Ask BO", 'sequence_code': "ask", 'create_backorder': "ask"})
+        picking_type_never = self.warehouse.manu_type_id.copy({'name': "Never BO", 'sequence_code': "never", 'create_backorder': "never"})
+
+        # always + ask (backorder=yes) => both are backordered in the end
+        mo_produce_all = create_mo()
+        mo_all_produced = create_mo()
+        mo_always = create_mo(picking_type_always.id)
+        mo_ask = create_mo(picking_type_ask.id)
+        mos = (mo_produce_all | mo_all_produced | mo_always | mo_ask)
+        mos.action_confirm()
+
+        with Form(mo_all_produced) as mo_form:
+            mo_all_produced.qty_producing = product_qty
+        mo_form.save()
+        with Form(mo_always) as mo_form:
+            mo_form.qty_producing = qty_produced
+        mo_form.save()
+        with Form(mo_ask) as mo_form:
+            mo_form.qty_producing = qty_produced
+        mo_form.save()
+
+        self.assertTrue(all(p == '1' for p in mos.mapped("priority")))
+        action = mos.button_mark_done()
+        backorder = Form(self.env['mrp.production.backorder'].with_context(**action['context']))
+        backorder.save().action_backorder()
+        self.assertRecordValues(mo_produce_all, [{'state': 'done', 'qty_produced': product_qty, 'mrp_production_backorder_count': 1, 'priority': '0'}])
+        self.assertRecordValues(mo_all_produced, [{'state': 'done', 'qty_produced': product_qty, 'mrp_production_backorder_count': 1, 'priority': '0'}])
+        self.assertRecordValues(mo_always, [{'state': 'done', 'qty_produced': qty_produced, 'mrp_production_backorder_count': 2, 'priority': '0'}])
+        self.assertRecordValues(mo_ask, [{'state': 'done', 'qty_produced': qty_produced, 'mrp_production_backorder_count': 2, 'priority': '0'}])
+        bo = mo_always.procurement_group_id.mrp_production_ids - mo_always
+        bo2 = mo_ask.procurement_group_id.mrp_production_ids - mo_ask
+        self.assertEqual(bo.product_qty, product_qty - qty_produced)
+        self.assertEqual(bo2.product_qty, product_qty - qty_produced)
+
+        # always + never => only 1 backordered
+        mo_produce_all = create_mo()
+        mo_all_produced = create_mo()
+        mo_always = create_mo(picking_type_always.id)
+        mo_never = create_mo(picking_type_never.id)
+        mos = (mo_produce_all | mo_all_produced | mo_always | mo_never)
+        mos.action_confirm()
+
+        with Form(mo_all_produced) as mo_form:
+            mo_all_produced.qty_producing = product_qty
+        mo_form.save()
+        with Form(mo_always) as mo_form:
+            mo_form.qty_producing = qty_produced
+        mo_form.save()
+        with Form(mo_never) as mo_form:
+            mo_form.qty_producing = qty_produced
+        mo_form.save()
+
+        self.assertTrue(all(p == '1' for p in mos.mapped("priority")))
+        action = mos.button_mark_done()
+        self.assertRecordValues(mo_produce_all, [{'state': 'done', 'qty_produced': product_qty, 'mrp_production_backorder_count': 1, 'priority': '0'}])
+        self.assertRecordValues(mo_all_produced, [{'state': 'done', 'qty_produced': product_qty, 'mrp_production_backorder_count': 1, 'priority': '0'}])
+        self.assertRecordValues(mo_always, [{'state': 'done', 'qty_produced': qty_produced, 'mrp_production_backorder_count': 2, 'priority': '0'}])
+        self.assertRecordValues(mo_never, [{'state': 'done', 'qty_produced': qty_produced, 'mrp_production_backorder_count': 1, 'priority': '0'}])
+        bo = mo_always.procurement_group_id.mrp_production_ids - mo_always
+        self.assertEqual(bo.product_qty, product_qty - qty_produced)
+
+        # ask (backorder=yes) + never => only 1 backordered
+        mo_produce_all = create_mo()
+        mo_all_produced = create_mo()
+        mo_ask = create_mo(picking_type_ask.id)
+        mo_never = create_mo(picking_type_never.id)
+        mos = (mo_produce_all | mo_all_produced | mo_ask | mo_never)
+        mos.action_confirm()
+
+        with Form(mo_all_produced) as mo_form:
+            mo_all_produced.qty_producing = product_qty
+        mo_form.save()
+        with Form(mo_ask) as mo_form:
+            mo_form.qty_producing = qty_produced
+        mo_ask = mo_form.save()
+        with Form(mo_never) as mo_form:
+            mo_form.qty_producing = qty_produced
+        mo_never = mo_form.save()
+
+        self.assertTrue(all(p == '1' for p in mos.mapped("priority")))
+        action = mos.button_mark_done()
+        backorder = Form(self.env['mrp.production.backorder'].with_context(**action['context']))
+        backorder.save().action_backorder()
+        self.assertRecordValues(mo_produce_all, [{'state': 'done', 'qty_produced': product_qty, 'mrp_production_backorder_count': 1, 'priority': '0'}])
+        self.assertRecordValues(mo_all_produced, [{'state': 'done', 'qty_produced': product_qty, 'mrp_production_backorder_count': 1, 'priority': '0'}])
+        self.assertRecordValues(mo_ask, [{'state': 'done', 'qty_produced': qty_produced, 'mrp_production_backorder_count': 2, 'priority': '0'}])
+        self.assertRecordValues(mo_never, [{'state': 'done', 'qty_produced': qty_produced, 'mrp_production_backorder_count': 1, 'priority': '0'}])
+        bo = mo_ask.procurement_group_id.mrp_production_ids - mo_ask
+        self.assertEqual(bo.product_qty, product_qty - qty_produced)
+
+        # always + ask (backorder=no) => only 1 backordered
+        mo_produce_all = create_mo()
+        mo_all_produced = create_mo()
+        mo_always = create_mo(picking_type_always.id)
+        mo_ask = create_mo(picking_type_ask.id)
+        mos = (mo_produce_all | mo_all_produced | mo_always | mo_ask)
+        mos.action_confirm()
+
+        with Form(mo_all_produced) as mo_form:
+            mo_all_produced.qty_producing = product_qty
+        mo_form.save()
+        with Form(mo_always) as mo_form:
+            mo_form.qty_producing = qty_produced
+        mo_form.save()
+        with Form(mo_ask) as mo_form:
+            mo_form.qty_producing = qty_produced
+        mo_form.save()
+
+        self.assertTrue(all(p == '1' for p in mos.mapped("priority")))
+        action = mos.button_mark_done()
+        backorder = Form(self.env['mrp.production.backorder'].with_context(**action['context']))
+        backorder.save().action_close_mo()
+        self.assertRecordValues(mo_produce_all, [{'state': 'done', 'qty_produced': product_qty, 'mrp_production_backorder_count': 1, 'priority': '0'}])
+        self.assertRecordValues(mo_all_produced, [{'state': 'done', 'qty_produced': product_qty, 'mrp_production_backorder_count': 1, 'priority': '0'}])
+        self.assertRecordValues(mo_always, [{'state': 'done', 'qty_produced': qty_produced, 'mrp_production_backorder_count': 2, 'priority': '0'}])
+        self.assertRecordValues(mo_ask, [{'state': 'done', 'qty_produced': qty_produced, 'mrp_production_backorder_count': 1, 'priority': '0'}])
+        bo = mo_always.procurement_group_id.mrp_production_ids - mo_always
+        self.assertEqual(bo.product_qty, product_qty - qty_produced)
+
+        # ask (backorder=no) + never => neither is backordered
+        mo_produce_all = create_mo()
+        mo_all_produced = create_mo()
+        mo_ask = create_mo(picking_type_ask.id)
+        mo_never = create_mo(picking_type_never.id)
+        mos = (mo_produce_all | mo_all_produced | mo_ask | mo_never)
+        mos.action_confirm()
+
+        with Form(mo_all_produced) as mo_form:
+            mo_all_produced.qty_producing = product_qty
+        mo_form.save()
+        with Form(mo_ask) as mo_form:
+            mo_form.qty_producing = qty_produced
+        mo_form.save()
+        with Form(mo_never) as mo_form:
+            mo_form.qty_producing = qty_produced
+        mo_form.save()
+
+        self.assertTrue(all(p == '1' for p in mos.mapped("priority")))
+        action = mos.button_mark_done()
+        backorder = Form(self.env['mrp.production.backorder'].with_context(**action['context']))
+        backorder.save().action_close_mo()
+        self.assertRecordValues(mo_produce_all, [{'state': 'done', 'qty_produced': product_qty, 'mrp_production_backorder_count': 1, 'priority': '0'}])
+        self.assertRecordValues(mo_all_produced, [{'state': 'done', 'qty_produced': product_qty, 'mrp_production_backorder_count': 1, 'priority': '0'}])
+        self.assertRecordValues(mo_ask, [{'state': 'done', 'qty_produced': qty_produced, 'mrp_production_backorder_count': 1, 'priority': '0'}])
+        self.assertRecordValues(mo_never, [{'state': 'done', 'qty_produced': qty_produced, 'mrp_production_backorder_count': 1, 'priority': '0'}])
 
 
 class TestMrpWorkorderBackorder(TransactionCase):

--- a/addons/mrp/wizard/mrp_production_backorder.py
+++ b/addons/mrp/wizard/mrp_production_backorder.py
@@ -31,10 +31,13 @@ class MrpProductionBackorder(models.TransientModel):
             wizard.show_backorder_lines = len(wizard.mrp_production_backorder_line_ids) > 1
 
     def action_close_mo(self):
-        return self.mrp_production_ids.with_context(skip_backorder=True, no_procurement=True).button_mark_done()
+        ctx = dict(self.env.context)
+        always_backorder_mo_ids = ctx.pop('always_backorder_mo_ids', [])
+        return self.mrp_production_ids.with_context(ctx, skip_backorder=True, mo_ids_to_backorder=always_backorder_mo_ids).button_mark_done()
 
     def action_backorder(self):
         ctx = dict(self.env.context)
         ctx.pop('default_mrp_production_ids', None)
-        mo_ids_to_backorder = self.mrp_production_backorder_line_ids.filtered(lambda l: l.to_backorder).mrp_production_id.ids
+        always_backorder_mo_ids = ctx.pop('always_backorder_mo_ids', [])
+        mo_ids_to_backorder = self.mrp_production_backorder_line_ids.filtered(lambda l: l.to_backorder).mrp_production_id.ids + always_backorder_mo_ids
         return self.mrp_production_ids.with_context(ctx, skip_backorder=True, mo_ids_to_backorder=mo_ids_to_backorder).button_mark_done()


### PR DESCRIPTION
Fixes 2 bugs (2nd noticed while investigating the 1st bug):

1. When selecting `create_backorder="always"` for a manufacturing operation type, the auto-printing didn't work for the MOs after they were marked as done.

Steps to reproduce:
- create a new lot tracked product
- set the manufacture operation type `create_backorder="always"`
- set the operation type > Hardware > Print When Done > Lot/SN Labels to true
- create a MO for the lot tracked product with a product_qty > 1
- set a `lot_producing_id` and mark `qty_producing=1`
- click "Produce" button

Expected result:
MO is backordered + the lot label is auto-printed (i.e. generated and downloaded as a pdf if no iot printer is set up)

Actual result:
MO is backordered and has a status=Done, but nothing is printed + the values that should be written within `button_mark_done` are not written (i.e. `priority` is not set to 0 and `date_finished` is not set to now())

Issue was due to use of the backorder wizard without passing the MOs that are always backordered as `mrp_production_ids`, this resulted in the MOs being backordered due to the context logic within the backorder wizard, but not applying the rest of the logic within `button_mark_done` that is applied to the `self` records (i.e. the MOs being backordered)

2. If more than 2 manufacturing operation types were set, then depending on the combination of `create_backorder` values, the backordering mechanism might not work. E.g. if `always` + `ask`, the `always` backordering logic would return and ended the logic before the `ask` or `never` MOs backordering logic was ever reached.

Steps to reproduce:
- set up 2 manufacture operation types, one with `always` and one with `ask`/`never`
- set up 2 MOs with product_qty > 1 using the 2 different operation types
- mark `qty_producing=1` for each MO and then select both MOs in the list view + action > "Mark as Done"

Expected result:
the `always` MO is backordered automatically and the `ask` MO has the backorder wizard pop up for it

Actual result:
the `always` MO is backordered automatically and the `ask` MO does nothing (it is not even set to done)

opw-3987144

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
