### PR TITLE
[FIX] website_event: show s_speaker_bio again in snippets menu

### DIFF
--- a/addons/website_event/views/event_snippets.xml
+++ b/addons/website_event/views/event_snippets.xml
@@ -2,16 +2,6 @@
 <odoo>
 
 <!-- Snippets and options -->
-<template id="snippets" inherit_id="website.snippets">
-    <xpath expr="//t[@id='event_speaker_bio_hook']" position="replace">
-        <t t-snippet="website_event.s_speaker_bio" string="Speaker Bio" t-thumbnail="/website_event/static/src/img/snippets_thumbs/s_speaker_bio.svg"/>
-    </xpath>
-</template>
-
-<template id="snippet_options" inherit_id="website.snippet_options">
-    <xpath expr="//*[@t-set='so_content_addition_selector']" position="inside">, .s_speaker_bio</xpath>
-</template>
-
 <template id="event_searchbar_input_snippet_options" inherit_id="website.searchbar_input_snippet_options" name="event search bar snippet options">
     <xpath expr="//div[@data-js='SearchBar']/we-select[@data-name='scope_opt']" position="inside">
         <we-button data-set-search-type="events" data-select-data-attribute="events" data-name="search_events_opt" data-form-action="/events">Events</we-button>

--- a/addons/website_event/views/snippets/snippets.xml
+++ b/addons/website_event/views/snippets/snippets.xml
@@ -9,6 +9,9 @@
     <xpath expr="//t[@id='event_upcoming_snippet_hook']" position="replace">
         <t t-snippet="website_event.s_events" string="Events" t-thumbnail="/website/static/src/img/snippets_thumbs/s_event_upcoming_snippet.svg"/>
     </xpath>
+    <xpath expr="//t[@id='event_speaker_bio_hook']" position="replace">
+        <t t-snippet="website_event.s_speaker_bio" string="Speaker Bio" t-thumbnail="/website_event/static/src/img/snippets_thumbs/s_speaker_bio.svg"/>
+    </xpath>
 </template>
 
 <template id="snippet_options" inherit_id="website.snippet_options" name="Event snippet options">
@@ -83,6 +86,9 @@
                          data-reload="/"/>
         </div>
     </xpath>
+
+    <!-- Speaker Bio -->
+    <xpath expr="//*[@t-set='so_content_addition_selector']" position="inside">, .s_speaker_bio</xpath>
 </template>
 
 </odoo>


### PR DESCRIPTION
The `s_speaker_bio` (Speaker Bio) snippet doesn't show anymore in the list of drag-and-droppable snippets in the snippets menu on the website editor.

Steps to reproduce:
- Open website editor
- Enter edit mode
- There is no "Speaker Bio" snippet (under "Inner Content" category)

This bug was introduced in this commit [1], the file `snippets/snippets.xml` was introduced which added a new `snippets` and `snippet_options` templates.

However, these template ids are already used in
`views/event_snippets.xml` in the same module, which means these have a duplicate ir.ui.view id and one of those doesn't show.

To fix this, this commit resolves the template id collisions.

[1]: b5c87d86cad1aa2b44f805da0b2d6635aeb85b96

task-4084801
