### PR TITLE
[IMP] bus, *: avoid running NOTIFY multiple times

### DIFF
--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -1030,6 +1030,7 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
             _hook_invoice_document_before_pdf_report_render,
         ):
             self.env.ref('account.ir_cron_account_move_send').method_direct_trigger()  # force processing
+            self.env.cr.precommit.run()  # trigger the creation of bus.bus records
 
         bus_1 = self.env['bus.bus'].sudo().search(
             [('channel', 'like', f'"res.partner",{sp_partner_1.id}')],

--- a/addons/bus/models/bus.py
+++ b/addons/bus/models/bus.py
@@ -8,12 +8,13 @@ import os
 import selectors
 import threading
 import time
-from psycopg2 import InterfaceError, sql
+from psycopg2 import InterfaceError
 
 import odoo
 from odoo import api, fields, models
 from odoo.service.server import CommonServer
-from odoo.tools import date_utils
+from odoo.tools import date_utils, SQL
+from odoo.tools.misc import OrderedSet
 
 _logger = logging.getLogger(__name__)
 
@@ -38,9 +39,9 @@ def get_notify_payload_max_length(default=8000):
 NOTIFY_PAYLOAD_MAX_LENGTH = get_notify_payload_max_length()
 
 
-#----------------------------------------------------------
+# ---------------------------------------------------------
 # Bus
-#----------------------------------------------------------
+# ---------------------------------------------------------
 def json_dump(v):
     return json.dumps(v, separators=(',', ':'), default=date_utils.json_default)
 
@@ -96,38 +97,60 @@ class ImBus(models.Model):
 
     @api.model
     def _sendmany(self, notifications):
-        channels = set()
-        values = []
-        for target, notification_type, message in notifications:
-            channel = channel_with_db(self.env.cr.dbname, target)
-            channels.add(channel)
-            values.append({
-                'channel': json_dump(channel),
-                'message': json_dump({
-                    'type': notification_type,
-                    'payload': message,
-                })
-            })
-        self.sudo().create(values)
-        if channels:
+        for notification in notifications:
+            self._sendone(*notification)
+
+    @api.model
+    def _sendone(self, target, notification_type, message):
+        self._ensure_hooks()
+        channel = channel_with_db(self.env.cr.dbname, target)
+        self.env.cr.precommit.data["bus.bus.values"].append(
+            {
+                "channel": json_dump(channel),
+                "message": json_dump(
+                    {
+                        "type": notification_type,
+                        "payload": message,
+                    }
+                ),
+            }
+        )
+        self.env.cr.postcommit.data["bus.bus.channels"].add(channel)
+
+    def _ensure_hooks(self):
+        if "bus.bus.values" not in self.env.cr.precommit.data:
+            self.env.cr.precommit.data["bus.bus.values"] = []
+
+            @self.env.cr.precommit.add
+            def create_bus():
+                self.sudo().create(self.env.cr.precommit.data.pop("bus.bus.values"))
+
+        if "bus.bus.channels" not in self.env.cr.postcommit.data:
+            self.env.cr.postcommit.data["bus.bus.channels"] = OrderedSet()
+
             # We have to wait until the notifications are commited in database.
             # When calling `NOTIFY imbus`, notifications will be fetched in the
             # bus table. If the transaction is not commited yet, there will be
             # nothing to fetch, and the websocket will return no notification.
             @self.env.cr.postcommit.add
             def notify():
-                with odoo.sql_db.db_connect('postgres').cursor() as cr:
-                    query = sql.SQL("SELECT {}('imbus', %s)").format(sql.Identifier(ODOO_NOTIFY_FUNCTION))
-                    payloads = get_notify_payloads(list(channels))
-                    if len(payloads) > 1:
-                        _logger.info("The imbus notification payload was too large, "
-                                     "it's been split into %d payloads.", len(payloads))
+                payloads = get_notify_payloads(
+                    list(self.env.cr.postcommit.data.pop("bus.bus.channels"))
+                )
+                if len(payloads) > 1:
+                    _logger.info(
+                        "The imbus notification payload was too large, it's been split into %d payloads.",
+                        len(payloads),
+                    )
+                with odoo.sql_db.db_connect("postgres").cursor() as cr:
                     for payload in payloads:
-                        cr.execute(query, (payload,))
-
-    @api.model
-    def _sendone(self, channel, notification_type, message):
-        self._sendmany([[channel, notification_type, message]])
+                        cr.execute(
+                            SQL(
+                                "SELECT %s('imbus', %s)",
+                                SQL.identifier(ODOO_NOTIFY_FUNCTION),
+                                payload,
+                            )
+                        )
 
     @api.model
     def _poll(self, channels, last=0):
@@ -154,9 +177,9 @@ class ImBus(models.Model):
         return last.id if last else 0
 
 
-#----------------------------------------------------------
+# ---------------------------------------------------------
 # Dispatcher
-#----------------------------------------------------------
+# ---------------------------------------------------------
 
 class BusSubscription:
     def __init__(self, channels, last):

--- a/addons/bus/tests/common.py
+++ b/addons/bus/tests/common.py
@@ -113,6 +113,7 @@ class WebsocketCase(HttpCase):
         notifications are available. Usefull since the bus is not able to do
         it during tests.
         """
+        self.env.cr.precommit.run()  # trigger the creation of bus.bus records
         channels = [
             hashable(channel_with_db(self.registry.db_name, c)) for c in channels
         ]

--- a/addons/bus/tests/test_notify.py
+++ b/addons/bus/tests/test_notify.py
@@ -1,11 +1,16 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests import BaseCase
+import json
+import selectors
+import threading
+
+import odoo
+from odoo.tests import TransactionCase
 
 from ..models.bus import json_dump, get_notify_payloads, NOTIFY_PAYLOAD_MAX_LENGTH
 
 
-class NotifyTests(BaseCase):
+class NotifyTests(TransactionCase):
 
     def test_get_notify_payloads(self):
         """
@@ -47,3 +52,39 @@ class NotifyTests(BaseCase):
                          "as it contains only 1 channel")
         with self.assertRaises(AssertionError):
             check_payloads_size(payloads)
+
+    def test_postcommit(self):
+        """Asserts all ``postcommit`` channels are fetched with a single listen."""
+        channels = []
+
+        def single_listen():
+            nonlocal channels
+            with odoo.sql_db.db_connect(
+                "postgres"
+            ).cursor() as cr, selectors.DefaultSelector() as sel:
+                cr.execute("listen imbus")
+                cr.commit()
+                conn = cr._cnx
+                sel.register(conn, selectors.EVENT_READ)
+                if sel.select(5):
+                    conn.poll()
+                    channels.extend(json.loads(conn.notifies.pop().payload))
+
+        thread = threading.Thread(target=single_listen)
+        thread.start()
+
+        self.env["bus.bus"].search([]).unlink()
+        self.env["bus.bus"]._sendone("channel 1", "test 1", {})
+        self.env["bus.bus"]._sendone("channel 2", "test 2", {})
+        self.env["bus.bus"]._sendone("channel 1", "test 3", {})
+        self.assertEqual(self.env["bus.bus"].search_count([]), 0)
+        self.assertEqual(channels, [])
+        self.env.cr.precommit.run()  # trigger the creation of bus.bus records
+        self.assertEqual(self.env["bus.bus"].search_count([]), 3)
+        self.assertEqual(channels, [])
+        self.env.cr.postcommit.run()  # notify
+        self.assertEqual(self.env["bus.bus"].search_count([]), 3)
+        self.assertEqual(
+            channels, [[self.env.cr.dbname, "channel 1"], [self.env.cr.dbname, "channel 2"]]
+        )
+        thread.join()

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -164,7 +164,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                     "last_interest_dt": fields.Datetime.to_string(visitor_member.last_interest_dt),
                     "last_seen_dt": False,
                     "message_unread_counter": 0,
-                    "message_unread_counter_bus_id": self.env["bus.bus"]._bus_last_id(),
+                    "message_unread_counter_bus_id": self.env["bus.bus"]._bus_last_id() - 1,
                     "new_message_separator": 0,
                     "persona": {"id": test_user.partner_id.id, "type": "partner"},
                     "seen_message_id": False,
@@ -249,7 +249,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                     "last_interest_dt": fields.Datetime.to_string(operator_member.last_interest_dt),
                     "last_seen_dt": False,
                     "message_unread_counter": 0,
-                    "message_unread_counter_bus_id": self.env["bus.bus"]._bus_last_id(),
+                    "message_unread_counter_bus_id": self.env["bus.bus"]._bus_last_id() - 1,
                     "new_message_separator": 0,
                     "persona": {"id": operator.partner_id.id, "type": "partner"},
                     "seen_message_id": False,
@@ -334,7 +334,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
             },
         )
         channel = self.env["discuss.channel"].browse(data["discuss.channel"][0]["id"])
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [(self.env.cr.dbname, "res.partner", self.env.user.partner_id.id)],
             [

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -806,12 +806,14 @@ class MailCase(MockEmail):
 
         with patch.object(ImBus, 'create', autospec=True, wraps=ImBus, side_effect=_bus_bus_create) as _bus_bus_create_mock:
             yield
+            self.env.cr.precommit.run()  # trigger the creation of bus.bus records
 
     def _init_mock_bus(self):
         self._new_bus_notifs = self.env['bus.bus'].sudo()
 
     def _reset_bus(self):
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self.env.cr.precommit.run()  # trigger the creation of bus.bus records
+        self.env["bus.bus"].sudo().search([]).unlink()
 
     @contextmanager
     def mock_mail_app(self):
@@ -1185,6 +1187,7 @@ class MailCase(MockEmail):
               }}
             }, {...}]
         """
+        self.env.cr.precommit.run()  # trigger the creation of bus.bus records
         bus_notifs = self.env['bus.bus'].sudo().search([('channel', 'in', [json_dump(channel) for channel in channels])])
         new_line = "\n"
         self.assertEqual(

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -396,9 +396,7 @@ class TestChannelInternals(MailCommon, HttpCase):
         chat = self.env['discuss.channel'].with_user(self.user_admin).channel_get((self.partner_employee | self.user_admin.partner_id).ids)
         msg_1 = self._add_messages(chat, 'Body1', author=self.user_employee.partner_id)
         member = chat.channel_member_ids.filtered(lambda m: m.partner_id == self.user_admin.partner_id)
-        last_bus_id = self.env['bus.bus'].sudo()._bus_last_id()
-
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [
                 (self.env.cr.dbname, "discuss.channel", chat.id),
@@ -412,7 +410,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                             {
                                 "id": member.id,
                                 "message_unread_counter": 0,
-                                "message_unread_counter_bus_id": last_bus_id + 1,
+                                "message_unread_counter_bus_id": 0,
                                 "new_message_separator": msg_1.id + 1,
                                 "persona": {"id": self.user_admin.partner_id.id, "type": "partner"},
                                 "syncUnread": False,
@@ -454,7 +452,7 @@ class TestChannelInternals(MailCommon, HttpCase):
             member._mark_as_read(msg_1.id)
         # There should be no channel member to be set as seen in the second time
         # So no notification should be sent
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus([], []):
             member._mark_as_read(msg_1.id)
 
@@ -582,7 +580,7 @@ class TestChannelInternals(MailCommon, HttpCase):
 
     def test_channel_write_should_send_notification(self):
         channel = self.env['discuss.channel'].create({"name": "test", "description": "test"})
-        self.env['bus.bus'].search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [(self.cr.dbname, "discuss.channel", channel.id)],
             [
@@ -600,7 +598,7 @@ class TestChannelInternals(MailCommon, HttpCase):
         channel.image_128 = base64.b64encode(("<svg/>").encode())
         avatar_cache_key = channel.avatar_cache_key
         channel.image_128 = False
-        self.env['bus.bus'].search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [(self.cr.dbname, "discuss.channel", channel.id)],
             [
@@ -776,7 +774,7 @@ class TestChannelInternals(MailCommon, HttpCase):
         """Ensures the command '/help' works in a channel"""
         channel = self.env["discuss.channel"].browse(self.test_channel.ids)
         channel.name = "<strong>R&D</strong>"
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [(self.env.cr.dbname, "res.partner", self.env.user.partner_id.id)],
             [
@@ -814,7 +812,7 @@ class TestChannelInternals(MailCommon, HttpCase):
             'channel_partner_ids': [(6, 0, test_user.partner_id.id)]
         })
         test_group.add_members(self.partner_employee_nomail.ids)
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [(self.env.cr.dbname, "res.partner", self.env.user.partner_id.id)],
             [

--- a/addons/mail/tests/discuss/test_guest_feature.py
+++ b/addons/mail/tests/discuss/test_guest_feature.py
@@ -3,10 +3,11 @@
 import json
 from odoo.tests import tagged
 from odoo.addons.bus.tests.common import WebsocketCase
+from odoo.addons.mail.tests.common import MailCommon
 
 
 @tagged("post_install", "-at_install")
-class TestGuestFeature(WebsocketCase):
+class TestGuestFeature(WebsocketCase, MailCommon):
     def test_mark_as_read_as_guest(self):
         guest = self.env["mail.guest"].create({"name": "Guest"})
         partner = self.env["res.partner"].create({"name": "John"})
@@ -34,7 +35,7 @@ class TestGuestFeature(WebsocketCase):
         self.assertEqual(guest_member.seen_message_id, channel.message_ids[0])
 
     def test_subscribe_to_guest_channel(self):
-        self.env["bus.bus"].search([]).unlink()
+        self._reset_bus()
         guest = self.env["mail.guest"].create({"name": "Guest"})
         guest_websocket = self.websocket_connect()
         self.subscribe(guest_websocket, [f"mail.guest_{guest._format_auth_cookie()}"], guest.id)
@@ -51,7 +52,7 @@ class TestGuestFeature(WebsocketCase):
             group_id=None, name="General"
         )
         channel.add_members(guest_ids=[guest.id])
-        self.env["bus.bus"].search([]).unlink()
+        self._reset_bus()
         guest_websocket = self.websocket_connect()
         self.subscribe(guest_websocket, [f"mail.guest_{guest._format_auth_cookie()}"], guest.id)
         self.env["bus.bus"]._sendone(channel, "lambda", {"foo": "bar"})

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -21,7 +21,7 @@ class TestChannelRTC(MailCommon):
         channel = self.env['discuss.channel'].channel_create(name='Test Channel', group_id=self.env.ref('base.group_user').id)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
         channel_member._rtc_join_call()
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [
                 (self.cr.dbname, "discuss.channel", channel.id),  # update sessions
@@ -142,7 +142,7 @@ class TestChannelRTC(MailCommon):
         last_rtc_session_id = channel_member.rtc_session_ids.id
         channel_member._rtc_leave_call()
 
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [
                 (self.cr.dbname, 'discuss.channel', channel.id),  # update new session
@@ -239,7 +239,7 @@ class TestChannelRTC(MailCommon):
         last_rtc_session_id = channel_member.rtc_session_ids.id
         channel_member._rtc_leave_call()
 
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [
                 (self.cr.dbname, 'discuss.channel', channel.id),  # update new session
@@ -394,7 +394,7 @@ class TestChannelRTC(MailCommon):
         channel_member._rtc_join_call()
 
         channel_member_test_user = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == test_user.partner_id)
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [
                 (self.cr.dbname, "res.partner", test_user.partner_id.id),  # update invitation
@@ -485,7 +485,7 @@ class TestChannelRTC(MailCommon):
             channel_member_test_user._rtc_join_call()
 
         channel_member_test_guest = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.guest_id == test_guest)
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [
                 (self.cr.dbname, "mail.guest", test_guest.id),  # update invitation
@@ -586,7 +586,7 @@ class TestChannelRTC(MailCommon):
         channel_member._rtc_join_call()
 
         channel_member_test_user = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == test_user.partner_id)
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [
                 (self.cr.dbname, "res.partner", test_user.partner_id.id),  # update invitation
@@ -637,7 +637,7 @@ class TestChannelRTC(MailCommon):
             channel_member_test_user._rtc_leave_call()
 
         channel_member_test_guest = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.guest_id == test_guest)
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [
                 (self.cr.dbname, "mail.guest", test_guest.id),  # update invitation
@@ -699,7 +699,7 @@ class TestChannelRTC(MailCommon):
         channel_member_test_guest = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.guest_id == test_guest)
         channel_member._rtc_join_call()
 
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [
                 (self.cr.dbname, "res.partner", test_user.partner_id.id),  # update invitation
@@ -809,7 +809,7 @@ class TestChannelRTC(MailCommon):
         now = fields.Datetime.now()
         with patch.object(fields.Datetime, 'now', lambda: now + relativedelta(seconds=5)):
             channel_member._rtc_join_call()
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
 
         with self.mock_bus():
             with patch.object(fields.Datetime, 'now', lambda: now + relativedelta(seconds=10)):
@@ -969,7 +969,7 @@ class TestChannelRTC(MailCommon):
         channel = self.env['discuss.channel'].create_group(partners_to=self.user_employee.partner_id.ids)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
         channel_member._rtc_join_call()
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [
                 (self.cr.dbname, "discuss.channel", channel.id),  # update list of sessions
@@ -1008,7 +1008,7 @@ class TestChannelRTC(MailCommon):
         channel_member._rtc_join_call()
         channel_member.rtc_session_ids.flush_model()
         channel_member.rtc_session_ids._write({'write_date': fields.Datetime.now() - relativedelta(days=2)})
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [
                 (self.cr.dbname, "discuss.channel", channel.id),  # update list of sessions
@@ -1043,7 +1043,7 @@ class TestChannelRTC(MailCommon):
         channel = self.env['discuss.channel'].create_group(partners_to=self.user_employee.partner_id.ids)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
         channel_member._rtc_join_call()
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [
                 (self.cr.dbname, "discuss.channel", channel.id),  # update list of sessions
@@ -1089,7 +1089,7 @@ class TestChannelRTC(MailCommon):
         test_session.flush_model()
         test_session._write({'write_date': fields.Datetime.now() - relativedelta(days=2)})
         unused_ids = [9998, 9999]
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [
                 (self.cr.dbname, "discuss.channel", channel.id),  # update list of sessions

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -375,7 +375,7 @@ class TestDiscuss(MailCommon, TestRecipients):
         msg_2.with_user(self.user_employee).toggle_message_starred()
         self.assertIn(self.partner_admin, msg.starred_partner_ids)
         self.assertIn(self.partner_employee, msg.starred_partner_ids)
-        self.env["bus.bus"].search([]).unlink()
+        self._reset_bus()
         bus_last_id = self.env["bus.bus"].sudo()._bus_last_id()
         self.test_record._message_update_content(message=msg, body="")
         self.assertFalse(msg.starred)


### PR DESCRIPTION
\* = account, im_livechat, mail, test_mail

Every time we called `_sendone` or `_sendmany`, it would create a new cursor, then call `NOTIFY` for all the channels.
By using `postcommit.data`, we can reduce the number of calls.

Since everything is delayed and batched by default, we can now also deprecate `_sendmany`.

https://github.com/odoo/enterprise/pull/67547

Taken from https://github.com/odoo/odoo/pull/161495