### PR TITLE
[IMP] product,_*: improved backend product editing for ecommerce

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -158,12 +158,12 @@
                         <page string="Sales" name="sales" invisible="1 or not sale_ok">
                             <group name="sale">
                                 <group string="Upsell &amp; Cross-Sell" name="upsell" invisible="1"/>
-                                <group name="tags" string="Extra Info">
+                                <group name="extra_info" string="Extra Info">
                                     <field name="product_tag_ids" widget="many2many_tags" context="{'product_template_id': id}"/>
                                 </group>
                             </group>
                             <group>
-                                <group string="Sales Description" name="description">
+                                <group string="Quotation Description" name="description">
                                     <field colspan="2" name="description_sale" nolabel="1" placeholder="This note is added to sales orders and invoices."/>
                                 </group>
                             </group>

--- a/addons/sale/views/product_views.xml
+++ b/addons/sale/views/product_views.xml
@@ -19,9 +19,6 @@
             <field name="service_tracking" position="attributes">
                 <attribute name="invisible" add="not sale_ok" separator="or"/>
             </field>
-            <group name="tags" position="inside">
-                <field name="expense_policy" widget="radio" invisible="not visible_expense_policy"/>
-            </group>
             <group name="description" position="after">
                 <t groups="sales_team.group_sale_salesman">
                     <group string="Warning when Selling this Product" groups="sale.group_warning_sale">
@@ -33,6 +30,9 @@
                                required="sale_line_warn != 'no-message'"/>
                     </group>
                 </t>
+                <group name="expense_info" string="Expense" invisible="not visible_expense_policy">
+                    <field name="expense_policy" widget="radio"/>
+                </group>
             </group>
         </field>
     </record>

--- a/addons/website_sale/views/product_views.xml
+++ b/addons/website_sale/views/product_views.xml
@@ -170,20 +170,40 @@
                 <field name="description_ecommerce" invisible="1" />         <!-- Adding this field as we needed in product_barcodelookup module to store value in this field -->
             </group>
             <xpath expr="//page[@name='sales']/group[@name='sale']" position="inside">
-                <group string="eCommerce Shop" name="shop" invisible="not sale_ok">
-                    <field name="website_url" invisible="1"/>
-                    <field name="website_id"
-                        options="{'no_create': True}"
-                        groups="website.group_multi_website"
-                        placeholder="All"/>
-                    <field name="website_sequence" groups="base.group_no_one"/>
-                    <field name="public_categ_ids" widget="many2many_tags" string="Categories"/>
-                    <field name="website_ribbon_id" groups="base.group_no_one" options="{'no_quick_create': True}"/>
-                </group>
                 <group colspan="2" name="product_template_images" string="eCommerce Media" invisible="not sale_ok">
                     <field colspan="2" name="product_template_image_ids" class="o_website_sale_image_list" context="{'default_name': name}" mode="kanban" add-label="Add Media" nolabel="1" widget="x2_many_media_viewer"/>
                 </group>
             </xpath>
+            <xpath expr="//page[@name='sales']//group[@name='description']" position="after">
+                <group string="Ecommerce Description" name="ecom_description">
+                   <field
+                        colspan="2"
+                        name="description_ecommerce"
+                        nolabel="1"
+                        placeholder="A detailed,formatted description to promote your product on
+                                     this page. Use '/' to discover more features."
+                    />
+                </group>
+            </xpath>
+            <group name="extra_info" position="inside">
+                <field name="is_published"/>
+                <field
+                    name="website_id"
+                    options="{'no_create': True}"
+                    groups="website.group_multi_website"
+                    placeholder="All"
+                />
+                <field name="website_sequence" groups="base.group_no_one"/>
+                <field name="public_categ_ids" widget="many2many_tags" string="Categories"/>
+                <field
+                    name="website_ribbon_id"
+                    groups="base.group_no_one"
+                    options="{'no_quick_create': True}"
+                />
+            </group>
+            <group name="extra_info" position="attributes">
+                <attribute name="string">Ecommerce Shop</attribute>
+            </group>
         </field>
     </record>
 

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1248,7 +1248,6 @@
                                     </t>
                                 </a>
                             </t>
-                            <p t-field="product.description_sale" class="text-muted my-2" placeholder="A short description that will also appear on documents." />
                             <div t-field="product.description_ecommerce" class="oe_structure"
                                 placeholder="A detailed, formatted description to promote your product on this page. Use '/' to discover more features."/>
                             <form t-if="product._is_add_to_cart_possible()" action="/shop/cart/update" method="POST">


### PR DESCRIPTION
_* = website_sale,sale

Description:
This commit introduces several enhancements to the backend product.
It includes renaming, hiding, reorganizing fields, adding new fields.

Before this commit:
-Two separate groups, "Extra Info" and "E-commerce Shop," both
contained fields related to eCommerce.

After this commit:
-The "Extra Info" group is renamed to "E-commerce Shop"
when the eCommerce module is installed.
-The "Extra Info" and "E-commerce Shop" groups are combined
into a single group called "E-commerce Shop."
-The "Sales Description" field is renamed to "Quotation Description."
-A new group, "E-commerce Description," is introduced.
-The "Sales Description" field is removed from the eCommerce section.
-The "expense_policy" field is placed in a new section after the
"Quotation Description."

task-4011651