### PR TITLE
[FIX] stock: reusable package weight

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -668,7 +668,7 @@ class Picking(models.Model):
     weight_bulk = fields.Float(
         'Bulk Weight', compute='_compute_bulk_weight', help="Total weight of products which are not in a package.")
     shipping_weight = fields.Float(
-        "Weight for Shipping", compute='_compute_shipping_weight',
+        "Weight for Shipping", compute='_compute_shipping_weight', store=True,
         help="Total weight of packages and products not in a package. "
         "Packages with no shipping weight specified will default to their products' total weight. "
         "This is the weight used to compute the cost of the shipping.")
@@ -856,12 +856,9 @@ class Picking(models.Model):
     @api.depends('move_line_ids.result_package_id', 'move_line_ids.result_package_id.shipping_weight', 'weight_bulk')
     def _compute_shipping_weight(self):
         for picking in self:
-            # if shipping weight is not assigned => default to calculated product weight
-            packages_weight = picking.move_line_ids.result_package_id.sudo()._get_weight(picking.id)
-            picking.shipping_weight = (
-                picking.weight_bulk +
-                sum(pack.shipping_weight or packages_weight[pack] for pack in picking.move_line_ids.result_package_id)
-            )
+            if picking.state == 'done':
+                continue
+            picking.shipping_weight = picking._get_shipping_weight()
 
     def _compute_shipping_volume(self):
         for picking in self:
@@ -1225,6 +1222,9 @@ class Picking(models.Model):
                 picking.move_line_ids.write({'owner_id': picking.owner_id.id})
         todo_moves._action_done(cancel_backorder=self.env.context.get('cancel_backorder'))
         self.write({'date_done': fields.Datetime.now(), 'priority': '0'})
+        # recompute the shipping weight now that it can't be altered by its compute method
+        for picking in self:
+            picking.shipping_weight = picking._get_shipping_weight()
 
         # if incoming/internal moves make other confirmed/partially_available moves available, assign them
         done_incoming_moves = self.filtered(lambda p: p.picking_type_id.code in ('incoming', 'internal')).move_ids.filtered(lambda m: m.state == 'done')
@@ -2008,3 +2008,10 @@ class Picking(models.Model):
                 clean_action(action, self.env)
                 report_actions.append(action)
         return report_actions
+
+    def _get_shipping_weight(self):
+        # if shipping weight is not assigned => default to calculated product weight
+        self.ensure_one()
+        packages_weight = self.move_line_ids.result_package_id.sudo()._get_weight(self.id)
+        packing_weight = sum(pack.shipping_weight or packages_weight[pack] for pack in self.move_line_ids.result_package_id)
+        return self.weight_bulk + packing_weight

--- a/addons/stock/tests/test_packing.py
+++ b/addons/stock/tests/test_packing.py
@@ -1890,6 +1890,73 @@ class TestPacking(TestPackingCommon):
             {'package_id': pack3.id, 'state': 'assigned', 'is_done': True},
         ])
 
+    def test_reusable_package_weight(self):
+        """
+        Check that the shipping_weight of a done picking is not recomputed
+        """
+        reusable_box = self.env['stock.quant.package'].create({
+            'name': 'Reusable Box',
+            'package_use': 'reusable',
+        })
+
+        self.productA.weight = 4.0
+        delivery_a = self.env['stock.picking'].create({
+            'picking_type_id': self.warehouse.out_type_id.id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'move_ids_without_package': [Command.create({
+                'name': self.productA.name,
+                'product_id': self.productA.id,
+                'product_uom_qty': 5.0,
+                'location_id': self.stock_location.id,
+                'product_uom': self.productA.uom_id.id,
+                'location_dest_id': self.customer_location.id,
+            })],
+            'move_line_ids': [Command.create({
+                'location_id': self.stock_location.id,
+                'result_package_id': reusable_box.id,
+                'quantity': 5.0,
+                'product_id': self.productA.id,
+                'location_dest_id': self.customer_location.id,
+                'product_uom_id': self.productA.uom_id.id,
+            })],
+        })
+        delivery_a.action_confirm()
+        self.assertEqual(delivery_a.shipping_weight, 20.0)
+        reusable_box.shipping_weight = 19.0
+        self.assertEqual(delivery_a.shipping_weight, 19.0)
+        delivery_a.button_validate()
+
+        reusable_box.unpack()
+        reusable_box.shipping_weight = 0.0
+        self.assertEqual(delivery_a.shipping_weight, 19.0)
+
+        delivery_b = self.env['stock.picking'].create({
+            'picking_type_id': self.warehouse.out_type_id.id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'move_ids_without_package': [Command.create({
+                'name': self.productA.name,
+                'product_id': self.productA.id,
+                'product_uom_qty': 3.0,
+                'location_id': self.stock_location.id,
+                'product_uom': self.productA.uom_id.id,
+                'location_dest_id': self.customer_location.id,
+            })],
+            'move_line_ids': [Command.create({
+                'location_id': self.stock_location.id,
+                'result_package_id': reusable_box.id,
+                'quantity': 3.0,
+                'product_id': self.productA.id,
+                'location_dest_id': self.customer_location.id,
+                'product_uom_id': self.productA.uom_id.id,
+            })],
+        })
+        delivery_b.action_confirm()
+        delivery_b.button_validate()
+        self.assertEqual(delivery_b.shipping_weight, 12.0)
+        self.assertEqual(delivery_a.shipping_weight, 19.0)
+
 
 @odoo.tests.tagged('post_install', '-at_install')
 class TestPackagePropagation(TestPackingCommon):


### PR DESCRIPTION
### Steps to reproduce:

1. Activate packages in inventory > configuration > settings.
2. Create a delivery for any product with a set weight, and put the products of the delivery in a reusable package.
3. Validate the transfer and then unpack the package.
4. Create a new delivery for a different product with a different weight, and put the products of the delivery in the same reusable package as in step 2.
5. If you look at the additional info tab of both inventory transfers, the "weight for shipping" is the same in both cases, even if the products of both packages had different weights.
6. Additionally, if the weight for shipping field is modified in any of the inventory transfers, then the weight will be modified in all of the transfers that used the same reusable package.

### Fix:

Store the picking weight and do not updated it once it's done this fixes the issue because the package is only used on one picking at a time (the active one) change the weight field to stored to keep track of it once the picking is done and the package is reused

opw-3834199
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
