### PR TITLE
[IMP] core: SQL for boolean is (field IS TRUE)

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -3,7 +3,6 @@ from contextlib import contextmanager
 
 from odoo import api, fields, models, _, Command
 from odoo.exceptions import UserError
-from odoo.tools import create_index
 from odoo.tools.misc import formatLang
 
 
@@ -103,18 +102,8 @@ class AccountBankStatement(models.Model):
         string="Attachments",
     )
 
-    def init(self):
-        super().init()
-        create_index(self.env.cr,
-                     indexname='account_bank_statement_journal_id_date_desc_id_desc_idx',
-                     tablename='account_bank_statement',
-                     expressions=['journal_id', 'date DESC', 'id DESC'])
-        create_index(
-            self.env.cr,
-            indexname='account_bank_statement_first_line_index_idx',
-            tablename='account_bank_statement',
-            expressions=['journal_id', 'first_line_index'],
-        )
+    _journal_id_date_desc_id_desc_idx = models.Index("(journal_id, date DESC, id DESC)")
+    _first_line_index_idx = models.Index("(journal_id, first_line_index)")
 
     # -------------------------------------------------------------------------
     # COMPUTE METHODS

--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -3,7 +3,7 @@ from odoo.exceptions import UserError, ValidationError
 
 from xmlrpc.client import MAXINT
 
-from odoo.tools import create_index, SQL
+from odoo.tools import SQL
 
 
 class AccountBankStatementLine(models.Model):
@@ -144,28 +144,9 @@ class AccountBankStatementLine(models.Model):
     # Technical field to store details about the bank statement line
     transaction_details = fields.Json(readonly=True)
 
-    def init(self):
-        super().init()
-        create_index(  # used for default filters
-            self.env.cr,
-            indexname='account_bank_statement_line_unreconciled_idx',
-            tablename='account_bank_statement_line',
-            expressions=['journal_id', 'company_id', 'internal_index'],
-            where='NOT is_reconciled OR is_reconciled IS NULL',
-        )
-        create_index(  # used for the dashboard
-            self.env.cr,
-            indexname='account_bank_statement_line_orphan_idx',
-            tablename='account_bank_statement_line',
-            expressions=['journal_id', 'company_id', 'internal_index'],
-            where='statement_id IS NULL',
-        )
-        create_index(  # used in other cases
-            self.env.cr,
-            indexname='account_bank_statement_line_main_idx',
-            tablename='account_bank_statement_line',
-            expressions=['journal_id', 'company_id', 'internal_index'],
-        )
+    _unreconciled_idx = models.Index("(journal_id, company_id, internal_index) WHERE is_reconciled IS NOT TRUE")
+    _orphan_idx = models.Index("(journal_id, company_id, internal_index) WHERE statement_id IS NULL")
+    _main_idx = models.Index("(journal_id, company_id, internal_index)")
 
     # -------------------------------------------------------------------------
     # COMPUTE METHODS

--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -153,7 +153,7 @@ class AccountJournal(models.Model):
                       JOIN account_journal journal ON move.journal_id = journal.id
                      WHERE move.journal_id = ANY(%(journal_ids)s)
                        AND move.company_id = %(company_id)s
-                       AND move.made_sequence_gap = TRUE
+                       AND move.made_sequence_gap IS TRUE
                        AND move.date > %(fiscal_lock_date)s
                        AND (journal.type <> 'sale' OR move.date > %(sale_lock_date)s)
                        AND (journal.type <> 'purchase' OR move.date > %(purchase_lock_date)s)
@@ -444,7 +444,7 @@ class AccountJournal(models.Model):
               JOIN account_move st_line_move ON st_line_move.id = st_line.move_id
              WHERE st_line.journal_id IN %s
                AND st_line.company_id IN %s
-               AND NOT st_line.is_reconciled
+               AND st_line.is_reconciled IS NOT TRUE
                AND st_line_move.checked IS TRUE
                AND st_line_move.state = 'posted'
           GROUP BY st_line.journal_id
@@ -844,7 +844,7 @@ class AccountJournal(models.Model):
                    SUM(amount_company_currency_signed) AS amount_total_company
               FROM account_payment payment
               JOIN account_move move ON move.origin_payment_id = payment.id
-             WHERE (NOT payment.is_matched OR payment.is_matched IS NULL)
+             WHERE payment.is_matched IS NOT TRUE
                AND move.state = 'posted'
                AND payment.journal_id = ANY(%s)
                AND payment.company_id = ANY(%s)

--- a/addons/account/models/account_lock_exception.py
+++ b/addons/account/models/account_lock_exception.py
@@ -1,6 +1,5 @@
 from odoo import _, api, fields, models, Command
 from odoo.osv import expression
-from odoo.tools import create_index
 from odoo.tools.misc import format_datetime
 from odoo.exceptions import UserError, ValidationError
 
@@ -95,15 +94,7 @@ class AccountLock_Exception(models.Model):
         help="The date the Purchase Lock Date is set to by this exception. If the lock date is not changed it is set to the maximal date.",
     )
 
-    def init(self):
-        super().init()
-        create_index(
-            self.env.cr,
-            indexname='account_lock_exception_company_id_end_datetime_idx',
-            tablename=self._table,
-            expressions=['company_id', 'user_id', 'end_datetime'],
-            where="active = TRUE"
-        )
+    _company_id_end_datetime_idx = models.Index("(company_id, user_id, end_datetime) WHERE active IS TRUE")
 
     def _compute_display_name(self):
         for record in self:

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -19,7 +19,6 @@ from odoo.addons.account.tools import format_structured_reference_iso
 from odoo.exceptions import UserError, ValidationError, AccessError, RedirectWarning
 from odoo.osv import expression
 from odoo.tools import (
-    create_index,
     date_utils,
     float_compare,
     float_is_zero,
@@ -30,7 +29,6 @@ from odoo.tools import (
     frozendict,
     get_lang,
     groupby,
-    index_exists,
     OrderedSet,
     SQL,
 )
@@ -694,7 +692,7 @@ class AccountMove(models.Model):
         search='_search_next_payment_date',
     )
 
-    _checked_idx = models.Index("(journal_id) WHERE (checked = FALSE)")
+    _checked_idx = models.Index("(journal_id) WHERE (checked IS NOT TRUE)")
     _payment_idx = models.Index("(journal_id, state, payment_state, move_type, date)")
     _unique_name = models.UniqueIndex(
         "(name, journal_id) WHERE (state = 'posted'AND name != '/')",
@@ -702,7 +700,7 @@ class AccountMove(models.Model):
     )
     _journal_id_company_id_idx = models.Index('(journal_id, company_id, date)')
     # used in <account.journal>._query_has_sequence_holes
-    _made_gaps = models.Index('(journal_id, state, payment_state, move_type, date) WHERE (made_sequence_gap = TRUE)')
+    _made_gaps = models.Index('(journal_id, state, payment_state, move_type, date) WHERE (made_sequence_gap IS TRUE)')
 
     def _auto_init(self):
         super()._auto_init()

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -7,8 +7,7 @@ import re
 from odoo import api, fields, models, Command, _
 from odoo.exceptions import ValidationError, UserError
 from odoo.osv import expression
-from odoo.tools import frozendict, format_date, float_compare, format_list, Query
-from odoo.tools.sql import create_index, SQL
+from odoo.tools import frozendict, float_compare, format_list, Query, SQL
 from odoo.addons.web.controllers.utils import clean_action
 
 from odoo.addons.account.models.account_move import MAX_HASH_VERSION
@@ -433,6 +432,17 @@ class AccountMoveLine(models.Model):
         "CHECK(display_type NOT IN ('line_section', 'line_note') OR (amount_currency = 0 AND debit = 0 AND credit = 0 AND account_id IS NULL))",
         'Forbidden balance or account on non-accountable line',
     )
+
+    # change index on partner_id to a multi-column index on (partner_id, ref), the new index will behave in the
+    # same way when we search on partner_id, with the addition of being optimal when having a query that will
+    # search on partner_id and ref at the same time (which is the case when we open the bank reconciliation widget)
+    _partner_id_ref_idx = models.Index("(partner_id, ref)")
+    _date_name_id_idx = models.Index("(date desc, move_name desc, id)")
+    # Match exactly how the ORM converts domains to ensure the query planner uses it
+    _unreconciled_index = models.Index("(account_id, partner_id) WHERE reconciled IS NOT TRUE AND parent_state = 'posted'")
+    _journal_id_neg_amnt_residual_idx = models.Index("(journal_id) WHERE amount_residual < 0 AND parent_state = 'posted'")
+    # covers the standard index on account_id
+    _account_id_date_idx = models.Index("(account_id, date)")
 
     @api.model
     def get_views(self, views, options=None):
@@ -1358,28 +1368,6 @@ class AccountMoveLine(models.Model):
             order_cumulated_balance=order,
         )
         return super(AccountMoveLine, contextualized).search_fetch(domain, field_names, offset, limit, order)
-
-    def init(self):
-        """ change index on partner_id to a multi-column index on (partner_id, ref), the new index will behave in the
-            same way when we search on partner_id, with the addition of being optimal when having a query that will
-            search on partner_id and ref at the same time (which is the case when we open the bank reconciliation widget)
-        """
-        create_index(self._cr, 'account_move_line_partner_id_ref_idx', 'account_move_line', ["partner_id", "ref"])
-        create_index(self._cr, 'account_move_line_date_name_id_idx', 'account_move_line', ["date desc", "move_name desc", "id"])
-        # Match exactly how the ORM converts domains to ensure the query planner uses it
-        create_index(self._cr, 'account_move_line__unreconciled_index', 'account_move_line', ['account_id', 'partner_id'],
-                     where="(reconciled IS NULL OR reconciled = false OR reconciled IS NOT true) AND parent_state = 'posted'")
-        create_index(self.env.cr,
-                     indexname='account_move_line_journal_id_neg_amnt_residual_idx',
-                     tablename='account_move_line',
-                     expressions=['journal_id'],
-                     where="amount_residual < 0 AND parent_state = 'posted'")
-        # covers the standard index on account_id
-        create_index(self.env.cr,
-                     indexname='account_move_line_account_id_date_idx',
-                     tablename='account_move_line',
-                     expressions=['account_id', 'date'])
-        super().init()
 
     def default_get(self, fields_list):
         defaults = super().default_get(fields_list)

--- a/addons/account/models/account_move_line_tax_details.py
+++ b/addons/account/models/account_move_line_tax_details.py
@@ -185,7 +185,7 @@ class AccountMoveLine(models.Model):
                         OR (tax.tax_exigibility = 'on_payment' AND tax.cash_basis_transition_account_id IS NOT NULL)
                     )
                     AND (
-                        (tax.analytic IS NULL OR tax.analytic = FALSE)
+                        (tax.analytic IS NOT TRUE)
                         OR (base_line.analytic_distribution IS NULL AND account_move_line.analytic_distribution IS NULL)
                         OR base_line.analytic_distribution = account_move_line.analytic_distribution
                     )

--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -1,8 +1,5 @@
-# -*- coding: utf-8 -*-
 from odoo import models, fields, api, _, Command
 from odoo.exceptions import UserError, ValidationError
-from odoo.tools.misc import format_date, formatLang
-from odoo.tools import create_index
 from odoo.tools import SQL
 
 
@@ -198,22 +195,8 @@ class AccountPayment(models.Model):
         'CHECK(amount >= 0.0)',
         'The payment amount cannot be negative.',
     )
-
-    def init(self):
-        super().init()
-        create_index(
-            self.env.cr,
-            indexname='account_payment_journal_id_company_id_idx',
-            tablename='account_payment',
-            expressions=['journal_id', 'company_id']
-        )
-        create_index(
-            self.env.cr,
-            indexname='account_payment_unmatched_idx',
-            tablename='account_payment',
-            expressions=['journal_id', 'company_id'],
-            where="NOT is_matched OR is_matched IS NULL"
-        )
+    _journal_id_company_id_idx = models.Index("(journal_id, company_id)")
+    _unmatched_idx = models.Index("(journal_id, company_id) WHERE is_matched IS NOT TRUE")
 
     # -------------------------------------------------------------------------
     # HELPERS

--- a/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
+++ b/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
@@ -56,11 +56,11 @@ class Account_Edi_Proxy_ClientUser(models.Model):
 
     _unique_id_client = models.Constraint('unique(id_client)', "This id_client is already used on another user.")
     _unique_active_edi_identification = models.UniqueIndex(
-        '(edi_identification, proxy_type, edi_mode) WHERE (active = TRUE)',
+        '(edi_identification, proxy_type, edi_mode) WHERE (active IS TRUE)',
         "This edi identification is already assigned to an active user",
     )
     _unique_active_company_proxy = models.UniqueIndex(
-        '(company_id, proxy_type, edi_mode) WHERE (active = TRUE)',
+        '(company_id, proxy_type, edi_mode) WHERE (active IS TRUE)',
         "This company has an active user already created for this EDI type",
     )
 

--- a/addons/gamification/models/res_users.py
+++ b/addons/gamification/models/res_users.py
@@ -159,7 +159,7 @@ FROM (
         SELECT "res_users".id as user_id, COALESCE(SUM("tracking".new_value - "tracking".old_value), 0) as karma_gain_total
         FROM %s
         LEFT JOIN "gamification_karma_tracking" as "tracking"
-        ON "res_users".id = "tracking".user_id AND "res_users"."active" = TRUE
+        ON "res_users".id = "tracking".user_id AND "res_users"."active" IS TRUE
         WHERE %s %s %s
         GROUP BY "res_users".id
         ORDER BY karma_gain_total DESC

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1360,7 +1360,7 @@ class TestQueries(TransactionCase):
             FROM "res_partner"
             WHERE (
                 (
-                    ("res_partner"."active" = %s) AND
+                    ("res_partner"."active" IS TRUE) AND
                     ("res_partner"."name" LIKE %s)
                 ) AND (
                     ("res_partner"."title" = %s) OR (
@@ -1380,7 +1380,7 @@ class TestQueries(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner"."id"
             FROM "res_partner"
-            WHERE (("res_partner"."active" = %s) AND ("res_partner"."name" LIKE %s))
+            WHERE (("res_partner"."active" IS TRUE) AND ("res_partner"."name" LIKE %s))
             ORDER BY "res_partner"."complete_name" ASC,"res_partner"."id" DESC
         ''']):
             Model.search([('name', 'like', 'foo')])
@@ -1388,7 +1388,7 @@ class TestQueries(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner"."id"
             FROM "res_partner"
-            WHERE (("res_partner"."active" = %s) AND ("res_partner"."name" LIKE %s))
+            WHERE (("res_partner"."active" IS TRUE) AND ("res_partner"."name" LIKE %s))
             ORDER BY "res_partner"."id"
         ''']):
             Model.search([('name', 'like', 'foo')], order='id')
@@ -1396,7 +1396,7 @@ class TestQueries(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner"."id"
             FROM "res_partner"
-            WHERE (("res_partner"."active" = %s) AND ("res_partner"."name" LIKE %s))
+            WHERE (("res_partner"."active" IS TRUE) AND ("res_partner"."name" LIKE %s))
             ORDER BY "res_partner"."company_id"
         ''']):
             Model.search([('name', 'like', 'foo')], order='company_id.id')
@@ -1404,7 +1404,7 @@ class TestQueries(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner"."id"
             FROM "res_partner"
-            WHERE (("res_partner"."active" = %s) AND ("res_partner"."name" LIKE %s))
+            WHERE (("res_partner"."active" IS TRUE) AND ("res_partner"."name" LIKE %s))
             ORDER BY "res_partner"."company_id" DESC
         ''']):
             Model.search([('name', 'like', 'foo')], order='company_id.id DESC')
@@ -1419,7 +1419,7 @@ class TestQueries(TransactionCase):
         with self.assertQueries(['''
             SELECT COUNT(*)
             FROM "res_partner"
-            WHERE (("res_partner"."active" = %s) AND ("res_partner"."name" LIKE %s))
+            WHERE (("res_partner"."active" IS TRUE) AND ("res_partner"."name" LIKE %s))
         ''']):
             Model.search_count([('name', 'like', 'foo')])
 
@@ -1430,7 +1430,7 @@ class TestQueries(TransactionCase):
         with self.assertQueries(['''
             SELECT COUNT(*) FROM (
                 SELECT FROM "res_partner"
-                WHERE (("res_partner"."active" = %s) AND ("res_partner"."name" LIKE %s))
+                WHERE (("res_partner"."active" IS TRUE) AND ("res_partner"."name" LIKE %s))
                 LIMIT %s
             ) t
         ''']):
@@ -1476,7 +1476,7 @@ class TestQueries(TransactionCase):
             FROM "res_users"
             LEFT JOIN "res_partner" AS "res_users__partner_id" ON
                 ("res_users"."partner_id" = "res_users__partner_id"."id")
-            WHERE ("res_users"."active" = %s)
+            WHERE ("res_users"."active" IS TRUE)
             AND (("res_users"."id" = %s) AND ("res_users__partner_id"."id" = %s))
             ORDER BY "res_users__partner_id"."name", "res_users"."login"
         ''']):
@@ -1626,7 +1626,7 @@ class TestMany2one(TransactionCase):
             WHERE ("res_partner"."company_id" IN (
                 SELECT "res_company"."id"
                 FROM "res_company"
-                WHERE (("res_company"."active" = %s) AND ("res_company"."name" LIKE %s))
+                WHERE (("res_company"."active" IS TRUE) AND ("res_company"."name" LIKE %s))
             ))
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
@@ -1640,7 +1640,7 @@ class TestMany2one(TransactionCase):
             WHERE ("res_partner"."company_id" IN (
                 SELECT "res_company"."id"
                 FROM "res_company"
-                WHERE (("res_company"."active" = %s) AND ("res_company"."name" LIKE %s))
+                WHERE (("res_company"."active" IS TRUE) AND ("res_company"."name" LIKE %s))
                 ORDER BY "res_company"."id"
                 LIMIT %s
             ))
@@ -1653,7 +1653,7 @@ class TestMany2one(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_company"."id"
             FROM "res_company"
-            WHERE (("res_company"."active" = %s) AND ("res_company"."name" LIKE %s))
+            WHERE (("res_company"."active" IS TRUE) AND ("res_company"."name" LIKE %s))
             ORDER BY "res_company"."id"
         ''', '''
             SELECT "res_partner"."id"
@@ -1669,7 +1669,7 @@ class TestMany2one(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_company"."id"
             FROM "res_company"
-            WHERE (("res_company"."active" = %s) AND ("res_company"."name" LIKE %s))
+            WHERE (("res_company"."active" IS TRUE) AND ("res_company"."name" LIKE %s))
             ORDER BY "res_company"."id"
         ''', '''
             SELECT "res_partner"."id"
@@ -1688,7 +1688,7 @@ class TestMany2one(TransactionCase):
             WHERE ("res_partner"."company_id" IN (
                 SELECT "res_company"."id"
                 FROM "res_company"
-                WHERE (("res_company"."active" = %s) AND ("res_company"."name" LIKE %s))
+                WHERE (("res_company"."active" IS TRUE) AND ("res_company"."name" LIKE %s))
             ))
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
@@ -1864,7 +1864,7 @@ class TestOne2many(TransactionCase):
                 SELECT "res_partner"."parent_id"
                 FROM "res_partner"
                 WHERE (
-                    ("res_partner"."active" = TRUE)
+                    ("res_partner"."active" IS TRUE)
                     AND ("res_partner"."id" IN (
                         SELECT "res_partner_bank"."partner_id"
                         FROM "res_partner_bank"
@@ -1932,7 +1932,7 @@ class TestOne2many(TransactionCase):
             WHERE ("res_partner"."id" IN
                      (SELECT "res_partner"."parent_id"
                       FROM "res_partner"
-                      WHERE (("res_partner"."active" = TRUE) AND ("res_partner"."id" IN
+                      WHERE (("res_partner"."active" IS TRUE) AND ("res_partner"."id" IN
                                 (SELECT "res_partner_bank"."partner_id"
                                  FROM "res_partner_bank"
                                  WHERE ("res_partner_bank"."sanitized_acc_number" LIKE %s)))
@@ -1988,7 +1988,7 @@ class TestOne2many(TransactionCase):
                 LEFT JOIN "res_country" AS "res_partner__state_id__country_id"
                     ON ("res_partner__state_id"."country_id" = "res_partner__state_id__country_id"."id")
                 WHERE ((
-                    "res_partner"."active" = TRUE
+                    "res_partner"."active" IS TRUE
                 ) AND (
                     "res_partner__state_id__country_id"."code" LIKE %s
                 ))

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -2371,7 +2371,7 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
         """ test search on many2one ordered by id """
         with self.assertQueries(['''
             SELECT "test_new_api_message"."id" FROM "test_new_api_message"
-            WHERE ("test_new_api_message"."active" = %s)
+            WHERE ("test_new_api_message"."active" IS TRUE)
             ORDER BY  "test_new_api_message"."discussion"
         ''']):
             self.env['test_new_api.message'].search([], order='discussion')
@@ -2402,6 +2402,37 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
             self._search(Model, [('parent_id', 'child_of', 'Parent')]),
             active_parent + child_of_active + child_of_inactive,
         )
+
+    def test_53_boolean_query(self):
+        Model = self.env['test_new_api.model_active_field']
+
+        with self.assertQueries(["""
+            SELECT "test_new_api_model_active_field"."id"
+            FROM "test_new_api_model_active_field"
+            WHERE ("test_new_api_model_active_field"."active" IS TRUE)
+            ORDER BY "test_new_api_model_active_field"."id"
+        """, """
+            SELECT "test_new_api_model_active_field"."id"
+            FROM "test_new_api_model_active_field"
+            WHERE ("test_new_api_model_active_field"."active" IS NOT TRUE)
+            ORDER BY "test_new_api_model_active_field"."id"
+        """]):
+            Model.search([('active', '=', True)])
+            Model.search([('active', '=', False)])
+
+        with self.assertQueries(["""
+            SELECT "test_new_api_model_active_field"."id"
+            FROM "test_new_api_model_active_field"
+            WHERE TRUE
+            ORDER BY "test_new_api_model_active_field"."id"
+        """, """
+            SELECT "test_new_api_model_active_field"."id"
+            FROM "test_new_api_model_active_field"
+            WHERE FALSE
+            ORDER BY "test_new_api_model_active_field"."id"
+        """]):
+            Model.search([('active', 'in', [True, False])])
+            Model.search([('active', 'not in', [True, False])])
 
     def test_60_one2many_domain(self):
         """ test the cache consistency of a one2many field with a domain """


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The comparison of booleans in SQL is now expressed as (expression IS TRUE) or (expression IS NOT TRUE).
This way we handle null values correctly and reference the field only once. We can even reduce to TRUE or FALSE if we have an `in`condition.

Current behavior before PR:
`('active', '=', False)` becomes `"active" = %s OR "active" IS NULL`
`('active', 'in', [True, False])` becomes `"active" IN %s OR "active" IS NULL`

Desired behavior after PR is merged:
`('active', '=', False)` becomes `"active" IS NOT TRUE`
`('active', 'in', [True, False])` becomes `TRUE`

task-4067946
odoo/enterprise#73554

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
