### PR TITLE
[FIX] bus: add kill switch for outdated tabs

### DIFF
--- a/addons/bus/controllers/websocket.py
+++ b/addons/bus/controllers/websocket.py
@@ -10,12 +10,15 @@ from ..websocket import WebsocketConnectionHandler
 
 class WebsocketController(Controller):
     @route('/websocket', type="http", auth="public", cors='*', websocket=True)
-    def websocket(self):
+    def websocket(self, version=None):
         """
-        Handle the websocket handshake, upgrade the connection if
-        successfull.
+        Handle the websocket handshake, upgrade the connection if successfull.
+
+        :param version: The version of the WebSocket worker that tries to
+            connect. Connections with an outdated version will result in the
+            websocket being closed. See :attr:`WebsocketConnectionHandler._VERSION`.
         """
-        return WebsocketConnectionHandler.open_connection(request)
+        return WebsocketConnectionHandler.open_connection(request, version)
 
     @route('/websocket/health', type='http', auth='none', save_session=False)
     def health(self):

--- a/addons/bus/i18n/bus.pot
+++ b/addons/bus/i18n/bus.pot
@@ -52,6 +52,11 @@ msgid "Display Name"
 msgstr ""
 
 #. module: bus
+#: model:ir.model,name:bus.model_ir_http
+msgid "HTTP Routing"
+msgstr ""
+
+#. module: bus
 #: model:ir.model.fields,field_description:bus.field_bus_bus__id
 #: model:ir.model.fields,field_description:bus.field_bus_presence__id
 msgid "ID"
@@ -108,13 +113,28 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/bus/static/src/services/assets_watchdog_service.js:0
 #: code:addons/bus/static/src/services/assets_watchdog_service.js:0
+#: code:addons/bus/static/src/services/bus_service.js:0
 msgid "Refresh"
+msgstr ""
+
+#. module: bus
+#. odoo-javascript
+#: code:addons/bus/static/src/services/bus_service.js:0
+msgid ""
+"Save your work and refresh to get the latest updates and avoid potential "
+"issues."
 msgstr ""
 
 #. module: bus
 #. odoo-javascript
 #: code:addons/bus/static/src/services/assets_watchdog_service.js:0
 msgid "The page appears to be out of date."
+msgstr ""
+
+#. module: bus
+#. odoo-javascript
+#: code:addons/bus/static/src/services/bus_service.js:0
+msgid "The page is out of date"
 msgstr ""
 
 #. module: bus

--- a/addons/bus/models/__init__.py
+++ b/addons/bus/models/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from . import bus
 from . import bus_presence
+from . import ir_http
 from . import ir_model
 from . import ir_websocket
 from . import res_users

--- a/addons/bus/models/ir_http.py
+++ b/addons/bus/models/ir_http.py
@@ -1,0 +1,19 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+from ..websocket import WebsocketConnectionHandler
+
+
+class Http(models.AbstractModel):
+    _inherit = "ir.http"
+
+    @api.model
+    def get_frontend_session_info(self):
+        session_info = super().get_frontend_session_info()
+        session_info["websocket_worker_version"] = WebsocketConnectionHandler._VERSION
+        return session_info
+
+    def session_info(self):
+        session_info = super().session_info()
+        session_info["websocket_worker_version"] = WebsocketConnectionHandler._VERSION
+        return session_info

--- a/addons/bus/static/src/multi_tab_service.js
+++ b/addons/bus/static/src/multi_tab_service.js
@@ -146,7 +146,11 @@ export const multiTabService = {
             }
         }
 
-        function onPagehide() {
+        /**
+         * Unregister this tab from the multi-tab service. It will no longer
+         * be able to become the main tab.
+         */
+        function unregister() {
             clearTimeout(heartbeatTimeout);
             const lastPresenceByTab = getItemFromStorage("lastPresenceByTab", {});
             delete lastPresenceByTab[tabId];
@@ -160,7 +164,7 @@ export const multiTabService = {
             }
         }
 
-        browser.addEventListener("pagehide", onPagehide);
+        browser.addEventListener("pagehide", unregister);
         browser.addEventListener("storage", onStorage);
 
         // REGISTER THIS TAB
@@ -216,6 +220,11 @@ export const multiTabService = {
             removeSharedValue(key) {
                 browser.localStorage.removeItem(generateLocalStorageKey(key));
             },
+            /**
+             * Unregister this tab from the multi-tab service. It will no longer
+             * be able to become the main tab.
+             */
+            unregister: unregister,
         };
     },
 };

--- a/addons/bus/static/src/services/bus_service.js
+++ b/addons/bus/static/src/services/bus_service.js
@@ -1,13 +1,15 @@
 /** @odoo-module **/
 
 import { browser } from "@web/core/browser/browser";
+import { _t } from "@web/core/l10n/translation";
 import { Deferred } from "@web/core/utils/concurrency";
 import { registry } from "@web/core/registry";
 import { session } from "@web/session";
 import { isIosApp } from "@web/core/browser/feature_detection";
-import { WORKER_VERSION } from "@bus/workers/websocket_worker";
 import { EventBus } from "@odoo/owl";
 
+// List of worker events that should not be broadcasted.
+const INTERNAL_EVENTS = new Set(["initialized", "outdated", "notification"]);
 /**
  * Communicate with a SharedWorker in order to provide a single websocket
  * connection shared across multiple tabs.
@@ -18,10 +20,10 @@ import { EventBus } from "@odoo/owl";
  *  @emits reconnecting
  */
 export const busService = {
-    dependencies: ["bus.parameters", "localization", "multi_tab"],
+    dependencies: ["bus.parameters", "localization", "multi_tab", "notification"],
     async: true,
 
-    start(env, { multi_tab: multiTab, "bus.parameters": params }) {
+    start(env, { multi_tab: multiTab, notification, "bus.parameters": params }) {
         const bus = new EventBus();
         const notificationBus = new EventBus();
         const subscribeFnToWrapper = new Map();
@@ -60,21 +62,46 @@ export const busService = {
          * @param {{type: WorkerEvent, data: any}[]}  messageEv.data
          */
         function handleMessage(messageEv) {
-            const { type } = messageEv.data;
-            let { data } = messageEv.data;
-            if (type === "notification") {
-                data.forEach((d) => (d.message.id = d.id)); // put notification id in notif message
-                multiTab.setSharedValue("last_notification_id", data[data.length - 1].id);
-                data = data.map((notification) => notification.message);
-                for (const { id, type, payload } of data) {
-                    notificationBus.trigger(type, { id, payload });
+            const { type, data } = messageEv.data;
+            switch (type) {
+                case "notification": {
+                    const notifications = data.map(({ id, message }) => ({ id, ...message }));
+                    multiTab.setSharedValue("last_notification_id", notifications.at(-1).id);
+                    for (const { id, type, payload } of notifications) {
+                        notificationBus.trigger(type, { id, payload });
+                    }
+                    break;
                 }
-            } else if (type === "initialized") {
-                isInitialized = true;
-                connectionInitializedDeferred.resolve();
-                return;
+                case "initialized": {
+                    isInitialized = true;
+                    connectionInitializedDeferred.resolve();
+                    break;
+                }
+                case "outdated": {
+                    multiTab.unregister();
+                    notification.add(
+                        _t(
+                            "Save your work and refresh to get the latest updates and avoid potential issues."
+                        ),
+                        {
+                            title: _t("The page is out of date"),
+                            type: "warning",
+                            sticky: true,
+                            buttons: [
+                                {
+                                    name: _t("Refresh"),
+                                    primary: true,
+                                    onClick: () => {
+                                        browser.location.reload();
+                                    },
+                                },
+                            ],
+                        }
+                    );
+                    break;
+                }
             }
-            if (type !== "notification") {
+            if (!INTERNAL_EVENTS.has(type)) {
                 bus.trigger(type, data);
             }
         }
@@ -98,7 +125,9 @@ export const busService = {
                 uid = false;
             }
             send("initialize_connection", {
-                websocketURL: `${params.serverURL.replace("http", "ws")}/websocket`,
+                websocketURL: `${params.serverURL.replace("http", "ws")}/websocket?version=${
+                    session.websocket_worker_version
+                }`,
                 db: session.db,
                 debug: odoo.debug,
                 lastNotificationId: multiTab.getSharedValue("last_notification_id", 0),
@@ -111,7 +140,7 @@ export const busService = {
          * Start the "bus_service" worker.
          */
         function startWorker() {
-            let workerURL = `${params.serverURL}/bus/websocket_worker_bundle?v=${WORKER_VERSION}`;
+            let workerURL = `${params.serverURL}/bus/websocket_worker_bundle?v=${session.websocket_worker_version}`;
             if (params.serverURL !== window.origin) {
                 // Bus service is loaded from a different origin than the bundle
                 // URL. The Worker expects an URL from this origin, give it a base64

--- a/addons/bus/static/tests/legacy/bus_tests.js
+++ b/addons/bus/static/tests/legacy/bus_tests.js
@@ -15,6 +15,9 @@ import { WEBSOCKET_CLOSE_CODES } from "@bus/workers/websocket_worker";
 
 import { makeTestEnv } from "@web/../tests/helpers/mock_env";
 import { makeDeferred, patchWithCleanup } from "@web/../tests/helpers/utils";
+import { nextTick } from "@web/../tests/legacy/legacy_tests/helpers/test_utils";
+import { createWebClient } from "@web/../tests/legacy/webclient/helpers";
+import { assertSteps, step, click, contains } from "@web/../tests/legacy/utils";
 import { browser } from "@web/core/browser/browser";
 import { session } from "@web/session";
 
@@ -266,7 +269,7 @@ QUnit.test("WebSocket connects with URL corresponding to given serverURL", async
     const env = await makeTestEnv();
     env.services["bus_service"].start();
     await websocketCreatedDeferred;
-    assert.verifySteps([`${serverURL.replace("http", "ws")}/websocket`]);
+    assert.verifySteps([`${serverURL.replace("http", "ws")}/websocket?version=undefined`]);
 });
 
 QUnit.test("Disconnect on offline, re-connect on online", async () => {
@@ -390,4 +393,86 @@ QUnit.test("subscribe to single notification", async (assert) => {
     });
     await messageReceivedDeferred;
     assert.verifySteps(["message"]);
+});
+
+QUnit.test("do not reconnect when worker version is outdated", async () => {
+    await startServer();
+    addBusServicesToRegistry();
+    const worker = patchWebsocketWorkerWithCleanup();
+    const env = await makeTestEnv({ activateMockServer: true });
+    env.services["bus_service"].addEventListener("connect", () => step("connect"));
+    env.services["bus_service"].addEventListener("reconnect", () => step("reconnect"));
+    env.services["bus_service"].addEventListener("disconnect", () => step("disconnect"));
+    env.services["bus_service"].start();
+    await assertSteps(["connect"]);
+    worker.websocket.close(WEBSOCKET_CLOSE_CODES.ABNORMAL_CLOSURE);
+    await assertSteps(["disconnect", "reconnect"]);
+    patchWithCleanup(console, { warn: (message) => step(message) });
+    worker.websocket.close(WEBSOCKET_CLOSE_CODES.CLEAN, "OUTDATED_VERSION");
+    await assertSteps(["Worker deactivated due to an outdated version.", "disconnect"]);
+    env.services["bus_service"].start();
+    env.services["bus_service"].send("hello", "world");
+    await nextTick();
+    await assertSteps([]);
+});
+
+QUnit.test("reconnect on demande after clean close code", async () => {
+    await startServer();
+    addBusServicesToRegistry();
+    const worker = patchWebsocketWorkerWithCleanup();
+    const env = await makeTestEnv({ activateMockServer: true });
+    env.services["bus_service"].addEventListener("connect", () => step("connect"));
+    env.services["bus_service"].addEventListener("reconnect", () => step("reconnect"));
+    env.services["bus_service"].addEventListener("disconnect", () => step("disconnect"));
+    env.services["bus_service"].start();
+    await assertSteps(["connect"]);
+    worker.websocket.close(WEBSOCKET_CLOSE_CODES.ABNORMAL_CLOSURE);
+    await assertSteps(["disconnect", "reconnect"]);
+    worker.websocket.close(WEBSOCKET_CLOSE_CODES.CLEAN);
+    await assertSteps(["disconnect"]);
+    env.services["bus_service"].start();
+    await assertSteps(["connect"]);
+});
+
+QUnit.test("remove from main tab candidates when version is outdated", async (assert) => {
+    await startServer();
+    addBusServicesToRegistry();
+    const worker = patchWebsocketWorkerWithCleanup();
+    const env = await makeTestEnv({ activateMockServer: true });
+    patchWithCleanup(console, { warn: (message) => step(message) });
+    env.services["bus_service"].addEventListener("connect", () => step("connect"));
+    env.services["bus_service"].addEventListener("disconnect", () => step("disconnect"));
+    env.services["bus_service"].start();
+    await assertSteps(["connect"]);
+    patchWithCleanup(env.services.multi_tab, { isOnMainTab: () => true });
+    assert.ok(env.services["multi_tab"].isOnMainTab());
+    env.services.multi_tab.bus.addEventListener("no_longer_main_tab", () =>
+        step("no_longer_main_tab")
+    );
+    worker.websocket.close(WEBSOCKET_CLOSE_CODES.CLEAN, "OUTDATED_VERSION");
+    await assertSteps([
+        "Worker deactivated due to an outdated version.",
+        "disconnect",
+        "no_longer_main_tab",
+    ]);
+});
+
+QUnit.test("show notification when version is outdated", async () => {
+    await startServer();
+    addBusServicesToRegistry();
+    const worker = patchWebsocketWorkerWithCleanup();
+    const { env } = await createWebClient({});
+    patchWithCleanup(console, { warn: (message) => step(message) });
+    patchWithCleanup(browser.location, { reload: () => step("reload") });
+    env.services["bus_service"].addEventListener("connect", () => step("connect"));
+    env.services["bus_service"].addEventListener("disconnect", () => step("disconnect"));
+    env.services["bus_service"].start();
+    await assertSteps(["connect"]);
+    worker.websocket.close(WEBSOCKET_CLOSE_CODES.CLEAN, "OUTDATED_VERSION");
+    await assertSteps(["Worker deactivated due to an outdated version.", "disconnect"]);
+    await contains(".o_notification", {
+        text: "Save your work and refresh to get the latest updates and avoid potential issues.",
+    });
+    await click(".o_notification_buttons .btn-primary", { text: "Refresh" });
+    await assertSteps(["reload"]);
 });

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -820,13 +820,17 @@ class WebsocketConnectionHandler:
         'connection', 'host', 'sec-websocket-key',
         'sec-websocket-version', 'upgrade', 'origin',
     }
+    # Latest version of the websocket worker. This version should be incremented
+    # every time `websocket_worker.js` is modified to force the browser to fetch
+    # the new worker bundle.
+    _VERSION = "1.0.8"
 
     @classmethod
     def websocket_allowed(cls, request):
         return not modules.module.current_test
 
     @classmethod
-    def open_connection(cls, request):
+    def open_connection(cls, request, version):
         """
         Open a websocket connection if the handshake is successfull.
         :return: Response indicating the server performed a connection
@@ -846,6 +850,7 @@ class WebsocketConnectionHandler:
                 Websocket(socket, session, httprequest.cookies),
                 db,
                 httprequest,
+                version
             ))
             # Force save the session. Session must be persisted to handle
             # WebSocket authentication.
@@ -930,12 +935,21 @@ class WebsocketConnectionHandler:
             )
 
     @classmethod
-    def _serve_forever(cls, websocket, db, httprequest):
+    def _serve_forever(cls, websocket, db, httprequest, version):
         """
         Process incoming messages and dispatch them to the application.
         """
         current_thread = threading.current_thread()
         current_thread.type = 'websocket'
+        if version != cls._VERSION:
+            # Close the connection from an outdated worker. We can't use a
+            # custom close code because the connection is considered successful,
+            # preventing exponential reconnect backoff. This would cause old
+            # workers to reconnect frequently, putting pressure on the server.
+            # Clean closes don't trigger reconnections, assuming they are
+            # intentional. The reason indicates to the origin worker not to
+            # reconnect, preventing old workers from lingering after updates.
+            websocket.disconnect(CloseCode.CLEAN, "OUTDATED_VERSION")
         for message in websocket.get_messages():
             with WebsocketRequest(db, httprequest, websocket) as req:
                 try:

--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -7,6 +7,7 @@ import re
 from operator import itemgetter
 
 from odoo import api, Command, fields, models, modules, _
+from odoo.addons.bus.websocket import WebsocketConnectionHandler
 
 
 class ImLivechatChannel(models.Model):
@@ -332,6 +333,7 @@ class ImLivechatChannel(models.Model):
         info['server_url'] = self.get_base_url()
         if info['available']:
             info['options'] = self._get_channel_infos()
+            info["options"]["websocket_worker_version"] = WebsocketConnectionHandler._VERSION
             info['options']['current_partner_id'] = (
                 self.env.user.partner_id.id if not self.env.user._is_public() else None
             )

--- a/addons/im_livechat/static/src/embed/common/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_service.js
@@ -8,6 +8,8 @@ import { registry } from "@web/core/registry";
 import { Deferred } from "@web/core/utils/concurrency";
 import { session } from "@web/session";
 
+session.websocket_worker_version ??= session.livechatData?.options?.websocket_worker_version;
+
 /**
  * @typedef LivechatRule
  * @property {"auto_popup"|"display_button_and_text"|undefined} [action]


### PR DESCRIPTION
The WebSocket worker is tied to a specific version. When this version
changes, the worker's URL updates, creating a new worker. The old
worker remains active as long as clients are connected to it. The
updates may take time to propagate, leading to both the old and new
workers being active simultaneously.

This PR introduces a mechanism to ensure that client code updates are
applied quicker.

When the worker opens a WebSocket connection (typically after the
server comes back online following an update), it provides the server
with its version. If the version is outdated, the server closes the
connection. Consequently, the worker will no longer open new WebSocket
connections.

Clients connected to an outdated worker will receive a notification
prompting them to reload the tab. Additionally, outdated tabs will not
be considered for the main tab election process.