### PR TITLE
[IMP] hr_holidays: multiple request UX

### DIFF
--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -266,11 +266,12 @@
                 <field name="employee_id" decoration-muted="not active_employee" widget="many2one_avatar_user" readonly="state in ['refuse', 'validate']"/>
                 <field name="department_id" optional="hide" readonly="state not in ['confirm']"/>
                 <field name="holiday_status_id" class="fw-bold" readonly="state in ['refuse', 'validate', 'validate1']"/>
-                <field name="name"/>
+                <field name="name" string="Title" optional="hide"/>
                 <field name="duration_display" string="Amount"/>
                 <field name="date_from" string="Validity Start" optional="hide"/>
                 <field name="date_to" string="Validity Stop" optional="hide" readonly="state in ['refuse', 'validate', 'validate1']"/>
                 <field name="allocation_type" readonly="state not in ['confirm']"/>
+                <field name="notes" string="Reason" optional="hide"/>
                 <field name="message_needaction" column_invisible="True"/>
                 <field name="active_employee" column_invisible="True"/>
                 <field name="state" widget="badge" decoration-warning="state == 'confirm'" decoration-success="state == 'validate'"/>

--- a/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard_views.xml
+++ b/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard_views.xml
@@ -6,7 +6,7 @@
             <form string="Generate time off allocations for multiple employees">
                 <div id="title" class="oe_title">
                     <h2>
-                        <field name="name" class="w-100" placeholder="e.g. Time Off type (From validity start to validity end / no limit)"/>
+                        <field name="name" class="w-100" placeholder="e.g. Time Off type (From validity start to validity end / no limit)" required="1"/>
                     </h2>
                 </div>
                 <group>
@@ -44,6 +44,7 @@
                         </div>
                     </group>
                 </group>
+                <field name="notes" placeholder="Add a reason..." nolabel="1"/>
                 <footer>
                     <button name="action_generate_allocations" type="object" class="btn-primary" string="Create Allocations" accesskey="c"/>
                     <button special="cancel" string="Discard" close="1" accesskey="j" />

--- a/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard_views.xml
+++ b/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard_views.xml
@@ -20,7 +20,7 @@
                                 options="{'end_date_field': 'date_to'}"/>
                             <field name="date_to" invisible="1" />
                         </div>
-                        <field name="name" widget="text" placeholder="Add a description..."/>
+                        <field name="name" widget="text" placeholder="e.g. Extra recuperation, Company unavailability, ..."/>
                     </group>
                 </group>
                 <footer>


### PR DESCRIPTION
With commit, the multiple request wizard introduced in saas-17.4 gets a UX's improvement to be able to do the same as with a simple request.

A user can add a multiple_allocation's reason as he can do it for single_allocation. The multiple_request's name will have a default name depends of time off type and duration.

task-4012327

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
