### PR TITLE
[IMP] html_editor*: introduction to custom x2Many widget

### DIFF
--- a/addons/html_editor/static/src/main/media/media_dialog/media_dialog.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/media_dialog.js
@@ -118,7 +118,6 @@ export class MediaDialog extends Component {
     addTabs() {
         const onlyImages =
             this.props.onlyImages ||
-            this.props.multiImages ||
             (this.props.media &&
                 this.props.media.parentElement &&
                 (this.props.media.parentElement.dataset.oeField === "image" ||

--- a/addons/html_editor/static/src/others/custom_media_dialog.js
+++ b/addons/html_editor/static/src/others/custom_media_dialog.js
@@ -1,0 +1,30 @@
+import { MediaDialog } from "../main/media/media_dialog/media_dialog";
+
+export class CustomMediaDialog extends MediaDialog {
+    async save() {
+        if (this.errorMessages[this.state?.activeTab]) {
+            this.notificationService.add(this.errorMessages[this.state.activeTab], {
+                type: "danger",
+            });
+            return;
+        }
+        if (this.state.activeTab == "IMAGES") {
+            const attachments = this.selectedMedia[this.state.activeTab];
+            const preloadedAttachments = attachments.filter((attachment) => attachment.res_model);
+            this.selectedMedia[this.state.activeTab] = attachments.filter(
+                (attachment) => !preloadedAttachments.includes(attachment)
+            );
+            if (this.selectedMedia[this.state.activeTab].length > 0) {
+                await super.save();
+                const newAttachments = this.selectedMedia[this.state.activeTab];
+                this.props.imageSave(newAttachments);
+            }
+            if (preloadedAttachments.length) {
+                this.props.imageSave(preloadedAttachments);
+            }
+        } else {
+            this.props.videoSave(this.selectedMedia[this.state.activeTab]);
+        }
+        this.props.close();
+    }
+}

--- a/addons/html_editor/static/src/others/x2many_image_field.js
+++ b/addons/html_editor/static/src/others/x2many_image_field.js
@@ -1,0 +1,76 @@
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+import { ImageField, imageField } from "@web/views/fields/image/image_field";
+import { CustomMediaDialog } from "./custom_media_dialog";
+import { getVideoUrl } from "@html_editor/utils/url";
+
+export class X2ManyImageField extends ImageField {
+    static template = "html_editor.ImageField";
+    setup() {
+        super.setup();
+        this.orm = useService("orm");
+        this.dialog = useService("dialog");
+    }
+
+    /**
+     * New method and a new edit button is introduced here to overwrite,
+     * standard behavior of opening file input box in order to update a record.
+     */
+    onFileEdit(ev) {
+        const isVideo = this.props.record.data.video_url;
+        let mediaEl;
+        if (isVideo) {
+            mediaEl = document.createElement("img");
+            mediaEl.dataset.src = this.props.record.data.video_url;
+        }
+        this.dialog.add(CustomMediaDialog, {
+            noDocuments: true,
+            noIcons: true,
+            media: mediaEl,
+            activeTab: isVideo ? "VIDEOS" : "IMAGES",
+            save: (el) => {}, // Simple rebound to fake its execution
+            imageSave: this.onImageSave.bind(this),
+            videoSave: this.onVideoSave.bind(this),
+        });
+    }
+
+    async onImageSave(attachment) {
+        const attachmentRecord = await this.orm.searchRead(
+            "ir.attachment",
+            [["id", "=", attachment[0].id]],
+            ["id", "datas", "name"],
+            {}
+        );
+        if (!attachmentRecord[0].datas) {
+            // URL type attachments are mostly demo records which don't have any ir.attachment datas
+            // TODO: make it work with URL type attachments
+            return this.notification.add(`Cannot add URL type attachment "${attachmentRecord[0].name}". Please try to reupload this image.`, {
+                type: "warning",
+            });
+        }
+        await this.props.record.update({
+            [this.props.name]: attachmentRecord[0].datas,
+            name: attachmentRecord[0].name,
+        });
+    }
+
+    async onVideoSave(videoInfo) {
+        const url = getVideoUrl(videoInfo[0].platform, videoInfo[0].videoId, videoInfo[0].params);
+        await this.props.record.update({
+            video_url: url.href,
+            name: videoInfo[0].platform + " - [Video]",
+        });
+    }
+
+    onFileRemove() {
+        const parentRecord = this.props.record._parentRecord.data;
+        parentRecord[this.env.parentField].delete(this.props.record);
+    }
+}
+
+export const x2ManyImageField = {
+    ...imageField,
+    component: X2ManyImageField,
+};
+
+registry.category("fields").add("x2_many_image", x2ManyImageField);

--- a/addons/html_editor/static/src/others/x2many_image_field.xml
+++ b/addons/html_editor/static/src/others/x2many_image_field.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<templates>
+    <t t-name="html_editor.ImageField" t-inherit="web.ImageField" t-inherit-mode="primary">
+        <xpath expr="//div[hasclass('position-relative')]//div" position="replace">
+            <div t-attf-class="position-absolute d-flex justify-content-between w-100 bottom-0 opacity-0 opacity-100-hover {{isMobile ? 'o_mobile_controls' : ''}}" aria-atomic="true" t-att-style="sizeStyle">
+                <button
+                    t-if="props.record.data[props.name] and state.isValid"
+                    class="o_select_file_button btn btn-light border-0 rounded-circle m-1 p-1"
+                    data-tooltip="Edit"
+                    aria-label="Edit"
+                    t-on-click.prevent.stop="onFileEdit">
+                    <i class="fa fa-pencil fa-fw"/>
+                </button>
+                <button
+                    t-if="props.record.data[props.name] and state.isValid"
+                    class="o_clear_file_button btn btn-light border-0 rounded-circle m-1 p-1"
+                    data-tooltip="Clear"
+                    aria-label="Clear"
+                    t-on-click.prevent.stop="onFileRemove">
+                    <i class="fa fa-trash-o fa-fw"/>
+                </button>
+            </div>
+        </xpath>
+    </t>
+</templates>

--- a/addons/html_editor/static/src/others/x2many_media_viewer.js
+++ b/addons/html_editor/static/src/others/x2many_media_viewer.js
@@ -1,0 +1,82 @@
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+import { X2ManyField, x2ManyField } from "@web/views/fields/x2many/x2many_field";
+import { getVideoUrl } from "../utils/url";
+import { useChildSubEnv } from "@odoo/owl";
+import { CustomMediaDialog } from "./custom_media_dialog";
+
+export class X2ManyMediaViewer extends X2ManyField {
+    static template = "html_editor.X2ManyMediaViewer";
+
+    setup() {
+        super.setup();
+        this.dialogs = useService("dialog");
+        this.orm = useService("orm");
+        this.notification = useService("notification");
+        this.supportedFields = ["image_1920", "image_1024", "image_512", "image_256", "image_128"];
+        useChildSubEnv({
+            parentField: this.props.name,
+        });
+    }
+
+    addMedia() {
+        this.dialogs.add(CustomMediaDialog, {
+            save: (el) => {}, // Simple rebound to fake its execution
+            multiImages: true,
+            noDocuments: true,
+            noIcons: true,
+            imageSave: this.onImageSave.bind(this),
+            videoSave: this.onVideoSave.bind(this),
+        });
+    }
+
+    onVideoSave(videoInfo) {
+        const url = getVideoUrl(videoInfo[0].platform, videoInfo[0].videoId, videoInfo[0].params);
+        const videoList = this.props.record.data[this.props.name];
+        videoList.addNewRecord({ position: "bottom" }).then((record) => {
+            record.update({ name: videoInfo[0].platform + " - [Video]", video_url: url.href });
+        });
+    }
+
+    async onImageSave(attachments) {
+        const attachmentIds = attachments.map((attachment) => attachment.id);
+        const attachmentRecords = await this.orm.searchRead(
+            "ir.attachment",
+            [["id", "in", attachmentIds]],
+            ["id", "datas", "name"],
+            {}
+        );
+        attachmentRecords.forEach((attachment) => {
+            const imageList = this.props.record.data[this.props.name];
+            if (!attachment.datas) {
+                // URL type attachments are mostly demo records which don't have any ir.attachment datas
+                // TODO: make it work with URL type attachments
+                return this.notification.add(`Cannot add URL type attachment "${attachment.name}". Please try to reupload this image.`, {
+                    type: "warning",
+                });
+            }
+            imageList.addNewRecord({ position: "bottom" }).then((record) => {
+                const activeFields = imageList.activeFields;
+                const updateData = {};
+                for (const field in activeFields) {
+                    if (attachment.datas && this.supportedFields.includes(field)) {
+                        updateData[field] = attachment.datas;
+                        updateData["name"] = attachment.name;
+                    }
+                }
+                record.update(updateData);
+            });
+        });
+    }
+
+    async onAdd({ context, editable } = {}) {
+        this.addMedia();
+    }
+}
+
+export const x2ManyMediaViewer = {
+    ...x2ManyField,
+    component: X2ManyMediaViewer,
+};
+
+registry.category("fields").add("x2_many_media_viewer", x2ManyMediaViewer);

--- a/addons/html_editor/static/src/others/x2many_media_viewer.xml
+++ b/addons/html_editor/static/src/others/x2many_media_viewer.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<templates xml:space="preserve">
+    <t t-name="html_editor.X2ManyMediaViewer" t-inherit="web.X2ManyField" t-inherit-mode="primary">
+        <xpath expr="//div[hasclass('o_x2m_control_panel')]" position="before">
+           <KanbanRenderer t-if="props.viewMode" t-props="rendererProps"/>
+        </xpath>
+        <xpath expr="//KanbanRenderer[last()]" position="replace"/>
+    </t>
+</templates>

--- a/addons/html_editor/static/src/utils/url.js
+++ b/addons/html_editor/static/src/utils/url.js
@@ -5,3 +5,33 @@ export function isImageUrl(url) {
     const urlFileExtention = url.split(".").pop();
     return ["jpg", "jpeg", "png", "gif", "svg", "webp"].includes(urlFileExtention.toLowerCase());
 }
+
+/**
+ * @param {string} platform
+ * @param {string} videoId
+ * @param {object} params
+ */
+export function getVideoUrl(platform, videoId, params) {
+    let url;
+    switch (platform) {
+        case "youtube":
+            url = new URL(`https://www.youtube.com/embed/${videoId}`);
+            break;
+        case "vimeo":
+            url = new URL(`https://player.vimeo.com/video/${videoId}`);
+            break;
+        case "dailymotion":
+            url = new URL(`https://www.dailymotion.com/embed/video/${videoId}`);
+            break;
+        case "instagram":
+            url = new URL(`https://www.instagram.com/p/${videoId}/embed`);
+            break;
+        case "youku":
+            url = new URL(`https://player.youku.com/embed/${videoId}`);
+            break;
+        default:
+            throw new Error(`Unsupported platform: ${platform}`);
+    }
+    url.search = new URLSearchParams(params);
+    return url;
+}

--- a/addons/web/static/src/views/fields/x2many/x2many_field.xml
+++ b/addons/web/static/src/views/fields/x2many/x2many_field.xml
@@ -3,7 +3,7 @@
 
     <t t-name="web.X2ManyField">
         <div t-att-class="className">
-            <div class="o_x2m_control_panel d-empty-none mb-4">
+            <div class="o_x2m_control_panel d-empty-none mt-1">
                 <t t-if="displayControlPanelButtons">
                     <div class="o_cp_buttons gap-1" role="toolbar" aria-label="Control panel buttons" t-ref="buttons">
                         <t t-foreach="creates" t-as="create" t-key="create_index">

--- a/addons/website/static/src/components/media_dialog/image_selector.js
+++ b/addons/website/static/src/components/media_dialog/image_selector.js
@@ -2,8 +2,18 @@
 
 import { patch } from "@web/core/utils/patch";
 import { ImageSelector } from '@web_editor/components/media_dialog/image_selector';
+import { ImageSelector as HtmlImageSelector } from "@html_editor/main/media/media_dialog/image_selector";
 
 patch(ImageSelector.prototype, {
+    get attachmentsDomain() {
+        const domain = super.attachmentsDomain;
+        domain.push('|', ['url', '=', false], '!', ['url', '=like', '/web/image/website.%']);
+        domain.push(['key', '=', false]);
+        return domain;
+    }
+});
+
+patch(HtmlImageSelector.prototype, {
     get attachmentsDomain() {
         const domain = super.attachmentsDomain;
         domain.push('|', ['url', '=', false], '!', ['url', '=like', '/web/image/website.%']);

--- a/addons/website_sale/__manifest__.py
+++ b/addons/website_sale/__manifest__.py
@@ -137,6 +137,7 @@
             'website_sale/static/src/scss/website_sale_backend.scss',
             'website_sale/static/src/js/tours/website_sale_shop.js',
             'website_sale/static/src/xml/website_sale.xml',
+            'website_sale/static/src/scss/kanban_record.scss',
         ],
         'website.assets_wysiwyg': [
             'website_sale/static/src/scss/website_sale.editor.scss',

--- a/addons/website_sale/static/src/scss/kanban_record.scss
+++ b/addons/website_sale/static/src/scss/kanban_record.scss
@@ -1,0 +1,17 @@
+.o_form_renderer {
+    .o_field_x2_many_media_viewer .o_kanban_renderer {
+        --KanbanRecord-width: 100px;
+
+        article.o_kanban_record {
+            display: flex;
+            justify-content: center;
+            margin-bottom: unset !important;
+
+            & img {
+                height: 128px;
+                width: 168.86px;
+                object-fit: contain;
+            }
+        }
+    }
+}

--- a/addons/website_sale/views/product_image_views.xml
+++ b/addons/website_sale/views/product_image_views.xml
@@ -44,16 +44,17 @@
                 <field name="id"/>
                 <field name="name"/>
                 <field name="image_1920"/>
+                <field name="video_url"/>
                 <field name="sequence" widget="handle"/>
                 <templates>
                     <t t-name="kanban-box">
-                        <div class="card oe_kanban_global_click p-0">
+                        <div class="card p-0">
                             <div class="o_squared_image">
-                                <img class="card-img-top" t-att-src="kanban_image('product.image', 'image_1920', record.id.raw_value)" t-att-alt="record.name.value"/>
+                                <field class="card-img-top" name="image_1920" widget="x2_many_image"/>
                             </div>
                             <div class="card-body p-0">
                                 <h4 class="card-title p-2 m-0 bg-200">
-                                    <small><field name="name"/></small>
+                                    <small t-attf-title="#{record.name.value}"><field name="name" class="text-truncate d-block"/></small>
                                 </h4>
                             </div>
                             <!-- below 100 Kb: good -->
@@ -71,7 +72,7 @@
                                 <t t-set="size_status" t-value="'text-bg-danger'"/>
                                 <t t-set="message">Optimization required! Reduce the image size or increase your compression settings.</t>
                             </t>
-                            <span t-attf-class="badge #{size_status} o_product_image_size" t-esc="record.image_1920.value" t-att-title="message"/>
+                            <span t-attf-class="badge #{size_status} o_product_image_size" t-att-title="message"></span>
                         </div>
                     </t>
                 </templates>

--- a/addons/website_sale/views/product_views.xml
+++ b/addons/website_sale/views/product_views.xml
@@ -179,8 +179,8 @@
                     <field name="public_categ_ids" widget="many2many_tags" string="Categories"/>
                     <field name="website_ribbon_id" groups="base.group_no_one" options="{'no_quick_create': True}"/>
                 </group>
-                <group name="product_template_images" string="eCommerce Media" invisible="not sale_ok">
-                    <field name="product_template_image_ids" class="o_website_sale_image_list" context="{'default_name': name}" mode="kanban" add-label="Add a Media" nolabel="1"/>
+                <group colspan="2" name="product_template_images" string="eCommerce Media" invisible="not sale_ok">
+                    <field colspan="2" name="product_template_image_ids" class="o_website_sale_image_list" context="{'default_name': name}" mode="kanban" add-label="Add Media" nolabel="1" widget="x2_many_media_viewer"/>
                 </group>
             </xpath>
         </field>
@@ -206,8 +206,8 @@
                 <field name="variant_ribbon_id" options="{'no_quick_create': True}"/>
             </group>
             <group name="packaging" position="after">
-                <group name="product_variant_images" string="Extra Variant Media">
-                    <field name="product_variant_image_ids" class="o_website_sale_image_list" context="{'default_name': name}" mode="kanban" add-label="Add a Media" nolabel="1"/>
+                <group colspan="2" name="product_variant_images" string="Extra Variant Media">
+                    <field name="product_variant_image_ids" class="o_website_sale_image_list" context="{'default_name': name}" mode="kanban" add-label="Add Media" nolabel="1" widget="x2_many_media_viewer"/>
                 </group>
             </group>
         </field>


### PR DESCRIPTION
*=website_sale

Purpose:
- Make MediaDialog available for backend applications.
- Redesign Website Sale product image uploader and image tiles.

Specs:
html_editor:
- Introduction of new widget `x2_many_media_viewer` for static list fields to support
MediaDialog for adding images or videos.
- Introduction of new widget `x2_many_image_field` an override of image_field but with
additional support of media dialog for editing a specific image.

website_sale:
- Old form view for uploading images got replaced by `x2_many_media_viewer`, which
supports Multiple image uploads, and has a cleaner view for image and video
upload screens.
- Uploaded images now has two hover buttons on them, which allows modifying or
direct delection of the image by using `x2_many_image_field`
- Repurposed the kanban global click on product image view.

Task- 3390792
