### PR TITLE
[IMP] base: add street in list view of res_partner

### DIFF
--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -62,6 +62,7 @@
                     <field name="mobile" optional="hide"/>
                     <field name="email" optional="show"/>
                     <field name="user_id" optional="show" widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
+                    <field name="street" optional="hide"/>
                     <field name="city" optional="show"/>
                     <field name="state_id" optional="hide" readonly="1"/>
                     <field name="country_id" optional="show" readonly="1"/>


### PR DESCRIPTION
Before this commit, when using search more on customer it is difficult to differentiate customer when customer have several address with same city.

After this commit, add street field in list view of res_partner so it can be used in search more when selecting customer. keep the field by default hidden.

task-4079877





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
