### PR TITLE
[FIX] test_http: fix another patch issue in noble

### DIFF
--- a/odoo/addons/test_http/tests/test_device.py
+++ b/odoo/addons/test_http/tests/test_device.py
@@ -3,6 +3,8 @@
 from freezegun import freeze_time
 from unittest.mock import patch
 
+import odoo
+
 from odoo import Command
 from odoo.addons.test_http.utils import (
     TEST_IP,
@@ -42,7 +44,7 @@ class TestDevice(TestHttpBase):
                 'X-Forwarded-Proto': 'https'
             }
         with freeze_time(time), \
-            patch.dict('odoo.tools.config.options', {'proxy_mode': bool(ip)}):
+            patch.dict(odoo.tools.config.options, {'proxy_mode': bool(ip)}):
             res = self.url_open(url=endpoint, headers=headers)
         return res
 


### PR DESCRIPTION
Since python 3.11, the patch.dict method changed [0] to use pkgutil to resolve names. This new method is not able to patch our `odoo.tools.config.options`.

Fixed by using the object instead of a string literal.

[0]: python/cpython@ab7fcc8fbdc11091370deeb000a787fb02f9b13d
