### PR TITLE
[FIX] mail: no scrollbar in chat window when author name is long

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -33,7 +33,7 @@
                     <div class="w-100 o-min-width-0" t-att-class="{ 'flex-grow-1': message.composer }" t-ref="messageContent">
                         <div t-if="!props.squashed" class="o-mail-Message-header d-flex flex-wrap align-items-baseline mb-1 lh-1">
                             <span t-if="(message.author or message.email_from) and shouldDisplayAuthorName" class="o-mail-Message-author">
-                                <strong class="me-1 text-truncate"><t t-if="message.author" t-esc="message.author.name"/><t t-else="" t-esc="message.email_from"/></strong>
+                                <strong class="me-1"><t t-if="message.author" t-esc="message.author.name"/><t t-else="" t-esc="message.email_from"/></strong>
                             </span>
                             <t t-if="!isAlignedRight" t-call="mail.Message.notification"/>
                             <small t-if="!message.is_transient" class="o-mail-Message-date text-muted opacity-75" t-att-class="{ 'me-2': !isAlignedRight }" t-att-title="message.datetimeShort">


### PR DESCRIPTION
Before this commit, when message author is too long, it displays a horizontal scrollbar in a chat window.

Steps to reproduce:

- Rename Demo User with a very long name
- As Mitchell Admin, open a chat window DM with former Demo User

There was a `text-truncate` to manage overflow, but this didn't work and instead put an implicit `overflow-auto` which causes this horizontal scrollbar as a result.

`text-truncate` is actually not good even if it worked, because this would mean the name is not fully visible. And adding a `title` with full name adds a floating UI elements, which is bothersome. We should not be afraid of default wrap behavior when the text is long.

This commit fixes the issue by simply removing `text-truncate`, which makes the text wrap when it's too long.

Before / After
![before](https://github.com/user-attachments/assets/51f045b2-7380-4671-af52-903182ba4ad1) ![after](https://github.com/user-attachments/assets/eca14e2b-7b42-460a-8d31-a411d6492cf3)

