### PR TITLE
[FIX] snailmail: tax id breaking pingen validation

### DIFF
--- a/addons/snailmail/static/src/scss/snailmail_external_layout_asset.scss
+++ b/addons/snailmail/static/src/scss/snailmail_external_layout_asset.scss
@@ -29,6 +29,12 @@ div .address.row {
         > span:not(:first-child) {
             display: none;
         }
+
+        > address {
+            // Moving anything under the address (eg Tax ID) further down to
+            // avoid breaking Pingen validation.
+            margin-bottom: 12mm !important;
+        }
     }
 }
 
@@ -49,6 +55,11 @@ div .row.fallback_header {
         // Hide VAT number line
         > span:not(:first-child) {
             display: none;
+        }
+
+        div[itemscope="itemscope"] > div:first-child {
+            // Same as above move anything under the address further down
+            margin-bottom: 12mm;
         }
     }
 }


### PR DESCRIPTION
When a tax ID is displayed on a report, pingen is failing because the tax ID is rendered in pingen's postable area.

This commit adds a margin after the address to ensure nothing disturbs the address area for pingen.

Target 17 -> 17.4, to be adapted for master in https://github.com/odoo/odoo/pull/174635 .

task-4080193


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
