### PR TITLE
[FIX] mail: access error when guest removes reaction

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -876,7 +876,8 @@ class Message(models.Model):
             self._bus_notification_target(),
             "mail.record/insert",
             Store(self, {"reactions": [(group_command, group_values)]})
-            .add(guest or partner, fields=["name", "write_date"])
+            # sudo: mail.guest - guest can send their own name when reacting
+            .add(guest.sudo() or partner, fields=["name", "write_date"])
             .get_result(),
         )
 

--- a/addons/mail/static/tests/tours/discuss_channel_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_public_tour.js
@@ -67,6 +67,36 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
             trigger: '.o-mail-Message .o-mail-AttachmentCard:contains("text.txt")',
         },
         {
+            trigger: ".o-mail-Message [title='Add a Reaction']",
+            run: "click",
+        },
+        {
+            trigger: ".o-EmojiPicker .o-Emoji:contains('🙂')",
+            run: "click",
+        },
+        {
+            content: "Reload page (fetch reactions)",
+            trigger: ".o-mail-Message",
+            run() {
+                location.reload();
+            },
+        },
+        {
+            content: "Remove reaction",
+            trigger: ".o-mail-MessageReaction:contains('🙂')",
+            run: "click",
+        },
+        {
+            content: "Reload page (fetch reactions)",
+            trigger: ".o-mail-Message",
+            run() {
+                location.reload();
+            },
+        },
+        {
+            trigger: ".o-mail-Message:not(:has(.o-mail-MessageReaction))",
+        },
+        {
             content: "Click on more menu",
             trigger: ".o-mail-Message [title='Expand']",
             run: "click",


### PR DESCRIPTION
Before this commit, when a guest tried removing a reaction you would get an access error.

Steps to reproduce:
- Make a channel public
- Join channel as guest
- Add reaction to message
- Remove reaction to message

This happens because the content of the notification sent on the bus has data from the `mail.guest` table, which the guest has no access right to.
This data was added in 5633f799c577cc531944376a1f348577668e1519.

This commit fixes the issue by adding sudo privileges.