### PR TITLE
[PERF] bus, *: only update presence when needed

### DIFF
--- a/addons/bus/controllers/websocket.py
+++ b/addons/bus/controllers/websocket.py
@@ -52,6 +52,10 @@ class WebsocketController(Controller):
         request.env['ir.websocket']._update_bus_presence(int(inactivity_period), im_status_ids_by_model)
         return {}
 
+    @route("/websocket/on_closed", type="json", auth="public", cors="*")
+    def on_websocket_closed(self):
+        request.env["ir.websocket"]._on_websocket_closed(request.httprequest.cookies)
+
     @route('/bus/websocket_worker_bundle', type='http', auth='public', cors='*')
     def get_websocket_worker_bundle(self, v=None):  # pylint: disable=unused-argument
         """

--- a/addons/bus/models/bus_presence.py
+++ b/addons/bus/models/bus_presence.py
@@ -5,11 +5,13 @@ from psycopg2 import OperationalError
 
 from odoo import api, fields, models
 from odoo import tools
+from odoo.osv import expression
 from odoo.service.model import PG_CONCURRENCY_ERRORS_TO_RETRY
 
 UPDATE_PRESENCE_DELAY = 60
 DISCONNECTION_TIMER = UPDATE_PRESENCE_DELAY + 5
 AWAY_TIMER = 1800  # 30 minutes
+PRESENCE_OUTDATED_TIMER = 12 * 60 * 60  # 12 hours
 
 
 class BusPresence(models.Model):
@@ -31,6 +33,24 @@ class BusPresence(models.Model):
     def init(self):
         self.env.cr.execute("CREATE UNIQUE INDEX IF NOT EXISTS bus_presence_user_unique ON %s (user_id) WHERE user_id IS NOT NULL" % self._table)
 
+    def create(self, values):
+        presences = super().create(values)
+        presences._invalidate_im_status()
+        presences._send_presence()
+        return presences
+
+    def write(self, values):
+        status_by_user = {presence._get_identity_field_name(): presence.status for presence in self}
+        result = super().write(values)
+        updated = self.filtered(lambda p: status_by_user[p._get_identity_field_name()] != p.status)
+        updated._invalidate_im_status()
+        updated._send_presence()
+        return result
+
+    def unlink(self):
+        self._send_presence("offline")
+        return super().unlink()
+
     @api.model
     def update_presence(self, inactivity_period, identity_field, identity_value):
         """ Updates the last_poll and last_presence of the current user
@@ -51,22 +71,66 @@ class BusPresence(models.Model):
                 return self.env.cr.rollback()
             raise
 
+    def _get_bus_target(self):
+        self.ensure_one()
+        return self.env.ref("base.group_user")
+
+    def _get_identity_field_name(self):
+        self.ensure_one()
+        return "user_id" if self.user_id else None
+
+    def _get_identity_data(self):
+        self.ensure_one()
+        return {"partner_id": self.user_id.partner_id.id} if self.user_id else None
+
     @api.model
     def _update_presence(self, inactivity_period, identity_field, identity_value):
-        presence = self.search([(identity_field, '=', identity_value)], limit=1)
-        # compute last_presence timestamp
-        last_presence = fields.Datetime.now() - datetime.timedelta(milliseconds=inactivity_period)
-        values = {"last_poll": fields.Datetime.now()}
-        # update the presence or a create a new one
-        if not presence:  # create a new presence for the user
+        presence = self.search([(identity_field, "=", identity_value)])
+        values = {
+            "last_poll": fields.Datetime.now(),
+            "last_presence": fields.Datetime.now() - datetime.timedelta(milliseconds=inactivity_period),
+            "status": "away" if inactivity_period > AWAY_TIMER * 1000 else "online",
+        }
+        if not presence:
             values[identity_field] = identity_value
-            values['last_presence'] = last_presence
-            self.create(values)
-        else:  # update the last_presence if necessary, and write values
-            if presence.last_presence < last_presence:
-                values['last_presence'] = last_presence
+            presence = self.create(values)
+        else:
             presence.write(values)
+
+    def _invalidate_im_status(self):
+        self.user_id.invalidate_recordset(["im_status"])
+        self.user_id.partner_id.invalidate_recordset(["im_status"])
+
+    def _send_presence(self, im_status=None):
+        """Send notification related to bus presence update.
+
+        :param im_status: 'online', 'away' or 'offline'
+        """
+        notifications = []
+        for presence in self:
+            if identity_data := presence._get_identity_data():
+                notifications.append(
+                    (
+                        presence._get_bus_target(),
+                        "bus.bus/im_status_updated",
+                        {"im_status": im_status or presence.status, **identity_data},
+                    )
+                )
+        self.env["bus.bus"]._sendmany(notifications)
 
     @api.autovacuum
     def _gc_bus_presence(self):
-        self.search([('user_id.active', '=', False)]).unlink()
+        domain = expression.OR(
+            [
+                [("user_id.active", "=", False)],
+                [("status", "=", "offline")],
+                [
+                    (
+                        "last_poll",
+                        "<",
+                        fields.Datetime.now() - datetime.timedelta(seconds=PRESENCE_OUTDATED_TIMER),
+                    )
+                ],
+            ]
+        )
+        self.search(domain).unlink()

--- a/addons/bus/models/ir_websocket.py
+++ b/addons/bus/models/ir_websocket.py
@@ -49,9 +49,10 @@ class IrWebsocket(models.AbstractModel):
                 identity_field='user_id',
                 identity_value=self.env.uid
             )
-            im_status_notification = self._get_im_status(im_status_ids_by_model)
-            if im_status_notification:
-                self.env['bus.bus']._sendone(self.env.user.partner_id, 'mail.record/insert', im_status_notification)
+
+    def _on_websocket_closed(self, cookies):
+        if self.env.user and not self.env.user._is_public():
+            self.env["bus.presence"].search([("user_id", "=", self.env.uid)]).unlink()
 
     @classmethod
     def _authenticate(cls):

--- a/addons/bus/models/res_partner.py
+++ b/addons/bus/models/res_partner.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from odoo import api, fields, models
-from odoo.addons.bus.models.bus_presence import AWAY_TIMER
-from odoo.addons.bus.models.bus_presence import DISCONNECTION_TIMER
+from odoo import fields, models
 
 
 class ResPartner(models.Model):
@@ -11,19 +9,14 @@ class ResPartner(models.Model):
     im_status = fields.Char('IM Status', compute='_compute_im_status')
 
     def _compute_im_status(self):
-        self.env.cr.execute("""
-            SELECT
-                U.partner_id as id,
-                CASE WHEN max(B.last_poll) IS NULL THEN 'offline'
-                    WHEN age(now() AT TIME ZONE 'UTC', max(B.last_poll)) > interval %s THEN 'offline'
-                    WHEN age(now() AT TIME ZONE 'UTC', max(B.last_presence)) > interval %s THEN 'away'
-                    ELSE 'online'
-                END as status
-            FROM bus_presence B
-            RIGHT JOIN res_users U ON B.user_id = U.id
-            WHERE U.partner_id IN %s AND U.active = 't'
-         GROUP BY U.partner_id
-        """, ("%s seconds" % DISCONNECTION_TIMER, "%s seconds" % AWAY_TIMER, tuple(self.ids)))
-        res = dict(((status['id'], status['status']) for status in self.env.cr.dictfetchall()))
+        status_by_partner = {}
+        for presence in self.env["bus.presence"].search([("user_id", "in", self.user_ids.ids)]):
+            partner = presence.user_id.partner_id
+            if (
+                status_by_partner.get(partner, "offline") == "offline"
+                or presence.status == "online"
+            ):
+                status_by_partner[partner] = presence.status
         for partner in self:
-            partner.im_status = res.get(partner.id, 'im_partner')  # if not found, it is a partner, useful to avoid to refresh status in js
+            default_status = "offline" if partner.user_ids else "im_partner"
+            partner.im_status = status_by_partner.get(partner, default_status)

--- a/addons/bus/models/res_users.py
+++ b/addons/bus/models/res_users.py
@@ -1,28 +1,19 @@
 # -*- coding: utf-8 -*-
 
-from odoo import api, fields, models
-from odoo.addons.bus.models.bus_presence import AWAY_TIMER
-from odoo.addons.bus.models.bus_presence import DISCONNECTION_TIMER
+from odoo import fields, models
 
 
 class ResUsers(models.Model):
 
     _inherit = "res.users"
 
-    im_status = fields.Char('IM Status', compute='_compute_im_status')
+    im_status = fields.Char("IM Status", compute="_compute_im_status")
 
     def _compute_im_status(self):
-        """ Compute the im_status of the users """
-        self.env.cr.execute("""
-            SELECT
-                user_id as id,
-                CASE WHEN age(now() AT TIME ZONE 'UTC', last_poll) > interval %s THEN 'offline'
-                     WHEN age(now() AT TIME ZONE 'UTC', last_presence) > interval %s THEN 'away'
-                     ELSE 'online'
-                END as status
-            FROM bus_presence
-            WHERE user_id IN %s
-        """, ("%s seconds" % DISCONNECTION_TIMER, "%s seconds" % AWAY_TIMER, tuple(self.ids)))
-        res = dict(((status['id'], status['status']) for status in self.env.cr.dictfetchall()))
+        """Compute the im_status of the users"""
+        presence_by_user = {
+            presence.user_id: presence.status
+            for presence in self.env["bus.presence"].search([("user_id", "in", self.ids)])
+        }
         for user in self:
-            user.im_status = res.get(user.id, 'offline')
+            user.im_status = presence_by_user.get(user, "offline")

--- a/addons/bus/static/src/im_status_service.js
+++ b/addons/bus/static/src/im_status_service.js
@@ -2,48 +2,63 @@
 
 import { browser } from "@web/core/browser/browser";
 import { registry } from "@web/core/registry";
-import { timings } from "@bus/misc";
+import { user } from "@web/core/user";
+import { session } from "@web/session";
 
+export const AWAY_DELAY = 30 * 60 * 1000; // 30 minutes
+export const FIRST_UPDATE_DELAY = 500;
 export const UPDATE_BUS_PRESENCE_DELAY = 60000;
+
 /**
  * This service updates periodically the user presence in order for the
  * im_status to be up to date.
- *
- * In order to receive bus notifications related to im_status, one must
- * register model/ids to monitor to this service.
  */
 export const imStatusService = {
     dependencies: ["bus_service", "multi_tab", "presence"],
 
     start(env, { bus_service, multi_tab, presence }) {
-        const imStatusModelToIds = {};
-        let updateBusPresenceTimeout;
-        const throttledUpdateBusPresence = timings.throttle(function updateBusPresence() {
-            clearTimeout(updateBusPresenceTimeout);
+        let lastSentInactivity;
+        let becomeAwayTimeout;
+
+        const updateBusPresence = () => {
+            lastSentInactivity = presence.getInactivityPeriod();
+            startAwayTimeout();
             if (!multi_tab.isOnMainTab()) {
                 return;
             }
-            const now = luxon.DateTime.now().ts;
             bus_service.send("update_presence", {
-                inactivity_period: now - presence.getLastPresence(),
-                im_status_ids_by_model: { ...imStatusModelToIds },
+                inactivity_period: lastSentInactivity,
+                im_status_ids_by_model: {},
             });
-            updateBusPresenceTimeout = browser.setTimeout(
-                throttledUpdateBusPresence,
-                UPDATE_BUS_PRESENCE_DELAY
-            );
-        }, UPDATE_BUS_PRESENCE_DELAY);
+        };
+        this.updateBusPresence = updateBusPresence;
+
+        const startAwayTimeout = () => {
+            clearTimeout(becomeAwayTimeout);
+            const awayTime = AWAY_DELAY - lastSentInactivity;
+            if (awayTime > 0) {
+                becomeAwayTimeout = browser.setTimeout(() => updateBusPresence(), awayTime);
+            }
+        };
 
         bus_service.addEventListener("connect", () => {
-            // wait for im_status model/ids to be registered before starting.
-            browser.setTimeout(throttledUpdateBusPresence, 250);
+            browser.setTimeout(updateBusPresence, FIRST_UPDATE_DELAY);
         });
-        multi_tab.bus.addEventListener("become_main_tab", throttledUpdateBusPresence);
-        bus_service.addEventListener("reconnect", throttledUpdateBusPresence);
-        multi_tab.bus.addEventListener("no_longer_main_tab", () =>
-            clearTimeout(updateBusPresenceTimeout)
-        );
-        bus_service.addEventListener("disconnect", () => clearTimeout(updateBusPresenceTimeout));
+        bus_service.subscribe("bus.bus/im_status_updated", async ({ partner_id, im_status }) => {
+            if (session.is_public || !partner_id || partner_id !== user.partnerId) {
+                return;
+            }
+            const isOnline = presence.getInactivityPeriod() < AWAY_DELAY;
+            if (im_status === "offline" || (im_status === "away" && isOnline)) {
+                this.updateBusPresence();
+            }
+        });
+        presence.bus.addEventListener("presence", () => {
+            if (lastSentInactivity >= AWAY_DELAY) {
+                this.updateBusPresence();
+            }
+            startAwayTimeout();
+        });
 
         return {
             /**
@@ -52,24 +67,19 @@ export const imStatusService = {
              * through the bus. Overwrite registration if already
              * present.
              *
+             * @deprecated
              * @param {string} model model related to the given ids.
              * @param {Number[]} ids ids whose im_status should be
              * monitored.
              */
-            registerToImStatus(model, ids) {
-                if (!ids.length) {
-                    return this.unregisterFromImStatus(model);
-                }
-                imStatusModelToIds[model] = ids;
-            },
+            registerToImStatus(model, ids) {},
             /**
              * Unregister model from im_status notifications.
              *
+             * @deprecated
              * @param {string} model model to unregister.
              */
-            unregisterFromImStatus(model) {
-                delete imStatusModelToIds[model];
-            },
+            unregisterFromImStatus(model) {},
         };
     },
 };

--- a/addons/bus/static/src/services/presence_service.js
+++ b/addons/bus/static/src/services/presence_service.js
@@ -1,12 +1,13 @@
 /** @odoo-module **/
 
+import { EventBus } from "@odoo/owl";
 import { browser } from "@web/core/browser/browser";
 import { registry } from "@web/core/registry";
 
 export const presenceService = {
     start(env) {
         const LOCAL_STORAGE_PREFIX = "presence";
-
+        const bus = new EventBus();
         let isOdooFocused = true;
         let lastPresenceTime =
             browser.localStorage.getItem(`${LOCAL_STORAGE_PREFIX}.lastPresence`) ||
@@ -15,6 +16,7 @@ export const presenceService = {
         function onPresence() {
             lastPresenceTime = luxon.DateTime.now().ts;
             browser.localStorage.setItem(`${LOCAL_STORAGE_PREFIX}.lastPresence`, lastPresenceTime);
+            bus.trigger("presence");
         }
 
         function onFocusChange(isFocused) {
@@ -38,6 +40,7 @@ export const presenceService = {
             }
             if (key === `${LOCAL_STORAGE_PREFIX}.lastPresence`) {
                 lastPresenceTime = JSON.parse(newValue);
+                bus.trigger("presence");
             }
         }
         browser.addEventListener("storage", onStorage);
@@ -48,11 +51,15 @@ export const presenceService = {
         browser.addEventListener("keydown", onPresence);
 
         return {
+            bus,
             getLastPresence() {
                 return lastPresenceTime;
             },
             isOdooFocused() {
                 return isOdooFocused;
+            },
+            getInactivityPeriod() {
+                return luxon.DateTime.now().ts - this.getLastPresence();
             },
         };
     },

--- a/addons/bus/static/tests/legacy/im_status_tests.js
+++ b/addons/bus/static/tests/legacy/im_status_tests.js
@@ -1,0 +1,175 @@
+/* @odoo-module */
+
+import { startServer } from "@bus/../tests/helpers/mock_python_environment";
+import { patchWebsocketWorkerWithCleanup } from "@bus/../tests/helpers/mock_websocket";
+import { addBusServicesToRegistry } from "@bus/../tests/helpers/test_utils";
+import { waitUntilSubscribe } from "@bus/../tests/helpers/websocket_event_deferred";
+import {
+    AWAY_DELAY as ACTUAL_AWAY_DELAY,
+    FIRST_UPDATE_DELAY,
+    imStatusService,
+} from "@bus/im_status_service";
+import { makeTestEnv } from "@web/../tests/helpers/mock_env";
+import { mockTimeout, nextTick, patchWithCleanup } from "@web/../tests/helpers/utils";
+import { registerCleanup } from "@web/../tests/helpers/cleanup";
+import { assertSteps, step } from "@web/../tests/utils";
+import { browser } from "@web/core/browser/browser";
+import { registry } from "@web/core/registry";
+import { session } from "@web/session";
+
+// Delays can slighly differ since time is not frozen. Let's tolerate 1000ms
+// of difference.
+const TOLERANCE = 1000;
+const AWAY_DELAY = ACTUAL_AWAY_DELAY + TOLERANCE;
+function assertAlmostEqual(a, b) {
+    QUnit.assert.ok(Math.abs(a - b) < TOLERANCE, `${a} and ${b} should be almost equal`);
+}
+
+QUnit.module("IM status", {
+    async beforeEach() {
+        addBusServicesToRegistry();
+        patchWebsocketWorkerWithCleanup();
+        registry.category("services").add("im_status", imStatusService);
+        const pyEnv = await startServer();
+        patchWithCleanup(session, { partner_id: pyEnv.currentPartner.id });
+        registry.category("mock_server").add("res.users/has_group", (route, args) => {
+            return args[0] === "base.group_public";
+        });
+        registerCleanup(() => registry.category("mock_server").remove("res.users/has_group"));
+    },
+});
+
+QUnit.test(
+    "update presence if IM status changes to offline while this device is online",
+    async () => {
+        const { advanceTime } = mockTimeout();
+        const pyEnv = await startServer();
+        const env = await makeTestEnv({ activateMockServer: true });
+        patchWithCleanup(env.services.bus_service, { send: (type) => step(type) });
+        env.services.bus_service.start();
+        await waitUntilSubscribe();
+        advanceTime(FIRST_UPDATE_DELAY);
+        await assertSteps(["update_presence"]);
+        pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "bus.bus/im_status_updated", {
+            im_status: "offline",
+            partner_id: pyEnv.currentPartner.id,
+        });
+        await assertSteps(["update_presence"]);
+    }
+);
+
+QUnit.test("update presence if IM status changes to away while this device is online", async () => {
+    const { advanceTime } = mockTimeout();
+    const pyEnv = await startServer();
+    const env = await makeTestEnv({ activateMockServer: true });
+    patchWithCleanup(env.services.bus_service, { send: (type) => step(type) });
+    patchWithCleanup(env.services.presence, { getLastPresence: () => new Date().getTime() });
+    env.services.bus_service.addEventListener("connect", () => step("connect"), { once: true });
+    env.services.bus_service.start();
+    await assertSteps(["connect"]);
+    advanceTime(FIRST_UPDATE_DELAY);
+    await assertSteps(["update_presence"]);
+    pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "bus.bus/im_status_updated", {
+        im_status: "away",
+        partner_id: pyEnv.currentPartner.id,
+    });
+    await assertSteps(["update_presence"]);
+});
+
+QUnit.test(
+    "do not update presence if IM status changes to away while this device is away",
+    async () => {
+        const { advanceTime } = mockTimeout();
+        const pyEnv = await startServer();
+        const env = await makeTestEnv({ activateMockServer: true });
+        patchWithCleanup(env.services.bus_service, { send: (type) => step(type) });
+        patchWithCleanup(env.services.presence, {
+            getLastPresence: () => new Date().getTime() - AWAY_DELAY,
+        });
+        env.services.bus_service.addEventListener("connect", () => step("connect"), { once: true });
+        env.services.bus_service.start();
+        await assertSteps(["connect"]);
+        advanceTime(FIRST_UPDATE_DELAY);
+        await assertSteps(["update_presence"]);
+        pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "bus.bus/im_status_updated", {
+            im_status: "away",
+            partner_id: pyEnv.currentPartner.id,
+        });
+        await nextTick();
+        await assertSteps([]);
+    }
+);
+
+QUnit.test("do not update presence if other user's IM status changes to away", async () => {
+    const { advanceTime } = mockTimeout();
+    const pyEnv = await startServer();
+    const env = await makeTestEnv({ activateMockServer: true });
+    patchWithCleanup(env.services.bus_service, { send: (type) => step(type) });
+    patchWithCleanup(env.services.presence, { getLastPresence: () => new Date().getTime() });
+    env.services.bus_service.addEventListener("connect", () => step("connect"), { once: true });
+    env.services.bus_service.start();
+    await assertSteps(["connect"]);
+    advanceTime(FIRST_UPDATE_DELAY);
+    await assertSteps(["update_presence"]);
+    pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "bus.bus/im_status_updated", {
+        im_status: "away",
+        partner_id: pyEnv.publicPartnerId,
+    });
+    await nextTick();
+    await assertSteps([]);
+});
+
+QUnit.test("update presence when user comes back from away", async () => {
+    const { advanceTime } = mockTimeout();
+    const env = await makeTestEnv();
+    patchWithCleanup(env.services.bus_service, {
+        send: (type, payload) => {
+            if (type === "update_presence") {
+                assertAlmostEqual(expectedInactivityPeriod, payload.inactivity_period);
+                step("update_presence");
+            }
+        },
+    });
+    patchWithCleanup(env.services.presence, {
+        getLastPresence: () => new Date().getTime() - AWAY_DELAY,
+    });
+    let expectedInactivityPeriod = AWAY_DELAY;
+    env.services.bus_service.addEventListener("connect", () => step("connect"), { once: true });
+    env.services.bus_service.start();
+    await assertSteps(["connect"]);
+    advanceTime(FIRST_UPDATE_DELAY);
+    await assertSteps(["update_presence"]);
+    const event = new StorageEvent("storage", {
+        key: "presence.lastPresence",
+        newValue: new Date().getTime(),
+    });
+    patchWithCleanup(env.services.presence, { getLastPresence: () => new Date().getTime() });
+    expectedInactivityPeriod = 0;
+    browser.dispatchEvent(event);
+    await assertSteps(["update_presence"]);
+});
+
+QUnit.test("update presence when user status changes to away", async () => {
+    const { advanceTime } = mockTimeout();
+    const env = await makeTestEnv();
+    patchWithCleanup(env.services.bus_service, {
+        send: (type, payload) => {
+            if (type === "update_presence") {
+                assertAlmostEqual(expectedInactivityPeriod, payload.inactivity_period);
+                step("update_presence");
+            }
+        },
+    });
+    let expectedInactivityPeriod = FIRST_UPDATE_DELAY;
+    env.services.bus_service.addEventListener("connect", () => step("connect"), { once: true });
+    env.services.bus_service.start();
+    await assertSteps(["connect"]);
+    advanceTime(FIRST_UPDATE_DELAY);
+    await assertSteps(["update_presence"]);
+    expectedInactivityPeriod = AWAY_DELAY;
+    patchWithCleanup(env.services.presence, {
+        getLastPresence: () => new Date().getTime() - AWAY_DELAY,
+    });
+    advanceTime(AWAY_DELAY);
+    await assertSteps(["update_presence"]);
+});

--- a/addons/bus/tests/__init__.py
+++ b/addons/bus/tests/__init__.py
@@ -1,5 +1,6 @@
 from . import common
 from . import test_assetsbundle
+from . import test_bus_presence
 from . import test_health
 from . import test_ir_model
 from . import test_ir_websocket

--- a/addons/bus/tests/common.py
+++ b/addons/bus/tests/common.py
@@ -102,7 +102,7 @@ class WebsocketCase(HttpCase):
             sub = {'event_name': 'subscribe', 'data': {
                 'channels': channels or [],
             }}
-            if last:
+            if last is not None:
                 sub['data']['last'] = last
             websocket.send(json.dumps(sub))
             if wait_for_dispatch:

--- a/addons/bus/tests/test_bus_presence.py
+++ b/addons/bus/tests/test_bus_presence.py
@@ -1,0 +1,44 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import datetime, timedelta
+from freezegun import freeze_time
+
+from odoo.tests import HttpCase, tagged, new_test_user
+from ..models.bus_presence import PRESENCE_OUTDATED_TIMER
+
+
+@tagged("-at_install", "post_install")
+class TestBusPresence(HttpCase):
+    def test_bus_presence_auto_vacuum(self):
+        user = new_test_user(self.env, login="bob_user")
+        more_than_away_timer_ago = datetime.now() - timedelta(seconds=PRESENCE_OUTDATED_TIMER + 1)
+        more_than_away_timer_ago = more_than_away_timer_ago.replace(microsecond=0)
+        with freeze_time(more_than_away_timer_ago):
+            self.env["bus.presence"]._update_presence(
+                inactivity_period=0, identity_field="user_id", identity_value=user.id
+            )
+        presence = self.env["bus.presence"].search([("user_id", "=", user.id)])
+        self.assertEqual(presence.last_poll, more_than_away_timer_ago)
+        self.env["bus.presence"]._gc_bus_presence()
+        presence = self.env["bus.presence"].search([("user_id", "=", user.id)])
+        self.assertFalse(presence)
+        # user is not active anymore
+        self.env["bus.presence"]._update_presence(
+            inactivity_period=0, identity_field="user_id", identity_value=user.id
+        )
+        presence = self.env["bus.presence"].search([("user_id", "=", user.id)])
+        self.assertTrue(presence)
+        user.active = False
+        self.env["bus.presence"]._gc_bus_presence()
+        presence = self.env["bus.presence"].search([("user_id", "=", user.id)])
+        self.assertFalse(presence)
+        # presence is offline
+        self.env["bus.presence"]._update_presence(
+            inactivity_period=0, identity_field="user_id", identity_value=user.id
+        )
+        presence = self.env["bus.presence"].search([("user_id", "=", user.id)])
+        presence.status = "offline"
+        self.assertEqual(presence.status, "offline")
+        self.env["bus.presence"]._gc_bus_presence()
+        presence = self.env["bus.presence"].search([("user_id", "=", user.id)])
+        self.assertFalse(presence)

--- a/addons/bus/tests/test_ir_websocket.py
+++ b/addons/bus/tests/test_ir_websocket.py
@@ -1,9 +1,19 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import json
+from datetime import datetime, timedelta
+from freezegun import freeze_time
+try:
+    import websocket as ws
+except ImportError:
+    websocket = None
 
-from odoo.tests import common
+from odoo.tests import new_test_user, tagged
+from .common import WebsocketCase
+from ..models.bus_presence import AWAY_TIMER
 
 
-class TestIrWebsocket(common.HttpCase):
+@tagged("-at_install", "post_install")
+class TestIrWebsocket(WebsocketCase):
     def test_only_allow_string_channels_from_frontend(self):
         with self.assertRaises(ValueError):
             self.env['ir.websocket']._subscribe({
@@ -11,3 +21,73 @@ class TestIrWebsocket(common.HttpCase):
                 'last': 0,
                 'channels': [('odoo', 'discuss.channel', 5)],
             })
+
+    def test_notify_on_status_change(self):
+        bob = new_test_user(self.env, login="bob_user", groups="base.group_user")
+        group_user = self.env.ref("base.group_user")
+        session = self.authenticate("bob_user", "bob_user")
+        websocket = self.websocket_connect(cookie=f"session_id={session.sid};")
+        self.subscribe(websocket, [], self.env["bus.bus"]._bus_last_id())
+        # offline => online
+        websocket.send(
+            json.dumps(
+                {
+                    "event_name": "update_presence",
+                    "data": {"inactivity_period": 0, "im_status_ids_by_model": {}},
+                }
+            )
+        )
+        self.trigger_notification_dispatching([group_user])
+        message = json.loads(websocket.recv())[0]["message"]
+        self.assertEqual(message["type"], "bus.bus/im_status_updated")
+        self.assertEqual(message["payload"]["im_status"], "online")
+        self.assertEqual(message["payload"]["partner_id"], bob.partner_id.id)
+        # online => away
+        away_timer_later = datetime.now() + timedelta(seconds=AWAY_TIMER + 1)
+        with freeze_time(away_timer_later):
+            websocket.send(
+                json.dumps(
+                    {
+                        "event_name": "update_presence",
+                        "data": {
+                            "inactivity_period": (AWAY_TIMER + 1) * 1000,
+                            "im_status_ids_by_model": {},
+                        },
+                    }
+                )
+            )
+            self.trigger_notification_dispatching([group_user])
+            message = json.loads(websocket.recv())[0]["message"]
+            self.assertEqual(message["type"], "bus.bus/im_status_updated")
+            self.assertEqual(message["payload"]["im_status"], "away")
+            self.assertEqual(message["payload"]["partner_id"], bob.partner_id.id)
+        # away => online
+        ten_minutes_later = datetime.now() + timedelta(minutes=10)
+        with freeze_time(ten_minutes_later):
+            websocket.send(
+                json.dumps(
+                    {
+                        "event_name": "update_presence",
+                        "data": {"inactivity_period": 0, "im_status_ids_by_model": {}},
+                    }
+                )
+            )
+            self.trigger_notification_dispatching([self.env.ref("base.group_user")])
+            message = json.loads(websocket.recv())[0]["message"]
+            self.assertEqual(message["type"], "bus.bus/im_status_updated")
+            self.assertEqual(message["payload"]["im_status"], "online")
+            self.assertEqual(message["payload"]["partner_id"], bob.partner_id.id)
+        # online => online, nothing happens
+        ten_minutes_later = datetime.now() + timedelta(minutes=10)
+        with freeze_time(ten_minutes_later):
+            websocket.send(
+                json.dumps(
+                    {
+                        "event_name": "update_presence",
+                        "data": {"inactivity_period": 0, "im_status_ids_by_model": {}},
+                    }
+                )
+            )
+            self.trigger_notification_dispatching([group_user])
+            with self.assertRaises(ws._exceptions.WebSocketTimeoutException):
+                message = json.loads(websocket.recv())[0]["message"]

--- a/addons/bus/tests/test_websocket_caryall.py
+++ b/addons/bus/tests/test_websocket_caryall.py
@@ -277,3 +277,10 @@ class TestWebsocketCaryall(WebsocketCase):
             )
             serve_forever_called_event.wait(timeout=5)
             self.assertTrue(mock.called)
+
+    def test_trigger_on_websocket_closed(self):
+        with patch('odoo.addons.bus.models.ir_websocket.IrWebsocket._on_websocket_closed') as mock:
+            ws = self.websocket_connect()
+            ws.close(CloseCode.CLEAN)
+            self.wait_remaining_websocket_connections()
+            self.assertTrue(mock.called)

--- a/addons/bus/tests/test_websocket_controller.py
+++ b/addons/bus/tests/test_websocket_controller.py
@@ -1,7 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import json
-
 from odoo.tests import JsonRpcException
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 
@@ -69,3 +67,20 @@ class TestWebsocketController(HttpCaseWithUserDemo):
                 'last': 0,
                 'is_first_poll': False,
             }, headers=headers)
+
+    def test_on_websocket_closed(self):
+        session = self.authenticate("demo", "demo")
+        headers = {"Cookie": f"session_id={session.sid};"}
+        self.env["bus.presence"]._update_presence(
+            inactivity_period=0, identity_field="user_id", identity_value=self.user_demo.id
+        )
+        self.env["bus.bus"].search([]).unlink()
+        self.make_jsonrpc_request("/websocket/on_closed", {}, headers=headers)
+        message = self.make_jsonrpc_request(
+            "/websocket/peek_notifications",
+            {"channels": [], "last": 0, "is_first_poll": True},
+            headers=headers,
+        )["notifications"][0]["message"]
+        self.assertEqual(message["type"], "bus.bus/im_status_updated")
+        self.assertEqual(message["payload"]["partner_id"], self.partner_demo.id)
+        self.assertEqual(message["payload"]["im_status"], "offline")

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -228,9 +228,11 @@ class Websocket:
     # How many seconds between each request.
     RL_DELAY = float(config['websocket_rate_limit_delay'])
 
-    def __init__(self, sock, session):
+    def __init__(self, sock, session, cookies):
         # Session linked to the current websocket connection.
         self._session = session
+        # Cookies linked to the current websocket connection.
+        self._cookies = cookies
         self._db = session.db
         self.__socket = sock
         self._close_sent = False
@@ -542,6 +544,9 @@ class Websocket:
         self.state = ConnectionState.CLOSED
         dispatch.unsubscribe(self)
         self._trigger_lifecycle_event(LifecycleEvent.CLOSE)
+        with acquire_cursor(self._db) as cr:
+            env = api.Environment(cr, self._session.uid, self._session.context)
+            env["ir.websocket"]._on_websocket_closed(self._cookies)
 
     def _handle_control_frame(self, frame):
         if frame.opcode is Opcode.PING:
@@ -838,7 +843,7 @@ class WebsocketConnectionHandler:
             socket = request.httprequest._HTTPRequest__environ['socket']
             session, db, httprequest = (public_session or request.session), request.db, request.httprequest
             response.call_on_close(lambda: cls._serve_forever(
-                Websocket(socket, session),
+                Websocket(socket, session, httprequest.cookies),
                 db,
                 httprequest,
             ))

--- a/addons/hr_holidays/tests/test_out_of_office.py
+++ b/addons/hr_holidays/tests/test_out_of_office.py
@@ -85,21 +85,21 @@ class TestOutOfOfficePerformance(TestHrHolidaysCommon, TransactionCaseWithUserDe
     @users('__system__', 'demo')
     @warmup
     def test_leave_im_status_performance_partner_offline(self):
-        with self.assertQueryCount(__system__=2, demo=2):
+        with self.assertQueryCount(__system__=3, demo=3):
             self.assertEqual(self.employer_partner.im_status, 'offline')
 
     @users('__system__', 'demo')
     @warmup
     def test_leave_im_status_performance_user_leave_offline(self):
         self.leave.write({'state': 'validate'})
-        with self.assertQueryCount(__system__=2, demo=2):
+        with self.assertQueryCount(__system__=3, demo=3):
             self.assertEqual(self.hr_user.im_status, 'leave_offline')
 
     @users('__system__', 'demo')
     @warmup
     def test_leave_im_status_performance_partner_leave_offline(self):
         self.leave.write({'state': 'validate'})
-        with self.assertQueryCount(__system__=2, demo=2):
+        with self.assertQueryCount(__system__=3, demo=3):
             self.assertEqual(self.hr_partner.im_status, 'leave_offline')
 
     def test_search_absent_employee(self):

--- a/addons/mail/models/bus_presence.py
+++ b/addons/mail/models/bus_presence.py
@@ -14,3 +14,17 @@ class BusPresence(models.Model):
     _sql_constraints = [
         ("partner_or_guest_exists", "CHECK((user_id IS NOT NULL AND guest_id IS NULL) OR (user_id IS NULL AND guest_id IS NOT NULL))", "A bus presence must have a user or a guest."),
     ]
+
+    def _get_bus_target(self):
+        return "broadcast" if self.guest_id else super()._get_bus_target()
+
+    def _get_identity_field_name(self):
+        return "guest_id" if self.guest_id else super()._get_identity_field_name()
+
+    def _get_identity_data(self):
+        self.ensure_one()
+        return {"guest_id": self.guest_id.id} if self.guest_id else super()._get_identity_data()
+
+    def _invalidate_im_status(self, fnames=None, flush=True):
+        super().invalidate_recordset(fnames, flush)
+        self.guest_id.invalidate_recordset(["im_status"])

--- a/addons/mail/models/discuss/ir_websocket.py
+++ b/addons/mail/models/discuss/ir_websocket.py
@@ -58,3 +58,12 @@ class IrWebsocket(models.AbstractModel):
                 identity_field="guest_id",
                 identity_value=guest.id,
             )
+
+    def _on_websocket_closed(self, cookies):
+        super()._on_websocket_closed(cookies)
+        if self.env.user and not self.env.user._is_public():
+            return
+        token = cookies.get(self.env["mail.guest"]._cookie_name, "")
+        if guest := self.env["mail.guest"]._get_guest_from_token(token):
+            # sudo - bus.presence: guests can delete their presences
+            self.env["bus.presence"].sudo().search([("guest_id", "=", guest.id)]).unlink()

--- a/addons/mail/static/src/core/common/im_status_service_patch.js
+++ b/addons/mail/static/src/core/common/im_status_service_patch.js
@@ -1,0 +1,38 @@
+/* @odoo-module */
+
+import { AWAY_DELAY, imStatusService } from "@bus/im_status_service";
+import { patch } from "@web/core/utils/patch";
+
+export const imStatusServicePatch = {
+    start(env, services) {
+        const { bus_service, presence } = services;
+        const API = super.start(env, services);
+
+        bus_service.subscribe(
+            "bus.bus/im_status_updated",
+            ({ im_status, partner_id, guest_id }) => {
+                const store = env.services["mail.store"];
+                if (!store) {
+                    return;
+                }
+                const persona = store.Persona.get({
+                    type: partner_id ? "partner" : "guest",
+                    id: partner_id ?? guest_id,
+                });
+                if (!persona) {
+                    return; // Do not store unknown persona's status
+                }
+                persona.im_status = im_status;
+                if (persona.type !== "guest" || persona.notEq(store.self)) {
+                    return; // Partners are already handled by the original service
+                }
+                const isOnline = presence.getInactivityPeriod() < AWAY_DELAY;
+                if ((im_status === "away" && isOnline) || im_status === "offline") {
+                    this.updateBusPresence();
+                }
+            }
+        );
+        return API;
+    },
+};
+export const unpatchImStatusService = patch(imStatusService, imStatusServicePatch);

--- a/addons/mail/static/tests/legacy/helpers/unpatch_im_status_service.js
+++ b/addons/mail/static/tests/legacy/helpers/unpatch_im_status_service.js
@@ -1,0 +1,3 @@
+import { unpatchImStatusService } from "@mail/core/common/im_status_service_patch";
+
+unpatchImStatusService();

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -21,10 +21,10 @@ class TestDiscussFullPerformance(HttpCase):
     #     4: settings
     #     1: has_access_livechat
     _query_count_init_store = 17
-    _query_count = 49 + 1  # +1 is necessary to fix nondeterministic issue on runbot
+    _query_count = 50 + 1  # +1 is necessary to fix nondeterministic issue on runbot
     # Queries for _query_count_discuss_channels:
     #     1: bus last id
-    _query_count_discuss_channels = 69
+    _query_count_discuss_channels = 70
 
     def setUp(self):
         super().setUp()

--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -91,6 +91,7 @@ class Http(models.AbstractModel):
             "uid": session_uid,
             "is_system": user._is_system() if session_uid else False,
             "is_admin": user._is_admin() if session_uid else False,
+            "is_public": user._is_public(),
             "is_internal_user": is_internal_user,
             "user_context": user_context,
             "db": self.env.cr.dbname,
@@ -172,6 +173,7 @@ class Http(models.AbstractModel):
         session_info = {
             'is_admin': user._is_admin() if session_uid else False,
             'is_system': user._is_system() if session_uid else False,
+            'is_public': user._is_public(),
             'is_website_user': user._is_public() if session_uid else False,
             'user_id': user.id if session_uid else False,
             'is_frontend': True,


### PR DESCRIPTION
*: hr_holidays, mail.

Before this PR, the main tab updated the user presence every minute. As a result of this update, it would also receive the IM statuses it was interested in.

However, this approach puts significant pressure on the gevent worker, especially when it handles more databases than the registry can hold.

To address this issue, this PR improves the way presences are updated:
- Presences are sent and broadcasted when they change (e.g. away => online).
- When a websocket disconnects, the user is considered disconnected. If other devices receive this notification, they will update the user presence immediately.

These changes greatly reduce traffic caused by presence updates while keeping the IM statuses reliable.