### PR TITLE
[FIX] stock: traceback due to missing field

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -857,9 +857,10 @@ class Picking(models.Model):
     def _compute_shipping_weight(self):
         for picking in self:
             # if shipping weight is not assigned => default to calculated product weight
+            packages_weight = picking.move_line_ids.result_package_id.sudo()._get_weight(picking.id)
             picking.shipping_weight = (
                 picking.weight_bulk +
-                sum(pack.shipping_weight or pack.weight for pack in picking.move_line_ids.result_package_id.sudo())
+                sum(pack.shipping_weight or packages_weight[pack] for pack in picking.move_line_ids.result_package_id)
             )
 
     def _compute_shipping_volume(self):


### PR DESCRIPTION
Usecase:
- Install only stock
- Create a picking with some packages

It crashes since the shipping weight is zero then it fallback on weight but this field only exists in `stock_delivery`

Share the compute code and we will move the field in master

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
