### PR TITLE
[IMP] base: enhance error message during pdf merge

### DIFF
--- a/addons/account/tests/test_ir_actions_report.py
+++ b/addons/account/tests/test_ir_actions_report.py
@@ -6,7 +6,7 @@ from PyPDF2 import PdfFileReader, PdfFileWriter
 
 from odoo import Command
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
-from odoo.exceptions import UserError
+from odoo.exceptions import RedirectWarning
 from odoo.tools import pdf
 from odoo.tests import tagged
 from odoo.tools import file_open
@@ -45,7 +45,7 @@ class TestIrActionsReport(AccountTestInvoicingCommon):
         test_record_report = self.env['ir.actions.report'].with_context(force_report_rendering=True)._render_qweb_pdf('account.action_account_original_vendor_bill', res_ids=in_invoice_1.id)
         self.assertTrue(test_record_report, "The PDF should have been generated")
 
-    def test_download_one_encrypted_pdf(self):
+    def test_download_with_encrypted_pdf(self):
         """
         Same as test_download_one_corrupted_pdf
         but for encrypted pdf with no password and set encryption type to 5 (not known by PyPDF2)
@@ -96,7 +96,7 @@ class TestIrActionsReport(AccountTestInvoicingCommon):
             'res_id': in_invoice_2.id,
         })
         # trying to merge with a corrupted attachment should not work
-        with self.assertRaises(UserError):
+        with self.assertRaises(RedirectWarning):
             self.env['ir.actions.report'].with_context(force_report_rendering=True)._render_qweb_pdf('account.action_account_original_vendor_bill', res_ids=[in_invoice_1.id, in_invoice_2.id])
 
     def test_report_with_some_resources_reloaded_from_attachment(self):

--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -22493,6 +22493,12 @@ msgid "Odoo is unable to merge the generated PDFs."
 msgstr ""
 
 #. module: base
+#. odoo-python
+#: code:addons/base/models/ir_actions_report.py:0
+msgid "Odoo is unable to merge the generated PDFs because of {num_errors} corrupted file(s)"
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_sequence__padding
 msgid ""
 "Odoo will automatically adds some '0' on the left of the 'Next Number' to "
@@ -30507,6 +30513,12 @@ msgstr ""
 #. module: base
 #: model:ir.module.module,summary:base.module_website_crm_livechat
 msgid "View livechat sessions for leads"
+msgstr ""
+
+#. module: base
+#. odoo-python
+#: code:addons/base/models/ir_actions_report.py:0
+msgid "View Problematic Record(s)"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -4,7 +4,7 @@ from markupsafe import Markup
 from urllib.parse import urlparse
 
 from odoo import api, fields, models, tools, SUPERUSER_ID, _
-from odoo.exceptions import UserError, AccessError
+from odoo.exceptions import UserError, AccessError, RedirectWarning
 from odoo.tools.safe_eval import safe_eval, time
 from odoo.tools.misc import find_in_path, ustr
 from odoo.tools import check_barcode_encoding, config, is_html_empty, parse_version
@@ -646,6 +646,11 @@ class IrActionsReport(models.Model):
                 reader = PdfFileReader(stream)
                 writer.appendPagesFromReader(reader)
             except (PdfReadError, TypeError, NotImplementedError, ValueError):
+                # TODO : make custom_error_handler a parameter in master
+                custom_error_handler = self.env.context.get('custom_error_handler')
+                if custom_error_handler:
+                    custom_error_handler(stream)
+                    continue
                 raise UserError(_("Odoo is unable to merge the generated PDFs."))
         result_stream = io.BytesIO()
         streams.append(result_stream)
@@ -894,13 +899,38 @@ class IrActionsReport(models.Model):
                 else:
                     _logger.info("The PDF documents %r are now saved in the database", attachment_names)
 
+        stream_to_ids = {v['stream']: k for k, v in collected_streams.items() if v['stream']}
         # Merge all streams together for a single record.
-        streams_to_merge = [x['stream'] for x in collected_streams.values() if x['stream']]
+        streams_to_merge = list(stream_to_ids.keys())
+        error_record_ids = []
+
         if len(streams_to_merge) == 1:
             pdf_content = streams_to_merge[0].getvalue()
         else:
-            with self._merge_pdfs(streams_to_merge) as pdf_merged_stream:
+            with self.with_context(
+                    custom_error_handler=lambda error_stream: error_record_ids.append(stream_to_ids[error_stream])
+            )._merge_pdfs(streams_to_merge) as pdf_merged_stream:
                 pdf_content = pdf_merged_stream.getvalue()
+
+        if error_record_ids:
+            action = {
+                'type': 'ir.actions.act_window',
+                'name': _('Problematic record(s)'),
+                'res_model': report_sudo.model,
+                'domain': [('id', 'in', error_record_ids)],
+                'views': [(False, 'tree'), (False, 'form')],
+            }
+            num_errors = len(error_record_ids)
+            if num_errors == 1:
+                action.update({
+                    'views': [(False, 'form')],
+                    'res_id': error_record_ids[0],
+                })
+            raise RedirectWarning(
+                message=_('Odoo is unable to merge the generated PDFs because of %(num_errors)s corrupted file(s)', num_errors=num_errors),
+                action=action,
+                button_text=_('View Problematic Record(s)'),
+            )
 
         for stream in streams_to_merge:
             stream.close()


### PR DESCRIPTION
Before this commit, the user would get a UserError when multiple attachments are merged for export and one of them is corrupted. The error message did not contain information helping the user identify the problematic records.

After this commit, the user will get a RedirectWarning stating the number of corrupted files and a link to a form view (if single) or a list view (if multiple) of problematic record(s).

### Example workflow:
1. Go to Accounting > Vendors > Bills.
2. Create a bill with a corrupted attachment.
3. Select the corrupted bill amongst other bills with valid attachments.
4. Click on Print > Original Bills.
5. The error is: "Odoo is unable to merge the generated PDFs."

### Cause:
Errors raised by instantiating a PdfFileReader of a corrupted file were handled with a UserError with a static error message.

### Solution:
In `_merge_pdfs` method signature, add an optional callback to define the way errors are handled. The default callback reproduces the default behavior.

In `_render_qweb_pdf`, a custom callback is defined to keep track of the corrupted streams and log them in the RedirectWarning popup.

opw-4067992
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
