### PR TITLE
[FIX] l10n_sa_edi: fix down-payment value calculations

### DIFF
--- a/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
+++ b/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
@@ -236,13 +236,8 @@ class AccountEdiXmlUBL21Zatca(models.AbstractModel):
         allowance_charge_vals = vals['vals']['allowance_charge_vals']
         allowance_total_amount = sum(a['amount'] for a in allowance_charge_vals if a['charge_indicator'] == 'false')
         if downpayment_vals:
-            # - BR-KSA-80: To calculate prepaid, we need to sum up the amounts of standard lines (neither a down-payments, nor a discount)
-            #   then we add the total amount of the down-payment.
-            # - BR-CO-16: To calculate payable amount, we substract the calculated prepaid amount from the total tax inclusive amount of the invoice
-            regular_line_vals = invoice._prepare_edi_tax_details(
-                filter_invl_to_apply=lambda line: (line.price_subtotal > 0 and not line._get_downpayment_lines())
-            )
-            prepaid_amount = abs(regular_line_vals['base_amount_currency'] + regular_line_vals['tax_amount_currency']) + downpayment_vals['total_amount']
+            # - BR-KSA-80: To calculate payable amount, we deduct prepaid amount from total tax inclusive amount
+            prepaid_amount = downpayment_vals['total_amount']
             payable_amount = tax_inclusive_amount - prepaid_amount
         return {
             'line_extension_amount': line_extension_amount - allowance_total_amount,
@@ -397,6 +392,11 @@ class AccountEdiXmlUBL21Zatca(models.AbstractModel):
             line_vals['price_vals']['price_amount'] = 0
             line_vals['tax_total_vals'][0]['tax_amount'] = 0
             line_vals['prepayment_vals'] = self._l10n_sa_get_line_prepayment_vals(line, taxes_vals)
+        else:
+            # - BR-KSA-80: only down-payment lines should have a tax subtotal breakdown, as that is
+            # used during computation of prepaid amount as ZATCA sums up tax amount/taxable amount of all lines
+            # irrespective of whether they are down-payment lines.
+            line_vals['tax_total_vals'][0].pop('tax_subtotal_vals', None)
         line_vals['tax_total_vals'][0]['total_amount_sa'] = total_amount_sa
         line_vals['invoiced_quantity'] = abs(line_vals['invoiced_quantity'])
         line_vals['line_extension_amount'] = extension_amount

--- a/addons/l10n_sa_edi/tests/compliance/simplified/credit.xml
+++ b/addons/l10n_sa_edi/tests/compliance/simplified/credit.xml
@@ -195,18 +195,6 @@
     <cac:TaxTotal>
       <cbc:TaxAmount currencyID="SAR">119.25</cbc:TaxAmount>
       <cbc:RoundingAmount currencyID="SAR">914.25</cbc:RoundingAmount>
-      <cac:TaxSubtotal>
-        <cbc:TaxableAmount currencyID="SAR">795.00</cbc:TaxableAmount>
-        <cbc:TaxAmount currencyID="SAR">119.25</cbc:TaxAmount>
-        <cbc:Percent>15.0</cbc:Percent>
-        <cac:TaxCategory>
-          <cbc:ID>S</cbc:ID>
-          <cbc:Percent>15.0</cbc:Percent>
-          <cac:TaxScheme>
-            <cbc:ID>VAT</cbc:ID>
-          </cac:TaxScheme>
-        </cac:TaxCategory>
-      </cac:TaxSubtotal>
     </cac:TaxTotal>
     <cac:Item>
       <cbc:Description>Burger</cbc:Description>

--- a/addons/l10n_sa_edi/tests/compliance/simplified/debit.xml
+++ b/addons/l10n_sa_edi/tests/compliance/simplified/debit.xml
@@ -196,18 +196,6 @@
     <cac:TaxTotal>
       <cbc:TaxAmount currencyID="SAR">79.50</cbc:TaxAmount>
       <cbc:RoundingAmount currencyID="SAR">609.50</cbc:RoundingAmount>
-      <cac:TaxSubtotal>
-        <cbc:TaxableAmount currencyID="SAR">530.00</cbc:TaxableAmount>
-        <cbc:TaxAmount currencyID="SAR">79.50</cbc:TaxAmount>
-        <cbc:Percent>15.0</cbc:Percent>
-        <cac:TaxCategory>
-          <cbc:ID>S</cbc:ID>
-          <cbc:Percent>15.0</cbc:Percent>
-          <cac:TaxScheme>
-            <cbc:ID>VAT</cbc:ID>
-          </cac:TaxScheme>
-        </cac:TaxCategory>
-      </cac:TaxSubtotal>
     </cac:TaxTotal>
     <cac:Item>
       <cbc:Description>Burger</cbc:Description>

--- a/addons/l10n_sa_edi/tests/compliance/simplified/invoice.xml
+++ b/addons/l10n_sa_edi/tests/compliance/simplified/invoice.xml
@@ -187,18 +187,6 @@
     <cac:TaxTotal>
       <cbc:TaxAmount currencyID="SAR">119.25</cbc:TaxAmount>
       <cbc:RoundingAmount currencyID="SAR">914.25</cbc:RoundingAmount>
-      <cac:TaxSubtotal>
-        <cbc:TaxableAmount currencyID="SAR">795.00</cbc:TaxableAmount>
-        <cbc:TaxAmount currencyID="SAR">119.25</cbc:TaxAmount>
-        <cbc:Percent>15.0</cbc:Percent>
-        <cac:TaxCategory>
-          <cbc:ID>S</cbc:ID>
-          <cbc:Percent>15.0</cbc:Percent>
-          <cac:TaxScheme>
-            <cbc:ID>VAT</cbc:ID>
-          </cac:TaxScheme>
-        </cac:TaxCategory>
-      </cac:TaxSubtotal>
     </cac:TaxTotal>
     <cac:Item>
       <cbc:Description>Burger</cbc:Description>

--- a/addons/l10n_sa_edi/tests/compliance/standard/credit.xml
+++ b/addons/l10n_sa_edi/tests/compliance/standard/credit.xml
@@ -186,18 +186,6 @@
         <cac:TaxTotal>
             <cbc:TaxAmount currencyID="SAR">48.00</cbc:TaxAmount>
             <cbc:RoundingAmount currencyID="SAR">368.00</cbc:RoundingAmount>
-            <cac:TaxSubtotal>
-                <cbc:TaxableAmount currencyID="SAR">320.00</cbc:TaxableAmount>
-                <cbc:TaxAmount currencyID="SAR">48.00</cbc:TaxAmount>
-                <cbc:Percent>15.0</cbc:Percent>
-                <cac:TaxCategory>
-                <cbc:ID>S</cbc:ID>
-                <cbc:Percent>15.0</cbc:Percent>
-                <cac:TaxScheme>
-                    <cbc:ID>VAT</cbc:ID>
-                </cac:TaxScheme>
-                </cac:TaxCategory>
-            </cac:TaxSubtotal>
         </cac:TaxTotal>
         <cac:Item>
             <cbc:Description>[P0001] Product A</cbc:Description>

--- a/addons/l10n_sa_edi/tests/compliance/standard/debit.xml
+++ b/addons/l10n_sa_edi/tests/compliance/standard/debit.xml
@@ -187,18 +187,6 @@
         <cac:TaxTotal>
             <cbc:TaxAmount currencyID="SAR">2.37</cbc:TaxAmount>
             <cbc:RoundingAmount currencyID="SAR">18.17</cbc:RoundingAmount>
-            <cac:TaxSubtotal>
-                <cbc:TaxableAmount currencyID="SAR">15.80</cbc:TaxableAmount>
-                <cbc:TaxAmount currencyID="SAR">2.37</cbc:TaxAmount>
-                <cbc:Percent>15.0</cbc:Percent>
-                <cac:TaxCategory>
-                <cbc:ID>S</cbc:ID>
-                <cbc:Percent>15.0</cbc:Percent>
-                <cac:TaxScheme>
-                    <cbc:ID>VAT</cbc:ID>
-                </cac:TaxScheme>
-                </cac:TaxCategory>
-            </cac:TaxSubtotal>
         </cac:TaxTotal>
         <cac:Item>
             <cbc:Description>[P0002] Product B</cbc:Description>

--- a/addons/l10n_sa_edi/tests/compliance/standard/invoice.xml
+++ b/addons/l10n_sa_edi/tests/compliance/standard/invoice.xml
@@ -181,18 +181,6 @@
         <cac:TaxTotal>
             <cbc:TaxAmount currencyID="SAR">48.00</cbc:TaxAmount>
             <cbc:RoundingAmount currencyID="SAR">368.00</cbc:RoundingAmount>
-            <cac:TaxSubtotal>
-                <cbc:TaxableAmount currencyID="SAR">320.00</cbc:TaxableAmount>
-                <cbc:TaxAmount currencyID="SAR">48.00</cbc:TaxAmount>
-                <cbc:Percent>15.0</cbc:Percent>
-                <cac:TaxCategory>
-                <cbc:ID>S</cbc:ID>
-                <cbc:Percent>15.0</cbc:Percent>
-                <cac:TaxScheme>
-                    <cbc:ID>VAT</cbc:ID>
-                </cac:TaxScheme>
-                </cac:TaxCategory>
-            </cac:TaxSubtotal>
         </cac:TaxTotal>
         <cac:Item>
             <cbc:Description>[P0001] Product A</cbc:Description>


### PR DESCRIPTION
This commit fixes an issue regarding down-payment calculation. ZATCA defines one rule to govern the way prepaid amounts (down-payment) is calculated, where PrepaidAmount = SUM([LINE.TaxableAmount + LINE.TaxAmount for LINE in invoice.invoice_line_ids]), obviously this poses a problem when we have a mix of down-payment and normal lines on our invoice since the formula does not differentiate between those. To fix this, we make sure that only down-payment lines actually include a Tax Subtotal breakdown (TaxableAmount & TaxAmount)

Description of the issue/feature this PR addresses:
PrepaidAmount value in invoice XML, representing down-payment amounts, is Wrong, both on the XML and QR code associated, even though ZATCA returns a Valid submission status

Current behavior before PR:
PrepaidAmount value in invoice XML, representing down-payment amounts, is Wrong, both on the XML and QR code associated, even though ZATCA returns a Valid submission status

Desired behavior after PR is merged:
PrepaidAMount is calculated correctly on the XML invoice submitted to ZATCA and also represented correctly on the QR code




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
