### PR TITLE
[FIX] payment: avoid creating account.payment.method.line when viewing Wire Transfer data

### DIFF
--- a/addons/payment/models/payment_acquirer.py
+++ b/addons/payment/models/payment_acquirer.py
@@ -198,6 +198,18 @@ class PaymentAcquirer(models.Model):
             pay_method_line.journal_id = self.journal_id
         elif allow_create:
             default_payment_method_id = self._get_default_payment_method_id()
+
+            pay_method_line = self.env['account.payment.method.line'].search(
+                [
+                    ('payment_acquirer_id', '=', self.id),
+                    ('payment_method_id', '=', default_payment_method_id),
+                    ('journal_id', '=', self.journal_id.id),
+                ],
+                limit=1,
+            )
+            if pay_method_line:
+                return
+
             create_values = {
                 'name': self.name,
                 'payment_method_id': default_payment_method_id,


### PR DESCRIPTION
**Impacted versions:** v15.0, v16.0, v17.0

**Description of the issue/feature this PR addresses:**
Steps:
1. Open form to view Wire Transfer
2. Viewing bank journal will have a lot of `account.payment.method.line` created

Because Wire Transfer has the code `transfer`, there is no `account.payment.method` corresponding to it.

https://github.com/user-attachments/assets/bb4aac11-e735-4e59-8797-49a471ceea64

**Desired behavior after PR is merged:**
Do not create `account.payment.method.line`



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
