### PR TITLE
[FIX] point_of_sale: fix partner test

### DIFF
--- a/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
@@ -292,7 +292,7 @@ registry.category("web_tour.tours").add("PosCustomerAllFieldsDisplayed", {
             // Check searches
             ProductScreenPartnerList.searchCustomerValueAndClear("John Doe"),
             ProductScreenPartnerList.searchCustomerValueAndClear("1 street of astreet"),
-            ProductScreenPartnerList.searchCustomerValueAndClear("99999"),
+            ProductScreenPartnerList.searchCustomerValueAndClear("26432685463"),
             ProductScreenPartnerList.searchCustomerValueAndClear("Acity"),
             ProductScreenPartnerList.searchCustomerValueAndClear("United States"),
             ProductScreenPartnerList.searchCustomerValueAndClear("1234567890"),

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1332,7 +1332,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             "city": "Acity",
             "state_id": self.env.ref("base.state_us_30").id,  # Ohio
             "country_id": self.env.ref("base.us").id,
-            "zip": "99999",
+            "zip": "26432685463",
             "phone": "1234567890",
             "mobile": "0987654321",
             "email": "john@doe.com"


### PR DESCRIPTION
The test was failing because it tried to check the ZIP code of the partner. That was because the ZIP in the test was 99999, and another partner has a tax ID that contains 99999. The test was checking the first partner displayed on the list, and it was not the one with the ZIP but the one with the tax ID.

This commit makes the ZIP code of the partner more long and unique to avoid this kind of issue.

Runbot error: 72516, 72515, 72513

