### PR TITLE
[FIX] base: align phone field when applying text-end class

### DIFF
--- a/odoo/addons/base/views/ir_qweb_widget_templates.xml
+++ b/odoo/addons/base/views/ir_qweb_widget_templates.xml
@@ -37,14 +37,14 @@
                 </span>
             </div>
             <div class="d-flex align-items-center gap-1" t-if="phone and 'phone' in fields">
-                <i t-if="not options.get('no_marker') or options.get('phone_icons')" class='fa fa-phone fa-fw' role="img" aria-label="Phone" title="Phone"/> <span class="o_force_ltr" itemprop="telephone" t-esc="phone"/>
+                <i t-if="not options.get('no_marker') or options.get('phone_icons')" class='fa fa-phone fa-fw' role="img" aria-label="Phone" title="Phone"/> <span class="o_force_ltr w-100" itemprop="telephone" t-esc="phone"/>
             </div>
             <div class="d-flex align-items-center gap-1" t-if="mobile and 'mobile' in fields">
-                <i t-if="not options.get('no_marker') or options.get('phone_icons')" class='fa fa-mobile fa-fw' role="img" aria-label="Mobile" title="Mobile"/> <span class="o_force_ltr" itemprop="telephone" t-esc="mobile"/>
+                <i t-if="not options.get('no_marker') or options.get('phone_icons')" class='fa fa-mobile fa-fw' role="img" aria-label="Mobile" title="Mobile"/> <span class="o_force_ltr w-100" itemprop="telephone" t-esc="mobile"/>
             </div>
             <div class="d-flex align-items-center gap-1" t-if="website and 'website' in fields">
                 <i t-if="not options.get('no_marker')" class='fa fa-globe fa-fw' role="img" aria-label="Website" title="Website"/>
-                <a t-att-href="website and '%s%s' % ('http://' if '://' not in website else '',website)"><span itemprop="website" t-esc="website"/></a>
+                <a t-att-href="website and '%s%s' % ('http://' if '://' not in website else '',website)"><span class="w-100" itemprop="website" t-esc="website"/></a>
             </div>
             <div class="d-flex align-items-center gap-1" t-if="email and 'email' in fields"><i t-if="not options.get('no_marker')" class='fa fa-envelope fa-fw' role="img" aria-label="Email" title="Email"/> <span class="text-break" itemprop="email" t-esc="email"/></div>
         </div>


### PR DESCRIPTION
When customizing a report by aligning the coordinates fields in the header to the right (using text-end class), basically we have an element where we apply text-align:right and its child has the text and not taking the full width of the parent so it doesnt move its content to the right.

Steps to reproduce:

- open studio on accounting

- open reports

- add "phone" to the options of your company contact

- then use text-end class to move said contact to the right of the report

opw-3915904

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
