### PR TITLE
[FIX] point_of_sale: empty render-container before using it

### DIFF
--- a/addons/point_of_sale/static/src/app/printer/render_service.js
+++ b/addons/point_of_sale/static/src/app/printer/render_service.js
@@ -65,6 +65,7 @@ const renderService = {
         };
         const whenMounted = async ({ el, container, callback }) => {
             container ||= document.querySelector(".render-container");
+            container.innerHTML = "";
             return await applyWhenMounted({ el, container, callback });
         };
         return { toHtml, toCanvas, toJpeg, whenMounted };


### PR DESCRIPTION
If you print changes in a restaurant, then print the receipt of the same order. The receipt would contain the changes.

Steps to reproduce:
-------------------
* Setup a printer to print changes and give it the IP 0.0.0.0 so that it fails
* Open a PoS restaurant
* Add some product to the order, and send it in preparation
* You will have an error
* Pay for the order, and print the receipt with web print
> Observation: The changes of the order appears on top of the receipt

Why the fix:
------------
This was happening because the content of `render-container` was not emptied. So when trying to print the receipt, the content of the receipt was added to the changes already in the `render-container`

opw-4027722
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
