### PR TITLE
[FIX] point_of_sale: show correct base amount on receipt

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -72,7 +72,7 @@
                     <span t-if="taxValues.amount_type != 'fixed'"><t t-esc="taxValues.tax_percentage"/>%</span>
                     <span t-else="" t-esc="taxValues.name"/>
                     <span t-esc="props.formatCurrency(taxValues.amount, false)" />
-                    <span t-esc="props.formatCurrency(taxValues.base, false)" />
+                    <span t-esc="props.formatCurrency(taxValues.display_base || taxValues.base, false)" />
                     <span t-esc="props.formatCurrency(taxValues.amount + taxValues.base, false)" />
                 </t>
                 <t t-if="props.data.tax_details.length > 1">

--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -2223,10 +2223,12 @@ export class Order extends PosModel {
                     taxDetails[taxId] = Object.assign({}, taxValues, {
                         amount: 0.0,
                         base: 0.0,
+                        display_base: 0.0,
                         tax_percentage: taxValues.amount,
                     });
                 }
-                taxDetails[taxId].base += taxValues.display_base;
+                taxDetails[taxId].base += taxValues.base;
+                taxDetails[taxId].display_base += taxValues.display_base;
                 taxDetails[taxId].amount += taxValues.tax_amount_factorized;
             }
         }

--- a/addons/point_of_sale/static/tests/tours/TicketScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/TicketScreen.tour.js
@@ -221,6 +221,7 @@ registry.category("web_tour.tours").add("LotRefundTour", {
             PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickValidate(),
             ReceiptScreen.isShown(),
+            ReceiptScreen.checkTaxDetails("10%", 20, 200, 200),
             ReceiptScreen.clickNextOrder(),
             ...ProductScreen.clickRefund(),
             TicketScreen.selectOrder("-0001"),

--- a/addons/point_of_sale/static/tests/tours/helpers/ReceiptScreenTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/ReceiptScreenTourMethods.js
@@ -107,3 +107,11 @@ export function shippingDateExists() {
         },
     ];
 }
+export function checkTaxDetails(tax, amount, base, total) {
+    return [
+        {
+            trigger: `.pos-receipt-taxes span:contains('${tax}') ~ span:contains('${amount}') ~ span:contains('${base}') ~ span:contains('${total}')`,
+            run: () => {},
+        },
+    ];
+}

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1052,6 +1052,12 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'FiscalPositionNoTaxRefund', login="pos_user")
 
     def test_lot_refund(self):
+        percent_included_tax = self.env['account.tax'].create({
+            'name': 'fixed amount tax',
+            'amount_type': 'division',
+            'amount': 10,
+            'price_include': True,
+        })
 
         self.product1 = self.env['product.product'].create({
             'name': 'Product A',
@@ -1059,6 +1065,8 @@ class TestUi(TestPointOfSaleHttpCommon):
             'tracking': 'serial',
             'categ_id': self.env.ref('product.product_category_all').id,
             'available_in_pos': True,
+            'list_price': 200,
+            'taxes_id': [(6, 0, [percent_included_tax.id])],
         })
 
         self.main_pos_config.with_user(self.pos_user).open_ui()


### PR DESCRIPTION
 Currently, when buying a product with a division tax using price included
the base price used to compute the total is not correct and will show a wrong total value.

Steps to reproduce:
-------------------
* Go into the **Accounting** app
* Under **Configuration** select **Taxes**
* Create a new Tax
  * Tax Computation: `Percentage of Price Tax Included`
  * Amount 10%
  * Advenced Options > Included in price: `True`
* Go to the **Point of sale** App
* Create a new product.
  * Price: 200
  * Tax: the one just created
* Open shop session
* Create an order with the new product and pay it
> Observation: On the receipt, on the tax details, we can see: Tax: 10%, Amount: 20, Base: 200, Total: 220. This is not correct, the client paid 200 as tax is included in price.

Why the fix:
------------
Currently the Base value on the receipt is given `taxValues.base`. The same quantity is also used for the computation of the Total shown.

https://github.com/odoo/odoo/blob/49cecec35421cc36258f900d99c1040596601167/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml#L75-L76

However, if we look where the `taxValues` come from we see that they correspond to `tax_details` in `export_for_printing`.
https://github.com/odoo/odoo/blob/49cecec35421cc36258f900d99c1040596601167/addons/point_of_sale/static/src/app/store/models.js#L1314

When checking the function `get_tax_details` we realize that `taxValues.base` actually refers to the `display_base`
https://github.com/odoo/odoo/blob/49cecec35421cc36258f900d99c1040596601167/addons/point_of_sale/static/src/app/store/models.js#L2228

As disucssed with LAS, here is how the values on the receipt should be computed:
```
Amount = amount = 20
Base = display_base = 200
Total = base + amount = 180 + 20
```

Technically, prior to the fix, here is how the value shown are computed:
```
Amount = amount = 20
Base = display_base = 200
Total = display_base + amount = 180 + 20
```

This computation is problematic only in the setting explained earlier as this is the only one which will have a different value for `base` and `display_base`:
https://github.com/odoo/odoo/blob/b8baa83e575a36dd539c9fda10d5ffbe3ef01183/addons/account/static/src/helpers/account_tax.js#L408-L411

Why do we write
```<span t-esc="props.formatCurrency(taxValues.display_base || taxValues.base, false)" />```
instead of just
```<span t-esc="props.formatCurrency(taxValues.display_base, false)" />``` with the changes currently applied in `get_Tax_details`?

Well, when using the kiosk, information about the `display_base` does not exist in `_compute_tax_details`:
https://github.com/odoo/odoo/blob/b8baa83e575a36dd539c9fda10d5ffbe3ef01183/addons/pos_self_order/models/pos_order.py#L41-L61

Thus we avoid an error when using the function `export_for_printing` by using `taxValues.base` as there is no `taxValues.display_base` provided.

This is currently the only other time where the function `export_for_printing` sets the value sent for `tax_details`.

opw-4032366