### PR TITLE
[FIX] sale: apply discount correctly on unit price with tax included

### DIFF
--- a/addons/sale/tests/test_sale_order_discount.py
+++ b/addons/sale/tests/test_sale_order_discount.py
@@ -32,7 +32,7 @@ class TestSaleOrderDiscount(SaleCommon):
 
     def test_so_discount(self):
         solines = self.sale_order.order_line
-        amount_before_discount = self.sale_order.amount_total
+        amount_before_discount = sum(line.price_unit for line in solines)
         self.assertEqual(len(solines), 2)
 
         # No taxes
@@ -44,7 +44,7 @@ class TestSaleOrderDiscount(SaleCommon):
         self.wizard.action_apply_discount()
 
         discount_line = self.sale_order.order_line[-1]
-        self.assertAlmostEqual(discount_line.price_unit, -amount_before_discount*0.5)
+        self.assertAlmostEqual(discount_line.price_unit, -amount_before_discount * 0.5)
         self.assertFalse(discount_line.tax_id)
         self.assertEqual(discount_line.product_uom_qty, 1.0)
 
@@ -56,7 +56,7 @@ class TestSaleOrderDiscount(SaleCommon):
 
         discount_line = self.sale_order.order_line - solines
         discount_line.ensure_one()
-        self.assertAlmostEqual(discount_line.price_unit, -amount_before_discount*0.5)
+        self.assertAlmostEqual(discount_line.price_unit, -sum(line.price_unit for line in solines) * 0.5)
         self.assertEqual(discount_line.tax_id, dumb_tax)
         self.assertEqual(discount_line.product_uom_qty, 1.0)
 
@@ -66,11 +66,10 @@ class TestSaleOrderDiscount(SaleCommon):
         self.wizard.action_apply_discount()
         discount_lines = self.sale_order.order_line - solines
         self.assertEqual(len(discount_lines), 2)
-        self.assertEqual(discount_lines[0].price_unit, -solines[0].price_subtotal * 0.5)
-        self.assertEqual(discount_lines[1].price_unit, -solines[1].price_subtotal * 0.5)
-        self.assertEqual(discount_lines[0].tax_id, solines[0].tax_id)
-        self.assertEqual(discount_lines[1].tax_id, solines[1].tax_id)
-        self.assertTrue(all(line.product_uom_qty == 1.0 for line in discount_lines))
+        for soline, discount_line in zip(solines, discount_lines):
+            self.assertEqual(discount_line.price_unit, -soline.price_unit * 0.5)
+            self.assertEqual(discount_line.tax_id, soline.tax_id)
+            self.assertEqual(discount_line.product_uom_qty, 1.0)
 
     def test_sol_discount(self):
         so_amount = self.sale_order.amount_untaxed

--- a/addons/sale/wizard/sale_order_discount.py
+++ b/addons/sale/wizard/sale_order_discount.py
@@ -93,7 +93,7 @@ class SaleOrderDiscount(models.TransientModel):
                 if not line.product_uom_qty or not line.price_unit:
                     continue
 
-                total_price_per_tax_groups[line.tax_id] += line.price_subtotal
+                total_price_per_tax_groups[line.tax_id] += line.price_unit
 
             if not total_price_per_tax_groups:
                 # No valid lines on which the discount can be applied


### PR DESCRIPTION
Issue : 17.0

When a global discount is applied on a sale order with tax included in the price, the discount was incorrectly calculated based on the tax-excluded price. This resulted in inaccurate discount amounts and incorrect tax calculations.

steps to reproduce:
- Create a tax with included in price (e.g. 10% incl).
- Create a sale order with the 10% incl tax.
- Now, apply a global discount (e.g. 10%)

Cause :
When applying a global discount, the system incorrectly calculates the discount based on the tax-excluded price rather than the unit price.

Fix :
Ensure the total amount is calculated useing price_unit(price_unit) instead of subtotal.
This corrects the discount application and maintains accurate pricing.

opw-4018841