### PR TITLE
[FIX] account: only show amount due in emails when relevant

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4376,7 +4376,11 @@ class AccountMove(models.Model):
             force_email_company=force_email_company, force_email_lang=force_email_lang
         )
         subtitles = [render_context['record'].name]
-        if self.invoice_date_due and self.payment_state not in ('in_payment', 'paid'):
+        if (
+            self.invoice_date_due
+            and self.is_invoice(include_receipts=True)
+            and self.payment_state not in ('in_payment', 'paid')
+        ):
             subtitles.append(_('%(amount)s due\N{NO-BREAK SPACE}%(date)s',
                            amount=format_amount(self.env, self.amount_total, self.currency_id, lang_code=render_context.get('lang')),
                            date=format_date(self.env, self.invoice_date_due, date_format='short', lang_code=render_context.get('lang'))


### PR DESCRIPTION
Currently the amount due of a move was always sent in an email for any type of move. The condition only checked if there was an `invoice_date_due` set. This field is set for any kind of move and default to the creation date of that move.

However it only makes sense to show amounts due for invoices, bills, receipts and credit notes. Showing these for miscellaneous moves like the tax closing entry causes users to be confused. The amount displayed is the total amount of the move and not the amount to be paid to the authorities.

This fix makes sure we only show the amount due in emails for the right move types in order not to confuse users.

Task link: https://www.odoo.com/odoo/project/967/tasks/4042715
opw-4042715