### PR TITLE
[FIX] mail: Attachment preview buttons not clickable

### DIFF
--- a/addons/mail/static/src/core/common/attachment_view.scss
+++ b/addons/mail/static/src/core/common/attachment_view.scss
@@ -67,7 +67,7 @@
 }
 
 // Attachment in external window
-body > .o_attachment_preview {
+.o-mail-PopoutAttachmentView {
     width: auto;
 
     @include o-mail-AttachmentView;

--- a/addons/mail/static/src/core/common/attachment_view.xml
+++ b/addons/mail/static/src/core/common/attachment_view.xml
@@ -22,4 +22,10 @@
         </div>
     </t>
 
+    <t t-name="mail.PopoutAttachmentView">
+        <div class="o-mail-PopoutAttachmentView">
+            <t t-call="mail.AttachmentView"/>
+        </div>
+    </t>
+
 </templates>

--- a/addons/mail/static/src/core/common/mail_popout_service.js
+++ b/addons/mail/static/src/core/common/mail_popout_service.js
@@ -1,84 +1,95 @@
 import { registry } from "@web/core/registry";
-import { reactive } from "@odoo/owl";
+import { App } from "@odoo/owl";
+import { getTemplate } from "@web/core/templates";
+import { browser } from "@web/core/browser/browser";
 
 export const mailPopoutService = {
-    dependencies: ["ui"],
-    start(env, { ui }) {
-        const anchor = document.createElement("div");
+    start(env) {
         let externalWindow;
-        let currentReplacement;
+        let beforeFn;
+        let afterFn;
+        let app;
 
         /**
          * Reset the external window to its initial state:
-         * - put the current replacement back in the document
+         * - Reset the external window header from main window (for appropriate title and other meta data)
          * - clear the external window's document body
-         * - set the current replacement to null
+         * - destroy the current app mounted on the window
          */
         function reset() {
-            if (externalWindow?.document?.body?.firstChild && anchor.isConnected) {
-                anchor.after(externalWindow.document.body.firstChild);
-            }
             if (externalWindow) {
+                externalWindow.document.head.innerHTML = "";
+                externalWindow.document.write(window.document.head.outerHTML);
                 externalWindow.document.body = externalWindow.document.createElement("body");
             }
-            currentReplacement = null;
+            if (app) {
+                app.destroy();
+                app = null;
+            }
         }
 
         /**
          * Poll the external window to detect when it is closed.
-         * Trigger a resize event on the main window when the external window is closed.
+         * the afterPopout hook (afterFn) is then called after the window is closed
          */
         async function pollClosedWindow() {
             while (externalWindow) {
                 await new Promise((r) => setTimeout(r, 1000));
                 if (externalWindow.closed) {
-                    reset();
                     externalWindow = null;
-                    ui.bus.trigger("resize");
+                    afterFn();
                 }
             }
         }
 
         /**
-         * Swap the given element to the external window.
+         * This function registers hooks (before/after the window popout)
+         * @param {Function} beforePopout: this function is called before the component is initially mounted on the external window.
+         * @param {Function} afterPopout: this function is called after the external window is closed.
+         */
+        function addHooks(beforePopout = () => {}, afterPopout = () => {}) {
+            beforeFn = beforePopout;
+            afterFn = afterPopout;
+        }
+
+        /**
+         * Mounts the passed component (with its props) on an external window.
          * If the external window does not exist, it is created.
-         * If an element was already swapped, it is put back in the document before the new element is swapped.
-         * @param {Element} element: The element to swap to the external window
-         * @param {Boolean} triggerResize: Whether to trigger a resize event on the main window
+         * @param {class} component: The component to be mounted.
+         * @param {Props} props: The props of the component.
          * @returns {Window} The external window
          */
-        function popout(element, triggerResize = true) {
+        function popout(component, props) {
             if (!externalWindow || externalWindow.closed) {
-                externalWindow = window.open("about:blank", "_blank", "popup=yes");
+                externalWindow = browser.open("about:blank", "_blank", "popup=yes");
                 window.addEventListener("beforeunload", () => {
                     if (externalWindow && !externalWindow.closed) {
                         externalWindow.close();
                     }
                 });
                 pollClosedWindow();
-                externalWindow.document.write(window.document.head.outerHTML);
             }
-            if (element !== currentReplacement) {
-                reset();
-                if (element) {
-                    currentReplacement = element;
-                    element.after(anchor);
-                    externalWindow.document.body.append(element);
-                }
-            }
-            if (triggerResize) {
-                ui.bus.trigger("resize");
-            }
+
+            beforeFn();
+            reset();
+            app = new App(component, {
+                name: "Popout",
+                env,
+                props,
+                getTemplate,
+            });
+            app.mount(externalWindow.document.body);
             return externalWindow;
         }
 
-        return reactive({
+        return {
             get externalWindow() {
                 return externalWindow && externalWindow.closed ? null : externalWindow;
             },
             popout,
             reset,
-        });
+            addHooks,
+        };
     },
 };
 

--- a/addons/test_mail/static/tests/attachment_view.test.js
+++ b/addons/test_mail/static/tests/attachment_view.test.js
@@ -1,0 +1,125 @@
+import { defineTestMailModels } from "@test_mail/../tests/test_mail_test_helpers";
+import { describe, test, expect } from "@odoo/hoot";
+import { queryOne, waitUntil } from "@odoo/hoot-dom";
+import { animationFrame } from "@odoo/hoot-mock";
+import {
+    click,
+    contains,
+    openFormView,
+    registerArchs,
+    start,
+    startServer,
+    patchUiSize,
+    SIZES,
+} from "@mail/../tests/mail_test_helpers";
+import { browser } from "@web/core/browser/browser";
+import { patchWithCleanup } from "@web/../tests/web_test_helpers";
+
+describe.current.tags("desktop");
+defineTestMailModels();
+
+test("Attachment view popout controls test", async () => {
+    /*
+     * This test makes sure that the attachment view controls are working in the following cases:
+     * - Before opening the popout window
+     * - Inside the popout window
+     * - After closing the popout window
+     */
+    const popoutIframe = document.createElement("iframe");
+    const popoutWindow = {
+        closed: false,
+        get document() {
+            const doc = popoutIframe.contentDocument;
+            const originalWrite = doc.write;
+            doc.write = (content) => {
+                // This avoids duplicating the test script in the popoutWindow
+                const sanitizedContent = content.replace(
+                    /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,
+                    ""
+                );
+                originalWrite.call(doc, sanitizedContent);
+            };
+            return doc;
+        },
+        close: () => {
+            popoutWindow.closed = true;
+            popoutIframe.remove(popoutAttachmentViewBody());
+        },
+    };
+    patchWithCleanup(browser, {
+        open: () => {
+            queryOne(".o_popout_holder").append(popoutIframe);
+            return popoutWindow;
+        },
+    });
+
+    function popoutAttachmentViewBody() {
+        return popoutWindow.document.querySelector(".o-mail-PopoutAttachmentView");
+    }
+    async function popoutContains(selector) {
+        await animationFrame();
+        await waitUntil(() => popoutAttachmentViewBody());
+        const target = popoutAttachmentViewBody().querySelector(selector);
+        expect(target).toBeDisplayed();
+        return target;
+    }
+    async function popoutClick(selector) {
+        const target = await popoutContains(selector);
+        click(target);
+    }
+
+    const pyEnv = await startServer();
+    const recordId = pyEnv["mail.test.simple.main.attachment"].create({
+        display_name: "first partner",
+        message_attachment_count: 2,
+    });
+    const attachmentIds = pyEnv["ir.attachment"].create([
+        {
+            mimetype: "image/jpeg",
+            res_id: recordId,
+            res_model: "mail.test.simple.main.attachment",
+        },
+        {
+            mimetype: "application/pdf",
+            res_id: recordId,
+            res_model: "mail.test.simple.main.attachment",
+        },
+    ]);
+    pyEnv["mail.message"].create({
+        attachment_ids: attachmentIds,
+        model: "mail.test.simple.main.attachment",
+        res_id: recordId,
+    });
+    registerArchs({
+        "mail.test.simple.main.attachment,false,form": `
+                <form string="Test document">
+                    <div class="o_popout_holder"/>
+                    <sheet>
+                        <field name="name"/>
+                    </sheet>
+                    <div class="o_attachment_preview"/>
+                    <chatter/>
+                </form>`,
+    });
+
+    patchUiSize({ size: SIZES.XXL });
+    await start();
+    await openFormView("mail.test.simple.main.attachment", recordId);
+    await click(".o_attachment_preview .o_attachment_control");
+    await animationFrame();
+    expect(".o_attachment_preview").not.toBeVisible();
+    await popoutClick(".o_move_next");
+    await popoutContains("img");
+    await popoutClick(".o_move_previous");
+    await popoutContains("iframe");
+    popoutWindow.close();
+    await contains(".o_attachment_preview:not(.d-none)");
+    expect(".o_attachment_preview").toBeVisible();
+    await click(".o_attachment_preview .o_move_next");
+    await contains(".o_attachment_preview img");
+    await click(".o_attachment_preview .o_move_previous");
+    await contains(".o_attachment_preview iframe");
+    await click(".o_attachment_preview .o_attachment_control");
+    await animationFrame();
+    expect(".o_attachment_preview").not.toBeVisible();
+});

--- a/addons/test_mail/static/tests/mock_server/models/mail_test_simple_main_attachment.js
+++ b/addons/test_mail/static/tests/mock_server/models/mail_test_simple_main_attachment.js
@@ -1,0 +1,5 @@
+import { models } from "@web/../tests/web_test_helpers";
+
+export class MailTestSimpleMainAttachment extends models.ServerModel {
+    _name = "mail.test.simple.main.attachment";
+}

--- a/addons/test_mail/static/tests/test_mail_test_helpers.js
+++ b/addons/test_mail/static/tests/test_mail_test_helpers.js
@@ -3,6 +3,7 @@ import { MailTestActivity } from "@test_mail/../tests/mock_server/models/mail_te
 import { MailTestMultiCompany } from "@test_mail/../tests/mock_server/models/mail_test_multi_company";
 import { MailTestMultiCompanyRead } from "@test_mail/../tests/mock_server/models/mail_test_multi_company_read";
 import { MailTestProperties } from "@test_mail/../tests/mock_server/models/mail_test_properties";
+import { MailTestSimpleMainAttachment } from "./mock_server/models/mail_test_simple_main_attachment";
 import { MailTestSimple } from "@test_mail/../tests/mock_server/models/mail_test_simple";
 import { MailTestTrackAll } from "@test_mail/../tests/mock_server/models/mail_test_track_all";
 import { defineModels, defineParams } from "@web/../tests/web_test_helpers";
@@ -13,6 +14,7 @@ export const testMailModels = {
     MailTestMultiCompany,
     MailTestMultiCompanyRead,
     MailTestProperties,
+    MailTestSimpleMainAttachment,
     MailTestSimple,
     MailTestTrackAll,
 };


### PR DESCRIPTION
In chromium based browsers, after poping out the attachment and closing the new window, the buttons (next, previous, popout) in the attachment preview are not clickable any more.
This was happening because the mail_popout_service was relying on DOM manipulations instead of using owl framework.
This commit fixes this problem.

task-4032316


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
