### PR TITLE
[FIX] web: autofocus on email at login

### DIFF
--- a/addons/web/static/src/core/user_switch/user_switch.js
+++ b/addons/web/static/src/core/user_switch/user_switch.js
@@ -16,6 +16,9 @@ export class UserSwitch extends Component {
         });
         this.form = document.querySelector("form.oe_login_form");
         this.form.classList.toggle("d-none", users.length);
+        if (!users.length) {
+            this.form.querySelector("input#login")?.focus();
+        }
         useEffect(
             (el) => el?.querySelector("button.list-group-item-action")?.focus(),
             () => [this.root.el]

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -151,7 +151,7 @@
 
                 <div class="mb-3 field-login">
                     <label for="login" class="form-label d-flex justify-content-between">Email</label>
-                    <input type="text" placeholder="Email" name="login" t-att-value="login" id="login" class="form-control" required="required" autocapitalize="off"/>
+                    <input type="text" placeholder="Email" name="login" t-att-value="login" id="login" class="form-control" required="required" autocapitalize="off" t-att-autofocus="'autofocus' if not login else None"/>
                 </div>
 
                 <div class="mb-3">


### PR DESCRIPTION
enable the autofocus on email input on login page
this functionality was lost in commit https://github.com/odoo/odoo/commit/ce71c5d17f093db195d7a212fe610d55824f6fbc

Note that the autofocus (email) on xml will have no effect but makes sense to have it in case one day the user_switch gets removed


task-4077091
