### PR TITLE
[IMP] account: remove unnecessary assignment of refund_sequence field

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -806,10 +806,6 @@ class AccountJournal(models.Model):
             if not vals['code']:
                 raise UserError(_("Cannot generate an unused journal code. Please change the name for journal %s.", vals['name']))
 
-        # === Fill missing refund_sequence ===
-        if 'refund_sequence' not in vals:
-            vals['refund_sequence'] = vals['type'] in ('sale', 'purchase')
-
         # === Fill missing alias name for sale / purchase, to force alias creation ===
         if journal_type in {'sale', 'purchase'}:
             if 'alias_name' not in vals:


### PR DESCRIPTION
In the commit found at https://github.com/odoo/odoo/commit/ce8690517b4b12a5271f4d374836df68e6658f9e :

The refund_sequence field was changed to a stored computed field. Consequently, assigning the refund_sequence field in the _fill_missing_values method is no longer necessary.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
