### PR TITLE
[IMP] survey,utm,*: simplify kanban archs

### DIFF
--- a/addons/crm/views/utm_campaign_views.xml
+++ b/addons/crm/views/utm_campaign_views.xml
@@ -5,10 +5,10 @@
         <field name="model">utm.campaign</field>
         <field name="inherit_id" ref="utm.utm_campaign_view_kanban"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='user_id']" position="after">
+            <xpath expr="//field[@name='active']" position="after">
                 <field name="use_leads"/>
             </xpath>
-            <xpath expr="//div[hasclass('oe_kanban_bottom_left')]" position="inside">
+            <xpath expr="//footer/div" position="inside">
                 <t t-if="record.use_leads.raw_value">
                     <t t-set="crm_lead_count_label">Leads</t>
                 </t>
@@ -17,7 +17,7 @@
                 </t>
                 <a t-if="record.crm_lead_count" href="#" t-att-title="crm_lead_count_label" role="button"
                     groups="sales_team.group_sale_salesman" data-type="object" data-name="action_redirect_to_leads_opportunities"
-                    class="oe_kanban_action oe_kanban_action_a btn-outline-primary rounded-pill me-1 order-3">
+                    class="btn-outline-primary rounded-pill me-1 order-3">
                     <span class="badge">
                         <i class="fa fa-fw fa-star" t-att-aria-label="crm_lead_count_label" role="img"/>
                         <field name="crm_lead_count"/>

--- a/addons/link_tracker/views/utm_campaign_views.xml
+++ b/addons/link_tracker/views/utm_campaign_views.xml
@@ -19,16 +19,13 @@
         <field name="model">utm.campaign</field>
         <field name="inherit_id" ref="utm.utm_campaign_view_kanban"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='stage_id']" position="after">
-                <field name="click_count"/>
-            </xpath>
-            <xpath expr="//div[hasclass('oe_kanban_bottom_left')]" position="inside">
+            <xpath expr="//footer/div" position="inside">
                 <a t-if="record.click_count" href="#" title="Clicks" role="button"
                     data-type="action" data-name="%(link_tracker_action_campaign)d"
-                    class="oe_kanban_action oe_kanban_action_a btn-outline-primary rounded-pill me-1 order-4">
+                    class="btn-outline-primary rounded-pill me-1 order-4">
                     <span class="badge">
                         <i class="fa fa-fw fa-mouse-pointer" aria-label="Clicks" role="img"/>
-                        <t t-out="record.click_count.raw_value"/>
+                        <field name="click_count"/>
                     </span>
                 </a>
             </xpath>

--- a/addons/mass_mailing/static/tests/tours/mailing_campaign.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_campaign.js
@@ -19,7 +19,7 @@ registry.category('web_tour.tours').add('mailing_campaign', {
         },
         {
             content: 'Select "Newsletter" campaign',
-            trigger: '.oe_kanban_card:contains("Newsletter")',
+            trigger: '.o_kanban_record:contains("Newsletter")',
             run: "click",
         },
         {

--- a/addons/mass_mailing/views/utm_campaign_views.xml
+++ b/addons/mass_mailing/views/utm_campaign_views.xml
@@ -64,13 +64,13 @@
         <field name="model">utm.campaign</field>
         <field name="inherit_id" ref="utm.utm_campaign_view_kanban"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='user_id']" position="after">
+            <xpath expr="//field[@name='active']" position="after">
                 <field name="mailing_mail_ids" groups="mass_mailing.group_mass_mailing_user"/>
                 <field name="is_mailing_campaign_activated"/>
             </xpath>
             <xpath expr="//ul[@id='o_utm_actions']">
                 <a name="%(action_view_mass_mailings_from_campaign)d" type="action"
-                    t-attf-class="oe_mailings #{record.mailing_mail_ids.raw_value.length === 0 ? 'text-muted' : ''}"
+                    t-attf-class="pe-2 oe_mailings #{record.mailing_mail_ids.raw_value.length === 0 ? 'text-muted' : ''}"
                     t-if="record.is_mailing_campaign_activated.raw_value"
                     groups="mass_mailing.group_mass_mailing_user">
                     <t t-out="record.mailing_mail_ids.raw_value.length"/> Mailings

--- a/addons/mass_mailing_sms/views/utm_campaign_views.xml
+++ b/addons/mass_mailing_sms/views/utm_campaign_views.xml
@@ -59,15 +59,12 @@
         <field name="model">utm.campaign</field>
         <field name="inherit_id" ref="utm.utm_campaign_view_kanban"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='user_id']" position="after">
-                <field name="mailing_sms_count" groups="mass_mailing.group_mass_mailing_user"/>
-            </xpath>
             <xpath expr="//ul[@id='o_utm_actions']">
                 <a name="action_redirect_to_mailing_sms" type="object"
-                    t-attf-class="oe_mailings #{record.mailing_sms_count.raw_value === 0 ? 'text-muted' : ''}"
+                    t-attf-class="pe-2 oe_mailings #{record.mailing_sms_count.raw_value === 0 ? 'text-muted' : ''}"
                     t-if="record.is_mailing_campaign_activated.raw_value"
                     groups="mass_mailing.group_mass_mailing_user">
-                    <t t-out="record.mailing_sms_count.raw_value"/> SMS
+                    <field name="mailing_sms_count"/> SMS
                 </a>
             </xpath>
         </field>

--- a/addons/sale/views/utm_campaign_views.xml
+++ b/addons/sale/views/utm_campaign_views.xml
@@ -6,10 +6,10 @@
         <field name="model">utm.campaign</field>
         <field name="inherit_id" ref="utm.utm_campaign_view_kanban"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[hasclass('oe_kanban_bottom_left')]" position="inside">
+            <xpath expr="//footer/div" position="inside">
                 <a t-if="record.invoiced_amount" href="#" title="Revenues" role="button"
                     groups="sales_team.group_sale_salesman" data-type="object" data-name="action_redirect_to_invoiced"
-                    class="oe_kanban_action oe_kanban_action_a btn-outline-primary rounded-pill me-1 order-1">
+                    class="btn-outline-primary rounded-pill me-1 order-1">
                     <span class="badge">
                         <field name="currency_id" invisible="True"/>
                         <field name="invoiced_amount" widget="monetary" options="{'currency_field': 'currency_id'}"/>
@@ -17,7 +17,7 @@
                 </a>
                 <a t-if="record.quotation_count" href="#" title="Quotations" role="button"
                     groups="sales_team.group_sale_salesman" data-type="object" data-name="action_redirect_to_quotations"
-                    class="oe_kanban_action oe_kanban_action_a btn-outline-primary rounded-pill me-1 order-2">
+                    class="btn-outline-primary rounded-pill me-1 order-2">
                     <span class="badge">
                         <i class="fa fa-fw fa-money me-1" aria-label="Quotations" role="img"/>
                         <field name="quotation_count"/>

--- a/addons/survey/static/tests/tours/survey_tour_session_tools.js
+++ b/addons/survey/static/tests/tours/survey_tour_session_tools.js
@@ -18,7 +18,7 @@ export const accessSurveysteps = [
         run: "click",
     },
     {
-        trigger: '.oe_kanban_card:contains("User Session Survey")',
+        trigger: '.o_kanban_record:contains("User Session Survey")',
         run: "click",
     },
 ];

--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -221,36 +221,30 @@
         <field name="name">survey.survey.view.kanban</field>
         <field name="model">survey.survey</field>
         <field name="arch" type="xml">
-            <kanban js_class="survey_view_kanban">
+            <kanban highlight_color="color" js_class="survey_view_kanban">
                 <field name="active"/>
                 <field name="certification"/>
-                <field name="color"/>
                 <field name="create_date"/>
                 <field name="scoring_type"/>
                 <field name="session_state"/>
-                <field name="success_ratio"/>
-                <field name="session_available" invisible="1"/>
+                <field name="session_available"/>
                 <templates>
                     <div t-name="kanban-menu" t-if="widget.editable">
-                        <a role="menuitem" type="edit" class="dropdown-item">Edit Survey</a>
+                        <a role="menuitem" type="open" class="dropdown-item">Edit Survey</a>
                         <a t-if="record.active.raw_value" role="menuitem" type="object" class="dropdown-item" name="action_send_survey">Share</a>
                         <a t-if="widget.deletable" role="menuitem" type="delete" class="dropdown-item">Delete</a>
                         <div role="separator" class="dropdown-divider"/>
                         <div role="separator" class="dropdown-item-text">Color</div>
-                        <ul class="oe_kanban_colorpicker" data-field="color"/>
+                        <field name="color" widget="kanban_color_picker"/>
                     </div>
-                    <div t-name="kanban-box"
-                        t-attf-class="oe_kanban_color_#{kanban_getcolor(record.color.raw_value)}
-                                      oe_kanban_card oe_kanban_global_click
-                                      o_survey_kanban_card #{record.certification.raw_value ? 'o_survey_kanban_card_certification' : ''}">
+                    <div t-name="kanban-card"
+                        t-attf-class="o_survey_kanban_card #{record.certification.raw_value ? 'o_survey_kanban_card_certification' : ''}" class="px-0">
                         <!-- displayed in ungrouped mode -->
-                        <div class="o_survey_kanban_card_ungrouped row mx-0">
-                            <widget name="web_ribbon" title="Archived"
-                                bg_color="text-bg-danger"
-                                invisible="active"/>
-                            <div class="col-lg-2 col-sm-8 py-0 my-2 my-lg-0 col-12">
+                        <div class="o_survey_kanban_card_ungrouped row mx-4">
+                            <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
+                            <div class="col-lg-2 col-sm-8 py-0 my-2 my-lg-0 col-12 g-0">
                                 <div class="d-flex flex-grow-1 flex-column my-0 my-lg-2">
-                                    <span class="fw-bold"><field name="title"/></span>
+                                    <field name="title" class="fw-bold"/>
                                     <span t-if="!selection_mode" class="d-flex align-items-center">
                                         <field name="user_id" widget="many2one_avatar_user"
                                             options="{'display_avatar_name': True}"/>
@@ -260,16 +254,14 @@
                                 </div>
                             </div>
                             <div t-attf-class="col-lg-1 col-sm-4 d-none d-sm-block py-0 my-2 col-#{selection_mode ? '12' : '6'}">
-                                <span class="fw-bold"><field name="question_count"/></span><br t-if="!selection_mode"/>
+                                <field name="question_count" class="fw-bold"/><br t-if="!selection_mode"/>
                                 <span class="text-muted">Questions</span>
                             </div>
                             <div t-if="selection_mode" class="col-12 d-flex justify-content-end">
                                 <field name="user_id" widget="many2one_avatar_user"/>
                             </div>
                             <div t-if="!selection_mode" class="col-lg-1 col-sm-4 col-6 py-0 my-2">
-                                <span class="fw-bold">
-                                    <field name="answer_duration_avg" widget="float_time"/>
-                                </span><br />
+                                <field name="answer_duration_avg" widget="float_time" class="fw-bold"/>
                                 <span class="text-muted">Average Duration</span>
                             </div>
                             <div t-if="!selection_mode" class="col-lg-1 col-sm-4 col-6 py-0 my-2">
@@ -294,7 +286,7 @@
                                    type="object"
                                    name="action_survey_user_input_certified"
                                    class="fw-bold">
-                                    <field name="success_ratio" widget="progressbar" class="d-block"/>
+                                    <field name="success_ratio" widget="progressbar" class="d-block" style="word-break: normal;"/>
                                     <span class="text-muted" t-if="!record.certification.raw_value">Passed</span>
                                     <span class="text-muted" t-else="">Certified</span>
                                 </a>
@@ -302,13 +294,13 @@
                             <div t-if="!selection_mode" class="col-lg-3 col-sm-12 d-none d-sm-flex justify-content-end gap-1 my-2 ms-auto pb-lg-3 py-0">
                                 <button name="action_send_survey"
                                         string="Share" type="object"
-                                        class="btn btn-secondary"
+                                        class="btn btn-secondary text-nowrap"
                                         invisible="not active">
                                     Share
                                 </button>
                                 <button name="action_test_survey"
                                         string="Test" type="object"
-                                        class="btn btn-secondary"
+                                        class="btn btn-secondary text-nowrap"
                                         invisible="not active">
                                     Test
                                 </button>
@@ -333,35 +325,29 @@
                             </div>
                         </div>
                         <!-- displayed in grouped mode -->
-                        <div class="o_survey_kanban_card_grouped">
-                            <widget name="web_ribbon" title="Archived"
-                                bg_color="text-bg-danger"
-                                invisible="active"/>
-                            <div class="o_kanban_record_top">
-                                <h4 class="o_kanban_record_title p-0 mb4"><field name="title" /></h4>
-                            </div>
+                        <div class="o_survey_kanban_card_grouped px-1">
+                            <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
+                            <field name="title" class="fw-bold mb-1 fs-5 mb-1"/>
                             <div class="row g-0">
-                                <div class="col-10 p-0 pb-1">
-                                    <div class="container o_kanban_card_content" t-if="record.answer_count.raw_value != 0">
-                                        <div class="row mt-4 ms-2">
-                                            <div class="col-4 p-0">
-                                                <a name="action_survey_user_input" type="object" class="d-flex flex-column align-items-center">
-                                                    <span class="fw-bold"><field name="answer_count"/></span>
-                                                    <span class="text-break text-muted">Registered</span>
-                                                </a>
-                                            </div>
-                                            <div class="col-4 p-0 border-start">
-                                                <a name="action_survey_user_input_completed" type="object" class="d-flex flex-column align-items-center">
-                                                    <span class="fw-bold"><field name="answer_done_count"/></span>
-                                                    <span class="text-break text-muted">Completed</span>
-                                                </a>
-                                            </div>
-                                            <div class="col-4 p-0 border-start" t-if="record.scoring_type.raw_value != 'no_scoring'" >
-                                                <a name="action_survey_user_input_certified" type="object" class="d-flex flex-column align-items-center">
-                                                    <span class="fw-bold"> <t t-esc="Math.round(record.success_ratio.raw_value)"></t> %</span>
-                                                    <span class="text-break text-muted" >Success</span>
-                                                </a>
-                                            </div>
+                                <div class="col-10 p-0 pb-1" t-if="record.answer_count.raw_value != 0">
+                                    <div class="row mt-4 ms-2">
+                                        <div class="col-4 p-0">
+                                            <a name="action_survey_user_input" type="object" class="d-flex flex-column align-items-center">
+                                                <field name="answer_count" class="fw-bold"/>
+                                                <span class="text-break text-muted">Registered</span>
+                                            </a>
+                                        </div>
+                                        <div class="col-4 p-0 border-start">
+                                            <a name="action_survey_user_input_completed" type="object" class="d-flex flex-column align-items-center">
+                                                <field name="answer_done_count" class="fw-bold"/>
+                                                <span class="text-break text-muted">Completed</span>
+                                            </a>
+                                        </div>
+                                        <div class="col-4 p-0 border-start" t-if="record.scoring_type.raw_value != 'no_scoring'" >
+                                            <a name="action_survey_user_input_certified" type="object" class="d-flex flex-column align-items-center">
+                                                <span class="fw-bold"> <t t-esc="Math.round(record.success_ratio.raw_value)"></t> %</span>
+                                                <span class="text-break text-muted">Success</span>
+                                            </a>
                                         </div>
                                     </div>
                                 </div>

--- a/addons/survey/views/survey_user_views.xml
+++ b/addons/survey/views/survey_user_views.xml
@@ -137,28 +137,13 @@
         <field name="model">survey.user_input</field>
         <field name="arch" type="xml">
             <kanban create="false" group_create="false">
-                <field name="survey_id"/>
-                <field name="create_date"/>
-                <field name="partner_id"/>
-                <field name="email"/>
-                <field name="state"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_global_click">
-                            <div class="o_kanban_record_top">
-                                <div class="o_kanban_record_headings">
-                                    <strong class="o_kanban_record_title"><t t-esc="record.survey_id.value"/></strong>
-                                </div>
-                            </div>
-                            <div class="o_kanban_record_bottom">
-                                <div class="oe_kanban_bottom_left">
-                                    <field name="create_date"/>
-                                </div>
-                                <div class="oe_kanban_bottom_right mr4">
-                                    <field name="state" widget="label_selection" options="{'classes': {'new': 'default', 'done': 'success', 'in_progress':'warning'}}"/>
-                                </div>
-                            </div>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="survey_id" class="fw-bold fs-5 mb-1"/>
+                        <footer class="fs-6 pt-0">
+                            <field name="create_date"/>
+                            <field name="state" widget="label_selection" options="{'classes': {'new': 'default', 'done': 'success', 'in_progress':'warning'}}" class="ms-auto"/>
+                        </footer>
                     </t>
                 </templates>
             </kanban>

--- a/addons/test_base_automation/tests/test_tour.py
+++ b/addons/test_base_automation/tests/test_tour.py
@@ -47,12 +47,8 @@ class BaseAutomationTestUi(HttpCase):
                 "arch": """
                     <kanban default_group_by="tag_ids">
                         <templates>
-                            <t t-name="kanban-box">
-                                <div class="oe_kanban_global_click">
-                                    <div class="o_kanban_card_content">
-                                        <field name="name" />
-                                    </div>
-                                </div>
+                            <t t-name="kanban-card">
+                                <field name="name" />
                             </t>
                         </templates>
                     </kanban>

--- a/addons/test_website/views/test_model_multi_website_views.xml
+++ b/addons/test_website/views/test_model_multi_website_views.xml
@@ -7,25 +7,17 @@
     <field name="model">test.model.multi.website</field>
     <field name="arch" type="xml">
         <kanban js_class="website_pages_kanban" class="o_kanban_mobile" action="open_website_url" type="object" sample="1">
-            <field name="name"/>
-            <field name="website_url"/>
             <templates>
-                <t t-name="kanban-box">
-                    <div class="oe_kanban_global_click d-flex flex-column">
-                        <div class="row mb-auto">
-                            <strong class="col-8">
-                                <span class="o_text_overflow" t-esc="record.name.value"/>
-                                <div class="text-muted" t-if="record.website_id.value" groups="website.group_multi_website">
-                                    <i class="fa fa-globe me-1" title="Website"/>
-                                    <field name="website_id"/>
-                                </div>
-                            </strong>
-                        </div>
-                        <div class="border-top mt-2 pt-2">
-                            <field name="is_published" widget="boolean_toggle"/>
-                            <t t-if="record.is_published.raw_value">Published</t>
-                            <t t-else="">Not Published</t>
-                        </div>
+                <t t-name="kanban-card">
+                    <field name="name" class="text-truncate fw-bolder mb-auto"/>
+                    <div class="text-muted fw-bolder" t-if="record.website_id.value" groups="website.group_multi_website">
+                        <i class="fa fa-globe me-1" title="Website"/>
+                        <field name="website_id"/>
+                    </div>
+                    <div class="d-flex border-top mt-2 pt-2">
+                        <field name="is_published" widget="boolean_toggle"/>
+                        <t t-if="record.is_published.raw_value">Published</t>
+                        <t t-else="">Not Published</t>
                     </div>
                 </t>
             </templates>

--- a/addons/test_website/views/test_model_views.xml
+++ b/addons/test_website/views/test_model_views.xml
@@ -7,21 +7,13 @@
     <field name="model">test.model</field>
     <field name="arch" type="xml">
         <kanban js_class="website_pages_kanban" class="o_kanban_mobile" action="open_website_url" type="object" sample="1">
-            <field name="name"/>
-            <field name="website_url"/>
             <templates>
-                <t t-name="kanban-box">
-                    <div class="oe_kanban_global_click d-flex flex-column">
-                        <div class="row mb-auto">
-                            <strong class="col-8">
-                                <span class="o_text_overflow" t-esc="record.name.value"/>
-                            </strong>
-                        </div>
-                        <div class="border-top mt-2 pt-2">
-                            <field name="is_published" widget="boolean_toggle"/>
-                            <t t-if="record.is_published.raw_value">Published</t>
-                            <t t-else="">Not Published</t>
-                        </div>
+                <t t-name="kanban-card">
+                    <field class="text-truncate mb-auto fw-bolder" name="name"/>
+                    <div class="d-flex border-top mt-2 pt-2">
+                        <field name="is_published" widget="boolean_toggle"/>
+                        <t t-if="record.is_published.raw_value">Published</t>
+                        <t t-else="">Not Published</t>
                     </div>
                 </t>
             </templates>

--- a/addons/utm/views/utm_campaign_views.xml
+++ b/addons/utm/views/utm_campaign_views.xml
@@ -85,15 +85,14 @@
         <field name="name">utm.campaign.view.kanban</field>
         <field name="model">utm.campaign</field>
         <field name="arch" type="xml">
-            <kanban default_group_by='stage_id' class="o_utm_kanban" on_create="quick_create" quick_create_view="utm.utm_campaign_view_form_quick_create" examples="utm_campaign" sample="1">
-                <field name='color'/>
+            <kanban highlight_color="color" default_group_by='stage_id' class="o_utm_kanban" on_create="quick_create" quick_create_view="utm.utm_campaign_view_form_quick_create" examples="utm_campaign" sample="1">
                 <field name='user_id'/>
                 <field name="stage_id"/>
                 <field name='active'/>
                 <templates>
                     <t t-name="kanban-menu">
                         <t t-if="widget.editable">
-                            <a role="menuitem" type="edit" class="dropdown-item">Edit</a>
+                            <a role="menuitem" type="open" class="dropdown-item">Edit</a>
                         </t>
                         <t t-if="widget.deletable">
                             <a role="menuitem" type="delete" class="dropdown-item">Delete</a>
@@ -103,29 +102,16 @@
                             <t t-else="">Restore</t>
                         </a>
                         <div role="separator" class="dropdown-divider"/>
-                        <ul class="oe_kanban_colorpicker" data-field="color"/>
+                        <field name="color" widget="kanban_color_picker"/>
                     </t>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_color_#{kanban_getcolor(record.color.raw_value)} oe_kanban_card oe_kanban_global_click">
-                            <div class="oe_kanban_content">
-                                <div class="o_kanban_record_top">
-                                    <div class="o_kanban_record_headings">
-                                        <h3 class="oe_margin_bottom_8 o_kanban_record_title"><field name="title"/></h3>
-                                    </div>
-                                </div>
-                                <div class="o_kanban_record_body">
-                                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
-                                    <ul id="o_utm_actions" class="list-group list-group-horizontal my-0"/>
-                                </div>
-                                <div class="o_kanban_record_bottom h5 mt-2 mb-0">
-                                    <div class="oe_kanban_bottom_left py-auto"/>
-                                    <div class="oe_kanban_bottom_right">
-                                         <field name="user_id" widget="many2one_avatar_user"/>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="clearfix"></div>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="title" class="fw-bold fs-5"/>
+                        <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                        <ul id="o_utm_actions" class="list-group list-group-horizontal my-0"/>
+                        <footer class="mt-2 mb-0 pt-0">
+                            <div class="py-auto"/>
+                            <field name="user_id" widget="many2one_avatar_user" class="ms-auto"/>
+                        </footer>
                     </t>
                 </templates>
             </kanban>

--- a/addons/website_slides_survey/views/survey_survey_views.xml
+++ b/addons/website_slides_survey/views/survey_survey_views.xml
@@ -54,9 +54,6 @@
         <field name="model">survey.survey</field>
         <field name="inherit_id" ref="survey.survey_survey_view_kanban"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='session_state']" position="after">
-                <field name="slide_channel_count"/>
-            </xpath>
             <xpath expr="//div[@name='o_survey_kanban_card_section_success']" position="after">
                 <div class="col-lg-1 col-sm-4 col-6 py-0 my-2" groups="website_slides.group_website_slides_officer">
                     <a t-if="record.slide_channel_count.raw_value"


### PR DESCRIPTION
`*crm,link_tracker,mass_mailing,mass_mailing_sms,sale,test_website,`
`test_base_automation,website_slides_survey`
In this commit we have simplified the kanban arch for the test_website,survey, utm and their related modules.the goal is to simplify them, make them easier to read and use bootstrap utility classnames.

- Previously, we used kanban-box, but now we are using kanban-card instead.
- Deprecated oe_kanban_global_click and oe_kanban_global_click_edit.
- More use of <field/> tags
- Removed the oe_kanban_colorpicker class and replaced it with the kanban_color_picker widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- kanban_image from rendering context, is deprecated so we use <field name="..." widget="image"/> instead
- kanban_color, kanban_getcolor and kanban_getcolorname are deprecated use new attribute highlight_color="color_field_name" on root node

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
