### PR TITLE
[IMP] tools, web: export props with .translate modifier to .pot files

### DIFF
--- a/addons/web/i18n/web.pot
+++ b/addons/web/i18n/web.pot
@@ -5812,6 +5812,7 @@ msgstr ""
 #: code:addons/web/static/src/legacy/js/views/list/list_controller.js:0
 #: code:addons/web/static/src/legacy/xml/base.xml:0
 #: code:addons/web/static/src/legacy/xml/base.xml:0
+#: code:addons/web/static/src/legacy/xml/control_panel.xml:0
 #: code:addons/web/static/src/search/favorite_menu/favorite_menu.js:0
 #: code:addons/web/static/src/views/fields/domain/domain_field.xml:0
 #: code:addons/web/static/src/views/fields/domain/domain_field.xml:0

--- a/addons/web/static/src/legacy/xml/control_panel.xml
+++ b/addons/web/static/src/legacy/xml/control_panel.xml
@@ -4,7 +4,7 @@
 <t t-name="web.Legacy.FavoriteMenu" t-inherit="web.FavoriteMenu" t-inherit-mode="primary" owl="1">
     <xpath expr="//t[@t-set-slot='toggler']" position="inside">
         <Dialog t-if="state.deletedFavorite"
-            title="'Warning'"
+            title.translate="Warning"
             size="'medium'"
             onClosed="() => { state.deletedFavorite = false }"
             >

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -876,18 +876,12 @@ def _extract_translatable_qweb_terms(element, callback):
                 and el.get("t-translation", '').strip() != "off"):
 
             _push(callback, el.text, el.sourceline)
-            # Do not export terms contained on the Component directive of OWL
-            # attributes in this context are most of the time variables,
-            # not real HTML attributes.
-            # Node tags starting with a capital letter are considered OWL Components
-            # and a widespread convention and good practice for DOM tags is to write
-            # them all lower case.
-            # https://www.w3schools.com/html/html5_syntax.asp
-            # https://github.com/odoo/owl/blob/master/doc/reference/component.md#composition
-            if not el.tag[0].isupper() and 't-component' not in el.attrib and 't-set-slot' not in el.attrib:
-                for att in TRANSLATED_ATTRS:
-                    if att in el.attrib:
-                        _push(callback, el.attrib[att], el.sourceline)
+            # heuristic: tags with names starting with an uppercase letter are
+            # component nodes
+            is_component = el.tag[0].isupper() or "t-component" in el.attrib or "t-set-slot" in el.attrib
+            for attr in el.attrib:
+                if (not is_component and attr in TRANSLATED_ATTRS) or (is_component and attr.endswith(".translate")):
+                    _push(callback, el.attrib[attr], el.sourceline)
             _extract_translatable_qweb_terms(el, callback)
         _push(callback, el.tail, el.sourceline)
 


### PR DESCRIPTION
v2.3.0 of Owl added the .translate modifier to props, allowing them to be translated. This commit updates the script that generates the .pot files (the list of source terms to translate) in order to take into account props with the .translate modifier.

Task-3980675