### PR TITLE
[IMP] project, project*: convert project updates into dashboard

### DIFF
--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -510,6 +510,15 @@
             <field name="groups_ids" eval="[(4, ref('hr_timesheet.group_hr_timesheet_user'))]" />
         </record>
 
+        <record id="project_embedded_action_timesheets_dashboard" model="ir.embedded.actions">
+            <field name="parent_res_model">project.project</field>
+            <field name="sequence">30</field>
+            <field name="parent_action_id" ref="project.project_update_all_action"/>
+            <field name="action_id" ref="hr_timesheet.act_hr_timesheet_line_by_project"/>
+            <field name="domain">[('allow_timesheets', '=', True)]</field>
+            <field name="groups_ids" eval="[(4, ref('hr_timesheet.group_hr_timesheet_user'))]" />
+        </record>
+
         <record id="act_hr_timesheet_line_by_project_view_tree" model="ir.actions.act_window.view">
             <field name="view_mode">tree</field>
             <field name="sequence" eval="1"/>

--- a/addons/hr_timesheet/views/project_update_views.xml
+++ b/addons/hr_timesheet/views/project_update_views.xml
@@ -19,7 +19,7 @@
             <field name="arch" type="xml">
                 <b id="tasks_stats" position='after'>
                     <field name="display_timesheet_stats" invisible="1"/>
-                    <div invisible="not display_timesheet_stats">
+                    <div class="o_pupdate_kanban_width" invisible="not display_timesheet_stats">
                         <field name="timesheet_time"/><span invisible="not allocated_time"> / <field name="allocated_time"/></span> <field name="uom_id" no_open="1"/><span invisible="not allocated_time"> (<field name="timesheet_percentage"/>%)</span>
                     </div>
                 </b>

--- a/addons/project/static/src/components/project_right_side_panel/components/project_profitability.js
+++ b/addons/project/static/src/components/project_right_side_panel/components/project_profitability.js
@@ -7,6 +7,7 @@ export class ProjectProfitability extends Component {
         data: Object,
         labels: Object,
         formatMonetary: Function,
+        onProjectActionClick: Function,
         onClick: Function,
     };
     static template = "project.ProjectProfitability";

--- a/addons/project/static/src/components/project_right_side_panel/components/project_profitability.xml
+++ b/addons/project/static/src/components/project_right_side_panel/components/project_profitability.xml
@@ -6,33 +6,35 @@
                 <thead class="bg-100 align-middle">
                     <tr>
                         <th>Revenues</th>
-                        <th class="text-end">Invoiced</th>
-                        <th class="text-end">To Invoice</th>
                         <th class="text-end">Expected</th>
+                        <th class="text-end">To Invoice</th>
+                        <th class="text-end">Invoiced</th>
                     </tr>
                 </thead>
                 <tbody>
-                    <tr t-foreach="revenues.data" t-as="revenue" t-key="revenue.id" t-if="revenue.invoiced !== 0 || revenue.to_invoice !== 0">
-                        <t t-set="revenue_label" t-value="props.labels[revenue.id] or revenue.id"/>
-                        <td class="align-middle">
-                            <a t-if="revenue.action" href="#"
-                                t-on-click="() => this.props.onClick(revenue.action)"
-                            >
-                                <t t-esc="revenue_label"/>
-                            </a>
-                            <t t-esc="revenue_label" t-else=""/>
-                        </td>
-                        <td t-attf-class="text-end align-middle {{ revenue.invoiced === 0 ? 'text-500' : ''}}"><t t-esc="props.formatMonetary(revenue.invoiced)"/></td>
-                        <td t-attf-class="text-end align-middle {{ revenue.to_invoice === 0 ? 'text-500' : ''}}"><t t-esc="props.formatMonetary(revenue.to_invoice)"/></td>
-                        <td t-attf-class="text-end align-middle {{ revenue.invoiced + revenue.to_invoice === 0 ? 'text-500' : ''}}"><t t-esc="props.formatMonetary(revenue.invoiced + revenue.to_invoice)"/></td>
-                    </tr>
+                    <t t-foreach="revenues.data" t-as="revenue" t-key="revenue.id" t-if="revenue.invoiced !== 0 || revenue.to_invoice !== 0">
+                        <tr class="revenue_section">
+                            <t t-set="revenue_label" t-value="props.labels[revenue.id] or revenue.id"/>
+                            <td class="align-middle">
+                                <a class="revenue_section" t-if="revenue.action" href="#"
+                                    t-on-click="() => this.props.onClick(revenue.action)"
+                                >
+                                    <t t-esc="revenue_label"/>
+                                </a>
+                                <t t-esc="revenue_label" t-else=""/>
+                            </td>
+                            <td t-attf-class="text-end align-middle {{ revenue.invoiced + revenue.to_invoice === 0 ? 'text-500' : ''}}"><t t-esc="props.formatMonetary(revenue.invoiced + revenue.to_invoice)"/></td>
+                            <td t-attf-class="text-end align-middle {{ revenue.to_invoice === 0 ? 'text-500' : ''}}"><t t-esc="props.formatMonetary(revenue.to_invoice)"/></td>
+                            <td t-attf-class="text-end align-middle {{ revenue.invoiced === 0 ? 'text-500' : ''}}"><t t-esc="props.formatMonetary(revenue.invoiced)"/></td>
+                        </tr>
+                    </t>
                 </tbody>
                 <tfoot>
                     <tr class="fw-bolder">
-                        <td>Total</td>
-                        <td t-attf-class="text-end {{ revenues.total.invoiced === 0 ? 'text-500' : ''}}"><t t-esc="props.formatMonetary(revenues.total.invoiced)"/></td>
-                        <td t-attf-class="text-end {{ revenues.total.to_invoice === 0 ? 'text-500' : ''}}"><t t-esc="props.formatMonetary(revenues.total.to_invoice)"/></td>
+                        <td>Total Revenues</td>
                         <td t-attf-class="text-end {{ revenues.total.invoiced + revenues.total.to_invoice === 0 ? 'text-500' : ''}}"><t t-esc="props.formatMonetary(revenues.total.invoiced + revenues.total.to_invoice)"/></td>
+                        <td t-attf-class="text-end {{ revenues.total.to_invoice === 0 ? 'text-500' : ''}}"><t t-esc="props.formatMonetary(revenues.total.to_invoice)"/></td>
+                        <td t-attf-class="text-end {{ revenues.total.invoiced === 0 ? 'text-500' : ''}}"><t t-esc="props.formatMonetary(revenues.total.invoiced)"/></td>
                     </tr>
                 </tfoot>
             </table>
@@ -42,9 +44,9 @@
                 <thead class="bg-100">
                     <tr>
                         <th>Costs</th>
-                        <th class="text-end">Billed</th>
-                        <th class="text-end">To Bill</th>
                         <th class="text-end">Expected</th>
+                        <th class="text-end">To Bill</th>
+                        <th class="text-end">Billed</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -65,7 +67,7 @@
                 </tbody>
                 <tfoot>
                     <tr class="fw-bolder">
-                        <td>Total</td>
+                        <td>Total Costs</td>
                         <td t-attf-class="text-end {{ costs.total.billed === 0 ? 'text-500' : ''}}"><t t-esc="props.formatMonetary(costs.total.billed)"/></td>
                         <td t-attf-class="text-end {{ costs.total.to_bill === 0 ? 'text-500' : ''}}"><t t-esc="props.formatMonetary(costs.total.to_bill)"/></td>
                         <td t-attf-class="text-end {{ costs.total.billed + costs.total.to_bill  === 0 ? 'text-500' : ''}}"><t t-esc="props.formatMonetary(costs.total.billed + costs.total.to_bill)"/></td>
@@ -77,11 +79,12 @@
             <table class="table table-sm table-borderless w-100 mb-0">
                 <thead>
                     <tr class="align-top">
-                        <th>Margin</th>
-                        <th class="text-end" t-att-class="margin.invoiced_billed &lt; 0 ? 'text-danger' : 'text-success'">
-                            <t t-out="props.formatMonetary(margin.invoiced_billed)"/><br/>
-                            <t t-if="revenues.total.invoiced != 0">
-                                <t t-out="margin.invoiced_billed > 0 ? '+' : ''"/><t t-out="(margin.invoiced_billed / revenues.total.invoiced * 100).toFixed()"/>%
+                        <th>Total</th>
+                        <th class="text-end" t-att-class="margin.total &lt; 0 ? 'text-danger' : 'text-success'">
+                            <t t-set="total_revenue" t-value="revenues.total.to_invoice + revenues.total.invoiced"/>
+                            <t t-out="props.formatMonetary(margin.total)"/><br/>
+                            <t t-if="total_revenue != 0">
+                                <t t-out="margin.total > 0 ? '+' : ''"/><t t-out="(margin.total / total_revenue * 100).toFixed()"/>%
                             </t>
                         </th>
                         <th class="text-end" t-att-class="margin.to_invoice_to_bill &lt; 0 ? 'text-danger' : 'text-success'">
@@ -90,11 +93,10 @@
                                 <t t-out="margin.to_invoice_to_bill > 0 ? '+' : ''"/><t t-out="(margin.to_invoice_to_bill / revenues.total.to_invoice * 100).toFixed()"/>%
                             </t>
                         </th>
-                        <th class="text-end" t-att-class="margin.total &lt; 0 ? 'text-danger' : 'text-success'">
-                            <t t-set="total_revenue" t-value="revenues.total.to_invoice + revenues.total.invoiced"/>
-                            <t t-out="props.formatMonetary(margin.total)"/><br/>
-                            <t t-if="total_revenue != 0">
-                                <t t-out="margin.total > 0 ? '+' : ''"/><t t-out="(margin.total / total_revenue * 100).toFixed()"/>%
+                        <th class="text-end" t-att-class="margin.invoiced_billed &lt; 0 ? 'text-danger' : 'text-success'">
+                            <t t-out="props.formatMonetary(margin.invoiced_billed)"/><br/>
+                            <t t-if="revenues.total.invoiced != 0">
+                                <t t-out="margin.invoiced_billed > 0 ? '+' : ''"/><t t-out="(margin.invoiced_billed / revenues.total.invoiced * 100).toFixed()"/>%
                             </t>
                         </th>
                     </tr>

--- a/addons/project/static/src/components/project_right_side_panel/components/project_right_side_panel_section.xml
+++ b/addons/project/static/src/components/project_right_side_panel/components/project_right_side_panel_section.xml
@@ -3,9 +3,9 @@
 
     <t t-name="project.ProjectRightSidePanelSection">
         <div class="o_rightpanel_section py-0" t-att-name="props.name" t-if="props.show">
-            <div class="o_rightpanel_header d-flex align-items-center justify-content-between py-2 bg-100 border-bottom" t-att-class="props.headerClassName" t-if="props.header">
+            <div class="o_rightpanel_header d-flex align-items-center justify-content-between py-2 border-bottom" t-att-class="props.headerClassName" t-if="props.header">
                 <div class="o_rightpanel_title d-flex flex-row-reverse align-items-center" t-if="props.slots.title">
-                    <h3 class="m-0 lh-lg"><t t-slot="title"/></h3>
+                    <h3 class="m-0 lh-lg ps-1"><t t-slot="title"/></h3>
                 </div>
                 <t t-slot="header"/>
             </div>

--- a/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.js
+++ b/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.js
@@ -1,7 +1,5 @@
-/** @odoo-module **/
-
 import { _t } from "@web/core/l10n/translation";
-import { useService } from '@web/core/utils/hooks';
+import { useBus, useService } from "@web/core/utils/hooks";
 import { formatFloat } from "@web/views/fields/formatters";
 import { ViewButton } from '@web/views/view_button/view_button';
 import { FormViewDialog } from '@web/views/view_dialogs/form_view_dialog';
@@ -11,6 +9,7 @@ import { ProjectMilestone } from './components/project_milestone';
 import { ProjectProfitability } from './components/project_profitability';
 import { getCurrency } from '@web/core/currency';
 import { Component, onWillStart, useState } from "@odoo/owl";
+import { SIZES } from "@web/core/ui/ui_service";
 
 export class ProjectRightSidePanel extends Component {
     static components = {
@@ -29,6 +28,8 @@ export class ProjectRightSidePanel extends Component {
         this.orm = useService('orm');
         this.actionService = useService('action');
         this.dialog = useService('dialog');
+        this.uiService = useService("ui");
+        useBus(this.uiService.bus, "resize", this.updateGridTemplateColumns)
         this.state = useState({
             data: {
                 milestones: {
@@ -40,10 +41,28 @@ export class ProjectRightSidePanel extends Component {
                 },
                 user: {},
                 currency_id: false,
-            }
+            },
+            gridTemplateColumns: this._getGridTemplateColumns(),
         });
 
         onWillStart(() => this.loadData());
+    }
+
+    _getGridTemplateColumns() {
+        switch (this.uiService.size) {
+            case SIZES.XS:
+                return 2;
+            case SIZES.VSM:
+                return 3;
+            case SIZES.XXL:
+                return 6;
+            default:
+                return 4;
+        }
+    }
+
+    updateGridTemplateColumns() {
+        this.state.gridTemplateColumns = this._getGridTemplateColumns();
     }
 
     get panelVisible() {

--- a/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.scss
+++ b/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.scss
@@ -36,39 +36,9 @@ $o-rightpanel-p-tiny: $o-rightpanel-p-small*0.5;
                 box-shadow: inset 0 -1px 0 $border-color;
 
                 .oe_stat_button {
-                    flex-basis: 25%;
-                    margin: 0;
-
-                    &:nth-child(4n):not(:last-child) {
-                        border-right-width: 0;
-                    }
 
                     .o_stat_text {
                         white-space: normal;
-                    }
-                }
-
-                @include media-breakpoint-down(lg) {
-                    .oe_stat_button {
-                        flex-basis: 33.33%;
-
-                        &:nth-child(3n):not(:last-child) {
-                            border-right-width: 0px;
-                        }
-
-                        &:nth-child(4n):not(:last-child){
-                            border-right-width: 1px;
-                        }
-                    }
-                }
-
-                @include media-breakpoint-down(md) {
-                    .oe_stat_button {
-                        flex-basis: 50%;
-
-                        &:nth-child(2n) {
-                            border-right-width: 0px;
-                        }
                     }
                 }
             }

--- a/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.xml
+++ b/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.xml
@@ -2,19 +2,23 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="project.ProjectRightSidePanel">
-        <div t-if="panelVisible" class="o_rightpanel pt-0 bg-view border-start border-bottom overflow-auto">
+        <div t-if="panelVisible" class="o_rightpanel ps-0 pt-0 bg-view border-start border-bottom overflow-auto">
             <ProjectRightSidePanelSection
                 name="'stat_buttons'"
                 header="false"
                 show="!!state.data.buttons"
+                dataClassName="'ps-3'"
             >
                 <div class="o_form_view">
-                    <div class="oe_button_box o-form-buttonbox d-print-none d-flex flex-wrap">
+                    <div
+                        class="oe_button_box o-form-buttonbox d-print-none d-grid"
+                        t-attf-style="grid-template-columns: repeat({{ state.gridTemplateColumns }}, 1fr);"
+                    >
                         <t t-foreach="state.data.buttons" t-as="button" t-key="button.sequence">
                             <ViewButton
                                 t-if="button.show"
                                 defaultRank="'oe_stat_button'"
-                                className="'flex-grow-0 h-auto py-2 border border-start-0 border-top-0 text-start rounded-0'"
+                                className="'h-auto py-2 border border-start-0 border-top-0 text-start rounded-0'"
                                 icon="`fa-${button.icon}`"
                                 title="button.text"
                                 clickParams="_getStatButtonClickParams(button)"
@@ -54,14 +58,15 @@
                 <div t-foreach="state.data.milestones.data" t-as="milestone" t-key="milestone.id" class="o_rightpanel_data_row">
                     <ProjectMilestone context="context" milestone="milestone" open.bind="openFormViewDialog" load.bind="loadMilestones"/>
                 </div>
-                <span t-if="state.data.milestones.data.length === 0" class="text-muted fst-italic">
-                    Track major progress points that must be reached to achieve success.
-                </span>
+                <div t-if="state.data.milestones.data.length === 0" class="ps-3">
+                    <span class="text-muted fst-italic">
+                        Track major progress points that must be reached to achieve success.
+                    </span>
+                </div>
             </ProjectRightSidePanelSection>
             <ProjectRightSidePanelSection
                 name="'profitability'"
                 show="state.data.show_project_profitability_helper"
-                dataClassName="'py-3'"
             >
                 <t t-set-slot="title">
                     Profitability
@@ -71,11 +76,14 @@
                     data="state.data.profitability_items"
                     labels="state.data.profitability_labels"
                     formatMonetary="formatMonetary.bind(this)"
+                    onProjectActionClick="onProjectActionClick.bind(this)"
                     onClick="(params) => this.onProjectActionClick(params)"
                 />
-                <span t-elif="state.data.show_project_profitability_helper" class="text-muted fst-italic">
-                    Track project costs, revenues, and margin by setting the analytic account associated with the project on relevant documents.
-                </span>
+                <div t-elif="state.data.show_project_profitability_helper" class="ps-3">
+                    <span class="text-muted fst-italic">
+                        Track project costs, revenues, and margin by setting the analytic account associated with the project on relevant documents.
+                    </span>
+                </div>
             </ProjectRightSidePanelSection>
         </div>
         <!-- If this is called from notif, multiples updates but no specific project -->

--- a/addons/project/static/src/components/project_status_with_color_selection/project_status_with_color_selection_field.js
+++ b/addons/project/static/src/components/project_status_with_color_selection/project_status_with_color_selection_field.js
@@ -9,6 +9,7 @@ export class ProjectStatusWithColorSelectionField extends SelectionField {
     static props = {
         ...SelectionField.props,
         statusLabel: { type: String, optional: true },
+        hideStatusName: { type: Boolean, optional: true },
     };
 
     static template = "project.ProjectStatusWithColorSelectionField";
@@ -34,6 +35,7 @@ export const projectStatusWithColorSelectionField = {
     extractProps: (fieldInfo, dynamicInfo) => {
         const props = selectionField.extractProps(fieldInfo, dynamicInfo);
         props.statusLabel = fieldInfo.attrs.status_label;
+        props.hideStatusName = Boolean(fieldInfo.attrs.hideStatusName);
         return props;
     },
 };

--- a/addons/project/static/src/components/project_status_with_color_selection/project_status_with_color_selection_field.xml
+++ b/addons/project/static/src/components/project_status_with_color_selection/project_status_with_color_selection_field.xml
@@ -4,12 +4,13 @@
     <t t-name="project.ProjectStatusWithColorSelectionField" t-inherit="web.SelectionField" t-inherit-mode="primary">
         <xpath expr="//t[@t-if='props.readonly']/span" position="replace">
             <div class="d-flex align-items-center">
-                <div>
-                    <span t-attf-class="o_status {{ statusColor(currentValue) }} d-inline-block"/>
-                </div>
+                <span t-attf-class="o_status {{ statusColor(currentValue) }} d-inline-block"/>
                 <div class="ps-2">
                     <div class="o_stat_text" t-if="this.props.statusLabel" t-out="this.props.statusLabel"/>
-                    <div class="o_stat_value" t-out="string" t-att-raw-value="value"/>
+                    <div class="o_stat_value" t-out="string" t-if="!this.props.hideStatusName" t-att-raw-value="value"/>
+                    <div class="o_stat_value" t-else="">
+                        <span><t t-out="this.props.record.data['update_count']"/> Status</span>
+                    </div>
                 </div>
             </div>
         </xpath>

--- a/addons/project/static/src/views/project_update_kanban/project_update_kanban.scss
+++ b/addons/project/static/src/views/project_update_kanban/project_update_kanban.scss
@@ -14,6 +14,10 @@
                     display: grid;
                     align-items: center;
                 }
+                .o_pupdate_kanban_width {
+                    flex-basis: 15%;
+                    flex-grow: 1;
+                }
                 .o_pupdate_kanban_image {
                     width: 56px;
                     height: 56px;

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -49,17 +49,11 @@
                                 </span>
                             </div>
                         </button>
-                        <button class="oe_stat_button" name="project_update_all_action" type="object" groups="project.group_project_user">
+                        <button class="oe_stat_button" name="project_update_all_action" type="object" groups="project.group_project_user" context="{'active_id': id}">
                             <field name="last_update_color" invisible="1"/>
                             <div class="o_stat_info">
-                                <field name="last_update_status" readonly="1" widget="status_with_color" status_label="Project Status"/>
-                            </div>
-                        </button>
-                        <!-- To Do: remove me in master -->
-                        <button class="oe_stat_button o_project_not_clickable" disabled="disabled" groups="!project.group_project_manager" invisible="1">
-                            <div>
-                                <field name="last_update_color" invisible="1"/>
-                                <field name="last_update_status" readonly="1" widget="status_with_color" status_label="Project Status"/>
+                                <field name="update_count" invisible="1"/>
+                                <field name="last_update_status" readonly="1" widget="status_with_color" status_label="Dashboard" hideStatusName="True"/>
                             </div>
                         </button>
                     </div>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -226,8 +226,17 @@
         <record id="project_embedded_action_project_updates" model="ir.embedded.actions">
             <field name="parent_res_model">project.project</field>
             <field name="sequence">110</field>
+            <field name="name">Dashboard</field>
             <field name="parent_action_id" ref="project.act_project_project_2_project_task_all"/>
             <field name="action_id" ref="project.project_update_all_action"/>
+        </record>
+
+        <record id="project_embedded_action_all_tasks_dashboard" model="ir.embedded.actions">
+            <field name="parent_res_model">project.project</field>
+            <field name="sequence">20</field>
+            <field name="name">Tasks</field>
+            <field name="parent_action_id" ref="project.project_update_all_action"/>
+            <field name="action_id" ref="project.act_project_project_2_project_task_all"/>
         </record>
 
     <!-- Set pivot view and arrange in order -->

--- a/addons/project/views/project_update_views.xml
+++ b/addons/project/views/project_update_views.xml
@@ -68,28 +68,28 @@
                     <t t-name="kanban-box">
                         <div t-attf-class="{{!selection_mode ? 'oe_kanban_color_' + record.color.raw_value : ''}} oe_kanban_global_click o_pupdate_kanban_card">
                             <!-- Project Update Kanban View is always ungrouped - see js_class -->
-                            <div class="o_kanban_detail_ungrouped row">
-                                <div class="col-sm-4 col-6 o_pupdate_name">
+                            <div class="o_kanban_detail_ungrouped d-flex align-items-center">
+                                <div class="pb-0 o_pupdate_name mr8 o_pupdate_kanban_width">
                                     <b><field name="name_cropped"/></b>
                                     <div class="d-flex gap-1">
                                         <field name="user_id" widget="many2one_avatar_user"/>
                                         <t t-esc="record.user_id.value"/>
                                     </div>
                                 </div>
-                                <div class="col-sm-2 text-sm-start col-6 align-end">
+                                <div class="mr8 text-sm-start o_pupdate_kanban_width">
                                     <field name="color" invisible="1"/>
                                     <b><field name="status" readonly="1" widget="status_with_color"/></b>
                                 </div>
-                                <div class="col-sm-2 col-6 pb-0">
+                                <div class="mr8 o_pupdate_kanban_width">
                                     <b><field name="progress_percentage" widget="percentage"/></b>
                                     <div>Progress</div>
                                 </div>
-                                <div class="col-sm-2 col-6 pb-0">
+                                <div class="mr8 o_pupdate_kanban_width">
                                     <b id="tasks_stats">
                                         <field name="closed_task_count"/> / <field name="task_count"/> Tasks<span invisible="not task_count"> (<field name="closed_task_percentage"/>%)</span>
                                     </b>
                                 </div>
-                                <div class="col-sm-2 col-6 pb-0 pt-2">
+                                <div class="mr8 o_pupdate_kanban_width">
                                     <b><field name="date"/></b>
                                     <div>Date</div>
                                 </div>

--- a/addons/sale_project/models/__init__.py
+++ b/addons/sale_project/models/__init__.py
@@ -1,3 +1,4 @@
+from . import account_move
 from . import account_move_line
 from . import product_product
 from . import product_template

--- a/addons/sale_project/models/account_move.py
+++ b/addons/sale_project/models/account_move.py
@@ -1,0 +1,11 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def _get_action_per_item(self):
+        action = self.env.ref('account.action_move_out_invoice_type').id
+        return {invoice.id: action for invoice in self}

--- a/addons/sale_project/static/src/components/project_right_side_panel/components/project_profitability.js
+++ b/addons/sale_project/static/src/components/project_right_side_panel/components/project_profitability.js
@@ -1,0 +1,73 @@
+import { patch } from "@web/core/utils/patch";
+import { useService } from "@web/core/utils/hooks";
+import { ProjectProfitability } from "@project/components/project_right_side_panel/components/project_profitability";
+import { formatFloat, formatFloatTime } from "@web/views/fields/formatters";
+
+patch(ProjectProfitability.prototype, {
+    setup() {
+        super.setup();
+        this.orm = useService("orm");
+        this.actionService = useService("action");
+    },
+
+    toggleSaleItems(section) {
+        section.isFolded = !section.isFolded;
+    },
+
+    _getOrmValue(offset, section) {
+        return {
+            function: "get_sale_items_data",
+            args: [this.props.projectId, offset, 5, true, section.id],
+        };
+    },
+
+    async onLoadMoreClick(section) {
+        const offset = section.sale_items.length;
+        const orm_value = this._getOrmValue(offset, section);
+        const newItems = await this.orm.call(
+            "project.project",
+            orm_value.function,
+            orm_value.args,
+            {
+                context: this.props.context,
+            }
+        );
+        if (newItems.length < 5) {
+            section.displayLoadMore = false;
+        }
+        section.sale_items = [...section.sale_items, ...newItems];
+    },
+
+    formatValue(value, unit) {
+        return unit === "Hours" ? formatFloatTime(value) : formatFloat(value);
+    },
+
+    //---------------------------------------------------------------------
+    // Handlers
+    //---------------------------------------------------------------------
+
+    /**
+     * @private
+     * @param {Object} params
+     */
+    async onSaleItemActionClick(params) {
+        if (params.resId && params.type !== "object") {
+            const action = await this.actionService.loadAction(params.name, this.props.context);
+            this.actionService.doAction({
+                ...action,
+                res_id: params.resId,
+                views: [[false, "form"]],
+            });
+        } else {
+            this.props.onProjectActionClick(params);
+        }
+    },
+});
+
+patch(ProjectProfitability, {
+    props: {
+        ...ProjectProfitability.props,
+        projectId: Number,
+        context: Object,
+    },
+});

--- a/addons/sale_project/static/src/components/project_right_side_panel/components/project_profitability.xml
+++ b/addons/sale_project/static/src/components/project_right_side_panel/components/project_profitability.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates id="template" xml:space="preserve">
+
+    <t t-name="sale_project.ProjectProfitability" t-inherit="project.ProjectProfitability" t-inherit-mode="extension">
+        <xpath expr="//a[hasclass('revenue_section')]" position="before">
+            <t t-if="revenue.isFolded">
+                <button class="btn o_group_caret fa fa-fw fa-caret-right me-1" t-on-click="() => this.toggleSaleItems(revenue)"/>
+            </t>
+            <t t-if="!revenue.isFolded and revenue.isFolded !== undefined">
+                <button name="displaySaleItems" class="btn o_group_caret fa fa-fw fa-caret-down me-1" t-on-click="() => this.toggleSaleItems(revenue)"/>
+            </t>
+        </xpath>
+        <xpath expr="//tr[hasclass('revenue_section')]" position="after">
+            <t t-if="!revenue.isFolded and revenue.isFolded !== undefined">
+                <tr>
+                    <td colspan="4" class="p-0 m-0">
+                        <table class="table table-sm table-striped table-hover mb-0">
+                            <thead>
+                                <tr class="bg-light">
+                                    <th style="padding-left:30px">Sales Order Items</th>
+                                    <th class="text-end">Sold</th>
+                                    <th class="text-end">Delivered</th>
+                                    <th class="text-end">Invoiced</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr class="bg-light" t-foreach="revenue.sale_items" t-as="sale_item" t-key="sale_item.id">
+                                    <t t-set="uom_name" t-value="sale_item.product_uom and sale_item.product_uom[1]"/>
+                                    <td style="padding-left: 30px">
+                                        <a t-if="sale_item.action" href="#" t-on-click="() => this.onSaleItemActionClick(sale_item.action)">
+                                            <t t-esc="sale_item.name"/>
+                                        </a>
+                                        <t t-else="" t-esc="sale_item.name"/>
+                                    </td>
+                                    <td class="text-end align-middle"><t t-esc="formatValue(sale_item.product_uom_qty, uom_name)"/> <t t-esc="uom_name"/></td>
+                                    <td class="text-end align-middle"><t t-esc="formatValue(sale_item.qty_delivered, uom_name)"/> <t t-esc="uom_name"/></td>
+                                    <td class="text-end align-middle"><t t-esc="formatValue(sale_item.qty_invoiced, uom_name)"/> <t t-esc="uom_name"/></td>
+                                </tr>
+                            </tbody>
+                            <tfoot>
+                                <tr class="border-0 bg-light" t-if="revenue.displayLoadMore">
+                                    <td class="text-center" colspan="4">
+                                        <a class="cursor-pointer btn-link w-100" t-on-click="() => this.onLoadMoreClick(revenue)">
+                                            Load more
+                                        </a>
+                                    </td>
+                                </tr>
+                            </tfoot>
+                        </table>
+                    </td>
+                </tr>
+            </t>
+        </xpath>
+    </t>
+</templates>

--- a/addons/sale_project/static/src/components/project_right_side_panel/project_right_side_panel.js
+++ b/addons/sale_project/static/src/components/project_right_side_panel/project_right_side_panel.js
@@ -1,56 +1,7 @@
-/** @odoo-module */
-
 import { patch } from "@web/core/utils/patch";
-import { formatFloat, formatFloatTime } from "@web/views/fields/formatters";
 import { ProjectRightSidePanel } from '@project/components/project_right_side_panel/project_right_side_panel';
 
 patch(ProjectRightSidePanel.prototype, {
-    async _loadAdditionalSalesOrderItems() {
-        const offset = this.state.data.sale_items.data.length;
-        const totalRecords = this.state.data.sale_items.total;
-        const limit = totalRecords - offset <= 5 ? totalRecords - offset : 5;
-        const saleOrderItems = await this.orm.call(
-            'project.project',
-            'get_sale_items_data',
-            [this.projectId, offset, limit],
-            {
-                context: this.context,
-            },
-        );
-        this.state.data.sale_items.data = [...this.state.data.sale_items.data, ...saleOrderItems];
-    },
-
-    async onLoadSalesOrderLinesClick() {
-        const saleItems = this.state.data.sale_items;
-        if (saleItems && saleItems.total > saleItems.data.length) {
-            await this._loadAdditionalSalesOrderItems();
-        }
-    },
-
-    formatValue(value, unit) {
-        return unit === 'Hours' ? formatFloatTime(value) : formatFloat(value);
-    },
-
-    //---------------------------------------------------------------------
-    // Handlers
-    //---------------------------------------------------------------------
-
-    /**
-     * @private
-     * @param {Object} params
-     */
-    async onSaleItemActionClick(params) {
-        if (params.resId && params.type !== 'object') {
-            const action = await this.actionService.loadAction(params.name, this.context);
-            this.actionService.doAction({
-                ...action,
-                res_id: params.resId,
-                views: [[false, 'form']]
-            });
-        } else {
-            this.onProjectActionClick(params);
-        }
-    },
 
     get panelVisible() {
         return super.panelVisible || this.state.data.show_sale_items;

--- a/addons/sale_project/static/src/components/project_right_side_panel/project_right_side_panel.xml
+++ b/addons/sale_project/static/src/components/project_right_side_panel/project_right_side_panel.xml
@@ -2,54 +2,17 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="sale_project.ProjectRightSidePanel" t-inherit="project.ProjectRightSidePanel" t-inherit-mode="extension">
-        <xpath expr="//ProjectRightSidePanelSection[@name=&quot;'milestones'&quot;]" position="after">
-            <ProjectRightSidePanelSection
-                name="'sales'"
-                show="!!state.data.sale_items?.data"
-                dataClassName="'py-3'"
-            >
-                <t t-set-slot="title">
-                    Sales
-                </t>
-                <span t-if="!state.data.sale_items.data.length" class="text-muted fst-italic">
-                    Track what you sold, delivered, and invoiced.
-                </span>
-                <table t-else="" class="table table-sm table-striped table-hover mb-0">
-                    <thead class="bg-100">
-                        <tr>
-                            <th>Sales Order Items</th>
-                            <th class="text-end">Sold</th>
-                            <th class="text-end">Delivered</th>
-                            <th class="text-end">Invoiced</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr t-foreach="state.data.sale_items.data" t-as="sale_item" t-key="sale_item.id">
-                            <t t-set="uom_name" t-value="sale_item.product_uom and sale_item.product_uom[1]"/>
-                            <td>
-                                <t t-set="sol_name" t-value="sale_item.display_name"/>
-                                <a t-if="sale_item.action" class="o_rightpanel_button" href="#" t-on-click="() => this.onSaleItemActionClick(sale_item.action)">
-                                    <t t-esc="sol_name"/>
-                                </a>
-                                <t t-else="" t-esc="sol_name"/>
-                            </td>
-                            <td class="text-end align-middle"><t t-esc="formatValue(sale_item.product_uom_qty, uom_name)"/> <t t-esc="uom_name"/></td>
-                            <td class="text-end align-middle"><t t-esc="formatValue(sale_item.qty_delivered, uom_name)"/> <t t-esc="uom_name"/></td>
-                            <td class="text-end align-middle"><t t-esc="formatValue(sale_item.qty_invoiced, uom_name)"/> <t t-esc="uom_name"/></td>
-                        </tr>
-                    </tbody>
-                    <tfoot>
-                        <tr class="o_rightpanel_nohover border-0" t-if="state.data.sale_items.total &gt; state.data.sale_items.data.length">
-                            <td class="py-3 border-bottom text-center" colspan="4">
-                                <a class="btn btn-link w-100" t-on-click="onLoadSalesOrderLinesClick">
-                                    Load more
-                                </a>
-                            </td>
-                        </tr>
-                    </tfoot>
-                </table>
-            </ProjectRightSidePanelSection>
+        <xpath expr="//ProjectProfitability" position="replace">
+            <ProjectProfitability
+                t-if="showProjectProfitability"
+                data="state.data.profitability_items"
+                labels="state.data.profitability_labels"
+                formatMonetary="formatMonetary.bind(this)"
+                onProjectActionClick="onProjectActionClick.bind(this)"
+                onClick="(params) => this.onProjectActionClick(params)"
+                projectId="projectId"
+                context="context"
+            />
         </xpath>
     </t>
-
 </templates>

--- a/addons/sale_project/tests/__init__.py
+++ b/addons/sale_project/tests/__init__.py
@@ -9,3 +9,4 @@ from . import test_reinvoice
 from . import test_res_config_settings
 from . import test_sale_project
 from . import test_so_line_milestones
+from . import test_sale_project_dashboard

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -192,19 +192,18 @@ class TestSaleProject(HttpCase, TestSaleProjectCommon):
         self.assertEqual(self.project_global._get_sale_orders(), sale_order | sale_order_2)
 
         sale_order_lines = sale_order.order_line + sale_line_1_order_2  # exclude the Section and Note Sales Order Items
-        sale_items_data = self.project_global._get_sale_items(with_action=False)
-        self.assertEqual(sale_items_data['total'], len(sale_order_lines - so_line_order_new_task_new_project - so_line_order_only_project),
-                         "Should be all the sale items linked to the global project.")
+        sale_items_data = self.project_global.get_sale_items_data(limit=5, with_action=False)
         expected_sale_line_dict = {
             sol_read['id']: sol_read
-            for sol_read in sale_order_lines.read(['display_name', 'product_uom_qty', 'qty_delivered', 'qty_invoiced', 'product_uom'])
+            for sol_read in sale_order_lines._read_format(['name', 'product_uom_qty', 'qty_delivered', 'qty_invoiced', 'product_uom', 'product_id'])
         }
         actual_sol_ids = []
-        for line in sale_items_data['data']:
-            sol_id = line['id']
-            actual_sol_ids.append(sol_id)
-            self.assertIn(sol_id, expected_sale_line_dict)
-            self.assertDictEqual(line, expected_sale_line_dict[sol_id])
+        for section in sale_items_data:
+            for line in sale_items_data[section]['data']:
+                sol_id = line['id']
+                actual_sol_ids.append(sol_id)
+                self.assertIn(sol_id, expected_sale_line_dict)
+                self.assertDictEqual(line, expected_sale_line_dict[sol_id])
         self.assertNotIn(section_sale_line_order_2.id, actual_sol_ids, 'The section Sales Order Item should not be takken into account in the Sales section of project.')
         self.assertNotIn(note_sale_line_order_2.id, actual_sol_ids, 'The note Sales Order Item should not be takken into account in the Sales section of project.')
 

--- a/addons/sale_project/tests/test_sale_project_dashboard.py
+++ b/addons/sale_project/tests/test_sale_project_dashboard.py
@@ -1,0 +1,133 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.sale_project.tests.test_project_profitability import TestProjectProfitabilityCommon as Common
+
+
+class TestProjectDashboardCommon(Common):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.dashboard_project = cls.env['project.project'].with_context({'mail_create_nolog': True}).create({
+            'name': 'Project',
+            'partner_id': cls.partner.id,
+            'account_id': cls.analytic_account.id,
+            'allow_billable': True,
+        })
+        cls.dashboard_sale_order = cls.env['sale.order'].with_context(tracking_disable=True).create({
+            'partner_id': cls.partner.id,
+            'partner_invoice_id': cls.partner.id,
+            'partner_shipping_id': cls.partner.id,
+        })
+        cls.dashboard_sale_order.action_confirm()
+        cls.dashboardSaleOrderLine = cls.env['sale.order.line'].with_context(tracking_disable=True, default_order_id=cls.dashboard_sale_order.id)
+        cls.dashboard_product_delivery_service, cls.product_milestone, cls.product_prepaid = cls.env['product.product'].create([{
+            'name': "Service Delivery",
+            'standard_price': 30,
+            'list_price': 90,
+            'type': 'service',
+            'invoice_policy': 'delivery',
+            'service_type': 'manual',
+            'uom_id': cls.uom_hour.id,
+            'uom_po_id': cls.uom_hour.id,
+            'default_code': 'SERV-ORDERED2',
+            'service_tracking': 'task_global_project',
+            'project_id': cls.dashboard_project.id,
+        }, {
+            'name': "Service Milestone",
+            'standard_price': 30,
+            'list_price': 90,
+            'type': 'service',
+            'invoice_policy': 'delivery',
+            'service_type': 'milestones',
+            'uom_id': cls.uom_hour.id,
+            'uom_po_id': cls.uom_hour.id,
+            'default_code': 'SERV-ORDERED2',
+            'service_tracking': 'task_global_project',
+            'project_id': cls.dashboard_project.id,
+        }, {
+            'name': "Product prepaid",
+            'standard_price': 30,
+            'list_price': 90,
+            'type': 'service',
+            'uom_id': cls.uom_hour.id,
+            'uom_po_id': cls.uom_hour.id,
+            'default_code': 'SERV-ORDERED2',
+            'service_tracking': 'task_global_project',
+            'project_id': cls.dashboard_project.id,
+        }])
+
+
+class TestDashboardProject(TestProjectDashboardCommon):
+    """
+    This test ensures that the method get_sale_item_data compute correctly the data needed for the project_profitability sale sub section.
+    Since the data is different for the same input when the timesheet module is installed, those tests have to be run at_install
+    """
+
+    def test_get_sale_item_data_limit_and_load_more(self):
+        """This test ensures that when more than 5 sols are present, only 5 are computed on the first call.
+        It also ensures that the call from the 'load more' button is correctly computed"""
+
+        sols = self.dashboardSaleOrderLine.create([{
+            'product_id': self.dashboard_product_delivery_service.id,
+            'product_uom_qty': i,
+        } for i in range(1, 8)])
+        sale_item_data = self.dashboard_project.get_sale_items_data(limit=5)
+        expected_dict = {
+            'materials': {'data': [], 'displayLoadMore': False},
+            'service_revenues': {
+                'data':
+                    [
+                        {'id': sols[0].id, 'name': '[SERV-ORDERED2] Service Delivery', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.dashboard_product_delivery_service.id, '[SERV-ORDERED2] Service Delivery')},
+                        {'id': sols[1].id, 'name': '[SERV-ORDERED2] Service Delivery', 'product_uom_qty': 2.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.dashboard_product_delivery_service.id, '[SERV-ORDERED2] Service Delivery')},
+                        {'id': sols[2].id, 'name': '[SERV-ORDERED2] Service Delivery', 'product_uom_qty': 3.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.dashboard_product_delivery_service.id, '[SERV-ORDERED2] Service Delivery')},
+                        {'id': sols[3].id, 'name': '[SERV-ORDERED2] Service Delivery', 'product_uom_qty': 4.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.dashboard_product_delivery_service.id, '[SERV-ORDERED2] Service Delivery')},
+                        {'id': sols[4].id, 'name': '[SERV-ORDERED2] Service Delivery', 'product_uom_qty': 5.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.dashboard_product_delivery_service.id, '[SERV-ORDERED2] Service Delivery')},
+                    ],
+                'displayLoadMore': True,
+            },
+        }
+        self.assertEqual(sale_item_data, expected_dict)
+        # add a new call with the 'section_id' to ensure that the 2 extra sol are fetched correctly.
+        sale_item_data = self.dashboard_project.get_sale_items_data(offset=5, limit=5, section_id='service_revenues')
+        expected_list = [
+            {'id': sols[5].id, 'name': '[SERV-ORDERED2] Service Delivery', 'product_uom_qty': 6.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.dashboard_product_delivery_service.id, '[SERV-ORDERED2] Service Delivery')},
+            {'id': sols[6].id, 'name': '[SERV-ORDERED2] Service Delivery', 'product_uom_qty': 7.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.dashboard_product_delivery_service.id, '[SERV-ORDERED2] Service Delivery')},
+        ]
+        self.assertEqual(sale_item_data, expected_list)
+
+    def test_get_sale_item_data_various_sols(self):
+        """This test ensures that the sols are computed and put into the correct profitability sections"""
+        self.dashboard_project.allow_billable = True
+        sol_service_1, sol_service_2, sol_service_3, sol_service_4 = self.dashboardSaleOrderLine.create([{
+                'product_id': self.product_milestone.id,
+                'product_uom_qty': 1,
+            }, {
+                'product_id': self.product_prepaid.id,
+                'product_uom_qty': 1,
+            }, {
+                'product_id': self.material_product.id,
+                'product_uom_qty': 1,
+            }, {
+                'product_id': self.dashboard_product_delivery_service.id,
+                'product_uom_qty': 1,
+        }])
+        expected_dict = {
+            'materials': {
+                'data': [
+                    {'id': sol_service_3.id, 'name': 'Material', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (1, 'Units'), 'product_id': (self.material_product.id, 'Material')}
+                ],
+                'displayLoadMore': False,
+            },
+            'service_revenues': {
+                'data': [
+                     {'id': sol_service_1.id, 'name': '[SERV-ORDERED2] Service Milestone', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.product_milestone.id, '[SERV-ORDERED2] Service Milestone')},
+                     {'id': sol_service_2.id, 'name': '[SERV-ORDERED2] Product prepaid', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.product_prepaid.id, '[SERV-ORDERED2] Product prepaid')},
+                     {'id': sol_service_4.id, 'name': '[SERV-ORDERED2] Service Delivery', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.dashboard_product_delivery_service.id, '[SERV-ORDERED2] Service Delivery')},
+                ],
+                'displayLoadMore': False,
+            },
+        }
+
+        sale_item_data = self.dashboard_project.get_sale_items_data(limit=5)
+        self.assertEqual(sale_item_data, expected_dict)

--- a/addons/sale_project/views/project_views.xml
+++ b/addons/sale_project/views/project_views.xml
@@ -42,6 +42,28 @@
         <field name="domain">[('allow_billable', '=', True)]</field>
     </record>
 
+    <record id="project_embedded_action_invoices_dashboard" model="ir.embedded.actions">
+        <field name="parent_res_model">project.project</field>
+        <field name="sequence">70</field>
+        <field name="name">Invoices</field>
+        <field name="parent_action_id" ref="project.project_update_all_action"/>
+        <field name="python_method">action_open_project_invoices</field>
+        <field name="context">{"from_embedded_action": true}</field>
+        <field name="groups_ids" eval="[(4, ref('account.group_account_invoice')), (4, ref('sales_team.group_sale_salesman'))]" />
+        <field name="domain">[('allow_billable', '=', True)]</field>
+    </record>
+
+    <record id="project_embedded_action_sales_orders_dashboard" model="ir.embedded.actions">
+        <field name="parent_res_model">project.project</field>
+        <field name="sequence">50</field>
+        <field name="name">Sales Orders</field>
+        <field name="parent_action_id" ref="project.project_update_all_action"/>
+        <field name="python_method">action_view_sos</field>
+        <field name="context">{"from_embedded_action": true}</field>
+        <field name="groups_ids" eval="[(4, ref('sales_team.group_sale_salesman'))]" />
+        <field name="domain">[('allow_billable', '=', True)]</field>
+    </record>
+
     <record id="project_embedded_action_vendor_bills" model="ir.embedded.actions">
         <field name="parent_res_model">project.project</field>
         <field name="sequence">75</field>

--- a/addons/sale_timesheet/models/project_project.py
+++ b/addons/sale_timesheet/models/project_project.py
@@ -331,6 +331,43 @@ class ProjectProject(models.Model):
         ]))
         return query
 
+    def _get_items_id_per_section_id(self):
+        return {
+            'materials': {'data': [], 'displayLoadMore': False},
+            'billable_fixed': {'data': [], 'displayLoadMore': False},
+            'billable_milestones': {'data': [], 'displayLoadMore': False},
+            'billable_time': {'data': [], 'displayLoadMore': False},
+            'billable_manual': {'data': [], 'displayLoadMore': False},
+        }
+
+    def _get_domain_from_section_id(self, section_id):
+        section_domains = {
+            'materials': [
+                ('product_id.type', '!=', 'service')
+            ],
+            'billable_fixed': [
+                ('product_id.type', '=', 'service'),
+                ('product_id.invoice_policy', '=', 'order')
+            ],
+            'billable_milestones': [
+                ('product_id.type', '=', 'service'),
+                ('product_id.invoice_policy', '=', 'delivery'),
+                ('product_id.service_type', '=', 'milestones'),
+            ],
+            'billable_time': [
+                ('product_id.type', '=', 'service'),
+                ('product_id.invoice_policy', '=', 'delivery'),
+                ('product_id.service_type', '=', 'timesheet'),
+            ],
+            'billable_manual': [
+                ('product_id.type', '=', 'service'),
+                ('product_id.invoice_policy', '=', 'delivery'),
+                ('product_id.service_type', '=', 'manual'),
+            ],
+        }
+
+        return self._get_sale_items_domain(section_domains.get(section_id, []))
+
     def _get_profitability_labels(self):
         return {
             **super()._get_profitability_labels(),

--- a/addons/sale_timesheet/models/project_update.py
+++ b/addons/sale_timesheet/models/project_update.py
@@ -12,58 +12,14 @@ class ProjectUpdate(models.Model):
     @api.model
     def _get_template_values(self, project):
         template_values = super(ProjectUpdate, self)._get_template_values(project)
-        services = self._get_services_values(project)
         profitability_values = self._get_profitability_values(project)
         show_profitability = bool(profitability_values and profitability_values.get('account_id') and (profitability_values.get('costs') or profitability_values.get('revenues')))
-        show_sold = template_values['project'].allow_billable and len(services.get('data', [])) > 0
         return {
             **template_values,
-            'show_sold': show_sold,
             'show_profitability': show_profitability,
-            'show_activities': template_values['show_activities'] or show_profitability or show_sold,
-            'services': services,
+            'show_activities': template_values['show_activities'] or show_profitability,
             'profitability': profitability_values,
             'format_value': lambda value, is_hour: str(round(value, 2)) if not is_hour else format_duration(value),
-        }
-
-    @api.model
-    def _get_services_values(self, project):
-        if not project.allow_billable:
-            return {}
-
-        services = []
-        sols = self.env['sale.order.line'].search(
-            project._get_sale_items_domain([
-                ('is_downpayment', '=', False),
-            ]),
-        )
-        product_uom_unit = self.env.ref('uom.product_uom_unit')
-        product_uom_hour = self.env.ref('uom.product_uom_hour')
-        company_uom = self.env.company.timesheet_encode_uom_id
-        for sol in sols:
-            #We only want to consider hours and days for this calculation
-            is_unit = sol.product_uom == product_uom_unit
-            if sol.product_uom.category_id == company_uom.category_id or is_unit:
-                product_uom_qty = sol.product_uom._compute_quantity(sol.product_uom_qty, company_uom, raise_if_failure=False)
-                qty_delivered = sol.product_uom._compute_quantity(sol.qty_delivered, company_uom, raise_if_failure=False)
-                qty_invoiced = sol.product_uom._compute_quantity(sol.qty_invoiced, company_uom, raise_if_failure=False)
-                unit = sol.product_uom if is_unit else company_uom
-                services.append({
-                    'name': sol.with_context(with_price_unit=True).display_name,
-                    'sold_value': product_uom_qty,
-                    'effective_value': qty_delivered,
-                    'remaining_value': product_uom_qty - qty_delivered,
-                    'invoiced_value': qty_invoiced,
-                    'unit': unit.name,
-                    'is_unit': is_unit,
-                    'is_hour': unit == product_uom_hour,
-                    'sol': sol,
-                })
-
-        return {
-            'data': services,
-            'company_unit_name': company_uom.name,
-            'is_hour': company_uom == product_uom_hour,
         }
 
     @api.model
@@ -72,13 +28,28 @@ class ProjectUpdate(models.Model):
         if not (self.env.user.has_group('project.group_project_manager') and costs_revenues):
             return {}
         profitability_items = project._get_profitability_items(False)
+        if project._get_profitability_sequence_per_invoice_type() and profitability_items and 'revenues' in profitability_items and 'costs' in profitability_items:  # sort the data values
+            profitability_items['revenues']['data'] = sorted(profitability_items['revenues']['data'], key=lambda k: k['sequence'])
+            profitability_items['costs']['data'] = sorted(profitability_items['costs']['data'], key=lambda k: k['sequence'])
         costs = sum(profitability_items['costs']['total'].values())
         revenues = sum(profitability_items['revenues']['total'].values())
         margin = revenues + costs
+        to_bill_to_invoice = profitability_items['costs']['total']['to_bill'] + profitability_items['revenues']['total']['to_invoice']
+        billed_invoiced = profitability_items['costs']['total']['billed'] + profitability_items['revenues']['total']['invoiced']
+        expected_percentage, to_bill_to_invoice_percentage, billed_invoiced_percentage = 0, 0, 0
+        if revenues:
+            expected_percentage = formatLang(self.env, (margin / revenues) * 100, digits=0)
+        if profitability_items['revenues']['total']['to_invoice']:
+            to_bill_to_invoice_percentage = formatLang(self.env, (to_bill_to_invoice / profitability_items['revenues']['total']['to_invoice']) * 100, digits=0)
+        if profitability_items['revenues']['total']['invoiced']:
+            billed_invoiced_percentage = formatLang(self.env, (billed_invoiced / profitability_items['revenues']['total']['invoiced']) * 100, digits=0)
         return {
             'account_id': project.account_id,
             'costs': profitability_items['costs'],
             'revenues': profitability_items['revenues'],
+            'expected_percentage': expected_percentage,
+            'to_bill_to_invoice_percentage': to_bill_to_invoice_percentage,
+            'billed_invoiced_percentage': billed_invoiced_percentage,
             'total': {
                 'costs': costs,
                 'revenues': revenues,

--- a/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
+++ b/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
@@ -272,26 +272,27 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
     content: "Open Dashboard",
     run: "click",
 }, {
-    trigger: ".o_rightpanel_section[name='sales'] .o_rightpanel_title:contains('Sales')",
-    content: 'Check the user sees Sales section',
-}, {
-    trigger: ".o_rightpanel_section[name='sales'] .o_rightpanel_data:contains('Prepaid Hours')",
-    content: 'Check the user sees a line in the Sales section',
-    // timer: 300,
-}, {
-    trigger: ".o_rightpanel_section .o-form-buttonbox .o_stat_text:contains('Sales Orders')",
-    content: 'Check the user sees Sales Orders Stat Button',
-}, {
     trigger: ".o_rightpanel_section[name='profitability'] .o_rightpanel_title:contains('Profitability')",
     content: 'Check the user sees Profitability section',
 }, {
     trigger: ".o_rightpanel_section[name='profitability'] .o_rightpanel_data > .o_rightpanel_subsection:eq(0) > table > thead > tr > th:eq(0):contains('Revenues')",
     content: 'Check the user sees Profitability subsection row',
 }, {
+    trigger: "button.fa-caret-right",
+    content: 'Check that the dropdown button is present',
+    run: "click",
+}, {
+    trigger: "th:contains('Sales Order Items')",
+    content: 'Check that the sale items section is present',
+}, {
+    trigger: "button.fa-caret-down",
+    content: 'Check that the button has changed',
+    run: "click",
+}, {
     trigger: ".o_rightpanel_section[name='profitability'] .o_rightpanel_data > .o_rightpanel_subsection:eq(1) > table > thead > tr > th:eq(0):contains('Costs')",
     content: 'Check the user sees Profitability subsection row',
 }, {
-    trigger: ".o_rightpanel_section[name='profitability'] .o_rightpanel_data > .o_rightpanel_subsection:eq(2) > table > thead > tr > th:eq(0):contains('Margin')",
+    trigger: ".o_rightpanel_section[name='profitability'] .o_rightpanel_data > .o_rightpanel_subsection:eq(2) > table > thead > tr > th:eq(0):contains('Total')",
     content: 'Check the user sees Profitability subsection row',
 }, {
     trigger: ".o_rightpanel_section[name='milestones'] .o_rightpanel_title:contains('Milestones')",
@@ -321,12 +322,6 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
     trigger: "div.o_field_widget[name=name] input",
     content: "Give a name to Project Update",
     run: "edit New update",
-}, {
-    trigger: ".o_field_widget[name=description] h3:contains('Sales')",
-    content: "Sales title must be in description in description",
-    }, {
-    trigger: ".o_field_widget[name=description] td:contains('Prepaid Hours')",
-    content: "Prepaid Hours title must be in description",
 }, {
     trigger: ".o_field_widget[name=description] h3:contains('Profitability')",
     content: "Profitability title must be in description",

--- a/addons/sale_timesheet/tests/__init__.py
+++ b/addons/sale_timesheet/tests/__init__.py
@@ -16,3 +16,4 @@ from . import test_project_pricing_type
 from . import test_project_update
 from . import test_sale_timesheet_accrued_entries
 from . import test_sale_timesheet_report
+from . import test_sale_timesheet_dashboard

--- a/addons/sale_timesheet/tests/test_sale_timesheet_dashboard.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet_dashboard.py
@@ -1,0 +1,81 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import tagged
+from odoo.addons.sale_project.tests.test_sale_project_dashboard import TestProjectDashboardCommon as Common
+
+
+@tagged('-at_install', 'post_install')
+class TestSaleTimesheetDashboard(Common):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.dashboard_product_delivery_timesheet = cls.env['product.product'].create({
+            'name': "Service delivered",
+            'standard_price': 11,
+            'list_price': 13,
+            'type': 'service',
+            'invoice_policy': 'delivery',
+            'uom_id': cls.uom_hour.id,
+            'uom_po_id': cls.uom_hour.id,
+            'default_code': 'SERV-DELI1',
+            'service_type': 'timesheet',
+            'service_tracking': 'no',
+            'project_id': False,
+            'taxes_id': False,
+        })
+
+    def test_get_sale_item_data_various_sol_with_timesheet_installed(self):
+        """This test ensures that when the timesheet module is installed, the sols are computed and put into the new profitability sections."""
+
+        sol_service_1, sol_service_2, sol_service_3, sol_service_4, sol_service_5 = self.dashboardSaleOrderLine.create([{
+            'product_id': self.product_milestone.id,
+            'product_uom_qty': 1,
+        }, {
+            'product_id': self.product_prepaid.id,
+            'product_uom_qty': 1,
+        }, {
+            'product_id': self.material_product.id,
+            'product_uom_qty': 1,
+        }, {
+            'product_id': self.dashboard_product_delivery_timesheet.id,
+            'product_uom_qty': 1,
+        }, {
+            'product_id': self.dashboard_product_delivery_service.id,
+            'product_uom_qty': 1,
+        }])
+        expected_dict = {
+            'materials': {
+                'data': [
+                    {'id': sol_service_3.id, 'name': 'Material', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (1, 'Units'), 'product_id': (self.material_product.id, 'Material')},
+                ],
+                'displayLoadMore': False,
+            },
+            'billable_fixed': {
+                'data': [
+                    {'id': sol_service_2.id, 'name': '[SERV-ORDERED2] Product prepaid', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.product_prepaid.id, '[SERV-ORDERED2] Product prepaid')},
+                ],
+                'displayLoadMore': False,
+            },
+            'billable_milestones': {
+                'data': [
+                    {'id': sol_service_1.id, 'name': '[SERV-ORDERED2] Service Milestone', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.product_milestone.id, '[SERV-ORDERED2] Service Milestone')},
+                ],
+                'displayLoadMore': False,
+            },
+            'billable_time': {
+                'data': [
+                    {'id': sol_service_4.id, 'name': '[SERV-DELI1] Service delivered', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.dashboard_product_delivery_timesheet.id, '[SERV-DELI1] Service delivered')},
+                ],
+                'displayLoadMore': False,
+            },
+            'billable_manual': {
+                'data': [
+                    {'id': sol_service_5.id, 'name': '[SERV-ORDERED2] Service Delivery', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.dashboard_product_delivery_service.id, '[SERV-ORDERED2] Service Delivery')},
+                ],
+                'displayLoadMore': False,
+            },
+        }
+        sale_item_data = self.dashboard_project.get_sale_items_data(with_action=False, limit=5)
+
+        self.assertEqual(sale_item_data, expected_dict)

--- a/addons/sale_timesheet/views/project_update_templates.xml
+++ b/addons/sale_timesheet/views/project_update_templates.xml
@@ -2,70 +2,35 @@
 <odoo>
     <template id="project_update_default_description" inherit_id="project.project_update_default_description">
         <!--As this template is rendered in an html field, the spaces may be interpreted as nbsp while editing. -->
-        <xpath expr="//div[@name='activities']" position="after">
+        <xpath expr="//div[@name='milestone']" position="after">
 <br/>
-<div t-if="show_sold">
-<br/>
-<h3 style="font-weight: bolder"><u>Sales</u></h3>
-<table class="table table-striped">
-<thead class="border-2 border-start-0 border-end-0">
-<td class="w-50" style="font-weight: bolder">Sales Order Items</td>
-<td style="font-weight: bolder; text-align: right;">Sold</td>
-<td style="font-weight: bolder; text-align: right;">Delivered</td>
-<td style="font-weight: bolder; text-align: right;">Remaining</td>
-<td style="font-weight: bolder; text-align: right;">Invoiced</td>
-</thead>
-<tbody>
-<tr t-foreach="services['data']" t-as="service">
-<t t-set="is_unit" t-value="service['is_unit']"/>
-<td t-attf-class="#{ 'fst-italic' if is_unit else ''}"><t t-out="service['name']"/></td>
-<td t-attf-class="#{ 'fst-italic' if is_unit else ''}" style="text-align: right; vertical-align: middle;"><t t-out="format_value(service['sold_value'], service['is_hour'])"/> <t t-out="service['unit']"/></td>
-<td t-attf-class="#{ 'fst-italic' if is_unit else ''}" style="text-align: right; vertical-align: middle;"><t t-out="format_value(service['effective_value'], service['is_hour'])"/> <t t-out="service['unit']"/></td>
-<td t-attf-class="#{ 'fst-italic' if is_unit else ''}" style="text-align: right; vertical-align: middle;"><t t-out="format_value(service['remaining_value'], service['is_hour'])"/> <t t-out="service['unit']"/></td>
-<td t-attf-class="#{ 'fst-italic' if is_unit else ''}" style="text-align: right; vertical-align: middle;"><t t-out="format_value(service['invoiced_value'], service['is_hour'])"/> <t t-out="service['unit']"/></td>
-</tr>
-</tbody>
-</table>
-<br/>
-</div>
 
 <div name="profitability" t-if="show_profitability">
 <t t-if="project.account_id and project.allow_billable and user.has_group('project.group_project_manager')" name="costs">
 <h3 style="font-weight: bolder"><u>Profitability</u></h3>
-<t t-if="project.sudo().account_id"> The cost of the project is now at <t t-out="format_monetary(profitability['total']['costs'])"/>, for a revenue of <t t-out="format_monetary(profitability['total']['revenues'])"/>, leading to a
-<span>
-<font t-if="profitability['total']['margin'] &gt; 0"  style="color: rgb(0, 128, 0)">
-<b><t t-out="format_monetary(profitability['total']['margin'])"/></b>
-</font>
-<font t-elif="profitability['total']['margin'] &lt; 0" style="color: rgb(128, 0, 0)">
-<b><t t-out="format_monetary(profitability['total']['margin'])"/></b>
-</font>
-<t t-else="" t-out="format_monetary(profitability['total']['margin'])"/>
-</span> margin (<t t-out="profitability['total']['margin_percentage']"/>%).
-</t>
 
 <div t-if="profitability['costs']['data'] or profitability['revenues']['data']" name="profitability_detail" class="mt-4">
 <table class="table table-striped">
 <thead class="border-2 border-start-0 border-end-0">
 <tr>
-<th class="fw-bolder">Revenues</th>
-<th class="fw-bolder text-end">Invoiced</th>
-<th class="fw-bolder text-end">To Invoice</th>
-<th class="fw-bolder text-end">Expected</th>
+<th class="fw-bolder" style="width: 55%">Revenues</th>
+<th class="fw-bolder text-end" style="width: 15%">Expected</th>
+<th class="fw-bolder text-end" style="width: 15%">To Invoice</th>
+<th class="fw-bolder text-end" style="width: 15%">Invoiced</th>
 </tr>
 </thead>
 <tbody>
 <tr t-foreach="profitability['revenues']['data']" t-as="revenue">
 <td t-out="profitability['labels'][revenue['id']]"/>
-<td class="text-end" t-out="format_monetary(revenue['invoiced'])"/>
-<td class="text-end" t-out="format_monetary(revenue['to_invoice'])"/>
 <td class="text-end" t-out="format_monetary(revenue['invoiced'] + revenue['to_invoice'])"/>
+<td class="text-end" t-out="format_monetary(revenue['to_invoice'])"/>
+<td class="text-end" t-out="format_monetary(revenue['invoiced'])"/>
 </tr>
 <tfoot>
 <td class="fw-bolder text-end">Total</td>
-<td class="fw-bolder text-end" t-out="format_monetary(profitability['revenues']['total']['invoiced'])"/>
-<td class="fw-bolder text-end" t-out="format_monetary(profitability['revenues']['total']['to_invoice'])"/>
 <td class="fw-bolder text-end" t-out="format_monetary(profitability['revenues']['total']['invoiced'] + profitability['revenues']['total']['to_invoice'])"/>
+<td class="fw-bolder text-end" t-out="format_monetary(profitability['revenues']['total']['to_invoice'])"/>
+<td class="fw-bolder text-end" t-out="format_monetary(profitability['revenues']['total']['invoiced'])"/>
 </tfoot>
 </tbody>
 </table>
@@ -73,24 +38,24 @@
 <table class="table table-striped mt-4">
 <thead class="border-2 border-start-0 border-end-0">
 <tr>
-<th class="fw-bolder">Costs</th>
-<th class="fw-bolder text-end">Billed</th>
-<th class="fw-bolder text-end">To Bill</th>
-<th class="fw-bolder text-end">Expected</th>
+<th class="fw-bolder" style="width: 55%">Costs</th>
+<th class="fw-bolder text-end" style="width: 15%">Expected</th>
+<th class="fw-bolder text-end" style="width: 15%">To Bill</th>
+<th class="fw-bolder text-end" style="width: 15%">Billed</th>
 </tr>
 </thead>
 <tbody>
 <tr t-foreach="profitability['costs']['data']" t-as="cost">
 <td t-out="profitability['labels'][cost['id']]"/>
-<td class="text-end" t-out="format_monetary(cost['billed'])"/>
-<td class="text-end" t-out="format_monetary(cost['to_bill'])"/>
 <td class="text-end" t-out="format_monetary(cost['billed'] - cost['to_bill'])"/>
+<td class="text-end" t-out="format_monetary(cost['to_bill'])"/>
+<td class="text-end" t-out="format_monetary(cost['billed'])"/>
 </tr>
 <tfoot>
 <td class="fw-bolder text-end">Total</td>
-<td class="fw-bolder text-end" t-out="format_monetary(profitability['costs']['total']['billed'])"/>
-<td class="fw-bolder text-end" t-out="format_monetary(profitability['costs']['total']['to_bill'])"/>
 <td class="fw-bolder text-end" t-out="format_monetary(profitability['costs']['total']['billed'] - profitability['costs']['total']['to_bill'])"/>
+<td class="fw-bolder text-end" t-out="format_monetary(profitability['costs']['total']['to_bill'])"/>
+<td class="fw-bolder text-end" t-out="format_monetary(profitability['costs']['total']['billed'])"/>
 </tfoot>
 </tbody>
 </table>
@@ -98,9 +63,27 @@
 <table class="table table-sm mt-4">
 <tr>
 <td class="fw-bolder">Margin</td>
-<td t-attf-class="#{'text-danger' if profitability['total']['costs'] &lt; 0 else 'text-success'}" style="text-align: right; font-weight: bolder"><t t-out="format_monetary(profitability['total']['costs'])"/></td>
-<td t-attf-class="#{'text-danger' if profitability['total']['revenues'] &lt; 0 else 'text-success'}" style="text-align: right; font-weight: bolder"><t t-out="format_monetary(profitability['total']['revenues'])"/></td>
-<td t-attf-class="#{'text-danger' if profitability['total']['margin'] &lt; 0 else 'text-success'}" style="text-align: right; font-weight: bolder"><t t-out="format_monetary(profitability['total']['margin'])"/></td>
+<td t-attf-class="#{'text-danger' if profitability['total']['margin'] &lt; 0 else 'text-success'}" style="text-align: right; font-weight: bolder">
+<t t-out="format_monetary(profitability['total']['margin'])"/><br/>
+    <t t-if="profitability['expected_percentage']">
+
+        <t t-out="profitability['expected_percentage']"/><t>%</t>
+    </t>
+</td>
+<td t-attf-class="#{'text-danger' if profitability['total']['revenues'] &lt; 0 else 'text-success'}" style="text-align: right; font-weight: bolder">
+    <t t-out="format_monetary(profitability['total']['revenues'])"/><br/>
+    <t t-if="profitability['to_bill_to_invoice_percentage']">
+
+        <t t-out="profitability['to_bill_to_invoice_percentage']"/><t>%</t>
+    </t>
+</td>
+<td t-attf-class="#{'text-danger' if profitability['total']['costs'] &lt; 0 else 'text-success'}" style="text-align: right; font-weight: bolder">
+    <t t-out="format_monetary(profitability['total']['costs'])"/><br/>
+    <t t-if="profitability['billed_invoiced_percentage']">
+
+        <t t-out="profitability['billed_invoiced_percentage']"/><t>%</t>
+    </t>
+</td>
 </tr>
 </table>
 </div>


### PR DESCRIPTION
This commit's purpose is to improve the visual of the project update section. See the task for more detail on the visual improvement.

Functionally, the sale section of the right panel data has been removed. The sale order lines can now instead be found under their corresponding profitability section by pressing the button to unfold the section. By default, only 5 items are loaded, when a section is open, it is possible for the user to press the load more button to load more sol that are specific to this section, and not generic. The reason we only load 5 items in total when the page is loaded on the first time, is to avoid needless searches. The project profitability is already potentially quite long to load.

task - 4047543

