### PR TITLE
[FIX] website_slides: limit payment info to bounding box

### DIFF
--- a/addons/website_sale_slides/views/website_slides_templates.xml
+++ b/addons/website_sale_slides/views/website_slides_templates.xml
@@ -86,7 +86,7 @@
 <template name="Buy Course Button" id="course_buy_course_button">
     <t t-if="channel.product_id.website_published">
         <div t-attf-class="text-center d-flex align-items-center text-center pb-1 #{'justify-content-between' if product_info['has_discounted_price'] else 'justify-content-around'}">
-            <div class="css_editable_mode_hidden">
+            <div class="css_editable_mode_hidden overflow-auto">
                 <!-- real price -->
                 <div class="oe_price font-weight-bold text-nowrap h2 my-2"
                      t-esc="product_info['price']"

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -240,7 +240,7 @@
     <!-- Channel sidebar (aka general information + CTAs) -->
     <div class="o_wslides_course_sidebar bg-white px-3 py-2 py-md-3 mb-3 mb-md-5">
 
-        <div class="o_wslides_sidebar_top d-flex justify-content-between">
+        <div class="o_wslides_sidebar_top justify-content-between">
             <div class="o_wslides_js_course_join flex-grow-1">
                 <a t-if="not channel.is_member and channel.enroll == 'public'" role="button"
                     class="btn btn-primary btn-block o_wslides_js_course_join_link"


### PR DESCRIPTION
Steps to reproduce:
- Elearning > Configuration > Enable paid courses
- Any course > Options tab
- Set enroll policy to 'on payment'
- Set a course product with a very high price (12+ digits)
- Back to course > 'Go To Website' button
- Leave course if you are enrolled

The payment info menu leaves its bounding box and becomes unreadable after overlapping with the course content. Not really a problem in euro because price should never get that high, but with other currencies it could interfere.

Out of all the display options I chose a scrollbar because it is the most conspicuous, wouldn't want to trick people by hiding half the price tag.

opw-4077007

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
