### PR TITLE
[FIX] website_event: fix domain typo, prevent menu recreation

### DIFF
--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -62,7 +62,7 @@ class Event(models.Model):
         readonly=False, store=True)
     location_menu_ids = fields.One2many(
         "website.event.menu", "event_id", string="Location Menus",
-        domain=[("menu_type", "=", "location_menu")])
+        domain=[("menu_type", "=", "location")])
     register_menu = fields.Boolean(
         "Register Menu", compute="_compute_website_menu_data",
         readonly=False, store=True)


### PR DESCRIPTION
location_menu_ids field domain was set to match a menu_type that doesn't exist.

[reproduce orginal bug]
- install website_event
- open some event in debug mode
- Edit -> select "Website Submenu" -> Save
- Edit -> select "Website Submenu" -> deselect "Website Submenu" -> Save
- Open Event's page, BUG: location menu duplicated

opw-4049804


PS. enums :+1:   string collections :-1: 