### PR TITLE
[IMP] project: disable regional formatting for id fields

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -472,7 +472,7 @@
                                     <field name="allow_milestones" column_invisible="True"/>
                                     <field name="display_in_project" column_invisible="True" force_save="1"/>
                                     <field name="sequence" widget="handle"/>
-                                    <field name="id" optional="hide"/>
+                                    <field name="id" optional="hide" options="{'enable_formatting': False}"/>
                                     <field name="parent_id" column_invisible="True"/>
                                     <field name="priority" widget="priority" nolabel="1" width="20px"/>
                                     <field name="state" widget="project_task_state_selection" nolabel="1" width="20px"/>
@@ -517,7 +517,7 @@
                                     <field name="parent_id" column_invisible="True" />
                                     <field name="subtask_count" column_invisible="True"/>
                                     <field name="closed_subtask_count" column_invisible="True"/>
-                                    <field name="id" optional="hide"/>
+                                    <field name="id" optional="hide" options="{'enable_formatting': False}"/>
                                     <field name="priority" widget="priority" nolabel="1" width="20px"/>
                                     <field name="state" widget="project_task_state_selection" nolabel="1" width="20px"/>
                                     <field name="name" widget="name_with_subtask_count"/>
@@ -768,7 +768,7 @@
                     <field name="allow_milestones" column_invisible="True"/>
                     <field name="subtask_count" column_invisible="True"/>
                     <field name="closed_subtask_count" column_invisible="True"/>
-                    <field name="id" optional="hide"/>
+                    <field name="id" optional="hide" options="{'enable_formatting': False}"/>
                     <field name="priority" widget="priority" nolabel="1" width="20px"/>
                     <field name="state" widget="project_task_state_selection" nolabel="1" width="20px" options="{'is_toggle_mode': false}"/>
                     <field name="name" string="Title" widget="name_with_subtask_count"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
- ID fields are formatted according to regional settings in the project task list views.

Desired behavior after PR is merged:
- ID fields are displayed without regional formatting in the project task list views.

task-4080330
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
