### PR TITLE
[FIX] l10n_fr_hr_holidays: fix French holidays computation

### DIFF
--- a/addons/l10n_fr_hr_holidays/models/hr_leave.py
+++ b/addons/l10n_fr_hr_holidays/models/hr_leave.py
@@ -33,6 +33,28 @@ class HrLeave(models.Model):
         if not (self.resource_calendar_id.attendance_ids):
             raise UserError(_("An employee can't take paid time off in a period without any work hours."))
 
+        if not self.request_unit_hours:
+            # extend the date range to the full day or requested period so that the difference of hours
+            # between employee's work hours and the company's work hours doesn't affect the computation
+            date_from = date_from.replace(hour=0, minute=0, second=0)
+            date_to = date_to.replace(hour=23, minute=59, second=59)
+
+            def adjust_date_range(date_from, date_to, period, attendance_ids, employee_id):
+                period_ids = attendance_ids.filtered(lambda a: a.day_period == period)
+                max_hour = max(attendance.hour_to for attendance in period_ids)
+                min_hour = min(attendance.hour_from for attendance in period_ids)
+                date_from = self._to_utc(date_from, min_hour, employee_id)
+                date_to = self._to_utc(date_to, max_hour, employee_id)
+                return date_from, date_to
+
+            if self.request_unit_half:
+                attendance_ids = self.company_id.resource_calendar_id.attendance_ids.filtered(
+                    lambda a: int(a.dayofweek) == date_to.weekday() and a.day_period != "lunch"
+                )
+                if attendance_ids:
+                    period = 'morning' if self.request_date_from_period == 'am' else 'afternoon'
+                    date_from, date_to = adjust_date_range(date_from, date_to, period, attendance_ids, self.employee_id)
+
         if self.request_unit_half and self.request_date_from_period == 'am':
             # In normal workflows request_unit_half implies that date_from and date_to are the same
             # request_unit_half allows us to choose between `am` and `pm`


### PR DESCRIPTION
to reproduce:
=============
- install the module l10n_fr_hr_holidays
- create calendar for company Mon -> Fri 9:00 -> 12:00, 13:00 -> 18:00
- create calendar for employee Mon -> Fri 8:00 -> 12:00, 14:00 -> 17:00
- change `request_unit` for the paid time off to `half_day`
- take a a monday off for the employee -> the duration is 0.9 days instead of 1 day

Problem:
========
we compute the duration of the leave using the hours from the employee calendar but based on the company calendar, where the day of the employee ends at 17:00 but the day of the company ends at 18:00, so this difference is impacting the duration of the leave

Solution:
=========
when computing the duration of the leave, we extend the hours of start and end of the day to the company calendar.

opw-3898282

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
