### PR TITLE
[IMP] website_payment:  improve error display  in payment form

### DIFF
--- a/addons/website_payment/static/src/js/payment_form.js
+++ b/addons/website_payment/static/src/js/payment_form.js
@@ -83,39 +83,24 @@ PaymentForm.include({
      */
     async _initiatePaymentFlow(providerCode, paymentOptionId, paymentMethodCode, flow) {
         if (document.querySelector('.o_donation_payment_form')) {
-            const errorFields = {};
-            if (!this.el.querySelector('input[name="email"]').checkValidity()) {
-                errorFields['email'] = _t("Email is invalid");
-            }
             const mandatoryFields = {
                 'name': _t('Name'),
                 'email': _t('Email'),
                 'country_id': _t('Country'),
             };
+
+            let firstInvalidFieldEl;
             for (const id in mandatoryFields) {
                 const fieldEl = this.el.querySelector(`input[name="${id}"],select[name="${id}"]`);
-                fieldEl.classList.remove('is-invalid');
-                Popover.getOrCreateInstance(fieldEl)?.dispose();
-                if (!fieldEl.value.trim()) {
-                    errorFields[id] = _t("Field '%s' is mandatory", mandatoryFields[id]);
+                const isInvalid =
+                    !fieldEl.value.trim() || (id === "email" && !fieldEl.checkValidity());
+                fieldEl.classList.toggle("is-invalid", isInvalid);
+                if (isInvalid && !firstInvalidFieldEl) {
+                    firstInvalidFieldEl = fieldEl;
                 }
             }
-            if (Object.keys(errorFields).length) {
-                for (const id in errorFields) {
-                    const fieldEl = this.el.querySelector(
-                        `input[name="${id}"],select[name="${id}"]`
-                    );
-                    fieldEl.classList.add('is-invalid');
-                    Popover.getOrCreateInstance(fieldEl, {
-                        content: errorFields[id],
-                        placement: 'top',
-                        trigger: 'hover',
-                    });
-                }
-                this._displayErrorDialog(
-                    _t("Payment processing failed"),
-                    _t("Some information is missing to process your payment.")
-                );
+            if (firstInvalidFieldEl) {
+                firstInvalidFieldEl.focus();
                 this._enableButton();
                 return;
             }

--- a/addons/website_payment/views/payment_form_templates.xml
+++ b/addons/website_payment/views/payment_form_templates.xml
@@ -45,21 +45,27 @@
                 <label class="col-form-label fw-bold" for="name">Name
                     <span class="s_website_form_mark"> *</span>
                 </label>
-                <input t-att-readonly="'1' if 'name' in partner_details and partner_id else None" type="text" name="name" t-attf-class="form-control #{error.get('name') and 'is-invalid' or ''}" t-att-value="partner_details.get('name')" />
+                <input t-att-readonly="'1' if 'name' in partner_details and partner_id else None" type="text" name="name" t-attf-class="form-control #{error.get('name') and 'is-invalid' or ''}" t-att-value="partner_details.get('name')" required="1"/>
+                <div class="invalid-feedback">
+                    Please provide a name.
+                </div>
             </div>
             <div class="w-100"/>
             <div t-attf-class="mb-3 #{error.get('email') and 'o_has_error' or ''} col-lg-6" id="div_email">
                 <label class="col-form-label fw-bold" for="email">Email
                     <span class="s_website_form_mark"> *</span>
                 </label>
-                <input t-att-readonly="'1' if 'email' in partner_details and partner_id else None" type="email" name="email" t-attf-class="form-control #{error.get('email') and 'is-invalid' or ''}" t-att-value="partner_details.get('email')" />
+                <input t-att-readonly="'1' if 'email' in partner_details and partner_id else None" type="email" name="email" t-attf-class="form-control #{error.get('email') and 'is-invalid' or ''}" t-att-value="partner_details.get('email')" required="1"/>
+                <div class="invalid-feedback">
+                    Please enter a valid email address.
+                </div>
             </div>
             <t t-set="country_id" t-value="partner_details.get('country_id')"/>
             <div t-attf-class="mb-3 #{error.get('country_id') and 'o_has_error' or ''} col-lg-6 div_country">
                 <label class="col-form-label fw-bold" for="country_id">Country
                     <span class="s_website_form_mark"> *</span>
                 </label>
-                <select t-att-disabled="'1' if country_id and partner_id else None" id="country_id" name="country_id" t-attf-class="form-select #{error.get('country_id') and 'is-invalid' or ''}">
+                <select t-att-disabled="'1' if country_id and partner_id else None" id="country_id" name="country_id" t-attf-class="form-select #{error.get('country_id') and 'is-invalid' or ''}" required="1">
                     <option value="">Country...</option>
                     <t t-foreach="countries" t-as="c">
                         <option t-att-value="c.id" t-att-selected="c.id == (country_id or -1)">
@@ -67,6 +73,9 @@
                         </option>
                     </t>
                 </select>
+                <div class="invalid-feedback">
+                    Please select a country.
+                </div>
             </div>
             <div class="w-100"/>
             <div class="mb-3 col-lg-12 o_donation_payment_form">


### PR DESCRIPTION
This PR aims to improve the error handling and display in the donation payment form, here are the key changes:
- Refactored the validation logic to remove the use of Popover for error messages.
- Implemented a cleaner approach for displaying validation errors, now the errors will be displayed under the input.
- Enhanced error messages to be more user-friendly, such as "Please enter %s" instead of "Field '%s' is mandatory".
- Ensured that any existing error messages are removed before re-validating the form fields.
- Set focus on the first invalid field after displaying the validation errors to improve user experience.
- Removed error dialog display for missing information.

These changes streamline the validation process, making it more efficient and user-friendly by providing clearer error messages and improving form usability.

task-4008417
