### PR TITLE
[IMP] stock{_landed_costs}: add fields in reporting & better search in landed

### DIFF
--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -359,6 +359,7 @@
                         <filter string="Status" name="status" domain="[]" context="{'group_by': 'state'}"/>
                         <filter string="Creation Date" name="groupby_create_date" domain="[]" context="{'group_by': 'create_date'}" groups="base.group_no_one"/>
                         <filter string="Scheduled Date" name="groupby_date" domain="[]" context="{'group_by': 'date'}"/>
+                        <filter string="Is Late" name="is_late" domain="[]" context="{'group_by': 'is_late'}"/>
                     </group>
                 </search>
             </field>

--- a/addons/stock_landed_costs/models/__init__.py
+++ b/addons/stock_landed_costs/models/__init__.py
@@ -9,3 +9,4 @@ from . import stock_landed_cost
 from . import account_move
 from . import stock_valuation_layer
 from . import stock_move
+from . import stock_picking

--- a/addons/stock_landed_costs/models/account_move.py
+++ b/addons/stock_landed_costs/models/account_move.py
@@ -18,6 +18,14 @@ class AccountMove(models.Model):
             else:
                 account_move.landed_costs_visible = any(line.is_landed_costs_line for line in account_move.line_ids)
 
+    @api.depends('partner_id.name')
+    @api.depends_context('landed_cost_form')
+    def _compute_display_name(self):
+        super()._compute_display_name()
+        for move in self:
+            if self.env.context.get('landed_cost_form', False) and move.partner_id:
+                move.display_name += f" {move.partner_id.name}"
+
     def button_create_landed_costs(self):
         """Create a `stock.landed.cost` record associated to the account move of `self`, each
         `stock.landed.costs` lines mirroring the current `account.move.line` of self.

--- a/addons/stock_landed_costs/models/stock_picking.py
+++ b/addons/stock_landed_costs/models/stock_picking.py
@@ -1,0 +1,15 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class Picking(models.Model):
+    _inherit = "stock.picking"
+
+    @api.depends('partner_id.name')
+    @api.depends_context('landed_cost_form')
+    def _compute_display_name(self):
+        super()._compute_display_name()
+        for picking in self:
+            if self.env.context.get('landed_cost_form', False) and picking.partner_id:
+                picking.display_name += f" {picking.partner_id.name}"

--- a/addons/stock_landed_costs/views/stock_landed_cost_views.xml
+++ b/addons/stock_landed_costs/views/stock_landed_cost_views.xml
@@ -37,14 +37,15 @@
                                 <field name="target_model" widget="radio" invisible="1" readonly="state == 'done'"/>
                                 <field name="picking_ids" widget="many2many_tags" 
                                     options="{'no_create_edit': True}" invisible="target_model != 'picking'" readonly="state == 'done'"
-                                    domain="[('company_id', '=', company_id), ('move_ids.stock_valuation_layer_ids', '!=', False)]"/>
+                                    domain="[('company_id', '=', company_id), ('move_ids.stock_valuation_layer_ids', '!=', False)]"
+                                    context="{'landed_cost_form': True}"/>
                             </group>
                             <group>
                                 <label for="account_journal_id" string="Journal"/>
                                 <field name="account_journal_id" nolabel="1" readonly="state == 'done'"/>
                                 <field name="company_id" groups="base.group_multi_company"/>
                                 <field name="account_move_id" invisible="not account_move_id"/>
-                                <field name="vendor_bill_id"/>
+                                <field name="vendor_bill_id" context="{'landed_cost_form': True}"/>
                             </group>
                         </group>
                         <notebook>


### PR DESCRIPTION
## stock: add fields in moves analysis pivot
Fill rate:
This percentage is computed by dividing the quantity
by the demand.

On-Time Delivery rate:
This percentage is computed by dividing the quantity
of on-time deliveries by the total quantity of deliveries.

To check it, go to Stock > Reporting > Move Analysis

## stock_landed_costs: improve the display name in the form view
This commit introduces the contact name after the picking name
and vendor bill name in the stock landed costs form view.
This change makes it easier to find pickings or vendor bills
related to a specific partner.

task: 3983531