### PR TITLE
[IMP] *: update a bunch of pg error codes to exception classes

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -6,7 +6,7 @@ import time
 import re
 import logging
 
-from psycopg2 import sql, DatabaseError
+from psycopg2 import sql, errors as pgerrors
 
 from odoo import api, fields, models, _
 from odoo.osv import expression
@@ -762,11 +762,7 @@ class ResPartner(models.Model):
                     """).format(field=sql.Identifier(field))
                     self.env.cr.execute(query, {'partner_ids': tuple(self.ids), 'n': n})
                     self.invalidate_recordset([field])
-            except DatabaseError as e:
-                # 55P03 LockNotAvailable
-                # 40001 SerializationFailure
-                if e.pgcode not in ('55P03', '40001'):
-                    raise e
+            except (pgerrors.LockNotAvailable, pgerrors.SerializationFailure):
                 _logger.debug('Another transaction already locked partner rows. Cannot update partner ranks.')
 
     @api.model

--- a/addons/account/models/sequence_mixin.py
+++ b/addons/account/models/sequence_mixin.py
@@ -8,7 +8,7 @@ from odoo.tools import frozendict, mute_logger, date_utils
 
 import re
 from collections import defaultdict
-from psycopg2 import sql, DatabaseError
+from psycopg2 import sql, errors as pgerrors
 
 
 class SequenceMixin(models.AbstractModel):
@@ -311,11 +311,8 @@ class SequenceMixin(models.AbstractModel):
                     self[self._sequence_field] = sequence
                     self.flush_recordset([self._sequence_field])
                     break
-            except DatabaseError as e:
-                # 23P01 ExclusionViolation
-                # 23505 UniqueViolation
-                if e.pgcode not in ('23P01', '23505'):
-                    raise e
+            except (pgerrors.ExclusionViolation, pgerrors.UniqueViolation):
+                pass
         self._compute_split_sequence()
         self.flush_recordset(['sequence_prefix', 'sequence_number'])
 

--- a/addons/bus/models/bus_presence.py
+++ b/addons/bus/models/bus_presence.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
 import datetime
 
-from psycopg2 import OperationalError
-
 from odoo import api, fields, models
 from odoo import tools
-from odoo.service.model import PG_CONCURRENCY_ERRORS_TO_RETRY
+from odoo.service.model import PG_CONCURRENCY_EXCEPTIONS_TO_RETRY
 
 UPDATE_PRESENCE_DELAY = 60
 DISCONNECTION_TIMER = UPDATE_PRESENCE_DELAY + 5
@@ -45,11 +43,9 @@ class BusPresence(models.Model):
                 self._update_presence(inactivity_period=inactivity_period, identity_field=identity_field, identity_value=identity_value)
                 # commit on success
                 self.env.cr.commit()
-        except OperationalError as e:
-            if e.pgcode in PG_CONCURRENCY_ERRORS_TO_RETRY:
-                # ignore concurrency error
-                return self.env.cr.rollback()
-            raise
+        except PG_CONCURRENCY_EXCEPTIONS_TO_RETRY:
+            # ignore concurrency error
+            return self.env.cr.rollback()
 
     @api.model
     def _update_presence(self, inactivity_period, identity_field, identity_value):

--- a/addons/mail/controllers/discuss/public_page.py
+++ b/addons/mail/controllers/discuss/public_page.py
@@ -1,7 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
-from psycopg2 import IntegrityError
-from psycopg2.errorcodes import UNIQUE_VIOLATION
+import psycopg2.errors
 from werkzeug.exceptions import NotFound
 
 from odoo import _, http
@@ -76,9 +74,7 @@ class PublicPageController(http.Controller):
                         "uuid": create_token,
                     }
                 )
-            except IntegrityError as e:
-                if e.pgcode != UNIQUE_VIOLATION:
-                    raise
+            except psycopg2.errors.UniqueViolation:
                 # concurrent insert attempt: another request created the channel.
                 # commit the current transaction and get the channel.
                 request.env.cr.commit()

--- a/addons/onboarding/tests/test_onboarding_concurrency.py
+++ b/addons/onboarding/tests/test_onboarding_concurrency.py
@@ -4,7 +4,7 @@
 import threading
 from concurrent.futures import ThreadPoolExecutor
 
-from psycopg2 import IntegrityError
+import psycopg2.errors
 
 import odoo
 from odoo.tests.common import get_db_name, tagged, BaseCase
@@ -44,8 +44,6 @@ class TestOnboardingConcurrency(BaseCase):
         barrier = threading.Barrier(2)
 
         def run():
-            raised_unique_violation = False
-
             with self.registry.cursor() as cr:
                 env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
                 onboarding = env['onboarding.onboarding'].search([
@@ -58,11 +56,10 @@ class TestOnboardingConcurrency(BaseCase):
                 barrier.wait(timeout=2)
                 try:
                     onboarding._create_progress()
-                except IntegrityError as e:
-                    if e.pgcode == "23505":  # UniqueViolation
-                        raised_unique_violation = True
+                except psycopg2.errors.UniqueViolation:
+                    return True
 
-            return raised_unique_violation
+            return False
 
         with ThreadPoolExecutor(max_workers=2) as executor:
             future_1 = executor.submit(run)

--- a/odoo/addons/test_http/controllers.py
+++ b/odoo/addons/test_http/controllers.py
@@ -4,7 +4,7 @@ import logging
 
 import werkzeug
 from psycopg2.errorcodes import SERIALIZATION_FAILURE
-from psycopg2 import OperationalError
+from psycopg2.errors import SerializationFailure
 
 from odoo import http
 from odoo.exceptions import AccessError, UserError
@@ -22,10 +22,6 @@ WSGI_SAFE_KEYS = {'PATH_INFO', 'QUERY_STRING', 'RAW_URI', 'SCRIPT_NAME', 'wsgi.u
 
 # Force serialization errors. Patched in some tests.
 should_fail = None
-
-
-class SerializationFailureError(OperationalError):
-    pgcode = SERIALIZATION_FAILURE
 
 
 class TestHttp(http.Controller):
@@ -227,7 +223,9 @@ class TestHttp(http.Controller):
         data = ufile.read()
         if should_fail:
             should_fail = False  # Fail once
-            raise SerializationFailureError()
+            sf = SerializationFailure()
+            sf.__setstate__({'pgcode': SERIALIZATION_FAILURE})
+            raise sf
 
         return data.decode()
 

--- a/odoo/cli/server.py
+++ b/odoo/cli/server.py
@@ -18,7 +18,7 @@ import re
 import sys
 from pathlib import Path
 
-from psycopg2 import ProgrammingError, errorcodes
+from psycopg2.errors import InsufficientPrivilege
 
 import odoo
 
@@ -145,15 +145,12 @@ def main(args):
             try:
                 odoo.service.db._create_empty_database(db_name)
                 config['init']['base'] = True
-            except ProgrammingError as err:
-                if err.pgcode == errorcodes.INSUFFICIENT_PRIVILEGE:
-                    # We use an INFO loglevel on purpose in order to avoid
-                    # reporting unnecessary warnings on build environment
-                    # using restricted database access.
-                    _logger.info("Could not determine if database %s exists, "
-                                 "skipping auto-creation: %s", db_name, err)
-                else:
-                    raise err
+            except InsufficientPrivilege as err:
+                # We use an INFO loglevel on purpose in order to avoid
+                # reporting unnecessary warnings on build environment
+                # using restricted database access.
+                _logger.info("Could not determine if database %s exists, "
+                             "skipping auto-creation: %s", db_name, err)
             except odoo.service.db.DatabaseExists:
                 pass
 


### PR DESCRIPTION
Exception classes were added in psycopg2 2.8 and are already widely used in the codebase. They generally allow for terser and clearer error handling as their naming is a lot more explicit and they don't require handling mismatches.

Not all uses of pgcode have been replaced, as some uses specifically categorise between different sub-exceptions (usually with common handling code around), or are in sub-helpers. It would technically be possible to replace those with uses of `isinstance` on the exception objects but that feels like going too far the other way.
