### PR TITLE
[FIX] point_of_sale: display the product categories on a line

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
@@ -20,7 +20,7 @@
             <div class="rightpane d-flex flex-grow-1 flex-column bg-view w-60 bg-100" t-if="!ui.isSmall || pos.mobile_pane === 'right'">
                 <div t-if="!ui.isSmall" t-ref="category-box" t-att-class="{'d-none': state.scrollDown and ui.isSmall}" class="d-flex flex-column shadow-sm control-top-bar">
                     <div class="category-box flex-grow-1">
-                        <CategorySelector class="'category-selector d-grid p-1 gap-1'" categories="getCategoriesAndSub()" onClick="(id) => this.pos.setSelectedCategory(id)"/>
+                        <CategorySelector class="'category-selector d-grid p-1 gap-1 d-flex overflow-auto'" categories="getCategoriesAndSub()" onClick="(id) => this.pos.setSelectedCategory(id)"/>
                     </div>
                 </div>
                 <div t-ref="products" class="overflow-y-auto flex-grow-1">


### PR DESCRIPTION
Fix for 17.1 and 17.2

Current behavior:
When a shop has a lot of product categories, they take all the place on the screen so it is impossible to select the products

Steps to reproduce:
- Install "Point of Sale" app
- Go to the settings, create hundreds of product categories (you can duplicate to be faster)
- Assign all these product categories to the shop
- Start a shop session

Before:
![Screenshot from 2024-07-26 12-09-07](https://github.com/user-attachments/assets/8ecfc0ae-704f-4df0-baf1-f0655bbedec3)

After:
![Screenshot from 2024-07-26 12-09-39](https://github.com/user-attachments/assets/74a8dd46-711f-4565-8eac-16dedaa8f2e1)

opw-4058676


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
