### PR TITLE
[FIX] pos_viva_wallet: prevent an error when failed transactions

### DIFF
--- a/addons/pos_viva_wallet/models/pos_payment_method.py
+++ b/addons/pos_viva_wallet/models/pos_payment_method.py
@@ -110,7 +110,7 @@ class PosPaymentMethod(models.Model):
 
         MerchantTrns = data_webhook.get('MerchantTrns')
         if not MerchantTrns:
-            self._send_notification(
+            return self._send_notification(
                 {'error': _(
                     "Your transaction with Viva Wallet failed. Please try again later."
                     )}


### PR DESCRIPTION
Currently,  If 'MerchantTrns' is not available due to failed transactions, The System only sends a notification but does not return it. therefore errors occur from here [1] due to the unavailable of 'MerchantTrns'.

link [1]: https://github.com/odoo/odoo/blob/ede5da1f72088ac1f78c9bc5206ccd666dce8c3d/addons/pos_viva_wallet/models/pos_payment_method.py#L118

To resolve this issue, return a send notification if 'MerchantTrns' is not available in 'data_webhook'.

Related PR: https://github.com/odoo/odoo/pull/171764
Sentry - 5466498742

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
