### PR TITLE
[FIX] mail: improve chat bubble style

### DIFF
--- a/addons/mail/static/src/core/common/chat_bubble.dark.scss
+++ b/addons/mail/static/src/core/common/chat_bubble.dark.scss
@@ -1,0 +1,7 @@
+.o-mail-ChatBubble, .o-mail-ChatBubble-menu {
+    --ChatBubble-previewBorderColor: #{$o-gray-600};
+
+    & + .popover-arrow {
+        --ChatBubble-previewBorderColor: #{$o-gray-600};
+    }
+}

--- a/addons/mail/static/src/core/common/chat_bubble.scss
+++ b/addons/mail/static/src/core/common/chat_bubble.scss
@@ -3,8 +3,8 @@
     height: auto !important;
     z-index: $o-mail-ChatBubble-zindex;
     border: none !important;
-    background-color: transparent;
-    padding: 0;
+    padding: 0 map-get($spacers, 2);
+    background-color: transparent !important;
 
     &:hover {
         .o-mail-ChatBubble-close {
@@ -13,6 +13,10 @@
         .o-mail-ChatBubble-counter {
             display: none;
         }
+    }
+
+    &:hover, &.o-active {
+        filter: brightness(1.1);
     }
 
     &.o-bouncing {
@@ -35,21 +39,29 @@
 }
 
 .o-mail-ChatBubble-close {
-    right: 2px;
-    top: 2px;
+    right: 3px;
+    top: -3px;
     z-index: 6;
     font-size: 11px;
     display: none;
+    padding: map-get($spacers, 1) / 2;
+    border: $border-width solid mix($o-gray-300, $o-gray-400);
+
+    &:not(:hover) {
+        color: $text-muted;
+    }
 
     &:hover {
         background-color: $o-gray-300 !important;
+        border-color: $o-gray-500;
     }
 }
 
 .o-mail-ChatBubble-counter {
     padding: 3px 6px;
     z-index: 7;
-    right: -2px;
+    top: -3px;
+    right: 3px;
     display: inline-flex;
 }
 
@@ -57,10 +69,12 @@
     max-width: 225px;
     right: $o-mail-ChatHub-bubblesWidth;
     z-index: $o-mail-ChatBubble-zindex - 1;
-
+    border-color: var(--ChatBubble-previewBorderColor, mix($o-gray-300, $o-gray-400)) !important;
+    
     & + .popover-arrow {
         // puts arrow above preview border
         &::before {
+            border-left-color: var(--ChatBubble-previewBorderColor, mix($o-gray-300, $o-gray-400)) !important;
             right: 1px !important;
         }
         &::after {
@@ -72,8 +86,9 @@
 
 .o-mail-ChatBubble-status {
     z-index: 6;
-    bottom: 2px;
-    right: -3px;
+    bottom: -2px;
+    right: 2px;
+    background-color: transparent;
 }
 
 @keyframes o-mail-ChatBubble-bouncing { 

--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.ChatBubble">
-        <Dropdown t-if="!env.embedLivechat" state="preview" position="'left-middle'" menuClass="'bg-view border-0 p-0 m-0 overflow-visible rounded-3'" arrow="true" manual="true">
+        <Dropdown t-if="!env.embedLivechat" state="preview" position="'left-middle'" menuClass="'bg-view border-0 p-0 overflow-visible rounded-3'" arrow="true" manual="true">
             <t t-call="mail.ChatBubble.core"/>
             <t t-set-slot="content">
                 <t t-call="mail.ChatBubble.preview"/>
@@ -11,20 +11,20 @@
     </t>
 
     <t t-name="mail.ChatBubble.core">
-        <button class="o-mail-ChatBubble" t-att-name="props.chatWindow.displayName" t-att-class="{ 'o-bouncing': state.bouncing, 'position-fixed': env.embedLivechat, 'position-relative': !env.embedLivechat }" t-att-style="env.embedLivechat ? `top: ${ position.top }; left: ${ position.left };` : ''" t-on-click="() => props.chatWindow.open()" t-on-animationend="() => state.bouncing = false" t-ref="root">
-            <div t-if="thread?.importantCounter > 0" class="o-mail-ChatBubble-counter position-absolute badge rounded-pill fw-bold o-discuss-badge" t-out="thread?.importantCounter"/>
-            <button t-if="state.showClose and !env.embedLivechat" class="o-mail-ChatBubble-close position-absolute border-0 shadow rounded-pill fw-bold oi oi-close bg-view p-0" title="Close Chat Window" t-on-click.stop="() => this.props.chatWindow.close()"/>
+        <button class="o-mail-ChatBubble" t-att-name="props.chatWindow.displayName" t-att-class="{ 'o-bouncing': state.bouncing, 'position-fixed': env.embedLivechat, 'position-relative': !env.embedLivechat, 'o-active': preview.isOpen }" t-att-style="env.embedLivechat ? `top: ${ position.top }; left: ${ position.left };` : ''" t-on-click="() => props.chatWindow.open()" t-on-animationend="() => state.bouncing = false" t-ref="root">
+            <div t-if="thread?.importantCounter > 0" class="o-mail-ChatBubble-counter position-absolute badge rounded-pill fw-bold o-discuss-badge shadow" t-out="thread?.importantCounter"/>
+            <button t-if="state.showClose and !env.embedLivechat" class="o-mail-ChatBubble-close position-absolute shadow rounded-circle fw-bold bg-view" title="Close Chat Window" t-on-click.stop="() => this.props.chatWindow.close()"><i class="oi oi-close"/></button>
             <ImStatus t-if="thread?.correspondent?.persona?.im_status and thread?.correspondent?.persona?.im_status != 'offline'" className="'o-mail-ChatBubble-status position-absolute o-mail-brighter'" persona="thread.correspondent.persona" thread="thread"/>
-            <button class="o-mail-ChatHub-bubbleBtn btn ms-1 border-0">
-                <img class="o-mail-ChatBubble-avatar rounded-circle shadow" t-att-class="{ 'o-big': env.embedLivechat }" t-att-src="thread?.avatarUrl" alt="Thread image" draggable="false"/>
+            <button class="o-mail-ChatHub-bubbleBtn btn">
+                <img class="o-mail-ChatBubble-avatar rounded-circle" t-att-class="{ 'o-big': env.embedLivechat }" t-att-src="thread?.avatarUrl" alt="Thread image" draggable="false"/>
             </button>
         </button>
     </t>
 
     <t t-name="mail.ChatBubble.preview">
-        <div class="o-mail-ChatBubble-preview px-0 py-1 shadow border rounded-3" t-ref="preview">
+        <div class="o-mail-ChatBubble-preview o-mail-ChatBubble-menu px-0 py-1 shadow-sm border rounded" t-ref="preview">
             <div class="text-truncate fw-bolder mb-0 mx-2" t-esc="props.chatWindow.displayName"/>
-            <div t-if="previewContent" class="text-truncate small mx-2">
+            <div t-if="previewContent" class="text-truncate small mx-2 text-muted">
                 <t t-call="mail.message_preview_prefix">
                     <t t-set="message" t-value="thread?.newestPersistentNotEmptyOfAllMessage"/>
                 </t>

--- a/addons/mail/static/src/core/common/chat_hub.dark.scss
+++ b/addons/mail/static/src/core/common/chat_hub.dark.scss
@@ -1,0 +1,3 @@
+.o-mail-ChatHub, .o-mail-ChatHub-menu {
+    --ChatHub-menuBorderColor: #{$o-gray-600};
+}

--- a/addons/mail/static/src/core/common/chat_hub.scss
+++ b/addons/mail/static/src/core/common/chat_hub.scss
@@ -8,7 +8,10 @@
 }
 
 .o-mail-ChatHub-bubbleBtn {
-    padding: map-get($spacers, 1);
+    padding: 0;
+    border: none !important;
+    border-radius: 50%;
+    box-shadow: $box-shadow-sm;
 }
 
 .o-mail-ChatHub-hiddenAvatar {
@@ -16,28 +19,30 @@
     height: 28px;
 }
 
-.o-mail-ChatHub-hiddenBtn {
+.o-mail-ChatHub-hiddenBtnIcon {
     color: #FFFFFF!important;
-    background-color: #875A7B !important;
+    background-color: $primary !important;
     width: $o-mail-ChatBubble-sizeBig !important;
     height: $o-mail-ChatBubble-sizeBig !important;
-
-    &.o-active {
-        filter: drop-shadow(0px 0px 15px #{$gray-300});
-    }
 }
 
 .o-mail-ChatHub-hiddenBtnCounter {
     padding: 4px 8px;
     z-index: $o-mail-NavigableList-zIndex - 1;
-    right: 4px;
+    top: -4px;
+    right: -4px;
 }
 
 .o-mail-ChatHub-hiddenClose {
     margin-left: auto;
-    border: none;
     background-color: transparent;
     opacity: 25%;
+    padding: map-get($spacers, 1) / 2;
+    border: $border-width solid transparent;
+
+    &:hover {
+        border-color: var(--ChatHub-menuBorderColor, mix($o-gray-300, $o-gray-400));
+    }
 }
 
 .o-mail-ChatHub-hiddenCounter {
@@ -62,6 +67,10 @@
     }
 }
 
+.o-mail-ChatHub-hiddenMenu {
+    border-color: var(--ChatHub-menuBorderColor, mix($o-gray-300, $o-gray-400)) !important;
+}
+
 .o-mail-ChatHub-option {
     &:hover, &.o-active {
         background-color: $o-gray-300;
@@ -73,7 +82,7 @@
     font-size: 15px;
     width: 30px !important;
     height: 30px !important;
-    margin-bottom: 10px !important;
+    border: $border-width solid var(--ChatHub-menuBorderColor, mix($o-gray-300, $o-gray-400)) !important;
 
     &:hover, &.show {
         background-color: $o-gray-300 !important;
@@ -81,5 +90,5 @@
 }
 
 .o-mail-ChatHub-optionsMenu {
-    border-radius: 10px;
+    border-color: var(--ChatHub-menuBorderColor, mix($o-gray-300, $o-gray-400)) !important;
 }

--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -9,16 +9,16 @@
             </t>
         </t>
         <div t-if="!store.discuss.isActive and !ui.isSmall" class="o-mail-ChatHub-bubbles position-fixed end-0 d-flex flex-column align-content-start justify-content-end align-items-center" t-att-class="{ 'bottom-0': !store.chatHub.compact or compactPosition.top === 'auto' }" t-ref="bubbles" t-att-style="store.chatHub.compact ? `top: ${ compactPosition.top }; left: ${ compactPosition.left };` : ''">
-            <div class="d-flex flex-column align-content-start justify-content-end align-items-center">
+            <div class="d-flex flex-column align-content-start justify-content-end align-items-center gap-1">
                 <t t-if="store.chatHub.compact">
                     <t t-call="mail.ChatHub.compactButton"/>
                 </t>
                 <t t-else="">
-                    <Dropdown t-if="chatHub.actuallyFolded.length gt 1" state="options" position="'top-end'" menuClass="'o-mail-ChatHub-optionsMenu d-flex flex-column bg-view shadow m-0 p-0 mb-1'">
-                        <button class="o-mail-ChatHub-bubbleBtn btn o-mail-ChatHub-optionsBtn ms-1 rounded-circle shadow fa fa-ellipsis-h bg-view mt-1 border" t-att-class="{ 'opacity-0': !chatHub.actuallyFolded.length or !bubblesHover.isHover and !options.isOpen }" aria-label="Chat Hub Options"/>
+                    <Dropdown t-if="chatHub.actuallyFolded.length gt 1" state="options" position="'top-end'" menuClass="'o-mail-ChatHub-optionsMenu o-mail-ChatHub-menu d-flex flex-column bg-view shadow-sm m-0 p-0 mb-1'">
+                        <button class="o-mail-ChatHub-bubbleBtn btn o-mail-ChatHub-optionsBtn fa fa-ellipsis-h bg-view mt-1" t-att-class="{ 'opacity-0': !chatHub.actuallyFolded.length or !bubblesHover.isHover and !options.isOpen, 'o-active': bubblesHover.isHover or options.isOpen }" aria-label="Chat Hub Options"/>
                         <t t-set-slot="content">
-                            <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0" t-on-click="() => chatHub.closeAll()"><i class="oi fa-fw oi-close"></i>Close all conversations</button>
-                            <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0" t-on-click="() => chatHub.compact = true"><i class="fa fa-fw fa-eye-slash"></i>Hide all conversations</button>
+                            <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.closeAll()"><i class="oi fa-fw oi-close"></i>Close all conversations</button>
+                            <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.compact = true"><i class="fa fa-fw fa-eye-slash"></i>Hide all conversations</button>
                         </t>
                     </Dropdown>
                     <t t-foreach="chatHub.actuallyFolded" t-as="cw" t-key="cw.localId">
@@ -33,26 +33,26 @@
 
 <t t-name="mail.ChatHub.compactButton">
     <!-- In dropdown to keep same layout as other items-->
-    <Dropdown>
-        <div class="o-mail-ChatHub-bubbleBtn o-mail-ChatHub-compact o-mail-ChatBubble justify-content-center ms-1 border-0" t-ref="compact">
-            <div t-if="compactCounter > 0" class="o-mail-ChatHub-hiddenBtnCounter position-absolute badge rounded-pill fw-bold o-discuss-badge">
+    <Dropdown manual="true">
+        <div class="o-mail-ChatHub-bubbleBtn o-mail-ChatHub-compact o-mail-ChatBubble justify-content-center" t-ref="compact">
+            <div t-if="compactCounter > 0" class="o-mail-ChatHub-hiddenBtnCounter position-absolute badge rounded-pill fw-bold o-discuss-badge shadow">
                 <t t-out="compactCounter"/>
             </div>
-            <button class="o-mail-ChatHub-bubbleBtn btn border-0 fs-2" t-on-click="expand">
-                <i class="o-mail-ChatHub-hiddenBtn d-flex justify-content-center align-items-center btn rounded-circle shadow fa fa-commenting"/>
+            <button class="o-mail-ChatHub-bubbleBtn btn fs-2" t-on-click="expand">
+                <i class="o-mail-ChatHub-hiddenBtnIcon d-flex justify-content-center align-items-center btn rounded-circle shadow-sm fa fa-commenting"/>
             </button>
         </div>
     </Dropdown>
 </t>
 
 <t t-name="mail.ChatHub.hiddenButton">
-    <Dropdown t-if="chatHub.actuallyHidden.length > 0" state="more" position="'left-middle'" menuClass="'bg-view shadow p-0 m-0 rounded-3'" manual="true">
-        <div class="o-mail-ChatHub-bubbleBtn o-mail-ChatBubble justify-content-center border-0" t-on-click="() => store.chatHub.compact = true" t-ref="more-button">
-            <div t-if="hiddenCounter > 0" class="o-mail-ChatHub-hiddenBtnCounter position-absolute badge rounded-pill fw-bold o-discuss-badge">
+    <Dropdown t-if="chatHub.actuallyHidden.length > 0" state="more" position="'left-middle'" menuClass="'o-mail-ChatHub-hiddenMenu o-mail-ChatHub-menu bg-view shadow-sm p-0 m-0'" manual="true">
+        <div class="o-mail-ChatBubble o-mail-ChatHub-hiddenBtn justify-content-center" t-att-class="{ 'o-active': more.isOpen }" t-on-click="() => store.chatHub.compact = true" t-ref="more-button">
+            <div t-if="hiddenCounter > 0" class="o-mail-ChatHub-hiddenBtnCounter position-absolute badge rounded-pill fw-bold o-discuss-badge shadow">
                 <t t-out="hiddenCounter"/>
             </div>
-            <button class="o-mail-ChatHub-bubbleBtn ms-1 btn outline-0 border-0">
-                <i class="o-mail-ChatHub-hiddenBtn d-flex justify-content-center align-items-center btn rounded-circle shadow fs-2" t-att-class="{ 'o-active': more.isOpen }">+<t t-esc="chatHub.actuallyHidden.length"/></i>
+            <button class="o-mail-ChatHub-bubbleBtn btn outline-0">
+                <i class="o-mail-ChatHub-hiddenBtnIcon d-flex justify-content-center align-items-center btn rounded-circle shadow-sm fs-2" t-att-class="{ 'o-active': more.isOpen }">+<t t-esc="chatHub.actuallyHidden.length"/></i>
             </button>
         </div>
         <t t-set-slot="content">
@@ -64,8 +64,8 @@
                         <div t-if="cw.thread?.importantCounter > 0" class="o-mail-ChatHub-hiddenCounter badge rounded-pill fw-bold o-discuss-badge" style="padding: 3px 6px">
                             <t t-out="cw.thread?.importantCounter"/>
                         </div>
-                        <button class="o-mail-ChatHub-hiddenClose o-mail-ChatBubble-close d-flex align-items-center rounded-circle p-0" t-on-click.stop="() => cw.close()">
-                            <i class="oi fa-fw oi-close"/>
+                        <button class="o-mail-ChatHub-hiddenClose o-mail-ChatBubble-close d-flex align-items-center rounded" t-on-click.stop="() => cw.close()">
+                            <i class="oi oi-close"/>
                         </button>
                     </li>
                 </t>

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -14,6 +14,9 @@
     --o-discuss-badge-bg: #{$o-success}; // sync with --o-navbar-badge-bg
     color: white !important;
     background-color: var(--o-discuss-badge-bg) !important;
+    align-items: center;
+    justify-content: center;
+    min-width: 2.1ch;
 
     &.o-muted {
         --o-discuss-badge-bg: #{$gray-400};
@@ -28,6 +31,7 @@
     display: flex;
     transform: translate(0, 0) !important; // cancel systray style on badge
     font-size: .78572 * $font-size-base !important; // roughly 11px, small but readable
+    user-select: none;
 }
 
 .o-min-height-0 {


### PR DESCRIPTION
Before this commit, chat bubble style was not looking great when there was some content below. This is mostly due to 2 issues: too much spacing, and lack of borders on floating items.

This commit makes the following improvements:

1. Reduced spacing between chat bubbles.
2. Stronger borders on floating items (chat bubble preview, hidden bubble menu, options)
2. Improved hover effect on chat bubbles and close buttons
3. Improved position of im status / counter / close button
4. More spacing between chat bubbles and floating items (message preview, hidden bubble menu)
5. Counter is more rounded when single digit
6. Floating items are less rounded
7. Remove some shadow (was making it look dirty rather than emphasis from background, which borders and spacing are more effective)

Also make the following improvements:
- Compact button was showing an empty dropdown content
- Hidden/compact button uses theme-specific primary color
- Make option items more readable (text was too bold)
- Badge counter are no longer user selectable

<img width="1750" alt="6" src="https://github.com/user-attachments/assets/8d946726-f14e-4c2a-aa51-7330144a9c28">
