### PR TITLE
[FIX] web: remove animationFrame from tooltip hoot test mobile

### DIFF
--- a/addons/web/static/tests/core/tooltip/tooltip_service.test.js
+++ b/addons/web/static/tests/core/tooltip/tooltip_service.test.js
@@ -374,8 +374,6 @@ test.tags("mobile")("touch rendering - hold-to-show", async () => {
     expect(".o_popover").toHaveText("hello");
 
     pointerUp("button");
-    await animationFrame();
-    expect(".o_popover").toHaveCount(1);
     await runAllTimers();
     expect(".o_popover").toHaveCount(0);
 });


### PR DESCRIPTION
In the mobile test hold-to-show, the close delay was too short and the await animationFrame() was too much to be sure that the tooltip was still showed. So, it has been removed. There was no await after the pointerUp in the original test (QUnit) to start with.

Build error: 66172699


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
