### PR TITLE
[REF] *: less jQuery

### DIFF
--- a/addons/auth_totp_mail/static/tests/totp_flow.js
+++ b/addons/auth_totp_mail/static/tests/totp_flow.js
@@ -2,6 +2,7 @@
 
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
+import { queryFirst } from "@odoo/hoot-dom";
 
 function openAccountSettingsTab() {
     return [{
@@ -25,13 +26,13 @@ function openAccountSettingsTab() {
             // selection get discarded by the action reloading, so here try to
             // see if we're already on the users action through the breadcrumb and
             // just close the menu if so
-            const $crumb = $('.breadcrumb');
-            if ($crumb.text().indexOf('Users') === -1) {
+            const breadcrumb = document.querySelector('.breadcrumb');
+            if (!breadcrumb || !breadcrumb.textContent.includes("Users")) {
                 // on general settings page, click menu
                 helpers.click();
             } else {
                 // else close menu
-                helpers.click($('[data-menu-xmlid="base.menu_users"]'));
+                helpers.click('[data-menu-xmlid="base.menu_users"]');
             }
         }
     }];
@@ -52,9 +53,9 @@ registry.category("web_tour.tours").add('totp_admin_self_invite', {
     content: "check that user cannot invite themselves to use 2FA.",
     trigger: "body",
     run: function () {
-        const inviteBtn = $('button:contains(Invite to use 2FA)')[0];
+        const inviteBtn = queryFirst('button:contains(Invite to use 2FA)');
         if (!inviteBtn) {
-            $('body').addClass('CannotInviteYourself');
+            document.body.classList.add('CannotInviteYourself');
         }
     }
 }, {

--- a/addons/html_editor/static/src/main/media/image_crop.js
+++ b/addons/html_editor/static/src/main/media/image_crop.js
@@ -15,7 +15,7 @@ import {
     useExternalListener,
 } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
-import { scrollTo } from "@web/core/utils/scrolling";
+import { scrollTo, closestScrollableY } from "@web/core/utils/scrolling";
 
 export class ImageCrop extends Component {
     static template = "html_editor.ImageCrop";
@@ -221,20 +221,10 @@ export class ImageCrop extends Component {
         const rect = this.media.getBoundingClientRect();
         const viewportTop = this.document.documentElement.scrollTop || 0;
         const viewportBottom = viewportTop + window.innerHeight;
-        const closestScrollable = (el) => {
-            if (!el) {
-                return null;
-            }
-            if (el.scrollHeight > el.clientHeight) {
-                return el;
-            } else {
-                return closestScrollable(el.parentElement);
-            }
-        };
         // Give priority to the closest scrollable element (e.g. for images in
         // HTML fields, the element to scroll is different from the document's
         // scrolling element).
-        const scrollable = closestScrollable(this.media);
+        const scrollable = closestScrollableY(this.media);
 
         // The image must be in a position that allows access to it and its crop
         // options buttons. Otherwise, the crop widget container can be scrolled

--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -13,6 +13,7 @@ import { HtmlField, htmlField } from "@web_editor/js/backend/html_field";
 import { getRangePosition } from '@web_editor/js/editor/odoo-editor/src/utils/utils';
 import { utils as uiUtils } from "@web/core/ui/ui_service";
 import { onWillStart, reactive, useSubEnv, status } from "@odoo/owl";
+import { closestScrollableY } from "@web/core/utils/scrolling";
 
 export class MassMailingHtmlField extends HtmlField {
     static props = {
@@ -209,7 +210,7 @@ export class MassMailingHtmlField extends HtmlField {
         if ($(window.top.document).find('.o_mass_mailing_form_full_width')[0]) {
             // In full width form mode, ensure the snippets menu's scrollable is
             // in the form view, not in the iframe.
-            this.fieldConfig.$scrollable = this.wysiwyg.$el.closestScrollable();
+            this.fieldConfig.$scrollable = $(closestScrollableY(this.wysiwyg.$el[0]));
             // Ensure said scrollable keeps its scrollbar at all times to
             // prevent the scrollbar from appearing at awkward moments (ie: when
             // previewing an option)

--- a/addons/web/static/src/core/effects/effect_service.js
+++ b/addons/web/static/src/core/effects/effect_service.js
@@ -34,12 +34,7 @@ const effectRegistry = registry.category("effects");
  */
 function rainbowMan(env, params = {}) {
     let message = params.message;
-    if (message instanceof jQuery) {
-        console.log(
-            "Providing a jQuery element to an effect is deprecated. Note that all event handlers will be lost."
-        );
-        message = message.html();
-    } else if (message instanceof Element) {
+    if (message instanceof Element) {
         console.log(
             "Providing an HTML element to an effect is deprecated. Note that all event handlers will be lost."
         );

--- a/addons/web/static/src/legacy/js/libs/bootstrap.js
+++ b/addons/web/static/src/legacy/js/libs/bootstrap.js
@@ -1,5 +1,7 @@
 /** @odoo-module **/
 
+import { compensateScrollbar, getScrollingElement } from "@web/core/utils/scrolling";
+
 /**
  * The bootstrap library extensions and fixes should be done here to avoid
  * patching in place.
@@ -103,9 +105,9 @@ const bsAdjustDialogFunction = Modal.prototype._adjustDialog;
 Modal.prototype._adjustDialog = function () {
     const document = this._element.ownerDocument;
     document.body.classList.remove('modal-open');
-    const $scrollable = $().getScrollingElement(document);
-    if (document.body.contains($scrollable[0])) {
-        $scrollable.compensateScrollbar(true);
+    const scrollable = getScrollingElement(document);
+    if (document.body.contains(scrollable)) {
+        compensateScrollbar(scrollable, true);
     }
     document.body.classList.add('modal-open');
     return bsAdjustDialogFunction.apply(this, arguments);
@@ -115,9 +117,9 @@ const bsResetAdjustmentsFunction = Modal.prototype._resetAdjustments;
 Modal.prototype._resetAdjustments = function () {
     const document = this._element.ownerDocument;
     document.body.classList.remove('modal-open');
-    const $scrollable = $().getScrollingElement(document);
-    if (document.body.contains($scrollable[0])) {
-        $scrollable.compensateScrollbar(false);
+    const scrollable = getScrollingElement(document);
+    if (document.body.contains(scrollable)) {
+        compensateScrollbar(scrollable, false);
     }
     return bsResetAdjustmentsFunction.apply(this, arguments);
 };

--- a/addons/web/static/src/legacy/js/libs/jquery.js
+++ b/addons/web/static/src/legacy/js/libs/jquery.js
@@ -7,38 +7,8 @@
 
 // jQuery selectors extensions
 $.extend($.expr[':'], {
-    containsLike: function (element, index, matches){
-        return element.innerHTML.toUpperCase().indexOf(matches[3].toUpperCase()) >= 0;
-    },
-    containsTextLike: function (element, index, matches){
-        return element.innerText.toUpperCase().indexOf(matches[3].toUpperCase()) >= 0;
-    },
-    containsExact: function (element, index, matches){
-        return $.trim(element.innerHTML) === matches[3];
-    },
-    containsExactText: function (element, index, matches) {
-        return element.innerText.trim() === matches[3].trim();
-    },
-    /**
-     * Note all escaped characters need to be double escaped inside of the
-     * expression, so "\(" needs to be "\\("
-     */
-    containsRegex: function (element, index, matches){
-        var regreg =  /^\/((?:\\\/|[^\/])+)\/([mig]{0,3})$/,
-        reg = regreg.exec(matches[3]);
-        return reg ? new RegExp(reg[1], reg[2]).test($.trim(element.innerHTML)) : false;
-    },
-    propChecked: function (element, index, matches) {
-        return $(element).prop("checked") === true;
-    },
-    propSelected: function (element, index, matches) {
-        return $(element).prop("selected") === true;
-    },
     propValue: function (element, index, matches) {
         return $(element).prop("value") === matches[3];
-    },
-    propValueContains: function (element, index, matches) {
-        return $(element).prop("value") && $(element).prop("value").indexOf(matches[3]) !== -1;
     },
     hasData: function (element) {
         return !!_.toArray(element.dataset).length;
@@ -46,49 +16,10 @@ $.extend($.expr[':'], {
     data: function (element, index, matches) {
         return $(element).data(matches[3]);
     },
-    hasVisibility: function (element, index, matches) {
-        var $element = $(element);
-        if ($(element).css('visibility') === 'hidden') {
-            return false;
-        }
-        var $parent = $element.parent();
-        if (!$parent.length || $element.is('html')) {
-            return true;
-        }
-        return $parent.is(':hasVisibility');
-    },
-    hasOpacity: function (element, index, matches) {
-        var $element = $(element);
-        if (parseFloat($(element).css('opacity')) <= 0.01) {
-            return false;
-        }
-        var $parent = $element.parent();
-        if (!$parent.length || $element.is('html')) {
-            return true;
-        }
-        return $parent.is(':hasOpacity');
-    },
 });
 
 // jQuery functions extensions
 $.fn.extend({
-    /**
-     * Returns all the attributes of a DOM element (first one in the jQuery
-     * set).
-     *
-     * @returns {Object} attribute name -> attribute value
-     */
-    getAttributes: function () {
-        var o = {};
-        if (this.length) {
-            var attrs = this[0].attributes;
-            for (var i = 0, l = attrs.length ; i < l ; i++) {
-                var attr = attrs.item(i);
-                o[attr.name] = attr.value;
-            }
-        }
-        return o;
-    },
     /**
      * Makes DOM elements bounce the way Odoo decided it.
      *
@@ -120,62 +51,6 @@ $.fn.extend({
                 $._data(el, 'events')[evName].unshift(handler);
             });
         });
-    },
-    /**
-     * @todo Should really be converted to no jQuery and probably even removed
-     * from jQuery utilities in master
-     * @return {jQuery}
-     */
-    closestScrollable() {
-        const document = this.length ? this[0].ownerDocument : window.document;
-
-        let $el = this;
-        while ($el[0] !== document.scrollingElement) {
-            if (!$el.length || $el[0] instanceof Document) {
-                // Ensure that $().closestScrollable() -> $() and handle the
-                // case of elements not attached to the DOM.
-                // Also, .parent() used to loop through ancestors can
-                // theoretically reach the document if nothing up to the HTML
-                // included is not scrollable.
-                return $();
-            }
-            if ($el.isScrollable()) {
-                return $el;
-            }
-            $el = $el.parent();
-        }
-        return $el;
-    },
-    /**
-     * Adapt the given css property by adding the size of a scrollbar if any.
-     * Limitation: only works if the given css property is not already used as
-     * inline style for another reason.
-     *
-     * @param {boolean} [add=true]
-     * @param {boolean} [isScrollElement=true]
-     * @param {string} [cssProperty='padding-right']
-     */
-    compensateScrollbar(add = true, isScrollElement = true, cssProperty = 'padding-right') {
-        for (const el of this) {
-            // Compensate scrollbar
-            const scrollableEl = isScrollElement ? el : $(el).parent().closestScrollable()[0];
-            const isRTL = scrollableEl.matches(".o_rtl");
-            if (isRTL) {
-                cssProperty = cssProperty.replace("right", "left");
-            }
-            el.style.removeProperty(cssProperty);
-            if (!add) {
-                return;
-            }
-            const style = window.getComputedStyle(el);
-            // Round up to the nearest integer to be as close as possible to
-            // the correct value in case of browser zoom.
-            const borderLeftWidth = Math.ceil(parseFloat(style.borderLeftWidth.replace('px', '')));
-            const borderRightWidth = Math.ceil(parseFloat(style.borderRightWidth.replace('px', '')));
-            const bordersWidth = borderLeftWidth + borderRightWidth;
-            const newValue = parseInt(style[cssProperty]) + scrollableEl.offsetWidth - scrollableEl.clientWidth - bordersWidth;
-            el.style.setProperty(cssProperty, `${newValue}px`, 'important');
-        }
     },
     /**
      * @returns {jQuery}

--- a/addons/web_editor/__manifest__.py
+++ b/addons/web_editor/__manifest__.py
@@ -83,6 +83,7 @@ Odoo Web Editor widget.
             'web/static/lib/select2/select2.js',
             'web/static/src/legacy/js/libs/bootstrap.js',
             'web/static/src/legacy/js/libs/jquery.js',
+            'web/static/src/core/utils/scrolling.js',
             'web/static/src/core/registry.js',
             'web/static/src/core/templates.js',
             'web/static/src/core/template_inheritance.js',

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop.js
@@ -12,7 +12,7 @@ import {
     markup,
 } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
-import { scrollTo } from "@web/core/utils/scrolling";
+import { scrollTo, closestScrollableY } from "@web/core/utils/scrolling";
 
 export class ImageCrop extends Component {
     static template = 'web_editor.ImageCrop';
@@ -238,21 +238,10 @@ export class ImageCrop extends Component {
         const rect = this.media.getBoundingClientRect();
         const viewportTop = this.document.documentElement.scrollTop || 0;
         const viewportBottom = viewportTop + window.innerHeight;
-        const closestScrollable = el => {
-            if (!el) {
-                return null;
-            }
-            if (el.scrollHeight > el.clientHeight) {
-                return $(el);
-            } else {
-                return closestScrollable(el.parentElement);
-            }
-        };
         // Give priority to the closest scrollable element (e.g. for images in
         // HTML fields, the element to scroll is different from the document's
         // scrolling element).
-        const $scrollable = closestScrollable(this.media);
-        const scrollable = $scrollable?.get(0);
+        const scrollable = closestScrollableY(this.media);
 
         // The image must be in a position that allows access to it and its crop
         // options buttons. Otherwise, the crop widget container can be scrolled
@@ -260,7 +249,7 @@ export class ImageCrop extends Component {
         if (rect.top < viewportTop || viewportBottom - rect.bottom < 100) {
             await scrollTo(this.media, {
                 behavior: "smooth",
-                ...(scrollable && { scrollable: scrollable }),
+                ...(scrollable && { scrollable }),
             });
         }
     }

--- a/addons/website/static/src/client_actions/website_preview/website_preview.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.js
@@ -26,6 +26,7 @@ import {
     useState,
     useExternalListener,
 } from "@odoo/owl";
+import { getScrollingElement } from "@web/core/utils/scrolling";
 
 class BlockPreview extends Component {
     static template = "website.BlockPreview";
@@ -272,19 +273,21 @@ export class WebsitePreview extends Component {
 
     addWelcomeMessage() {
         if (this.websiteService.isRestrictedEditor) {
-            const $wrap = $(this.iframe.el.contentDocument.querySelector('#wrapwrap.homepage')).find('#wrap');
-            if ($wrap.length && $wrap.html().trim() === '') {
-                this.$welcomeMessage = $(renderToElement('website.homepage_editor_welcome_message'));
-                this.$welcomeMessage.addClass('o_homepage_editor_welcome_message');
-                this.$welcomeMessage.css('min-height', $wrap.parent('main').height() - ($wrap.outerHeight(true) - $wrap.height()));
-                $wrap.empty().append(this.$welcomeMessage);
+            const wrap = this.iframe.el.contentDocument.querySelector('#wrapwrap.homepage #wrap');
+            if (wrap && !wrap.textContent.trim()) {
+                this.welcomeMessage = renderToElement('website.homepage_editor_welcome_message');
+                this.welcomeMessage.classList.add('o_homepage_editor_welcome_message', 'h-100');
+                while (wrap.firstChild) {
+                    wrap.removeChild(wrap.lastChild);
+                }
+                wrap.append(this.welcomeMessage);
             }
         }
     }
 
     removeWelcomeMessage() {
-        if (this.$welcomeMessage) {
-            this.$welcomeMessage.detach();
+        if (this.welcomeMessage) {
+            this.welcomeMessage.remove();
         }
     }
 
@@ -502,7 +505,7 @@ export class WebsitePreview extends Component {
         if (!this.websiteContext.edition && this.iframe.el.contentDocument.body && this.iframefallback.el) {
             this.iframefallback.el.contentDocument.body.replaceWith(this.iframe.el.contentDocument.body.cloneNode(true));
             this.iframefallback.el.classList.remove('d-none');
-            $().getScrollingElement(this.iframefallback.el.contentDocument)[0].scrollTop = $().getScrollingElement(this.iframe.el.contentDocument)[0].scrollTop;
+            getScrollingElement(this.iframefallback.el.contentDocument).scrollTop = getScrollingElement(this.iframe.el.contentDocument).scrollTop;
             this._cleanIframeFallback();
         }
     }

--- a/addons/website/static/src/js/content/menu.js
+++ b/addons/website/static/src/js/content/menu.js
@@ -4,6 +4,7 @@ import publicWidget from "@web/legacy/js/public/public_widget";
 import animations from "@website/js/content/snippets.animation";
 export const extraMenuUpdateCallbacks = [];
 import { SIZES, utils as uiUtils } from "@web/core/ui/ui_service";
+import { compensateScrollbar } from "@web/core/utils/scrolling";
 
 // The header height may vary with sections hidden on scroll (see the class
 // `o_header_hide_on_scroll`). To avoid scroll jumps, we cache the value.
@@ -95,7 +96,7 @@ const BaseAnimatedHeader = animations.Animation.extend({
      * @private
      */
     _adaptFixedHeaderPosition() {
-        $(this.el).compensateScrollbar(this.fixedHeader, false, 'right');
+        compensateScrollbar(this.el, this.fixedHeader, false, 'right');
     },
     /**
      * @private

--- a/addons/website/static/src/js/content/snippets.animation.js
+++ b/addons/website/static/src/js/content/snippets.animation.js
@@ -23,7 +23,7 @@ import {
 } from "@website/js/text_processing";
 import { touching } from "@web/core/utils/ui";
 import { ObservingCookieWidgetMixin } from "@website/snippets/observing_cookie_mixin";
-import { scrollTo } from "@web/core/utils/scrolling";
+import { scrollTo, closestScrollableY } from "@web/core/utils/scrolling";
 
 // Initialize fallbacks for the use of requestAnimationFrame,
 // cancelAnimationFrame and performance.now()
@@ -1126,13 +1126,13 @@ registry.FullScreenHeight = publicWidget.Widget.extend({
         const firstContentEl = $('#wrapwrap > main > :first-child')[0]; // first child to consider the padding-top of main
         // When a modal is open, we remove the "modal-open" class from the body.
         // This is because this class sets "#wrapwrap" and "<body>" to
-        // "overflow: hidden," preventing the "closestScrollable" function from
+        // "overflow: hidden," preventing the "closestScrollableY" (?) function from
         // correctly recognizing the scrollable element closest to the element
         // for which the height needs to be calculated. Without this, the
         // "mainTopPos" variable would be incorrect.
         const modalOpen = document.body.classList.contains("modal-open");
         document.body.classList.remove("modal-open");
-        const mainTopPos = firstContentEl.getBoundingClientRect().top + $(firstContentEl.parentNode).closestScrollable()[0].scrollTop;
+        const mainTopPos = firstContentEl.getBoundingClientRect().top + closestScrollableY(firstContentEl.parentNode).scrollTop;
         document.body.classList.toggle("modal-open", modalOpen);
         return (windowHeight - mainTopPos);
     },

--- a/addons/website/static/src/snippets/s_table_of_content/000.js
+++ b/addons/website/static/src/snippets/s_table_of_content/000.js
@@ -2,6 +2,7 @@
 
 import publicWidget from "@web/legacy/js/public/public_widget";
 import {extraMenuUpdateCallbacks} from "@website/js/content/menu";
+import { closestScrollableY } from "@web/core/utils/scrolling";
 
 const CLASS_NAME_DROPDOWN_ITEM = 'dropdown-item';
 const CLASS_NAME_ACTIVE = 'active';
@@ -63,7 +64,7 @@ const TableOfContent = publicWidget.Widget.extend({
     async start() {
         this._stripNavbarStyles();
         await this._super(...arguments);
-        this._scrollElement = this.$target.closest(".s_table_of_content").closestScrollable()[0];
+        this._scrollElement = closestScrollableY(this.$target.closest(".s_table_of_content")[0]);
         this._scrollTarget = $().getScrollingTarget(this._scrollElement)[0];
         this._tocElement = this.el.querySelector('.s_table_of_content_navbar');
         this.previousPosition = -1;

--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -11,7 +11,7 @@ import { rpc } from "@web/core/network/rpc";
 import { escape } from "@web/core/utils/strings";
 import { _t } from "@web/core/l10n/translation";
 import { renderToElement } from "@web/core/utils/render";
-import { scrollTo } from "@web/core/utils/scrolling";
+import { scrollTo, closestScrollableY } from "@web/core/utils/scrolling";
 
 publicWidget.registry.websiteForum = publicWidget.Widget.extend({
     selector: '.website_forum',
@@ -173,7 +173,7 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
 
         this.$('#post_reply').on('shown.bs.collapse', function (e) {
             const replyEl = document.querySelector('#post_reply');
-            const scrollingElement = $(replyEl.parentNode).closestScrollable()[0];
+            const scrollingElement = closestScrollableY(replyEl.parentNode);
             scrollTo(replyEl, {
                 behavior: "smooth",
                 offset: $(scrollingElement).innerHeight() - $(replyEl).innerHeight(),


### PR DESCRIPTION
In our effort to remove jQuery from the backend, we:
- define two functions compensateScrollbar and getScrollingElement
  in @web/core/utils/scrolling.js and use them in replacement of the
  same functions in @web/legacy/js/libs/jquery.js (our extension of jQuery)
- use closestScrollableY from @web/core/utils/scrolling.js when possible
- simplify some locs that were using jQuery.
- remove dead code from @web/legacy/js/libs/jquery.js.