### PR TITLE
[FIX] mrp,stock: make produce_delay a dependency of qty_forecast

### DIFF
--- a/addons/mrp/models/stock_orderpoint.py
+++ b/addons/mrp/models/stock_orderpoint.py
@@ -48,6 +48,10 @@ class StockWarehouseOrderpoint(models.Model):
         for orderpoint in self:
             orderpoint.show_bom = orderpoint.route_id.id in manufacture_route
 
+    @api.model
+    def _forecast_dependencies(self):
+        return super()._forecast_dependencies() + ['product_id.produce_delay']
+
     def _compute_visibility_days(self):
         res = super()._compute_visibility_days()
         for orderpoint in self:


### PR DESCRIPTION
Steps
---
* Create a manufactured product with a bom and a reordering rule.
        * product: Routes = *Manufacture*
        * reordering rule: min = 5, max = 15
* Create an MO for 10 of this product, planned in 7 days week > Confirm
    * (=> as expected the reordering rule's forecast is 0)
* Change the *Manufacturing lead time* (`produce_delay`) of the product
  to 7 days
    * => on the reordering rules' list view:
        * the reordering rule's forecast is 10 (ok, we now see the
          previously planned MO)
        * the qty_to_order is still 15 (Should be 0 since 10 > 5)

Fix
---
create a method where we can define common dependencies of
``_compute_qty`` and ``qty_to_order``, because they are bound to have
a lot in common and as of https://github.com/odoo/odoo/commit/cb764a9f6f94bbe94d31d5fd21eea1e48aaa0c03 `qty_forecast` is no longer a dependency of `qty_to_order`.

Add `product_id.produce_delay` in a mrp specific overload of this
method, to make the dependency explicit to the orm.

Note
---
Even though it looks like the `qty_forecast` has changed, since it is
non-store, merely computing it for a view won't trigger dependant
computes unless we touch an explicit dependency

opw-3994353