### PR TITLE
[FIX] point_of_sale: improved error for zero quantity conversion

### DIFF
--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -238,6 +238,35 @@ class StockMove(models.Model):
         # Moves with product_id not in related_order_lines. This can happend e.g. when product_id has a phantom-type bom.
         moves_to_assign = self.filtered(lambda m: m.product_id.id not in lines_data or m.product_id.tracking == 'none'
                                                   or (not m.picking_type_id.use_existing_lots and not m.picking_type_id.use_create_lots))
+
+        # Check for any conversion issues in the moves before setting quantities
+        uoms_with_issues = set()
+        for move in moves_to_assign:
+            converted_qty = move.product_uom._compute_quantity(
+                move.product_uom_qty,
+                move.product_id.uom_id,
+                rounding_method='HALF-UP'
+            )
+            if not converted_qty:
+                uoms_with_issues.add(
+                    (move.product_uom.name, move.product_id.uom_id.name)
+                )
+
+        if uoms_with_issues:
+            error_message_lines = [
+                _("Conversion Error: The following unit of measure conversions result in a zero quantity due to rounding:")
+            ]
+            for uom_from, uom_to in uoms_with_issues:
+                error_message_lines.append(_(' - From "%s" to "%s"', uom_from, uom_to))
+
+            error_message_lines.append(
+                _("\nThis issue occurs because the quantity becomes zero after rounding during the conversion. "
+                "To fix this, adjust the conversion factors or rounding method to ensure that even the smallest quantity in the original unit "
+                "does not round down to zero in the target unit.")
+            )
+
+            raise UserError('\n'.join(error_message_lines))
+
         for move in moves_to_assign:
             move.quantity = move.product_uom_qty
         moves_remaining = self - moves_to_assign


### PR DESCRIPTION
Before this commit, when using a product in a kit with a smaller unit of measure than the base product UoM, and the conversion resulted in a zero quantity, an unclear error message was displayed upon closing the PoS session: "Quantity or Reserved Quantity should be set." This error message lacked sufficient information, making it difficult to diagnose the issue, especially with multiple orders.

This commit enhances the error message to clearly indicate the cause of the problem, providing specific details about the UoM conversion that resulted in a zero quantity.

To reproduce the issue:
1. Create a product with a base UoM in kilograms (kg).
2. Include this product in a kit with a UoM of grams (g).
3. Set the rounding precision for both UoMs to 0.01.
4. Sell one kit through the PoS.

The error would occur due to the quantity conversion from grams to kilograms resulting in zero, given the rounding precision settings.

opw-4084783

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
