### PR TITLE
[FIX] mail: wrongly assigned attachment as main attachment

### DIFF
--- a/addons/mail/models/ir_attachment.py
+++ b/addons/mail/models/ir_attachment.py
@@ -58,7 +58,9 @@ class IrAttachment(models.Model):
 
         if force or not related_record.message_main_attachment_id:
             with contextlib.suppress(AccessError):
-                related_record.message_main_attachment_id = self
+                not_allowed_mimetypes = ["application/xml", "application/pkcs7-mime"]
+                if self.mimetype not in not_allowed_mimetypes:
+                    related_record.message_main_attachment_id = self
 
     def _delete_and_notify(self, message=None):
         if message:

--- a/addons/mail/models/mail_thread_main_attachment.py
+++ b/addons/mail/models/mail_thread_main_attachment.py
@@ -25,6 +25,7 @@ class MailMainAttachmentMixin(models.AbstractModel):
         if attachment_ids and not self.message_main_attachment_id:
             # we filter out attachment with 'xml' and 'octet' types
             attachments = self.env['ir.attachment'].browse(attachment_ids).filtered(lambda r: not r.mimetype.endswith('xml')
+                                                                                              and not r.mimetype.endswith('application/pkcs7-mime')
                                                                                               and not r.mimetype.endswith('application/octet-stream'))
 
             # Assign one of the attachments as the main according to the following priority: pdf, image, other types.


### PR DESCRIPTION
Before this commit:
Sometimes attachments with extension 'p7m' or 'xml' were incorrectly assigned as the main attachment. This caused the attachment viewer to treat these attachments as previews that could be displayed.

Approach to fix this issue:
Added a check for attachments with file extensions 'xml' and 'p7m' to prevent them from being considered as the main attachment.

After this commit:
Attachments with mimetypes 'xml' and 'p7m' will no longer be considered as the main attachment, preventing them from appearing in the attachment viewer.

task-3669465
