### PR TITLE
[IMP] *: simplify kanban archs

### DIFF
--- a/addons/hr_timesheet/views/project_task_sharing_views.xml
+++ b/addons/hr_timesheet/views/project_task_sharing_views.xml
@@ -114,7 +114,7 @@
                 <field name="allow_timesheets"/>
                 <field name="encode_uom_in_days" invisible="1"/>
             </templates>
-            <div class="oe_kanban_bottom_left" position="inside">
+            <field name="priority" position="after">
                 <t name="allocated_hours" t-if="record.allocated_hours.raw_value &gt; 0 and record.allow_timesheets.raw_value">
                     <t t-set="badge" t-value="'border border-success'"/>
                     <t t-set="badge" t-value="'border border-warning'" t-if="record.progress.raw_value &gt;= 0.8 and record.progress.raw_value &lt;= 1"/>
@@ -125,7 +125,7 @@
                         <field name="remaining_hours" widget="timesheet_uom" />
                     </div>
                 </t>
-            </div>
+            </field>
         </field>
     </record>
 </odoo>

--- a/addons/hr_timesheet/views/project_task_views.xml
+++ b/addons/hr_timesheet/views/project_task_views.xml
@@ -160,7 +160,7 @@
                     <field name="allow_timesheets"/>
                     <field name="encode_uom_in_days" invisible="1"/>
                 </templates>
-                <div class="oe_kanban_bottom_left" position="inside">
+                <xpath expr="//footer/div" position="inside">
                    <t name="allocated_hours" t-if="record.allocated_hours.raw_value &gt; 0 and record.allow_timesheets.raw_value" groups="hr_timesheet.group_hr_timesheet_user">
                         <t t-set="badge" t-value=""/>
                         <t t-set="badge" t-value="'border border-warning'" t-if="record.progress.raw_value &gt;= 0.8 and record.progress.raw_value &lt;= 1"/>
@@ -171,7 +171,7 @@
                             <field name="remaining_hours" widget="timesheet_uom" />
                         </div>
                    </t>
-                </div>
+                </xpath>
              </field>
          </record>
 

--- a/addons/project/static/src/js/tours/project.js
+++ b/addons/project/static/src/js/tours/project.js
@@ -103,7 +103,7 @@ registry.category("web_tour.tours").add('project_tour', {
     trigger: ".o_kanban_project_tasks",
 },
 {
-    trigger: ".o_kanban_record .oe_kanban_content",
+    trigger: ".o_kanban_record",
     content: markup(_t("<b>Drag &amp; drop</b> the card to change your task from stage.")),
     tooltipPosition: "bottom",
     run: "drag_and_drop(.o_kanban_group:eq(1))",
@@ -228,7 +228,7 @@ registry.category("web_tour.tours").add('project_tour', {
     run: 'click',
 }, {
     isActive: ["auto"],
-    trigger: ".o_kanban_record .oe_kanban_content .o_widget_subtask_counter .subtask_list_button",
+    trigger: ".o_kanban_record .o_widget_subtask_counter .subtask_list_button",
     content: _t("You can open sub-tasks from the kanban card!"),
     run: "click",
 }, 
@@ -268,7 +268,7 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "click",
 }, {
     isActive: ["auto"],
-    trigger: ".o_kanban_record .oe_kanban_content .o_widget_subtask_counter .subtask_list_button:contains('1/2')",
+    trigger: ".o_kanban_record .o_widget_subtask_counter .subtask_list_button:contains('1/2')",
     content: _t("Close the sub-tasks list"),
     run: "click",
 }, {

--- a/addons/project/static/src/views/project_update_kanban/project_update_kanban.scss
+++ b/addons/project/static/src/views/project_update_kanban/project_update_kanban.scss
@@ -1,5 +1,9 @@
 .o_project_update_kanban_view .o_kanban_renderer {
     overflow: auto;
+    .o_pupdate_kanban_width {
+        flex-basis: 15%;
+        flex-grow: 1;
+    }
     &.o_kanban_ungrouped {
         padding:0px;
         .o_pupdate_kanban_card {
@@ -13,10 +17,6 @@
                 > div {
                     display: grid;
                     align-items: center;
-                }
-                .o_pupdate_kanban_width {
-                    flex-basis: 15%;
-                    flex-grow: 1;
                 }
                 .o_pupdate_kanban_image {
                     width: 56px;

--- a/addons/project/static/tests/legacy/project_state_selection_tests.js
+++ b/addons/project/static/tests/legacy/project_state_selection_tests.js
@@ -39,13 +39,9 @@ QUnit.module("Project", (hooks) => {
             },
             arch: `
                 <kanban  class="o_kanban_test">
-                    <field name="last_update_status"/>
-                    <field name="last_update_color"/>
                     <template>
-                        <t t-name="kanban-box">
-                            <div>
-                                <field name="last_update_status" widget="project_state_selection"/>
-                            </div>
+                        <t t-name="kanban-card">
+                            <field name="last_update_status" widget="project_state_selection"/>
                         </t>
                     </template>
                 </kanban>`,

--- a/addons/project/static/tests/legacy/project_status_with_color_selection_tests.js
+++ b/addons/project/static/tests/legacy/project_status_with_color_selection_tests.js
@@ -35,13 +35,9 @@ QUnit.module("Project", (hooks) => {
             },
             arch: `
                 <kanban  class="o_kanban_test">
-                    <field name="status"/>
-                    <field name="id"/>
                     <template>
-                        <t t-name="kanban-box">
-                            <div>
-                                <field name="status" widget="status_with_color" readonly="1" status_label="test status label"/>
-                            </div>
+                        <t t-name="kanban-card">
+                            <field name="status" widget="status_with_color" readonly="1" status_label="test status label"/>
                         </t>
                     </template>
                 </kanban>`,

--- a/addons/project/static/tests/legacy/project_subtask_kanban_list_form_tests.js
+++ b/addons/project/static/tests/legacy/project_subtask_kanban_list_form_tests.js
@@ -46,19 +46,16 @@ QUnit.module('Subtask Kanban List tests', {
             "project.task,false,kanban":
                 `<kanban js_class="project_task_kanban">
                     <field name="subtask_count"/>
-                    <field name="closed_subtask_count"/>
                     <field name="project_id"/>
+                    <field name="user_ids"/>
+                    <field name="state"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div>
-                                <field name="display_name" widget="name_with_subtask_count"/>
-                                <field name="user_ids" invisible="1" widget="many2many_avatar_user"/>
-                                <field name="state" invisible="1" widget="project_task_state_selection"/>
-                                <t t-if="record.project_id.raw_value and record.subtask_count.raw_value">
-                                    <widget name="subtask_counter"/>
-                                </t>
-                                <widget name="subtask_kanban_list" />
-                            </div>
+                        <t t-name="kanban-card">
+                            <field name="display_name" widget="name_with_subtask_count"/>
+                            <t t-if="record.project_id.raw_value and record.subtask_count.raw_value">
+                                <widget name="subtask_counter"/>
+                            </t>
+                            <widget name="subtask_kanban_list" />
                         </t>
                     </templates>
                 </kanban>`,

--- a/addons/project/static/tests/legacy/project_task_groupby_tests.js
+++ b/addons/project/static/tests/legacy/project_task_groupby_tests.js
@@ -104,7 +104,7 @@ QUnit.module("Project", (hooks) => {
         const views = {
             "project.task,false,kanban": `<kanban js_class="project_task_kanban" default_group_by="project_id">
                     <templates>
-                        <t t-name="kanban-box"/>
+                        <t t-name="kanban-card"/>
                     </templates>
                 </kanban>`,
         };
@@ -125,7 +125,7 @@ QUnit.module("Project", (hooks) => {
         const views = {
             "project.task,false,kanban": `<kanban js_class="project_task_kanban" default_group_by="user_ids">
                     <templates>
-                        <t t-name="kanban-box"/>
+                        <t t-name="kanban-card"/>
                     </templates>
                 </kanban>`,
         };
@@ -146,7 +146,7 @@ QUnit.module("Project", (hooks) => {
         const views = {
             "project.task,false,kanban": `<kanban js_class="project_task_kanban" default_group_by="date_deadline">
                     <templates>
-                        <t t-name="kanban-box"/>
+                        <t t-name="kanban-card"/>
                     </templates>
                 </kanban>`,
         };

--- a/addons/project/static/tests/legacy/project_task_state_selection_tests.js
+++ b/addons/project/static/tests/legacy/project_task_state_selection_tests.js
@@ -33,10 +33,8 @@ QUnit.module('Task State Tests', {
             "project.task,false,kanban":
                 `<kanban js_class="project_task_kanban">
                     <templates>
-                        <t t-name="kanban-box">
-                            <div>
-                                <field name="state" widget="project_task_state_selection" class="project_task_state_test"/>
-                            </div>
+                        <t t-name="kanban-card">
+                            <field name="state" widget="project_task_state_selection" class="project_task_state_test"/>
                         </t>
                     </templates>
                 </kanban>`,

--- a/addons/project/static/tests/legacy/views/project_task_kanban/project_task_kanban_view_tests.js
+++ b/addons/project/static/tests/legacy/views/project_task_kanban/project_task_kanban_view_tests.js
@@ -29,10 +29,8 @@ QUnit.module('Project', {
             "project.task,false,kanban":
                 `<kanban js_class="project_task_kanban">
                     <templates>
-                        <t t-name="kanban-box">
-                            <div>
-                                <field name="name"/>
-                            </div>
+                        <t t-name="kanban-card">
+                            <field name="name"/>
                         </t>
                     </templates>
                 </kanban>`,

--- a/addons/project/static/tests/project_is_favorite_field.test.js
+++ b/addons/project/static/tests/project_is_favorite_field.test.js
@@ -18,11 +18,9 @@ beforeEach(() => {
         "kanban,false": `
             <kanban class="o_kanban_test" edit="0">
                 <template>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="is_favorite" widget="project_is_favorite" nolabel="1"/>
-                            <field name="name"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="is_favorite" widget="project_is_favorite" nolabel="1"/>
+                        <field name="name"/>
                     </t>
                 </template>
             </kanban>

--- a/addons/project/static/tests/project_project_state_selection.test.js
+++ b/addons/project/static/tests/project_project_state_selection.test.js
@@ -32,13 +32,9 @@ test("project.project (kanban): check that ProjectStateSelectionField does not p
         type: "kanban",
         arch: `
             <kanban class="o_kanban_test">
-                <field name="last_update_status"/>
-                <field name="last_update_color"/>
                 <template>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="last_update_status" widget="project_state_selection"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="last_update_status" widget="project_state_selection"/>
                     </t>
                 </template>
             </kanban>

--- a/addons/project/static/tests/project_task_groupby.test.js
+++ b/addons/project/static/tests/project_task_groupby.test.js
@@ -53,7 +53,7 @@ test("project.task (kanban): check group label for no project", async () => {
         arch: `
             <kanban js_class="project_task_kanban" default_group_by="project_id">
                 <templates>
-                    <t t-name="kanban-box"/>
+                    <t t-name="kanban-card"/>
                 </templates>
             </kanban>
         `,
@@ -68,7 +68,7 @@ test("project.task (kanban): check group label for no assignees", async () => {
         arch: `
             <kanban js_class="project_task_kanban" default_group_by="user_ids">
                 <templates>
-                    <t t-name="kanban-box"/>
+                    <t t-name="kanban-card"/>
                 </templates>
             </kanban>
         `,
@@ -83,7 +83,7 @@ test("project.task (kanban): check group label for no deadline", async () => {
         arch: `
             <kanban js_class="project_task_kanban" default_group_by="date_deadline">
                 <templates>
-                    <t t-name="kanban-box"/>
+                    <t t-name="kanban-card"/>
                 </templates>
             </kanban>
         `,

--- a/addons/project/static/tests/project_task_kanban_view.test.js
+++ b/addons/project/static/tests/project_task_kanban_view.test.js
@@ -15,12 +15,9 @@ test("shadow stages should be displayed in the project Kanban", async () => {
         type: "kanban",
         arch: `
             <kanban default_group_by="stage_id" js_class="project_task_kanban">
-                <field name="name"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="name"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="name"/>
                     </t>
                 </templates>
             </kanban>

--- a/addons/project/static/tests/project_task_state_selection.test.js
+++ b/addons/project/static/tests/project_task_state_selection.test.js
@@ -14,10 +14,8 @@ test("project.task (kanban): check task state widget", async () => {
         arch: `
             <kanban js_class="project_task_kanban">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="state" widget="project_task_state_selection" class="project_task_state_test"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="state" widget="project_task_state_selection" class="project_task_state_test"/>
                     </t>
                 </templates>
             </kanban>

--- a/addons/project/static/tests/project_task_subtask.test.js
+++ b/addons/project/static/tests/project_task_subtask.test.js
@@ -90,15 +90,15 @@ beforeEach(() => {
         kanban: `
             <kanban js_class="project_task_kanban">
                 <field name="subtask_count"/>
-                <field name="closed_subtask_count"/>
                 <field name="project_id"/>
+                <field name="closed_subtask_count"/>
                 <field name="child_ids"/>
+                <field name="user_ids"/>
+                <field name="state"/>
                 <templates>
-                    <t t-name="kanban-box">
+                    <t t-name="kanban-card">
                         <div>
                             <field name="display_name" widget="name_with_subtask_count"/>
-                            <field name="user_ids" invisible="1" widget="many2many_avatar_user"/>
-                            <field name="state" invisible="1" widget="project_task_state_selection"/>
                             <t t-if="record.project_id.raw_value and record.subtask_count.raw_value">
                                 <widget name="subtask_counter"/>
                             </t>

--- a/addons/project/static/tests/project_update_with_color.test.js
+++ b/addons/project/static/tests/project_update_with_color.test.js
@@ -27,13 +27,9 @@ test("project.update (kanban): check that ProjectStatusWithColorSelectionField i
         type: "kanban",
         arch: `
             <kanban  class="o_kanban_test">
-                <field name="status"/>
-                <field name="id"/>
                 <template>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="status" widget="status_with_color" readonly="1" status_label="test status label"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="status" widget="status_with_color" readonly="1" status_label="test status label"/>
                     </t>
                 </template>
             </kanban>

--- a/addons/project/static/tests/tours/personal_stage_tour.js
+++ b/addons/project/static/tests/tours/personal_stage_tour.js
@@ -80,5 +80,5 @@ registry.category("web_tour.tours").add('personal_stage_tour', {
     run: "click",
 }, {
     content: "Check that task exists",
-    trigger: '.o_kanban_record_title:contains("New Test Task")',
+    trigger: '.o_kanban_record:contains("New Test Task")',
 }]});

--- a/addons/project/static/tests/tours/project_task_history.js
+++ b/addons/project/static/tests/tours/project_task_history.js
@@ -50,7 +50,7 @@ registry.category("web_tour.tours").add("project_task_history_tour", {
         run: "click",
     }, {
         content: "Open Test History Task",
-        trigger: "div strong.o_kanban_record_title:contains('Test History Task')",
+        trigger: ".o_kanban_record:contains('Test History Task')",
         run: "click",
     },
         // edit the description content 3 times and save after each edit
@@ -68,7 +68,7 @@ registry.category("web_tour.tours").add("project_task_history_tour", {
     },
     {
         content: "Open Test History Task",
-        trigger: "div strong.o_kanban_record_title:contains('Test History Task')",
+        trigger: ".o_kanban_record:contains('Test History Task')",
         run: "click",
     },
     {

--- a/addons/project/static/tests/tours/project_tour.js
+++ b/addons/project/static/tests/tours/project_tour.js
@@ -80,7 +80,7 @@ registry.category("web_tour.tours").add('project_test_tour', {
         tooltipPosition: "right",
         run: "click",
     }, {
-        trigger: ".o_kanban_record .oe_kanban_content .o_widget_subtask_counter .subtask_list_button",
+        trigger: ".o_kanban_record .o_widget_subtask_counter .subtask_list_button",
         content: 'open sub-tasks from kanban card',
         run: "click",
     }, 
@@ -112,7 +112,7 @@ registry.category("web_tour.tours").add('project_test_tour', {
         content: 'Mark the task as Canceled',
         run: "click",
     }, {
-        trigger: ".o_kanban_record .oe_kanban_content .o_widget_subtask_counter .subtask_list_button:contains('1/2')",
+        trigger: ".o_kanban_record .o_widget_subtask_counter .subtask_list_button:contains('1/2')",
         content: 'Close the sub-tasks list',
         id: "quick_create_tasks",
         run: "click",

--- a/addons/project/static/tests/tours/project_update_tour_tests.js
+++ b/addons/project/static/tests/tours/project_update_tour_tests.js
@@ -102,7 +102,7 @@ registry.category("web_tour.tours").add('project_update_tour', {
     trigger: '.o_kanban_project_tasks',
 },
 {
-    trigger: ".o_kanban_record .oe_kanban_content",
+    trigger: ".o_kanban_record",
     run: "drag_and_drop(.o_kanban_group:eq(1))",
 }, {
     trigger: ".o_control_panel_navigation button i.fa-sliders",

--- a/addons/project/views/project_project_stage_views.xml
+++ b/addons/project/views/project_project_stage_views.xml
@@ -57,22 +57,11 @@
         <field name="model">project.project.stage</field>
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile" sample="1" quick_create_view="project.project_project_stage_view_form_quick_create">
-                <field name="name"/>
-                <field name="mail_template_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div class="o_kanban_record oe_kanban_global_click">
-                            <strong><field name="name"/></strong>
-                            <br/>
-                            <span class="text-muted" invisible="not mail_template_id">
-                                <field name="mail_template_id"/>
-                                <br/>
-                            </span>
-                            <span groups="base.group_multi_company" invisible="not company_id">
-                                <field name="company_id"/>
-                                <br/>
-                            </span>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="name" class="fw-bolder mb-4"/>
+                        <field name="mail_template_id" class="text-muted mb-2" invisible="not mail_template_id"/>
+                        <field name="company_id" groups="base.group_multi_company" invisible="not company_id" class="mb-2"/>
                     </t>
                 </templates>
             </kanban>

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -301,25 +301,12 @@
             <field name="model">project.project</field>
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile">
-                    <field name="user_id" string="Project Manager"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="oe_kanban_content oe_kanban_global_click o_kanban_get_form">
-                                <div class="row">
-                                    <div class="col-12">
-                                        <strong><field name="name" string="Project Name"/></strong>
-                                    </div>
-                                </div>
-                                <div class="row">
-                                    <div class="col-8">
-                                        <field name="partner_id" string="Contact"/>
-                                    </div>
-                                    <div class="col-4">
-                                        <div class="oe_kanban_bottom_right float-end">
-                                            <field name="user_id" widget="many2one_avatar_user"/>
-                                        </div>
-                                    </div>
-                                </div>
+                        <t t-name="kanban-card">
+                            <field name="name" class="fw-bolder" string="Project Name"/>
+                            <div class="d-flex">
+                                <field name="partner_id" string="Contact"/>
+                                <field name="user_id" class="ms-auto" widget="many2one_avatar_user"/>
                             </div>
                         </t>
                     </templates>

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -21,6 +21,7 @@
         <field name="groups_id" eval="[(4, ref('base.group_portal')), (4, ref('base.group_user'))]"/>
         <field name="arch" type="xml">
             <kanban
+                highlight_color="color"
                 class="o_kanban_small_column o_kanban_project_tasks"
                 default_group_by="stage_id"
                 on_create="quick_create"
@@ -30,69 +31,37 @@
                 groups_draggable="0"
                 default_order="priority desc, sequence, state, date_deadline asc, id desc"
             >
-                <field name="color"/>
-                <field name="priority"/>
-                <field name="stage_id"/>
-                <field name="portal_user_names"/>
-                <field name="partner_id"/>
-                <field name="sequence"/>
                 <field name="state"/>
-                <field name="displayed_image_id"/>
-                <field name="active"/>
-                <field name="closed_subtask_count"/>
-                <field name="subtask_count"/>
                 <field name="allow_milestones" />
                 <field name="has_late_and_unreached_milestone"/>
                 <progressbar field="state" colors='{"1_done": "success", "03_approved": "success", "02_changes_requested": "warning", "1_canceled": "danger", "04_waiting_normal": "200", "01_in_progress": "200"}'/>
                 <templates>
                 <t t-name="kanban-menu" t-if="!selection_mode">
                     <div role="separator" class="dropdown-divider"></div>
-                    <ul class="oe_kanban_colorpicker" data-field="color"/>
+                    <field name="color" widget="kanban_color_picker"/>
                 </t>
-                <t t-name="kanban-box">
-                    <div t-attf-class="{{!selection_mode ? 'oe_kanban_color_' + kanban_getcolor(record.color.raw_value) : ''}} oe_kanban_card oe_kanban_global_click">
-                        <div class="oe_kanban_content">
-                            <div class="o_kanban_record_top" t-att-class="['1_done', '1_canceled'].includes(record.state.raw_value) ? 'opacity-50' : ''">
-                                <div class="o_kanban_record_headings text-muted">
-                                    <strong class="o_kanban_record_title">
-                                        <s t-if="!record.active.raw_value"><field name="name" widget="name_with_subtask_count"/></s>
-                                        <t t-else=""><field name="name" widget="name_with_subtask_count"/></t>
-                                    </strong>
-                                    <span invisible="context.get('default_project_id', False)"><br/><field name="project_id" required="1"/></span>
-                                    <span t-if="record.allow_milestones.raw_value and record.milestone_id.raw_value" t-attf-class="{{record.has_late_and_unreached_milestone.raw_value and !record.state.raw_value.startsWith('1_') ? 'text-danger' : ''}}">
-                                        <br/>
-                                        <field name="milestone_id" />
-                                    </span>
-                                    <br />
-                                    <span t-if="record.partner_id.value" t-att-title="record.partner_id.value">
-                                        <field name="partner_id" class="text-truncate d-block"/>
-                                    </span>
-                                </div>
-                            </div>
-                            <div class="o_kanban_record_body">
-                                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" context="{'project_id': project_id}"/>
-                                <div t-if="record.date_deadline.raw_value" name="date_deadline" invisible="state in ['1_done', '1_canceled']">
-                                    <field name="date_deadline" widget="remaining_days"/>
-                                </div>
-                                <div t-if="record.displayed_image_id.value" groups="base.group_user">
-                                    <field name="displayed_image_id" widget="attachment_image"/>
-                                </div>
-                            </div>
-                            <div class="o_kanban_record_bottom" t-if="!selection_mode">
-                                <div class="oe_kanban_bottom_left">
-                                    <field name="priority" widget="priority"/>
-                                </div>
-                                <div class="oe_kanban_bottom_right" t-if="!selection_mode">
-                                    <span t-if="record.portal_user_names.raw_value.length > 0" class="pe-2" t-att-title="record.portal_user_names.raw_value">
-                                        <t t-set="user_count" t-value="record.portal_user_names.raw_value.split(',').length"/>
-                                        <t t-if="user_count > 1"><t t-out="user_count"/> assignees</t>
-                                        <t t-else="" t-out="record.portal_user_names.raw_value"/>
-                                    </span>
-                                    <field name="state" widget="project_task_state_selection" options="{'is_toggle_mode': false}"/>
-                                </div>
-                            </div>
+                <t t-name="kanban-card">
+                    <div t-att-class="{'opacity-50': ['1_done', '1_canceled'].includes(record.state.raw_value)}">
+                        <field name="name" class="fw-bolder fs-5" widget="name_with_subtask_count"/>
+                        <field name="project_id" invisible="context.get('default_project_id', False)" required="1" class="text-muted"/>
+                        <span t-if="record.allow_milestones.raw_value and record.milestone_id.raw_value" t-attf-class="{{record.has_late_and_unreached_milestone.raw_value and !record.state.raw_value.startsWith('1_') ? 'text-danger' : ''}}">
+                            <field name="milestone_id" class="text-muted"/>
+                        </span>
+                        <field t-if="record.partner_id.value" name="partner_id" class="text-truncate text-muted d-block"/>
+                    </div>
+                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" context="{'project_id': project_id}"/>
+                    <field t-if="record.date_deadline.raw_value" name="date_deadline" invisible="state in ['1_done', '1_canceled']" widget="remaining_days"/>
+                    <field t-if="record.displayed_image_id.value" groups="base.group_user" name="displayed_image_id" widget="attachment_image"/>
+                    <div class="d-flex mt-2" t-if="!selection_mode">
+                        <field name="priority" class="me-2" widget="priority"/>
+                        <div class="d-flex ms-auto">
+                            <span t-if="record.portal_user_names.raw_value.length > 0" class="pe-2" t-att-title="record.portal_user_names.raw_value">
+                                <t t-set="user_count" t-value="record.portal_user_names.raw_value.split(',').length"/>
+                                <t t-if="user_count > 1"><t t-out="user_count"/> assignees</t>
+                                <field t-else="" name="portal_user_names"/>
+                            </span>
+                            <field name="state" widget="project_task_state_selection" options="{'is_toggle_mode': false}"/>
                         </div>
-                        <div class="clearfix"></div>
                     </div>
                 </t>
                 </templates>

--- a/addons/project/views/project_task_type_views.xml
+++ b/addons/project/views/project_task_type_views.xml
@@ -87,19 +87,10 @@
             <field name="model">project.task.type</field>
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile" sample="1" default_group_by="project_ids">
-                    <field name="name"/>
-                    <field name="fold"/>
-                    <field name="sequence" widget="handle"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="oe_kanban_global_click">
-                                <div class="row">
-                                    <div class="col-12">
-                                        <strong class="o_text_overflow"><t t-esc="record.name.value"/></strong>
-                                    </div>
-                                </div>
-                                <field name="project_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
-                            </div>
+                        <t t-name="kanban-card">
+                            <field name="name" class="fw-bolder text-truncate"/>
+                            <field name="project_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                         </t>
                     </templates>
                 </kanban>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -644,6 +644,7 @@
             <field name="model">project.task</field>
             <field name="arch" type="xml">
                 <kanban
+                    highlight_color="color"
                     default_group_by="stage_id"
                     class="o_kanban_small_column o_kanban_project_tasks"
                     on_create="quick_create"
@@ -652,26 +653,13 @@
                     js_class="project_task_kanban" sample="1"
                     default_order="priority desc, sequence, state, date_deadline asc, id desc"
                 >
-                    <field name="color"/>
-                    <field name="priority"/>
                     <field name="stage_id"/>
-                    <field name="user_ids"/>
-                    <field name="partner_id"/>
-                    <field name="sequence"/>
-                    <field name="displayed_image_id"/>
-                    <field name="active"/>
-                    <field name="activity_ids"/>
-                    <field name="activity_state"/>
                     <field name="rating_count"/>
                     <field name="rating_avg"/>
                     <field name="rating_active"/>
                     <field name="has_late_and_unreached_milestone" />
                     <field name="allow_milestones" />
                     <field name="state" />
-                    <field name="company_id"/>
-                    <field name="recurrence_id" />
-                    <field name="subtask_count"/>
-                    <field name="closed_subtask_count"/>
                     <field name="subtask_count"/>
                     <progressbar field="state" colors='{"1_done": "success-done", "1_canceled": "danger", "03_approved": "success", "02_changes_requested": "warning", "04_waiting_normal": "info", "01_in_progress": "200" }'/>
                     <templates>
@@ -679,72 +667,50 @@
                         <a t-if="widget.editable" role="menuitem" type="set_cover" class="dropdown-item" data-field="displayed_image_id">Set Cover Image</a>
                         <a name="%(portal.portal_share_action)d" role="menuitem" type="action" class="dropdown-item" context="{'dialog_size': 'medium'}">Share Task</a>
                         <div role="separator" class="dropdown-divider"></div>
-                        <ul class="oe_kanban_colorpicker" data-field="color"/>
+                        <field name="color" widget="kanban_color_picker"/>
                     </t>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="{{!selection_mode ? 'oe_kanban_color_' + kanban_getcolor(record.color.raw_value) : ''}} oe_kanban_card oe_kanban_global_click">
-                            <div class="oe_kanban_content">
-                                <div class="o_kanban_record_top" t-att-class="['1_done', '1_canceled'].includes(record.state.raw_value) ? 'opacity-50' : ''">
-                                    <div class="o_kanban_record_headings text-muted">
-                                        <strong class="o_kanban_record_title">
-                                            <s t-if="!record.active.raw_value">
-                                                <field name="name"/>
-                                            </s>
-                                            <t t-else="">
-                                                <field name="name"/>
-                                            </t>
-                                        </strong>
-                                        <span t-if="record.parent_id.raw_value" invisible="context.get('default_parent_id', False)" style="display: block; margin-top: 4px;">
-                                            <field name="parent_id"/>
-                                        </span>
-                                        <span invisible="context.get('default_project_id', False)" style="display: block; margin-top: 4px;">
-                                            <field name="project_id" options="{'no_open': True}"/>
-                                        </span>
-                                        <span t-if="record.partner_id.value" t-att-title="record.partner_id.value" style="display: block; margin-top: 4px;">
-                                            <field name="partner_id" class="text-truncate d-block"/>
-                                        </span>
-                                        <span t-if="record.allow_milestones.raw_value and record.milestone_id.raw_value" t-att-class="record.has_late_and_unreached_milestone.raw_value and !record.state.raw_value.startsWith('1_') ? 'text-danger' : ''" style="display: block; margin-top: 4px;">
-                                            <field name="milestone_id" options="{'no_open': True}" />
-                                        </span>
-                                    </div>
-                                </div>
-                                <div class="o_kanban_record_body" t-att-class="['1_done', '1_canceled'].includes(record.state.raw_value) ? 'opacity-50' : 'text-muted'">
-                                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
-                                    <div t-if="record.date_deadline.raw_value" name="date_deadline" invisible="state in ['1_done', '1_canceled']">
-                                        <field name="date_deadline" widget="remaining_days"/>
-                                    </div>
-                                    <field name="task_properties" widget="properties"/>
-                                    <div t-if="record.displayed_image_id.value">
-                                        <field name="displayed_image_id" widget="attachment_image"/>
-                                    </div>
-                                </div>
-                                <div class="o_kanban_record_bottom" t-if="!selection_mode">
-                                    <div class="oe_kanban_bottom_left" t-att-class="['1_done', '1_canceled'].includes(record.state.raw_value) ? 'opacity-50' : ''">
-                                        <field name="priority" widget="priority" style="margin-right: 5px;"/>
-                                        <field name="activity_ids" widget="kanban_activity" style="padding-top: 1.5px; margin-right: 2px"/>
-                                        <b t-if="record.rating_active.raw_value and record.rating_count.raw_value &gt; 0" groups="project.group_project_rating">
-                                            <span class="fa fa-fw fa-smile-o text-success rating_face" t-if="record.rating_avg.raw_value &gt;= 3.66" title="Average Rating: Satisfied" role="img" aria-label="Happy face"/>
-                                            <span class="fa fa-fw fa-meh-o text-warning rating_face" t-elif="record.rating_avg.raw_value &gt;= 2.33" title="Average Rating: Okay" role="img" aria-label="Neutral face"/>
-                                            <span class="fa fa-fw fa-frown-o text-danger rating_face" t-else="" title="Average Rating: Dissatisfied" role="img" aria-label="Sad face"/>
-                                        </b>
-                                        <a t-if="!record.project_id.raw_value" class="text-muted" style="font-size: 17px; padding-top: 1.5px; margin-left: 1.5px">
-                                            <i title="Private Task" class="fa fa-lock"/>
-                                        </a>
-                                        <t t-if="record.project_id.raw_value and record.subtask_count.raw_value">
-                                            <widget name="subtask_counter"/>
-                                        </t>
-                                    </div>
-                                    <div class="oe_kanban_bottom_right" t-if="!selection_mode">
-                                        <div  t-att-class="['1_done', '1_canceled'].includes(record.state.raw_value) ? 'opacity-50' : ''">
-                                            <field name="user_ids" widget="many2many_avatar_user"/>
-                                        </div>
-                                        <field name="state" widget="project_task_state_selection" options="{'is_toggle_mode': false}"/>
-                                    </div>
-                                </div>
+                    <t t-name="kanban-card">
+                        <div t-att-class="['1_done', '1_canceled'].includes(record.state.raw_value) ? 'opacity-50' : ''">
+                            <field name="name" class="fw-bold fs-5"/>
+                            <div class="text-muted">
+                                <field t-if="record.parent_id.raw_value" invisible="context.get('default_parent_id', False)" name="parent_id"/>
+                                <field invisible="context.get('default_project_id', False)" name="project_id" options="{'no_open': True}"/>
+                                <field t-if="record.partner_id.value" t-att-title="record.partner_id.value" name="partner_id" class="text-truncate d-block"/>
+                                <span t-if="record.allow_milestones.raw_value and record.milestone_id.raw_value" t-att-class="record.has_late_and_unreached_milestone.raw_value and !record.state.raw_value.startsWith('1_') ? 'text-danger' : ''">
+                                    <field name="milestone_id" options="{'no_open': True}" />
+                                </span>
                             </div>
-                            <widget name="subtask_kanban_list" />
-                            <div class="clearfix"></div>
                         </div>
+                        <div t-att-class="['1_done', '1_canceled'].includes(record.state.raw_value) ? 'opacity-50' : 'text-muted'">
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                            <field t-if="record.date_deadline.raw_value" invisible="state in ['1_done', '1_canceled']" name="date_deadline" widget="remaining_days"/>
+                            <field name="task_properties" widget="properties"/>
+                            <field name="displayed_image_id" widget="attachment_image"/>
+                        </div>
+                        <footer t-if="!selection_mode" class="fs-6 pt-1">
+                            <div class="d-flex align-items-center gap-1" t-att-class="['1_done', '1_canceled'].includes(record.state.raw_value) ? 'opacity-50' : ''">
+                                <field name="priority" widget="priority" style="margin-right: 5px;"/>
+                                <field name="activity_ids" widget="kanban_activity" style="margin-right: 2px"/>
+                                <b t-if="record.rating_active.raw_value and record.rating_count.raw_value &gt; 0" groups="project.group_project_rating">
+                                    <span class="fa fa-fw fa-smile-o text-success rating_face" t-if="record.rating_avg.raw_value &gt;= 3.66" title="Average Rating: Satisfied" role="img" aria-label="Happy face"/>
+                                    <span class="fa fa-fw fa-meh-o text-warning rating_face" t-elif="record.rating_avg.raw_value &gt;= 2.33" title="Average Rating: Okay" role="img" aria-label="Neutral face"/>
+                                    <span class="fa fa-fw fa-frown-o text-danger rating_face" t-else="" title="Average Rating: Dissatisfied" role="img" aria-label="Sad face"/>
+                                </b>
+                                <a t-if="!record.project_id.raw_value" class="text-muted" style="font-size: 17px; margin-left: 1.5px">
+                                    <i title="Private Task" class="fa fa-lock"/>
+                                </a>
+                                <t t-if="record.project_id.raw_value and record.subtask_count.raw_value">
+                                    <widget name="subtask_counter" class="me-1"/>
+                                </t>
+                            </div>
+                            <div class="d-flex ms-auto" t-if="!selection_mode">
+                                <div t-att-class="{'opacity-50': ['1_done', '1_canceled'].includes(record.state.raw_value)}">
+                                    <field name="user_ids" widget="many2many_avatar_user"/>
+                                </div>
+                                <field name="state" class="ms-1" widget="project_task_state_selection" options="{'is_toggle_mode': false}"/>
+                            </div>
+                        </footer>
+                        <widget name="subtask_kanban_list" />
                     </t>
                     </templates>
                 </kanban>
@@ -758,12 +724,10 @@
             <field name="inherit_id" ref="project.view_task_kanban"/>
             <field name="mode">primary</field>
             <field name="arch" type="xml">
-                <xpath expr="//div[hasclass('o_kanban_record_headings')]/span[@t-if='record.parent_id.raw_value']" position="after">
-                    <span invisible="project_id == context.get('active_id', False)" class="d-block mt-1">
-                        <field name="project_id" options="{'no_open': True}"/>
-                    </span>
+                <xpath expr="//field[@name='parent_id']" position="after">
+                    <field invisible="project_id == context.get('active_id', False)" class="mt-1" name="project_id" options="{'no_open': True}"/>
                 </xpath>
-                <xpath expr="//div[hasclass('o_kanban_record_headings')]/span[@t-if='record.parent_id.raw_value']" position="replace"/>
+                <xpath expr="//field[@name='parent_id']" position="replace"/>
             </field>
         </record>
 

--- a/addons/project/views/project_update_views.xml
+++ b/addons/project/views/project_update_views.xml
@@ -62,38 +62,34 @@
         <field name="name">project.update.view.kanban</field>
         <field name="model">project.update</field>
         <field name="arch" type="xml">
-            <kanban sample="1" js_class="project_update_kanban">
+            <kanban highlight_color="color" sample="1" js_class="project_update_kanban">
                 <field name="color"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="{{!selection_mode ? 'oe_kanban_color_' + record.color.raw_value : ''}} oe_kanban_global_click o_pupdate_kanban_card">
-                            <!-- Project Update Kanban View is always ungrouped - see js_class -->
-                            <div class="o_kanban_detail_ungrouped d-flex align-items-center">
-                                <div class="pb-0 o_pupdate_name mr8 o_pupdate_kanban_width">
-                                    <b><field name="name_cropped"/></b>
-                                    <div class="d-flex gap-1">
-                                        <field name="user_id" widget="many2one_avatar_user"/>
-                                        <t t-esc="record.user_id.value"/>
-                                    </div>
-                                </div>
-                                <div class="mr8 text-sm-start o_pupdate_kanban_width">
-                                    <field name="color" invisible="1"/>
-                                    <b><field name="status" readonly="1" widget="status_with_color"/></b>
-                                </div>
-                                <div class="mr8 o_pupdate_kanban_width">
-                                    <b><field name="progress_percentage" widget="percentage"/></b>
-                                    <div>Progress</div>
-                                </div>
-                                <div class="mr8 o_pupdate_kanban_width">
-                                    <b id="tasks_stats">
-                                        <field name="closed_task_count"/> / <field name="task_count"/> Tasks<span invisible="not task_count"> (<field name="closed_task_percentage"/>%)</span>
-                                    </b>
-                                </div>
-                                <div class="mr8 o_pupdate_kanban_width">
-                                    <b><field name="date"/></b>
-                                    <div>Date</div>
-                                </div>
+                    <t t-name="kanban-card" class="flex-row align-items-center">
+                        <!-- Project Update Kanban View is always ungrouped - see js_class -->
+                        <div class="pb-0 mb-2 mr8 o_pupdate_kanban_width">
+                            <field name="name_cropped" class="fw-bolder"/>
+                            <div class="d-flex gap-1">
+                                <field name="user_id" widget="many2one_avatar_user"/>
+                                <field name="user_id"/>
                             </div>
+                        </div>
+                        <div class="mr8 text-sm-start o_pupdate_kanban_width">
+                            <field name="color" invisible="1"/>
+                            <field name="status" class="fw-bolder" readonly="1" widget="status_with_color"/>
+                        </div>
+                        <div class="mr8 o_pupdate_kanban_width">
+                            <field name="progress_percentage" class="fw-bolder" widget="percentage"/>
+                            <div>Progress</div>
+                        </div>
+                        <div class="mr8 o_pupdate_kanban_width">
+                            <b id="tasks_stats">
+                                <field name="closed_task_count"/> / <field name="task_count"/> Tasks<span invisible="not task_count"> (<field name="closed_task_percentage"/>%)</span>
+                            </b>
+                        </div>
+                        <div class="mr8 o_pupdate_kanban_width">
+                            <field name="date" class="fw-bolder"/>
+                            <div>Date</div>
                         </div>
                     </t>
                 </templates>
@@ -107,7 +103,7 @@
         <field name="arch" type="xml">
             <list sample="1" js_class="project_update_list">
                 <field name="name"/>
-                <field name="user_id" widget="many2one_avatar_user" class="fw-bold" optional="show"/>
+                <field name="user_id" widget="many2one_avatar_user" class="fw-bolder" optional="show"/>
                 <field name="date" optional="show"/>
                 <field name="progress" string="Progress" widget="progressbar" optional="show"/>
                 <field name="color" column_invisible="True"/>

--- a/addons/project_todo/static/tests/todo_done_checkmark.test.js
+++ b/addons/project_todo/static/tests/todo_done_checkmark.test.js
@@ -34,10 +34,8 @@ beforeEach(() => {
         kanban: `
             <kanban>
                 <template>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="state" widget="todo_done_checkmark"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="state" widget="todo_done_checkmark"/>
                     </t>
                 </template>
             </kanban>

--- a/addons/project_todo/static/tests/tours/project_todo_main_functions.js
+++ b/addons/project_todo/static/tests/tours/project_todo_main_functions.js
@@ -67,7 +67,7 @@ registry.category("web_tour.tours").add('project_todo_main_functions', {
     trigger: ".o_project_task_kanban_view",
 },
 {
-    trigger: ".o_kanban_record .oe_kanban_content",
+    trigger: ".o_kanban_record",
     content: "Drag &amp; drop the card to change the personal task from personal stage.",
     run: "drag_and_drop(.o_kanban_group:eq(1))",
 }, 

--- a/addons/project_todo/views/project_task_views.xml
+++ b/addons/project_todo/views/project_task_views.xml
@@ -7,7 +7,8 @@
         <field name="model">project.task</field>
         <field name="priority">800</field>
         <field name="arch" type="xml">
-            <kanban default_group_by="personal_stage_type_id"
+            <kanban highlight_color="color"
+                    default_group_by="personal_stage_type_id"
                     class="o_kanban_small_column"
                     on_create="quick_create"
                     quick_create_view="project_todo.project_task_view_todo_quick_create_form"
@@ -15,55 +16,33 @@
                     js_class="project_task_kanban"
                     default_order="state, priority desc, date_deadline asc, sequence, id desc">
                 <field name="color"/>
-                <field name="priority"/>
                 <field name="sequence"/>
-                <field name="name"/>
                 <field name="active"/>
-                <field name="description"/>
-                <field name="message_partner_ids"/>
-                <field name="activity_ids" />
-                <field name="activity_state" />
                 <field name="state"/>
                 <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                 <templates>
                     <t t-name="kanban-menu">
                         <a t-if="widget.editable" role="menuitem" type="set_cover" class="dropdown-item" data-field="displayed_image_id">Set Cover Image</a>
                         <a role="menuitem" type="delete" class="dropdown-item">Delete</a>
-                        <ul class="oe_kanban_colorpicker" data-field="color"/>
+                        <field name="color" widget="kanban_color_picker"/>
                     </t>
-                    <t t-name="kanban-box">
+                    <t t-name="kanban-card">
                         <t t-set="todoHasAssignees" t-value="record.user_ids.raw_value.length &gt; 1"/>
-                        <div t-attf-class="#{kanban_color(record.color.raw_value)} oe_kanban_global_click_edit oe_semantic_html_override oe_kanban_card">
-                            <div class="oe_kanban_content">
-                                <div class="o_kanban_record_top">
-                                    <div class="o_kanban_record_headings">
-                                        <div class="d-flex justify-content-start">
-                                            <div t-att-class="['1_done', '1_canceled'].includes(record.state.raw_value) ? 'opacity-50' : ''">
-                                                <strong class="o_kanban_record_title align-middle">
-                                                    <field name="name" widget="name_with_subtask_count"/>
-                                                </strong>
-                                            </div>
-                                        </div>
-                                    </div>
+                        <div t-att-class="{'opacity-50': ['1_done', '1_canceled'].includes(record.state.raw_value)}">
+                            <field name="name" class="fw-bolder fs-5" widget="name_with_subtask_count"/>
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                            <field t-if="record.displayed_image_id.value" name="displayed_image_id" widget="attachment_image"/>
+                        </div>
+                        <div class="d-flex pt-2">
+                            <div class="d-flex" t-att-class="{'opacity-50': ['1_done', '1_canceled'].includes(record.state.raw_value)}">
+                                <field name="priority" class="me-2" widget="priority"/>
+                                <field name="activity_ids" widget="kanban_activity"/>
+                            </div>
+                            <div class="d-flex ms-auto">
+                                <div t-att-class="{'opacity-50': ['1_done', '1_canceled'].includes(record.state.raw_value), 'o_todo_hide_avatar': !todoHasAssignees}">
+                                    <field name="user_ids" widget="many2many_avatar_user" readonly="True"/>
                                 </div>
-                                <div class="o_kanban_record_body o_todo_kanban_card_body" t-att-class="['1_done', '1_canceled'].includes(record.state.raw_value) ? 'opacity-50' : ''">
-                                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
-                                    <div t-if="record.displayed_image_id.value">
-                                        <field name="displayed_image_id" widget="attachment_image"/>
-                                    </div>
-                                </div>
-                                <div class="o_kanban_record_bottom mt-2">
-                                    <div class="oe_kanban_bottom_left" t-att-class="['1_done', '1_canceled'].includes(record.state.raw_value) ? 'opacity-50' : ''">
-                                        <field name="priority" widget="priority"/>
-                                        <field name="activity_ids" widget="kanban_activity" style="padding-top: 1.5px;"/>
-                                    </div>
-                                    <div class="oe_kanban_bottom_right">
-                                        <div t-att-class="{'opacity-50': ['1_done', '1_canceled'].includes(record.state.raw_value), 'o_todo_hide_avatar': !todoHasAssignees}">
-                                            <field name="user_ids" widget="many2many_avatar_user" readonly="True"/>
-                                        </div>
-                                        <field name="state" widget="todo_done_checkmark"/>
-                                    </div>
-                                </div>
+                                <field name="state" widget="todo_done_checkmark"/>
                             </div>
                         </div>
                     </t>

--- a/addons/sale_project/static/tests/tours/task_create_sol_tour.js
+++ b/addons/sale_project/static/tests/tours/task_create_sol_tour.js
@@ -18,7 +18,7 @@ registry.category("web_tour.tours").add("task_create_sol_tour", {
         },
         {
             content: "Open the task name 'Test History Project' from kanban view.",
-            trigger: "div strong.o_kanban_record_title:contains(Test History Task)",
+            trigger: ".o_kanban_record:contains(Test History Task)",
             run: "click",
         },
         {


### PR DESCRIPTION
*hr_timesheet, project, project_todo, sale_project

In this commit we have simplified the kanban arch for the project and related module. The goal is to simplify them, make them easier to read, and use bootstrap utility classnames.
- Previously, we used `kanban-box`, but now we are using `kanban-card` instead.
- Deprecated `oe_kanban_global_click` and `oe_kanban_global_click_edit`.
- More use of `<field/>` tags
- Removed the `oe_kanban_colorpicker` class and replaced it with the `kanban_color_picker` widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- `kanban_image` from rendering context, is deprecated so we use `<field name=... widget=image/>` instead
- kanban_color, kanban_getcolor and kanban_getcolorname are deprecated use new attribute highlight_color=color_field_name on root node

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
