### PR TITLE
[FIX] html_editor: add string style to props

### DIFF
--- a/addons/html_editor/static/src/fields/html_viewer.js
+++ b/addons/html_editor/static/src/fields/html_viewer.js
@@ -20,7 +20,7 @@ function retargetLinks(container) {
 export class HtmlViewer extends Component {
     static template = "html_editor.HtmlViewer";
     static props = {
-        value: { type: Object },
+        value: { type: [Object, String] },
         hasFullHtml: { type: Boolean, optional: true },
         cssAssetId: { type: String, optional: true },
     };


### PR DESCRIPTION
`HtmlViewer` only accepts object type, which might not always be passed, for example when `body_html` is being rendered, therefore it makes sense to add string type as `body_html` has string type

task-4053127

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
