### PR TITLE
[IMP] project: remove the filter from project_update search view

### DIFF
--- a/addons/project/views/project_update_views.xml
+++ b/addons/project/views/project_update_views.xml
@@ -11,7 +11,6 @@
                 <field name="description"/>
                 <field name="status"/>
                 <filter string="My Updates" name="my_updates" domain="[('user_id', '=', uid)]"/>
-                <filter string="Followed Updates" name="followed_updates" domain="[('message_is_follower', '=', True)]"/>
                 <separator/>
                 <filter string="On Track" name="on_track" domain="[('status', '=', 'on_track')]"/>
                 <filter string="At Risk" name="at_risk" domain="[('status', '=', 'at_risk')]"/>


### PR DESCRIPTION
This change simplifies the project search interface. Removing Followed Updates filter aims to enhance the overall user experience.

task: 3893316
