### PR TITLE
[IMP] core: don't use `pkg_resources` anymore

### DIFF
--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -472,7 +472,7 @@ def check_python_external_dependency(pydep):
     except importlib.metadata.PackageNotFoundError as e:
         try:
             importlib.import_module(pydep)
-            _logger.info("python external dependency on '%s' does not appear to be a valid PyPI package. Using a PyPI package name is recommended.", pydep)
+            _logger.warning("python external dependency on '%s' does not appear to be a valid PyPI package. Using a PyPI package name is recommended.", pydep)
         except ImportError:
             # backward compatibility attempt failed
             _logger.warning("DistributionNotFound: %s", e)


### PR DESCRIPTION
pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html

Its use is becoming more and more problematic as, for instance, since setuptools 71, importing pkg_resources makes all vendored dependencies of setuptools visible on sys.path. See https://github.com/pypa/setuptools/issues/4516#issuecomment-2254578762

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
