### PR TITLE
[IMP] core: Environment._ for translations and LazyTranslate

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -821,16 +821,16 @@ class AccountAccount(models.Model):
                     cache[company.id].add(new_code)
 
             if 'name' not in default:
-                vals['name'] = _("%s (copy)", account.name or '')
+                vals['name'] = self.env._("%s (copy)", account.name or '')
 
         return vals_list
 
     def copy_translations(self, new, excluded=()):
         super().copy_translations(new, excluded=tuple(excluded)+('name',))
-        if new.name == _('%s (copy)', self.name):
+        if new.name == self.env._('%s (copy)', self.name):
             name_field = self._fields['name']
             self.env.cache.update_raw(new, name_field, [{
-                lang: _('%s (copy)', tr)
+                lang: self.env._('%s (copy)', tr)
                 for lang, tr in name_field._get_stored_translations(self).items()
             }], dirty=True)
 

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3512,7 +3512,7 @@ class AccountMove(models.Model):
             move_hashes = chain['moves']._calculate_hashes(chain['previous_hash'])
             for move, move_hash in move_hashes.items():
                 move.inalterable_hash = move_hash
-            chain['moves']._message_log_batch(bodies={m.id: _("This journal entry has been secured.") for m in chain['moves']})
+            chain['moves']._message_log_batch(bodies={m.id: self.env._("This journal entry has been secured.") for m in chain['moves']})
 
     def _get_chain_info(self, force_hash=False, include_pre_last_hash=False, early_stop=False):
         """All records in `self` must belong to the same journal and sequence_prefix
@@ -5006,6 +5006,7 @@ class AccountMove(models.Model):
         :param job_count: maximum number of jobs to process if specified.
         """
         def get_account_notification(moves, is_success: bool):
+            _ = self.env._
             return [
                 'account_notification',
                 {

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -993,7 +993,7 @@ class AccountMoveLine(models.Model):
                     'move_id': line.move_id.id,
                     'display_type': line.display_type,
                 }): {
-                    'name': _('%(tax_name)s (Discount)', tax_name=tax['name']) if line.display_type == 'epd' else tax['name'],
+                    'name': self.env._('%(tax_name)s (Discount)', tax_name=tax['name']) if line.display_type == 'epd' else tax['name'],
                     'balance': sign * tax['amount'] / rate,
                     'amount_currency': sign * tax['amount'],
                     'tax_base_amount': sign * tax['base'] / rate * (-1 if line.tax_tag_invert else 1),

--- a/addons/account/models/account_partial_reconcile.py
+++ b/addons/account/models/account_partial_reconcile.py
@@ -125,7 +125,7 @@ class AccountPartialReconcile(models.Model):
         if moves_to_reverse:
             default_values_list = [{
                 'date': move._get_accounting_date(move.date, move._affect_tax_report()),
-                'ref': _('Reversal of: %s', move.name),
+                'ref': move.env._('Reversal of: %s', move.name),
             } for move in moves_to_reverse]
             moves_to_reverse._reverse_moves(default_values_list, cancel=True)
 

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -365,7 +365,9 @@ class AccountTax(models.Model):
             for line in old_line_values_dict.keys() & new_line_values_dict.keys()
         ]
         added_and_deleted_lines = [
-            (line, _('Removed'), old_line_values_dict[line]) if line in old_line_values_dict else (line, _('New'), new_line_values_dict[line])
+            (line, self.env._('Removed'), old_line_values_dict[line])
+            if line in old_line_values_dict
+            else (line, self.env._('New'), new_line_values_dict[line])
             for line in old_line_values_dict.keys() ^ new_line_values_dict.keys()
         ]
 

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -10,14 +10,12 @@ from copy import deepcopy
 import logging
 import re
 
-from psycopg2.extras import Json
-
-from odoo import Command, _, models, api
+from odoo import Command, api, models
 from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
 from odoo.exceptions import AccessError, UserError
 from odoo.modules import get_resource_from_path
 from odoo.tools import file_open, get_lang, groupby, SQL
-from odoo.tools.translate import code_translations, TranslationImporter
+from odoo.tools.translate import _, code_translations, TranslationImporter
 
 _logger = logging.getLogger(__name__)
 
@@ -1115,7 +1113,7 @@ class AccountChartTemplate(models.AbstractModel):
                     format_tag = re.sub(r'\s+', ' ', tag.strip())
                     mapped_tag = tags.get(format_tag)
                     if not mapped_tag:
-                        raise UserError(_('Error while loading the localization. You should probably update your localization app first.'))
+                        raise UserError(self.env._('Error while loading the localization. You should probably update your localization app first.'))
                     res.append(mapped_tag)
             return res
         return mapping_getter

--- a/addons/account/models/mail_message.py
+++ b/addons/account/models/mail_message.py
@@ -1,5 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo import api, fields, models, _
+from odoo import api, fields, models
 from odoo.exceptions import UserError
 from odoo.osv.expression import OR
 
@@ -64,7 +64,7 @@ class Message(models.Model):
             title = message.subject or message.preview
             tracking_value_ids = message.sudo().tracking_value_ids._filter_has_field_access(self.env)
             if not title and tracking_value_ids:
-                title = _("Updated")
+                title = self.env._("Updated")
             if not title and message.subtype_id and not message.subtype_id.internal:
                 title = message.subtype_id.display_name
             audit_log_preview = (title or '') + '\n'
@@ -120,7 +120,7 @@ class Message(models.Model):
 
     def _search_account_audit_log_activated(self, operator, value):
         if operator not in ['=', '!='] or not isinstance(value, bool):
-            raise UserError(_('Operation not supported'))
+            raise UserError(self.env._('Operation not supported'))
         return [('message_type', '=', 'notification')] + OR([
             [('model', '=', model), ('res_id', 'in', self.env[model]._search(DOMAINS[model](operator, value)))]
             for model in DOMAINS
@@ -142,7 +142,7 @@ class Message(models.Model):
         elif operator in ['=', 'in', '!=', 'not in']:
             res_id_domain = [('res_id', operator, value)]
         else:
-            raise UserError(_('Operation not supported'))
+            raise UserError(self.env._('Operation not supported'))
         return [('model', '=', model)] + res_id_domain
 
     @api.ondelete(at_uninstall=True)
@@ -154,7 +154,7 @@ class Message(models.Model):
                 message.account_audit_log_move_id
                 and not message.account_audit_log_move_id.posted_before
             ):
-                raise UserError(_("You cannot remove parts of the audit trail. Archive the record instead."))
+                raise UserError(self.env._("You cannot remove parts of the audit trail. Archive the record instead."))
 
     def write(self, vals):
         if (

--- a/addons/account/wizard/account_move_reversal.py
+++ b/addons/account/wizard/account_move_reversal.py
@@ -142,7 +142,7 @@ class AccountMoveReversal(models.TransientModel):
         for moves, default_values_list, is_cancel_needed in batches:
             new_moves = moves._reverse_moves(default_values_list, cancel=is_cancel_needed)
             moves._message_log_batch(
-                bodies={move.id: _('This entry has been %s', reverse._get_html_link(title=_("reversed"))) for move, reverse in zip(moves, new_moves)}
+                bodies={move.id: move.env._('This entry has been %s', reverse._get_html_link(title=move.env._("reversed"))) for move, reverse in zip(moves, new_moves)}
             )
 
             if is_modify:

--- a/addons/account_test/report/report_account_test.py
+++ b/addons/account_test/report/report_account_test.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import datetime
-from odoo import api, models, _
+from odoo import api, models
 from odoo.tools.safe_eval import safe_eval
 #
 # Use period and Journal for selection or resources
@@ -41,7 +41,7 @@ class ReportAssertAccount(models.AbstractModel):
             'reconciled_inv': reconciled_inv,  # specific function used in different tests
             'result': None,  # used to store the result of the test
             'column_order': None,  # used to choose the display order of columns (in case you are returning a list of dict)
-            '_': _,
+            '_': self.env._,
         }
         safe_eval(code_exec, localdict, mode="exec", nocopy=True)
         result = localdict['result']
@@ -50,7 +50,7 @@ class ReportAssertAccount(models.AbstractModel):
         if not isinstance(result, (tuple, list, set)):
             result = [result]
         if not result:
-            result = [_('The test was passed successfully')]
+            result = [self.env._('The test was passed successfully')]
         else:
             def _format(item):
                 if isinstance(item, dict):

--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -9,11 +9,11 @@ from stdnum import luhn
 
 import logging
 
-from odoo import api, models, fields, _
-from odoo.tools import zeep
+from odoo import api, models, fields
+from odoo.tools import _, zeep, LazyTranslate
 from odoo.exceptions import ValidationError
 
-
+_lt = LazyTranslate(__name__)
 _logger = logging.getLogger(__name__)
 
 _eu_country_vat = {
@@ -24,32 +24,32 @@ _eu_country_vat_inverse = {v: k for k, v in _eu_country_vat.items()}
 
 _ref_vat = {
     'al': 'ALJ91402501L',
-    'ar': _('AR200-5536168-2 or 20055361682'),
+    'ar': _lt('AR200-5536168-2 or 20055361682'),
     'at': 'ATU12345675',
     'au': '83 914 571 673',
     'be': 'BE0477472701',
     'bg': 'BG1234567892',
-    'br': _('either 11 digits for CPF or 14 digits for CNPJ'),
-    'cr': _('3101012009'),
-    'ch': _('CHE-123.456.788 TVA or CHE-123.456.788 MWST or CHE-123.456.788 IVA'),  # Swiss by Yannick Vaucher @ Camptocamp
+    'br': _lt('either 11 digits for CPF or 14 digits for CNPJ'),
+    'cr': _lt('3101012009'),
+    'ch': _lt('CHE-123.456.788 TVA or CHE-123.456.788 MWST or CHE-123.456.788 IVA'),  # Swiss by Yannick Vaucher @ Camptocamp
     'cl': 'CL76086428-5',
-    'co': _('CO213123432-1 or CO213.123.432-1'),
+    'co': _lt('CO213123432-1 or CO213.123.432-1'),
     'cy': 'CY10259033P',
     'cz': 'CZ12345679',
-    'de': _('DE123456788 or 12/345/67890'),
+    'de': _lt('DE123456788 or 12/345/67890'),
     'dk': 'DK12345674',
-    'do': _('DO1-01-85004-3 or 101850043'),
-    'ec': _('1792060346001 or 1792060346'),
+    'do': _lt('DO1-01-85004-3 or 101850043'),
+    'ec': _lt('1792060346001 or 1792060346'),
     'ee': 'EE123456780',
     'es': 'ESA12345674',
     'fi': 'FI12345671',
     'fr': 'FR23334175221',
-    'gb': _('GB123456782 or XI123456782'),
+    'gb': _lt('GB123456782 or XI123456782'),
     'gr': 'EL123456783',
-    'hu': _('HU12345676 or 12345678-1-11 or 8071592153'),
+    'hu': _lt('HU12345676 or 12345678-1-11 or 8071592153'),
     'hr': 'HR01234567896',  # Croatia, contributed by Milan Tribuson
     'ie': 'IE1234567FA',
-    'il': _('XXXXXXXXX [9 digits] and it should respect the Luhn algorithm checksum'),
+    'il': _lt('XXXXXXXXX [9 digits] and it should respect the Luhn algorithm checksum'),
     'in': "12AAAAA1234AAZA",
     'is': 'IS062199',
     'it': 'IT12345670017',
@@ -58,11 +58,11 @@ _ref_vat = {
     'lv': 'LV41234567891',
     'mc': 'FR53000004605',
     'mt': 'MT12345634',
-    'mx': _('MXGODE561231GR8 or GODE561231GR8'),
+    'mx': _lt('MXGODE561231GR8 or GODE561231GR8'),
     'nl': 'NL123456782B90',
     'no': 'NO123456785',
-    'nz': _('49-098-576 or 49098576'),
-    'pe': _('10XXXXXXXXY or 20XXXXXXXXY or 15XXXXXXXXY or 16XXXXXXXXY or 17XXXXXXXXY'),
+    'nz': _lt('49-098-576 or 49098576'),
+    'pe': _lt('10XXXXXXXXY or 20XXXXXXXXY or 15XXXXXXXXY or 16XXXXXXXXY or 17XXXXXXXXY'),
     'ph': '123-456-789-123',
     'pl': 'PL1234567883',
     'pt': 'PT123456789',
@@ -73,11 +73,11 @@ _ref_vat = {
     'si': 'SI12345679',
     'sk': 'SK2022749619',
     'sm': 'SM24165',
-    'tr': _('TR1234567890 (VERGINO) or TR17291716060 (TCKIMLIKNO)'),  # Levent Karakas @ Eska Yazilim A.S.
-    'uy': _("'219999830019' (should be 12 digits)"),
+    'tr': _lt('TR1234567890 (VERGINO) or TR17291716060 (TCKIMLIKNO)'),  # Levent Karakas @ Eska Yazilim A.S.
+    'uy': _lt("'219999830019' (should be 12 digits)"),
     've': 'V-12345678-1, V123456781, V-12.345.678-1',
     'xi': 'XI123456782',
-    'sa': _('310175397400003 [Fifteen digits, first and last digits should be "3"]')
+    'sa': _lt('310175397400003 [Fifteen digits, first and last digits should be "3"]')
 }
 
 _region_specific_vat_codes = {

--- a/addons/delivery/models/delivery_carrier.py
+++ b/addons/delivery/models/delivery_carrier.py
@@ -223,7 +223,7 @@ class DeliveryCarrier(models.Model):
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)
-        return [dict(vals, name=_("%s (copy)", carrier.name)) for carrier, vals in zip(self, vals_list)]
+        return [dict(vals, name=self.env._("%s (copy)", carrier.name)) for carrier, vals in zip(self, vals_list)]
 
     def _get_delivery_type(self):
         """Return the delivery type.

--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -674,7 +674,7 @@ class EventEvent(models.Model):
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)
-        return [dict(vals, name=_("%s (copy)", event.name)) for event, vals in zip(self, vals_list)]
+        return [dict(vals, name=self.env._("%s (copy)", event.name)) for event, vals in zip(self, vals_list)]
 
     @api.model
     def _get_mail_message_access(self, res_ids, operation, model_name=None):

--- a/addons/event/models/event_stage.py
+++ b/addons/event/models/event_stage.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, fields, models
+from odoo import fields, models
 
 
 class EventStage(models.Model):
@@ -17,11 +17,11 @@ class EventStage(models.Model):
         string='End Stage', default=False,
         help='Events will automatically be moved into this stage when they are finished. The event moved into this stage will automatically be set as green.')
     legend_blocked = fields.Char(
-        'Red Kanban Label', default=lambda s: _('Blocked'), translate=True, prefetch='legend', required=True,
+        'Red Kanban Label', default=lambda s: s.env._('Blocked'), translate=True, prefetch='legend', required=True,
         help='Override the default value displayed for the blocked state for kanban selection.')
     legend_done = fields.Char(
-        'Green Kanban Label', default=lambda s: _('Ready for Next Stage'), translate=True, prefetch='legend', required=True,
+        'Green Kanban Label', default=lambda s: s.env._('Ready for Next Stage'), translate=True, prefetch='legend', required=True,
         help='Override the default value displayed for the done state for kanban selection.')
     legend_normal = fields.Char(
-        'Grey Kanban Label', default=lambda s: _('In Progress'), translate=True, prefetch='legend', required=True,
+        'Grey Kanban Label', default=lambda s: s.env._('In Progress'), translate=True, prefetch='legend', required=True,
         help='Override the default value displayed for the normal state for kanban selection.')

--- a/addons/hr/models/hr_job.py
+++ b/addons/hr/models/hr_job.py
@@ -47,7 +47,7 @@ class Job(models.Model):
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)
-        return [dict(vals, name=_("%s (copy)", job.name)) for job, vals in zip(self, vals_list)]
+        return [dict(vals, name=self.env._("%s (copy)", job.name)) for job, vals in zip(self, vals_list)]
 
     def write(self, vals):
         if len(self) == 1:

--- a/addons/hr_holidays/models/hr_leave_accrual_plan.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan.py
@@ -139,7 +139,7 @@ class AccrualPlan(models.Model):
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)
-        return [dict(vals, name=_("%s (copy)", plan.name)) for plan, vals in zip(self, vals_list)]
+        return [dict(vals, name=self.env._("%s (copy)", plan.name)) for plan, vals in zip(self, vals_list)]
 
     @api.ondelete(at_uninstall=False)
     def _prevent_used_plan_unlink(self):

--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -377,7 +377,7 @@ class HolidaysType(models.Model):
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)
-        return [dict(vals, name=_("%s (copy)", leave_type.name)) for leave_type, vals in zip(self, vals_list)]
+        return [dict(vals, name=self.env._("%s (copy)", leave_type.name)) for leave_type, vals in zip(self, vals_list)]
 
     def action_see_days_allocated(self):
         self.ensure_one()

--- a/addons/hr_homeworking/models/hr_homeworking.py
+++ b/addons/hr_homeworking/models/hr_homeworking.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 
 DAYS = ['monday_location_id', 'tuesday_location_id', 'wednesday_location_id', 'thursday_location_id', 'friday_location_id', 'saturday_location_id', 'sunday_location_id']
 
@@ -18,7 +18,7 @@ class HrEmployeeLocation(models.Model):
     day_week_string = fields.Char(compute="_compute_day_week_string")
 
     _sql_constraints = [
-        ('uniq_exceptional_per_day', 'unique(employee_id, date)', _('Only one default work location and one exceptional work location per day per employee.')),
+        ('uniq_exceptional_per_day', 'unique(employee_id, date)', 'Only one default work location and one exceptional work location per day per employee.'),
     ]
 
     @api.depends('date')

--- a/addons/hr_skills/models/hr_skill_type.py
+++ b/addons/hr_skills/models/hr_skill_type.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from random import randint
-from odoo import _, fields, models
+from odoo import fields, models
 
 
 class SkillType(models.Model):
@@ -20,4 +20,4 @@ class SkillType(models.Model):
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)
-        return [dict(vals, name=_("%s (copy)", skill_type.name), color=0) for skill_type, vals in zip(self, vals_list)]
+        return [dict(vals, name=self.env._("%s (copy)", skill_type.name), color=0) for skill_type, vals in zip(self, vals_list)]

--- a/addons/hr_timesheet/__init__.py
+++ b/addons/hr_timesheet/__init__.py
@@ -7,7 +7,7 @@ from . import report
 from . import wizard
 from . import populate
 
-from odoo import fields, _
+from odoo import fields
 
 from odoo.addons.project import _check_exists_collaborators_for_project_sharing
 
@@ -22,7 +22,7 @@ def create_internal_project(env):
         return
     project_ids = env['res.company'].search([])._create_internal_project_task()
     env['account.analytic.line'].create([{
-        'name': _("Analysis"),
+        'name': env._("Analysis"),
         'user_id': admin.id,
         'date': fields.datetime.today(),
         'unit_amount': 0,

--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -4,10 +4,11 @@ from collections import defaultdict
 from statistics import mode
 import re
 
-from odoo import api, fields, models, _, _lt
+from odoo import api, fields, models
 from odoo.exceptions import UserError, AccessError, ValidationError
 from odoo.osv import expression
 from odoo.tools import format_list
+from odoo.tools.translate import _
 
 
 class AccountAnalyticLine(models.Model):
@@ -230,7 +231,7 @@ class AccountAnalyticLine(models.Model):
                 employee_id_per_company_per_user[employee.user_id.id][employee.company_id.id] = employee.id
 
         # 4/ Put valid employee_id in each vals
-        error_msg = _lt('Timesheets must be created with an active employee in the selected companies.')
+        error_msg = _('Timesheets must be created with an active employee in the selected companies.')
         for vals in vals_list:
             if not vals.get('project_id'):
                 continue

--- a/addons/hr_timesheet/models/project_project.py
+++ b/addons/hr_timesheet/models/project_project.py
@@ -2,9 +2,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from collections import defaultdict
 
-from odoo import models, fields, api, _, _lt
-from odoo.exceptions import ValidationError, RedirectWarning
+from odoo import api, fields, models
+from odoo.exceptions import RedirectWarning, ValidationError
 from odoo.tools import SQL
+from odoo.tools.translate import _
 
 
 class Project(models.Model):
@@ -236,7 +237,7 @@ class Project(models.Model):
             number = f"{round(effective)} / {round(allocated)} {encode_uom.name}"
             success_rate = round(100 * effective / allocated)
             if success_rate > 100:
-                number = _lt(
+                number = self.env._(
                     "%(effective)s / %(allocated)s %(uom_name)s",
                     effective=round(effective),
                     allocated=round(allocated),
@@ -244,7 +245,7 @@ class Project(models.Model):
                 )
                 color = "text-danger"
             else:
-                number = _lt(
+                number = self.env._(
                     "%(effective)s / %(allocated)s %(uom_name)s (%(success_rate)s%%)",
                     effective=round(effective),
                     allocated=round(allocated),
@@ -256,7 +257,7 @@ class Project(models.Model):
                 else:
                     color = "text-success"
         else:
-            number = _lt(
+            number = self.env._(
                     "%(effective)s %(uom_name)s",
                     effective=round(effective),
                     uom_name=encode_uom.name,
@@ -264,7 +265,7 @@ class Project(models.Model):
 
         buttons.append({
             "icon": f"clock-o {color}",
-            "text": _lt("Timesheets"),
+            "text": self.env._("Timesheets"),
             "number": number,
             "action_type": "object",
             "action": "action_project_timesheets",
@@ -274,8 +275,8 @@ class Project(models.Model):
         if allocated and success_rate > 100:
             buttons.append({
                 "icon": f"warning {color}",
-                "text": _lt("Extra Time"),
-                "number": _lt(
+                "text": self.env._("Extra Time"),
+                "number": self.env._(
                     "%(exceeding_hours)s %(uom_name)s (+%(exceeding_rate)s%%)",
                     exceeding_hours=round(effective - allocated),
                     uom_name=encode_uom.name,

--- a/addons/im_livechat/models/chatbot_script.py
+++ b/addons/im_livechat/models/chatbot_script.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, api, models, fields
+from odoo import api, models, fields
 from odoo.http import request
 from odoo.tools import email_normalize, get_lang, html2plaintext, is_html_empty, plaintext2html
 
@@ -55,7 +55,7 @@ class ChatbotScript(models.Model):
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)
-        return [dict(vals, title=_("%s (copy)", script.title)) for script, vals in zip(self, vals_list)]
+        return [dict(vals, title=self.env._("%s (copy)", script.title)) for script, vals in zip(self, vals_list)]
 
     def copy(self, default=None):
         """ Correctly copy the 'triggering_answer_ids' field from the original script_step_ids to the clone.
@@ -204,7 +204,7 @@ class ChatbotScript(models.Model):
         posted_message = False
         error_message = False
         if not email_normalized:
-            error_message = _(
+            error_message = self.env._(
                 "'%(input_email)s' does not look like a valid email. Can you please try again?",
                 input_email=email_address
             )

--- a/addons/l10n_ar_website_sale/controllers/main.py
+++ b/addons/l10n_ar_website_sale/controllers/main.py
@@ -1,6 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, _lt
 from odoo.http import request
 
 from odoo.addons.website_sale.controllers.main import WebsiteSale
@@ -31,7 +30,7 @@ class L10nARWebsiteSale(WebsiteSale):
                 'identification_types': LatamIdentificationType.search([
                     '|', ('country_id', '=', False), ('country_id.code', '=', 'AR'),
                 ]) if can_edit_vat else LatamIdentificationType,
-                'vat_label': _lt("Number"),
+                'vat_label': request.env._("Number"),
             })
         return rendering_values
 
@@ -73,7 +72,7 @@ class L10nARWebsiteSale(WebsiteSale):
             # and if the identification type is different from CUIT
             if afip_resp.code not in ['5', '9'] and id_type != request.env.ref('l10n_ar.it_cuit'):
                 invalid_fields.add('l10n_latam_identification_type_id')
-                error_messages.append(_(
+                error_messages.append(request.env._(
                     "For the selected AFIP Responsibility you will need to set CUIT Identification Type"))
 
         return invalid_fields, missing_fields, error_messages

--- a/addons/l10n_ch/models/res_bank.py
+++ b/addons/l10n_ch/models/res_bank.py
@@ -7,8 +7,11 @@ from stdnum.util import clean
 from odoo import api, fields, models, _
 from odoo.addons.base.models.res_bank import sanitize_account_number
 from odoo.addons.base_iban.models.res_partner_bank import normalize_iban, pretty_iban, validate_iban
-from odoo.exceptions import ValidationError, UserError
+from odoo.exceptions import ValidationError
+from odoo.tools import LazyTranslate
 from odoo.tools.misc import mod10r
+
+_lt = LazyTranslate(__name__)
 
 
 def validate_qr_iban(qr_iban):
@@ -19,11 +22,11 @@ def validate_qr_iban(qr_iban):
     sanitized_qr_iban = sanitize_account_number(qr_iban)
 
     if sanitized_qr_iban[:2] not in ['CH', 'LI']:
-        raise ValidationError(_("QR-IBAN numbers are only available in Switzerland."))
+        raise ValidationError(_lt("QR-IBAN numbers are only available in Switzerland."))
 
     # Now, check if it's valid QR-IBAN (based on its IID).
     if not check_qr_iban_range(sanitized_qr_iban):
-        raise ValidationError(_("QR-IBAN “%s” is invalid.", qr_iban))
+        raise ValidationError(_lt("QR-IBAN “%s” is invalid.", qr_iban))
 
     return True
 

--- a/addons/l10n_cl/models/res_partner.py
+++ b/addons/l10n_cl/models/res_partner.py
@@ -1,23 +1,22 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import stdnum
-from odoo import _, api, fields, models
-from odoo.exceptions import UserError, ValidationError
+from odoo import api, fields, models
 
 
 class ResPartner(models.Model):
     _name = 'res.partner'
     _inherit = 'res.partner'
 
-    _sii_taxpayer_types = [
-        ('1', _('VAT Affected (1st Category)')),
-        ('2', _('Fees Receipt Issuer (2nd category)')),
-        ('3', _('End Consumer')),
-        ('4', _('Foreigner')),
-    ]
-
     l10n_cl_sii_taxpayer_type = fields.Selection(
-        _sii_taxpayer_types, 'Taxpayer Type', index='btree_not_null',
+        [
+            ('1', 'VAT Affected (1st Category)'),
+            ('2', 'Fees Receipt Issuer (2nd category)'),
+            ('3', 'End Consumer'),
+            ('4', 'Foreigner'),
+        ],
+        string='Taxpayer Type',
+        index='btree_not_null',
         help='1 - VAT Affected (1st Category) (Most of the cases)\n'
              '2 - Fees Receipt Issuer (Applies to suppliers who issue fees receipt)\n'
              '3 - End consumer (only receipts)\n'

--- a/addons/l10n_ec_website_sale/controllers/main.py
+++ b/addons/l10n_ec_website_sale/controllers/main.py
@@ -1,9 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _lt
-from odoo.http import request
-
 from odoo.addons.website_sale.controllers.main import WebsiteSale
+from odoo.http import request
 
 
 class L10nECWebsiteSale(WebsiteSale):
@@ -29,7 +27,7 @@ class L10nECWebsiteSale(WebsiteSale):
                 'identification_types': LatamIdentificationType.search([
                     '|', ('country_id', '=', False), ('country_id.code', '=', 'EC')
                 ]) if can_edit_vat else LatamIdentificationType,
-                'vat_label': _lt("Identification Number"),
+                'vat_label': request.env._("Identification Number"),
             })
 
         return rendering_values

--- a/addons/l10n_es_edi_tbai/models/l10n_es_edi_tbai_document.py
+++ b/addons/l10n_es_edi_tbai/models/l10n_es_edi_tbai_document.py
@@ -193,7 +193,7 @@ class L10nEsEdiTbaiDocument(models.Model):
                 except etree.XMLSyntaxError as e:
                     error = str(e)
             else:
-                error = _('No XML response received.')
+                error = self.env._('No XML response received.')
             return response.headers, response_xml, [error] if error else []
 
         if self.company_id.l10n_es_tbai_tax_agency in ('araba', 'gipuzkoa'):

--- a/addons/l10n_es_edi_tbai/models/res_company.py
+++ b/addons/l10n_es_edi_tbai/models/res_company.py
@@ -2,33 +2,36 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import markupsafe
-from odoo import _, api, fields, models, release
+from odoo import api, fields, models, release
+from odoo.tools import LazyTranslate
+
+_lt = LazyTranslate(__name__)
 
 # === TBAI license values ===
 L10N_ES_TBAI_LICENSE_DICT = {
     'production': {
-        'license_name': _('Production license'),  # all agencies
+        'license_name': _lt('Production license'),  # all agencies
         'license_number': 'TBAIGI5A266A7CCDE1EC',
         'license_nif': 'N0251909H',
         'software_name': 'Odoo SA',
         'software_version': release.version,
     },
     'araba': {
-        'license_name': _('Test license (Araba)'),
+        'license_name': _lt('Test license (Araba)'),
         'license_number': 'TBAIARbjjMClHKH00849',
         'license_nif': 'N0251909H',
         'software_name': 'Odoo SA',
         'software_version': release.version,
     },
     'bizkaia': {
-        'license_name': _('Test license (Bizkaia)'),
+        'license_name': _lt('Test license (Bizkaia)'),
         'license_number': 'TBAIBI00000000PRUEBA',
         'license_nif': 'A99800005',
         'software_name': 'SOFTWARE GARANTE TICKETBAI PRUEBA',
         'software_version': '1.0',
     },
     'gipuzkoa': {
-        'license_name': _('Test license (Gipuzkoa)'),
+        'license_name': _lt('Test license (Gipuzkoa)'),
         'license_number': 'TBAIGIPRE00000000965',
         'license_nif': 'N0251909H',
         'software_name': 'Odoo SA',
@@ -104,10 +107,10 @@ class ResCompany(models.Model):
             license_dict = company._get_l10n_es_tbai_license_dict()
             if license_dict:
                 license_dict.update({
-                    'tr_nif': _('Licence NIF'),
-                    'tr_number': _('Licence number'),
-                    'tr_name': _('Software name'),
-                    'tr_version': _('Software version')
+                    'tr_nif': self.env._('Licence NIF'),
+                    'tr_number': self.env._('Licence number'),
+                    'tr_name': self.env._('Software name'),
+                    'tr_version': self.env._('Software version')
                 })
                 company.l10n_es_tbai_license_html = markupsafe.Markup('''
 <strong>{license_name}</strong><br/>
@@ -119,7 +122,7 @@ class ResCompany(models.Model):
 </p>''').format(**license_dict)
             else:
                 company.l10n_es_tbai_license_html = markupsafe.Markup('''
-<strong>{tr_no_license}</strong>''').format(tr_no_license=_('TicketBAI is not configured'))
+<strong>{tr_no_license}</strong>''').format(tr_no_license=self.env._('TicketBAI is not configured'))
 
     def _get_l10n_es_tbai_license_dict(self):
         self.ensure_one()

--- a/addons/l10n_es_pos/__init__.py
+++ b/addons/l10n_es_pos/__init__.py
@@ -1,4 +1,3 @@
-from odoo import _
 from . import models
 
 

--- a/addons/l10n_hu_edi/models/account_tax.py
+++ b/addons/l10n_hu_edi/models/account_tax.py
@@ -1,6 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _lt, fields, models, api
+from odoo import api, fields, models
+from odoo.tools.translate import LazyTranslate
+
+_lt = LazyTranslate(__name__)
+
 
 _SELECTION_TAX_TYPE = [
     ('VAT', 'Normal VAT (percent based)'),
@@ -58,4 +62,5 @@ class AccountTax(models.Model):
     @api.depends('l10n_hu_tax_type')
     def _compute_l10n_hu_tax_reason(self):
         for tax in self:
-            tax.l10n_hu_tax_reason = _DEFAULT_TAX_REASONS.get(tax.l10n_hu_tax_type, False)
+            reason = _DEFAULT_TAX_REASONS.get(tax.l10n_hu_tax_type, '')
+            tax.l10n_hu_tax_reason = self.env._(reason)  # pylint: disable=gettext-variable

--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -85,8 +85,8 @@ class AccountMove(models.Model):
         def build_warning(record, action_name, message, views, domain=False):
             return {
                 'message': message,
-                'action_text': _("View %s", action_name),
-                'action': record._get_records_action(name=_("Check %s", action_name), target='current', views=views, domain=domain or [])
+                'action_text': self.env._("View %s", action_name),
+                'action': record._get_records_action(name=self.env._("Check %s", action_name), target='current', views=views, domain=domain or [])
             }
 
         indian_invoice = self.filtered(lambda m: m.country_code == 'IN' and m.move_type != 'entry')

--- a/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
+++ b/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
@@ -373,7 +373,7 @@ class AccountEdiFormat(models.Model):
         return res
 
     def _l10n_in_edi_ewaybill_get_error_message(self, code):
-        error_message = ERROR_CODES.get(code)
+        error_message = self.env._(ERROR_CODES.get(code), '')  # pylint: disable=gettext-variable
         return error_message or _("We don't know the error message for this error code. Please contact support.")
 
     def _get_l10n_in_edi_saler_buyer_party(self, move):

--- a/addons/l10n_in_edi_ewaybill/models/error_codes.py
+++ b/addons/l10n_in_edi_ewaybill/models/error_codes.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _lt
+from odoo.tools.translate import LazyTranslate
+
+_lt = LazyTranslate(__name__)
 
 ERROR_CODES = {
     "100": _lt("Invalid json"),

--- a/addons/l10n_in_ewaybill_stock/tools/ewaybill_api.py
+++ b/addons/l10n_in_ewaybill_stock/tools/ewaybill_api.py
@@ -6,9 +6,11 @@ import contextlib
 from datetime import timedelta
 from markupsafe import Markup
 
-from odoo import fields, _
+from odoo import fields
 from odoo.exceptions import AccessError
 from odoo.addons.l10n_in_edi_ewaybill.models.error_codes import ERROR_CODES
+from odoo.tools import _, LazyTranslate
+_lt = LazyTranslate(__name__)
 
 
 _logger = logging.getLogger(__name__)
@@ -44,7 +46,7 @@ class EWayBillError(Exception):
 
 class EWayBillApi:
 
-    DEFAULT_HELP_MESSAGE = _(
+    DEFAULT_HELP_MESSAGE = _lt(
         "Somehow this E-waybill has been %s in the government portal before. "
         "You can verify by checking the details into the government "
         "(https://ewaybillgst.gov.in/Others/EBPrintnew.asp)"

--- a/addons/l10n_pe_website_sale/controllers/main.py
+++ b/addons/l10n_pe_website_sale/controllers/main.py
@@ -1,9 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _lt
-from odoo.http import request, route
-
 from odoo.addons.website_sale.controllers.main import WebsiteSale
+from odoo.http import request, route
 
 
 class L10nPEWebsiteSale(WebsiteSale):
@@ -46,7 +44,7 @@ class L10nPEWebsiteSale(WebsiteSale):
                 'identification_types': LatamIdentificationType.search([
                     '|', ('country_id', '=', False), ('country_id.code', '=', 'PE')
                 ]) if can_edit_vat else LatamIdentificationType,
-                'vat_label': _lt("Identification Number"),
+                'vat_label': request.env._("Identification Number"),
             })
 
         state = request.env['res.country.state'].browse(rendering_values['state_id'])

--- a/addons/mail/models/ir_mail_server.py
+++ b/addons/mail/models/ir_mail_server.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 
 
 class IrMailServer(models.Model):
@@ -18,7 +18,8 @@ class IrMailServer(models.Model):
         usages_super = super()._active_usages_compute()
         for record in self.filtered('mail_template_ids'):
             usages_super.setdefault(record.id, []).extend(
-                map(lambda t: _('%s (Email Template)', t.display_name), record.mail_template_ids)
+                self.env._('%s (Email Template)', t.display_name)
+                for t in record.mail_template_ids
             )
         return usages_super
 

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -201,7 +201,7 @@ class MailTemplate(models.Model):
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)
-        return [dict(vals, name=_("%s (copy)", template.name)) for template, vals in zip(self, vals_list)]
+        return [dict(vals, name=self.env._("%s (copy)", template.name)) for template, vals in zip(self, vals_list)]
 
     def unlink_action(self):
         for template in self:

--- a/addons/mail/models/mail_tracking_value.py
+++ b/addons/mail/models/mail_tracking_value.py
@@ -3,7 +3,7 @@
 
 from datetime import datetime
 
-from odoo import api, fields, models, _
+from odoo import api, fields, models
 
 
 class MailTracking(models.Model):
@@ -176,7 +176,7 @@ class MailTracking(models.Model):
         # generate dict of field information, if available
         fields_col_info = (
             tracked_fields.get(tracking.field_id.name) or {
-                'string': tracking.field_info['desc'] if tracking.field_info else _('Unknown'),
+                'string': tracking.field_info['desc'] if tracking.field_info else self.env._('Unknown'),
                 'type': tracking.field_info['type'] if tracking.field_info else 'char',
             } for tracking in self
         )

--- a/addons/mail/tools/parser.py
+++ b/addons/mail/tools/parser.py
@@ -3,11 +3,11 @@
 
 import ast
 
-from odoo import _, tools
 from odoo.exceptions import ValidationError
+from odoo.tools import is_list_of
 
 
-def parse_res_ids(res_ids):
+def parse_res_ids(res_ids, env):
     """ Returns the already valid list/tuple of int or returns the literal eval
     of the string as a list/tuple of int. Void strings / missing values are
     evaluated as an empty list.
@@ -19,17 +19,19 @@ def parse_res_ids(res_ids):
 
     :return list: list of ids
     """
-    if tools.is_list_of(res_ids, int) or not res_ids:
+    if is_list_of(res_ids, int) or not res_ids:
         return res_ids
-    error_msg = _("Invalid res_ids %(res_ids_str)s (type %(res_ids_type)s)",
-                  res_ids_str=res_ids,
-                  res_ids_type=type(res_ids))
+    error_msg = env._(
+        "Invalid res_ids %(res_ids_str)s (type %(res_ids_type)s)",
+        res_ids_str=res_ids,
+        res_ids_type=str(res_ids.__class__.__name__),
+    )
     try:
         res_ids = ast.literal_eval(res_ids)
     except Exception as e:
         raise ValidationError(error_msg) from e
 
-    if not tools.is_list_of(res_ids, int):
+    if not is_list_of(res_ids, int):
         raise ValidationError(error_msg)
 
     return res_ids

--- a/addons/mail/wizard/base_partner_merge_automatic_wizard.py
+++ b/addons/mail/wizard/base_partner_merge_automatic_wizard.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo import api, models, _
+from odoo import models
 from odoo.tools import format_list
 
 
@@ -11,12 +11,12 @@ class MergePartnerAutomatic(models.TransientModel):
     def _log_merge_operation(self, src_partners, dst_partner):
         super(MergePartnerAutomatic, self)._log_merge_operation(src_partners, dst_partner)
         dst_partner.message_post(
-            body=_(
+            body=self.env._(
                 "Merged with the following partners: %s",
                 format_list(
                     self.env,
                     [
-                        _("%(partner)s <%(email)s> (ID %(id)s)", partner=p.name, email=p.email or "n/a", id=p.id)
+                        self.env._("%(partner)s <%(email)s> (ID %(id)s)", partner=p.name, email=p.email or "n/a", id=p.id)
                         for p in src_partners
                     ]
                 ),

--- a/addons/mail/wizard/mail_activity_schedule.py
+++ b/addons/mail/wizard/mail_activity_schedule.py
@@ -20,7 +20,7 @@ class MailActivitySchedule(models.TransientModel):
     def default_get(self, fields_list):
         res = super().default_get(fields_list)
         context = self.env.context
-        active_res_ids = parse_res_ids(context.get('active_ids'))
+        active_res_ids = parse_res_ids(context.get('active_ids'), self.env)
         if 'res_ids' in fields_list:
             if active_res_ids and len(active_res_ids) <= self._batch_size:
                 res['res_ids'] = f"{context['active_ids']}"
@@ -88,7 +88,7 @@ class MailActivitySchedule(models.TransientModel):
     def _compute_res_ids(self):
         context = self.env.context
         for scheduler in self.filtered(lambda scheduler: not scheduler.res_ids):
-            active_res_ids = parse_res_ids(context.get('active_ids'))
+            active_res_ids = parse_res_ids(context.get('active_ids'), self.env)
             if active_res_ids and len(active_res_ids) <= self._batch_size:
                 scheduler.res_ids = f"{context['active_ids']}"
             elif not active_res_ids and context.get('active_id'):
@@ -322,7 +322,7 @@ class MailActivitySchedule(models.TransientModel):
 
         :return: a list of IDs (empty list in case of falsy strings)"""
         self.ensure_one()
-        return parse_res_ids(self.res_ids) or []
+        return parse_res_ids(self.res_ids, self.env) or []
 
     def _get_applied_on_records(self):
         return self.env[self.res_model].browse(self._evaluate_res_ids())

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -391,7 +391,7 @@ class MailComposer(models.TransientModel):
             if composer.parent_id and composer.composition_mode == 'comment':
                 composer.res_ids = f"{[composer.parent_id.res_id]}"
             else:
-                active_res_ids = parse_res_ids(self.env.context.get('active_ids'))
+                active_res_ids = parse_res_ids(self.env.context.get('active_ids'), self.env)
                 # beware, field is limited in storage, usage of active_ids in context still required
                 if active_res_ids and len(active_res_ids) <= self._batch_size:
                     composer.res_ids = f"{self.env.context['active_ids']}"
@@ -1391,7 +1391,8 @@ class MailComposer(models.TransientModel):
         return parse_res_ids(
             self.env.context.get('composer_force_res_ids') or
             self.res_ids or
-            self.env.context.get('active_ids')
+            self.env.context.get('active_ids'),
+            self.env,
         ) or []
 
     def _set_value_from_template(self, template_fname, composer_fname=False):

--- a/addons/mass_mailing/models/mailing_list.py
+++ b/addons/mass_mailing/models/mailing_list.py
@@ -129,7 +129,7 @@ class MassMailingList(models.Model):
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)
-        return [dict(vals, name=_("%s (copy)", mailing_list.name)) for mailing_list, vals in zip(self, vals_list)]
+        return [dict(vals, name=self.env._("%s (copy)", mailing_list.name)) for mailing_list, vals in zip(self, vals_list)]
 
     # ------------------------------------------------------
     # ACTIONS

--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -14,7 +14,7 @@ class MrpUnbuild(models.Model):
     _inherit = ['mail.thread', 'mail.activity.mixin']
     _order = 'id desc'
 
-    name = fields.Char('Reference', copy=False, readonly=True, default=lambda x: _('New'))
+    name = fields.Char('Reference', copy=False, readonly=True, default=lambda s: s.env._('New'))
     product_id = fields.Many2one(
         'product.product', 'Product', check_company=True,
         domain="[('type', '=', 'consu')]",

--- a/addons/mrp/models/stock_picking.py
+++ b/addons/mrp/models/stock_picking.py
@@ -113,7 +113,7 @@ class StockPickingType(models.Model):
         # Make sure that all picking type IDs are represented, even if empty
         picking_type_id_to_dates = {i: [] for i in production_picking_types.ids}
         picking_type_id_to_dates.update({r[0].id: r[1] for r in mrp_records})
-        mrp_records = [(i, d, _('Confirmed')) for i, d in picking_type_id_to_dates.items()]
+        mrp_records = [(i, d, self.env._('Confirmed')) for i, d in picking_type_id_to_dates.items()]
         return records + mrp_records
 
 class StockPicking(models.Model):

--- a/addons/onboarding/models/onboarding_onboarding.py
+++ b/addons/onboarding/models/onboarding_onboarding.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 from odoo.addons.onboarding.models.onboarding_progress import ONBOARDING_PROGRESS_STATES
 
 
@@ -16,7 +16,7 @@ class Onboarding(models.Model):
     step_ids = fields.Many2many('onboarding.onboarding.step', string='Onboarding steps')
 
     text_completed = fields.Char(
-        'Message at completion', default=_('Nice work! Your configuration is done.'),
+        'Message at completion', default=lambda s: s.env._('Nice work! Your configuration is done.'),
         help='Text shown on onboarding when completed')
 
     is_per_company = fields.Boolean(

--- a/addons/onboarding/models/onboarding_onboarding_step.py
+++ b/addons/onboarding/models/onboarding_onboarding_step.py
@@ -17,11 +17,11 @@ class OnboardingStep(models.Model):
     title = fields.Char('Title', translate=True)
     description = fields.Char('Description', translate=True)
     button_text = fields.Char(
-        'Button text', required=True, default=_("Let's do it"), translate=True,
+        'Button text', required=True, default=lambda s: s.env._("Let's do it"), translate=True,
         help="Text on the panel's button to start this step")
     done_icon = fields.Char('Font Awesome Icon when completed', default='fa-star')
     done_text = fields.Char(
-        'Text to show when step is completed', default=_('Step Completed!'), translate=True)
+        'Text to show when step is completed', default=lambda s: s.env._('Step Completed!'), translate=True)
     step_image = fields.Binary("Step Image")
     step_image_filename = fields.Char("Step Image Filename")
     step_image_alt = fields.Char(

--- a/addons/payment/const.py
+++ b/addons/payment/const.py
@@ -1,6 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _
+from odoo.tools.translate import LazyTranslate
+
+_lt = LazyTranslate(__name__, default_lang='en_US')
 
 
 # According to https://en.wikipedia.org/wiki/ISO_4217#Minor_unit_fractions
@@ -284,13 +286,13 @@ CURRENCY_MINOR_UNITS = {
 }
 
 REPORT_REASONS_MAPPING = {
-    'exceed_max_amount': _("maximum amount exceeded"),
-    'express_checkout_not_supported': _("express checkout not supported"),
-    'incompatible_country': _("incompatible country"),
-    'incompatible_currency': _("incompatible currency"),
-    'incompatible_website': _("incompatible website"),
-    'manual_capture_not_supported': _("manual capture not supported"),
-    'provider_not_available': _("no supported provider available"),
-    'tokenization_not_supported': _("tokenization not supported"),
-    'validation_not_supported': _("tokenization without payment no supported"),
+    'exceed_max_amount': _lt("maximum amount exceeded"),
+    'express_checkout_not_supported': _lt("express checkout not supported"),
+    'incompatible_country': _lt("incompatible country"),
+    'incompatible_currency': _lt("incompatible currency"),
+    'incompatible_website': _lt("incompatible website"),
+    'manual_capture_not_supported': _lt("manual capture not supported"),
+    'provider_not_available': _lt("no supported provider available"),
+    'tokenization_not_supported': _lt("tokenization not supported"),
+    'validation_not_supported': _lt("tokenization without payment no supported"),
 }

--- a/addons/payment_mercado_pago/const.py
+++ b/addons/payment_mercado_pago/const.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _
+from odoo.tools import LazyTranslate
+_lt = LazyTranslate(__name__)
 
 
 # Currency codes of the currencies supported by Mercado Pago in ISO 4217 format.
@@ -71,45 +72,45 @@ TRANSACTION_STATUS_MAPPING = {
 # Mapping of error states to Mercado Pago error messages.
 # See https://www.mercadopago.com.ar/developers/en/docs/checkout-api/response-handling/collection-results
 ERROR_MESSAGE_MAPPING = {
-    'accredited': _(
+    'accredited': _lt(
         "Your payment has been credited. In your summary you will see the charge as a statement "
         "descriptor."
     ),
-    'pending_contingency': _(
+    'pending_contingency': _lt(
         "We are processing your payment. Don't worry, in less than 2 business days, we will notify "
         "you by e-mail if your payment has been credited."
     ),
-    'pending_review_manual': _(
+    'pending_review_manual': _lt(
         "We are processing your payment. Don't worry, less than 2 business days we will notify you "
         "by e-mail if your payment has been credited or if we need more information."
     ),
-    'cc_rejected_bad_filled_card_number': _("Check the card number."),
-    'cc_rejected_bad_filled_date': _("Check expiration date."),
-    'cc_rejected_bad_filled_other': _("Check the data."),
-    'cc_rejected_bad_filled_security_code': _("Check the card security code."),
-    'cc_rejected_blacklist': _("We were unable to process your payment, please use another card."),
-    'cc_rejected_call_for_authorize': _("You must authorize the payment with this card."),
-    'cc_rejected_card_disabled': _(
+    'cc_rejected_bad_filled_card_number': _lt("Check the card number."),
+    'cc_rejected_bad_filled_date': _lt("Check expiration date."),
+    'cc_rejected_bad_filled_other': _lt("Check the data."),
+    'cc_rejected_bad_filled_security_code': _lt("Check the card security code."),
+    'cc_rejected_blacklist': _lt("We were unable to process your payment, please use another card."),
+    'cc_rejected_call_for_authorize': _lt("You must authorize the payment with this card."),
+    'cc_rejected_card_disabled': _lt(
         "Call your card issuer to activate your card or use another payment method. The phone "
         "number is on the back of your card."
     ),
-    'cc_rejected_card_error': _(
+    'cc_rejected_card_error': _lt(
         "We were unable to process your payment, please check your card information."
     ),
-    'cc_rejected_duplicated_payment': _(
+    'cc_rejected_duplicated_payment': _lt(
         "You have already made a payment for that value. If you need to pay again, use another card"
         " or another payment method."
     ),
-    'cc_rejected_high_risk': _(
+    'cc_rejected_high_risk': _lt(
         "We were unable to process your payment, please use another card."
     ),
-    'cc_rejected_insufficient_amount': _("Your card has not enough funds."),
-    'cc_rejected_invalid_installments': _(
+    'cc_rejected_insufficient_amount': _lt("Your card has not enough funds."),
+    'cc_rejected_invalid_installments': _lt(
         "This payment method does not process payments in installments."
     ),
-    'cc_rejected_max_attempts': _(
+    'cc_rejected_max_attempts': _lt(
         "You have reached the limit of allowed attempts. Choose another card or other means of "
         "payment."
     ),
-    'cc_rejected_other_reason': _("Payment was not processed, use another card or contact issuer.")
+    'cc_rejected_other_reason': _lt("Payment was not processed, use another card or contact issuer.")
 }

--- a/addons/phone_validation/tools/phone_validation.py
+++ b/addons/phone_validation/tools/phone_validation.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _
 from odoo.exceptions import UserError
+from odoo.tools import LazyTranslate
 
 import logging
 
+_lt = LazyTranslate(__name__, default_lang='en_US')  # TODO pass env to functions and remove _lt
 _logger = logging.getLogger(__name__)
 _phonenumbers_lib_warning = False
 
@@ -18,15 +19,15 @@ try:
             phone_nbr = phonenumbers.parse(number, region=country_code or None, keep_raw_input=True)
         except phonenumbers.phonenumberutil.NumberParseException as e:
             raise UserError(
-                _('Unable to parse %(phone)s: %(error)s', phone=number, error=str(e))
+                _lt('Unable to parse %(phone)s: %(error)s', phone=number, error=str(e))
             ) from e
 
         if not phonenumbers.is_possible_number(phone_nbr):
             reason = phonenumbers.is_possible_number_with_reason(phone_nbr)
             if reason == phonenumbers.ValidationResult.INVALID_COUNTRY_CODE:
-                raise UserError(_('Impossible number %s: not a valid country prefix.', number))
+                raise UserError(_lt('Impossible number %s: not a valid country prefix.', number))
             if reason == phonenumbers.ValidationResult.TOO_SHORT:
-                raise UserError(_('Impossible number %s: not enough digits.', number))
+                raise UserError(_lt('Impossible number %s: not enough digits.', number))
             # in case of "TOO_LONG", we may try to reformat the number in case it was
             # entered without '+' prefix or using leading '++' not always recognized;
             # in any case final error should keep the original number to ease tracking
@@ -36,23 +37,23 @@ try:
                     try:
                         phone_nbr = phone_parse(f'+{number.lstrip("00")}', country_code)
                     except UserError:
-                        raise UserError(_('Impossible number %s: too many digits.', number))
+                        raise UserError(_lt('Impossible number %s: too many digits.', number))
                 # people may enter 33... instead of +33...
                 elif not number.startswith('+'):
                     try:
                         phone_nbr = phone_parse(f'+{number}', country_code)
                     except UserError:
-                        raise UserError(_('Impossible number %s: too many digits.', number))
+                        raise UserError(_lt('Impossible number %s: too many digits.', number))
                 else:
-                    raise UserError(_('Impossible number %s: too many digits.', number))
+                    raise UserError(_lt('Impossible number %s: too many digits.', number))
             else:
-                raise UserError(_('Impossible number %s: probably invalid number of digits.', number))
+                raise UserError(_lt('Impossible number %s: probably invalid number of digits.', number))
         if not phonenumbers.is_valid_number(phone_nbr):
             # Force format with international to force metadata to apply
             formatted_intl = phonenumbers.format_number(phone_nbr, phonenumbers.PhoneNumberFormat.INTERNATIONAL)
             phone_nbr_intl = phonenumbers.parse(formatted_intl, region=country_code or None, keep_raw_input=True)
             if not phonenumbers.is_valid_number(phone_nbr_intl):
-                raise UserError(_('Invalid number %s: probably incorrect prefix.', number))
+                raise UserError(_lt('Invalid number %s: probably incorrect prefix.', number))
             return phone_nbr_intl
 
         return phone_nbr

--- a/addons/product/models/product_tag.py
+++ b/addons/product/models/product_tag.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 from odoo.osv import expression
 
 class ProductTag(models.Model):
@@ -47,7 +47,7 @@ class ProductTag(models.Model):
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)
-        return [dict(vals, name=_("%s (copy)", tag.name)) for tag, vals in zip(self, vals_list)]
+        return [dict(vals, name=self.env._("%s (copy)", tag.name)) for tag, vals in zip(self, vals_list)]
 
     def _search_product_ids(self, operator, operand):
         if operator in expression.NEGATIVE_TERM_OPERATORS:

--- a/addons/project/models/project_project_stage.py
+++ b/addons/project/models/project_project_stage.py
@@ -20,7 +20,7 @@ class ProjectProjectStage(models.Model):
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)
-        return [dict(vals, name=_("%s (copy)", stage.name)) for stage, vals in zip(self, vals_list)]
+        return [dict(vals, name=self.env._("%s (copy)", stage.name)) for stage, vals in zip(self, vals_list)]
 
     def unlink_wizard(self, stage_view=False):
         wizard = self.with_context(active_test=False).env['project.project.stage.delete.wizard'].create({

--- a/addons/project/models/project_task_type.py
+++ b/addons/project/models/project_task_type.py
@@ -79,7 +79,7 @@ class ProjectTaskType(models.Model):
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)
-        return [dict(vals, name=_("%s (copy)", task_type.name)) for task_type, vals in zip(self, vals_list)]
+        return [dict(vals, name=self.env._("%s (copy)", task_type.name)) for task_type, vals in zip(self, vals_list)]
 
     @api.ondelete(at_uninstall=False)
     def _unlink_if_remaining_personal_stages(self):

--- a/addons/project_account/models/project_project.py
+++ b/addons/project_account/models/project_project.py
@@ -4,7 +4,7 @@ import json
 from ast import literal_eval
 from collections import defaultdict
 
-from odoo import models, _lt
+from odoo import models
 
 
 class Project(models.Model):
@@ -82,9 +82,9 @@ class Project(models.Model):
     def _get_profitability_labels(self):
         return {
             **super()._get_profitability_labels(),
-            'other_purchase_costs': _lt('Vendor Bills'),
-            'other_revenues_aal': _lt('Other Revenues'),
-            'other_costs_aal': _lt('Other Costs'),
+            'other_purchase_costs': self.env._('Vendor Bills'),
+            'other_revenues_aal': self.env._('Other Revenues'),
+            'other_costs_aal': self.env._('Other Costs'),
         }
 
     def _get_profitability_sequence_per_invoice_type(self):

--- a/addons/project_hr_expense/models/project_project.py
+++ b/addons/project_hr_expense/models/project_project.py
@@ -2,8 +2,9 @@
 
 import json
 
-from odoo import models, _, _lt
+from odoo import models
 from odoo.osv import expression
+
 
 class Project(models.Model):
     _inherit = 'project.project'
@@ -17,7 +18,7 @@ class Project(models.Model):
             return {}
         action = self.env["ir.actions.actions"]._for_xml_id("hr_expense.hr_expense_actions_all")
         action.update({
-            'display_name': _('Expenses'),
+            'display_name': self.env._('Expenses'),
             'views': [[False, 'list'], [False, 'form'], [False, 'kanban'], [False, 'graph'], [False, 'pivot']],
             'context': {'project_id': self.id},
             'domain': domain or [('id', 'in', expense_ids)],
@@ -48,7 +49,7 @@ class Project(models.Model):
 
     def _get_profitability_labels(self):
         labels = super()._get_profitability_labels()
-        labels['expenses'] = _lt('Expenses')
+        labels['expenses'] = self.env._('Expenses')
         return labels
 
     def _get_profitability_sequence_per_invoice_type(self):

--- a/addons/project_mrp/models/project_project.py
+++ b/addons/project_mrp/models/project_project.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, fields, models
+from odoo import fields, models
 
 
 class ProjectProject(models.Model):
@@ -35,7 +35,7 @@ class ProjectProject(models.Model):
             'type': 'ir.actions.act_window',
             'res_model': 'mrp.bom',
             'domain': [('project_id', '=', self.id)],
-            'name': _('Bills of Materials'),
+            'name': self.env._('Bills of Materials'),
             'view_mode': 'list,form',
             'context': {'default_project_id': self.id},
         }
@@ -62,7 +62,7 @@ class ProjectProject(models.Model):
             self_sudo = self.sudo()
             buttons.extend([{
                 'icon': 'flask',
-                'text': _('Bills of Materials'),
+                'text': self.env._('Bills of Materials'),
                 'number': self_sudo.bom_count,
                 'action_type': 'object',
                 'action': 'action_view_mrp_bom',
@@ -71,7 +71,7 @@ class ProjectProject(models.Model):
             },
             {
                 'icon': 'wrench',
-                'text': _('Manufacturing Orders'),
+                'text': self.env._('Manufacturing Orders'),
                 'number': self_sudo.production_count,
                 'action_type': 'object',
                 'action': 'action_view_mrp_production',

--- a/addons/project_mrp_account/models/project_project.py
+++ b/addons/project_mrp_account/models/project_project.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models, _
+from odoo import models
 from odoo.osv import expression
 
 
@@ -13,7 +13,7 @@ class Project(models.Model):
 
     def _get_profitability_labels(self):
         labels = super()._get_profitability_labels()
-        labels['manufacturing_order'] = _('Manufacturing Orders')
+        labels['manufacturing_order'] = self.env._('Manufacturing Orders')
         return labels
 
     def _get_profitability_sequence_per_invoice_type(self):

--- a/addons/project_purchase/models/project_project.py
+++ b/addons/project_purchase/models/project_project.py
@@ -2,7 +2,7 @@
 
 import json
 
-from odoo import api, fields, models, _, _lt
+from odoo import fields, models
 from odoo.osv import expression
 
 
@@ -28,7 +28,7 @@ class Project(models.Model):
     def action_open_project_purchase_orders(self):
         purchase_orders_domain = [('project_id', '=', self.id)]
         action_window = {
-            'name': _('Purchase Orders'),
+            'name': self.env._('Purchase Orders'),
             'type': 'ir.actions.act_window',
             'res_model': 'purchase.order',
             'views': [[False, 'list'], [False, 'form']],
@@ -46,7 +46,7 @@ class Project(models.Model):
     def action_profitability_items(self, section_name, domain=None, res_id=False):
         if section_name == 'purchase_order':
             action = {
-                'name': _('Purchase Order Items'),
+                'name': self.env._('Purchase Order Items'),
                 'type': 'ir.actions.act_window',
                 'res_model': 'purchase.order.line',
                 'views': [[False, 'list'], [False, 'form']],
@@ -78,7 +78,7 @@ class Project(models.Model):
             self_sudo = self.sudo()
             buttons.append({
                 'icon': 'credit-card',
-                'text': _lt('Purchase Orders'),
+                'text': self.env._('Purchase Orders'),
                 'number': self_sudo.purchase_orders_count,
                 'action_type': 'object',
                 'action': 'action_open_project_purchase_orders',
@@ -98,7 +98,7 @@ class Project(models.Model):
 
     def _get_profitability_labels(self):
         labels = super()._get_profitability_labels()
-        labels['purchase_order'] = _lt('Purchase Orders')
+        labels['purchase_order'] = self.env._('Purchase Orders')
         return labels
 
     def _get_profitability_sequence_per_invoice_type(self):

--- a/addons/project_timesheet_holidays/__init__.py
+++ b/addons/project_timesheet_holidays/__init__.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import models
-from odoo import _
 
 
 def post_init(env):
@@ -20,7 +19,7 @@ def post_init(env):
         if not company.internal_project_id:
             if not internal_projects_by_company_dict:
                 internal_projects_by_company_read = project.search_read([
-                    ('name', '=', _('Internal')),
+                    ('name', '=', env._('Internal')),
                     ('allow_timesheets', '=', True),
                     ('company_id', 'in', companies.ids),
                 ], ['company_id', 'id'])
@@ -28,7 +27,7 @@ def post_init(env):
             project_id = internal_projects_by_company_dict.get(company.id, False)
             if not project_id:
                 project_id = project.create({
-                    'name': _('Internal'),
+                    'name': env._('Internal'),
                     'allow_timesheets': True,
                     'company_id': company.id,
                     'type_ids': type_ids,
@@ -36,7 +35,7 @@ def post_init(env):
             company.write({'internal_project_id': project_id})
         if not company.leave_timesheet_task_id:
             task = company.env['project.task'].create({
-                'name': _('Time Off'),
+                'name': env._('Time Off'),
                 'project_id': company.internal_project_id.id,
                 'active': True,
                 'company_id': company.id,

--- a/addons/project_todo/models/project_task.py
+++ b/addons/project_todo/models/project_task.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, models, _, _lt, Command
+from odoo import api, models, Command
 from odoo.tools import html2plaintext
+
 
 class Task(models.Model):
     _inherit = 'project.task'
@@ -17,7 +18,7 @@ class Task(models.Model):
                     name = text.strip().replace('*', '').partition("\n")[0]
                     vals['name'] = (name[:97] + '...') if len(name) > 100 else name
                 else:
-                    vals['name'] = _('Untitled to-do')
+                    vals['name'] = self.env._('Untitled to-do')
         return super().create(vals_list)
 
     def _ensure_onboarding_todo(self):
@@ -28,7 +29,8 @@ class Task(models.Model):
 
     def _generate_onboarding_todo(self, user):
         user.ensure_one()
-        body = self.with_context(lang=user.lang or self.env.user.lang).env['ir.qweb']._render(
+        self_lang = self.with_context(lang=user.lang or self.env.user.lang)
+        body = self_lang.env['ir.qweb']._render(
             'project_todo.todo_user_onboarding',
             {'object': user},
             minimal_qcontext=True,
@@ -36,7 +38,7 @@ class Task(models.Model):
         )
         if not body:
             return
-        title = _lt('Welcome %s!', user.name)
+        title = self_lang.env._('Welcome %s!', user.name)
         self.env['project.task'].create([{
             'user_ids': user.ids,
             'description': body,

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -134,7 +134,7 @@ class ResourceCalendar(models.Model):
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)
-        return [dict(vals, name=_("%s (copy)", calendar.name)) for calendar, vals in zip(self, vals_list)]
+        return [dict(vals, name=self.env._("%s (copy)", calendar.name)) for calendar, vals in zip(self, vals_list)]
 
     @api.constrains('attendance_ids')
     def _check_attendance_ids(self):

--- a/addons/resource/models/resource_resource.py
+++ b/addons/resource/models/resource_resource.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from dateutil.relativedelta import relativedelta
 from pytz import timezone
 
-from odoo import api, fields, models, _
+from odoo import api, fields, models
 from odoo.addons.base.models.res_partner import _tz_get
 
 from .utils import timezone_datetime, make_aware, Intervals
@@ -74,7 +74,7 @@ class ResourceResource(models.Model):
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)
-        return [dict(vals, name=_("%s (copy)", resource.name)) for resource, vals in zip(self, vals_list)]
+        return [dict(vals, name=self.env._("%s (copy)", resource.name)) for resource, vals in zip(self, vals_list)]
 
     def write(self, values):
         if self.env.context.get('check_idempotence') and len(self) == 1:

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -5,11 +5,12 @@ from datetime import timedelta
 
 from markupsafe import Markup
 
-from odoo import _, _lt, api, fields, models
+from odoo import api, fields, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Command
 from odoo.osv import expression
 from odoo.tools import float_compare, float_is_zero, format_date, groupby
+from odoo.tools.translate import _
 
 
 class SaleOrderLine(models.Model):
@@ -443,7 +444,7 @@ class SaleOrderLine(models.Model):
             return _("Down Payments")
 
         dp_state = self._get_downpayment_state()
-        name = _lt("Down Payment")
+        name = _("Down Payment")
         if dp_state == 'draft':
             name = _(
                 "Down Payment: %(date)s (Draft)",

--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -4,10 +4,11 @@ import ast
 import json
 from collections import defaultdict
 
-from odoo import api, fields, models, _, _lt
+from odoo import api, fields, models
 from odoo.osv import expression
 from odoo.tools import Query, SQL
 from odoo.tools.misc import unquote
+from odoo.tools.translate import _
 
 
 class ProjectProject(models.Model):
@@ -490,10 +491,10 @@ class ProjectProject(models.Model):
     def _get_profitability_labels(self):
         return {
             **super()._get_profitability_labels(),
-            'service_revenues': _lt('Other Services'),
-            'materials': _lt('Materials'),
-            'other_invoice_revenues': _lt('Customer Invoices'),
-            'downpayments': _lt('Down Payments'),
+            'service_revenues': self.env._('Other Services'),
+            'materials': self.env._('Materials'),
+            'other_invoice_revenues': self.env._('Customer Invoices'),
+            'downpayments': self.env._('Down Payments'),
         }
 
     def _get_profitability_sequence_per_invoice_type(self):
@@ -746,7 +747,7 @@ class ProjectProject(models.Model):
             self_sudo = self.sudo()
             buttons.append({
                 'icon': 'dollar',
-                'text': _lt('Sales Orders'),
+                'text': self.env._('Sales Orders'),
                 'number': self_sudo.sale_order_count,
                 'action_type': 'object',
                 'action': 'action_view_sos',
@@ -759,7 +760,7 @@ class ProjectProject(models.Model):
         if self.env.user.has_group('sales_team.group_sale_salesman_all_leads'):
             buttons.append({
                 'icon': 'dollar',
-                'text': _lt('Sales Order Items'),
+                'text': self.env._('Sales Order Items'),
                 'number': self.sale_order_line_count,
                 'action_type': 'object',
                 'action': 'action_view_sols',
@@ -770,7 +771,7 @@ class ProjectProject(models.Model):
             self_sudo = self.sudo()
             buttons.append({
                 'icon': 'pencil-square-o',
-                'text': _lt('Invoices'),
+                'text': self.env._('Invoices'),
                 'number': self_sudo.invoice_count,
                 'action_type': 'object',
                 'action': 'action_open_project_invoices',
@@ -781,7 +782,7 @@ class ProjectProject(models.Model):
             self_sudo = self.sudo()
             buttons.append({
                 'icon': 'pencil-square-o',
-                'text': _lt('Vendor Bills'),
+                'text': self.env._('Vendor Bills'),
                 'number': self_sudo.vendor_bill_count,
                 'action_type': 'object',
                 'action': 'action_open_project_vendor_bills',

--- a/addons/sale_timesheet/models/project_project.py
+++ b/addons/sale_timesheet/models/project_project.py
@@ -2,10 +2,11 @@
 
 import json
 
-from odoo import api, fields, models, _, _lt
+from odoo import api, fields, models
 from odoo.osv import expression
 from odoo.tools import SQL
 from odoo.exceptions import ValidationError, UserError
+from odoo.tools.translate import _
 
 
 class ProjectProject(models.Model):
@@ -371,13 +372,13 @@ class ProjectProject(models.Model):
     def _get_profitability_labels(self):
         return {
             **super()._get_profitability_labels(),
-            'billable_fixed': _lt('Timesheets (Fixed Price)'),
-            'billable_time': _lt('Timesheets (Billed on Timesheets)'),
-            'billable_milestones': _lt('Timesheets (Billed on Milestones)'),
-            'billable_manual': _lt('Timesheets (Billed Manually)'),
-            'non_billable': _lt('Timesheets (Non-Billable)'),
-            'timesheet_revenues': _lt('Timesheets revenues'),
-            'other_costs': _lt('Materials'),
+            'billable_fixed': self.env._('Timesheets (Fixed Price)'),
+            'billable_time': self.env._('Timesheets (Billed on Timesheets)'),
+            'billable_milestones': self.env._('Timesheets (Billed on Milestones)'),
+            'billable_manual': self.env._('Timesheets (Billed Manually)'),
+            'non_billable': self.env._('Timesheets (Non-Billable)'),
+            'timesheet_revenues': self.env._('Timesheets revenues'),
+            'other_costs': self.env._('Materials'),
         }
 
     def _get_profitability_sequence_per_invoice_type(self):

--- a/addons/sms/models/sms_template.py
+++ b/addons/sms/models/sms_template.py
@@ -43,7 +43,7 @@ class SMSTemplate(models.Model):
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)
-        return [dict(vals, name=_("%s (copy)", template.name)) for template, vals in zip(self, vals_list)]
+        return [dict(vals, name=self.env._("%s (copy)", template.name)) for template, vals in zip(self, vals_list)]
 
     def unlink(self):
         self.sudo().mapped('sidebar_action_id').unlink()

--- a/addons/sms/tools/sms_api.py
+++ b/addons/sms/tools/sms_api.py
@@ -1,9 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _
 from odoo.addons.iap.tools import iap_tools
-from odoo.tools.translate import _lt
+from odoo.tools.translate import _, LazyTranslate
 
+_lt = LazyTranslate(__name__)
 
 ERROR_MESSAGES = {
     # Errors that could occur while updating sender name

--- a/addons/stock/models/stock_package_type.py
+++ b/addons/stock/models/stock_package_type.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models, fields, _
+from odoo import fields, models
 
 
 class PackageType(models.Model):
@@ -45,4 +45,4 @@ class PackageType(models.Model):
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)
-        return [dict(vals, name=_("%s (copy)", package_type.name)) for package_type, vals in zip(self, vals_list)]
+        return [dict(vals, name=self.env._("%s (copy)", package_type.name)) for package_type, vals in zip(self, vals_list)]

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -495,7 +495,7 @@ class PickingType(models.Model):
         # Make sure that all picking type IDs are represented, even if empty
         picking_type_id_to_dates = {i: [] for i in self.ids}
         picking_type_id_to_dates.update({r[0].id: r[1] for r in records})
-        return [(i, d, _('Transfers')) for i, d in picking_type_id_to_dates.items()]
+        return [(i, d, self.env._('Transfers')) for i, d in picking_type_id_to_dates.items()]
 
     def _prepare_graph_data(self, summaries):
         """

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -383,6 +383,7 @@ class StockRule(models.Model):
         :return: the cumulative delay and cumulative delay's description
         :rtype: tuple[defaultdict(float), list[str, str]]
         """
+        _ = self.env._
         delays = defaultdict(float)
         delay = sum(self.filtered(lambda r: r.action in ['pull', 'pull_push']).mapped('delay'))
         delays['total_delay'] += delay

--- a/addons/stock/models/stock_storage_category.py
+++ b/addons/stock/models/stock_storage_category.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 
 
 class StorageCategory(models.Model):
@@ -41,7 +41,7 @@ class StorageCategory(models.Model):
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)
-        return [dict(vals, name=_("%s (copy)", category.name)) for category, vals in zip(self, vals_list)]
+        return [dict(vals, name=self.env._("%s (copy)", category.name)) for category, vals in zip(self, vals_list)]
 
 
 class StorageCategoryProductCapacity(models.Model):

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import logging
 from collections import namedtuple
 
-from odoo import _, _lt, api, fields, models
+from odoo import api, fields, models
 from odoo.exceptions import UserError, RedirectWarning
 from odoo.tools import format_list
+from odoo.tools.translate import _, LazyTranslate
 
-_logger = logging.getLogger(__name__)
+_lt = LazyTranslate(__name__)
 
 
 ROUTE_NAMES = {
@@ -778,7 +778,7 @@ class Warehouse(models.Model):
         return customer_loc, supplier_loc
 
     def _get_route_name(self, route_type):
-        return str(ROUTE_NAMES[route_type])
+        return self.env._(ROUTE_NAMES[route_type])  # pylint: disable=gettext-variable
 
     def get_rules_dict(self):
         """ Define the rules source/destination locations, picking_type and

--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -496,7 +496,7 @@ class Survey(models.Model):
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)
-        return [dict(vals, title=_("%s (copy)", survey.title)) for survey, vals in zip(self, vals_list)]
+        return [dict(vals, title=self.env._("%s (copy)", survey.title)) for survey, vals in zip(self, vals_list)]
 
     def toggle_active(self):
         super(Survey, self).toggle_active()

--- a/addons/test_import_export/__manifest__.py
+++ b/addons/test_import_export/__manifest__.py
@@ -5,7 +5,8 @@
     'sequence': 3843,
     'summary': 'Base Import & Export Tests: Ensure Flow Robustness',
     'description': """This module contains tests related to base import and export.""",
-    'depends': ['web', 'base_import'],
+    # website is there only for MockRequest
+    'depends': ['web', 'base_import', 'website'],
     'data': [
         'security/ir.model.access.csv',
     ],

--- a/addons/test_import_export/tests/test_export.py
+++ b/addons/test_import_export/tests/test_export.py
@@ -6,6 +6,7 @@ from odoo import http
 from odoo.tests import common, tagged
 from odoo.tools.misc import get_lang
 from odoo.addons.web.controllers.export import ExportXlsxWriter, Export
+from odoo.addons.website.tools import MockRequest
 
 
 class XlsxCreatorCase(common.HttpCase):
@@ -80,8 +81,7 @@ class TestExport(XlsxCreatorCase):
             'name': {'string': 'Name', 'type': 'char'},
             'properties': {'string': 'Properties', 'type': 'properties'},
             'properties_definition': {'string': 'Properties Definition', 'type': 'properties_definition'}
-        }):
-            # TODO: change the test to handle because fields_get handle properties
+        }), MockRequest(self.env):
             fields = Export().get_fields("mock_model", import_compat=True)
             field_names = [field['id'] for field in fields]
             self.assertNotIn('properties', field_names)

--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -18,7 +18,6 @@ from odoo.exceptions import UserError
 from odoo.http import content_disposition, request
 from odoo.tools import lazy_property, osutil
 from odoo.tools.misc import xlsxwriter
-from odoo.tools.translate import _
 
 
 _logger = logging.getLogger(__name__)
@@ -197,7 +196,7 @@ class ExportXlsxWriter:
         self.value = False
 
         if row_count > self.worksheet.xls_rowmax:
-            raise UserError(_('There are too many rows (%(count)s rows, limit: %(limit)s) to export as Excel 2007-2013 (.xlsx) format. Consider splitting the export.', count=row_count, limit=self.worksheet.xls_rowmax))
+            raise UserError(request.env._('There are too many rows (%(count)s rows, limit: %(limit)s) to export as Excel 2007-2013 (.xlsx) format. Consider splitting the export.', count=row_count, limit=self.worksheet.xls_rowmax))
 
     def __enter__(self):
         self.write_header()
@@ -231,13 +230,13 @@ class ExportXlsxWriter:
                 # fails note that you can't export
                 cell_value = cell_value.decode()
             except UnicodeDecodeError:
-                raise UserError(_("Binary fields can not be exported to Excel unless their content is base64-encoded. That does not seem to be the case for %s.", self.field_names)[column]) from None
+                raise UserError(request.env._("Binary fields can not be exported to Excel unless their content is base64-encoded. That does not seem to be the case for %s.", self.field_names)[column]) from None
         elif isinstance(cell_value, (list, tuple, dict)):
             cell_value = str(cell_value)
 
         if isinstance(cell_value, str):
             if len(cell_value) > self.worksheet.xls_strmax:
-                cell_value = _("The content of this cell is too long for an XLSX file (more than %s characters). Please use the CSV format for this export.", self.worksheet.xls_strmax)
+                cell_value = request.env._("The content of this cell is too long for an XLSX file (more than %s characters). Please use the CSV format for this export.", self.worksheet.xls_strmax)
             else:
                 cell_value = cell_value.replace("\r", " ")
         elif isinstance(cell_value, datetime.datetime):
@@ -255,7 +254,7 @@ class GroupExportXlsxWriter(ExportXlsxWriter):
     def write_group(self, row, column, group_name, group, group_depth=0):
         group_name = group_name[1] if isinstance(group_name, tuple) and len(group_name) > 1 else group_name
         if group._groupby_type[group_depth] != 'boolean':
-            group_name = group_name or _("Undefined")
+            group_name = group_name or request.env._("Undefined")
         row, column = self._write_group_header(row, column, group_name, group, group_depth)
 
         # Recursively write sub-groups
@@ -323,10 +322,10 @@ class Export(http.Controller):
         else:
             fields['.id'] = {**fields['id']}
 
-        fields['id']['string'] = _('External ID')
+        fields['id']['string'] = request.env._('External ID')
 
         if parent_field:
-            parent_field['string'] = _('External ID')
+            parent_field['string'] = request.env._('External ID')
             fields['id'] = parent_field
 
         fields_sequence = sorted(fields.items(),
@@ -539,7 +538,7 @@ class CSVExport(ExportFormat, http.Controller):
         return '.csv'
 
     def from_group_data(self, fields, columns_headers, groups):
-        raise UserError(_("Exporting grouped data to csv is not supported."))
+        raise UserError(request.env._("Exporting grouped data to csv is not supported."))
 
     def from_data(self, fields, columns_headers, rows):
         fp = io.StringIO()

--- a/addons/website/controllers/form.py
+++ b/addons/website/controllers/form.py
@@ -8,12 +8,15 @@ from psycopg2 import IntegrityError
 import re
 from werkzeug.exceptions import BadRequest
 
-from odoo import http, SUPERUSER_ID, _, _lt
+from odoo import http, SUPERUSER_ID
 from odoo.addons.base.models.ir_qweb_fields import nl2br, nl2br_enclose
 from odoo.http import request
 from odoo.tools import plaintext2html
 from odoo.exceptions import AccessDenied, ValidationError, UserError
 from odoo.tools.misc import hmac, consteq
+from odoo.tools.translate import _, LazyTranslate
+
+_lt = LazyTranslate(__name__)
 
 
 class WebsiteForm(http.Controller):

--- a/addons/website/tools.py
+++ b/addons/website/tools.py
@@ -23,7 +23,7 @@ def MockRequest(
         # website_sale
         sale_order_id=None, website_sale_current_pl=None,
 ):
-    # TODO move MockRequest to a package in tests
+    # TODO move MockRequest to a package in addons/web/tests
     from odoo.tests.common import HttpCase  # noqa: PLC0415
     lang_code = context.get('lang', env.context.get('lang', 'en_US'))
     env = env(context=dict(context, lang=lang_code))

--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -264,7 +264,7 @@ class BlogPost(models.Model):
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)
-        return [dict(vals, name=_("%s (copy)", blog.name)) for blog, vals in zip(self, vals_list)]
+        return [dict(vals, name=self.env._("%s (copy)", blog.name)) for blog, vals in zip(self, vals_list)]
 
     def _get_access_action(self, access_uid=None, force_website=False):
         """ Instead of the classic form view, redirect to the post on website

--- a/addons/website_event_track/models/event_track_stage.py
+++ b/addons/website_event_track/models/event_track_stage.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 
 
 class TrackStage(models.Model):
@@ -18,9 +18,9 @@ class TrackStage(models.Model):
     # legends
     color = fields.Integer(string='Color')
     description = fields.Text(string='Description', translate=True)
-    legend_blocked = fields.Char('Red Kanban Label', default=lambda s: _('Blocked'), translate=True)
-    legend_done = fields.Char('Green Kanban Label', default=lambda s: _('Ready for Next Stage'), translate=True)
-    legend_normal = fields.Char('Grey Kanban Label', default=lambda s: _('In Progress'), translate=True)
+    legend_blocked = fields.Char('Red Kanban Label', default=lambda s: s.env._('Blocked'), translate=True)
+    legend_done = fields.Char('Green Kanban Label', default=lambda s: s.env._('Ready for Next Stage'), translate=True)
+    legend_normal = fields.Char('Grey Kanban Label', default=lambda s: s.env._('In Progress'), translate=True)
     # pipe
     fold = fields.Boolean(
         string='Folded in Kanban',

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1,20 +1,20 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
-import logging
 
 from datetime import datetime
 
 from werkzeug.exceptions import Forbidden, NotFound
 from werkzeug.urls import url_decode, url_encode, url_parse
 
-from odoo import _, _lt, fields
+from odoo import fields
 from odoo.exceptions import ValidationError
 from odoo.fields import Command
 from odoo.http import request, route
 from odoo.osv import expression
 from odoo.tools import clean_context, float_round, groupby, lazy, single_email_re, str2bool, SQL
 from odoo.tools.json import scriptsafe as json_scriptsafe
+from odoo.tools.translate import _
 
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment.controllers import portal as payment_portal
@@ -22,8 +22,6 @@ from odoo.addons.portal.controllers.portal import _build_url_w_params
 from odoo.addons.sale.controllers import portal as sale_portal
 from odoo.addons.website.controllers.main import QueryURL
 from odoo.addons.website.models.ir_http import sitemap_qs2dom
-
-_logger = logging.getLogger(__name__)
 
 
 class TableCompute:
@@ -1158,7 +1156,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
                     )  # On the main partner only, if the VAT was set.
                 )
             ),
-            'vat_label': _lt("VAT"),
+            'vat_label': request.env._("VAT"),
         }
 
     @route(

--- a/addons/website_sale/models/product_public_category.py
+++ b/addons/website_sale/models/product_public_category.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 from odoo.tools.translate import html_translate
 
 
@@ -68,7 +68,7 @@ class ProductPublicCategory(models.Model):
     def _compute_display_name(self):
         for category in self:
             category.display_name = " / ".join(category.parents_and_self.mapped(
-                lambda cat: cat.name or _("New")
+                lambda cat: cat.name or self.env._("New")
             ))
 
     #=== CONSTRAINT METHODS ===#
@@ -76,7 +76,7 @@ class ProductPublicCategory(models.Model):
     @api.constrains('parent_id')
     def check_parent_id(self):
         if self._has_cycle():
-            raise ValueError(_("Error! You cannot create recursive categories."))
+            raise ValueError(self.env._("Error! You cannot create recursive categories."))
 
     #=== BUSINESS METHODS ===#
 

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -1,8 +1,11 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import SUPERUSER_ID, _, _lt, api, fields, models, tools
+from odoo import SUPERUSER_ID, api, fields, models, tools
 from odoo.http import request
 from odoo.osv import expression
+from odoo.tools.translate import _, LazyTranslate
+
+_lt = LazyTranslate(__name__)
 
 
 class Website(models.Model):

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -351,7 +351,8 @@ class IrAttachment(models.Model):
                 except UserError as e:
                     # Catch error during test where we provide fake image
                     # raise UserError(_("This file could not be decoded as an image file. Please try with a different file."))
-                    _logger.info('Post processing ignored : %s', e)
+                    msg = str(e)  # the exception can be lazy-translated, resolve it here
+                    _logger.info('Post processing ignored : %s', msg)
         return values
 
     def _check_contents(self, values):

--- a/odoo/addons/base/models/ir_fields.py
+++ b/odoo/addons/base/models/ir_fields.py
@@ -8,9 +8,11 @@ import itertools
 import psycopg2
 import pytz
 
-from odoo import api, Command, fields, models, _
+from odoo import api, Command, fields, models
 from odoo.tools import OrderedSet
-from odoo.tools.translate import code_translations, _lt
+from odoo.tools.translate import _, code_translations, LazyTranslate
+
+_lt = LazyTranslate(__name__)
 
 REFERENCING_FIELDS = {None, 'id', '.id'}
 def only_ref_fields(record):

--- a/odoo/addons/base/models/ir_filters.py
+++ b/odoo/addons/base/models/ir_filters.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, tools, _
+from odoo import api, fields, models, tools
 from odoo.exceptions import UserError
 from odoo.tools.safe_eval import safe_eval, datetime
 
@@ -39,7 +39,7 @@ class IrFilters(models.Model):
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)
-        return [dict(vals, name=_("%s (copy)", ir_filter.name)) for ir_filter, vals in zip(self, vals_list)]
+        return [dict(vals, name=self.env._("%s (copy)", ir_filter.name)) for ir_filter, vals in zip(self, vals_list)]
 
     def write(self, vals):
         new_filter = super().write(vals)
@@ -115,7 +115,7 @@ class IrFilters(models.Model):
         if matching_filters and (matching_filters[0]['id'] == defaults.id):
             return
 
-        raise UserError(_("There is already a shared filter set as default for %(model)s, delete or change it before setting a new default", model=vals.get('model_id')))
+        raise UserError(self.env._("There is already a shared filter set as default for %(model)s, delete or change it before setting a new default", model=vals.get('model_id')))
 
     @api.model
     @api.returns('self', lambda value: value.id)

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -12,12 +12,14 @@ from operator import itemgetter
 
 from psycopg2.extras import Json
 
-from odoo import api, fields, models, tools, _, _lt, Command
+from odoo import api, fields, models, tools, Command
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.osv import expression
 from odoo.tools import format_list, sql, unique, OrderedSet, SQL
 from odoo.tools.safe_eval import safe_eval, datetime, dateutil, time
+from odoo.tools.translate import _, LazyTranslate
 
+_lt = LazyTranslate(__name__)
 _logger = logging.getLogger(__name__)
 
 # Messages are declared in extenso so they are properly exported in translation terms
@@ -1498,6 +1500,13 @@ class IrModelSelection(models.Model):
         ]
         if not fields:
             return
+        if invalid_fields := OrderedSet(
+            field for field in fields
+            for selection in field.selection
+            for value_label in selection
+            if not isinstance(value_label, str)
+        ):
+            raise ValidationError(_("Fields %s contain a non-str value/label in selection", invalid_fields))
 
         # determine expected and existing rows
         IMF = self.env['ir.model.fields']

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -342,9 +342,8 @@ class Module(models.Model):
         """ Domain to retrieve the modules that should be loaded by the registry. """
         return [('state', '=', 'installed')]
 
-    @classmethod
-    def check_external_dependencies(cls, module_name, newstate='to install'):
-        terp = cls.get_module_info(module_name)
+    def check_external_dependencies(self, module_name, newstate='to install'):
+        terp = self.get_module_info(module_name)
         try:
             modules.check_manifest_dependencies(terp)
         except Exception as e:

--- a/odoo/addons/base/models/ir_qweb_fields.py
+++ b/odoo/addons/base/models/ir_qweb_fields.py
@@ -12,12 +12,14 @@ from markupsafe import Markup, escape, escape_silent
 from PIL import Image
 from lxml import etree, html
 
-from odoo import api, fields, models, _, _lt, tools
+from odoo import api, fields, models, tools
 from odoo.tools import posix_to_ldml, float_utils, format_date, format_duration
 from odoo.tools.mail import safe_attrs
 from odoo.tools.misc import get_lang, babel_locale_parse
 from odoo.tools.mimetypes import guess_mimetype
+from odoo.tools.translate import _, LazyTranslate
 
+_lt = LazyTranslate(__name__)
 _logger = logging.getLogger(__name__)
 
 

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -2918,6 +2918,7 @@ class NameManager:
 
     def __init__(self, model, parent=None, model_groups=None):
         self.model = model
+        self.env = model.env  # for dynamically-resolved translations
         self.available_fields = collections.defaultdict(dict)  # {field_name: {'groups': groups, 'info': field_info}}
         self.available_actions = set()
         self.available_names = set()

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -478,7 +478,7 @@ class Partner(models.Model):
         vals_list = super().copy_data(default=default)
         if default.get('name'):
             return vals_list
-        return [dict(vals, name=_("%s (copy)", partner.name)) for partner, vals in zip(self, vals_list)]
+        return [dict(vals, name=self.env._("%s (copy)", partner.name)) for partner, vals in zip(self, vals_list)]
 
     @api.onchange('parent_id')
     def onchange_parent_id(self):

--- a/odoo/addons/test_lint/tests/_odoo_checker_gettext.py
+++ b/odoo/addons/test_lint/tests/_odoo_checker_gettext.py
@@ -53,7 +53,15 @@ class OdooBaseChecker(BaseChecker):
 
     @only_required_for_messages('gettext-variable', 'gettext-placeholders', 'gettext-repr')
     def visit_call(self, node):
-        if not isinstance(node.func, astroid.Name) or node.func.name not in ("_", "_lt"):
+        if isinstance(node.func, astroid.Name):
+            # direct function call to _
+            node_name = node.func.name
+        elif isinstance(node.func, astroid.Attribute):
+            # method call to env._
+            node_name = node.func.attrname
+        else:
+            return
+        if node_name not in ("_", "_lt"):
             return
         first_arg = node.args[0]
         if not (isinstance(first_arg, astroid.Const) and isinstance(first_arg.value, str)):

--- a/odoo/addons/test_lint/tests/test_checkers.py
+++ b/odoo/addons/test_lint/tests/test_checkers.py
@@ -70,6 +70,28 @@ class TestPylintChecks(TransactionCase):
 
 
 @unittest.skipUnless(pylint and pylint_bin, "testing lints requires pylint")
+class TestGetTextLint(TestPylintChecks):
+    def check(self, testtext):
+        return super().check(testtext, "_odoo_checker_gettext", "gettext-placeholders")
+
+    def test_gettext_env(self):
+        # check that _ and self.env._ are checked in the same way
+        r, errs = self.check("""
+        def method(self, vars):
+            _("something %s %s", *vars)
+        """)
+        self.assertTrue(r, "_() should have raised for multiple placeholders")
+        self.assertEqual(errs[0]['line'], 2, errs)
+
+        r, errs = self.check("""
+        def method(self, vars):
+            self.env._("something %s %s", *vars)
+        """)
+        self.assertTrue(r, "self.env._() should have raised for multiple placeholders")
+        self.assertEqual(errs[0]['line'], 2, errs)
+
+
+@unittest.skipUnless(pylint and pylint_bin, "testing lints requires pylint")
 class TestSqlLint(TestPylintChecks):
     def check(self, testtext):
         return super().check(testtext, "_odoo_checker_sql_injection", "sql-injection")

--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -4,13 +4,13 @@
 import datetime
 import logging
 
+from odoo import Command, api, fields, models
+from odoo.exceptions import AccessError, ValidationError
 from odoo.tools import SQL
 from odoo.tools.float_utils import float_round
-_logger = logging.getLogger('precompute_setter')
-
-from odoo import models, fields, api, _, Command
-from odoo.exceptions import AccessError, ValidationError
 from odoo.tools.translate import html_translate
+
+_logger = logging.getLogger('precompute_setter')
 
 
 class Category(models.Model):
@@ -172,7 +172,7 @@ class Message(models.Model):
     def _check_author(self):
         for message in self.with_context(active_test=False):
             if message.discussion and message.author not in message.discussion.sudo().participants:
-                raise ValidationError(_("Author must be among the discussion participants."))
+                raise ValidationError(self.env._("Author must be among the discussion participants."))
 
     @api.depends('author.name', 'discussion.name')
     def _compute_name(self):
@@ -855,7 +855,7 @@ class ComputeOnchange(models.Model):
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)
-        return [dict(vals, foo=_("%s (copy)", record.foo)) for record, vals in zip(self, vals_list)]
+        return [dict(vals, foo=self.env._("%s (copy)", record.foo)) for record, vals in zip(self, vals_list)]
 
 
 class ComputeOnchangeLine(models.Model):

--- a/odoo/addons/test_translation_import/models/models.py
+++ b/odoo/addons/test_translation_import/models/models.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
-from odoo import fields, models, _, _lt
-from odoo.tools.translate import xml_translate
+from odoo import fields, models
+from odoo.tools.translate import _, xml_translate, LazyTranslate
+
+_lt = LazyTranslate(__name__)
+
 
 class TestTranslationImportModel1(models.Model):
     _name = 'test.translation.import.model1'

--- a/odoo/service/model.py
+++ b/odoo/service/model.py
@@ -13,10 +13,10 @@ from odoo.exceptions import UserError, ValidationError
 from odoo.http import request
 from odoo.models import check_method_name
 from odoo.modules.registry import Registry
-from odoo.tools import DotDict
-from odoo.tools.translate import _, translate_sql_constraint
+from odoo.tools import DotDict, lazy
+from odoo.tools.translate import translate_sql_constraint
+
 from . import security
-from ..tools import lazy
 
 _logger = logging.getLogger(__name__)
 
@@ -48,7 +48,7 @@ def execute_cr(cr, uid, obj, method, *args, **kw):
     env = odoo.api.Environment(cr, uid, {})
     recs = env.get(obj)
     if recs is None:
-        raise UserError(_("Object %s doesn't exist", obj))
+        raise UserError(env._("Object %s doesn't exist", obj))
     result = retrying(partial(odoo.api.call_kw, recs, method, args, kw), env)
     # force evaluation of lazy values before the cursor is closed, as it would
     # error afterwards if the lazy isn't already evaluated (and cached)
@@ -74,9 +74,9 @@ def execute(db, uid, obj, method, *args, **kw):
 def _as_validation_error(env, exc):
     """ Return the IntegrityError encapsuled in a nice ValidationError """
 
-    unknown = _('Unknown')
-    model = DotDict({'_name': unknown.lower(), '_description': unknown})
-    field = DotDict({'name': unknown.lower(), 'string': unknown})
+    unknown = env._('Unknown')
+    model = DotDict({'_name': 'unknown', '_description': unknown})
+    field = DotDict({'name': 'unknown', 'string': unknown})
     for _name, rclass in env.registry.items():
         if exc.diag.table_name == rclass._table:
             model = rclass
@@ -85,7 +85,7 @@ def _as_validation_error(env, exc):
 
     match exc:
         case errors.NotNullViolation():
-            return ValidationError(_(
+            return ValidationError(env._(
                 "The operation cannot be completed:\n"
                 "- Create/update: a mandatory field is not set.\n"
                 "- Delete: another model requires the record being deleted."
@@ -99,7 +99,7 @@ def _as_validation_error(env, exc):
             ))
 
         case errors.ForeignKeyViolation():
-            return ValidationError(_(
+            return ValidationError(env._(
                 "The operation cannot be completed: another model requires "
                 "the record being deleted. If possible, archive it instead.\n\n"
                 "Model: %(model_name)s (%(model_tech_name)s)\n"
@@ -110,12 +110,12 @@ def _as_validation_error(env, exc):
             ))
 
     if exc.diag.constraint_name in env.registry._sql_constraints:
-        return ValidationError(_(
+        return ValidationError(env._(
             "The operation cannot be completed: %s",
             translate_sql_constraint(env.cr, exc.diag.constraint_name, env.context.get('lang', 'en_US'))
         ))
 
-    return ValidationError(_("The operation cannot be completed: %s", exc.args[0]))
+    return ValidationError(env._("The operation cannot be completed: %s", exc.args[0]))
 
 
 def retrying(func, env):

--- a/odoo/tools/__init__.py
+++ b/odoo/tools/__init__.py
@@ -23,7 +23,7 @@ from .mail import *
 from .misc import *
 from .query import Query
 from .sql import *
-from .translate import _, _lt, html_translate, xml_translate
+from .translate import _, html_translate, xml_translate, LazyTranslate
 from .xml_utils import cleanup_xml_node, load_xsd_files_from_url, validate_xml_from_attachment
 from .convert import convert_csv_import, convert_file, convert_sql_import, convert_xml_import
 from . import osutil

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -25,7 +25,6 @@ except ImportError:
 import odoo
 from .config import config
 from .misc import file_open, file_path, SKIPPED_ELEMENT_TYPES
-from .translate import _
 from odoo.exceptions import ValidationError
 
 from .safe_eval import safe_eval as s_eval, pytz, time
@@ -648,7 +647,7 @@ def convert_csv_import(env, module, fname, csvcontent, idref=None, mode='init',
     if any(msg['type'] == 'error' for msg in result['messages']):
         # Report failed import and abort module install
         warning_msg = "\n".join(msg['message'] for msg in result['messages'])
-        raise Exception(_(
+        raise Exception(env._(
             "Module loading %(module)s failed: file %(file)s could not be processed:\n%(message)s",
             module=module,
             file=fname,

--- a/odoo/tools/image.py
+++ b/odoo/tools/image.py
@@ -17,11 +17,11 @@ from random import randrange
 
 from odoo.exceptions import UserError
 from odoo.tools.misc import DotDict
-from odoo.tools.translate import _
+from odoo.tools.translate import LazyTranslate
 
 
 __all__ = ["image_process"]
-
+_lt = LazyTranslate('base')
 
 # Preload PIL with the minimal subset of image formats we need
 Image.preinit()
@@ -85,7 +85,7 @@ class ImageProcess:
             try:
                 self.image = Image.open(io.BytesIO(source))
             except (OSError, binascii.Error):
-                raise UserError(_("This file could not be decoded as an image file."))
+                raise UserError(_lt("This file could not be decoded as an image file."))
 
             # Original format has to be saved before fixing the orientation or
             # doing any other operations because the information will be lost on
@@ -96,7 +96,7 @@ class ImageProcess:
 
             w, h = self.image.size
             if verify_resolution and w * h > IMAGE_MAX_RESOLUTION:
-                raise UserError(_("Image size excessive, uploaded images must be smaller than %s million pixels.", str(IMAGE_MAX_RESOLUTION / 1e6)))
+                raise UserError(_lt("Image size excessive, uploaded images must be smaller than %s million pixels.", str(IMAGE_MAX_RESOLUTION / 1e6)))
 
     def image_quality(self, quality=0, output_format=''):
         """Return the image resulting of all the image processing
@@ -422,7 +422,7 @@ def binary_to_image(source):
     try:
         return Image.open(io.BytesIO(source))
     except (OSError, binascii.Error):
-        raise UserError(_("This file could not be decoded as an image file."))
+        raise UserError(_lt("This file could not be decoded as an image file."))
 
 def base64_to_image(base64_source: Union[str, bytes]) -> Image:
     """Return a PIL image from the given `base64_source`.
@@ -433,7 +433,7 @@ def base64_to_image(base64_source: Union[str, bytes]) -> Image:
     try:
         return Image.open(io.BytesIO(base64.b64decode(base64_source)))
     except (OSError, binascii.Error):
-        raise UserError(_("This file could not be decoded as an image file."))
+        raise UserError(_lt("This file could not be decoded as an image file."))
 
 
 def image_apply_opt(image: Image, output_format: str, **params) -> bytes:
@@ -475,7 +475,7 @@ def get_webp_size(source):
     :return: (width, height) tuple, or None if not supported
     """
     if not (source[0:4] == b'RIFF' and source[8:15] == b'WEBPVP8'):
-        raise UserError(_("This file is not a webp file."))
+        raise UserError(_lt("This file is not a webp file."))
 
     vp8_type = source[15]
     if vp8_type == 0x20:  # 0x20 = ' '

--- a/odoo/tools/template_inheritance.py
+++ b/odoo/tools/template_inheritance.py
@@ -6,12 +6,13 @@ import re
 from lxml import etree
 from lxml.builder import E
 
-from odoo.tools.translate import _
+from odoo.tools.translate import LazyTranslate
 from odoo.exceptions import ValidationError
 from .misc import SKIPPED_ELEMENT_TYPES, html_escape
 
 __all__ = []
 
+_lt = LazyTranslate('base')
 _logger = logging.getLogger(__name__)
 RSTRIP_REGEXP = re.compile(r'\n[ \t]*$')
 
@@ -85,7 +86,7 @@ def locate_node(arch, spec):
         try:
             xPath = etree.ETXPath(expr)
         except etree.XPathSyntaxError as e:
-            raise ValidationError(_("Invalid Expression while parsing xpath “%s”", expr)) from e
+            raise ValidationError(_lt("Invalid Expression while parsing xpath “%s”", expr)) from e
         nodes = xPath(arch)
         return nodes[0] if nodes else None
     elif spec.tag == 'field':
@@ -130,7 +131,7 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
         """
         if len(spec):
             raise ValueError(
-                _("Invalid specification for moved nodes: “%s”", etree.tostring(spec, encoding='unicode'))
+                _lt("Invalid specification for moved nodes: “%s”", etree.tostring(spec, encoding='unicode'))
             )
         pre_locate(spec)
         to_extract = locate_node(source, spec)
@@ -139,7 +140,7 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
             return to_extract
         else:
             raise ValueError(
-                _("Element “%s” cannot be located in parent view", etree.tostring(spec, encoding='unicode'))
+                _lt("Element “%s” cannot be located in parent view", etree.tostring(spec, encoding='unicode'))
             )
 
     while len(specs):
@@ -211,7 +212,7 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
                     node.text = spec.text
 
                 else:
-                    raise ValueError(_("Invalid mode attribute: “%s”", mode))
+                    raise ValueError(_lt("Invalid mode attribute: “%s”", mode))
             elif pos == 'attributes':
                 for child in spec.getiterator('attribute'):
                     # The element should only have attributes:
@@ -225,7 +226,7 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
                         and not key.startswith('data-oe-')
                     ]
                     if unknown:
-                        raise ValueError(_(
+                        raise ValueError(_lt(
                             "Invalid attributes %s in element <attribute>",
                             ", ".join(map(repr, unknown)),
                         ))
@@ -235,7 +236,7 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
 
                     if child.get('add') or child.get('remove'):
                         if child.text:
-                            raise ValueError(_(
+                            raise ValueError(_lt(
                                 "Element <attribute> with 'add' or 'remove' cannot contain text %s",
                                 repr(child.text),
                             ))
@@ -248,7 +249,7 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
                             # attribute containing a python expression
                             separator = separator.strip()
                             if separator not in ('and', 'or'):
-                                raise ValueError(_(
+                                raise ValueError(_lt(
                                     "Invalid separator %(separator)s for python expression %(expression)s; "
                                     "valid values are 'and' and 'or'",
                                     separator=repr(separator), expression=repr(attribute),
@@ -310,10 +311,7 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
                 add_stripped_items_before(node, spec, extract)
 
             else:
-                raise ValueError(
-                    _("Invalid position attribute: '%s'") %
-                    pos
-                )
+                raise ValueError(_lt("Invalid position attribute: '%s'", pos))
 
         else:
             attrs = ''.join([
@@ -323,7 +321,7 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
             ])
             tag = "<%s%s>" % (spec.tag, attrs)
             raise ValueError(
-                _("Element '%s' cannot be located in parent view", tag)
+                _lt("Element '%s' cannot be located in parent view", tag)
             )
 
     return source

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -20,7 +20,7 @@ import os
 import polib
 import re
 import tarfile
-import threading
+import typing
 import warnings
 from collections import defaultdict, namedtuple
 from contextlib import suppress
@@ -41,7 +41,7 @@ from .misc import file_open, file_path, get_iso_codes, OrderedSet, ReadonlyDict,
 
 __all__ = [
     "_",
-    "_lt",
+    "LazyTranslate",
     "html_translate",
     "xml_translate",
 ]
@@ -443,155 +443,218 @@ def translate_sql_constraint(cr, key, lang):
         """, (lang, key))
     return cr.fetchone()[0]
 
-class GettextAlias(object):
 
-    def _get_db(self):
-        # find current DB based on thread/worker db name (see netsvc)
-        db_name = getattr(threading.current_thread(), 'dbname', None)
-        if db_name:
-            return odoo.sql_db.db_connect(db_name)
-
-    def _get_cr(self, frame, allow_create=True):
-        # try, in order: cr, cursor, self.env.cr, self.cr,
-        # request.env.cr
-        if 'cr' in frame.f_locals:
-            return frame.f_locals['cr'], False
-        if 'cursor' in frame.f_locals:
-            return frame.f_locals['cursor'], False
-        s = frame.f_locals.get('self')
-        if hasattr(s, 'env'):
-            return s.env.cr, False
-        if hasattr(s, 'cr'):
-            return s.cr, False
-        try:
-            from odoo.http import request
-            return request.env.cr, False
-        except RuntimeError:
-            pass
-        if allow_create:
-            # create a new cursor
-            db = self._get_db()
-            if db is not None:
-                return db.cursor(), True
-        return None, False
-
-    def _get_uid(self, frame):
-        # try, in order: uid, user, self.env.uid
-        if 'uid' in frame.f_locals:
-            return frame.f_locals['uid']
-        if 'user' in frame.f_locals:
-            return int(frame.f_locals['user'])      # user may be a record
-        s = frame.f_locals.get('self')
-        return s.env.uid
-
-    def _get_lang(self, frame):
-        # try, in order: context.get('lang'), kwargs['context'].get('lang'),
-        # self.env.lang, request.env.lang
-        lang = None
-        if frame.f_locals.get('context'):
-            lang = frame.f_locals['context'].get('lang')
-        if not lang:
-            kwargs = frame.f_locals.get('kwargs', {})
-            if kwargs.get('context'):
-                lang = kwargs['context'].get('lang')
-        if not lang:
-            s = frame.f_locals.get('self')
-            if hasattr(s, 'env'):
-                lang = s.env.lang
-            if not lang:
-                try:
-                    from odoo.http import request
-                    lang = request.env.lang
-                except RuntimeError:
-                    pass
-            if not lang:
-                # Last resort: attempt to guess the language of the user
-                # Pitfall: some operations are performed in sudo mode, and we
-                #          don't know the original uid, so the language may
-                #          be wrong when the admin language differs.
-                (cr, dummy) = self._get_cr(frame, allow_create=False)
-                uid = self._get_uid(frame)
-                if cr and uid:
-                    env = odoo.api.Environment(cr, uid, {})
-                    lang = env['res.users'].context_get()['lang']
-        return lang
-
-    def __call__(self, source, *args, **kwargs):
-        translation = self._get_translation(source)
-        assert not (args and kwargs)
-        if args or kwargs:
-            if any(isinstance(a, Markup) for a in itertools.chain(args, kwargs.values())):
-                translation = escape(translation)
-            try:
-                return translation % (args or kwargs)
-            except (TypeError, ValueError, KeyError):
-                bad = translation
-                # fallback: apply to source before logging exception (in case source fails)
-                translation = source % (args or kwargs)
-                _logger.exception('Bad translation %r for string %r', bad, source)
+def get_translation(module: str, lang: str, source: str, args: tuple | dict) -> str:
+    """Translate and format using a module, language, source text and args."""
+    # get the translation by using the language
+    assert lang, "missing language for translation"
+    if lang == 'en_US':
+        translation = source
+    else:
+        assert module, "missing module name for translation"
+        translation = code_translations.get_python_translations(module, lang).get(source, source)
+    # skip formatting if we have no args
+    if not args:
         return translation
+    # we need to check the args for markup values and for lazy translations
+    args_is_dict = isinstance(args, dict)
+    if any(isinstance(a, Markup) for a in (args.values() if args_is_dict else args)):
+        translation = escape(translation)
+    if any(isinstance(a, LazyGettext) for a in (args.values() if args_is_dict else args)):
+        if args_is_dict:
+            args = {k: v._translate(lang) if isinstance(v, LazyGettext) else v for k, v in args.items()}
+        else:
+            args = tuple(v._translate(lang) if isinstance(v, LazyGettext) else v for v in args)
+    # format
+    try:
+        return translation % args
+    except (TypeError, ValueError, KeyError):
+        bad = translation
+        # fallback: apply to source before logging exception (in case source fails)
+        translation = source % args
+        _logger.exception('Bad translation %r for string %r', bad, source)
+    return translation
 
-    def _get_translation(self, source, module=None):
-        try:
-            frame = inspect.currentframe().f_back.f_back
-            lang = self._get_lang(frame)
-            if lang and lang != 'en_US':
-                if not module:
-                    path = inspect.getfile(frame)
-                    path_info = odoo.modules.get_resource_from_path(path)
-                    module = path_info[0] if path_info else 'base'
-                return code_translations.get_python_translations(module, lang).get(source, source)
-            else:
-                _logger.debug('no translation language detected, skipping translation for "%r" ', source)
-        except Exception:
-            _logger.debug('translation went wrong for "%r", skipped', source)
-                # if so, double-check the root/base translations filenames
-        return source
+
+def get_translated_module(arg: str | int | typing.Any) -> str:  # frame not represented as hint
+    """Get the addons name.
+
+    :param arg: can be any of the following:
+                str ("name_of_module") returns itself;
+                str (__name__) use to resolve module name;
+                int is number of frames to go back to the caller;
+                frame of the caller function
+    """
+    if isinstance(arg, str):
+        if arg.startswith('odoo.addons.'):
+            # get the name of the module
+            return arg.split('.')[2]
+        if '.' in arg or not arg:
+            # module name is not in odoo.addons.
+            return 'base'
+        else:
+            return arg
+    else:
+        if isinstance(arg, int):
+            frame = inspect.currentframe()
+            while arg > 0:
+                arg -= 1
+                frame = frame.f_back
+        else:
+            frame = arg
+        if not frame:
+            return 'base'
+        if (module_name := frame.f_globals.get("__name__")) and module_name.startswith('odoo.addons.'):
+            # just a quick lookup because `get_resource_from_path is slow compared to this`
+            return module_name.split('.')[2]
+        path = inspect.getfile(frame)
+        path_info = odoo.modules.get_resource_from_path(path)
+        return path_info[0] if path_info else 'base'
+
+
+def _get_cr(frame):
+    # try, in order: cr, cursor, self.env.cr, self.cr,
+    # request.env.cr
+    if 'cr' in frame.f_locals:
+        return frame.f_locals['cr']
+    if 'cursor' in frame.f_locals:
+        return frame.f_locals['cursor']
+    if (local_self := frame.f_locals.get('self')) is not None:
+        if (local_env := getattr(local_self, 'env', None)) is not None:
+            return local_env.cr
+        if (cr := getattr(local_self, 'cr', None)) is not None:
+            return cr
+    try:
+        from odoo.http import request  # noqa: PLC0415
+        request_env = request.env
+        if request_env is not None and (cr := request_env.cr) is not None:
+            return cr
+    except RuntimeError:
+        pass
+    return None
+
+
+def _get_uid(frame) -> int | None:
+    # try, in order: uid, user, self.env.uid
+    if 'uid' in frame.f_locals:
+        return frame.f_locals['uid']
+    if 'user' in frame.f_locals:
+        return int(frame.f_locals['user'])      # user may be a record
+    if (local_self := frame.f_locals.get('self')) is not None:
+        if hasattr(local_self, 'env') and (uid := local_self.env.uid):
+            return uid
+    return None
+
+
+def _get_lang(frame, default_lang='') -> str:
+    # get from: context.get('lang'), kwargs['context'].get('lang'),
+    if local_context := frame.f_locals.get('context'):
+        if lang := local_context.get('lang'):
+            return lang
+    if (local_kwargs := frame.f_locals.get('kwargs')) and (local_context := local_kwargs.get('context')):
+        if lang := local_context.get('lang'):
+            return lang
+    # get from self.env
+    log_level = logging.WARNING
+    local_self = frame.f_locals.get('self')
+    local_env = local_self is not None and getattr(local_self, 'env', None)
+    if local_env:
+        if lang := local_env.lang:
+            return lang
+        # we found the env, in case we fail, just log in debug
+        log_level = logging.DEBUG
+    # get from request?
+    try:
+        from odoo.http import request  # noqa: PLC0415
+        request_env = request.env
+        if request_env and (lang := request_env.lang):
+            return lang
+    except RuntimeError:
+        pass
+    # Last resort: attempt to guess the language of the user
+    # Pitfall: some operations are performed in sudo mode, and we
+    #          don't know the original uid, so the language may
+    #          be wrong when the admin language differs.
+    cr = _get_cr(frame)
+    uid = _get_uid(frame)
+    if cr and uid:
+        env = odoo.api.Environment(cr, uid, {})
+        if lang := env['res.users'].context_get().get('lang'):
+            return lang
+    # fallback
+    if default_lang:
+        _logger.debug('no translation language detected, fallback to %s', default_lang)
+        return default_lang
+    # give up
+    _logger.log(log_level, 'no translation language detected, skipping translation %s', frame, stack_info=True)
+    return ''
+
+
+def _get_translation_source(stack_level: int, module: str = '', lang: str = '', default_lang: str = '') -> tuple[str, str]:
+    if not (module and lang):
+        frame = inspect.currentframe()
+        for _index in range(stack_level + 1):
+            frame = frame.f_back
+        lang = lang or _get_lang(frame, default_lang)
+    if lang and lang != 'en_US':
+        return get_translated_module(module or frame), lang
+    else:
+        # we don't care about the module for 'en_US'
+        return module or 'base', 'en_US'
+
+
+def get_text_alias(source: str, *args, **kwargs):
+    assert not (args and kwargs)
+    assert isinstance(source, str)
+    module, lang = _get_translation_source(1)
+    return get_translation(module, lang, source, args or kwargs)
 
 
 @functools.total_ordering
-class _lt:
-    """ Lazy code translation
+class LazyGettext:
+    """ Lazy code translated term.
 
-    Similar to GettextAlias but the translation lookup will be done only at
+    Similar to get_text_alias but the translation lookup will be done only at
     __str__ execution.
+    This eases the search for terms to translate as lazy evaluated strings
+    are declared early.
 
     A code using translated global variables such as:
 
+    ```
+    _lt = LazyTranslate(__name__)
     LABEL = _lt("User")
 
     def _compute_label(self):
-        context = {'lang': self.partner_id.lang}
-        self.user_label = LABEL
+        env = self.with_env(lang=self.partner_id.lang).env
+        self.user_label = env._(LABEL)
+    ```
 
-    works as expected (unlike the classic GettextAlias implementation).
+    works as expected (unlike the classic get_text_alias implementation).
     """
 
-    __slots__ = ['_source', '_args', '_module']
+    __slots__ = ('_args', '_default_lang', '_module', '_source')
 
-    def __init__(self, source, *args, **kwargs):
-        self._source = source
+    def __init__(self, source, *args, _module='', _default_lang='', **kwargs):
         assert not (args and kwargs)
+        assert isinstance(source, str)
+        self._source = source
         self._args = args or kwargs
+        self._module = get_translated_module(_module or 2)
+        self._default_lang = _default_lang
 
-        frame = inspect.currentframe().f_back
-        path = inspect.getfile(frame)
-        path_info = odoo.modules.get_resource_from_path(path)
-        self._module = path_info[0] if path_info else 'base'
+    def _translate(self, lang: str = '') -> str:
+        module, lang = _get_translation_source(2, self._module, lang, default_lang=self._default_lang)
+        return get_translation(module, lang, self._source, self._args)
+
+    def __repr__(self):
+        """ Show for the debugger"""
+        args = {'_module': self._module, '_default_lang': self._default_lang, '_args': self._args}
+        return f"_lt({self._source!r}, **{args!r})"
 
     def __str__(self):
-        # Call _._get_translation() like _() does, so that we have the same number
-        # of stack frames calling _get_translation()
-        translation = _._get_translation(self._source, self._module)
-        if self._args:
-            try:
-                return translation % self._args
-            except (TypeError, ValueError, KeyError):
-                bad = translation
-                # fallback: apply to source before logging exception (in case source fails)
-                translation = self._source % self._args
-                _logger.exception('Bad translation %r for string %r', bad, self._source)
-        return translation
+        """ Translate."""
+        return self._translate()
 
     def __eq__(self, other):
         """ Prevent using equal operators
@@ -601,26 +664,50 @@ class _lt:
         """
         raise NotImplementedError()
 
+    def __hash__(self):
+        raise NotImplementedError()
+
     def __lt__(self, other):
         raise NotImplementedError()
 
     def __add__(self, other):
-        # Call _._get_translation() like _() does, so that we have the same number
-        # of stack frames calling _get_translation()
         if isinstance(other, str):
-            return _._get_translation(self._source) + other
-        elif isinstance(other, _lt):
-            return _._get_translation(self._source) + _._get_translation(other._source)
+            return self._translate() + other
+        elif isinstance(other, LazyGettext):
+            return self._translate() + other._translate()
         return NotImplemented
 
     def __radd__(self, other):
-        # Call _._get_translation() like _() does, so that we have the same number
-        # of stack frames calling _get_translation()
         if isinstance(other, str):
-            return other + _._get_translation(self._source)
+            return other + self._translate()
         return NotImplemented
 
-_ = GettextAlias()
+
+class LazyTranslate:
+    """ Lazy translation template.
+
+    Usage:
+    ```
+    _lt = LazyTranslate(__name__)
+    MYSTR = _lt('Translate X')
+    ```
+
+    You may specify a `default_lang` to fallback to a given language on error
+    """
+    module: str
+    default_lang: str
+
+    def __init__(self, module: str, *, default_lang: str = '') -> None:
+        self.module = module = get_translated_module(module or 2)
+        # set the default lang to en_US for lazy translations in the base module
+        self.default_lang = default_lang or ('en_US' if module == 'base' else '')
+
+    def __call__(self, source: str, *args, **kwargs) -> LazyGettext:
+        return LazyGettext(source, *args, **kwargs, _module=self.module, _default_lang=self.default_lang)
+
+
+_ = get_text_alias
+_lt = LazyGettext
 
 
 def quote(s):


### PR DESCRIPTION
Python translations need to know the language and the module to find the translated term. Today's `_` function must resolve both of these values from the current stack by using some heuristics.
These heuristics don't always work properly: to find the language we look in the caller's scope to find it in the context or to find the environment from which we can read lang.
For the module, if the function is used outside of an addon, we default to 'base'.

We add a function `Environment._` for translations. That function uses its `lang` property for the language without resorting to inspecting the call stack. You can also pass the module, but we can still resolve it dynamically.

For lazy translations, we create a new `LazyTranslate` factory that you can use as `_lt = LazyTranslate(__name__)` in any addon. This will resolve the addon name once per file from the name of the package without going through `inspect`. You can then use `Environment._` to get the translation or `str()` to resolve the lanugage dynamically.


odoo/enterprise#67528
odoo/documentation#10421
task-4034999

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
