### PR TITLE
[FIX] l10n_es: include receipts in the VAT Record books

### DIFF
--- a/addons/l10n_es/models/account_move.py
+++ b/addons/l10n_es/models/account_move.py
@@ -11,6 +11,8 @@ class AccountMove(models.Model):
     @api.depends('partner_id')
     def _compute_l10n_es_is_simplified(self):
         simplified_partner = self.env.ref('l10n_es.partner_simplified', raise_if_not_found=False)
-        if simplified_partner:
-            for move in self:
-                move.l10n_es_is_simplified = (move.partner_id == simplified_partner)
+        for move in self:
+            move.l10n_es_is_simplified = (
+                (not move.partner_id and move.move_type in ('in_receipt', 'out_receipt')) or
+                (simplified_partner and move.partner_id == simplified_partner)
+            )


### PR DESCRIPTION
Currently, receipts are not take into account when generating the VAT Record books

### Steps to reproduce

* install `l10n_es_reports`
* switch to a Spanish company
* enable sales (or purchase) receipts in the settings
* create and confirm a sales receipt
* open the generic tax report
* select the dates for the receipt.
* attempt to generate the VAT Record books

You will be met with a traceback.

### Fix

Include receipts and treat them as invoices. (confirmed with JCO)

opw-4053187


Enterprise PR: odoo/enterprise#67621