### PR TITLE
[IMP] account{_payment},payment,sale: support effectively paying in installments

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4981,6 +4981,49 @@ class AccountMove(models.Model):
     def is_outbound(self, include_receipts=True):
         return self.move_type in self.get_outbound_types(include_receipts)
 
+    def _get_installments_data(self):
+        self.ensure_one()
+        term_lines = self.line_ids.filtered(lambda l: l.display_type == 'payment_term')
+        return term_lines._get_installments_data()
+
+    def get_next_installment_due(self):
+        self.ensure_one()
+        return next((x for x in self._get_installments_data() if not x['reconciled']), None)
+
+    def get_amount_overdue(self):
+        self.ensure_one()
+        return sum(
+            x['amount_residual_currency_unsigned']
+            for x in self._get_installments_data()
+            if x['type'] == 'overdue'
+        )
+
+    def _get_invoice_portal_extra_values(self):
+        self.ensure_one()
+        installment = self.get_next_installment_due()
+        amount_overdue = self.get_amount_overdue()
+        show_payment_info = (
+            self.payment_state not in ('paid', 'in_payment', 'reversed') and self.move_type == 'out_invoice'
+        )
+        show_amount_overdue = show_payment_info and amount_overdue and amount_overdue != self.amount_residual
+        show_installment = (
+            show_payment_info
+            and installment
+            and installment['type'] != 'early_payment_discount'
+            and installment['amount_residual_currency_unsigned'] != self.amount_residual
+        )
+        return {
+            'invoice': self,
+            'amount_paid': self.amount_total - self.amount_residual,
+            'amount_due': self.amount_residual,
+            'show_installment': show_installment or show_amount_overdue,
+            'show_payment_info': show_payment_info,
+            'amount_next_installment': installment['amount_residual_currency_unsigned'] if show_installment else 0.0,
+            'date_next_installment': installment['date_maturity'] if show_installment else None,
+            'name_next_installment': f"{self.name}-{installment['number']}" if show_installment else "",
+            'amount_overdue': amount_overdue if show_amount_overdue else 0.0,
+        }
+
     def _get_accounting_date(self, invoice_date, has_tax, lock_dates=None):
         """Get correct accounting date for previous periods, taking tax lock date and affected journal into account.
         When registering an invoice in the past, we still want the sequence to be increasing.

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1180,7 +1180,7 @@ class AccountMoveLine(models.Model):
             ]
 
     def action_payment_items_register_payment(self):
-        return self.action_register_payment({'force_group_payment': True})
+        return self.action_register_payment(ctx={'default_group_payment': True})
 
     def action_register_payment(self, ctx=None):
         ''' Open the account.payment.register wizard to pay the selected journal items.
@@ -3133,6 +3133,69 @@ class AccountMoveLine(models.Model):
             'company_id': self.company_id.id or self.env.company.id,
             'category': 'invoice' if self.move_id.is_sale_document() else 'vendor_bill' if self.move_id.is_purchase_document() else 'other',
         }
+
+    # -------------------------------------------------------------------------
+    # INSTALLMENTS
+    # -------------------------------------------------------------------------
+
+    def _get_installments_data(self, payment_currency=None, payment_date=None):
+        move = self.move_id
+        move.ensure_one()
+
+        payment_date = payment_date or fields.Date.context_today(self)
+
+        term_lines = self.sorted(key=lambda line: (line.date_maturity, line.date))
+        sign = move.direction_sign
+        installments = []
+        first_installment_mode = False
+        current_installment_mode = False
+        for i, line in enumerate(term_lines, start=1):
+            installment = {
+                'number': i,
+                'line': line,
+                'date_maturity': line.date_maturity or line.date,
+                'amount_residual_currency': line.amount_residual_currency,
+                'amount_residual': line.amount_residual,
+                'amount_residual_currency_unsigned': -sign * line.amount_residual_currency,
+                'amount_residual_unsigned': -sign * line.amount_residual,
+                'type': 'other',
+                'reconciled': line.reconciled,
+            }
+            installments.append(installment)
+
+            # Already reconciled.
+            if line.reconciled:
+                continue
+
+            # Early payment discount.
+            # In that case, we want to report the difference of the epd and display it on the UI.
+            if move._is_eligible_for_early_payment_discount(payment_currency or line.currency_id, payment_date):
+                installment.update({
+                    'amount_residual_currency': line.discount_amount_currency,
+                    'amount_residual': line.discount_balance,
+                    'amount_residual_currency_unsigned': -sign * line.discount_amount_currency,
+                    'amount_residual_unsigned': -sign * line.discount_balance,
+                    'type': 'early_payment_discount',
+                })
+                continue
+
+            # Installments.
+            # In case of overdue, all of them are sum as a default amount to be paid.
+            # The next installment is added for the difference.
+            if line.display_type == 'payment_term':
+                if (line.date_maturity or line.date) < payment_date:
+                    # Collect all overdue installments.
+                    first_installment_mode = current_installment_mode = 'overdue'
+                elif not first_installment_mode:
+                    # Suggest the next installment in case of no overdue.
+                    first_installment_mode = 'next'
+                    current_installment_mode = 'next'
+                elif current_installment_mode == 'overdue':
+                    # After an overdue, just add the next installment for the difference.
+                    current_installment_mode = 'next'
+                installment['type'] = current_installment_mode
+
+        return installments
 
     # -------------------------------------------------------------------------
     # MISC

--- a/addons/account/static/src/components/account_payment_register_html/account_payment_register_html.js
+++ b/addons/account/static/src/components/account_payment_register_html/account_payment_register_html.js
@@ -1,0 +1,20 @@
+import {HtmlField, htmlField} from "@web_editor/js/backend/html_field";
+import {registry} from "@web/core/registry";
+
+export class AccountPaymentRegisterHtmlField extends HtmlField {
+    static template = "account.AccountPaymentRegisterHtmlField";
+
+    async switchInstallmentsAmount(ev) {
+        if (ev.srcElement.classList.contains("installments_switch_button")) {
+            const root = this.env.model.root;
+            await root.update({amount: root.data.installments_switch_amount});
+        }
+    }
+}
+
+export const accountPaymentRegisterHtmlField = {
+    ...htmlField,
+    component: AccountPaymentRegisterHtmlField,
+};
+
+registry.category("fields").add("account_payment_register_html", accountPaymentRegisterHtmlField);

--- a/addons/account/static/src/components/account_payment_register_html/account_payment_register_html.xml
+++ b/addons/account/static/src/components/account_payment_register_html/account_payment_register_html.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="account.AccountPaymentRegisterHtmlField" t-inherit="web_editor.HtmlField" t-inherit-mode="primary">
+        <xpath expr="//div[@t-ref='readonlyElement']" position="attributes">
+            <attribute name="t-on-click">switchInstallmentsAmount</attribute>
+        </xpath>
+    </t>
+</templates>

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -1546,9 +1546,9 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         action_data = move.action_register_payment()
         with Form(self.env[action_data['res_model']].with_context(action_data['context'])) as wiz_form:
             self.assertEqual(wiz_form.payment_date.strftime('%Y-%m-%d'), '2023-02-01')
-            self.assertEqual(wiz_form.amount, 920)
+            self.assertEqual(wiz_form.amount, 276)  # First installment of 30%
             self.assertTrue(wiz_form.group_payment)
-            self.assertFalse(wiz_form._get_modifier('group_payment', 'invisible'))
+            self.assertTrue(wiz_form._get_modifier('group_payment', 'invisible'))
             self.assertFalse(wiz_form._get_modifier('group_payment', 'readonly'))
 
         # We can also force the registration of the payment of a draft move with a button hidden

--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -53,12 +53,13 @@
                     <th>Invoice #</th>
                     <th>Invoice Date</th>
                     <th class='d-none d-md-table-cell'>Due Date</th>
+                    <th class="text-end pe-3">Amount Due</th>
                     <th>Status</th>
-                    <th class="text-end">Amount Due</th>
                 </tr>
             </thead>
             <tbody>
-                <t t-foreach="invoices" t-as="invoice">
+                <t t-foreach="invoices" t-as="invoice_data">
+                    <t t-set="invoice" t-value="invoice_data['invoice']"/>
                     <tr>
                         <td>
                             <a t-att-href="invoice.get_portal_url()" t-att-title="invoice.name">
@@ -68,6 +69,7 @@
                         </td>
                         <td><span t-field="invoice.invoice_date"/></td>
                         <td class='d-none d-md-table-cell'><span t-field="invoice.invoice_date_due"/></td>
+                        <td class="text-end pe-3"><span t-out="-invoice.amount_residual if invoice.move_type == 'out_refund' else invoice.amount_residual" t-options='{"widget": "monetary", "display_currency": invoice.currency_id}'/></td>
                         <td name="invoice_status">
                             <t t-if="invoice.state == 'posted'" name="invoice_status_posted">
                                 <span t-if="invoice.payment_state in ('paid', 'in_payment')"
@@ -92,7 +94,6 @@
                                 </span>
                             </t>
                         </td>
-                        <td class="text-end"><span t-out="-invoice.amount_residual if invoice.move_type == 'out_refund' else invoice.amount_residual" t-options='{"widget": "monetary", "display_currency": invoice.currency_id}'/></td>
                     </tr>
                 </t>
             </tbody>
@@ -114,10 +115,32 @@
                     <t t-set="classes" t-value="'col-lg-4 col-xxl-3 d-print-none'"/>
                     <t t-set="title">
                         <h2 class="mb-0 text-break">
-                            <span t-if="invoice.amount_residual > 0" t-field="invoice.amount_residual"/>
-                            <span t-else="1" t-field="invoice.amount_total"/>
+                            <span t-field="invoice.amount_total"/>
                         </h2>
-                        <div class="small" t-if="invoice.payment_state not in ('paid', 'in_payment', 'reversed') and invoice.move_type == 'out_invoice'"><i class="fa fa-clock-o"/><span class="o_portal_sidebar_timeago ml4" t-att-datetime="invoice.invoice_date_due"/></div>
+                        <div class="small" t-if="show_payment_info">
+                            <i class="fa fa-clock-o"/><span class="o_portal_sidebar_timeago ml4" t-att-datetime="invoice.invoice_date_due"/>
+                        </div>
+                        <div class="my-3 w-100">
+                            <div class="alert alert-success w-100 px-2 py-1 text-center" t-if="amount_paid">
+                                Amount Paid: <span t-out="amount_paid" t-options="{'widget': 'monetary', 'display_currency': invoice.currency_id}"/>
+                            </div>
+                            <div class="alert alert-warning w-100 px-2 py-1 text-center" t-if="amount_due">
+                                Amount Due: <span t-out="amount_due" t-options="{'widget': 'monetary', 'display_currency': invoice.currency_id}"/>
+                            </div>
+                        </div>
+                        <h4 name="installment_title" class="w-100" t-if="show_installment">
+                            Installment
+                        </h4>
+                        <h3
+                            name="installment_amount"
+                            class="mb-0 text-break"
+                            t-if="show_installment"
+                            t-out="amount_overdue or amount_next_installment"
+                            t-options="{'widget': 'monetary', 'display_currency': invoice.currency_id}"
+                        />
+                        <div name="installment_due_date" class="small" t-if="show_installment">
+                            <i class="fa fa-clock-o"/><span class="o_portal_sidebar_timeago ml4" t-att-datetime="date_next_installment or invoice.invoice_date_due"/>
+                        </div>
                     </t>
 
                     <t t-set="entries">

--- a/addons/account/wizard/account_payment_register_views.xml
+++ b/addons/account/wizard/account_payment_register_views.xml
@@ -12,6 +12,9 @@
                     <field name="can_edit_wizard" invisible="1" force_save="1"/>
                     <field name="can_group_payments" invisible="1" force_save="1"/>
                     <field name="early_payment_discount_mode" invisible="1" force_save="1"/>
+                    <field name="installments_mode" invisible="1"/>
+                    <field name="installments_switch_amount" invisible="1"/>
+                    <field name="installments_switch_html" invisible="1"/>
                     <field name="payment_type" invisible="1" force_save="1"/>
                     <field name="partner_type" invisible="1" force_save="1"/>
                     <field name="source_amount" invisible="1" force_save="1"/>
@@ -21,6 +24,8 @@
                     <field name="partner_id" invisible="1" force_save="1"/>
                     <field name="country_code" invisible="1" force_save="1"/>
                     <field name="currency_id" invisible="1" />
+                    <field name="custom_user_amount" invisible="1" />
+                    <field name="custom_user_currency_id" invisible="1" />
 
                     <field name="show_partner_bank_account" invisible="1"/>
                     <field name="require_partner_bank_account" invisible="1"/>
@@ -32,7 +37,6 @@
                     <field name="writeoff_is_exchange_account" invisible="1"/>
                     <field name="untrusted_bank_ids" invisible="1"/>
                     <field name="missing_account_partners" invisible="1"/>
-                    <field name="is_amount_forced_by_user" invisible="1"/>
 
                     <div role="alert" class="alert alert-info" invisible="not hide_writeoff_section">
                         <p><b>Early Payment Discount of <field name="payment_difference"/> has been applied.</b></p>
@@ -60,6 +64,40 @@
                                    context="{'display_account_trust': True, 'default_partner_id': partner_id}"/>
                             <field name="group_payment"
                                    invisible="not can_group_payments"/>
+                            <label for="payment_difference" invisible="payment_difference == 0.0 or early_payment_discount_mode or not can_edit_wizard or can_group_payments and not group_payment"/>
+                            <div invisible="payment_difference == 0.0 or early_payment_discount_mode or not can_edit_wizard or can_group_payments and not group_payment">
+                                <field name="payment_difference"/>
+                                <field name="payment_difference_handling" widget="radio" nolabel="1" invisible="is_register_payment_on_draft"/>
+                                <div class="o_inner_group grid col-lg-12 p-0"
+                                     invisible="hide_writeoff_section or payment_difference_handling == 'open'">
+                                    <div class="o_wrap_field d-flex d-sm-contents flex-column mb-3 mb-sm-0">
+                                        <div class="o_cell o_wrap_label text-break text-900">
+                                            <label for="writeoff_account_id"
+                                                   string="Post Difference In"
+                                                   class="oe_edit_only"/>
+                                        </div>
+                                        <div class="o_cell o_wrap_input text-break">
+                                            <field name="writeoff_account_id"
+                                                   string="Post Difference In"
+                                                   options="{'no_create': True}"
+                                                   required="payment_difference_handling == 'reconcile' and not early_payment_discount_mode"/>
+                                        </div>
+                                    </div>
+                                    <div class="o_wrap_field d-flex d-sm-contents flex-column mb-3 mb-sm-0">
+                                        <div class="o_cell o_wrap_label text-break text-900">
+                                            <label for="writeoff_label"
+                                                   class="oe_edit_only"
+                                                   string="Label"
+                                                   invisible="writeoff_is_exchange_account"/>
+                                        </div>
+                                        <div class="o_cell o_wrap_input text-break">
+                                            <field name="writeoff_label"
+                                                   required="payment_difference_handling == 'reconcile'"
+                                                   invisible="writeoff_is_exchange_account"/>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
                         </group>
                         <group name="group2">
                             <label for="amount"
@@ -72,31 +110,15 @@
                                        options="{'no_create': True, 'no_open': True}"
                                        groups="base.group_multi_currency"/>
                             </div>
+                            <field
+                                name="installments_switch_html"
+                                string=""
+                                widget="account_payment_register_html"
+                                invisible="not installments_switch_html"
+                            />
                             <field name="payment_date"/>
                             <field name="communication"
                                    invisible="not can_edit_wizard or (can_group_payments and not group_payment)"/>
-                        </group>
-                        <group name="group3"
-                               invisible="payment_difference == 0.0 or early_payment_discount_mode or not can_edit_wizard or can_group_payments and not group_payment">
-                            <label for="payment_difference"/>
-                            <div>
-                                <field name="payment_difference"/>
-                                <field name="payment_difference_handling" widget="radio" nolabel="1" invisible="is_register_payment_on_draft"/>
-                                <div invisible="hide_writeoff_section or payment_difference_handling == 'open'">
-                                    <label for="writeoff_account_id" string="Post Difference In" class="oe_edit_only"/>
-                                    <field name="writeoff_account_id"
-                                           string="Post Difference In"
-                                           options="{'no_create': True}"
-                                           required="payment_difference_handling == 'reconcile' and not early_payment_discount_mode"/>
-                                    <label for="writeoff_label"
-                                           class="oe_edit_only"
-                                           string="Label"
-                                           invisible="writeoff_is_exchange_account"/>
-                                    <field name="writeoff_label"
-                                           required="payment_difference_handling == 'reconcile'"
-                                           invisible="writeoff_is_exchange_account"/>
-                                </div>
-                            </div>
                         </group>
                         <field name="qr_code" invisible="1"/>
                         <div invisible="not qr_code" colspan="2" class="text-center">

--- a/addons/account_payment/__manifest__.py
+++ b/addons/account_payment/__manifest__.py
@@ -19,6 +19,7 @@
         'views/account_move_views.xml',
         'views/account_journal_views.xml',
         'views/account_payment_views.xml',
+        'views/payment_form_templates.xml',
         'views/payment_provider_views.xml',
         'views/payment_transaction_views.xml',
 
@@ -27,6 +28,13 @@
         'wizards/payment_refund_wizard_views.xml',
         'wizards/res_config_settings_views.xml',
     ],
+    'assets': {
+        'web.assets_frontend': [
+            'account_payment/static/src/js/payment_form.js',
+            'account_payment/static/src/js/portal_invoice_page_payment.js',
+            'account_payment/static/src/js/portal_my_invoices_payment.js',
+        ],
+    },
     'post_init_hook': 'post_init_hook',
     'uninstall_hook': 'uninstall_hook',
     'license': 'LGPL-3',

--- a/addons/account_payment/controllers/payment.py
+++ b/addons/account_payment/controllers/payment.py
@@ -32,7 +32,7 @@ class PaymentPortal(payment_portal.PaymentPortal):
 
         logged_in = not request.env.user._is_public()
         partner_sudo = request.env.user.partner_id if logged_in else invoice_sudo.partner_id
-        self._validate_transaction_kwargs(kwargs)
+        self._validate_transaction_kwargs(kwargs, additional_allowed_keys={'name_next_installment'})
         kwargs.update({
             'currency_id': invoice_sudo.currency_id.id,
             'partner_id': partner_sudo.id,

--- a/addons/account_payment/models/payment_transaction.py
+++ b/addons/account_payment/models/payment_transaction.py
@@ -88,7 +88,10 @@ class PaymentTransaction(models.Model):
             invoice_ids = self._fields['invoice_ids'].convert_to_cache(command_list, self)
             invoices = self.env['account.move'].browse(invoice_ids).exists()
             if len(invoices) == len(invoice_ids):  # All ids are valid
-                return separator.join(invoices.mapped('name'))
+                prefix = separator.join(invoices.mapped('name'))
+                if name := values.get('name_next_installment'):
+                    prefix = name
+                return prefix
         return super()._compute_reference_prefix(provider_code, separator, **values)
 
     #=== BUSINESS METHODS - POST-PROCESSING ===#

--- a/addons/account_payment/static/src/js/payment_form.js
+++ b/addons/account_payment/static/src/js/payment_form.js
@@ -1,0 +1,56 @@
+/** @odoo-module **/
+
+import PaymentForm from "@payment/js/payment_form";
+
+PaymentForm.include({
+    /**
+     * Set whether we are paying an installment before submitting.
+     *
+     * @override method from payment.payment_form
+     * @private
+     * @param {Event} ev
+     * @returns {void}
+     */
+    async _submitForm(ev) {
+        ev.stopPropagation();
+        ev.preventDefault();
+
+        const paymentDialog = this.el.closest("#pay_with");
+        const chosenPaymentDetails = paymentDialog
+            ? paymentDialog.querySelector(".o_btn_payment_tab.active")
+            : null;
+        if (chosenPaymentDetails && chosenPaymentDetails.id === "o_payment_installments_tab") {
+            this.paymentContext.payNextInstallment = true;
+        }
+        await this._super(...arguments);
+    },
+
+    /**
+     * Add installment specific params for the RPC to the transaction route.
+     *
+     * @override method from payment.payment_form
+     * @private
+     * @returns {Object} The transaction route params.
+     */
+    _prepareTransactionRouteParams() {
+        const transactionRouteParams = this._super(...arguments);
+
+        const amountCustom =
+            this.paymentContext.amountCustom && parseFloat(this.paymentContext.amountCustom);
+        const amountOverdue =
+            this.paymentContext.amountOverdue && parseFloat(this.paymentContext.amountOverdue);
+        const amountNextInstallment =
+            this.paymentContext.amountNextInstallment &&
+            parseFloat(this.paymentContext.amountNextInstallment);
+
+        if (this.paymentContext.payNextInstallment) {
+            transactionRouteParams.amount = amountCustom || amountOverdue || amountNextInstallment;
+            if (!amountCustom && !amountOverdue) {
+                transactionRouteParams.name_next_installment =
+                    this.paymentContext.nameNextInstallment;
+            }
+        }
+
+        return transactionRouteParams;
+    },
+});

--- a/addons/account_payment/static/src/js/portal_invoice_page_payment.js
+++ b/addons/account_payment/static/src/js/portal_invoice_page_payment.js
@@ -1,0 +1,20 @@
+/** @odoo-module **/
+
+import publicWidget from "@web/legacy/js/public/public_widget";
+
+publicWidget.registry.PortalInvoicePagePayment = publicWidget.Widget.extend({
+    selector: "#portal_pay",
+
+    /**
+     * Show the payment dialog when the context parameter is set.
+     *
+     * @returns {void}
+     */
+    start() {
+        if (this.el.dataset.payment) {
+            const paymentDialog = new Modal("#pay_with");
+            paymentDialog.show();
+        }
+        return this._super(...arguments);
+    },
+});

--- a/addons/account_payment/static/src/js/portal_my_invoices_payment.js
+++ b/addons/account_payment/static/src/js/portal_my_invoices_payment.js
@@ -1,0 +1,37 @@
+/** @odoo-module **/
+
+import {_t} from "@web/core/l10n/translation";
+import {deserializeDateTime} from "@web/core/l10n/dates";
+import publicWidget from "@web/legacy/js/public/public_widget";
+
+const {DateTime} = luxon;
+
+publicWidget.registry.PortalMyInvoicesPaymentList = publicWidget.Widget.extend({
+    selector: ".o_portal_my_doc_table",
+
+    start() {
+        this._setDueDateLabel();
+        return this._super(...arguments);
+    },
+
+    _setDueDateLabel() {
+        const dueDateLabels = this.el.querySelectorAll(".o_portal_invoice_due_date");
+        const today = DateTime.now().startOf("day");
+        dueDateLabels.forEach((label) => {
+            const dateTime = deserializeDateTime(label.getAttribute("datetime"));
+            const diff = dateTime.diff(today).as("days");
+
+            let dueDateLabel = "";
+
+            if (diff === 0) {
+                dueDateLabel = _t("due today");
+            } else if (diff > 0) {
+                dueDateLabel = _t("due in %s day(s)", Math.abs(diff).toFixed());
+            } else {
+                dueDateLabel = _t("%s day(s) overdue", Math.abs(diff).toFixed());
+            }
+            // We use `.createTextNode()` to escape possible HTML in translations (XSS)
+            label.replaceChildren(document.createTextNode(dueDateLabel));
+        });
+    },
+});

--- a/addons/account_payment/views/account_portal_templates.xml
+++ b/addons/account_payment/views/account_portal_templates.xml
@@ -1,12 +1,34 @@
 <odoo>
     <template id="portal_my_invoices_payment" name="Payment on My Invoices" inherit_id="account.portal_my_invoices">
-        <xpath expr="//t[@t-call='portal.portal_table']/thead/tr/th[last()]" position="before">
-            <th></th>
+        <xpath expr="//t[@t-call='portal.portal_table']/thead/tr/th[last()]" position="after">
+            <th class="d-none d-lg-table-cell"/>
+            <th/>
         </xpath>
-        <xpath expr="//t[@t-foreach='invoices']/tr/td[last()]" position="before">
+        <xpath expr="//t[@t-foreach='invoices']/tr/td[last()]" position="after">
+            <td class="d-none d-lg-table-cell text-center">
+                <span
+                    t-if="invoice_data['show_installment']"
+                    t-attf-class="{{'text-danger' if invoice_data['amount_overdue'] else ''}}"
+                    t-out="invoice_data['amount_overdue'] or invoice_data['amount_next_installment']"
+                    t-options="{'widget': 'monetary', 'display_currency': invoice.currency_id}"
+                />
+                <small
+                    t-if="invoice_data['show_installment'] and not invoice_data['amount_overdue']"
+                    class="o_portal_invoice_due_date"
+                    t-att-datetime="invoice_data['date_next_installment']"
+                />
+                <small t-if="invoice_data['amount_overdue']" class="text-danger">
+                    overdue
+                </small>
+            </td>
             <td class="text-center">
                 <a t-if="invoice._has_to_be_paid()"
-                    t-att-href="invoice.get_portal_url(anchor='portal_pay')" title="Pay Now" aria-label="Pay now" class="btn btn-sm btn-primary" role="button">
+                    t-att-href="invoice.get_portal_url(anchor='portal_pay', query_string='&amp;payment=True')"
+                    title="Pay Now"
+                    aria-label="Pay now"
+                    class="btn btn-sm btn-primary"
+                    role="button"
+                >
                     <i class="fa fa-arrow-circle-right"/><span class='d-none d-md-inline'> Pay Now</span>
                 </a>
             </td>
@@ -37,14 +59,132 @@
                 <div class="modal-dialog">
                     <div class="modal-content">
                         <div class="modal-header">
-                            <h3 class="modal-title">Pay with</h3>
+                            <h3 class="modal-title">Pay Invoice</h3>
                             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                         </div>
                         <div class="modal-body">
                             <div t-if="company_mismatch">
                                 <t t-call="payment.company_mismatch_warning"/>
                             </div>
-                            <t t-else="" t-call="payment.form"/>
+                            <div t-elif="amount_custom or amount_overdue or amount_next_installment" id="o_payment_installments_modal">
+                                <div class="btn-group w-100" id="o_payment_tabs" role="tablist">
+                                    <button class="btn btn-outline-primary o_btn_payment_tab active"
+                                        id="o_payment_installments_tab"
+                                        data-bs-toggle="pill"
+                                        data-bs-target="#o_payment_installments"
+                                        type="button"
+                                        role="tab"
+                                        aria-controls="o_payment_installments"
+                                        aria-selected="true"
+                                    >
+                                        <strong>Installment</strong>
+                                        <br/>
+                                        <t
+                                            t-out="amount_custom or amount_overdue or amount_next_installment"
+                                            t-options="{'widget': 'monetary', 'display_currency': currency}"
+                                        />
+                                    </button>
+                                    <button class="btn btn-outline-primary o_btn_payment_tab"
+                                        id="o_payment_full_tab"
+                                        data-bs-toggle="pill"
+                                        data-bs-target="#o_payment_full"
+                                        type="button"
+                                        role="tab"
+                                        aria-controls="o_payment_full"
+                                        aria-selected="false"
+                                    >
+                                        <strong>Full Amount</strong><br/>
+                                        <t t-out="amount" t-options="{'widget': 'monetary', 'display_currency': currency}"/>
+                                    </button>
+                                </div>
+                                <div class="tab-content" id="o_payment_tabcontent">
+                                    <div
+                                        class="tab-pane my-3 show active"
+                                        id="o_payment_installments"
+                                        role="tabpanel"
+                                        aria-labelledby="o_payment_installments_tab"
+                                        tabindex="0"
+                                    >
+                                        <div class="text-bg-light row row-cols-1 row-cols-md-2 mx-0 py-2 rounded">
+                                            <t t-call="payment.summary_item">
+                                                <t t-set="name" t-value="'amount_installment'"/>
+                                                <t t-set="label">Amount</t>
+                                                <t t-set="value" t-value="amount_custom or amount_overdue or amount_next_installment"/>
+                                                <t t-set="options"
+                                                    t-value="{'widget': 'monetary', 'display_currency': currency}"
+                                                />
+                                            </t>
+                                            <t t-call="payment.summary_item">
+                                                <t t-set="name" t-value="'reference_installment'"/>
+                                                <t t-set="label">Reference</t>
+                                                <t t-set="value" t-value="invoice_name if amount_custom or amount_overdue else invoice_name_installment"/>
+                                                <t t-set="include_separator" t-value="True"/>
+                                            </t>
+                                        </div>
+                                    </div>
+                                    <div class="tab-pane my-3"
+                                        id="o_payment_full"
+                                        role="tabpanel"
+                                        aria-labelledby="o_payment_full_tab"
+                                        tabindex="0"
+                                    >
+                                        <div class="text-bg-light row row-cols-1 row-cols-md-2 mx-0 py-2 rounded">
+                                            <t t-call="payment.summary_item">
+                                                <t t-set="name" t-value="'amount_full'"/>
+                                                <t t-set="label">Amount</t>
+                                                <t t-set="value" t-value="amount"/>
+                                                <t t-set="options"
+                                                    t-value="{'widget': 'monetary', 'display_currency': currency}"
+                                                />
+                                            </t>
+                                            <t t-call="payment.summary_item">
+                                                <t t-set="name" t-value="'reference_full'"/>
+                                                <t t-set="label">Reference</t>
+                                                <t t-set="value" t-value="invoice_name"/>
+                                                <t t-set="include_separator" t-value="True"/>
+                                            </t>
+                                        </div>
+                                    </div>
+                                    <t t-call="account_payment.form"/>
+                                </div>
+                            </div>
+                            <t t-elif="amount > 0">
+                                <div class="text-bg-light row row-cols-1 row-cols-md-2 mx-0 mb-3 py-2 rounded">
+                                    <t t-call="payment.summary_item">
+                                        <t t-set="name" t-value="'amount_full'"/>
+                                        <t t-set="label">Amount</t>
+                                        <t t-set="value" t-value="amount"/>
+                                        <t t-set="options"
+                                            t-value="{'widget': 'monetary', 'display_currency': currency}"
+                                        />
+                                    </t>
+                                    <t t-call="payment.summary_item">
+                                        <t t-set="name" t-value="'reference_full'"/>
+                                        <t t-set="label">Reference</t>
+                                        <t t-set="value" t-value="invoice_name"/>
+                                        <t t-set="include_separator" t-value="True"/>
+                                    </t>
+                                </div>
+                                <t t-call="account_payment.form"/>
+                            </t>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </template>
+
+    <template id="portal_invoice_payment_paid" name="Invoice Paid">
+        <div class="modal fade" id="pay_with" role="dialog">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h3 class="modal-title">Pay Invoice</h3>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="alert alert-warning text-center" role="alert">
+                            This invoice has already been paid.
                         </div>
                     </div>
                 </div>
@@ -78,9 +218,16 @@
                  t-att-data-invoice-id="invoice.id">
                 <t t-call="payment.state_header"/>
             </div>
-            <div t-if="invoice._has_to_be_paid()" id="portal_pay">
+            <div t-if="invoice._has_to_be_paid()" id="portal_pay" t-att-data-payment="payment">
                 <t t-call="account_payment.portal_invoice_payment"/>
             </div>
+            <div t-else="" id="portal_pay" t-att-data-payment="payment">
+                <t t-call="account_payment.portal_invoice_payment_paid"/>
+            </div>
+        </xpath>
+        <xpath expr="//h3[@name='installment_amount']" position="attributes">
+            <attribute name="t-if" separator=" or " add="amount_custom"/>
+            <attribute name="t-out">amount_custom or amount_overdue or amount_next_installment</attribute>
         </xpath>
     </template>
 

--- a/addons/account_payment/views/payment_form_templates.xml
+++ b/addons/account_payment/views/payment_form_templates.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="account_payment.form" inherit_id="payment.form" name="Invoice Payment Form">
+        <xpath expr="//form[@id='o_payment_form']" position="attributes">
+            <attribute name="t-att-data-amount-custom">amount_custom</attribute>
+            <attribute name="t-att-data-amount-overdue">amount_overdue</attribute>
+            <attribute name="t-att-data-amount-next-installment">amount_next_installment</attribute>
+            <attribute name="t-att-data-name-next-installment">name_next_installment</attribute>
+        </xpath>
+    </template>
+
+</odoo>

--- a/addons/account_payment/wizards/payment_link_wizard.py
+++ b/addons/account_payment/wizards/payment_link_wizard.py
@@ -1,26 +1,82 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models
+from odoo import _, api, fields, models
+from odoo.tools import formatLang
+
+from odoo.addons.payment import utils as payment_utils
 
 
 class PaymentLinkWizard(models.TransientModel):
     _inherit = 'payment.link.wizard'
 
-    def _get_additional_link_values(self):
-        """ Override of `payment` to add `invoice_id` to the payment link values.
+    invoice_amount_due = fields.Monetary(
+        string="Amount Due",
+        compute='_compute_invoice_amount_due',
+        currency_field='currency_id'
+    )
+    open_installments = fields.Json(export_string_translation=False)
+    open_installments_preview = fields.Html(
+        export_string_translation=False, compute='_compute_open_installments_preview'
+    )
 
-        The other values related to the invoice are directly read from the invoice.
+    @api.depends('amount_max')
+    def _compute_invoice_amount_due(self):
+        for wizard in self:
+            wizard.invoice_amount_due = wizard.amount_max
 
-        Note: self.ensure_one()
+    @api.depends('open_installments')
+    def _compute_open_installments_preview(self):
+        for wizard in self:
+            preview = ""
+            for installment in wizard.open_installments or []:
+                preview += "<div>"
+                preview += _(
+                    '#%(number)s - Installment of <strong>%(amount)s</strong> due on <strong class="text-primary">%(date)s</strong>',
+                    number=installment['number'],
+                    amount=formatLang(
+                        self.env,
+                        installment['amount'],
+                        monetary=True,
+                        currency_obj=wizard.currency_id,
+                    ),
+                    date=installment['date_maturity'],
+                )
+                preview += "</div>"
+            wizard.open_installments_preview = preview
 
-        :return: The additional payment link values.
-        :rtype: dict
-        """
-        res = super()._get_additional_link_values()
+    def _prepare_url(self, base_url, related_document):
+        """ Override of `payment` to use the portal page URL. """
+        res = super()._prepare_url(base_url, related_document)
         if self.res_model != 'account.move':
             return res
 
-        # Invoice-related fields are retrieved in the controller.
+        return f'{base_url}/{related_document.get_portal_url()}'
+
+    def _prepare_query_params(self, related_document):
+        """ Override of `payment` to define custom query params for invoice payment. """
+        res = super()._prepare_query_params(related_document)
+        if self.res_model != 'account.move':
+            return res
+
         return {
-            'invoice_id': self.res_id,
+            'move_id': related_document.id,
+            'amount': self.amount,
+            'payment_token': self._prepare_access_token(),
+            'payment': True,
         }
+
+    def _prepare_access_token(self):
+        """ Override of `payment` to generate the access token only based on the amount. """
+        res = super()._prepare_access_token()
+        if self.res_model != 'account.move':
+            return res
+
+        return payment_utils.generate_access_token(self.res_id, self.amount)
+
+    def _prepare_anchor(self):
+        """ Override of `payment` to set the 'portal_pay' anchor. """
+        res = super()._prepare_anchor()
+        if self.res_model != 'account.move':
+            return res
+
+        return '#portal_pay'

--- a/addons/account_payment/wizards/payment_link_wizard_views.xml
+++ b/addons/account_payment/wizards/payment_link_wizard_views.xml
@@ -11,4 +11,29 @@
         <field name="binding_view_types">form</field>
     </record>
 
+    <record id="payment_link_wizard__form_inherit_account_payment" model="ir.ui.view">
+        <field name="name">payment.link.wizard.form.inherit.account_payment</field>
+        <field name="model">payment.link.wizard</field>
+        <field name="inherit_id" ref="payment.payment_link_wizard_view_form"/>
+        <field name="arch" type="xml">
+            <field name="amount" position="after">
+                <field name="invoice_amount_due" invisible="res_model != 'account.move'"/>
+            </field>
+
+            <field name="currency_id" position="after">
+                <field name="open_installments" invisible="1"/>
+            </field>
+
+            <group name="payment_info" position="after">
+                <group name="next_installments"
+                    string="Next Installments"
+                    invisible="not open_installments"
+                    class="mt-n4"
+                >
+                    <field name="open_installments_preview" colspan="2" nolabel="1"/>
+                </group>
+            </group>
+        </field>
+    </record>
+
 </odoo>

--- a/addons/payment/wizards/payment_link_wizard_views.xml
+++ b/addons/payment/wizards/payment_link_wizard_views.xml
@@ -13,13 +13,13 @@
                      Setting an email for this partner is advised.
                 </div>
                 <group>
-                    <group>
+                    <group name="payment_info" string="Payment Info" class="mt-n4">
                         <field name="res_id" invisible="1"/>
                         <field name="res_model" invisible="1"/>
                         <field name="partner_id" invisible="1"/>
                         <field name="partner_email" invisible="1"/>
-                        <field name="amount_max" invisible="1"/>
                         <field name="amount"/>
+                        <field name="amount_max" invisible="1"/>
                         <field name="warning_message" invisible="1"/>
                         <field name="currency_id" invisible="1"/>
                     </group>

--- a/addons/sale/wizard/payment_link_wizard.py
+++ b/addons/sale/wizard/payment_link_wizard.py
@@ -29,21 +29,15 @@ class PaymentLinkWizard(models.TransientModel):
                         amount=format_amount(wizard.env, remaining_amount, wizard.currency_id),
                     )
 
-    def _get_additional_link_values(self):
-        """ Override of `payment` to add `sale_order_id` to the payment link values.
-
-        The other values related to the sales order are directly read from the sales order.
-
-        Note: self.ensure_one()
-
-        :return: The additional payment link values.
-        :rtype: dict
-        """
-        res = super()._get_additional_link_values()
+    def _prepare_query_params(self, *args):
+        """ Override of `payment` to add `sale_order_id` to the query params. """
+        res = super()._prepare_query_params(*args)
         if self.res_model != 'sale.order':
             return res
 
-        # Order-related fields are retrieved in the controller
+        # The other order-related values are read directly from the sales order in the controller.
         return {
+            'amount': self.amount,
+            'access_token': self._prepare_access_token(),
             'sale_order_id': self.res_id,
         }

--- a/addons/web_editor/static/src/js/backend/html_field.xml
+++ b/addons/web_editor/static/src/js/backend/html_field.xml
@@ -8,7 +8,7 @@
                 t-att-sandbox="sandboxedPreview ? 'allow-same-origin allow-popups allow-popups-to-escape-sandbox' : false"></iframe>
             </t>
             <t t-else="">
-                <div  t-ref="readonlyElement" class="o_readonly" t-out="markupValue" />
+                <div t-ref="readonlyElement" class="o_readonly" t-out="markupValue" />
             </t>
         </t>
         <div t-else="" class="h-100" t-ref="spellcheck" t-att-class="{'d-flex': this.wysiwygOptions.snippets}">


### PR DESCRIPTION
We already support configuring payment terms that allow customers to pay invoices in installments. However, nothing is provided for users to easily manage installment payments or for customers to easily pay an installment of an invoice.

This commit adds several features to facilitate that:

Register Payment Dialog
-----------------------

On the invoice form view, the dialog opened when clicking the `Register Payment` button has been updated to display the default amount as

1. the overdue installments amount, if there are any;
2. the next outstanding installment amount, if there is one;
3. the total outstanding amount if there are no installments, or the last outstanding amount equals the total outstanding amount.

In case 1 and 2, we display a text underneath the amount field indicating what users are paying and offer the choice to switch to paying the full outstanding amount. When switched to this mode, there is a link to switch back to installment mode.

The `Payment Difference` field is not displayed when paying less than the proposed overdue amount or next outstanding installment.

Payment Link Dialog
-------------------

When sharing a payment link with a customer, the dialog has been updated to show the same amount by default as the `Register Payment` dialog in case there are installments. An extra read-only field is added underneath to show the total amount due.

Next to the amounts, we show the outstanding installments, containing its number, amount due and date due. This makes it easy for the user to customize the amount in the payment link to generate.

Finally the generated payment link does not point to the generic payment portal page anymore, but rather to the related invoice portal page with the payment dialog open containing the custom amount entered.

Customer Portal: Invoice View
-----------------------------

Several improvements have been made on the customer invoice portal page.

In the left sidebar, we show the total amount of the invoice at the top instead of the amount due. Underneath we show the amount already paid and/or the remaining amount due, if applicable.

If there is an installment due or a custom amount specified (through a payment link), it is shown right above the `Pay Now` button so the customer knows which amount will be set by default when clicking that button.

**Payment Dialog**

The payment dialog now shows a switcher that allows paying the next installment or the full remaining amount, if there are installments. The dialog shows the payment reference and the amount that will be paid right above the payment form to make it clear for the customer. The reference will be appended with the installment number in case the
customer is paying an installment.

Finally the page and the dialog support a custom amount to be paid through the url parameter `amount`, which is checked against a `payment_token` parameter to make sure it hasn't been tampered with. An additional url parameter `payment=True` is supported to automatically open the dialog on page load.

If the user clicks on a payment link when the invoice has already been paid, we show the payment dialog with a simple message saying so.

Customer Portal: My Invoices List
---------------------------------

On the portal in the overview list of the customer's invoices, we made the payment button also open the payment dialog on the linked invoice page, so it's much more convenient to pay the invoice.

We also added an extra column for invoices with installments that displays the next amount due and the number of days until its due date. If there are overdue installments, it displays the overdue amount.

Clicking the `Pay Now` button will always open the payment dialog on the default amount, which equals the amount displayed in this previous column.

[task-3884561](https://www.odoo.com/odoo/967/tasks/3884561?cids=1)

Related to https://github.com/odoo/enterprise/pull/68477