### PR TITLE
[FIX] mail: prevent comments menu overlap on small screens

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -27,7 +27,7 @@
                         </t>
                     </div>
                     <div class="w-100 o-min-width-0" t-att-class="{ 'flex-grow-1': message.composer }" t-ref="messageContent">
-                        <div t-if="!props.squashed" class="o-mail-Message-header d-flex flex-wrap align-items-baseline lh-1" t-att-class="{ 'mb-1': !message.is_note }">
+                        <div t-if="!props.squashed" class="o-mail-Message-header d-flex align-items-baseline lh-1" t-att-class="{ 'mb-1': !message.is_note }">
                             <span t-if="authorName and shouldDisplayAuthorName" class="o-mail-Message-author" t-att-class="getAuthorAttClass()">
                                 <strong class="me-1 text-truncate" t-esc="authorName"/>
                             </span>


### PR DESCRIPTION
Steps to reproduce:
1. Open Knowledge
2. Select any text in an article
3. The menu will show
4. Click on comments
5. Write a log and shrink the screen
6. The comments menu breaks

The display of comments is a little bit odd

Removed 'flex-wrap' from the message header's CSS to prevent the menu from overlapping when the screen size is reduced. This ensures a consistent layout and better user experience on smaller screens.

Task-4063810