### PR TITLE
[FIX] account: fiscal pos differents bill/delivery addresses

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -240,8 +240,10 @@ class AccountFiscalPosition(models.Model):
             intra_eu = company.vat[:2] in eu_country_codes and partner.vat[:2] in eu_country_codes
             vat_exclusion = company.vat[:2] == partner.vat[:2]
 
-        # If company and partner have the same vat prefix (and are both within the EU), use invoicing
-        if not delivery or (intra_eu and vat_exclusion):
+        # Use invoicing when:
+        # - Partner is outside the EU.
+        # - Company and partner share the same vat prefix and are both within the EU.
+        if not delivery or not intra_eu or vat_exclusion:
             delivery = partner
 
         # partner manually set fiscal position always win

--- a/addons/account/tests/test_fiscal_position.py
+++ b/addons/account/tests/test_fiscal_position.py
@@ -211,6 +211,11 @@ class TestFiscalPosition(common.TransactionCase):
             'name': 'NL NO VAT',
             'country_id': self.nl.id,
         })
+        partner_us_vat = self.env['res.partner'].create({
+            'name': 'US VAT',
+            'vat': '34567',
+            'country_id': self.us.id,
+        })
         partner_us_no_vat = self.env['res.partner'].create({
             'name': 'US NO VAT',
             'country_id': self.us.id,
@@ -267,6 +272,24 @@ class TestFiscalPosition(common.TransactionCase):
         # Expected FP : Régime Extra-Communautaire
         self.assertEqual(
             self.env['account.fiscal.position'].get_fiscal_position(partner_us_no_vat.id, partner_us_no_vat.id),
+            fp_eu_extra
+        )
+
+        # Case : 7
+        # Billing (VAT/country) : None/US
+        # Delivery (VAT/country) : NL/NL
+        # Expected FP : Régime Extra-Communautaire
+        self.assertEqual(
+            self.env['account.fiscal.position'].get_fiscal_position(partner_us_no_vat.id, partner_nl_vat.id),
+            fp_eu_extra
+        )
+
+        # Case : 8
+        # Billing (VAT/country) : US/US
+        # Delivery (VAT/country) : NL/NL
+        # Expected FP : Régime Extra-Communautaire
+        self.assertEqual(
+            self.env['account.fiscal.position'].get_fiscal_position(partner_us_vat.id, partner_nl_vat.id),
             fp_eu_extra
         )
 


### PR DESCRIPTION
Steps:

- With a belgian company
- Activate custom addresses
- Create 2 customer with vat, 1 from NL, another from ZA
- Create an invoice with billing address ZA and
  delivery address NL
-> Fiscal position is set to intra-communautaire instead of
   extra-communautaire

opw-4072691
