### PR TITLE
[FIX] product: minimize packaging rounding error

### DIFF
--- a/addons/product/models/product_packaging.py
+++ b/addons/product/models/product_packaging.py
@@ -77,4 +77,4 @@ class ProductPackaging(models.Model):
         self.ensure_one()
         if qty_uom:
             qty = qty_uom._compute_quantity(qty, self.product_uom_id)
-        return float_round(qty / self.qty, precision_rounding=self.product_uom_id.rounding)
+        return qty / self.qty


### PR DESCRIPTION
### Issue:

The way that the `product_packaging_qty` field of the SOL model is defined and used can introduce an error on the qty of the SOL whose as high as half of the uom_rounding (seen as a percentage) of the qty_per_package 
E.G. with an uom_rounding of 0.01 you can introduce an error on the qty of the SOL that is up to 0.5% of the qty per package.

### Steps to reproduce the issue:

- Enable "Product Packagings" on products in the settings
- Create a storable product with a packaging containing 999 units
- Create a SO with a SOL for 1004 units of that product
- Add your packaging on the SOL

#### > the quantity went from 1004 to 1008.99 (error of 5 units that is 0.5%)

### Cause of the issue:

Rounding a float number can introduce an error of up to 0.5 the rounding precision e.g. 0.005 rounds up to 0.01 with rounding precision 0.01 which is is an error of half of its rounding precision.

The `product_uom_qty` of an SOL is computed by making the product of the `product_packaging_qty` with the `qty_per_packaging`: https://github.com/odoo/odoo/blob/0ffe4cbb5a112b3885f3b624872180bf7bc31891/addons/sale/models/sale_order_line.py#L424-L425 
As such, the `product_packaging_qty` is a ratio meant to be re-multiplied with product uom quantities. However, the `product_packaging_qty` is computed with the rounding precision of the `product_uom`:
https://github.com/odoo/odoo/blob/0ffe4cbb5a112b3885f3b624872180bf7bc31891/addons/product/models/product_packaging.py#L80 
Therefore the `product_packaging_qty` can carry an error as high as  half of the `uom_rounding`, that is, most often up to 0.5%. This introduce an error on the `product_uom_qty` that can therefore be as high as 0.5% of the `qty_per_packaging`.

### Fix:

Since each of the qty appearing in the quotients and products are rounded, it is impossible to avoid completely any rounding issue but since the `product_packaging_qty` is a ratio that is meant to be remultiplied by a product uom quantity its precision should as high as possible to not introduce any percentage deviation on the quantity.

opw-4057874
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
