### PR TITLE
[FIX] point_of_sale: translate text used to generate account move lines description.

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1266,10 +1266,10 @@ class PosSession(models.Model):
         account_id, sign, tax_keys, base_tag_ids = key
         tax_ids = set(tax[0] for tax in tax_keys)
         applied_taxes = self.env['account.tax'].browse(tax_ids)
-        title = 'Sales' if sign == 1 else 'Refund'
-        name = '%s untaxed' % title
+        title = _('Sales') if sign == 1 else _('Refund')
+        name = _('%s untaxed', title)
         if applied_taxes:
-            name = '%s with %s' % (title, ', '.join([tax.name for tax in applied_taxes]))
+            name = _('%s with %s', title, ', '.join([tax.name for tax in applied_taxes]))
         partial_vals = {
             'name': name,
             'account_id': account_id,


### PR DESCRIPTION
closes: #174647

Forward port of #174511 (Original PR in V16)

CC : @vlst-odoo

Note : i only cherry-picked the change of the .py file. I think that it was not a good idea to change the pot / po files in the original PR because when we forward-port the PR it generates conflicts on each version. This one should be OK against 17.0 (+ saas + master versions)