### PR TITLE
[FIX] pos_loyalty: tb while adding gift card code in empty cart

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -285,7 +285,7 @@ patch(PosStore.prototype, {
             return _t(
                 "Gift Card: %s\nBalance: %s",
                 code,
-                this.env.utils.formatCurrency(coupon.balance)
+                this.env.utils.formatCurrency(coupon.points)
             );
         }
         return true;


### PR DESCRIPTION
Steps:

- Create a program type = Coupon
- Set rules & rewards, In rewards give free product
- Generate a new coupon & copy it
- Open POS and open Enter code
- Paste the newly created coupon without adding any product in pos cart

Issue:
- Traceback error when manually applying a coupon in the POS with an empty cart.

Cause:
- Attempts to access coupon.balance to display a message,
  but the loyalty.card model does not have a field named balance.

Fix:
- Replace coupon.balance with coupon.points.

task-4070130