### PR TITLE
[IMP] sale: close onboarding video easily

### DIFF
--- a/addons/sale/static/src/js/sale_action_helper/sale_action_helper_dialog.xml
+++ b/addons/sale/static/src/js/sale_action_helper/sale_action_helper_dialog.xml
@@ -9,6 +9,7 @@
             size="'xl'"
             technical="false"
             withBodyPadding="false"
+            t-on-click="props.close"
         >
             <div class="ratio ratio-16x9">
                 <iframe


### PR DESCRIPTION
**Prior this commit:**
- We have an onboarding video on the empty screen of the quotations list view. But it wasn't easy to close as users had to use the hidden cross to exit the video.

**Post this commit:**
- The user doesn't have to actually click the cross, the popup can now be closed by clicking anywhere outside the video.

**Affected version**-master

Task-4075393