### PR TITLE
[IMP] web: add calculator to command pallet

### DIFF
--- a/addons/web/static/src/core/commands/command_palette.js
+++ b/addons/web/static/src/core/commands/command_palette.js
@@ -206,6 +206,9 @@ export class CommandPalette extends Component {
         this.categoryNames = {};
         const proms = this.providersByNamespace[namespace].map((provider) => {
             const { provide } = provider;
+            if (namespace === "=") {
+                options.searchValue = "=" + options.searchValue;
+            }
             const result = provide(this.env, options);
             return result;
         });
@@ -229,6 +232,9 @@ export class CommandPalette extends Component {
                 }
                 commands = commandsSorted;
             }
+        }
+        if (namespace === "=" && commands.length > 0) {
+            options.searchValue = commands[0].name;
         }
 
         this.state.commands = markRaw(
@@ -297,6 +303,9 @@ export class CommandPalette extends Component {
 
     async executeSelectedCommand(ctrlKey) {
         await this.searchValuePromise;
+        if (this.state.namespace === "=") {
+            this.state.searchValue = this.state.selectedCommand?.name;
+        }
         const selectedCommand = this.state.selectedCommand;
         if (selectedCommand) {
             if (!ctrlKey) {

--- a/addons/web/static/src/webclient/calculator/calculator_provider.js
+++ b/addons/web/static/src/webclient/calculator/calculator_provider.js
@@ -1,0 +1,58 @@
+import { Component } from "@odoo/owl";
+import { browser } from "@web/core/browser/browser";
+import { DefaultCommandItem } from "@web/core/commands/command_palette";
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { parseFloat } from "@web/views/fields/parsers";
+import { formatFloat } from "@web/core/utils/numbers";
+
+const commandCategoryRegistry = registry.category("command_categories");
+const commandSetupRegistry = registry.category("command_setup");
+const commandProviderRegistry = registry.category("command_provider");
+
+commandCategoryRegistry.add("calculator", { namespace: "=", name: _t("ans") }, { sequence: 120 });
+
+export class Calculator extends Component {
+    static template = "web.Calculator";
+    static props = {
+        ...DefaultCommandItem.props,
+    };
+}
+
+// -----------------------------------------------------------------------------
+// add = namespace + provider
+// -----------------------------------------------------------------------------
+
+commandSetupRegistry.add("=", {
+    emptyMessage: _t("Enter a valid expression"),
+    name: _t("calculator"),
+    debounceDelay: 200,
+    placeholder: _t("Enter mathematical expression"),
+});
+
+commandProviderRegistry.add("=", {
+    namespace: "=",
+    provide: (env, options = {}) => {
+        const commands = [];
+        try {
+            const result = parseFloat(options.searchValue);
+            if(result == "Infinity"){
+                throw new Error('Invalid Expression');
+            }
+            const formattedValue = formatFloat(result);
+            const resultString = formattedValue.toString();
+            const expressionCommand = {
+                Component: Calculator,
+                category: "calculator",
+                name: resultString,
+                action: () => {
+                    browser.navigator.clipboard.writeText(formattedValue);
+                },
+            };
+            commands.push(expressionCommand);
+        } catch {
+            return [];
+        }
+        return commands;
+    },
+});

--- a/addons/web/static/src/webclient/calculator/calculator_provider.xml
+++ b/addons/web/static/src/webclient/calculator/calculator_provider.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+  <t t-name="web.Calculator">
+    <div class="o_command_default d-flex align-items-center justify-content-between px-4 py-2 cursor-pointer">
+      <t t-slot="name"/>
+      <span class="ms-auto flex-shrink-0">
+        <small class="o_command_focus text-muted"><kbd>CTRL</kbd>+<kbd>⏎</kbd><span class="ms-1">to update</span></small>
+      </span>
+    </div>
+  </t>
+</templates>


### PR DESCRIPTION
This commit introduces a calculator feature to the command palette. Users can activate the calculator by pressing the "=" key.

Key features:

-The result of the calculation can be copied directly.
-Pressing "Enter" will copy the result to the clipboard and
 close the command palette.
-For continuous calculations, pressing the "Control" key will append the result
 to the input field.

This enhancement streamlines the process of performing and using calculations within the command palette.

task-4077618
