### PR TITLE
[IMP] hw_drivers: detect ESC/Label printers

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
@@ -89,7 +89,7 @@ class PrinterDriver(Driver):
 
         if any(cmd in device['device-id'] for cmd in ['CMD:STAR;', 'CMD:ESC/POS;']):
             self.device_subtype = "receipt_printer"
-        elif "COMMAND SET:ZPL;" in device['device-id']:
+        elif any(cmd in device['device-id'] for cmd in ['COMMAND SET:ZPL;', 'CMD:ESCLABEL;']):
             self.device_subtype = "label_printer"
         else:
             self.device_subtype = "office_printer"


### PR DESCRIPTION
This sets the subtype of ESC/Label printers (e.g. C4000e) so that they can be easily distinguished.

Previously, they would show as an 'Office Printer', after this PR they show as a 'Label Printer'.

task-4045816
Enterprise PR: https://github.com/odoo/enterprise/pull/67605

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
