### PR TITLE
[FIX] web: make the fields readonly in x2many when mode readonly

### DIFF
--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
@@ -81,6 +81,7 @@ export class Many2ManyTagsField extends Component {
                 create: this.props.canCreate && this.props.createDomain,
                 createEdit: this.props.canCreateEdit,
                 onDelete: removeRecord,
+                edit: this.props.record.isInEdition,
             },
             getEvalParams: (props) => {
                 return {

--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -99,6 +99,7 @@ export function useActiveActions({
         // We need to take care of tags "control" and "create" to set create stuff
         result.create = !readonly && evalAction("create");
         result.createEdit = !readonly && result.create && crudOptions.createEdit; // always a boolean
+        result.edit = crudOptions.edit;
         result.delete = !readonly && evalAction("delete");
 
         if (isMany2Many) {
@@ -695,6 +696,7 @@ export function useOpenX2ManyRecord({
     const viewService = useService("view");
     const userService = useService("user");
     const env = useEnv();
+    const component = useComponent();
 
     const addDialog = useOwnedDialogs();
     const viewMode = activeField.viewMode;
@@ -714,6 +716,9 @@ export function useOpenX2ManyRecord({
             userService,
             env,
         });
+        if (!component.props.record.isInEdition) {
+            archInfo.activeActions.edit = false;
+        }
 
         const { activeFields, fields } = extractFieldsFromArchInfo(archInfo, _fields);
 

--- a/addons/web/static/src/views/fields/x2many/x2many_field.js
+++ b/addons/web/static/src/views/fields/x2many/x2many_field.js
@@ -67,6 +67,7 @@ export class X2ManyField extends Component {
         this.activeActions = useActiveActions({
             crudOptions: Object.assign({}, this.props.crudOptions, {
                 onDelete: removeRecord,
+                edit: this.props.record.isInEdition,
             }),
             fieldType: this.isMany2Many ? "many2many" : "one2many",
             subViewActiveActions,

--- a/addons/web/static/tests/views/fields/one2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/one2many_field_tests.js
@@ -13534,6 +13534,61 @@ QUnit.module("Fields", (hooks) => {
         assert.verifySteps(["onchange partner", "web_save turtle"]);
     });
 
+    QUnit.test(
+        "Boolean toggle in x2many must not be editable if form is not editable",
+        async function (assert) {
+            serverData.views = {
+                "turtle,false,form": `<form>
+                        <field name="turtle_bar" widget="boolean_toggle"/>
+                        <field name="partner_ids">
+                            <tree>
+                                <field name="bar" widget="boolean_toggle"/>
+                            </tree>
+                        </field>
+                    </form>`,
+            };
+
+            await makeView({
+                type: "form",
+                resModel: "partner",
+                serverData,
+                arch: `
+                    <form edit="0">
+                        <field name="turtles">
+                            <tree>
+                                <field name="turtle_bar" widget="boolean_toggle"/>
+                            </tree>
+                        </field>
+                    </form>`,
+                resId: 1,
+            });
+
+            assert.hasClass(target.querySelector(".o_form_renderer"), "o_form_readonly");
+            const booleanToggle = target.querySelector(
+                "[name='turtles'] .o_data_row [name='turtle_bar'] .o_boolean_toggle input"
+            );
+            assert.ok(
+                booleanToggle.disabled,
+                "The boolean toggle should be disabled when the form is readonly"
+            );
+
+            await click(target, ".o_data_cell");
+            assert.containsOnce(target, ".modal-dialog");
+            assert.hasClass(target.querySelector(".o_form_renderer"), "o_form_readonly");
+            const booleanToggleInDialog = target.querySelector(".modal [name='turtle_bar'] input");
+            assert.ok(
+                booleanToggleInDialog.disabled,
+                "The boolean toggle in the form view dialog should be disabled when the main form is readonly"
+            );
+            assert.ok(
+                target.querySelector(
+                    ".modal [name='partner_ids'] .o_data_row [name='bar'] .o_boolean_toggle input"
+                ).disabled,
+                "The boolean toggle in x2m in the form view dialog should be disabled when the main form is readonly"
+            );
+        }
+    );
+
     QUnit.test("create a new record with an x2m invisible", async function (assert) {
         await makeView({
             type: "form",


### PR DESCRIPTION
Before this commit:

When a form view was set to non-editable (edit="0"), its x2many fields could still contain editable boolean fields (e.g., Boolean Toggle).

After this commit:
Boolean fields within x2many fields are now also read-only when the form view is non-editable.

Task-3802653

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
