### PR TITLE
[IMP] mrp:  Shipping Policy for internal transfers

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -150,6 +150,10 @@ class PickingType(models.Model):
         compute_sudo=True, string='Show Operation in Overview'
     )
     kanban_dashboard_graph = fields.Text(compute='_compute_kanban_dashboard_graph')
+    shipping_policy = fields.Selection([
+        ('direct', 'As soon as possible'), ('one', 'All at once')],
+        'Shipping Policy', default='direct', required=True,
+        help="It specifies goods to be transferred partially or all at once")
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/stock/views/stock_picking_type_views.xml
+++ b/addons/stock/views/stock_picking_type_views.xml
@@ -105,6 +105,7 @@
                                     <field invisible="code not in ['incoming', 'outgoing', 'internal']" name="return_picking_type_id" string="Returns Type"/>
                                     <field name="default_location_return_id" invisible="code not in ['incoming', 'outgoing', 'internal']" groups="stock.group_stock_multi_locations"/>
                                     <field name="create_backorder"/>
+                                    <field name="shipping_policy" invisible="code != 'internal'"/>
                                 </group>
                             </group>
                             <group name="second">


### PR DESCRIPTION
In this commit
==============
- Added a new field shipping_policy in stock_picking_type model
- This field is visible only for internal transfer type.

task  4080756