### PR TITLE
[FIX] hw_drivers: remove useless log warnings

### DIFF
--- a/addons/hw_drivers/main.py
+++ b/addons/hw_drivers/main.py
@@ -82,7 +82,7 @@ class Manager(Thread):
             except Exception:
                 _logger.exception('Could not reach configured server')
         else:
-            _logger.warning('Odoo server not set')
+            _logger.info('Ignoring sending the devices to the database: no associated database')
 
     def run(self):
         """
@@ -95,7 +95,7 @@ class Manager(Thread):
             helpers.check_git_branch()
             helpers.generate_password()
         is_certificate_ok, certificate_details = helpers.get_certificate_status()
-        if not is_certificate_ok:
+        if not is_certificate_ok and certificate_details != 'ERR_IOT_HTTPS_CHECK_NO_SERVER':
             _logger.warning("An error happened when trying to get the HTTPS certificate: %s",
                             certificate_details)
 

--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -92,6 +92,7 @@ def check_certificate():
     server = get_odoo_server_url()
 
     if not server:
+        _logger.info('Ignoring the nginx certificate check without a connected database')
         return {"status": CertificateStatus.ERROR,
                 "error_code": "ERR_IOT_HTTPS_CHECK_NO_SERVER"}
 


### PR DESCRIPTION
Currently the logs are being spammed with warning messages which shouldn't be warnings as it's a normal behavior

1) When no database is connected we log "warning invalid ssl
   certificate"
2) When no database is connected we log "warning odoo server not set"

I log both as info level to still keep this information but avoid spamming useful error logs with it