### PR TITLE
[IMP] stock, purchase_stock: update urls to the new format

### DIFF
--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -168,7 +168,6 @@ class Orderpoint(models.Model):
             domain = AND([domain, [('write_date', '>=', self.env.context.get('written_after'))]])
         order = self.env['purchase.order.line'].search(domain, limit=1).order_id
         if order:
-            action = self.env.ref('purchase.action_rfq_form')
             return {
                 'type': 'ir.actions.client',
                 'tag': 'display_notification',
@@ -177,7 +176,7 @@ class Orderpoint(models.Model):
                     'message': '%s',
                     'links': [{
                         'label': order.display_name,
-                        'url': f'/web#action={action.id}&id={order.id}&model=purchase.order',
+                        'url': f'/odoo/action-purchase.action_rfq_form/{order.id}',
                     }],
                     'sticky': False,
                     'next': {'type': 'ir.actions.act_window_close'},

--- a/addons/purchase_stock/tests/test_replenish_wizard.py
+++ b/addons/purchase_stock/tests/test_replenish_wizard.py
@@ -54,7 +54,7 @@ class TestReplenishWizard(TestStockCommon):
 
         last_po_id = False
         if purchase_order_id and model_name:
-            last_po_id = self.env[model_name[0]].browse(int(purchase_order_id[0]))
+            last_po_id = self.env[model_name].browse(int(purchase_order_id))
         self.assertTrue(last_po_id, 'Purchase Order not found')
         order_line = last_po_id.order_line.search([('product_id', '=', self.product1.id)])
         self.assertTrue(order_line, 'The product is not in the Purchase Order')
@@ -107,7 +107,7 @@ class TestReplenishWizard(TestStockCommon):
 
         last_po_id = False
         if purchase_order_id and model_name:
-            last_po_id = self.env[model_name[0]].browse(int(purchase_order_id[0]))
+            last_po_id = self.env[model_name].browse(int(purchase_order_id))
         self.assertEqual(last_po_id.partner_id, vendor1)
         self.assertEqual(last_po_id.order_line.price_unit, 100)
 
@@ -166,7 +166,7 @@ class TestReplenishWizard(TestStockCommon):
 
         last_po_id = False
         if purchase_order_id and model_name:
-            last_po_id = self.env[model_name[0]].browse(int(purchase_order_id[0]))
+            last_po_id = self.env[model_name].browse(int(purchase_order_id))
         self.assertEqual(last_po_id.partner_id, vendor1)
         self.assertEqual(last_po_id.order_line.price_unit, 100)
 
@@ -215,7 +215,7 @@ class TestReplenishWizard(TestStockCommon):
 
         last_po_id = False
         if purchase_order_id and model_name:
-            last_po_id = self.env[model_name[0]].browse(int(purchase_order_id[0]))
+            last_po_id = self.env[model_name].browse(int(purchase_order_id))
 
         self.assertEqual(last_po_id.partner_id, vendor2)
 
@@ -268,7 +268,7 @@ class TestReplenishWizard(TestStockCommon):
 
         last_po_id = False
         if purchase_order_id and model_name:
-            last_po_id = self.env[model_name[0]].browse(int(purchase_order_id[0]))
+            last_po_id = self.env[model_name].browse(int(purchase_order_id))
 
         self.assertEqual(last_po_id.partner_id, vendor1)
         self.assertEqual(last_po_id.order_line.price_unit, 60)
@@ -306,7 +306,7 @@ class TestReplenishWizard(TestStockCommon):
 
         last_po_id = False
         if purchase_order_id and model_name:
-            last_po_id = self.env[model_name[0]].browse(int(purchase_order_id[0]))
+            last_po_id = self.env[model_name].browse(int(purchase_order_id))
         self.assertEqual(last_po_id.partner_id, self.vendor)
         self.assertEqual(last_po_id.order_line.price_unit, 110)
         self.assertEqual(last_po_id.order_line.discount, 20.0)

--- a/addons/purchase_stock/tests/test_stockvaluation.py
+++ b/addons/purchase_stock/tests/test_stockvaluation.py
@@ -116,7 +116,7 @@ class TestStockValuation(TransactionCase):
         purchase_order_id, model_name = self.url_extract_rec_id_and_model(url)
         last_po_id = False
         if purchase_order_id and model_name:
-            last_po_id = self.env[model_name[0]].browse(int(purchase_order_id[0]))
+            last_po_id = self.env[model_name].browse(int(purchase_order_id))
 
         order_line = last_po_id.order_line.search([('product_id', '=', self.product1.id)])
         self.assertEqual(order_line.product_qty,

--- a/addons/purchase_stock/wizard/product_replenish.py
+++ b/addons/purchase_stock/wizard/product_replenish.py
@@ -63,10 +63,9 @@ class ProductReplenish(models.TransientModel):
 
     def _get_replenishment_order_notification_link(self, order_line):
         if order_line._name == 'purchase.order.line':
-            action = self.env.ref('purchase.action_rfq_form')
             return [{
                 'label': order_line.order_id.display_name,
-                'url': f'/web#action={action.id}&id={order_line.order_id.id}&model=purchase.order',
+                'url': f'/odoo/action-purchase.action_rfq_form/{order_line.order_id.id}',
             }]
         return super()._get_replenishment_order_notification_link(order_line)
 

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -544,7 +544,7 @@ class StockWarehouseOrderpoint(models.Model):
                     'message': '%s',
                     'links': [{
                         'label': move.picking_id.name,
-                        'url': f'/web#action={action.id}&id={move.picking_id.id}&model=stock.picking&view_type=form'
+                        'url': f'/odoo/action-stock.stock_picking_action_picking_type/{move.picking_id.id}'
                     }],
                     'sticky': False,
                     'next': {'type': 'ir.actions.act_window_close'},

--- a/addons/stock/tests/common.py
+++ b/addons/stock/tests/common.py
@@ -177,6 +177,8 @@ class TestStockCommon(TestProductCommon):
 
 
     def url_extract_rec_id_and_model(self, url):
-        rec_id = re.findall(r'[?&]id=([^&]+).*', url)
-        model_name = re.findall(r'[?&]model=([^&]+).*', url)
+        # Extract model and record ID
+        action_match = re.findall(r'action-([^/]+)', url)
+        model_name = self.env.ref(action_match[0]).res_model
+        rec_id = re.findall(r'/(\d+)$', url)[0]
         return rec_id, model_name

--- a/addons/stock/tests/test_move2.py
+++ b/addons/stock/tests/test_move2.py
@@ -2745,7 +2745,7 @@ class TestRoutes(TestStockCommon):
 
         last_picking_id = False
         if picking_id and model_name:
-            last_picking_id = self.env[model_name[0]].browse(int(picking_id[0]))
+            last_picking_id = self.env[model_name].browse(int(picking_id))
         self.assertTrue(last_picking_id, 'Picking not found')
         move_line = last_picking_id.move_ids.search([('product_id', '=', self.product1.id)])
         self.assertTrue(move_line,'The product is not in the picking')

--- a/addons/stock/tests/test_picking_tours.py
+++ b/addons/stock/tests/test_picking_tours.py
@@ -15,8 +15,7 @@ class TestStockPickingTour(HttpCase):
         return super().setUp()
 
     def _get_picking_url(self, picking_id):
-        action = self.env["ir.actions.actions"]._for_xml_id("stock.action_picking_tree_incoming")
-        return '/web#action=%s&id=%s&model=stock.picking&view_type=form' % (action['id'], picking_id)
+        return '/odoo/action-stock.action_picking_tree_incoming/%s' % (picking_id)
 
     def test_detailed_op_no_save_1(self):
         """validate a receipt with some move without any save except the last one"""
@@ -98,7 +97,7 @@ class TestStockPickingTour(HttpCase):
         ])
 
         menu = self.env.ref('stock.menu_action_inventory_tree')
-        url = '/web#menu_id=%s&model=stock.quant&view_type=list' % (menu['id'])
+        url = '/odoo/stock.quant?menu_id=%s' % (menu['id'])
 
         # We need a bigger window, so the "Apply All" button is immediately visible
         self.browser_size = '1920,1080'

--- a/addons/stock/tests/test_report_tours.py
+++ b/addons/stock/tests/test_report_tours.py
@@ -7,7 +7,7 @@ from odoo.tests import HttpCase, tagged
 class TestStockReportTour(HttpCase):
 
     def _get_report_url(self):
-        return '/web#&model=product.template&action=stock.product_template_action_product'
+        return '/odoo/action-stock.product_template_action_product'
 
     def test_stock_route_diagram_report(self):
         """ Open the route diagram report."""

--- a/addons/stock/wizard/product_replenish.py
+++ b/addons/stock/wizard/product_replenish.py
@@ -146,7 +146,7 @@ class ProductReplenish(models.TransientModel):
             action = self.env.ref('stock.stock_picking_action_picking_type')
             return [{
                 'label': move.picking_id.name,
-                'url': f'/web#action={action.id}&id={move.picking_id.id}&model=stock.picking&view_type=form'
+                'url': f'/odoo/action-stock.stock_picking_action_picking_type/{move.picking_id.id}'
             }]
         return False
 


### PR DESCRIPTION
This commit improves the readability of URLs by modifying them to a new, more human-friendly format. 
Additionally, the method `url_extract_rec_id_and_model` has been updated to enhance the extraction process for `model_name` and `rec_id`.

Task-3820230

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
