### PR TITLE
[FIX] base: prevent inheritance of is_company from parent

### DIFF
--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -217,6 +217,7 @@
                                 <kanban color="color">
                                     <field name="color"/>
                                     <field name="type"/>
+                                    <field name="is_company"/>
                                     <templates>
                                         <t t-name="kanban-card" class="flex-row">
                                             <aside class="o_kanban_aside_full">


### PR DESCRIPTION
Steps to reproduce:
- Contact > Any company > Contacts and Adresses tab
- Create a new delivery adress
- Save

The delivery adress will be displayed as a company (building icon).

In 17.2 and before, is_company used to be passed in the value list upon record creation, this is not the case anymore. Because the defaults are pulled from the parent company, this turns any contact created from a company's form into a company which does not make sense.

This fix restores one of the view's invisible fields, but several others were deleted to be inherited from the parent company. (see this commit 855560ed2e21c445c110a948669e336305f29c4c).

opw-4072057

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
