### PR TITLE
[IMP] website: review s_parallax snippet

### DIFF
--- a/addons/website/views/snippets/s_parallax.xml
+++ b/addons/website/views/snippets/s_parallax.xml
@@ -2,8 +2,8 @@
 <odoo>
 
 <template id="s_parallax" name="Parallax">
-    <section class="s_parallax parallax s_parallax_is_fixed bg-black-50 o_half_screen_height" data-scroll-background-ratio="1">
-        <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_parallax_default_image'); background-position: 50% 75%;"/>
+    <section class="s_parallax parallax s_parallax_is_fixed bg-black-50 o_half_screen_height" data-scroll-background-ratio="-1.5">
+        <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_cover_default_image'); background-position: 50% 100%"/>
         <div class="o_we_bg_filter bg-black-50"/>
         <div class="oe_structure oe_empty"/>
     </section>


### PR DESCRIPTION
This PR reviews the default image of the `s_parallax` snippet, in order to align it with the other images introduced within the snippets redesign, and remove the ability for users to drag & drop "structure" snippets, while allowing to drop inner content ones.

| Master | This PR |
|--------|--------|
| <img width="866" alt="image" src="https://github.com/user-attachments/assets/bc59d7d5-5874-4d7b-a878-b692fb2cec4c"> | <img width="866" alt="image" src="https://github.com/user-attachments/assets/8f9a8575-1b03-406b-8588-ee8f5e7806e6"> | 

task-3743690

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
