### PR TITLE
[FIX] spreadsheet: Force light theme

### DIFF
--- a/addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet_extended.dark.scss
+++ b/addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet_extended.dark.scss
@@ -32,4 +32,7 @@
       background: #f6f7fa !important;
       border-color: #d5dae8 !important;
   }
+  .o_domain_selector input{
+    background-color: #333 !important;
+  }
 }


### PR DESCRIPTION
The "active records" toggle from the domain editor was invisible in darkmode because it has a whit/transparent image over a forces white background. This revision forces a dak background limited to the toggle button so that it becomes visible again.

Task-4081249

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
