### PR TITLE
[IMP] website_event: slugify url tags

### DIFF
--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -561,7 +561,7 @@ class EventEvent(models.Model):
         search_tags = self.env['event.tag']
         if tags:
             try:
-                tag_ids = literal_eval(tags)
+                tag_ids = list(filter(None, [self.env['ir.http']._unslug(tag)[1] for tag in tags.split(',')])) or literal_eval(tags)
             except SyntaxError:
                 pass
             else:

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -58,13 +58,13 @@
                                     class="badge bg-primary ms-1"/>
                             </a>
                             <div class="dropdown-menu">
-                                <span t-att-data-post="'/event?%s' % keep_query('*', tags=str((search_tags - searched_category_tags).ids), prevent_redirect=True)"
+                                <span t-att-data-post="keep_event_url(tags=slugify_tags((search_tags - searched_category_tags).ids), prevent_redirect=True)"
                                    t-attf-class="post_link cursor-pointer dropdown-item d-flex align-items-center justify-content-between #{'active' if not searched_category_tags else ''}">
                                    All
                                 </span>
                                 <t t-foreach="category.tag_ids" t-as="tag">
                                     <span t-if="tag.color"
-                                        t-att-data-post="'/event?%s' % keep_query('*', tags=str((search_tags - tag).ids if tag in search_tags else (tag | search_tags).ids), prevent_redirect=True)"
+                                        t-att-data-post="keep_event_url(tags=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), prevent_redirect=True)"
                                         t-attf-class="post_link cursor-pointer dropdown-item d-flex align-items-center justify-content-between #{'active' if tag in search_tags else ''}">
                                         <t t-out="tag.name"/>
                                     </span>
@@ -77,7 +77,6 @@
                         <t t-call="website.website_search_box_input">
                             <t t-set="_classes" t-valuef="o_wevent_event_searchbar_form flex-grow-1"/>
                             <t t-set="search_type">events</t>
-                            <t t-set="action" t-value="'/event/'"/>
                             <t t-set="display_description" t-valuef="true"/>
                             <t t-set="display_detail" t-valuef="false"/>
                             <t t-set="search" t-value="search or searches and searches['search']"/>
@@ -123,7 +122,7 @@
                                         <ul class="list-group list-group-flush">
                                             <t t-if="category.is_published and category.tag_ids and any(tag.color for tag in category.tag_ids)" t-foreach="category.tag_ids" t-as="tag">
                                                 <li t-if="tag.color" class="list-group-item border-0 px-0">
-                                                    <span t-att-data-post="'/event?%s' % keep_query('*', tags=str((search_tags - tag).ids if tag in search_tags else (tag | search_tags).ids), prevent_redirect=True)"
+                                                    <span t-att-data-post="keep_event_url(tags=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), prevent_redirect=True)"
                                                         class="post_link text-reset cursor-pointer" t-att-title="tag.name">
                                                         <div class="form-check">
                                                             <input class="form-check-input pe-none" type="checkbox" t-attf-name="#{tag.color}" t-att-checked="tag in search_tags"/>
@@ -150,7 +149,7 @@
         <t t-foreach="search_tags" t-as="tag">
             <span t-attf-class="o_filter_tag d-inline-flex align-items-baseline rounded ps-2 #{'o_color_%s' % tag.color if tag.color else ''}">
                 <t t-out="tag.display_name"/>
-                <span t-att-data-post="'/event?%s' % keep_query('*', tags=str((search_tags - tag).ids), prevent_redirect=True)"
+                <span t-att-data-post="keep_event_url(tags=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), prevent_redirect=True)"
                     class="post_link cursor-pointer btn border-0 py-1 px-2 text-reset opacity-75-hover">
                     <i class="oi oi-close" role="img"/>
                 </span>
@@ -171,7 +170,7 @@
                 <t t-foreach="dates" t-as="date">
                     <t t-if="date[3] or (date[0] in ('old','upcoming','all'))">
                         <t t-set="is_active" t-value="searches.get('date') == date[0]"/>
-                        <a t-att-href="keep('/event', date=date[0])" t-attf-class="dropdown-item d-flex align-items-center justify-content-between #{is_active and 'active'}">
+                        <a t-att-href="keep_event_url('/event', date=date[0])" t-attf-class="dropdown-item d-flex align-items-center justify-content-between #{is_active and 'active'}">
                             <t t-out="date[1]"/>
                             <span t-if="date[3]" t-out="date[3]" t-attf-class="badge ms-3 text-bg-primary"/>
                         </a>
@@ -198,7 +197,7 @@
                         <t t-foreach="dates" t-as="date">
                             <li t-if="date[3] or (date[0] in ('old','upcoming','all'))" class="list-group-item px-0 border-0">
                                 <t t-set="is_active" t-value="searches.get('date') == date[0]"/>
-                                <a t-att-href="keep('/event', date=date[0])" class="d-flex align-items-center justify-content-between text-reset text-decoration-none" t-att-title="date[1]">
+                                <a t-att-href="keep_event_url(date=date[0])" class="d-flex align-items-center justify-content-between text-reset text-decoration-none" t-att-title="date[1]">
                                     <div class="form-check flex-basis-100">
                                         <input class="form-check-input pe-none" type="radio" t-attf-name="#{date[1]}" t-att-checked="is_active"/>
                                         <label class="form-check-label" t-attf-for="#{date[1]}" t-out="date[1]"/>
@@ -230,14 +229,14 @@
                 <t t-foreach="countries" t-as="country">
                     <t t-if="country['country_id']">
                         <t t-set="is_active" t-value="searches.get('country') == str(country['country_id'] and country['country_id'][0])"/>
-                        <a t-att-href="keep('/event', country=country['country_id'][0])" t-attf-class="dropdown-item d-flex align-items-center justify-content-between #{is_active and 'active'}" t-att-title="country['country_id'][1]">
+                        <a t-att-href="keep_event_url(country=country['country_id'][0])" t-attf-class="dropdown-item d-flex align-items-center justify-content-between #{is_active and 'active'}" t-att-title="country['country_id'][1]">
                             <t t-out="country['country_id'][1]"/>
                             <span t-out="country['country_id_count']" t-attf-class="badge ms-3 text-bg-primary"/>
                         </a>
                     </t>
                     <t t-else="">
                         <t t-set="is_active" t-value="searches.get('country') == 'online'"/>
-                        <a t-att-href="keep('/event', country='online')" t-attf-class="dropdown-item d-flex align-items-center justify-content-between #{is_active and 'active'}" title="Online Events">
+                        <a t-att-href="keep_event_url(country='online')" t-attf-class="dropdown-item d-flex align-items-center justify-content-between #{is_active and 'active'}" title="Online Events">
                             <span>Online Events</span>
                             <span t-out="country['country_id_count']" t-attf-class="badge ms-3 text-bg-primary"/>
                         </a>
@@ -264,7 +263,7 @@
                         <li t-foreach="countries" t-as="country" class="list-group-item px-0 border-0">
                             <t t-if="country['country_id']">
                                 <t t-set="is_active" t-value="searches.get('country') == str(country['country_id'] and country['country_id'][0])"/>
-                                <a t-att-href="keep('/event', country=country['country_id'][0])" class="d-flex align-items-center justify-content-between text-reset text-decoration-none" t-att-title="country['country_id'][1]">
+                                <a t-att-href="keep_event_url(country=country['country_id'][0])" class="d-flex align-items-center justify-content-between text-reset text-decoration-none" t-att-title="country['country_id'][1]">
                                     <div class="form-check flex-basis-100">
                                         <input class="form-check-input pe-none" type="radio" t-attf-name="#{country['country_id'][1]}" t-att-checked="is_active"/>
                                         <label class="form-check-label" t-attf-for="#{country['country_id'][1]}" t-out="country['country_id'][1]"/>
@@ -274,7 +273,7 @@
                             </t>
                             <t t-else="">
                                 <t t-set="is_active" t-value="searches.get('country') == 'online'"/>
-                                <a t-att-href="keep('/event', country='online')" class="d-flex align-items-center justify-content-between text-reset text-decoration-none">
+                                <a t-att-href="keep_event_url(country='online')" class="d-flex align-items-center justify-content-between text-reset text-decoration-none">
                                     <div class="form-check flex-basis-100">
                                         <input class="form-check-input pe-none" type="radio" name="Online Events" t-att-checked="is_active"/>
                                         <label class="form-check-label" for="Online Events">Online Events</label>


### PR DESCRIPTION

Purpose:
Having better looking URL for filtering and searching URLs for
searching channels based on tags were generated in a format like
/event?tags=%5B4%5D, which was not very user-friendly,
especially for sharing links.

Specifications:
This commit introduces slug-based URL generation for a cleaner and more readable
format. URLs now appear as /event/tags/culture-5,5-10-1, making them more
user-friendly.

Backward compatibility is maintained: /event?tags=%5B4%5D will still function
and display the same results as /event/tags/culture-5,5-10-1, ensuring that
existing links continue to work after this update.

Task-4061395