### PR TITLE
[FIX] website_sale: revert change of signature

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -265,9 +265,13 @@ class WebsiteSale(http.Controller):
             'order': order,
         }
 
-    def _get_additional_shop_values(self, values, **post):
+    def _get_additional_shop_values(self, values):
         """ Hook to update values used for rendering website_sale.products template """
         return {}
+
+    def _get_additional_extra_shop_values(self, values, **post):
+        """ Hook to update values used for rendering website_sale.products template """
+        return self._get_additional_shop_values(values)
 
     @http.route([
         '/shop',
@@ -452,7 +456,7 @@ class WebsiteSale(http.Controller):
             values['available_max_price'] = tools.float_round(available_max_price, 2)
         if category:
             values['main_object'] = category
-        values.update(self._get_additional_shop_values(values, **post))
+        values.update(self._get_additional_extra_shop_values(values, **post))
         return request.render("website_sale.products", values)
 
     @http.route(['/shop/<model("product.template"):product>'], type='http', auth="public", website=True, sitemap=True)


### PR DESCRIPTION
The signature of `_get_additional_shop_values` was wrongly changed in 6957035fd422ccfb825b354ce11d08829a1520f2.
