### PR TITLE
[FIX] web_editor: not able to select single cell

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -2660,7 +2660,8 @@ export class OdooEditor extends EventTarget {
         } else if (ev && startTd && !isProtected(startTd)) {
             // We're redirected from a mousemove event.
             const selectedNodes = getSelectedNodes(this.editable);
-            const areCellContentsFullySelected = descendants(startTd).filter(d => !isBlock(d)).every(child => selectedNodes.includes(child));
+            const cellContents = descendants(startTd);
+            const areCellContentsFullySelected = cellContents.filter(d => !isBlock(d)).every(child => selectedNodes.includes(child));
             if (areCellContentsFullySelected) {
                 const SENSITIVITY = 5;
                 const rangeRect = range.getBoundingClientRect();
@@ -2672,8 +2673,8 @@ export class OdooEditor extends EventTarget {
                     this._selectTableCells(range);
                     appliedCustomSelection = true;
                 }
-            } else if (!isVisible(startTd) &&
-                ev.clientX - (this._lastMouseClickPosition ? this._lastMouseClickPosition[0] : ev.clientX) >= 15
+            } else if (cellContents.filter(isBlock).every(isEmptyBlock) &&
+                Math.abs(ev.clientX - (this._lastMouseClickPosition ? this._lastMouseClickPosition[0] : ev.clientX)) >= 15
             ) {
                 // Handle selecting an empty cell.
                 this._selectTableCells(range);

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/style.scss
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/style.scss
@@ -35,7 +35,6 @@
     }
     .o_selected_td {
         background-color: rgba(117, 167, 249, 0.5) !important; /* #bad3fc equivalent when over white*/
-        cursor: pointer !important;
     }
 }
 .o_table_ui_container {


### PR DESCRIPTION
**Current behaviour before PR:**

In table, empty single cell is not selectable through mouse. This happens
because isVisible function fails to check if cell is empty or not.

**Desired behaviour after PR:**

Now it is possible to select empty cell through mouse. Now we are using isEmptyBlock
to check if cell is empty or not.

task-4067376




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
