### PR TITLE
[IMP] web,web_editor,website_sale: modify product img from front-end

### DIFF
--- a/addons/web/models/ir_qweb_fields.py
+++ b/addons/web/models/ir_qweb_fields.py
@@ -86,10 +86,14 @@ class Image(models.AbstractModel):
         itemprop = None
         if options.get('itemprop'):
             itemprop = options['itemprop']
+        mimetype = None
+        if options.get('mimetype'):
+            mimetype = options['mimetype']
 
         atts = OrderedDict()
         atts["src"] = src
         atts["itemprop"] = itemprop
+        atts["mimetype"] = mimetype
         atts["class"] = classes
         atts["style"] = options.get('style')
         atts["width"] = options.get('width')

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -6516,7 +6516,7 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
      * @returns {String} The right mimetype used to apply options on image.
      */
     _getImageMimetype(img) {
-        return img.dataset.mimetype;
+        return img.dataset.mimetype || img.getAttribute('mimetype');
     },
     /**
      * @private

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -192,7 +192,13 @@
                 <a t-att-href="product_href" class="oe_product_image_link d-block h-100 position-relative" itemprop="url" contenteditable="false">
                     <t t-set="image_holder" t-value="product._get_image_holder()"/>
                     <span t-field="image_holder.image_1920"
-                        t-options="{'widget': 'image', 'preview_image': image_type, 'itemprop': 'image', 'class': 'h-100 w-100 position-absolute'}"
+                        t-options="{
+                            'widget':'image',
+                            'preview_image': image_type,
+                            'itemprop': 'image',
+                            'mimetype': 'image/webp',
+                            'class': 'h-100 w-100 position-absolute'
+                        }"
                         class="oe_product_image_img_wrapper d-flex h-100 justify-content-center align-items-center position-absolute"/>
 
                     <t t-set="bg_color" t-value="td_product['ribbon'].bg_color"/>
@@ -2630,10 +2636,26 @@
             <div t-field="product_image.image_1920"
                  name="o_img_with_max_suggested_width"
                  class="d-flex align-items-start justify-content-center h-100 oe_unmovable"
-                 t-options='{"widget": "image", "preview_image": "image_1024", "class": "oe_unmovable product_detail_img mh-100", "alt-field": "name", "zoom": product_image.can_image_1024_be_zoomed and "image_1920"}'
+                 t-options='{
+                    "widget": "image",
+                    "mimetype": "image/webp",
+                    "preview_image": "image_1024",
+                    "class": "oe_unmovable product_detail_img mh-100",
+                    "alt-field": "name",
+                    "zoom": product_image.can_image_1024_be_zoomed and "image_1920"
+                }'
             />
         </div>
-        <div t-else="" t-field="product_image.image_1920" t-att-class="image_classes + ' oe_unmovable'" t-options='{"widget": "image", "preview_image": "image_1024", "class": "oe_unmovable product_detail_img mh-100", "alt-field": "name", "zoom": product_image.can_image_1024_be_zoomed and "image_1920"}'/>
+        <div t-else="" t-field="product_image.image_1920" t-att-class="image_classes + ' oe_unmovable'"
+             t-options='{
+                "widget": "image",
+                "mimetype": "image/webp",
+                "preview_image": "image_1024",
+                "class": "oe_unmovable product_detail_img mh-100",
+                "alt-field": "name",
+                "zoom": product_image.can_image_1024_be_zoomed and "image_1920"
+            }'
+        />
     </template>
 
     <!-- Product page images: Carousel -->


### PR DESCRIPTION
**Prior this commit:**
- The functionality for modifying product images was only available when an image was replaced. It was not available when the image was clicked or added.

**Post this commit:**
- The user can now modify product images from the editor, by clicking on the image in product page.
- The user can now modify the image directly when adding an additional image, in the same way as when replacing the image in product page.
- From the /shop page also, the user can modify the image by clicking on it.

**Affected version**-master
**Task**-3559237