### PR TITLE
[FIX] project_timesheet_holidays: fix read error on employee_ids

### DIFF
--- a/addons/project_timesheet_holidays/models/hr_holidays.py
+++ b/addons/project_timesheet_holidays/models/hr_holidays.py
@@ -122,7 +122,7 @@ class Holidays(models.Model):
             ("company_id.leave_timesheet_task_id", "!=", False),
         ])
         if global_leaves:
-            global_leaves._generate_public_time_off_timesheets(self.employee_ids)
+            global_leaves._generate_public_time_off_timesheets(self.sudo().employee_ids)
 
     def action_refuse(self):
         """ Remove the timesheets linked to the refused holidays """

--- a/addons/project_timesheet_holidays/tests/__init__.py
+++ b/addons/project_timesheet_holidays/tests/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_cancel_time_off
 from . import test_employee
 from . import test_timesheet_holidays
 from . import test_timesheet_global_time_off

--- a/addons/project_timesheet_holidays/tests/test_cancel_time_off.py
+++ b/addons/project_timesheet_holidays/tests/test_cancel_time_off.py
@@ -1,0 +1,67 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from freezegun import freeze_time
+
+from odoo.tests import TransactionCase, tagged, new_test_user
+
+
+@tagged('post_install', '-at_install')
+class TestCancelTimeOff(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env['res.company'].create({
+            'name': 'Test Company',
+        })
+        cls.global_leave = cls.env['resource.calendar.leaves'].create({
+            'name': 'Test Global Leave',
+            'date_from': '2020-01-08 00:00:00',
+            'date_to': '2020-01-08 23:59:59',
+            'calendar_id': cls.company.resource_calendar_id.id,
+            'company_id': cls.company.id,
+        })
+        cls.employee_user = new_test_user(
+            cls.env,
+            login='test_user',
+            name='Test User',
+            company_id=cls.company.id,
+            groups='base.group_user,hr_timesheet.group_hr_timesheet_user',
+        )
+        cls.employee = cls.env['hr.employee'].create({
+            'name': 'Test Employee',
+            'user_id': cls.employee_user.id,
+            'resource_calendar_id': cls.company.resource_calendar_id.id,
+            'company_id': cls.company.id,
+        })
+        cls.generic_time_off_type = cls.env['hr.leave.type'].create({
+            'name': 'Generic Time Off',
+            'requires_allocation': 'no',
+            'leave_validation_type': 'both',
+            'company_id': cls.company.id,
+        })
+
+    @freeze_time('2020-01-01')
+    def test_cancel_time_off(self):
+        """ Test that an employee can cancel a future time off, that crosses a global leave,
+            if the employee is not in the group_hr_holidays_user.
+
+            Test Case:
+            =========
+            1) Create a time off in the future and that crosses a global leave
+            2) Approve the time off with the admin
+            3) Cancel the time off with the user that is not in the group_hr_holidays_user
+            4) No read error on employee_ids should be raised
+        """
+        time_off = self.env['hr.leave'].create({
+            'name': 'Test Time Off',
+            'holiday_type': 'employee',
+            'holiday_status_id': self.generic_time_off_type.id,
+            'employee_id': self.employee.id,
+            'date_from': '2020-01-07 08:00:00',
+            'date_to': '2020-01-09 17:00:00',
+        })
+        time_off.action_validate()
+        HrHolidaysCancelLeave = self.env[
+            'hr.holidays.cancel.leave'].with_user(self.employee_user).with_company(self.company.id)
+        HrHolidaysCancelLeave.create({
+            'leave_id': time_off.id, 'reason': 'Test Reason'}).action_cancel_leave()


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This commit fixes a read access error on the field employee_ids of hr_leave when a user, who is not in group_hr_holidays_user, tries to cancel/refuse a timeoff. The bug only appears when the timeoff crosses a public holiday.

Current behavior before PR:

An access error pops up when an user , who is not a timeoff officer/admin, tries to cancel a timeoff. The timeoff should cross a public holiday in order for the bug to appear.

Desired behavior after PR is merged:

The user is able to cancel its timeoff even if he/she is not a timeoff officer/admin.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
