### PR TITLE
[IMP] core: _search_display_name replaces _name_search

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -477,10 +477,10 @@ class AccountTax(models.Model):
         return ''.join(list_name)
 
     @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
+    def _search_display_name(self, operator, value):
         if operator in ("ilike", "like"):
-            name = AccountTax._parse_name_search(name)
-        return super()._name_search(name, domain, operator, limit, order)
+            value = AccountTax._parse_name_search(value)
+        return super()._search_display_name(operator, value)
 
     def _search_name(self, operator, value):
         if operator not in ("ilike", "like") or not isinstance(value, str):

--- a/addons/account/models/mail_message.py
+++ b/addons/account/models/mail_message.py
@@ -138,7 +138,7 @@ class Message(models.Model):
 
     def _search_audit_log_related_record_id(self, model, operator, value):
         if operator in ['=', 'like', 'ilike', '!=', 'not ilike', 'not like'] and isinstance(value, str):
-            res_id_domain = [('res_id', 'in', self.env[model]._name_search(value, operator=operator))]
+            res_id_domain = [('res_id', 'in', self.env[model]._search([('display_name', operator, value)]))]
         elif operator in ['=', 'in', '!=', 'not in']:
             res_id_domain = [('res_id', operator, value)]
         else:

--- a/addons/analytic/models/analytic_mixin.py
+++ b/addons/analytic/models/analytic_mixin.py
@@ -67,8 +67,8 @@ class AnalyticMixin(models.AbstractModel):
             return super()._condition_to_sql(alias, fname, operator, value, query)
 
         if isinstance(value, str) and operator in ('=', '!=', 'ilike', 'not ilike'):
-            value = list(self.env['account.analytic.account']._name_search(
-                name=value, operator=('=' if operator in ('=', '!=') else 'ilike'),
+            value = list(self.env['account.analytic.account']._search(
+                [('display_name', '=' if operator in ('=', '!=') else 'ilike', value)]
             ))
             operator = 'in' if operator in ('=', 'ilike') else 'not in'
 

--- a/addons/event/models/mail_template.py
+++ b/addons/event/models/mail_template.py
@@ -9,17 +9,18 @@ class MailTemplate(models.Model):
     _inherit = 'mail.template'
 
     @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
+    def _search_display_name(self, operator, value):
         """Context-based hack to filter reference field in a m2o search box to emulate a domain the ORM currently does not support.
 
         As we can not specify a domain on a reference field, we added a context
         key `filter_template_on_event` on the template reference field. If this
-        key is set, we add our domain in the `domain` in the `_name_search`
+        key is set, we add our domain in the `domain` in the `_search_display_name`
         method to filtrate the mail templates.
         """
+        domain = super()._search_display_name(operator, value)
         if self.env.context.get('filter_template_on_event'):
-            domain = expression.AND([[('model', '=', 'event.registration')], domain or []])
-        return super()._name_search(name, domain, operator, limit, order)
+            domain = expression.AND([[('model', '=', 'event.registration')], domain])
+        return domain
 
     def unlink(self):
         res = super().unlink()

--- a/addons/event_sms/models/sms_template.py
+++ b/addons/event_sms/models/sms_template.py
@@ -9,17 +9,18 @@ class SmsTemplate(models.Model):
     _inherit = 'sms.template'
 
     @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
+    def _search_display_name(self, operator, value):
         """Context-based hack to filter reference field in a m2o search box to emulate a domain the ORM currently does not support.
 
         As we can not specify a domain on a reference field, we added a context
         key `filter_template_on_event` on the template reference field. If this
-        key is set, we add our domain in the `domain` in the `_name_search`
+        key is set, we add our domain in the `domain` in the `_search_display_name`
         method to filtrate the SMS templates.
         """
+        domain = super()._search_display_name(operator, value)
         if self.env.context.get('filter_template_on_event'):
             domain = expression.AND([[('model', '=', 'event.registration')], domain])
-        return super()._name_search(name, domain, operator, limit, order)
+        return domain
 
     def unlink(self):
         res = super().unlink()

--- a/addons/fleet/models/fleet_vehicle_model.py
+++ b/addons/fleet/models/fleet_vehicle_model.py
@@ -52,12 +52,15 @@ class FleetVehicleModel(models.Model):
     vehicle_range = fields.Integer(string="Range")
 
     @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
-        domain = domain or []
-        if operator != 'ilike' or (name or '').strip():
-            name_domain = ['|', ('name', 'ilike', name), ('brand_id.name', 'ilike', name)]
-            domain = expression.AND([name_domain, domain])
-        return self._search(domain, limit=limit, order=order)
+    def _search_display_name(self, operator, value):
+        if operator in expression.NEGATIVE_TERM_OPERATORS:
+            positive_operator = expression.TERM_OPERATORS_NEGATION[operator]
+        else:
+            positive_operator = operator
+        domain = expression.OR([[('name', positive_operator, value)], [('brand_id.name', positive_operator, value)]])
+        if positive_operator != operator:
+            domain = ['!', *domain]
+        return domain
 
     @api.depends('brand_id')
     def _compute_display_name(self):

--- a/addons/im_livechat/models/chatbot_script_answer.py
+++ b/addons/im_livechat/models/chatbot_script_answer.py
@@ -37,26 +37,23 @@ class ChatbotScriptAnswer(models.Model):
                 answer.display_name = answer.name
 
     @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
+    def _search_display_name(self, operator, value):
         """
         Search the records whose name or step message are matching the ``name`` pattern.
         The chatbot_script_id is also passed to the context through the custom widget
         ('chatbot_triggering_answers_widget') This allows to only see the question_answer
         from the same chatbot you're configuring.
         """
-        domain = domain or []
-
-        if name and operator == 'ilike':
+        domain = []
+        if value and operator == 'ilike':
             # search on both name OR step's message (combined with passed args)
-            name_domain = [('name', operator, name)]
-            step_domain = [('script_step_id.message', operator, name)]
-            domain = expression.AND([domain, expression.OR([name_domain, step_domain])])
+            domain = ['|', ('name', operator, value), ('script_step_id.message', operator, value)]
 
         force_domain_chatbot_script_id = self.env.context.get('force_domain_chatbot_script_id')
         if force_domain_chatbot_script_id:
             domain = expression.AND([domain, [('chatbot_script_id', '=', force_domain_chatbot_script_id)]])
 
-        return self._search(domain, limit=limit, order=order)
+        return domain
 
     def _to_store(self, store: Store, /, *, fields=None):
         if fields is None:

--- a/addons/l10n_eg_edi_eta/models/eta_activity_type.py
+++ b/addons/l10n_eg_edi_eta/models/eta_activity_type.py
@@ -2,21 +2,14 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 
-from odoo import models, fields, api
-from odoo.osv import expression
+from odoo import fields, models
 
 
 class EtaActivityType(models.Model):
     _name = 'l10n_eg_edi.activity.type'
     _description = 'ETA code for activity type'
+    _rec_name = 'name'
+    _rec_names_search = ['name', 'code']
 
     name = fields.Char(required=True, translate=True)
     code = fields.Char(required=True)
-
-    @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
-        domain = domain or []
-        if operator != 'ilike' or not (name or '').strip():
-            # ignore 'ilike' with name containing only spaces
-            domain = expression.AND([['|', ('name', operator, name), ('code', operator, name)], domain])
-        return self._search(domain, limit=limit, order=order)

--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -5,7 +5,6 @@ from dateutil.relativedelta import relativedelta
 from odoo.exceptions import ValidationError
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
-from odoo.osv import expression
 
 
 class MaintenanceStage(models.Model):
@@ -137,14 +136,6 @@ class MaintenanceEquipment(models.Model):
                 record.display_name = record.name + '/' + record.serial_no
             else:
                 record.display_name = record.name
-
-    @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
-        domain = domain or []
-        query = None
-        if name and operator not in expression.NEGATIVE_TERM_OPERATORS and operator != '=':
-            query = self._search([('name', '=', name)] + domain, limit=limit, order=order)
-        return query or super()._name_search(name, domain, operator, limit, order)
 
     name = fields.Char('Equipment Name', required=True, translate=True)
     active = fields.Boolean(default=True)

--- a/addons/pos_loyalty/models/loyalty_reward.py
+++ b/addons/pos_loyalty/models/loyalty_reward.py
@@ -62,7 +62,7 @@ class LoyaltyReward(models.Model):
 
             if field and field.type == 'many2one' and operator in ('ilike', 'not ilike'):
                 comodel = self.env[field.comodel_name]
-                matching_ids = list(comodel._name_search(value, [], operator, limit=None))
+                matching_ids = list(comodel._search([('display_name', operator, value)]))
 
                 new_operator = 'in' if operator == 'ilike' else 'not in'
                 domain[index] = [field_name, new_operator, matching_ids]

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -547,61 +547,21 @@ class ProductTemplate(models.Model):
                 ))
 
     @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
+    def _search_display_name(self, operator, value):
+        domain = super()._search_display_name(operator, value)
+        if self.env.context.get('search_product_product', bool(value)):
+            combine = expression.OR if operator not in expression.NEGATIVE_TERM_OPERATORS else expression.AND
+            domain = combine([domain, [('product_variant_ids', operator, value)]])
+        return domain
+
+    @api.model
+    def name_search(self, name='', args=None, operator='ilike', limit=100):
         # Only use the product.product heuristics if there is a search term and the domain
         # does not specify a match on `product.template` IDs.
-        domain = domain or []
-        search_pp = self.env.context.get('search_product_product')
-        if not search_pp and (not name or any(term[0] == 'id' for term in domain)):
-            return super()._name_search(name, domain, operator, limit, order)
-
-        Product = self.env['product.product']
-        templates = self.browse()
-
-        product_domain = domain.copy()
-        if search_pp:
-            for term in product_domain:  # Replace id related leaf to product_tmpl_id
-                if term[0] == 'id':
-                    term[0] = 'product_tmpl_id'
-        while True:
-            extra = templates and [('product_tmpl_id', 'not in', templates.ids)] or []
-            # Product._name_search has default value limit=100
-            # So, we either use that value or override it to None to fetch all products at once
-            products_ids = Product._name_search(name, product_domain + extra, operator, limit=None)
-            products = Product.browse(products_ids)
-            new_templates = products.product_tmpl_id
-            if new_templates & templates:
-                """Product._name_search can bypass the domain we passed (search on supplier info).
-                   If this happens, an infinite loop will occur."""
-                break
-            templates |= new_templates
-            if (not products) or (limit and (len(templates) > limit)):
-                break
-
-        searched_ids = set(templates.ids)
-        # some product.templates do not have product.products yet (dynamic variants configuration),
-        # we need to add the base _name_search to the results
-        tmpl_without_variant_ids = []
-        # Useless if variants is not set up as no tmpl_without_variant_ids could exist.
-        if self.env.user.has_group('product.group_product_variant') and (not limit or len(searched_ids) < limit):
-            # The ORM has to be bypassed because it would require a NOT IN which is inefficient.
-            self.env['product.product'].flush_model(['product_tmpl_id', 'active'])
-            tmpl_without_variant_ids = self.env['product.template']._search([], order='id')
-            tmpl_without_variant_ids.add_where("""
-                NOT EXISTS (
-                    SELECT product_tmpl_id
-                    FROM product_product
-                    WHERE product_product.active = true
-                        AND product_template.id = product_product.product_tmpl_id
-                )
-            """)
-        if tmpl_without_variant_ids:
-            domain2 = expression.AND([domain, [('id', 'in', tmpl_without_variant_ids)]])
-            searched_ids |= set(super()._name_search(name, domain2, operator, limit, order))
-
-        # re-apply product.template order + display_name
-        domain = [('id', 'in', list(searched_ids))]
-        return super()._name_search('', domain, 'ilike', limit, order)
+        self_obj = self
+        if 'search_product_product' not in self.env.context and any(term[0] == 'id' for term in (args or [])):
+            self_obj = self_obj.with_context(search_product_product=False)
+        return super(ProductTemplate, self_obj).name_search(name, args, operator, limit)
 
     #=== ACTION METHODS ===#
 

--- a/addons/sale_service/models/sale_order_line.py
+++ b/addons/sale_service/models/sale_order_line.py
@@ -94,11 +94,14 @@ class SaleOrderLine(models.Model):
 
         return name_per_id
 
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
+    @api.model
+    def name_search(self, name='', args=None, operator='ilike', limit=100):
+        domain = args or []
         # optimization for a SOL services name_search, to avoid joining on sale_order with too many lines
         if domain and ('is_service', '=', True) in domain and operator in ('like', 'ilike') and limit is not None:
-            query = self.env['sale.order.line']._search(domain, limit=limit, order=None)
+            query = self._search(domain, limit=limit)
             query.order = f'{query.table}.order_id DESC, {query.table}.sequence, {query.table}.id'
-            return query
-        else:
-            return super()._name_search(name, domain, operator, limit, order)
+            fields_to_fetch = self._determine_fields_to_fetch(['display_name'])
+            sols = self._fetch_query(query, fields_to_fetch)
+            return [(sol.id, sol.display_name) for sol in sols.sudo()]
+        return super().name_search(name, domain, operator, limit)

--- a/addons/sale_service/models/sale_order_line.py
+++ b/addons/sale_service/models/sale_order_line.py
@@ -99,9 +99,8 @@ class SaleOrderLine(models.Model):
         domain = args or []
         # optimization for a SOL services name_search, to avoid joining on sale_order with too many lines
         if domain and ('is_service', '=', True) in domain and operator in ('like', 'ilike') and limit is not None:
-            query = self._search(domain, limit=limit)
-            query.order = f'{query.table}.order_id DESC, {query.table}.sequence, {query.table}.id'
-            fields_to_fetch = self._determine_fields_to_fetch(['display_name'])
-            sols = self._fetch_query(query, fields_to_fetch)
-            return [(sol.id, sol.display_name) for sol in sols.sudo()]
+            sols = self.search_fetch(
+                domain, ['display_name'], limit=limit, order='order_id.id DESC, sequence, id',
+            )
+            return [(sol.id, sol.display_name) for sol in sols]
         return super().name_search(name, domain, operator, limit)

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -298,14 +298,12 @@ class PickingType(models.Model):
                 picking_type.use_existing_lots = True
 
     @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
+    def _search_display_name(self, operator, value):
         # Try to reverse the `display_name` structure
-        parts = name.split(': ')
-        domain = domain or []
-        if len(parts) == 2:
-            name_domain = [('warehouse_id.name', operator, parts[0]), ('name', operator, parts[1])]
-            return self._search(expression.AND([name_domain, domain]), limit=limit, order=order)
-        return super()._name_search(name, domain, operator, limit, order)
+        parts = isinstance(value, str) and value.split(': ')
+        if parts and len(parts) == 2:
+            return ['&', ('warehouse_id.name', operator, parts[0]), ('name', operator, parts[1])]
+        return super()._search_display_name(operator, value)
 
     @api.depends('code')
     def _compute_default_location_src_id(self):

--- a/addons/test_import_export/models/models_export_impex.py
+++ b/addons/test_import_export/models/models_export_impex.py
@@ -1,4 +1,5 @@
 from odoo import api, fields, models, _
+from odoo.osv.expression import FALSE_DOMAIN
 
 
 def selection_fn(self):
@@ -50,11 +51,10 @@ for name, field in MODELS:
                 record.display_name = f"{self._name}:{record.value}"
 
         @api.model
-        def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
-            if isinstance(name, str) and name.split(':')[0] == self._name:
-                return self._search([('value', operator, int(name.split(':')[1]))], limit=limit, order=order)
-            else:
-                return []
+        def _search_display_name(self, operator, value):
+            if isinstance(value, str) and value.split(':')[0] == self._name:
+                return [('value', operator, int(value.split(':')[1]))]
+            return FALSE_DOMAIN
 
 
 class One2ManyChild(models.Model):
@@ -73,11 +73,10 @@ class One2ManyChild(models.Model):
             record.display_name = f"{self._name}:{record.value}"
 
     @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
-        if isinstance(name, str) and name.split(':')[0] == self._name:
-            return self._search([('value', operator, int(name.split(':')[1]))], limit=limit, order=order)
-        else:
-            return []
+    def _search_display_name(self, operator, value):
+        if isinstance(value, str) and value.split(':')[0] == self._name:
+            return [('value', operator, int(value.split(':')[1]))]
+        return FALSE_DOMAIN
 
 
 class One2ManyMultiple(models.Model):
@@ -132,11 +131,10 @@ class Many2ManyChild(models.Model):
             record.display_name = f"{self._name}:{record.value}"
 
     @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
-        if isinstance(name, str) and name.split(':')[0] == self._name:
-            return self._search([('value', operator, int(name.split(':')[1]))], limit=limit, order=order)
-        else:
-            return []
+    def _search_display_name(self, operator, value):
+        if isinstance(value, str) and value.split(':')[0] == self._name:
+            return [('value', operator, int(value.split(':')[1]))]
+        return FALSE_DOMAIN
 
 
 class SelectionWithDefault(models.Model):

--- a/addons/website/models/website_rewrite.py
+++ b/addons/website/models/website_rewrite.py
@@ -20,12 +20,12 @@ class WebsiteRoute(models.Model):
     path = fields.Char('Route')
 
     @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
-        query = super()._name_search(name, domain, operator, limit, order)
-        if not query:
+    def _search_display_name(self, operator, value):
+        # in case we don't have results, refresh before returning the domain
+        domain = super()._search_display_name(operator, value)
+        if not self.search_count(domain, limit=1):
             self._refresh()
-            return super()._name_search(name, domain, operator, limit, order)
-        return query
+        return domain
 
     def _refresh(self):
         _logger.debug("Refreshing website.route")

--- a/odoo/addons/base/models/res_country.py
+++ b/odoo/addons/base/models/res_country.py
@@ -33,6 +33,7 @@ class Country(models.Model):
     _name = 'res.country'
     _description = 'Country'
     _order = 'name'
+    _rec_names_search = ['name', 'code']
 
     name = fields.Char(
         string='Country Name', required=True, translate=True)
@@ -82,20 +83,22 @@ class Country(models.Model):
             'The code of the country must be unique!')
     ]
 
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
-        if domain is None:
-            domain = []
-
-        ids = []
-        if len(name) == 2:
-            ids = list(self._search([('code', 'ilike', name)] + domain, limit=limit, order=order))
-
-        search_domain = [('name', operator, name)]
-        if ids:
-            search_domain.append(('id', 'not in', ids))
-        ids += list(self._search(search_domain + domain, limit=limit, order=order))
-
-        return ids
+    @api.model
+    def name_search(self, name='', args=None, operator='ilike', limit=100):
+        result = []
+        domain = args or []
+        # first search by code
+        if operator not in expression.NEGATIVE_TERM_OPERATORS and name and len(name) == 2:
+            countries = self.search_fetch(expression.AND([domain, [('code', operator, name)]]), ['display_name'], limit=limit)
+            result.extend((country.id, country.display_name) for country in countries.sudo())
+            domain = expression.AND([domain, [('id', 'not in', countries.ids)]])
+            if limit is not None:
+                limit -= len(countries)
+                if limit <= 0:
+                    return result
+        # normal search
+        result.extend(super().name_search(name, domain, operator, limit))
+        return result
 
     @api.model
     @tools.ormcache('code')
@@ -158,6 +161,7 @@ class CountryState(models.Model):
     _description = "Country state"
     _name = 'res.country.state'
     _order = 'code'
+    _rec_names_search = ['name', 'code']
 
     country_id = fields.Many2one('res.country', string='Country', required=True)
     name = fields.Char(string='State Name', required=True,
@@ -169,41 +173,34 @@ class CountryState(models.Model):
     ]
 
     @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
-        domain = domain or []
-        if self.env.context.get('country_id'):
-            domain = expression.AND([domain, [('country_id', '=', self.env.context.get('country_id'))]])
+    def name_search(self, name='', args=None, operator='ilike', limit=100):
+        result = []
+        domain = args or []
+        # first search by code (with =ilike)
+        if operator not in expression.NEGATIVE_TERM_OPERATORS and name:
+            states = self.search_fetch(expression.AND([domain, [('code', '=like', name)]]), ['display_name'], limit=limit)
+            result.extend((state.id, state.display_name) for state in states.sudo())
+            domain = expression.AND([domain, [('id', 'not in', states.ids)]])
+            if limit is not None:
+                limit -= len(states)
+                if limit <= 0:
+                    return result
+        # normal search
+        result.extend(super().name_search(name, domain, operator, limit))
+        return result
 
-        if operator == 'ilike' and not (name or '').strip():
-            domain1 = []
-            domain2 = []
-        else:
-            domain1 = [('code', '=ilike', name)]
-            domain2 = [('name', operator, name)]
-
-        first_state_ids = []
-        if domain1:
-            first_state_ids = list(self._search(
-                expression.AND([domain1, domain]), limit=limit, order=order,
-            ))
-        fallback_domain = None
-        if name:
-            m = re.fullmatch(r"(?P<name>.+)\((?P<country>.+)\)", name)
-            if m:
-                fallback_domain = [
-                    ('name', operator, m['name'].strip()),
-                    '|', ('country_id.name', 'ilike', m['country'].strip()),
-                         ('country_id.code', '=', m['country'].strip()),
-                ]
-        return first_state_ids + list(self._search(
-            expression.AND([domain2, domain, [('id', 'not in', first_state_ids)]]),
-            limit=limit,
-            order=order,
-        )) or (
-            list(self._search(expression.AND([fallback_domain, domain]), limit=limit))
-            if fallback_domain
-            else []
-        )
+    @api.model
+    def _search_display_name(self, operator, value):
+        domain = super()._search_display_name(operator, value)
+        if value and operator not in expression.NEGATIVE_TERM_OPERATORS and (m := re.fullmatch(r"(?P<name>.+)\((?P<country>.+)\)", value)):
+            fallback_domain = [
+                ('name', operator, m['name'].strip()),
+                ('country_id', 'ilike', m['country'].strip()),
+            ]
+            domain = expression.OR([domain, fallback_domain])
+        if country_id := self.env.context.get('country_id'):
+            domain = expression.AND([domain, [('country_id', '=', country_id)]])
+        return domain
 
     @api.depends('country_id')
     def _compute_display_name(self):

--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -456,8 +456,9 @@ class CurrencyRate(models.Model):
                 raise ValidationError("Currency rates should only be created for main companies")
 
     @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
-        return super()._name_search(parse_date(self.env, name), domain, operator, limit, order)
+    def _search_display_name(self, operator, value):
+        value = parse_date(self.env, value)
+        return super()._search_display_name(operator, value)
 
     @api.model
     def _get_view_cache_key(self, view_id=None, view_type='form', **options):

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1381,7 +1381,7 @@ class TestQueries(TransactionCase):
             SELECT "res_partner"."id"
             FROM "res_partner"
             WHERE (("res_partner"."active" = %s) AND ("res_partner"."name" LIKE %s))
-            ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
+            ORDER BY "res_partner"."complete_name" ASC,"res_partner"."id" DESC
         ''']):
             Model.search([('name', 'like', 'foo')])
 
@@ -1392,6 +1392,25 @@ class TestQueries(TransactionCase):
             ORDER BY "res_partner"."id"
         ''']):
             Model.search([('name', 'like', 'foo')], order='id')
+
+        with self.assertQueries(['''
+            SELECT "res_partner"."id"
+            FROM "res_partner"
+            WHERE (("res_partner"."active" = %s) AND ("res_partner"."name" LIKE %s))
+            ORDER BY "res_partner"."company_id"
+        ''']):
+            Model.search([('name', 'like', 'foo')], order='company_id.id')
+
+        with self.assertQueries(['''
+            SELECT "res_partner"."id"
+            FROM "res_partner"
+            WHERE (("res_partner"."active" = %s) AND ("res_partner"."name" LIKE %s))
+            ORDER BY "res_partner"."company_id" DESC
+        ''']):
+            Model.search([('name', 'like', 'foo')], order='company_id.id DESC')
+
+        with self.assertRaises(ValueError):
+            Model.search([('name', 'like', 'foo')], order='company_id.name')
 
     def test_count(self):
         Model = self.env['res.partner']

--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -26,8 +26,12 @@ class Category(models.Model):
     parent_path = fields.Char(index=True)
     depth = fields.Integer(compute="_compute_depth")
     root_categ = fields.Many2one(_name, compute='_compute_root_categ')
-    display_name = fields.Char(compute='_compute_display_name', recursive=True,
-                               inverse='_inverse_display_name')
+    display_name = fields.Char(
+        compute='_compute_display_name',
+        inverse='_inverse_display_name',
+        search='_search_display_name',
+        recursive=True,
+    )
     dummy = fields.Char(store=False)
     discussions = fields.Many2many('test_new_api.discussion', 'test_new_api_discussion_category',
                                    'category', 'discussion')
@@ -307,7 +311,6 @@ class MultiTag(models.Model):
     _description = 'Test New API Multi Tag'
 
     name = fields.Char()
-    display_name = fields.Char(compute='_compute_display_name')
 
     @api.depends('name')
     @api.depends_context('special_tag')

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -3271,7 +3271,7 @@ class TestX2many(TransactionExpressionCase):
         # a one2many field without context does not match its inactive children
         self.assertIn(parent, Model.search([('children_ids.name', '=', 'A')]))
         self.assertNotIn(parent, Model.search([('children_ids.name', '=', 'B')]))
-        # Same result when it used _name_search
+        # Same result when it used name_search
         self.assertIn(parent, Model.search([('children_ids', '=', 'A')]))
         self.assertNotIn(parent, Model.search([('children_ids', '=', 'B')]))
         # Same result with the child_of operator
@@ -3281,7 +3281,7 @@ class TestX2many(TransactionExpressionCase):
         # a one2many field with active_test=False matches its inactive children
         self.assertIn(parent, Model.search([('all_children_ids.name', '=', 'A')]))
         self.assertIn(parent, Model.search([('all_children_ids.name', '=', 'B')]))
-        # Same result when it used _name_search
+        # Same result when it used name_search
         self.assertIn(parent, Model.search([('all_children_ids', '=', 'A')]))
         # Same result with the child_of operator
         self.assertIn(parent, Model.search([('all_children_ids', 'child_of', 'A')]))
@@ -3304,7 +3304,7 @@ class TestX2many(TransactionExpressionCase):
         # a many2many field without context does not match its inactive children
         self.assertIn(parent, Model.search([('relatives_ids.name', '=', 'A')]))
         self.assertNotIn(parent, Model.search([('relatives_ids.name', '=', 'B')]))
-        # Same result when it used _name_search
+        # Same result when it used name_search
         self.assertIn(parent, Model.search([('relatives_ids', '=', 'A')]))
         self.assertNotIn(parent, Model.search([('relatives_ids', '=', 'B')]))
         # Same result with the child_of operator
@@ -3316,7 +3316,7 @@ class TestX2many(TransactionExpressionCase):
         # a many2many field with active_test=False matches its inactive children
         self.assertIn(parent, Model.search([('all_relatives_ids.name', '=', 'A')]))
         self.assertIn(parent, Model.search([('all_relatives_ids.name', '=', 'B')]))
-        # Same result when it used _name_search
+        # Same result when it used name_search
         self.assertIn(parent, Model.search([('all_relatives_ids', '=', 'A')]))
         self.assertIn(parent, Model.search([('all_relatives_ids', '=', 'B')]))
         # Same result with the child_of operator

--- a/odoo/addons/test_performance/tests/test_timeit.py
+++ b/odoo/addons/test_performance/tests/test_timeit.py
@@ -177,7 +177,7 @@ class TestPerformanceTimeit(TransactionCase):
         self.launch_perf("records._search([], limit=10)", self.Model)
         self.launch_perf("records._search([], order='id')", self.Model)
         self.launch_perf("records._search([], order='name')", self.Model)
-        self.launch_perf("records._search([], order='parent_id.name, id desc')", self.Model)
+        self.launch_perf("records._search([], order='parent_id, id desc')", self.Model)
 
     def test_perf_domain_search(self):
         for domain in self.example_domains:

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -863,7 +863,7 @@ class expression(object):
                 return list({
                     rid
                     for name in names
-                    for rid in comodel._name_search(name, [], 'ilike')
+                    for rid in comodel._search([('display_name', 'ilike', name)])
                 })
             return list(value)
 
@@ -1185,7 +1185,7 @@ class expression(object):
                     if isinstance(right, str):
                         op2 = (TERM_OPERATORS_NEGATION[operator]
                                if operator in NEGATIVE_TERM_OPERATORS else operator)
-                        ids2 = comodel._name_search(right, domain or [], op2)
+                        ids2 = comodel._search(AND([domain or [], [('display_name', op2, right)]]))
                     elif isinstance(right, collections.abc.Iterable):
                         ids2 = right
                     else:
@@ -1263,7 +1263,7 @@ class expression(object):
                         domain = field.get_domain_list(model)
                         op2 = (TERM_OPERATORS_NEGATION[operator]
                                if operator in NEGATIVE_TERM_OPERATORS else operator)
-                        ids2 = comodel._name_search(right, domain or [], op2)
+                        ids2 = comodel._search(AND([domain or [], [('display_name', op2, right)]]))
                     elif isinstance(right, collections.abc.Iterable):
                         ids2 = right
                     else:
@@ -1335,11 +1335,11 @@ class expression(object):
                     elif isinstance(right, list) and operator in ('!=', '='):  # for domain (FIELD,'=',['value1','value2'])
                         operator = dict_op[operator]
                     if operator in NEGATIVE_TERM_OPERATORS:
-                        res_ids = comodel._name_search(right, [], TERM_OPERATORS_NEGATION[operator])
+                        res_ids = comodel._search([('display_name', TERM_OPERATORS_NEGATION[operator], right)])
                         for dom_leaf in ('|', (left, 'not in', res_ids), (left, '=', False)):
                             push(dom_leaf, model, alias)
                     else:
-                        res_ids = comodel._name_search(right, [], operator)
+                        res_ids = comodel._search([('display_name', operator, right)])
                         push((left, 'in', res_ids), model, alias)
 
                 else:


### PR DESCRIPTION
Aligning the behaviour of name searches to other fields. Since the displayed name is `display_name`, implementing `search` on it gives the domain to use for searches by name.
The function `_name_search` has therefore no reason to exist anymore. We keep the function `name_search` which is public and move the logic linked to displaying a limited number of records there.

odoo/enterprise#67592
odoo/documentation#10856
task-3484032

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
