### PR TITLE
[IMP] core: move MIN_PY_VERSION to release.py

### DIFF
--- a/odoo/__init__.py
+++ b/odoo/__init__.py
@@ -16,8 +16,7 @@ __path__ = [
 ]
 
 import sys
-MIN_PY_VERSION = (3, 10)
-MAX_PY_VERSION = (3, 12)
+from odoo.release import MIN_PY_VERSION
 assert sys.version_info > MIN_PY_VERSION, f"Outdated python version detected, Odoo requires Python >= {'.'.join(map(str, MIN_PY_VERSION))} to run."
 
 # ----------------------------------------------------------

--- a/odoo/_monkeypatches/num2words.py
+++ b/odoo/_monkeypatches/num2words.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from decimal import ROUND_HALF_UP, Decimal
 from math import floor
 
-from odoo import MIN_PY_VERSION
+from odoo.release import MIN_PY_VERSION
 
 # The following section of the code is used to monkey patch
 # the Arabic class of num2words package as there are some problems

--- a/odoo/cli/server.py
+++ b/odoo/cli/server.py
@@ -20,6 +20,7 @@ import sys
 from psycopg2.errors import InsufficientPrivilege
 
 import odoo
+import odoo.release
 
 from . import Command
 
@@ -68,10 +69,10 @@ def report_configuration():
     replica_port = config['db_replica_port']
     if replica_host or replica_port:
         _logger.info('replica database: %s@%s:%s', user, replica_host or 'default', replica_port or 'default')
-    if sys.version_info[:2] > odoo.MAX_PY_VERSION:
+    if sys.version_info[:2] > odoo.release.MAX_PY_VERSION:
         _logger.warning("Python %s is not officially supported, please use Python %s instead",
             '.'.join(map(str, sys.version_info[:2])),
-            '.'.join(map(str, odoo.MAX_PY_VERSION))
+            '.'.join(map(str, odoo.release.MAX_PY_VERSION))
         )
 
 def rm_pid_file(main_pid):

--- a/odoo/release.py
+++ b/odoo/release.py
@@ -36,3 +36,6 @@ author_email = 'info@odoo.com'
 license = 'LGPL-3'
 
 nt_service_name = "odoo-server-" + series.replace('~','-')
+
+MIN_PY_VERSION = (3, 10)
+MAX_PY_VERSION = (3, 12)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# ruff: noqa: F821
+# (ruff don't see read variables from release.py)
 
 from setuptools import find_packages, setup
 from os.path import join, dirname
@@ -65,7 +67,7 @@ setup(
         'xlwt',
         'zeep',
     ],
-    python_requires='>=3.10',
+    python_requires='>=' + ".".join(map(str, MIN_PY_VERSION)),
     extras_require={
         'ldap': ['python-ldap'],
     },


### PR DESCRIPTION
In order to make `odoo` a namespace, we want to remove all variables and code from the init file. For min/max python version, the best place to define them is release.py.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
