### PR TITLE
[REM] requirements: remove cbor2 requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,6 @@
 # python3-* equivalent distributed in Ubuntu 22.04 and Debian 11
 Babel==2.9.1 ; python_version < '3.11'  # min version = 2.6.0 (Focal with security backports)
 Babel==2.10.3 ; python_version >= '3.11'
-cbor2==5.4.2 ; python_version < '3.12'
-cbor2==5.6.2 ; python_version >= '3.12'
 chardet==4.0.0 ; python_version < '3.11'  # (Jammy)
 chardet==5.2.0 ; python_version >= '3.11'
 cryptography==3.4.8; python_version < '3.12'  # incompatibility between pyopenssl 19.0.0 and cryptography>=37.0.0


### PR DESCRIPTION
Mistakenly backported.

Needed from saas-17.4 up to master