### PR TITLE
[FIX] mail: pinned message panel style issue

### DIFF
--- a/addons/mail/static/src/discuss/message_pin/common/pinned_messages_panel.scss
+++ b/addons/mail/static/src/discuss/message_pin/common/pinned_messages_panel.scss
@@ -1,3 +1,0 @@
-.o-discuss-PinnedMessagesPanel {
-    flex-basis: 425px;
-}


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/173856

PR above made possible to resize right panel of Discuss app, which could be either Member list, search messages, or listing of pinned messages. This latter pannel had a small UI glitch in its default size on medium and big screen size.

This comes from ResizePanel setting a width of `400px`, while the `flex-basis` of `PinnedMessagePanel` was `425px`. This resulted in `25px` of blank space on the right side of pinned message panel.

`400px` vs `425px` is just 25px, and 400 is good enough. So the fix simply consists in removing the `flex-basis: 425px`. That way, all panels have the default size of `400px`.

Before:
![before](https://github.com/user-attachments/assets/739a57f4-6453-45ed-ae27-f9a9d92ec17b)
After:
![after](https://github.com/user-attachments/assets/d9133c0a-d279-41f5-901e-1352ad12140c)

