### PR TITLE
[FIX] stock: picking origin should not be removed on new move assign

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1217,13 +1217,13 @@ Please change the quantity done or the rounding precision of your unit of measur
             picking = moves[0]._search_picking_for_assignation()
             if picking:
                 # If a picking is found, we'll append `move` to its move list and thus its
-                # `partner_id` and `ref` field will refer to multiple records. In this
-                # case, we chose to wipe them.
+                # `partner_id` will refer to multiple records. In this
+                # case, we chose to wipe it. The origin will be updated.
                 vals = {}
                 if any(picking.partner_id.id != m.partner_id.id for m in moves):
                     vals['partner_id'] = False
                 if any(picking.origin != m.origin for m in moves):
-                    vals['origin'] = False
+                    vals['origin'] = moves._get_new_picking_values().get('origin')
                 if vals:
                     picking.write(vals)
             else:

--- a/addons/stock/tests/test_move2.py
+++ b/addons/stock/tests/test_move2.py
@@ -2729,8 +2729,8 @@ class TestRoutes(TestStockCommon):
 
     def test_pick_ship_1(self):
         """ Enable the pick ship route, force a procurement group on the
-        pick. When a second move is added, make sure the `partner_id` and
-        `origin` fields are erased.
+        pick. When a second move is added, make sure the `partner_id` field is erased
+        `origin` field is recomputed.
         """
         self._enable_pick_ship()
 
@@ -2783,10 +2783,10 @@ class TestRoutes(TestStockCommon):
         self.assertEqual(picking_pick.partner_id.id, procurement_group1.partner_id.id)
         self.assertEqual(picking_pick.origin, move1.group_id.name)
 
-        # second out move, the "pick" picking should have lost its partner and origin
+        # second out move, the "pick" picking should have lost its partner and rebuild its origin
         move2._action_confirm()
         self.assertEqual(picking_pick.partner_id.id, False)
-        self.assertEqual(picking_pick.origin, False)
+        self.assertEqual(picking_pick.origin, procurement_group0.name)
 
     def test_replenish_pick_ship_1(self):
         """ Creates 2 warehouses and make a replenish using one warehouse

--- a/doc/cla/individual/johnny-longneck.md
+++ b/doc/cla/individual/johnny-longneck.md
@@ -1,0 +1,11 @@
+Germany, 2024-07-29
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+John Herholz j.longneck@gmail.com https://github.com/johnny-longneck


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR adresses ticket https://github.com/odoo/odoo/issues/174500

Current behavior before PR:
On MTO with multi step receive, the picking origin gets removed on the second receive step if a quantity on the purchase order is changed to zero after confirmation.

Desired behavior after PR is merged:
Keep the picking origin of the MTO sale order in order to process the picking in the warehouse correctly.

**Note**
I removed the part where the picking.origin is wiped. I did not find any useful scenario for this.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
