### PR TITLE
[FIX] point_of_sale: prevent barcode input as payment amount

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
@@ -44,6 +44,7 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
                 // When the buffer is updated, trigger this event.
                 // Note that the component listens to it.
                 triggerAtInput: 'update-selected-paymentline',
+                useWithBarcode: true,
             };
             // Check if pos has a cash payment method
             const hasCashPaymentMethod = this.payment_methods_from_config.some(


### PR DESCRIPTION
Before this commit, scanning a barcode on the payment screen would mistakenly capture the barcode value as the payment amount. This could lead to incorrect payment amounts being recorded if not noticed by the cashier.

opw-4079147

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
