### PR TITLE
[FIX] l10n_es_edi_tbai: operation date xml invoice

### DIFF
--- a/addons/l10n_es_edi_tbai/data/template_invoice.xml
+++ b/addons/l10n_es_edi_tbai/data/template_invoice.xml
@@ -106,7 +106,7 @@
                 </t>
             </CabeceraFactura>
             <DatosFactura t-if="is_emission">
-                <FechaOperacion t-out="format_date(invoice.invoice_date) if format_date(datetime_now) != format_date(invoice.invoice_date) else None"/>
+                <FechaOperacion t-if="invoice.delivery_date and format_date(invoice.invoice_date) != format_date(invoice.delivery_date)" t-out="format_date(invoice.delivery_date)"/>
                 <DescripcionFactura t-out="invoice.invoice_origin or 'manual'"/>
                 <DetallesFactura>
                     <IDDetalleFactura t-foreach="invoice_lines" t-as="line_values">


### PR DESCRIPTION
Use the delivery date to fill the `FechaOperacion` and fall
back to the invoice date if no delivery date is set.

Steps:

- Make an invoice with delivery_date != invoice_date != today
- Send invoice to gouvernment
- Download the xml generated
- The field `FechaOperacion` is the invoice date instead of the delivery
  date

opw-4072748
