### PR TITLE
[FIX] hr_work_entry_contract: generate correct entry for hourly wage

### DIFF
--- a/addons/hr_work_entry_contract/models/hr_contract.py
+++ b/addons/hr_work_entry_contract/models/hr_contract.py
@@ -227,6 +227,8 @@ class HrContract(models.Model):
                     ('state', 'draft'),
                 ] + contract._get_more_vals_attendance_interval(interval))]
 
+            if not contract._include_leaves():
+                continue
             for interval in real_leaves:
                 # Could happen when a leave is configured on the interface on a day for which the
                 # employee is not supposed to work, i.e. no attendance_ids on the calendar.
@@ -249,6 +251,10 @@ class HrContract(models.Model):
                     ('contract_id', contract.id),
                 ] + contract._get_more_vals_leave_interval(interval, interval_leaves))]
         return contract_vals
+
+    def _include_leaves(self):
+        self.ensure_one()
+        return True
 
     def _get_work_entries_values(self, date_start, date_stop):
         """


### PR DESCRIPTION
1. Create an employee and assign them to an attendance-based contract with a non-empty calendar(i.e., working hours during specific days).
2. Create a public holiday where the start and end times overlap with the selected employee's calendar.
3. Do not create any attendance records.
4. Generate the Work Entries for the period that includes the public holiday.

The Work Entry is incorrectly created for the hours in the calendar that overlap with the holiday hours.

To resolve this issue, we need to filter the entry under these specific conditions.

opw-3975435

enterprise-pr : https://github.com/odoo/enterprise/pull/67551