### PR TITLE
[IMP] mail: show Call Participants in sidebar

### DIFF
--- a/addons/im_livechat/static/tests/discuss_patch.test.js
+++ b/addons/im_livechat/static/tests/discuss_patch.test.js
@@ -56,7 +56,7 @@ test("add livechat in the sidebar on visitor sending first message", async () =>
             thread_model: "discuss.channel",
         })
     );
-    await contains(".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel", {
+    await contains(".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel-item", {
         text: "Visitor (Belgium)",
     });
 });
@@ -112,10 +112,13 @@ test("livechats are sorted by last activity time in the sidebar: most recent at 
     await start();
     await openDiscuss();
     await contains(".o-mail-DiscussSidebarChannel", { count: 2 });
-    await contains(":nth-child(1 of .o-mail-DiscussSidebarChannel)", { text: "Visitor 12" });
-    await click(":nth-child(2 of .o-mail-DiscussSidebarChannel)", { text: "Visitor 11" });
+    await contains(":nth-child(1 of .o-mail-DiscussSidebarChannel-item)", { text: "Visitor 12" });
+    await click(
+        ":nth-child(2 of .o-mail-DiscussSidebarChannel-item) .o-mail-DiscussSidebarChannel",
+        { text: "Visitor 11" }
+    );
     await insertText(".o-mail-Composer-input", "Blabla");
     await click(".o-mail-Composer-send:enabled");
-    await contains(":nth-child(1 of .o-mail-DiscussSidebarChannel)", { text: "Visitor 11" });
-    await contains(":nth-child(2 of .o-mail-DiscussSidebarChannel)", { text: "Visitor 12" });
+    await contains(":nth-child(1 of .o-mail-DiscussSidebarChannel-item)", { text: "Visitor 11" });
+    await contains(":nth-child(2 of .o-mail-DiscussSidebarChannel-item)", { text: "Visitor 12" });
 });

--- a/addons/im_livechat/static/tests/sidebar_patch.test.js
+++ b/addons/im_livechat/static/tests/sidebar_patch.test.js
@@ -85,9 +85,12 @@ test("Do not show channel when visitor is typing", async () => {
     await start();
     await openDiscuss();
     await contains(".o-mail-DiscussSidebarCategory", { count: 2 });
-    await contains(".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel", {
-        count: 0,
-    });
+    await contains(
+        ".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel-item .o-mail-DiscussSidebarChannel",
+        {
+            count: 0,
+        }
+    );
     // simulate livechat visitor typing
     const channel = pyEnv["discuss.channel"].search_read([["id", "=", channelId]])[0];
     await withGuest(guestId, () =>
@@ -98,9 +101,12 @@ test("Do not show channel when visitor is typing", async () => {
     );
     // weak test, no guaranteed that we waited long enough for the livechat to potentially appear
     await tick();
-    await contains(".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel", {
-        count: 0,
-    });
+    await contains(
+        ".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel-item .o-mail-DiscussSidebarChannel",
+        {
+            count: 0,
+        }
+    );
 });
 
 test("Smiley face avatar for livechat item linked to a guest", async () => {
@@ -119,7 +125,7 @@ test("Smiley face avatar for livechat item linked to a guest", async () => {
     await openDiscuss();
     const guest = pyEnv["mail.guest"].search_read([["id", "=", guestId]])[0];
     await contains(
-        `.o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel img[data-src='${url(
+        `.o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel-item .o-mail-DiscussSidebarChannel img[data-src='${url(
             `/web/image/mail.guest/${guestId}/avatar_128?unique=${
                 deserializeDateTime(guest.write_date).ts
             }`
@@ -142,7 +148,7 @@ test("Partner profile picture for livechat item linked to a partner", async () =
     await openDiscuss(channelId);
     const partner = pyEnv["res.partner"].search_read([["id", "=", partnerId]])[0];
     await contains(
-        `.o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel img[data-src='${url(
+        `.o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel-item .o-mail-DiscussSidebarChannel img[data-src='${url(
             `/web/image/res.partner/${partnerId}/avatar_128?unique=${
                 deserializeDateTime(partner.write_date).ts
             }`
@@ -233,7 +239,9 @@ test("Close manually by clicking the title", async () => {
     });
     await start();
     await openDiscuss();
-    await contains(".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel");
+    await contains(
+        ".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel-item .o-mail-DiscussSidebarChannel"
+    );
     // fold the livechat category
     await click(".o-mail-DiscussSidebarCategory-livechat .btn");
     await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
@@ -260,12 +268,17 @@ test("Open manually by clicking the title", async () => {
     // first, close the live chat category
     await click(".o-mail-DiscussSidebarCategory-livechat .btn");
     await contains(".o-mail-DiscussSidebarCategory-livechat");
-    await contains(".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel", {
-        count: 0,
-    });
+    await contains(
+        ".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel-item .o-mail-DiscussSidebarChannel",
+        {
+            count: 0,
+        }
+    );
     // open the livechat category
     await click(".o-mail-DiscussSidebarCategory-livechat .btn");
-    await contains(".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel");
+    await contains(
+        ".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel-item .o-mail-DiscussSidebarChannel"
+    );
 });
 
 test("Category item should be invisible if the category is closed", async () => {
@@ -282,11 +295,16 @@ test("Category item should be invisible if the category is closed", async () => 
     });
     await start();
     await openDiscuss();
-    await contains(".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel");
+    await contains(
+        ".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel-item .o-mail-DiscussSidebarChannel"
+    );
     await click(".o-mail-DiscussSidebarCategory-livechat .btn");
-    await contains(".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel", {
-        count: 0,
-    });
+    await contains(
+        ".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel-item .o-mail-DiscussSidebarChannel",
+        {
+            count: 0,
+        }
+    );
 });
 
 test("Active category item should be visible even if the category is closed", async () => {
@@ -307,13 +325,19 @@ test("Active category item should be visible even if the category is closed", as
     });
     await start();
     await openDiscuss();
-    await contains(".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel");
-    await click(".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel");
     await contains(
-        ".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel.o-active"
+        ".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel-item .o-mail-DiscussSidebarChannel"
+    );
+    await click(
+        ".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel-item .o-mail-DiscussSidebarChannel"
+    );
+    await contains(
+        ".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel-item .o-mail-DiscussSidebarChannel.o-active"
     );
     await click(".o-mail-DiscussSidebarCategory-livechat .btn");
-    await contains(".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel");
+    await contains(
+        ".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel-item .o-mail-DiscussSidebarChannel"
+    );
 });
 
 test("Clicking on unpin button unpins the channel", async () => {
@@ -383,7 +407,7 @@ test("unknown livechat can be displayed and interacted with", async () => {
     await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
     await openDiscuss(channelId);
     await contains(
-        ".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel.o-active",
+        ".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel-item .o-mail-DiscussSidebarChannel.o-active",
         { text: "Jane" }
     );
     await insertText(".o-mail-Composer-input", "Hello", { replace: true });

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -1,3 +1,5 @@
+$o-discuss-talkingColor: mix($white, darken($o-enterprise-action-color, 5%), 35%);
+
 .o-mail-discussSidebarBgColor {
     background-color: mix($white, $o-gray-100);
 }

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.scss
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.scss
@@ -3,10 +3,10 @@
     aspect-ratio: 16/9;
 
     &.o-isTalking {
-        box-shadow: inset 0 0 0 map-get($spacers, 1) darken($o-enterprise-action-color, 5%);
+        box-shadow: inset 0 0 0 map-get($spacers, 1) var(--discuss-talkingColor, $o-discuss-talkingColor);
 
         &.o-inset {
-            box-shadow: inset 0 0 0 map-get($spacers, 1)/2 darken($o-enterprise-action-color, 5%);
+            box-shadow: inset 0 0 0 map-get($spacers, 1)/2 var(--discuss-talkingColor, $o-discuss-talkingColor);
         }
     }
 
@@ -39,10 +39,11 @@
     max-height: #{"min(100%, 100px)"}; // interpolated as not supported by Sass
     max-width: #{"min(100%, 100px)"};
     aspect-ratio: 1;
-    border: solid $gray-500;
+    border: none;
 
     &.o-isTalking {
-        border: solid darken($o-enterprise-action-color, 5%);
+        outline: 4px solid var(--discuss-talkingColor, $o-discuss-talkingColor);
+        outline-offset: -4px;
     }
 
     &.o-isInvitation:not(:hover) {

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.dark.scss
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.dark.scss
@@ -1,3 +1,3 @@
-.o-discuss-CallParticipantCard {
+.o-mail-DiscussSidebarCallParticipants {
     --discuss-talkingColor: #{darken($o-enterprise-action-color, 5%)};
 }

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.js
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.js
@@ -1,0 +1,28 @@
+import { Component, useState } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+import { Thread } from "@mail/core/common/thread_model";
+/**
+ * @typedef {Object} Props
+ * @property {import(models").Thread} thread
+ * @extends {Component<Props, Env>}
+ */
+export class DiscussSidebarCallParticipants extends Component {
+    static template = "mail.DiscussSidebarCallParticipants";
+    static props = { thread: { type: Thread } };
+    static components = {};
+
+    setup() {
+        super.setup();
+        this.rtc = useState(useService("discuss.rtc"));
+    }
+
+    get participants() {
+        return this.props.thread.rtcSessions?.sort((s1, s2) => {
+            return (
+                s1.channelMember?.persona?.nameOrDisplayName?.localeCompare(
+                    s2.channelMember?.persona?.nameOrDisplayName
+                ) ?? 1
+            );
+        });
+    }
+}

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.scss
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.scss
@@ -1,0 +1,13 @@
+.o-mail-DiscussSidebarCallParticipants-avatar.o-isTalking {
+    outline: 3px solid var(--discuss-talkingColor, $o-discuss-talkingColor);
+    outline-offset: -3px;
+}
+
+.o-mail-DiscussSidebarCallParticipants-name {
+    color: $black;
+
+    &:not(.o-isTalking) {
+        color: $text-muted;
+        opacity: 75%;
+    }
+}

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="mail.DiscussSidebarCallParticipants">
+        <div t-if="participants.length>0" class="o-mail-DiscussSidebarCallParticipants d-flex flex-column gap-1 my-1 ps-4 pe-2">
+            <t t-foreach="participants" t-as="session" t-key="session.id">
+                <t t-set="channelMember" t-value="session.channelMember"/>
+                <div class="d-flex text-reset overflow-hidden align-items-center ms-3 me-2">
+                    <div class="bg-inherit position-relative d-flex ms-3 flex-shrink-0" style="width:28px;height:28px">
+                        <img class="o-mail-DiscussSidebarCallParticipants-avatar w-100 h-100 rounded-circle" t-att-src="channelMember.persona.avatarUrl" t-att-class="{'o-isTalking': !session.isMute and session.isTalking}" alt="Participant avatar"/>
+                    </div>
+                    <span class="o-mail-DiscussSidebarCallParticipants-name mx-1 text-truncate fw-bolder small user-select-none" t-att-class="{ 'o-isTalking': !session.isMute and session.isTalking }">
+                        <t t-esc="channelMember.persona.nameOrDisplayName"/>
+                    </span>
+                    <div class="flex-grow-1"/>
+                    <div class="o-mail-DiscussSidebarCallParticipants-status ms-1">
+                        <span t-if="session.isMute" class="p-1 fa fa-microphone-slash"/>
+                        <span t-if="session.isDeaf" class="p-1 fa fa-deaf"/>
+                    </div>
+                </div>
+            </t>
+        </div>
+    </t>
+</templates>

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_categories_patch.js
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_categories_patch.js
@@ -1,0 +1,6 @@
+import { DiscussSidebarCallParticipants } from "@mail/discuss/call/public_web/discuss_sidebar_call_participants";
+import { DiscussSidebarCategories } from "@mail/discuss/core/public_web/discuss_sidebar_categories";
+
+DiscussSidebarCategories.components = Object.assign(DiscussSidebarCategories.components || {}, {
+    DiscussSidebarCallParticipants,
+});

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_categories_patch.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_categories_patch.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-inherit="mail.DiscussSidebarChannel" t-inherit-mode="extension">
+        <xpath expr="//div[hasclass('o-mail-DiscussSidebar-item')]" position="after">
+            <DiscussSidebarCallParticipants thread="thread"/>
+        </xpath>
+    </t>
+</templates>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -32,38 +32,40 @@
     </t>
 
     <t t-name="mail.DiscussSidebarChannel">
-        <div class="o-mail-DiscussSidebarChannel o-mail-DiscussSidebar-item d-flex rounded-2 align-items-center mx-2 cursor-pointer"
-             t-att-class="{
-                    'bg-inherit': thread.notEq(store.discuss.thread),
-                    'o-active': thread.eq(store.discuss.thread),
-                    'o-unread': thread.selfMember?.message_unread_counter > 0 and !thread.mute_until_dt,
-                    'opacity-50': thread.mute_until_dt,
-                    }"
-             t-on-click="(ev) => this.openThread(ev, thread)"
-        >
-            <button class="o-mail-DiscussSidebarChannel-itemMain btn border-0 rounded-0 text-reset overflow-hidden d-flex align-items-center px-0 py-2">
-                <div class="bg-inherit position-relative d-flex ms-3 flex-shrink-0" style="width:26px;height:26px">
-                    <img class="w-100 h-100 rounded" t-att-src="thread.avatarUrl" alt="Thread Image"/>
-                    <ThreadIcon t-if="thread.channel_type === 'chat' or (thread.channel_type === 'channel' and !thread.authorizedGroupFullName)" thread="thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute bottom-0 end-0 p-1 me-n1 mb-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
+        <div class="o-mail-DiscussSidebarChannel-item d-flex flex-column">
+            <div class="o-mail-DiscussSidebarChannel o-mail-DiscussSidebar-item d-flex rounded-2 align-items-center mx-2 cursor-pointer"
+                t-att-class="{
+                        'bg-inherit': thread.notEq(store.discuss.thread),
+                        'o-active': thread.eq(store.discuss.thread),
+                        'o-unread': thread.selfMember?.message_unread_counter > 0 and !thread.mute_until_dt,
+                        'opacity-50': thread.mute_until_dt,
+                        }"
+                t-on-click="(ev) => this.openThread(ev, thread)"
+            >
+                <button class="o-mail-DiscussSidebarChannel-itemMain btn border-0 rounded-0 text-reset overflow-hidden d-flex align-items-center px-0 py-2">
+                    <div class="bg-inherit position-relative d-flex ms-3 flex-shrink-0" style="width:26px;height:26px">
+                        <img class="w-100 h-100 rounded" t-att-src="thread.avatarUrl" alt="Thread Image"/>
+                        <ThreadIcon t-if="thread.channel_type === 'chat' or (thread.channel_type === 'channel' and !thread.authorizedGroupFullName)" thread="thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute bottom-0 end-0 p-1 me-n1 mb-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
+                    </div>
+                    <span class="mx-2 text-truncate" t-att-class="thread.selfMember?.message_unread_counter > 0 and !thread.mute_until_dt ? 'o-item-unread fw-bolder' : 'text-muted'">
+                        <t t-esc="thread.displayName"/>
+                    </span>
+                </button>
+                <div class="flex-grow-1"/>
+                <div class="o-mail-DiscussSidebarChannel-commands d-none ms-1 me-2">
+                    <div class="btn-group btn-group-sm">
+                        <button t-if="thread.canLeave" class="btn btn-secondary" t-on-click.stop="() => this.leaveChannel(thread)" title="Leave this channel">
+                            <i t-attf-class="fa fa-times" role="img"/>
+                        </button>
+                        <button t-if="thread.canUnpin" class="btn btn-secondary" t-on-click.stop="() => thread.unpin()" title="Unpin Conversation">
+                            <i t-attf-class="fa fa-times" role="img"/>
+                        </button>
+                    </div>
                 </div>
-                <span class="mx-2 text-truncate" t-att-class="thread.selfMember?.message_unread_counter > 0 and !thread.mute_until_dt ? 'o-item-unread fw-bolder' : 'text-muted'">
-                    <t t-esc="thread.displayName"/>
-                </span>
-            </button>
-            <div class="flex-grow-1"/>
-            <div class="o-mail-DiscussSidebarChannel-commands d-none ms-1 me-2">
-                <div class="btn-group btn-group-sm">
-                    <button t-if="thread.canLeave" class="btn btn-secondary" t-on-click.stop="() => this.leaveChannel(thread)" title="Leave this channel">
-                        <i t-attf-class="fa fa-times" role="img"/>
-                    </button>
-                    <button t-if="thread.canUnpin" class="btn btn-secondary" t-on-click.stop="() => thread.unpin()" title="Unpin Conversation">
-                        <i t-attf-class="fa fa-times" role="img"/>
-                    </button>
+                <t t-foreach="channelIndicators" t-as="indicator" t-key="indicator_index" t-component="indicator" t-props="{ thread }"/>
+                <div t-if="thread.importantCounter > 0">
+                    <span t-attf-class="o-mail-DiscussSidebar-badge badge rounded-pill o-discuss-badge ms-1 me-2 fw-bold {{thread.mute_until_dt ? 'o-muted' : ''}}" t-esc="thread.importantCounter"/>
                 </div>
-            </div>
-            <t t-foreach="channelIndicators" t-as="indicator" t-key="indicator_index" t-component="indicator" t-props="{ thread }"/>
-            <div t-if="thread.importantCounter > 0">
-                <span t-attf-class="o-mail-DiscussSidebar-badge badge rounded-pill o-discuss-badge ms-1 me-2 fw-bold {{thread.mute_until_dt ? 'o-muted' : ''}}" t-esc="thread.importantCounter"/>
             </div>
         </div>
     </t>

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -173,8 +173,8 @@ test("Selection is kept when changing channel and going back to original channel
     const textarea = $(".o-mail-Composer-input")[0];
     textarea.setSelectionRange(0, textarea.value.length);
     await tick();
-    await click(":nth-child(2 of .o-mail-DiscussSidebarChannel)");
-    await click(":nth-child(1 of .o-mail-DiscussSidebarChannel)");
+    await click(":nth-child(2 of .o-mail-DiscussSidebarChannel-item)");
+    await click(":nth-child(1 of .o-mail-DiscussSidebarChannel-item)");
     expect(textarea.selectionStart).toBe(0);
     expect(textarea.selectionEnd).toBe(textarea.value.length);
 });

--- a/addons/mail/static/tests/discuss/core/web/sidebar.test.js
+++ b/addons/mail/static/tests/discuss/core/web/sidebar.test.js
@@ -72,7 +72,7 @@ test("unknown channel can be displayed and interacted with", async () => {
     await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
     await openDiscuss(channelId);
     await contains(
-        ".o-mail-DiscussSidebarCategory-channel + .o-mail-DiscussSidebarChannel.o-active",
+        ".o-mail-DiscussSidebarCategory-channel + .o-mail-DiscussSidebarChannel-item .o-mail-DiscussSidebarChannel.o-active",
         { text: "Not So Secret" }
     );
     await insertText(".o-mail-Composer-input", "Hello", { replace: true });

--- a/addons/mail/static/tests/thread/thread.test.js
+++ b/addons/mail/static/tests/thread/thread.test.js
@@ -807,11 +807,17 @@ test("Thread messages are only loaded once", async () => {
         },
     ]);
     await openDiscuss();
-    await click(":nth-child(1 of .o-mail-DiscussSidebarChannel");
+    await click(
+        ":nth-child(1 of .o-mail-DiscussSidebarChannel-item) .o-mail-DiscussSidebarChannel"
+    );
     await contains(".o-mail-Message-content", { text: "Message on channel1" });
-    await click(":nth-child(2 of .o-mail-DiscussSidebarChannel)");
+    await click(
+        ":nth-child(2 of .o-mail-DiscussSidebarChannel-item) .o-mail-DiscussSidebarChannel"
+    );
     await contains(".o-mail-Message-content", { text: "Message on channel2" });
-    await click(":nth-child(1 of .o-mail-DiscussSidebarChannel)");
+    await click(
+        ":nth-child(1 of .o-mail-DiscussSidebarChannel-item) .o-mail-DiscussSidebarChannel"
+    );
     await contains(".o-mail-Message-content", { text: "Message on channel1" });
     await assertSteps([`load messages - ${channelIds[0]}`, `load messages - ${channelIds[1]}`]);
 });


### PR DESCRIPTION
This commit provides the Call Participants in the sidebar of the Discuss app. When a call is active, the sidebar will show the participants of the call, as well as the status of the participants (e.g. isTalking, isMuted, isDeafened).
https://github.com/odoo/enterprise/pull/67614

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
