### PR TITLE
[FIX] account: move validate context

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4315,12 +4315,15 @@ class AccountMove(models.Model):
             not self.env.context.get('disable_abnormal_invoice_detection', True)
             and other_moves.filtered(lambda m: m.abnormal_amount_warning or m.abnormal_date_warning)
         ):
+            wizard = self.env['validate.account.move'].create({
+                'move_ids': [Command.set(other_moves.ids)],
+            })
             return {
                 'name': _("Confirm Entries"),
                 'type': 'ir.actions.act_window',
                 'res_model': 'validate.account.move',
+                'res_id': wizard.id,
                 'view_mode': 'form',
-                'context': {'default_move_ids': other_moves.ids},
                 'target': 'new',
             }
         if other_moves:


### PR DESCRIPTION
Create a sale order connected to an analytic account.
Create a vendor bill and on the line:
- use the same analytic account
- add a price such that the abnormal_amount_warning is triggered. (example: 20000000001)
- add a product line in the vendor bill which can be expensed and which has reinvoice expenses policy set to “Cost”

Click on Confirm, the warning will show, click on “Confirm” again

Issue: An error related to stock move record will show
This occurs because in order to show the warning wizard we add in
context `default_move_ids`
Then we don't cleanup the context, so if, during post, an
inventory-related flow is triggered, it may accidentally use the context
flag still set, raising an error as it will look for the wrong record

opw-4021038