### PR TITLE
[FIX] *: migrate studio demo data from default content to demo attribute

### DIFF
--- a/addons/account/views/report_payment_receipt_templates.xml
+++ b/addons/account/views/report_payment_receipt_templates.xml
@@ -10,7 +10,7 @@
                 <div class="mb-4 mt-3">
                     <div name="date" class="row">
                         <div class="col-6" t-if="o.date">
-                            Payment Date: <span t-field="o.date">2023-01-01</span>
+                            Payment Date: <span t-field="o.date" data-oe-demo="2023-01-01"/>
                         </div>
                     </div>
                     <div class="oe_structure"></div>
@@ -21,21 +21,21 @@
                             </t>
                             <t t-else="o.partner_type == 'supplier'">
                                 Vendor:
-                            </t><span t-field="o.partner_id">Marc Demo</span>
+                            </t><span t-field="o.partner_id" data-oe-demo="Marc Demo"/>
                         </div>
                         <div name="payment_method"
                              t-if="values['display_payment_method'] and o.payment_method_id"
                              class="col-6">
-                            Payment Method: <span t-field="o.payment_method_id.name">Credit card</span>
+                            Payment Method: <span t-field="o.payment_method_id.name" data-oe-demo="Credit card"/>
                         </div>
                     </div>
                     <div class="oe_structure"></div>
                     <div class="row">
                         <div class="col-6" t-if="o.amount">
-                            Payment Amount: <span t-field="o.amount" t-options="{'widget': 'monetary', 'display_currency': o.currency_id}">50 USD</span>
+                            Payment Amount: <span t-field="o.amount" t-options="{'widget': 'monetary', 'display_currency': o.currency_id}" data-oe-demo="50 USD"/>
                          </div>
                         <div class="col-6" t-if="o.ref">
-                            Memo: <span t-field="o.ref">Sample Memo</span>
+                            Memo: <span t-field="o.ref" data-oe-demo="Sample Memo"/>
                          </div>
                     </div>
                 </div>
@@ -65,18 +65,18 @@
                             <!-- MOVE -->
                             <t t-if="inv.move_type != 'entry'">
                                 <tr>
-                                    <td><span t-field="inv.invoice_date">2023-01-01</span></td>
-                                    <td><span t-field="inv.name">INV001</span></td>
-                                    <td><span t-field="inv.ref">Sample Ref</span></td>
+                                    <td><span t-field="inv.invoice_date" data-oe-demo="2023-01-01"/></td>
+                                    <td><span t-field="inv.name" data-oe-demo="INV001"/></td>
+                                    <td><span t-field="inv.ref" data-oe-demo="Sample Ref"/></td>
                                     <td t-if="otherCurrency"/>
-                                    <td class="text-end"><span t-field="inv.amount_total">100.00 USD</span></td>
+                                    <td class="text-end"><span t-field="inv.amount_total" data-oe-demo="100.00 USD"/></td>
                                 </tr>
                                 <!-- PAYMENTS/REVERSALS -->
                                 <tr t-foreach="inv._get_reconciled_invoices_partials()[0]" t-as="par">
                                     <t t-set="payment" t-value="par[2].move_id"/>
-                                    <td><span t-field="payment.date">2023-01-05</span></td>
-                                    <td><span t-field="payment.name">PAY001</span></td>
-                                    <td><span t-field="payment.ref">Payment Ref</span></td>
+                                    <td><span t-field="payment.date" data-oe-demo="2023-01-05"/></td>
+                                    <td><span t-field="payment.name" data-oe-demo="PAY001"/></td>
+                                    <td><span t-field="payment.ref" data-oe-demo="Payment Ref"/></td>
                                     <t t-set="amountPayment" t-value="-payment.amount_total"/>
                                     <t t-set="amountInvoice" t-value="-par[1]"/>
                                     <t t-set="currencyPayment" t-value="payment.currency_id"/>
@@ -88,10 +88,10 @@
                                 <!-- BALANCE -->
                                 <tr>
                                     <td/>
-                                    <td><strong>Due Amount for <span t-field="inv.name">INV001</span></strong></td>
+                                    <td><strong>Due Amount for <span t-field="inv.name" data-oe-demo="INV001"/></strong></td>
                                     <td/>
                                     <td t-if="otherCurrency"/>
-                                    <td class="text-end"><strong><span t-field="inv.amount_residual">25.0 USD</span></strong></td>
+                                    <td class="text-end"><strong><span t-field="inv.amount_residual" data-oe-demo="25.0 USD"/></strong></td>
                                 </tr>
                             </t>
                         </t>

--- a/addons/account/views/report_statement.xml
+++ b/addons/account/views/report_statement.xml
@@ -53,9 +53,9 @@
                                         <h5>
                                             <strong>
                                                 <span t-if="o.name">
-                                                    <span t-field="o.name">Statement Name</span>
+                                                    <span t-field="o.name" data-oe-demo="Statement Name"/>
                                                 - </span>
-                                                <span t-field="o.date">2023-08-15</span>
+                                                <span t-field="o.date" data-oe-demo="2023-08-15"/>
                                             </strong>
                                         </h5>
                                     </div>
@@ -79,7 +79,7 @@
                                                     </td>
                                                     <td class="text-end p-0">
                                                         <strong>
-                                                            <span t-field="o.balance_start">1000.0</span>
+                                                            <span t-field="o.balance_start" data-oe-demo="1000.0"/>
                                                         </strong>
                                                     </td>
                                                 </tr>
@@ -94,7 +94,7 @@
                                                     </td>
                                                     <td class="text-end p-0">
                                                         <strong>
-                                                            <span t-field="o.balance_end_real">1500.0</span>
+                                                            <span t-field="o.balance_end_real" data-oe-demo="1500.0"/>
                                                         </strong>
                                                     </td>
                                                 </tr>
@@ -109,17 +109,17 @@
                                 <tbody>
                                     <tr t-foreach="o.line_ids" t-as="line">
                                         <td class="w-25 py-1">
-                                            <span class="d-block fw-bold" t-field="line.date">2023-08-11</span>
+                                            <span class="d-block fw-bold" t-field="line.date" data-oe-demo="2023-08-11"/>
                                         </td>
                                         <td class="py-1">
                                             <span class="d-block fw-bold" t-if="line.partner_id">
                                                 <span t-out="line.partner_id.name">Marc Demo</span> <span t-if="line.partner_bank_id and line.partner_bank_id.partner_id != line.partner_id">(<span t-out="line.partner_bank_id.partner_id.name">Bank of odoo</span>)</span>
                                             </span>
                                             <span class="d-block" t-if="line.partner_bank_id or line.account_number" t-out="line.account_number or line.partner_bank_id.acc_number">534677881234</span>
-                                            <span class="d-block" t-if="line.payment_ref" t-field="line.payment_ref">Payment Reference</span>
+                                            <span class="d-block" t-if="line.payment_ref" t-field="line.payment_ref" data-oe-demo="Payment Reference"/>
                                         </td>
                                         <td class="text-end py-1">
-                                            <span t-att-class="'d-block fw-bold' + (' text-danger' if line.amount &lt; 0 else '')" t-field="line.amount">100.0</span>
+                                            <span t-att-class="'d-block fw-bold' + (' text-danger' if line.amount &lt; 0 else '')" t-field="line.amount" data-oe-demo="100.0"/>
                                         </td>
                                     </tr>
                                 </tbody>

--- a/addons/event/report/event_event_templates.xml
+++ b/addons/event/report/event_event_templates.xml
@@ -192,13 +192,13 @@
     <div class="row footer o_event_full_page_ticket_footer d-block">
         <div class="o_event_full_page_ticket_powered_by bg-odoo text-white text-center p-2 w-100">
             <span t-if="event.organizer_id">
-                <span class="fw-bold" t-field="event.organizer_id.name">Marc Demo</span>
+                <span class="fw-bold" t-field="event.organizer_id.name" data-oe-demo="Marc Demo"/>
                 <span t-if="event.organizer_id.phone" class="ps-3 fa fa-phone"/>
-                <span t-if="event.organizer_id.phone" t-field="event.organizer_id.phone">+123456789</span>
+                <span t-if="event.organizer_id.phone" t-field="event.organizer_id.phone" data-oe-demo="+123456789"/>
                 <span t-if="event.organizer_id.email_normalized" class="ps-3 fa fa-envelope"/>
-                <span t-if="event.organizer_id.email_normalized" t-field="event.organizer_id.email_normalized">organizer@email.com</span>
+                <span t-if="event.organizer_id.email_normalized" t-field="event.organizer_id.email_normalized" data-oe-demo="organizer@email.com"/>
                 <span t-if="event.organizer_id.website" class="ps-3 fa fa-globe"/>
-                <span t-if="event.organizer_id.website" t-field="event.organizer_id.website">https://www.example.com</span>
+                <span t-if="event.organizer_id.website" t-field="event.organizer_id.website" data-oe-demo="https://www.example.com"/>
             </span>
             <t t-else="">
                 <span t-out="event.name">Odoo Community Days</span> <!-- Force some content to avoid messing the layout -->

--- a/addons/hr/report/hr_employee_badge.xml
+++ b/addons/hr/report/hr_employee_badge.xml
@@ -39,7 +39,7 @@
                                 <table style="width:155pt; height:85pt" class="table-borderless">
                                     <tr><th><div style="font-size:15pt; margin-bottom:0pt;margin-top:0pt;" align="center"><span t-out="employee.name">Marc Demo</span></div></th></tr>
                                     <tr><td><div align="center" style="font-size:10pt;margin-bottom:5pt;"><span t-out="employee.job_id.name">Software Developer</span></div></td></tr>
-                                    <tr><td><div t-if="employee.barcode" t-field="employee.barcode" t-options="{'widget': 'barcode', 'width': 600, 'height': 120, 'img_style': 'max-height:50pt;max-width:100%;', 'img_align': 'center'}">12345678901</div></td></tr>
+                                    <tr><td><div t-if="employee.barcode" t-field="employee.barcode" t-options="{'widget': 'barcode', 'width': 600, 'height': 120, 'img_style': 'max-height:50pt;max-width:100%;', 'img_align': 'center'}" data-oe-demo="12345678901"/></td></tr>
                                 </table>
                             </td>
                         </table>

--- a/addons/hr_expense/report/hr_expense_report.xml
+++ b/addons/hr_expense/report/hr_expense_report.xml
@@ -12,21 +12,21 @@
                             <div class="col-6">
                                 <div class="row">
                                     <div class="col-3 fw-bold"><span>Employee:</span> </div>
-                                    <div class="col-9 text-muted"><span t-field="o.employee_id.name">Marc Demo</span></div>
+                                    <div class="col-9 text-muted"><span t-field="o.employee_id.name" data-oe-demo="Marc Demo"/></div>
                                 </div>
                                 <div class="row" t-if="o.accounting_date">
                                     <div class="col-3 fw-bold"><span>Date:</span></div>
-                                    <div class="col-9 text-muted"><span t-field="o.accounting_date">2023-08-11</span></div>
+                                    <div class="col-9 text-muted"><span t-field="o.accounting_date" data-oe-demo="2023-08-11"/></div>
                                 </div>
                             </div>
                             <div class="col-6">
                                 <div class="row" t-if="o.user_id.name">
                                     <div class="col-3 fw-bold"><span>Manager:</span></div>
-                                    <div class="col-9 text-muted"><span t-field="o.user_id">Mitchell Admin</span></div>
+                                    <div class="col-9 text-muted"><span t-field="o.user_id" data-oe-demo="Mitchell Admin"/></div>
                                 </div>
                                 <div class="row">
                                     <div class="col-3 fw-bold"><span>Paid by:</span></div>
-                                    <div class="col-9 text-muted"><span t-field="o.payment_mode">Credit Card</span></div>
+                                    <div class="col-9 text-muted"><span t-field="o.payment_mode" data-oe-demo="Credit Card"/></div>
                                 </div>
                             </div>
                         </div>
@@ -49,19 +49,19 @@
                                 <tr t-foreach="o.expense_line_ids" t-as="line">
                                     <td class="text-start"><span t-field="line.date"></span></td>
                                     <td t-att-class="'text-start' + (' o_overflow' if len(line.name) > 30 else '')">
-                                        <span t-field="line.name">Flight Ticket</span>
+                                        <span t-field="line.name" data-oe-demo="Flight Ticket"/>
                                     </td>
-                                    <td class="text-end"><span t-field="line.price_unit">$100.00</span></td>
-                                    <td class="text-end"><span t-field="line.quantity">1</span></td>
+                                    <td class="text-end"><span t-field="line.price_unit" data-oe-demo="$100.00"/></td>
+                                    <td class="text-end"><span t-field="line.quantity" data-oe-demo="1"/></td>
                                     <t t-set="taxes" t-value="', '.join([(tax.invoice_label or tax.name) for tax in line.tax_ids])"/>
                                     <td t-attf-class="text-end {{ 'text-nowrap' if len(taxes) &lt; 10 else '' }}">
                                         <span t-out="taxes" id="line_tax_ids">Tax 15%</span>
                                     </td>
                                     <td t-if="foreign_currencies" class="text-end">
-                                        <span t-field="line.total_amount_currency" t-options='{"widget": "monetary", "display_currency": line.currency_id}'>$120.00</span>
+                                        <span t-field="line.total_amount_currency" t-options='{"widget": "monetary", "display_currency": line.currency_id}' data-oe-demo="$120.00"/>
                                     </td>
                                     <td class="text-end">
-                                        <span t-field="line.total_amount" t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'>$100.00</span>
+                                        <span t-field="line.total_amount" t-options='{"widget": "monetary", "display_currency": o.company_currency_id}' data-oe-demo="$100.00"/>
                                     </td>
                                 </tr>
                             </tbody>
@@ -74,16 +74,16 @@
                                     <tbody>
                                         <tr>
                                             <td>Untaxed Amount</td>
-                                            <td class="text-end"><span t-field="o.untaxed_amount" t-options='{"widget": "monetary", "display_currency": o.currency_id}'>$500.00</span></td>
+                                            <td class="text-end"><span t-field="o.untaxed_amount" t-options='{"widget": "monetary", "display_currency": o.currency_id}' data-oe-demo="$500.00"/></td>
                                         </tr>
                                         <tr>
                                             <td>Taxes</td>
-                                            <td class="text-end"><span t-field="o.total_tax_amount" t-options='{"widget": "monetary", "display_currency": o.currency_id}'>$100.00</span></td>
+                                            <td class="text-end"><span t-field="o.total_tax_amount" t-options='{"widget": "monetary", "display_currency": o.currency_id}' data-oe-demo="$100.00"/></td>
                                         </tr>
                                         <tr class="fw-bold">
                                             <td>Total</td>
                                             <td class="text-end">
-                                                <span t-field="o.total_amount" t-options='{"widget": "monetary", "display_currency": o.currency_id}'>$600.00</span>
+                                                <span t-field="o.total_amount" t-options='{"widget": "monetary", "display_currency": o.currency_id}' data-oe-demo="$600.00"/>
                                             </td>
                                         </tr>
                                     </tbody>

--- a/addons/hr_skills/views/hr_employee_cv_templates.xml
+++ b/addons/hr_skills/views/hr_employee_cv_templates.xml
@@ -24,7 +24,7 @@
                 <span t-out="o.company_id.partner_id.name">Demo Company Name</span>
             </div>
             <div class="col-12">
-                <span t-field="o.company_id.partner_id" t-options='{"widget": "contact", "fields": ["address"], "no_marker": True}'>Demo Address</span>
+                <span t-field="o.company_id.partner_id" t-options='{"widget": "contact", "fields": ["address"], "no_marker": True}' data-oe-demo="Demo Address"/>
             </div>
         </div>
     </template>
@@ -36,23 +36,23 @@
             background-color: #{color_primary};">
             <div class="o_profile">
                 <img class="img img-fluid rounded-circle o_profile_image" t-attf-src="data:image/png;base64,#{o.image_128}" alt="" t-if="o.image_128"/>
-                <h1 class="o_profile_name mt-2" t-field="o.name">Marc Demo</h1>
-                <h3 class="o_profile_job mb-2" t-field="o.job_id">Software Developer</h3>
+                <h1 class="o_profile_name mt-2" t-field="o.name" data-oe-demo="Marc Demo"/>
+                <h3 class="o_profile_job mb-2" t-field="o.job_id" data-oe-demo="Software Developer"/>
             </div>
             <div class="oe_structure"></div>
             <div class="o_sidebar_section" t-if="show_contact">
                 <ul class="o_social">
                     <li class="email" t-if="o.company_id.email">
                         <i class="fa fa-solid fa-envelope pe-2"/>
-                        <a t-attf-href="mailto: #{o.company_id.email}" t-field="o.company_id.email">demo@email.com</a>
+                        <a t-attf-href="mailto: #{o.company_id.email}" t-field="o.company_id.email" data-oe-demo="demo@email.com"/>
                     </li>
                     <li class="phone" t-if="o.company_id.mobile">
                         <i class="fa fa-solid fa-phone pe-2"/>
-                        <a t-attf-href="tel:#{o.company_id.mobile}" t-field="o.company_id.mobile">+1234567890</a>
+                        <a t-attf-href="tel:#{o.company_id.mobile}" t-field="o.company_id.mobile" data-oe-demo="+1234567890"/>
                     </li>
                     <li class="website" t-if="o.company_id.website">
                         <i class="fa fa-solid fa-globe pe-2"/>
-                        <a t-attf-href="tel:#{o.company_id.website}" t-field="o.company_id.website">www.demo.com</a>
+                        <a t-attf-href="tel:#{o.company_id.website}" t-field="o.company_id.website" data-oe-demo="www.demo.com"/>
                     </li>
                 </ul>
             </div>
@@ -74,7 +74,7 @@
                     <t t-foreach="resume_lines[o][line_type]" t-as="resume_line">
                         <div class="o_main_panel_resume_title ps-5">
                             <div class="o_main_panel_resume_title_job">
-                                <h3 class="o_main_panel_resume_job" t-field="resume_line.name">Software Developer</h3>
+                                <h3 class="o_main_panel_resume_job" t-field="resume_line.name" data-oe-demo="Software Developer"/>
                             </div>
                             <div class="o_main_panel_resume_title_dates">
                                 <t t-set="present">Present</t>
@@ -128,7 +128,7 @@
                     <div class="o_main_panel_skills row ps-5">
                         <t t-foreach="skills_pair" t-as="skill_line">
                             <div class="o_main_panel_skill_line col-6 pe-4" t-if="skill_line.skill_type_id != skill_type_language">
-                                <h3 class="o_main_panel_skill_name" t-field="skill_line.skill_id">Python</h3>
+                                <h3 class="o_main_panel_skill_name" t-field="skill_line.skill_id" data-oe-demo="Python"/>
                                 <div class="progress o_main_panel_skill_progress_bar">
                                     <div
                                         class="o_main_panel_skill_progress_bar_color"

--- a/addons/loyalty/report/loyalty_report_templates.xml
+++ b/addons/loyalty/report/loyalty_report_templates.xml
@@ -28,7 +28,7 @@
                                 <br/>
                                 <h4 t-if="o.expiration_date">
                                     Use this promo code before
-                                    <span t-field="o.expiration_date" t-options='{"format": "yyyy-MM-d"}'>2023-08-20</span>
+                                    <span t-field="o.expiration_date" t-options='{"format": "yyyy-MM-d"}' data-oe-demo="2023-08-20"/>
                                 </h4>
                                 <h2 class="mt-4">
                                     <strong class="bg-light"><span t-out="o.code">DEMO_CODE</span></strong>
@@ -44,7 +44,7 @@
                                 </h4>
                                 <div class="oe_structure"></div>
                                 <br/>
-                                <span t-field="o.code" t-options="{'widget': 'barcode', 'width': 600, 'height': 100}">ABCDE12345</span>
+                                <span t-field="o.code" t-options="{'widget': 'barcode', 'width': 600, 'height': 100}" data-oe-demo="ABCDE12345"/>
                                 <div class="oe_structure"></div>
                                 <br/><br/>
                                 <h4>Thank you,</h4>
@@ -58,7 +58,7 @@
                                 <div>
                                     <div class="text-center d-inline-block">
                                         <span t-field="o.program_id.company_id.partner_id"
-                                            t-options='{"widget": "contact", "fields": ["address", "email"], "no_marker": True}'>John Doe</span>
+                                            t-options='{"widget": "contact", "fields": ["address", "email"], "no_marker": True}' data-oe-demo="John Doe"/>
                                     </div>
                                 </div>
                                 <div class="oe_structure"></div>
@@ -102,13 +102,13 @@
                         <strong>Gift Card Code</strong>
                     </p>
                     <p style="margin:0px; font-size:25px;font-family:arial, 'helvetica neue', helvetica, sans-serif; line-height:38px; color:#A9A9A9">
-                        <span t-field="o.code">ABCDE12345</span>
+                        <span t-field="o.code" data-oe-demo="ABCDE12345"/>
                     </p>
                 </div>
                 <div class="oe_structure"></div>
                 <div t-if="o.expiration_date" style="padding:0; margin:0px; padding-top:10px; padding-bottom:10px; text-align:center;">
                     <h3 style="margin:0px; line-height:17px; font-family:arial, 'helvetica neue', helvetica, sans-serif; font-size:14px; font-style:normal; font-weight:normal; color:#A9A9A9; text-align:center">
-                        Card expires <span t-field="o.expiration_date">2023-12-31</span>
+                        Card expires <span t-field="o.expiration_date" data-oe-demo="2023-12-31"/>
                     </h3>
                 </div>
                 <div class="oe_structure"></div>

--- a/addons/mrp/report/mrp_production_templates.xml
+++ b/addons/mrp/report/mrp_production_templates.xml
@@ -8,47 +8,47 @@
                     <div class="oe_structure"/>
                     <div class="row">
                         <div class="col-7">
-                            <h2><span t-field="o.name">MRP-001</span></h2>
+                            <h2><span t-field="o.name" data-oe-demo="MRP-001"/></h2>
                         </div>
                         <div class="col-5">
                             <span class="text-end">
-                                <span t-field="o.name" t-options="{'widget': 'barcode', 'width': 600, 'height': 100, 'img_style': 'width:350px;height:60px'}">Package barcode</span>
+                                <span t-field="o.name" t-options="{'widget': 'barcode', 'width': 600, 'height': 100, 'img_style': 'width:350px;height:60px'}" data-oe-demo="Package barcode"/>
                             </span>
                         </div>
                     </div>
                     <div class="row mt32 mb32">
                         <div class="col-3" t-if="o.origin">
                             <strong>Source:</strong><br/>
-                            <span t-field="o.origin">Vendor ABC</span>
+                            <span t-field="o.origin" data-oe-demo="Vendor ABC"/>
                         </div>
                         <div class="col-3" t-if="o.user_id">
                             <strong>Responsible:</strong><br/>
-                            <span t-field="o.user_id">John Doe</span>
+                            <span t-field="o.user_id" data-oe-demo="John Doe"/>
                         </div>
                         <div class="col-3" t-if="o.state not in ('done', 'cancel') and o.date_deadline">
                             <strong>Deadline:</strong><br/>
-                            <span t-field="o.date_deadline">2023-09-15</span>
+                            <span t-field="o.date_deadline" data-oe-demo="2023-09-15"/>
                         </div>
                     </div>
 
                     <div class="row mt32 mb32">
                         <div class="col-3">
                             <strong>Product:</strong><br/>
-                            <span t-field="o.product_id">Laptop Model X</span>
+                            <span t-field="o.product_id" data-oe-demo="Laptop Model X"/>
                         </div>
                         <div class="col-3" t-if="o.product_description_variants">
                             <strong>Description:</strong><br/>
-                            <span t-field="o.product_description_variants">Laptop with 16GB RAM</span>
+                            <span t-field="o.product_description_variants" data-oe-demo="Laptop with 16GB RAM"/>
                         </div>
                         <div class="col-3">
                             <strong>Quantity to Produce:</strong><br/>
-                            <span t-field="o.product_qty">100</span>
-                            <span t-field="o.product_uom_id.name" groups="uom.group_uom">Units</span>
+                            <span t-field="o.product_qty" data-oe-demo="100"/>
+                            <span t-field="o.product_uom_id.name" groups="uom.group_uom" data-oe-demo="Units"/>
                         </div>
                         <div class="col-3" t-if="o.qty_producing">
                             <strong>Quantity Producing:</strong><br/>
-                            <span t-field="o.qty_producing">50</span>
-                            <span t-field="o.product_uom_id.name" groups="uom.group_uom">Units</span>
+                            <span t-field="o.qty_producing" data-oe-demo="50"/>
+                            <span t-field="o.product_uom_id.name" groups="uom.group_uom" data-oe-demo="Units"/>
                         </div>
                     </div>
 
@@ -67,17 +67,17 @@
                                 <th style="width:30%"><strong>Barcode</strong></th>
                             </tr>
                             <tr t-foreach="o.workorder_ids" t-as="line2">
-                                <td><span t-field="line2.name">Assembling</span></td>
-                                <td><span t-field="line2.workcenter_id.name">Center A</span></td>
+                                <td><span t-field="line2.name" data-oe-demo="Assembling"/></td>
+                                <td><span t-field="line2.workcenter_id.name" data-oe-demo="Center A"/></td>
                                 <td>
-                                    <span t-if="o.state != 'done'" t-field="line2.duration_expected">60</span>
-                                    <span t-if="o.state == 'done'" t-field="line2.duration">58</span>
+                                    <span t-if="o.state != 'done'" t-field="line2.duration_expected" data-oe-demo="60"/>
+                                    <span t-if="o.state == 'done'" t-field="line2.duration" data-oe-demo="58"/>
                                 </td>
                                 <td t-if="o.state in ('progress', 'to_close')">
-                                    <span t-field="line2.duration">58</span>
+                                    <span t-field="line2.duration" data-oe-demo="58"/>
                                 </td>
                                 <td>
-                                    <span t-field="line2.barcode" t-options="{'widget': 'barcode', 'width': 600, 'height': 100, 'img_style': 'width:100%;height:35px'}">987654321098</span>
+                                    <span t-field="line2.barcode" t-options="{'widget': 'barcode', 'width': 600, 'height': 100, 'img_style': 'width:100%;height:35px'}" data-oe-demo="987654321098"/>
                                 </td>
                             </tr>
                         </table>
@@ -114,20 +114,20 @@
         <tbody>
             <tr t-foreach="o.move_raw_ids" t-as="raw_line">
                 <td>
-                    <span t-field="raw_line.product_id">8 GB RAM</span>
+                    <span t-field="raw_line.product_id" data-oe-demo="8 GB RAM"/>
                 </td>
                 <td t-attf-class="{{ 'text-end' if not has_product_barcode else '' }}" t-if="o.state in ('progress', 'to_close','done')">
                     <div>
-                        <span t-field="raw_line.quantity">2</span>
+                        <span t-field="raw_line.quantity" data-oe-demo="2"/>
                     </div>
                 </td>
                 <td t-attf-class="{{ 'text-end' if not has_product_barcode else '' }}">
-                    <span t-field="raw_line.product_uom_qty">25</span>
-                    <span t-field="raw_line.product_uom" groups="uom.group_uom">Pieces</span>
+                    <span t-field="raw_line.product_uom_qty" data-oe-demo="25"/>
+                    <span t-field="raw_line.product_uom" groups="uom.group_uom" data-oe-demo="Pieces"/>
                 </td>
                 <td t-if="has_product_barcode" width="15%" class="text-center">
                     <t t-if="raw_line.product_id.barcode">
-                        <span t-field="raw_line.product_id.barcode" t-options="{'widget': 'barcode', 'width': 600, 'height': 100, 'img_style': 'width:100%;height:35px'}">12345678901</span>
+                        <span t-field="raw_line.product_id.barcode" t-options="{'widget': 'barcode', 'width': 600, 'height': 100, 'img_style': 'width:100%;height:35px'}" data-oe-demo="12345678901"/>
                     </t>
                 </td>
             </tr>
@@ -180,7 +180,7 @@
                                         <div><span>Quantity: </span>
                                             <span t-if="move_line.product_uom_id.category_id == uom_categ_unit">1.0</span>
                                             <span t-else="" t-out="move_line.quantity">5</span>
-                                            <span t-field="move_line.product_uom_id" groups="uom.group_uom">UOM id</span>
+                                            <span t-field="move_line.product_uom_id" groups="uom.group_uom" data-oe-demo="UOM id"/>
                                         </div>
                                     </div>
                                     <t t-if="move_line.product_id.tracking != 'none' and (move_line.lot_name or move_line.lot_id)">

--- a/addons/mrp/report/mrp_workorder_templates.xml
+++ b/addons/mrp/report/mrp_workorder_templates.xml
@@ -8,11 +8,11 @@
                     <div class="oe_structure"/>
                     <div class="row">
                         <div class="col-7">
-                            <h2><span t-field="o.name">Laptop model X</span></h2>
+                            <h2><span t-field="o.name" data-oe-demo="Laptop model X"/></h2>
                         </div>
                         <div class="col-5">
                             <span class="text-end">
-                                <span t-field="o.name" t-options="{'widget': 'barcode', 'width': 600, 'height': 100, 'img_style': 'width:350px;height:60px'}">12345678901</span>
+                                <span t-field="o.name" t-options="{'widget': 'barcode', 'width': 600, 'height': 100, 'img_style': 'width:350px;height:60px'}" data-oe-demo="12345678901"/>
                             </span>
                         </div>
                     </div>
@@ -20,23 +20,23 @@
                     <div class="row mt32 mb32">
                         <div class="col-3">
                             <strong>Responsible:</strong><br/>
-                            <span t-field="o.production_id.user_id">Marc Demo</span>
+                            <span t-field="o.production_id.user_id" data-oe-demo="Marc Demo"/>
                         </div>
                         <div class="col-3">
                             <strong>Manufacturing Order:</strong><br/>
-                            <span t-field="o.production_id.name">RAM</span>
+                            <span t-field="o.production_id.name" data-oe-demo="RAM"/>
                         </div>
                     </div>
                     <br/>
                     <div class="row mt32 mb32">
                         <div class="col-3">
                             <strong>Finished Product:</strong><br/>
-                            <span t-field="o.product_id">Laptop</span>
+                            <span t-field="o.product_id" data-oe-demo="Laptop"/>
                         </div>
                         <div class="col-3">
                             <strong>Quantity to Produce:</strong><br/>
-                            <span t-field="o.qty_production">2</span>
-                            <span t-field="o.product_uom_id.name" groups="uom.group_uom">Unit</span>
+                            <span t-field="o.qty_production" data-oe-demo="2"/>
+                            <span t-field="o.product_uom_id.name" groups="uom.group_uom" data-oe-demo="Unit"/>
                         </div>
                     </div>
                     <br/>

--- a/addons/mrp_account/report/report_mrp_templates.xml
+++ b/addons/mrp_account/report/report_mrp_templates.xml
@@ -32,22 +32,22 @@
                                    <tbody>
                                         <tr t-foreach="docs" t-as="line" t-att-style="'background-color: #F1F1F1;' if line_index % 2 == 0 else ''">
                                             <td class="align-middle">
-                                               <span t-field="line.date">2023-08-15</span>
+                                               <span t-field="line.date" data-oe-demo="2023-08-15"/>
                                             </td>
                                             <td class="align-middle">
-                                               <span t-field="line.ref">REF123</span>
+                                               <span t-field="line.ref" data-oe-demo="REF123"/>
                                             </td>
                                             <td class="align-middle">
-                                                <span t-field="line.product_id">Laptop</span>
+                                                <span t-field="line.product_id" data-oe-demo="Laptop"/>
                                             </td>
                                             <td class="align-middle">
-                                                <span t-field="line.unit_amount">5</span>
+                                                <span t-field="line.unit_amount" data-oe-demo="5"/>
                                             </td>
                                             <td class="align-middle">
-                                                <span t-field="line.product_uom_id">Units</span>
+                                                <span t-field="line.product_uom_id" data-oe-demo="Units"/>
                                             </td>
                                             <td class="text-end align-middle">
-                                                <span t-field="line.amount">$1000</span>
+                                                <span t-field="line.amount" data-oe-demo="$1000"/>
                                             </td>
                                         </tr>
                                         <tr>

--- a/addons/point_of_sale/views/report_userlabel.xml
+++ b/addons/point_of_sale/views/report_userlabel.xml
@@ -17,9 +17,9 @@
                         <tbody>
                             <tr>
                                 <td>
-                                    <span t-if="user.barcode" t-field="user.barcode" t-options="{'widget': 'barcode', 'symbology': 'EAN13', 'width': 300, 'height': 50, 'img_style': 'width:100%;height:35%;'}">1234567890</span>
+                                    <span t-if="user.barcode" t-field="user.barcode" t-options="{'widget': 'barcode', 'symbology': 'EAN13', 'width': 300, 'height': 50, 'img_style': 'width:100%;height:35%;'}" data-oe-demo="1234567890"/>
                                 </td>
-                                <td><strong><span t-field="user.name">Marc Demo</span></strong></td>
+                                <td><strong><span t-field="user.name" data-oe-demo="Marc Demo"/></strong></td>
                             </tr>
                         </tbody>
                     </table>

--- a/addons/product/report/product_packaging.xml
+++ b/addons/product/report/product_packaging.xml
@@ -11,20 +11,20 @@
                             <table class="table table-condensed" style="border-bottom: 0px solid white !important;width: 3in;">
                                 <tr>
                                     <th style="text-align: left;">
-                                        <strong><span t-field="packaging.name">Package Type A</span></strong>
+                                        <strong><span t-field="packaging.name" data-oe-demo="Package Type A"/></strong>
                                     </th>
                                 </tr>
                                 <tr>
                                     <td>
-                                        <strong><span t-field="packaging.product_id.display_name">Eco-friendly Wooden Chair</span></strong>
+                                        <strong><span t-field="packaging.product_id.display_name" data-oe-demo="Eco-friendly Wooden Chair"/></strong>
                                     </td>
                                 </tr>
                                 <tr>
                                     <td>
                                         <div class="o_row">
                                             <strong>Qty: </strong>
-                                            <strong><span t-field="packaging.qty">10</span></strong>
-                                            <strong><span t-field="packaging.product_uom_id" groups="uom.group_uom">Units</span></strong>
+                                            <strong><span t-field="packaging.qty" data-oe-demo="10"/></strong>
+                                            <strong><span t-field="packaging.product_uom_id" groups="uom.group_uom" data-oe-demo="Units"/></strong>
                                         </div>
                                     </td>
                                 </tr>
@@ -32,7 +32,7 @@
                                     <tr>
                                     <td style="text-align: center; vertical-align: middle;" class="col-5">
                                         <div t-field="packaging.barcode" t-options="{'widget': 'barcode', 'symbology': 'auto', 'width': 600, 'height': 150, 'img_style': 'width:100%;height:20%;'}"/>
-                                        <span t-field="packaging.barcode">123456789012</span>
+                                        <span t-field="packaging.barcode" data-oe-demo="123456789012"/>
                                     </td>
                                 </tr>
                               </t>

--- a/addons/product/report/product_pricelist_report_templates.xml
+++ b/addons/product/report/product_pricelist_report_templates.xml
@@ -9,11 +9,11 @@
                     <h2 t-if="is_html_type">
                         Pricelist:
                         <a href="#" class="o_action" data-model="product.pricelist" t-att-data-res-id="pricelist.id">
-                            <span t-field="pricelist.display_name">Gold Member Pricelist</span>
+                            <span t-field="pricelist.display_name" data-oe-demo="Gold Member Pricelist"/>
                         </a>
                     </h2>
                     <h2 t-else="">
-                        Pricelist: <span t-field="pricelist.display_name">Gold Member Pricelist</span>
+                        Pricelist: <span t-field="pricelist.display_name" data-oe-demo="Gold Member Pricelist"/>
                     </h2>
                 </div>
             </div>

--- a/addons/purchase_requisition/report/report_purchaserequisition.xml
+++ b/addons/purchase_requisition/report/report_purchaserequisition.xml
@@ -21,11 +21,11 @@
                 </div>
                 <div t-if="o.ordering_date" class="col-3">
                     <strong>Scheduled Ordering Date:</strong><br/>
-                    <span t-field="o.ordering_date">2023-08-20</span>
+                    <span t-field="o.ordering_date" data-oe-demo="2023-08-20"/>
                 </div>
                 <div t-if="o.date_end" class="col-3">
                     <strong>Agreement Deadline:</strong><br/>
-                    <span t-field="o.date_end">2023-09-15</span>
+                    <span t-field="o.date_end" data-oe-demo="2023-09-15"/>
                 </div>
                 <div t-if="o.origin" class="col-3">
                     <strong>Source:</strong><br/>
@@ -53,24 +53,24 @@
                         <tr t-foreach="o.line_ids" t-as="line_ids">
                             <td>
                                 <span t-if="line_ids.product_id.code"><!--internal reference exists-->
-                                    [ <span t-field="line_ids.product_id.code">Code</span> ]
+                                    [ <span t-field="line_ids.product_id.code" data-oe-demo="Code"/> ]
                                 </span>
-                                <span t-field="line_ids.product_id.name">Product</span>
+                                <span t-field="line_ids.product_id.name" data-oe-demo="Product"/>
                             </td>
                             <td>
                                 <span t-if="line_ids.product_description_variants" t-field="line_ids.product_description_variants">Product description</span>
                             </td>
                             <td class="text-end">
-                                <span t-field="line_ids.product_qty">5</span>
+                                <span t-field="line_ids.product_qty" data-oe-demo="5"/>
                             </td>
                             <td class="text-center" groups="uom.group_uom">
-                                <span t-field="line_ids.product_uom_id.name">Unit</span>
+                                <span t-field="line_ids.product_uom_id.name" data-oe-demo="Unit"/>
                             </td>
                             <td t-if="o.type_id.quantity_copy == 'none'">
                                 <span t-field="line_ids.price_unit" t-options='{"widget": "monetary", "display_currency": line_ids.requisition_id.currency_id}'>$50</span>
                             </td>
                             <td class="text-end">
-                                <span t-if="line_ids.schedule_date" t-field="line_ids.schedule_date">2023-08-11</span>
+                                <span t-if="line_ids.schedule_date" t-field="line_ids.schedule_date" data-oe-demo="2023-08-11"/>
                             </td>
                         </tr>
                     </tbody>
@@ -89,10 +89,10 @@
                     <tbody>
                         <tr t-foreach="o.purchase_ids" t-as="purchase_ids">
                             <td>
-                                <span t-field="purchase_ids.partner_id.name">Vendor Name</span>
+                                <span t-field="purchase_ids.partner_id.name" data-oe-demo="Vendor Name"/>
                             </td>
                             <td class="text-end">
-                                <span t-field="purchase_ids.date_order">2023-08-15</span>
+                                <span t-field="purchase_ids.date_order" data-oe-demo="2023-08-15"/>
                             </td>
                             <td class="text-end">
                                 <span t-field="purchase_ids.name">PO000042</span>

--- a/addons/repair/report/repair_templates_repair_order.xml
+++ b/addons/repair/report/repair_templates_repair_order.xml
@@ -9,32 +9,32 @@
                     <div class="oe_structure"/>
                     <h2>
                         <span>Repair Order #:</span>
-                        <span t-field="o.name">RO123456</span>
+                        <span t-field="o.name" data-oe-demo="RO123456"/>
                     </h2>
                     <div class="oe_structure"/>
                     <div id="informations" class="row mb-3">
                         <div class="col-6">
                             <p t-if="o.partner_id" class="m-0">
                                 <strong>Customer:</strong>
-                                <span t-field="o.partner_id">John Doe</span>
+                                <span t-field="o.partner_id" data-oe-demo="John Doe"/>
                             </p>
                             <p t-if="o.product_id" class="m-0">
                                 <strong>Product:</strong>
-                                <span t-field="o.product_id">Laptop</span>
+                                <span t-field="o.product_id" data-oe-demo="Laptop"/>
                             </p>
                             <p t-if="o.lot_id" class="m-0" groups="stock.group_production_lot">
                                 <strong>Lot/Serial:</strong>
-                                <span t-field="o.lot_id">L12345</span>
+                                <span t-field="o.lot_id" data-oe-demo="L12345"/>
                             </p>
                         </div>
                         <div class="col-6">
                             <p class="m-0">
                                 <strong>Status:</strong>
-                                <span t-field="o.state">Pending</span>
+                                <span t-field="o.state" data-oe-demo="Pending"/>
                             </p>
                             <p t-if="o.user_id" class="m-0">
                                 <strong>Responsible:</strong>
-                                <span t-field="o.user_id">Jane Smith</span>
+                                <span t-field="o.user_id" data-oe-demo="Jane Smith"/>
                             </p>
                         </div>
                     </div>
@@ -50,12 +50,12 @@
                         <tbody>
                             <tr t-foreach="o.move_ids" t-as="line">
                                 <td>
-                                    <p t-if="line.repair_line_type == 'add'"><i>(Add)</i> <span t-field="line.product_id">Product A</span></p>
-                                    <p t-if="line.repair_line_type == 'remove'">(<i>Remove</i>) <span t-field="line.product_id">Product B</span></p>
+                                    <p t-if="line.repair_line_type == 'add'"><i>(Add)</i> <span t-field="line.product_id" data-oe-demo="Product A"/></p>
+                                    <p t-if="line.repair_line_type == 'remove'">(<i>Remove</i>) <span t-field="line.product_id" data-oe-demo="Product B"/></p>
                                 </td>
                                 <td class="text-end">
-                                    <span t-field="line.product_uom_qty">5</span>
-                                    <span groups="uom.group_uom" t-field="line.product_uom.name">Units</span>
+                                    <span t-field="line.product_uom_qty" data-oe-demo="5"/>
+                                    <span groups="uom.group_uom" t-field="line.product_uom.name" data-oe-demo="Units"/>
                                 </td>
                             </tr>
                         </tbody>
@@ -64,7 +64,7 @@
                     <div class="oe_structure"/>
                     <div t-if="o.internal_notes">
                         <h2 class="mb-3 border-bottom border-2 border-dark">Repair Notes</h2>
-                        <span t-field="o.internal_notes">This is a repair note.</span>
+                        <span t-field="o.internal_notes" data-oe-demo="This is a repair note."/>
                     </div>
                     <div class="oe_structure"/>
                 </div>

--- a/addons/stock/report/report_location_barcode.xml
+++ b/addons/stock/report/report_location_barcode.xml
@@ -20,11 +20,11 @@
                                         <td>
                                             <div class="o_label_full" style="width:47mm;height:37.1mm;border: 1px solid black;">
                                                 <div class="o_label_name text-center">
-                                                    <strong><span t-field="o.name">WH/Stock</span></strong>
+                                                    <strong><span t-field="o.name" data-oe-demo="WH/Stock"/></strong>
                                                 </div>
                                                 <div class="text-center mt-3">
                                                     <span t-if="o.barcode" t-field="o.barcode" style="padding:0"
-                                                        t-options="{'widget': 'barcode', 'humanreadable': 1, 'symbology': 'auto', 'img_style': 'width:47mm;height:11mm'}">1234567890</span>
+                                                        t-options="{'widget': 'barcode', 'humanreadable': 1, 'symbology': 'auto', 'img_style': 'width:47mm;height:11mm'}" data-oe-demo="1234567890"/>
                                                 </div>
                                             </div>
                                         </td>

--- a/addons/stock/report/report_lot_barcode.xml
+++ b/addons/stock/report/report_lot_barcode.xml
@@ -30,10 +30,10 @@
                                         <span class="o_label_4x12 lh-1">[<t t-out="o.product_id.default_code"/>]</span>
                                     </div>
                                     <div class="o_label_4x12" t-att-style="'width:22mm' if final_barcode else ''">
-                                        <span class="o_label_4x12 lh-1" t-field="o.product_id.name" >Demo Product</span>
+                                        <span class="o_label_4x12 lh-1" t-field="o.product_id.name" data-oe-demo="Demo Product" />
                                     </div>
                                     <div class="o_label_4x12" name="lot_name" t-att-style="'width:22mm; ' if final_barcode else ''">
-                                        <span class="o_label_4x12 lh-1" name="lot_name" t-field="o.name">Demo Name</span>
+                                        <span class="o_label_4x12 lh-1" name="lot_name" t-field="o.name" data-oe-demo="Demo Name"/>
                                     </div>
                                     <t t-if="env.user.has_group('stock.group_stock_lot_print_gs1')">
                                         <div t-if="final_barcode" t-att-style="'position:absolute; right:.5px; bottom:.5px'">
@@ -41,7 +41,7 @@
                                         </div>
                                     </t>
                                     <t t-else="">
-                                        <span t-field="o.name" t-options="{'widget': 'barcode', 'img_style': 'width:100%; height:35%'}">Customizable Desk</span>
+                                        <span t-field="o.name" t-options="{'widget': 'barcode', 'img_style': 'width:100%; height:35%'}" data-oe-demo="Customizable Desk"/>
                                     </t>
                                 </div>
                             </td>

--- a/addons/stock/report/report_package_barcode.xml
+++ b/addons/stock/report/report_package_barcode.xml
@@ -118,22 +118,22 @@
                                 <span t-out="barcode" t-options="{'widget': 'barcode', 'symbology': 'ECC200DataMatrix', 'width': 200, 'height': 200}">Barcode Demo</span>
                             </div>
                             <div class="col-7 text-start" style="font-size:20px;">
-                                <div class="row">SSCC: <span t-field="o.name">SSCC Demo</span></div>
-                                <div t-if="o.pack_date" class="row">Pack Date: <span t-field="o.pack_date">Pack Date Demo</span></div>
-                                <div t-if="o.package_type_id" class="row" name="datamatrix_pack_type">Package Type: <span t-field="o.package_type_id.name">Package Type Demo</span></div>
+                                <div class="row">SSCC: <span t-field="o.name" data-oe-demo="SSCC Demo"/></div>
+                                <div t-if="o.pack_date" class="row">Pack Date: <span t-field="o.pack_date" data-oe-demo="Pack Date Demo"/></div>
+                                <div t-if="o.package_type_id" class="row" name="datamatrix_pack_type">Package Type: <span t-field="o.package_type_id.name" data-oe-demo="Package Type Demo"/></div>
                             </div>
                         </div>
                     </t>
                     <t t-else="">
                         <div class="row">
                             <div class="text-center col-12">
-                                <span t-field="o.name" t-options="{'widget': 'barcode', 'width': 600, 'height': 100, 'img_style': 'width:600px;height:100px;'}">Name Demo</span>
-                                <span t-field="o.name" style="font-size:20px; margin:100px;">Name Demo</span>
+                                <span t-field="o.name" t-options="{'widget': 'barcode', 'width': 600, 'height': 100, 'img_style': 'width:600px;height:100px;'}" data-oe-demo="Name Demo"/>
+                                <span t-field="o.name" style="font-size:20px; margin:100px;" data-oe-demo="Name Demo"/>
                             </div>
                         </div>
-                        <div t-if="o.pack_date" class="col-12 text-center" style="font-size:24px; font-weight:bold;">Pack Date: <span t-field="o.pack_date">2023-01-01</span></div>
+                        <div t-if="o.pack_date" class="col-12 text-center" style="font-size:24px; font-weight:bold;">Pack Date: <span t-field="o.pack_date" data-oe-demo="2023-01-01"/></div>
                         <div class="row o_packaging_type" t-if="o.package_type_id">
-                            <div class="col-12 text-center" style="font-size:24px; font-weight:bold;"><span>Package Type: </span><span t-field="o.package_type_id.name">Package Type Demo</span></div>
+                            <div class="col-12 text-center" style="font-size:24px; font-weight:bold;"><span>Package Type: </span><span t-field="o.package_type_id.name" data-oe-demo="Package Type Demo"/></div>
                         </div>
                     </t>
                     <div class="oe_structure"/>

--- a/addons/stock/report/report_return_slip.xml
+++ b/addons/stock/report/report_return_slip.xml
@@ -16,11 +16,11 @@
                                 Your parcel must be sent to this address:
                             </p>
                             <span t-field="o.location_id.warehouse_id.partner_id"
-                                t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'>Demo Address and Name</span>
+                                t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}' data-oe-demo="Demo Address and Name"/>
                         </div>
                         <div class="col-4 text-center mt-4">
                             <div>
-                                <span t-field="o.name" t-options="{'widget': 'barcode', 'img_style': 'width:100%;'}">Default Barcode Name</span>
+                                <span t-field="o.name" t-options="{'widget': 'barcode', 'img_style': 'width:100%;'}" data-oe-demo="Default Barcode Name"/>
                                 <span t-out="o.name">Default Name</span>
                             </div>
                             <div style="margin-top:200px;">

--- a/addons/stock/report/report_stock_reception.xml
+++ b/addons/stock/report/report_stock_reception.xml
@@ -50,8 +50,8 @@
                                 <a href="#" t-att-res-model="doc_model" view-type="form" t-att-res-id="doc.id">
                                     <span t-out="doc.display_name">Demo Display Name</span>
                                 </a>
-                                <span t-field="doc.display_name" t-options="{'widget': 'barcode', 'width': 300, 'height': 50}">Display Name</span>
-                                <span t-field="doc.state" t-attf-class="badge rounded-pill bg-opacity-50 #{'bg-success' if doc.state == 'done' else 'bg-info'}">Andrwep</span>
+                                <span t-field="doc.display_name" t-options="{'widget': 'barcode', 'width': 300, 'height': 50}" data-oe-demo="Display Name"/>
+                                <span t-field="doc.state" t-attf-class="badge rounded-pill bg-opacity-50 #{'bg-success' if doc.state == 'done' else 'bg-info'}" data-oe-demo="Andrwep"/>
                             </div>
                         </t>
                     </t>
@@ -65,7 +65,7 @@
                     <thead t-if="any(line['is_assigned'] for line in sources_to_lines[source])">
                         <tr class="bg-light">
                             <th>
-                                <span t-field="source[0].display_name" t-options="{'widget': 'barcode', 'width': 200, 'height': 30}">Display Name</span>
+                                <span t-field="source[0].display_name" t-options="{'widget': 'barcode', 'width': 200, 'height': 30}" data-oe-demo="Display Name"/>
                                 <i t-if="source[0].priority == '1'" class="o_priority o_priority_star fa fa-star"/>
                                 <a name="source_link" href="#" t-att-res-model="source[0]._name" view-type="form" t-att-res-id="source[0].id">
                                     <span t-out="source[0].display_name">DEMO_SOURCE_DISPLAY_NAME</span>

--- a/addons/stock/report/report_stockinventory.xml
+++ b/addons/stock/report/report_stockinventory.xml
@@ -32,16 +32,16 @@
                                     </tr>
                                     <tr t-foreach="docs.filtered(lambda quant: quant.location_id.id == location.id)" t-as="line">
                                         <td groups="stock.group_stock_multi_locations"></td>
-                                        <td><span t-field="line.product_id">Laptop</span></td>
-                                        <td groups="stock.group_production_lot"><span t-field="line.lot_id">4</span></td>
-                                        <td groups="stock.group_tracking_lot"><span t-field="line.package_id">98</span></td>
-                                        <td class="text-end"><span t-field="line.available_quantity">2</span> <span t-field="line.product_uom_id" groups="uom.group_uom">Units</span></td>
-                                        <td class="text-end"><span t-field="line.quantity">5</span> <span t-field="line.product_uom_id" groups="uom.group_uom">Units</span></td>
+                                        <td><span t-field="line.product_id" data-oe-demo="Laptop"/></td>
+                                        <td groups="stock.group_production_lot"><span t-field="line.lot_id" data-oe-demo="4"/></td>
+                                        <td groups="stock.group_tracking_lot"><span t-field="line.package_id" data-oe-demo="98"/></td>
+                                        <td class="text-end"><span t-field="line.available_quantity" data-oe-demo="2"/> <span t-field="line.product_uom_id" groups="uom.group_uom" data-oe-demo="Units"/></td>
+                                        <td class="text-end"><span t-field="line.quantity" data-oe-demo="5"/> <span t-field="line.product_uom_id" groups="uom.group_uom" data-oe-demo="Units"/></td>
                                         <td class="text-end">
                                             <!-- If 0, then leave blank so users have space to write a number -->
                                             <t t-if="line.inventory_quantity == 0"><span></span></t>
-                                            <t t-else=""><span t-field="line.inventory_quantity">7</span></t>
-                                            <span t-field="line.product_uom_id" groups="uom.group_uom">Units</span>
+                                            <t t-else=""><span t-field="line.inventory_quantity" data-oe-demo="7"/></t>
+                                            <span t-field="line.product_uom_id" groups="uom.group_uom" data-oe-demo="Units"/>
                                         </td>
                                     </tr>
                                 </t>

--- a/addons/stock_picking_batch/report/report_picking_batch.xml
+++ b/addons/stock_picking_batch/report/report_picking_batch.xml
@@ -13,14 +13,14 @@
                     <t t-call="web.external_layout">
                         <div class="page">
                             <div class="d-flex">
-                                <div><h3>Summary: <span t-field="o.name">Batch Name</span></h3></div>
+                                <div><h3>Summary: <span t-field="o.name" data-oe-demo="Batch Name"/></h3></div>
                                 <div class="me-auto">
-                                    <span t-field="o.name" t-options="{'widget': 'barcode', 'width': 600, 'height': 150, 'img_style': 'width:300px;height:50px;'}">Batch</span>
+                                    <span t-field="o.name" t-options="{'widget': 'barcode', 'width': 600, 'height': 150, 'img_style': 'width:300px;height:50px;'}" data-oe-demo="Batch"/>
                                 </div>
                             </div>
                             <div t-if="o.user_id">
                                 <strong>Responsible:</strong>
-                                <span t-field="o.user_id">John Doe</span>
+                                <span t-field="o.user_id" data-oe-demo="John Doe"/>
                             </div><br/>
                             <div class="oe_structure"></div>
                             <table class="table table-condensed">
@@ -35,26 +35,26 @@
                                 <tbody>
                                     <tr t-foreach="o.picking_ids" t-as="pick">
                                         <td>
-                                            <span t-field="pick.name">Transfer Name</span>
+                                            <span t-field="pick.name" data-oe-demo="Transfer Name"/>
                                         </td>
                                         <td>
-                                            <span t-field="pick.name" t-options="{'widget': 'barcode', 'quiet': 0, 'width': 400, 'height': 100, 'img_style': 'width:200px;height:50px;'}">Transfer</span>
+                                            <span t-field="pick.name" t-options="{'widget': 'barcode', 'quiet': 0, 'width': 400, 'height': 100, 'img_style': 'width:200px;height:50px;'}" data-oe-demo="Transfer"/>
                                         </td>
                                         <td>
-                                            <span t-field="pick.state">Gujarat</span>
+                                            <span t-field="pick.state" data-oe-demo="Gujarat"/>
                                         </td>
                                         <td >
-                                            <span t-field="pick.scheduled_date">2023-08-20</span>
+                                            <span t-field="pick.scheduled_date" data-oe-demo="2023-08-20"/>
                                         </td>
                                     </tr>
                                 </tbody>
                             </table>
                             <p style="page-break-after: always;"/>
                             <div class="oe_structure"></div>
-                            <h3><span t-field="o.name">Batch Name</span></h3>
+                            <h3><span t-field="o.name" data-oe-demo="Batch Name"/></h3>
                             <div t-if="o.user_id">
                                 <strong>Responsible:</strong>
-                                <span t-field="o.user_id">John Doe</span>
+                                <span t-field="o.user_id" data-oe-demo="John Doe"/>
                             </div><br/>
                             <div class="oe_structure"></div>
                             <table class="table table-condensed">
@@ -90,25 +90,25 @@
                                             </tr>
                                             <tr t-foreach="move_lines" t-as="move_operation">
                                                 <td>
-                                                    <span t-field="move_operation.display_name">Product Name</span>
+                                                    <span t-field="move_operation.display_name" data-oe-demo="Product Name"/>
                                                 </td>
                                                 <td>
                                                     <span t-esc="sum(move_operation.mapped('quantity'))">Quantity Done</span>
-                                                    <span t-field="move_operation.uom_id" groups="move_operation.group_uom">Unit of Measure</span>
+                                                    <span t-field="move_operation.uom_id" groups="move_operation.group_uom" data-oe-demo="Unit of Measure"/>
                                                 </td>
                                                 <td>
                                                     <span t-out="move_operation.picking_id.display_name">Transfer Display Name</span>
                                                 </td>
                                                 <td t-if="has_serial_number" class="text-center h6" width="15%">
-                                                    <span t-if="move_operation.lot_id or move_operation.lot_name" t-field="move_operation.lot_id.name" t-options="{'widget': 'barcode', 'humanreadable': 1, 'width': 600, 'height': 100, 'img_style': 'width:100%;height:35px;'}">Lot Number</span>
+                                                    <span t-if="move_operation.lot_id or move_operation.lot_name" t-field="move_operation.lot_id.name" t-options="{'widget': 'barcode', 'humanreadable': 1, 'width': 600, 'height': 100, 'img_style': 'width:100%;height:35px;'}" data-oe-demo="Lot Number"/>
                                                 </td>
                                                 <td width="15%" class="text-center" t-if="has_barcode">
-                                                    <span t-field="move_operation.product_id.barcode" t-options="{'widget': 'barcode', 'symbology': 'auto', 'width': 600, 'height': 100, 'img_style': 'width:100%;height:35px;'}">Product Barcode</span>
+                                                    <span t-field="move_operation.product_id.barcode" t-options="{'widget': 'barcode', 'symbology': 'auto', 'width': 600, 'height': 100, 'img_style': 'width:100%;height:35px;'}" data-oe-demo="Product Barcode"/>
                                                 </td>
                                                 <td t-if="has_package" width="15%">
-                                                    <span t-field="move_operation.package_id">Package ID</span>
+                                                    <span t-field="move_operation.package_id" data-oe-demo="Package ID"/>
                                                     <t t-if="move_operation.result_package_id">
-                                                        <strong>→</strong> <span t-field="move_operation.result_package_id">Result Package ID</span>
+                                                        <strong>→</strong> <span t-field="move_operation.result_package_id" data-oe-demo="Result Package ID"/>
                                                     </t>
                                                 </td>
                                             </tr>

--- a/addons/survey/report/survey_templates.xml
+++ b/addons/survey/report/survey_templates.xml
@@ -37,8 +37,8 @@
                                 </t>
                                 <span t-att-style="certif_style" class="user-name" t-out="certified_name">DEMO_CERTIFIED_NAME</span>
 
-                                <br/> <span>by</span> <span class="certification-company" t-field="user_input.create_uid.company_id.display_name">Odoo</span> <span>for successfully completing</span>
-                                <br/><b><span class="certification-name" t-field="user_input.survey_id.display_name">Functional Training</span></b>
+                                <br/> <span>by</span> <span class="certification-company" t-field="user_input.create_uid.company_id.display_name" data-oe-demo="Odoo"/> <span>for successfully completing</span>
+                                <br/><b><span class="certification-name" t-field="user_input.survey_id.display_name" data-oe-demo="Functional Training"/></b>
                              </p>
                             <div class="oe_structure"/>
                         </div>
@@ -52,7 +52,7 @@
                     <div class="certification-bottom">
                         <div class="oe_structure"/>
                         <div class="certification-date-wrapper">
-                            <span class="certification-date" t-field="user_input.create_date" t-options='{"widget": "date"}'>2023-08-18</span>
+                            <span class="certification-date" t-field="user_input.create_date" t-options='{"widget": "date"}' data-oe-demo="2023-08-18"/>
                             <span>Date</span>
                         </div>
                         <div class="certification-company">


### PR DESCRIPTION
* = account, event, hr, hr_expense, hr_skills, loyalty, mrp, mrp_account, point_of_sale, product, purchase_requisition, repair, stock, stock_picking_batch, survey

During the introduction of the new studio report editor, some reports were edited to add some demo data as default content.

See: https://github.com/odoo/odoo/pull/135739

The assumption was that this would only be displayed inside the report editor and the field value outside.

Turns out that if the field value is falsy, the demo content is displayed inside the actual report.

This commit has been generated to only move the demo data added by those commits inside the new attribute `data-oe-demo`.

This attribute is only used inside studio to display the demo content.