### PR TITLE
[FIX] stock: allow same quant sml when splitting

### DIFF
--- a/addons/stock/static/src/fields/stock_move_line_x2_many_field.js
+++ b/addons/stock/static/src/fields/stock_move_line_x2_many_field.js
@@ -4,6 +4,9 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { X2ManyField, x2ManyField } from "@web/views/fields/x2many/x2many_field";
 import { useSelectCreate, useOpenMany2XRecord} from "@web/views/fields/relational_utils";
+import { onMounted } from "@odoo/owl"
+import { Domain } from "@web/core/domain";
+
 export class SMLX2ManyField extends X2ManyField {
     setup() {
         super.setup();
@@ -15,6 +18,42 @@ export class SMLX2ManyField extends X2ManyField {
             onCreateEdit: () => this.createOpenRecord(),
         });
 
+        onMounted(async () => {
+            const orm = this.env.model.orm;
+            this.quantsData = [];
+            const usedByQuant = {};
+            if (this.props.record.data.move_line_ids.records.length) {
+                const domains = [];
+                for (const ml of this.props.record.data.move_line_ids.records) {
+                    domains.push([
+                        ["product_id", "=", ml.data.product_id[0]],
+                        ["lot_id", "=", ml.data.lot_id?.[0] || false],
+                        ["location_id", "=", ml.data.location_id[0]],
+                        ["package_id", "=", ml.data.package_id?.[0] || false],
+                        ["owner_id", "=", ml.data.owner_id?.[0] || false],
+                    ]);
+                }
+                if (domains.length) {
+                    const quant_fields = ['display_name', 'product_id', 'lot_id', 'location_id', 'package_id', 'owner_id', 'available_quantity'];
+                    const quants = await orm.searchRead("stock.quant", Domain.or(domains).toList(), quant_fields);
+                    const quants_by_key = Object.fromEntries(quants.map(x => [
+                        [x.product_id[0], x.lot_id?.[0] || false, x.location_id[0], x.package_id?.[0] || false, x.owner_id?.[0] || false],
+                        [x.id, x.display_name, x.available_quantity]
+                    ]));
+                    for (const ml of this.props.record.data.move_line_ids.records) {
+                        const entry = quants_by_key[[ml.data.product_id[0], ml.data.lot_id?.[0] || false, ml.data.location_id[0], ml.data.package_id?.[0] || false, ml.data.owner_id?.[0] || false].toString()];
+                        if (!entry) {  // product not storable or has no quant yet
+                            ml.data.quant_id = [false, 0];
+                            continue;
+                        }
+                        ml.data.quant_id = [entry[0], entry[1]];
+                        usedByQuant[ml.data.quant_id[0]] = (usedByQuant[ml.data.quant_id[0]] || 0) + ml.data.quantity;
+                    }
+                    this.quantsData = quants.map(x => [x.id, x.available_quantity + (usedByQuant[x.id] || 0)]);
+                }
+            }
+        });
+
         this.selectCreate = (params) => {
             return selectCreate(params);
         };
@@ -22,7 +61,6 @@ export class SMLX2ManyField extends X2ManyField {
             resModel: "stock.quant",
             activeActions: this.activeActions,
             onRecordSaved: (record) => this.selectRecord([record.resId]),
-            onRecordDiscarted: (resId) => this.selectRecord(resId),
             fieldString: this.props.string,
             is2Many: true,
         });
@@ -39,9 +77,9 @@ export class SMLX2ManyField extends X2ManyField {
             search_default_on_hand: true,
             search_default_in_stock: true,
         };
-        const productName = this.props.record.data.product_id[1];
+        const data = this.props.record.data;
+        const productName = data.product_id[1];
         const title = _t("Add line: %s", productName);
-        const alreadySelected = this.props.record.data.move_line_ids.records.filter((line) => line.data.quant_id?.[0]);
         let domain = [
             ["product_id", "=", this.props.record.data.product_id[0]],
             ["location_id", "child_of", this.props.context.default_location_id],
@@ -49,9 +87,20 @@ export class SMLX2ManyField extends X2ManyField {
         if (this.props.domain) {
             domain = [...domain, ...this.props.domain()];
         }
-        if (alreadySelected.length) {
-            domain.push(["id", "not in", alreadySelected.map((line) => line.data.quant_id[0])]);
-        }
+        const usedByQuant = this.props.record.data.move_line_ids.records.reduce((result, current) => {
+            const quant_id = current.data.quant_id[0];
+            if (!quant_id)
+                return result;
+            result[quant_id] = (result[quant_id] || 0) + current.data.quantity;
+            return result;
+        }, {});
+        const fullyUsed = this.quantsData
+            .filter(([id, available_quantity]) => (usedByQuant[id] || 0) >= available_quantity)
+            .map(([id]) => id);
+
+        if (fullyUsed.length)
+            domain.push(["id", "not in", fullyUsed]);
+
         return this.selectCreate({ domain, context, title });
     }
 
@@ -59,10 +108,15 @@ export class SMLX2ManyField extends X2ManyField {
         const params = {
             context: { default_quant_id: res_ids[0] },
         };
-        this.list.addNewRecord(params).then((record) => {
+        this.list.addNewRecord(params).then(async (record) => {
             // Make it dirty to force the save of the record. addNewRecord make
             // the new record dirty === False by default to remove them at unfocus event
             record.dirty = true;
+            if (record.data.quant_id[0] && this.quantsData.every(a => a[0] != record.data.quant_id[0])) {
+                const orm = this.env.model.orm;
+                const quants = await orm.searchRead("stock.quant", [["id", "=", record.data.quant_id[0]]], ['available_quantity']);
+                this.quantsData.push([quants[0].id, quants[0].available_quantity]);
+            }
         });
     }
 


### PR DESCRIPTION
Steps
---
* In the setting enable *Multi Step Routes*
* Create an internal transfer with 1 operation for some product > *Mark as Todo*
* On the stock.move operation line click the list icon for detailed operations.
* *Add a line* => this opens a Wizard where we can choose the quant from which to pick the product for the sml
* After adding the line *Add a line* again, we cannot pick the same quant

Use case
---
For internal transfers, we would like to be able to pick products from the same quant and dispatch them to several sub-locations of the picking's destination location.

Side Fix
---
Delete `onRecordDiscarted` method, which wasn't being used because of the typo and doesn't appear to be necessary.

opw-4072541

Co-authored-by: @ajf-odoo 