### PR TITLE
[FIX] website: fix text-cover snippet image structure

### DIFF
--- a/addons/website/views/snippets/s_text_cover.xml
+++ b/addons/website/views/snippets/s_text_cover.xml
@@ -10,8 +10,8 @@
                     <p class="lead"><br/>Sell online easily with a user-friendly platform that streamlines all the steps, including setup, inventory management, and payment processing.<br/></p>
                     <a t-att-href="cta_btn_href" class="btn btn-lg btn-primary"><t t-esc="cta_btn_text">Contact us</t></a>
                 </div>
-                <div class="o_grid_item o_grid_item_image g-height-12 g-col-lg-6 col-lg-6 o_colored_level o_cc o_cc1 pt160 pb160 oe_img_bg d-none d-md-block" style="grid-area: 1 / 7 / 12 / 13; --grid-item-padding-x: 0px; --grid-item-padding-y: 0px; background-image: url('/web/image/website.s_text_cover_default_image'); background-position: 100% 0;">
-                    <img src="/web/image/website.s_text_cover_default_image" class="img img-fluid mx-auto rounded" alt=""/>
+                <div class="o_grid_item o_grid_item_image g-height-12 g-col-lg-6 col-lg-6 o_colored_level o_cc o_cc1 pt160 pb160 oe_img_bg d-none d-md-block" style="grid-area: 1 / 7 / 12 / 13; --grid-item-padding-x: 0px; --grid-item-padding-y: 0px;">
+                    <img src="/web/image/website.s_text_cover_default_image" class="img img-fluid mx-auto" alt=""/>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This PR aims to fix an issue about the XML structure of the image in use for the `text-cover` snippet.

Commit[1] introduced an improved version of the text-cover snippet, as part of the Odoo 18 snippet redesign, but this commit included some mistakes:

- A `rounded` class, while the image should not be rounded,

- A double declaration of the image, used as `background-image` as well as within an `<img>` tag.

Commit[1]: f44232ca96281f43feb63c13762ac5c3c78b6af5

task-4080033

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
