### PR TITLE
[FIX] website_sale: properly set session variable

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1568,7 +1568,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
     @http.route(['/shop/checkout'], type='http', auth="public", website=True, sitemap=False)
     def checkout(self, **post):
         order_sudo = request.website.sale_get_order()
-
+        request.session['sale_last_order_id'] = order_sudo.id
         redirection = self.checkout_redirection(order_sudo)
         if redirection:
             return redirection
@@ -1642,7 +1642,6 @@ class WebsiteSale(payment_portal.PaymentPortal):
             return redirection
 
         order.order_line._compute_tax_id()
-        request.session['sale_last_order_id'] = order.id
         request.website.sale_get_order(update_pricelist=True)
         extra_step = request.website.viewref('website_sale.extra_info')
         if extra_step.active:


### PR DESCRIPTION
To reproduce the bug:
- Add extra step during checkout
- Make Sign in/up at check out Mandatory
- Add a non-service product to the cart without being logged in and proceed to checkout
- Create an account and once logged in continue the checkout process normally until payment is done

When the process is done, a request is sent to /shop/payment/validate, and we get a server error message since we try to fetch `sale_last_order_id` from the session but it's not set.

To simplify, the buying process goes like this: cart > [sign in/up] > [delivery] > checkout > extra_step or confirm_order > payment. The issue is that `sale_last_order_id` is set in confirm_order, which we don't pass through if we have
extra_step enabled. To fix that, I moved the set operation a step earlier.

opw-3988807