### PR TITLE
[IMP] website_sale: mega menu for ecommerce categories

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -4115,10 +4115,12 @@ options.registry.MegaMenuLayout = options.registry.SelectTemplate.extend({
      * @returns {string} xmlid of the current template.
      */
     _getCurrentTemplateXMLID: function () {
-        const templateDefiningClass = this.containerEl.querySelector('section')
-            .classList.value.split(' ').filter(cl => cl.startsWith('s_mega_menu'))[0];
-        return `website.${templateDefiningClass}`;
-    },
+        const sectionEl = this.containerEl.querySelector('section');
+        const dataTemplateId = sectionEl.getAttribute('data-template-id');
+        const templateDefiningClass = sectionEl.classList.value
+            .split(' ').filter(cl => cl.startsWith('s_mega_menu'))[0];
+        return dataTemplateId || `website.${templateDefiningClass}`;
+    }
 });
 
 /**

--- a/addons/website_sale/__manifest__.py
+++ b/addons/website_sale/__manifest__.py
@@ -59,6 +59,7 @@
         'views/snippets/s_dynamic_snippet_products.xml',
         'views/snippets/s_dynamic_snippet_products_preview_data.xml',
         'views/snippets/s_popup.xml',
+        'views/snippets/s_mega_menu_ecommerce_categories.xml',
     ],
     'demo': [
         'data/demo.xml',

--- a/addons/website_sale/data/demo.xml
+++ b/addons/website_sale/data/demo.xml
@@ -124,68 +124,266 @@
         </record>
         <record id="public_category_furnitures" model="product.public.category">
           <field name="name">Furnitures</field>
-          <field name="sequence">17</field>
+          <field name="sequence">22</field>
           <field name="image_1920" type="base64" file="website_sale/static/src/img/categories/furnitures.jpg"/>
         </record>
         <record id="public_category_boxes" model="product.public.category">
             <field name="name">Boxes</field>
-            <field name="sequence">20</field>
+            <field name="sequence">29</field>
             <field name="image_1920" type="base64" file="website_sale/static/src/img/categories/boxes.jpg"/>
         </record>
         <record id="public_category_drawers" model="product.public.category">
           <field name="name">Drawers</field>
-          <field name="sequence">21</field>
+          <field name="sequence">35</field>
           <field name="image_1920" type="base64" file="website_sale/static/src/img/categories/drawers.jpg"/>
         </record>
         <record id="public_category_cabinets" model="product.public.category">
           <field name="name">Cabinets</field>
-          <field name="sequence">22</field>
+          <field name="sequence">40</field>
           <field name="image_1920" type="base64" file="website_sale/static/src/img/categories/cabinets.jpg"/>
         </record>
         <record id="public_category_bins" model="product.public.category">
           <field name="name">Bins</field>
-          <field name="sequence">23</field>
+          <field name="sequence">45</field>
           <field name="image_1920" type="base64" file="website_sale/static/src/img/categories/bins.jpg"/>
         </record>
         <record id="public_category_lamps" model="product.public.category">
           <field name="name">Lamps</field>
-          <field name="sequence">24</field>
+          <field name="sequence">49</field>
           <field name="image_1920" type="base64" file="website_sale/static/src/img/categories/lamps.jpg"/>
         </record>
-        <record id="services" model="product.public.category">
+        <record id="public_category_services" model="product.public.category">
           <field name="name">Services</field>
-          <field name="sequence">25</field>
+          <field name="sequence">55</field>
           <field name="image_1920" type="base64" file="website_sale/static/src/img/warranty.jpg"/>
         </record>
         <record id="public_category_multimedia" model="product.public.category">
           <field name="name">Multimedia</field>
-          <field name="sequence">26</field>
+          <field name="sequence">59</field>
           <field name="image_1920" type="base64" file="product/static/img/product_product_43-image.jpg"/>
         </record>
 
         <!-- subcategories -->
+
+        <!-- subcategories for desks -->
         <record id="public_category_desks_components" model="product.public.category">
           <field name="parent_id" eval="ref('public_category_desks')"/>
           <field name="name">Components</field>
           <field name="sequence">16</field>
           <field name="image_1920" type="base64" file="website_sale/static/src/img/categories/desk_components.jpg"/>
         </record>
+        <record id="public_category_desks_office" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_desks')"/>
+          <field name="name">Office Desks</field>
+          <field name="sequence">17</field>
+        </record>
+        <record id="public_category_desks_gaming" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_desks')"/>
+          <field name="name">Gaming Desks</field>
+          <field name="sequence">18</field>
+        </record>
+        <record id="public_category_desks_glass" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_desks')"/>
+          <field name="name">Glass Desks</field>
+          <field name="sequence">19</field>
+        </record>
+        <record id="public_category_desks_standing" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_desks')"/>
+          <field name="name">Standing Desks</field>
+          <field name="sequence">20</field>
+        </record>
+        <record id="public_category_desks_foldable" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_desks')"/>
+          <field name="name">Foldable Desks</field>
+          <field name="sequence">21</field>
+        </record>
+
+        <!-- subcategories for furnitures -->
+        <record id="public_category_furnitures_sofas" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_furnitures')"/>
+          <field name="name">Sofas</field>
+          <field name="sequence">23</field>
+        </record>
         <record id="public_category_furnitures_chairs" model="product.public.category">
           <field name="parent_id" eval="ref('public_category_furnitures')"/>
           <field name="name">Chairs</field>
-          <field name="sequence">18</field>
+          <field name="sequence">24</field>
         </record>
         <record id="public_category_furnitures_couches" model="product.public.category">
           <field name="parent_id" eval="ref('public_category_furnitures')"/>
           <field name="name">Couches</field>
-          <field name="sequence">19</field>
+          <field name="sequence">25</field>
+        </record>
+        <record id="public_category_furnitures_recliners" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_furnitures')"/>
+          <field name="name">Recliners</field>
+          <field name="sequence">26</field>
+        </record>
+        <record id="public_category_furnitures_beds" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_furnitures')"/>
+          <field name="name">Beds</field>
+          <field name="sequence">27</field>
+        </record>
+        <record id="public_category_furnitures_wardrobes" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_furnitures')"/>
+          <field name="name">Wardrobes</field>
+          <field name="sequence">28</field>
+        </record>
+
+        <!-- subcategories for boxes -->
+        <record id="public_category_boxes_vintage" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_boxes')"/>
+          <field name="name">Vintage Boxes</field>
+          <field name="sequence">30</field>
+        </record>
+        <record id="public_category_boxes_rustic" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_boxes')"/>
+          <field name="name">Rustic Boxes</field>
+          <field name="sequence">31</field>
+        </record>
+        <record id="public_category_boxes_luxury" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_boxes')"/>
+          <field name="name">Luxury Boxes</field>
+          <field name="sequence">32</field>
+        </record>
+        <record id="public_category_boxes_stackable" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_boxes')"/>
+          <field name="name">Stackable Boxes</field>
+          <field name="sequence">33</field>
+        </record>
+        <record id="public_category_boxes_collapsible" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_boxes')"/>
+          <field name="name">Collapsible Boxes</field>
+          <field name="sequence">34</field>
+        </record>
+
+        <!-- subcategories for drawers -->
+        <record id="public_category_drawers_nightstand" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_drawers')"/>
+          <field name="name">Nightstand Drawers</field>
+          <field name="sequence">36</field>
+        </record>
+        <record id="public_category_drawers_underbed" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_drawers')"/>
+          <field name="name">Under-bed Drawers</field>
+          <field name="sequence">37</field>
+        </record>
+        <record id="public_category_drawers_file" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_drawers')"/>
+          <field name="name">File Drawers</field>
+          <field name="sequence">38</field>
+        </record>
+        <record id="public_category_drawers_kitchen" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_drawers')"/>
+          <field name="name">Kitchen Drawer Units</field>
+          <field name="sequence">39</field>
+        </record>
+
+        <!-- subcategories for cabinets -->
+        <record id="public_category_cabinets_kitchen" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_cabinets')"/>
+          <field name="name">Kitchen Cabinets</field>
+          <field name="sequence">41</field>
+        </record>
+        <record id="public_category_cabinets_bathroom" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_cabinets')"/>
+          <field name="name">Bathroom Cabinets</field>
+          <field name="sequence">42</field>
+        </record>
+        <record id="public_category_cabinets_storage" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_cabinets')"/>
+          <field name="name">Storage Cabinets</field>
+          <field name="sequence">43</field>
+        </record>
+        <record id="public_category_cabinets_medicine" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_cabinets')"/>
+          <field name="name">Medicine Cabinets</field>
+          <field name="sequence">44</field>
+        </record>
+
+        <!-- subcategories for bins -->
+        <record id="public_category_bins_laundry" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_bins')"/>
+          <field name="name">Laundry Bins</field>
+          <field name="sequence">46</field>
+        </record>
+        <record id="public_category_bins_toy" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_bins')"/>
+          <field name="name">Toy Bins</field>
+          <field name="sequence">47</field>
+        </record>
+        <record id="public_category_bins_storage" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_bins')"/>
+          <field name="name">Food Storage Bins</field>
+          <field name="sequence">48</field>
+        </record>
+
+        <!-- subcategories for lamps -->
+        <record id="public_category_lamps_desk" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_lamps')"/>
+          <field name="name">Desk Lamps</field>
+          <field name="sequence">50</field>
+        </record>
+        <record id="public_category_lamps_ceiling" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_lamps')"/>
+          <field name="name">Ceiling Lamps</field>
+          <field name="sequence">51</field>
+        </record>
+        <record id="public_category_lamps_chandelier" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_lamps')"/>
+          <field name="name">Chandeliers</field>
+          <field name="sequence">52</field>
+        </record>
+        <record id="public_category_lamps_touch" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_lamps')"/>
+          <field name="name">Touch Lamps</field>
+          <field name="sequence">53</field>
+        </record>
+
+        <!-- subcategories for services -->
+        <record id="public_category_services_design_and_planning" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_services')"/>
+          <field name="name">Design and Planning</field>
+          <field name="sequence">55</field>
+        </record>
+        <record id="public_category_services_delivery_and_installation" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_services')"/>
+          <field name="name">Delivery and Installation</field>
+          <field name="sequence">56</field>
+        </record>
+        <record id="public_category_services_repair_and_maintenance" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_services')"/>
+          <field name="name">Repair and Maintenance</field>
+          <field name="sequence">57</field>
+        </record>
+        <record id="public_category_services_relocation_and_moving" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_services')"/>
+          <field name="name">Relocation and Moving</field>
+          <field name="sequence">58</field>
+        </record>
+
+        <!-- subcategories for lamps -->
+        <record id="public_category_multimedia_virtual_design" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_multimedia')"/>
+          <field name="name">Virtual Design Tools</field>
+          <field name="sequence">60</field>
+        </record>
+        <record id="public_category_multimedia_augmented_reality" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_multimedia')"/>
+          <field name="name">Augmented Reality Tools</field>
+          <field name="sequence">61</field>
+        </record>
+        <record id="public_category_multimedia_education" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_multimedia')"/>
+          <field name="name">Education Tools</field>
+          <field name="sequence">62</field>
         </record>
 
         <record id="product.product_product_1_product_template" model="product.template">
-            <field name="public_categ_ids" eval="[(6,0,[ref('services')])]"/>
+            <field name="public_categ_ids" eval="[(6,0,[ref('public_category_services')])]"/>
         </record>
         <record id="product.product_product_2_product_template" model="product.template">
-            <field name="public_categ_ids" eval="[(6,0,[ref('services')])]"/>
+            <field name="public_categ_ids" eval="[(6,0,[ref('public_category_services')])]"/>
         </record>
         <record id="product.product_product_3_product_template" model="product.template">
             <field name="public_categ_ids" eval="[(6,0,[ref('public_category_desks_components')])]"/>
@@ -670,7 +868,7 @@
             <field name="description_sale">Warranty, issued to the purchaser of an article by its manufacturer, promising to repair or replace it if necessary within a specified period of time.</field>
             <field name="categ_id" ref="product.product_category_3"/>
             <field name="invoice_policy">delivery</field>
-            <field name="public_categ_ids" eval="[(6, 0, [ref('website_sale.services')])]"/>
+            <field name="public_categ_ids" eval="[(6, 0, [ref('website_sale.public_category_services')])]"/>
             <field name="image_1920" type="base64" file="website_sale/static/src/img/warranty.jpg"/>
         </record>
 

--- a/addons/website_sale/static/src/img/snippets_thumbs/s_mega_menu_ecommerce_categories.svg
+++ b/addons/website_sale/static/src/img/snippets_thumbs/s_mega_menu_ecommerce_categories.svg
@@ -1,0 +1,78 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="82" height="60" viewBox="0 0 82 60">
+  <defs>
+    <rect id="path-1" width="14" height="2" x="0" y="0"/>
+    <filter id="filter-2" width="107.1%" height="200%" x="-3.6%" y="-25%" filterUnits="objectBoundingBox">
+      <feOffset dy="1" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feComposite in="shadowOffsetOuter1" in2="SourceAlpha" operator="out" result="shadowOffsetOuter1"/>
+      <feColorMatrix in="shadowOffsetOuter1" values="0 0 0 0 1   0 0 0 0 1   0 0 0 0 1  0 0 0 0.292012675 0"/>
+    </filter>
+    <path id="path-3" d="M13 12v1H0v-1h13zm-2-3v1H0V9h11zm2-3v1H0V6h13z"/>
+    <filter id="filter-4" width="107.7%" height="128.6%" x="-3.8%" y="-7.1%" filterUnits="objectBoundingBox">
+      <feOffset dy="1" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feComposite in="shadowOffsetOuter1" in2="SourceAlpha" operator="out" result="shadowOffsetOuter1"/>
+      <feColorMatrix in="shadowOffsetOuter1" values="0 0 0 0 1   0 0 0 0 1   0 0 0 0 1  0 0 0 0.0995137675 0"/>
+    </filter>
+    <rect id="path-5" width="14" height="2" x="20" y="0"/>
+    <filter id="filter-6" width="107.1%" height="200%" x="-3.6%" y="-25%" filterUnits="objectBoundingBox">
+      <feOffset dy="1" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feComposite in="shadowOffsetOuter1" in2="SourceAlpha" operator="out" result="shadowOffsetOuter1"/>
+      <feColorMatrix in="shadowOffsetOuter1" values="0 0 0 0 1   0 0 0 0 1   0 0 0 0 1  0 0 0 0.292012675 0"/>
+    </filter>
+    <path id="path-7" d="M33 12v1H20v-1h13zm-2-3v1H20V9h11zm2-3v1H20V6h13z"/>
+    <filter id="filter-8" width="107.7%" height="128.6%" x="-3.8%" y="-7.1%" filterUnits="objectBoundingBox">
+      <feOffset dy="1" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feComposite in="shadowOffsetOuter1" in2="SourceAlpha" operator="out" result="shadowOffsetOuter1"/>
+      <feColorMatrix in="shadowOffsetOuter1" values="0 0 0 0 1   0 0 0 0 1   0 0 0 0 1  0 0 0 0.0995137675 0"/>
+    </filter>
+    <rect id="path-9" width="14" height="2" x="39" y="0"/>
+    <filter id="filter-10" width="107.1%" height="200%" x="-3.6%" y="-25%" filterUnits="objectBoundingBox">
+      <feOffset dy="1" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feComposite in="shadowOffsetOuter1" in2="SourceAlpha" operator="out" result="shadowOffsetOuter1"/>
+      <feColorMatrix in="shadowOffsetOuter1" values="0 0 0 0 1   0 0 0 0 1   0 0 0 0 1  0 0 0 0.292012675 0"/>
+    </filter>
+    <path id="path-11" d="M52 12v1H39v-1h13zm-2-3v1H39V9h11zm2-3v1H39V6h13z"/>
+    <filter id="filter-12" width="107.7%" height="128.6%" x="-3.8%" y="-7.1%" filterUnits="objectBoundingBox">
+      <feOffset dy="1" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feComposite in="shadowOffsetOuter1" in2="SourceAlpha" operator="out" result="shadowOffsetOuter1"/>
+      <feColorMatrix in="shadowOffsetOuter1" values="0 0 0 0 1   0 0 0 0 1   0 0 0 0 1  0 0 0 0.0995137675 0"/>
+    </filter>
+    <linearGradient id="linearGradient-13" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#00A09D"/>
+      <stop offset="100%" stop-color="#00E2FF"/>
+    </linearGradient>
+  </defs>
+  <g fill="none" fill-rule="evenodd" class="snippets_thumbs">
+    <g class="s_mega_menu_odoo_menu">
+      <rect width="82" height="60" class="bg"/>
+      <g class="group" transform="translate(15 17)">
+        <g class="rectangle">
+          <use fill="#000" filter="url(#filter-2)" xlink:href="#path-1"/>
+          <use fill="#FFF" fill-opacity=".78" xlink:href="#path-1"/>
+        </g>
+        <rect width="14" height="1" class="rectangle" fill="url(#linearGradient-13)" transform="translate(0 4)"/>
+        <g class="combined_shape" transform="translate(0 3)">
+          <use fill="#000" filter="url(#filter-4)" xlink:href="#path-3"/>
+          <use fill="#FFF" fill-opacity=".348" xlink:href="#path-3"/>
+        </g>
+        <g class="rectangle">
+          <use fill="#000" filter="url(#filter-6)" xlink:href="#path-5"/>
+          <use fill="#FFF" fill-opacity=".78" xlink:href="#path-5"/>
+        </g>
+        <rect width="14" height="1" class="rectangle" fill="url(#linearGradient-13)" transform="translate(20 4)"/>
+        <g class="combined_shape" transform="translate(0 3)">
+          <use fill="#000" filter="url(#filter-8)" xlink:href="#path-7"/>
+          <use fill="#FFF" fill-opacity=".348" xlink:href="#path-7"/>
+        </g>
+        <g class="rectangle">
+          <use fill="#000" filter="url(#filter-10)" xlink:href="#path-9"/>
+          <use fill="#FFF" fill-opacity=".78" xlink:href="#path-9"/>
+        </g>
+        <rect width="14" height="1" class="rectangle" fill="url(#linearGradient-13)" transform="translate(39 4)"/>
+        <g class="combined_shape" transform="translate(0 3)">
+          <use fill="#000" filter="url(#filter-12)" xlink:href="#path-11"/>
+          <use fill="#FFF" fill-opacity=".348" xlink:href="#path-11"/>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/addons/website_sale/views/snippets/s_mega_menu_ecommerce_categories.xml
+++ b/addons/website_sale/views/snippets/s_mega_menu_ecommerce_categories.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="s_mega_menu_ecommerce_categories"
+              name="eCommerce Categories Mega Menu"
+              groups="base.group_user">
+        <section class="s_mega_menu_ecommerce_categories pt8 pb8 o_colored_level o_cc o_cc1 "
+                 data-template-id="website_sale.s_mega_menu_ecommerce_categories">
+            <div class="container">
+                <div class="row">
+                    <t t-set="categories"
+                       t-value="request.env['product.public.category'].search([('parent_id', '=', False)])"/>
+                    <t t-foreach="categories" t-as="category">
+                        <div class="col-md-6 col-lg-4 pt8 pb8">
+                            <h6 class="o_default_snippet_text text-uppercase fw-bold mt-0">
+                                <a t-att-href="'/shop/category/%s' % category.id"
+                                   class="nav-link o_default_snippet_text p-0"
+                                   t-esc="category.name"/>
+                            </h6>
+                            <nav class="nav flex-column">
+                                <t t-foreach="category.child_id" t-as="sub_category">
+                                    <a t-att-href="'/shop/category/%s' % sub_category.id"
+                                       class="nav-link o_default_snippet_text text-secondary p-0"
+                                       t-esc="sub_category.name"/>
+                                </t>
+                            </nav>
+                        </div>
+                    </t>
+                </div>
+            </div>
+        </section>
+    </template>
+</odoo>
+

--- a/addons/website_sale/views/snippets/snippets.xml
+++ b/addons/website_sale/views/snippets/snippets.xml
@@ -330,6 +330,14 @@
                          data-reload="/"/>
         </div>
     </xpath>
+    <xpath expr="//div[@data-js='MegaMenuLayout']/we-select" position="inside">
+        <t t-set="_label">Ecommerce Categories</t>
+        <we-button t-att-data-select-label="_label"
+                   data-select-template="website_sale.s_mega_menu_ecommerce_categories"
+                   data-img="/website_sale/static/src/img/snippets_thumbs/s_mega_menu_ecommerce_categories.svg"
+                   title="The menu has been generated based on the current eCommerce categories but will not be dynamically updated if they change"
+                   t-out="_label"/>
+    </xpath>
 </template>
 
 <template id="snippets_options_web_editor" inherit_id="web_editor.snippet_options" name="e-commerce base snippet options">


### PR DESCRIPTION
**Prior this commit:**
- There was no mega menu based on Ecommerce categories. Hence, if a user wanted one, he had to create it from scratch by typing in the name of each category  and copy/pasting each URL linked to it. 

**Post this commit:**
- The user can now easily use the mega menu of Ecommerce categories.

**Issue at hand:**
- The issue was that the original function did not account for templates defined in other modules and could return null if no `s_mega_menu` class was found. Adding the `data-template-id` attribute ensures a reliable identifier regardless of the module, providing a fallback when the class-based approach fails.

**Affected version**-master
**Task**-3718978