### PR TITLE
[FIX] web: no urgent save for forms in dialog

### DIFF
--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -988,7 +988,7 @@ export class Record extends DataPoint {
         if (!this._checkValidity({ displayNotification: true })) {
             return false;
         }
-        if (this.model._urgentSave && this.model.useSendBeaconToSaveUrgently) {
+        if (this.model._urgentSave && this.model.useSendBeaconToSaveUrgently && !this.model.env.inDialog) {
             // We are trying to save urgently because the user is closing the page. To
             // ensure that the save succeeds, we can't do a classic rpc, as these requests
             // can be cancelled (payload too heavy, network too slow, computer too fast...).

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -305,11 +305,13 @@ export class FormController extends Component {
             );
         }
 
-        useExternalListener(document, "visibilitychange", () => {
-            if (document.visibilityState === "hidden") {
-                this.model.root.save();
-            }
-        });
+        if (!this.env.inDialog) {
+            useExternalListener(document, "visibilitychange", () => {
+                if (document.visibilityState === "hidden") {
+                    this.model.root.save();
+                }
+            });
+        }
     }
 
     get modelParams() {

--- a/addons/web/static/tests/views/form/auto_save.test.js
+++ b/addons/web/static/tests/views/form/auto_save.test.js
@@ -11,6 +11,7 @@ import {
     makeServerError,
     models,
     mountView,
+    mountViewInDialog,
     mountWithCleanup,
     onRpc,
 } from "../../web_test_helpers";
@@ -855,4 +856,35 @@ test(`error on save when create button clicked`, async () => {
     expect.verifySteps(["save"]);
     await animationFrame();
     expect(`.o_error_dialog`).toHaveCount(1);
+});
+
+test(`doesn't autosave when in dialog (visibility change)`, async () => {
+    onRpc("web_save", () => {
+        expect.step("should not call web_save");
+    });
+    await mountViewInDialog({
+        resModel: "partner",
+        type: "form",
+        arch: `<form><field name="name"/></form>`,
+        resId: 1,
+    });
+    expect('.o_field_widget[name="name"] input').toHaveValue("Xavier Lancer");
+    await fieldInput("name").edit("Mathiew Brown");
+    await hideTab();
+    expect.verifySteps([]);
+});
+
+test(`doesn't autosave when in dialog (beacon)`, async () => {
+    mockSendBeacon(() => expect.step("sendBeacon"));
+    await mountViewInDialog({
+        resModel: "partner",
+        type: "form",
+        arch: `<form><field name="name"/></form>`,
+        resId: 1,
+    });
+    expect('.o_field_widget[name="name"] input').toHaveValue("Xavier Lancer");
+    await fieldInput("name").edit("Mathiew Brown");
+    unload();
+    await animationFrame();
+    expect.verifySteps([]);
 });


### PR DESCRIPTION
When a form view is in a dialog, there is a save and discard button.
The current implementation would autosave the form. The autosave
feature really doesn't make sense in that case.
So now, form views in dialog do not autosave.

Task ID: 3996654