### PR TITLE
[REF] html_editor: allow inheritance in toolbar buttons & support colors buttons in icon/table

### DIFF
--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -17,6 +17,7 @@ import { reactive } from "@odoo/owl";
 export class ColorPlugin extends Plugin {
     static name = "color";
     static dependencies = ["selection", "split", "history", "format"];
+    static shared = ["colorElement"];
     /** @type { (p: ColorPlugin) => Record<string, any> } */
     static resources = (p) => ({
         toolbarGroup: {
@@ -126,15 +127,11 @@ export class ColorPlugin extends Plugin {
      * @param {string} mode 'color' or 'backgroundColor'
      */
     applyColor(color, mode) {
-        const selectedTds = [...this.editable.querySelectorAll("td.o_selected_td")].filter(
-            (node) => node.isContentEditable
-        );
-        if (selectedTds.length && mode === "backgroundColor") {
-            for (const td of selectedTds) {
-                this.colorElement(td, color, mode);
+        for (const cb of this.resources.colorApply || []) {
+            if (cb(color, mode)) {
+                return;
             }
         }
-
         let selection = this.shared.getEditableSelection();
         let selectionNodes;
         // Get the <font> nodes to color

--- a/addons/html_editor/static/src/main/font/color_selector.js
+++ b/addons/html_editor/static/src/main/font/color_selector.js
@@ -66,7 +66,7 @@ export class ColorSelector extends Component {
     }
 
     applyColor(color) {
-        const mode = this.props.type === "foreground" ? "color" : "background";
+        const mode = this.props.type === "foreground" ? "color" : "backgroundColor";
         this.props.dispatch("APPLY_COLOR", { color: color || "", mode });
     }
 
@@ -81,7 +81,7 @@ export class ColorSelector extends Component {
 
     onColorPreview(ev) {
         const color = ev.hex ? ev.hex : this.processColorFromEvent(ev);
-        const mode = this.props.type === "foreground" ? "color" : "background";
+        const mode = this.props.type === "foreground" ? "color" : "backgroundColor";
         this.props.dispatch("COLOR_PREVIEW", { color: color || "", mode });
     }
 
@@ -100,7 +100,7 @@ export class ColorSelector extends Component {
     }
 
     getCurrentGradientColor() {
-        const mode = this.props.type === "foreground" ? "color" : "background";
+        const mode = this.props.type === "foreground" ? "color" : "backgroundColor";
         if (isColorGradient(this.selectedColors[mode])) {
             return this.selectedColors[mode];
         }

--- a/addons/html_editor/static/src/main/media/icon_plugin.js
+++ b/addons/html_editor/static/src/main/media/icon_plugin.js
@@ -3,7 +3,7 @@ import { _t } from "@web/core/l10n/translation";
 
 export class IconPlugin extends Plugin {
     static name = "icon";
-    static dependencies = ["history", "link", "selection"];
+    static dependencies = ["history", "link", "selection", "color"];
 
     static resources(p) {
         return {
@@ -16,6 +16,21 @@ export class IconPlugin extends Plugin {
                 },
             ],
             toolbarGroup: [
+                {
+                    id: "icon_color",
+                    sequence: 1,
+                    namespace: "icon",
+                    buttons: [
+                        {
+                            id: "icon_forecolor",
+                            inherit: "forecolor",
+                        },
+                        {
+                            id: "icon_backcolor",
+                            inherit: "backcolor",
+                        },
+                    ],
+                },
                 {
                     id: "icon_size",
                     sequence: 1,
@@ -85,6 +100,7 @@ export class IconPlugin extends Plugin {
                     ],
                 },
             ],
+            colorApply: p.applyIconColor.bind(p),
         };
     }
 
@@ -104,6 +120,7 @@ export class IconPlugin extends Plugin {
                     if (classString.match(/^fa-[2-5]x$/)) {
                         selectedIcon.classList.remove(classString);
                     }
+                    this.dispatch("ADD_STEP");
                 }
                 if (payload !== "1") {
                     selectedIcon.classList.add(`fa-${payload}x`);
@@ -140,5 +157,14 @@ export class IconPlugin extends Plugin {
             return;
         }
         return selectedIcon.classList.contains("fa-spin");
+    }
+
+    applyIconColor(color, mode) {
+        const selectedIcon = this.getSelectedIcon();
+        if (!selectedIcon) {
+            return;
+        }
+        this.shared.colorElement(selectedIcon, color, mode);
+        return true;
     }
 }

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -26,7 +26,7 @@ function isUnremovableTableComponent(element, root) {
  */
 export class TablePlugin extends Plugin {
     static name = "table";
-    static dependencies = ["dom", "history", "selection", "delete", "split"];
+    static dependencies = ["dom", "history", "selection", "delete", "split", "color"];
     /** @type { (p: TablePlugin) => Record<string, any> } */
     static resources = (p) => ({
         handle_tab: { callback: p.handleTab.bind(p), sequence: 20 },
@@ -36,6 +36,7 @@ export class TablePlugin extends Plugin {
         isUnsplittable: (element) =>
             element.tagName === "TABLE" || tableInnerComponents.has(element.tagName),
         onSelectionChange: p.updateSelectionTable.bind(p),
+        colorApply: p.applyTableColor.bind(p),
     });
 
     handleCommand(command, payload) {
@@ -500,5 +501,17 @@ export class TablePlugin extends Plugin {
             didDeselectTable = true;
         }
         return didDeselectTable;
+    }
+
+    applyTableColor(color, mode) {
+        const selectedTds = [...this.editable.querySelectorAll("td.o_selected_td")].filter(
+            (node) => node.isContentEditable
+        );
+        if (selectedTds.length && mode === "background") {
+            for (const td of selectedTds) {
+                this.shared.colorElement(td, color, mode);
+            }
+            return true;
+        }
     }
 }

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -507,11 +507,10 @@ export class TablePlugin extends Plugin {
         const selectedTds = [...this.editable.querySelectorAll("td.o_selected_td")].filter(
             (node) => node.isContentEditable
         );
-        if (selectedTds.length && mode === "background") {
+        if (selectedTds.length && mode === "backgroundColor") {
             for (const td of selectedTds) {
                 this.shared.colorElement(td, color, mode);
             }
-            return true;
         }
     }
 }

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -37,7 +37,7 @@ test("can set background color", async () => {
     expect(".o-we-toolbar").toHaveCount(1); // toolbar still open
     expect(".o_font_color_selector").toHaveCount(0); // selector closed
     expect(getContent(el)).toBe(
-        `<p><font style="background: rgb(107, 173, 222);">[test]</font></p>`
+        `<p><font style="background-color: rgb(107, 173, 222);">[test]</font></p>`
     );
 });
 

--- a/addons/html_editor/static/tests/icon.test.js
+++ b/addons/html_editor/static/tests/icon.test.js
@@ -1,6 +1,7 @@
 import { expect, test } from "@odoo/hoot";
 import { click, waitFor } from "@odoo/hoot-dom";
 import { setupEditor } from "./_helpers/editor";
+import { animationFrame } from "@odoo/hoot-mock";
 
 test("icon toolbar is displayed", async () => {
     await setupEditor(`<p><span class="fa fa-glass">[]</span></p>`);
@@ -33,4 +34,18 @@ test("Can spin an icon", async () => {
     expect("span.fa-glass").toHaveCount(1);
     click("button[name='icon_spin']");
     expect("span.fa-glass").toHaveClass("fa-spin");
+});
+
+test("Can set icon color", async () => {
+    await setupEditor(`<p><span class="fa fa-glass">[]</span></p>`);
+    await waitFor(".o-we-toolbar");
+    expect(".o_font_color_selector").toHaveCount(0);
+    click(".o-select-color-foreground");
+    await animationFrame();
+    expect(".o_font_color_selector").toHaveCount(1);
+    click(".o_color_button[data-color='#6BADDE']");
+    await animationFrame();
+    expect(".o-we-toolbar").toHaveCount(1); // toolbar still open
+    expect(".o_font_color_selector").toHaveCount(0); // selector closed
+    expect("span.fa-glass").toHaveStyle({ color: "rgb(107, 173, 222)" });
 });

--- a/addons/html_editor/static/tests/table/misc.test.js
+++ b/addons/html_editor/static/tests/table/misc.test.js
@@ -1,5 +1,7 @@
 import { expect, test } from "@odoo/hoot";
 import { setupEditor } from "../_helpers/editor";
+import { click, waitFor } from "@odoo/hoot-dom";
+import { animationFrame } from "@odoo/hoot-mock";
 
 function insertTable(editor, cols, rows) {
     editor.dispatch("INSERT_TABLE", { cols, rows });
@@ -10,4 +12,29 @@ test("can insert a table", async () => {
     insertTable(editor, 4, 3);
     expect(el.querySelectorAll("tr").length).toBe(3);
     expect(el.querySelectorAll("td").length).toBe(12);
+});
+
+test("can color cells", async () => {
+    await setupEditor(`
+        <table>
+            <tbody>
+                <tr>
+                    <td>[ab</td>
+                    <td>c]</td>
+                    <td>ef</td>
+                </tr>
+            </tbody>
+        </table>`);
+
+    await waitFor(".o-we-toolbar");
+    expect(".o_font_color_selector").toHaveCount(0);
+    click(".o-select-color-background");
+    await animationFrame();
+    expect(".o_font_color_selector").toHaveCount(1);
+
+    click(".o_color_button[data-color='#6BADDE']");
+    await animationFrame();
+    expect(".o-we-toolbar").toHaveCount(1); // toolbar still open
+    expect(".o_font_color_selector").toHaveCount(0); // selector closed
+    expect("td.o_selected_td").toHaveStyle({ "background-color": "rgb(107, 173, 222)" });
 });

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -339,6 +339,45 @@ test("toolbar correctly show namespace button group and stop showing when namesp
     expect(".btn-group[name='test_group']").toHaveCount(0);
 });
 
+test("toolbar correctly process inheritance buttons chain", async () => {
+    class TestPlugin extends Plugin {
+        static name = "TestPlugin";
+        static resources(p) {
+            return {
+                toolbarGroup: [
+                    {
+                        id: "test_group",
+                        buttons: [
+                            {
+                                id: "test_btn",
+                                name: "Test Button",
+                                icon: "fa-square",
+                            },
+                            {
+                                id: "test_btn2",
+                                inherit: "test_btn",
+                                name: "Test Button 2",
+                            },
+                        ],
+                    },
+                ],
+            };
+        }
+    }
+    await setupEditor("<p>[abc]</p>", {
+        config: { Plugins: [...MAIN_PLUGINS, TestPlugin] },
+    });
+    await waitFor(".o-we-toolbar");
+    expect(".btn-group[name='test_group']").toHaveCount(1);
+    expect("button[name='test_btn']").toHaveCount(1);
+    expect("button[name='test_btn']").toHaveClass("fa-square");
+    expect("button[name='test_btn']").toHaveAttribute("title", "Test Button");
+
+    expect("button[name='test_btn2']").toHaveCount(1);
+    expect("button[name='test_btn2']").toHaveClass("fa-square");
+    expect("button[name='test_btn2']").toHaveAttribute("title", "Test Button 2");
+});
+
 test("toolbar does not evaluate isFormatApplied when namespace does not match", async () => {
     class TestPlugin extends Plugin {
         static name = "TestPlugin";


### PR DESCRIPTION
[[REF] html_editor: allow inheritence in toolbar buttons](https://github.com/odoo/odoo/pull/174640/commits/f7101d32f27b362b558372de6471ac85be3bbad3) 

This commit enables plugins to create toolbar buttons inherited from
those defined in other plugins.

This is essential for plugins that need to use existing buttons
in different groups or with modified properties.

For instance, the `icon_plugin`may need to use the color selector
buttons, which aren't defined for the icon toolbar namespace.
With this commit, `icon_plugin`can now define a new group under the icon
namespace and include the color buttons.

[[FIX] html_editor: allow to color table cells](https://github.com/odoo/odoo/pull/174640/commits/7416607dfcca4504b3939b332713e99af286f085) 

Before, when selecting a cell it was not possible to color its
background color because of a typo used in the `APPLY_COLOR` command
option.

This commit fix it to allow users to color cells background.
This commit also introduce the `color_apply` resource, this resource
allows other plugin to take the hand on how certain element
can be colored. Instead of supporting creating an if each time
in the `colorApply` method from the `color_plugin`.

[[IMP] html_editor: implement color selector for icons](https://github.com/odoo/odoo/pull/174640/commits/37d77e79d54b8b538b488afe6d35150dc7eeb95e) 

This commit adds the color selector buttons in the toolbar
when clicking on an icon.