### PR TITLE
[IMP] spreadsheet_dashboard: publish dashboards by default

### DIFF
--- a/addons/spreadsheet_dashboard/models/spreadsheet_dashboard.py
+++ b/addons/spreadsheet_dashboard/models/spreadsheet_dashboard.py
@@ -12,7 +12,7 @@ class SpreadsheetDashboard(models.Model):
     name = fields.Char(required=True, translate=True)
     dashboard_group_id = fields.Many2one('spreadsheet.dashboard.group', required=True)
     sequence = fields.Integer()
-    is_published = fields.Boolean(default=False, copy=False)
+    is_published = fields.Boolean(default=True)
     group_ids = fields.Many2many('res.groups', default=lambda self: self.env.ref('base.group_user'))
 
 

--- a/addons/spreadsheet_dashboard/tests/test_spreadsheet_dashboard.py
+++ b/addons/spreadsheet_dashboard/tests/test_spreadsheet_dashboard.py
@@ -74,21 +74,21 @@ class TestSpreadsheetDashboard(DashboardTestCommon):
             self.env["res.currency"].get_company_currency_for_spreadsheet()
         )
 
-    def test_publish_dashboard(self):
-        group = self.env["spreadsheet.dashboard.group"].create({
-            "name": "Dashboard group"
-        })
-        dashboard = self.create_dashboard(group)
-        self.assertFalse(group.published_dashboard_ids)
-        dashboard.is_published = True
-        self.assertEqual(group.published_dashboard_ids, dashboard)
-
     def test_unpublish_dashboard(self):
         group = self.env["spreadsheet.dashboard.group"].create({
             "name": "Dashboard group"
         })
         dashboard = self.create_dashboard(group)
-        dashboard.is_published = True
         self.assertEqual(group.published_dashboard_ids, dashboard)
         dashboard.is_published = False
         self.assertFalse(group.published_dashboard_ids)
+
+    def test_publish_dashboard(self):
+        group = self.env["spreadsheet.dashboard.group"].create({
+            "name": "Dashboard group"
+        })
+        dashboard = self.create_dashboard(group)
+        dashboard.is_published = False
+        self.assertFalse(group.published_dashboard_ids)
+        dashboard.is_published = True
+        self.assertEqual(group.published_dashboard_ids, dashboard)


### PR DESCRIPTION
Purpose
-------

When users create a spreadsheet in the Documents app, then convert it to a dashboard (File > Add to dashboards), they don't understand why the spreadsheet doesn't appear in the main Dahsboards landing action. The reason is that the dashboard is not publised by default

Spec
----

Set dashboard to published by default to avoid not finding your dashboard

Task: 4077300



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
