### PR TITLE
[FIX] l10n_latam_invoice_document: prevent blocking foreign document …

### DIFF
--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -213,7 +213,7 @@ class AccountMove(models.Model):
             })
         return super()._reverse_moves(default_values_list=default_values_list, cancel=cancel)
 
-    @api.onchange('l10n_latam_document_type_id', 'l10n_latam_document_number')
+    @api.onchange('l10n_latam_document_type_id', 'l10n_latam_document_number', 'partner_id')
     def _inverse_l10n_latam_document_number(self):
         super()._inverse_l10n_latam_document_number()
 

--- a/addons/l10n_ec/models/account_move.py
+++ b/addons/l10n_ec/models/account_move.py
@@ -193,3 +193,18 @@ class AccountMove(models.Model):
                 """
                 param["l10n_latam_document_type_id"] = tuple(document_types.ids)
         return where_string, param
+
+    def _skip_format_document_number(self):
+        """
+        If a Credit Note is created from a Vendor Bill and the partner_id != "EC",
+        we want to allow the user to allocate any number without following the EC format.
+        """
+        self.ensure_one()
+        if self.country_code == 'EC':
+            return (
+                    self.l10n_latam_document_type_id.internal_type in ('credit_note', 'debit_note')
+                    and self.partner_id.country_code != "EC"
+                    and self.move_type == 'in_refund'
+                    and self.journal_id.type == 'purchase'
+            )
+        super()._skip_format_document_number()

--- a/addons/l10n_ec/tests/__init__.py
+++ b/addons/l10n_ec/tests/__init__.py
@@ -1,0 +1,2 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import test_account_move

--- a/addons/l10n_ec/tests/test_account_move.py
+++ b/addons/l10n_ec/tests/test_account_move.py
@@ -1,0 +1,38 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields
+from odoo.exceptions import UserError
+from odoo.tests import tagged, Form
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestEcAccountMove(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref='l10n_ec.l10n_ec_ifrs'):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+    def test_document_number_credit_note(self):
+        """
+        Test that when creating a Credit Note in the Purchase journal with a partner not from Ecuador a document number can be anything
+        If the partner is from Ecuador, an error should be raised
+        """
+        self.partner_b.country_id = self.env.ref('base.ec')
+
+        document_credit_note = self.env['l10n_latam.document.type'].search([
+            ('internal_type', '=', 'credit_note'),
+            ('country_id', '=', self.env.ref('base.ec').id),
+            ('l10n_ec_check_format', '=', True),
+        ], limit=1)
+        move_form = Form(self.env['account.move'].with_context(default_move_type='in_refund'))
+        move_form.partner_id = self.partner_agrolait
+        move_form.l10n_latam_document_type_id = document_credit_note
+        move_form.invoice_date = fields.Date.from_string('2024-08-08')
+        move_form.l10n_latam_document_number = '123456'
+
+        move_form.save()
+
+        with self.assertRaises(UserError, msg="Ecuadorian Document (04) Nota de Crédito must be like 001-001-123456789"):
+            move_form.partner_id = self.partner_b

--- a/addons/l10n_latam_invoice_document/models/account_move.py
+++ b/addons/l10n_latam_invoice_document/models/account_move.py
@@ -96,13 +96,15 @@ class AccountMove(models.Model):
         remaining = self - recs_with_name
         remaining.l10n_latam_document_number = False
 
-    @api.onchange('l10n_latam_document_type_id', 'l10n_latam_document_number')
+    @api.onchange('l10n_latam_document_type_id', 'l10n_latam_document_number', 'partner_id')
     def _inverse_l10n_latam_document_number(self):
         for rec in self.filtered(lambda x: x.l10n_latam_document_type_id):
             if not rec.l10n_latam_document_number:
                 rec.name = '/'
             else:
-                l10n_latam_document_number = rec.l10n_latam_document_type_id._format_document_number(rec.l10n_latam_document_number)
+                l10n_latam_document_number = rec.l10n_latam_document_number
+                if not rec._skip_format_document_number():
+                    l10n_latam_document_number = rec.l10n_latam_document_type_id._format_document_number(rec.l10n_latam_document_number)
                 if rec.l10n_latam_document_number != l10n_latam_document_number:
                     rec.l10n_latam_document_number = l10n_latam_document_number
                 rec.name = "%s %s" % (rec.l10n_latam_document_type_id.doc_code_prefix, l10n_latam_document_number)
@@ -126,6 +128,11 @@ class AccountMove(models.Model):
         if self.l10n_latam_use_documents:
             return 'never'
         return super(AccountMove, self)._deduce_sequence_number_reset(name)
+
+    def _skip_format_document_number(self):
+        """Hook to be overridden in localisation"""
+        self.ensure_one()
+        return False
 
     def _get_starting_sequence(self):
         if self.journal_id.l10n_latam_use_documents:

--- a/addons/l10n_pe/models/account_move.py
+++ b/addons/l10n_pe/models/account_move.py
@@ -15,7 +15,7 @@ class AccountMove(models.Model):
             result.append(("code", "in", ("01", "03", "07", "08", "20", "40")))
         return result
 
-    @api.onchange('l10n_latam_document_type_id', 'l10n_latam_document_number')
+    @api.onchange('l10n_latam_document_type_id', 'l10n_latam_document_number', 'partner_id')
     def _inverse_l10n_latam_document_number(self):
         """Inherit to complete the l10n_latam_document_number with the expected 8 characters after that a '-'
         Example: Change FFF-32 by FFF-00000032, to avoid incorrect values on the reports"""


### PR DESCRIPTION
…number

Steps to reproduce:
[l10n_ec]
- Create a credit note from the Bill journal
- Set a foreign customer
- Set a customized document number

Issue:
An error will be raised saying that the format is not correct

But, as defined by VBE, "If a Credit Note is created from a Vendor Bill and the partner_id != "EC", [we should] allow the user to allocate any number without following the EC format."

Solution:
When we call `_format_document_number` we don't have any information about the initial move. Instead of using a context or adding new fields, we add a hook in which we can specify certain conditions to bypass the document check/formatting for localisations.

opw-3993305