### PR TITLE
[FIX] website: add translation for previous fix

### DIFF
--- a/addons/website/i18n/website.pot
+++ b/addons/website/i18n/website.pot
@@ -10449,6 +10449,13 @@ msgid "We are in good company."
 msgstr ""
 
 #. module: website
+#. openerp-web
+#: code:addons/website/static/src/snippets/s_facebook_page/options.js:0
+#, python-format
+msgid "We couldn't find the Facebook page"
+msgstr ""
+
+#. module: website
 #: model_terms:ir.ui.view,arch_db:website.cookie_policy
 msgid ""
 "We do not currently support Do Not Track signals, as there is no industry "
@@ -10962,6 +10969,13 @@ msgstr ""
 msgid ""
 "You cannot delete this website menu as this serves as the default parent "
 "menu for new websites (e.g., /shop, /event, ...)."
+msgstr ""
+
+#. module: website
+#. openerp-web
+#: code:addons/website/static/src/snippets/s_facebook_page/options.js:0
+#, python-format
+msgid "You didn't provide a valid Facebook link"
 msgstr ""
 
 #. module: website


### PR DESCRIPTION
We did [1] to support more URL in facebook snippet and add user feedbacks but we forgot the translation of the user feedback messages

[1]: https://github.com/odoo/odoo/commit/e4e9a14cc9f8d752a29ee07ca7f6daadf5b93b34

task-3995431

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
