### PR TITLE
[IMP] web: add debug=1 as command

### DIFF
--- a/addons/web/static/src/core/debug/debug_providers.js
+++ b/addons/web/static/src/core/debug/debug_providers.js
@@ -51,6 +51,13 @@ commandProviderRegistry.add("debug", {
             if (options.searchValue.toLowerCase() === debugKey) {
                 result.push({
                     action() {
+                        router.pushState({ debug: "1" }, { reload: true });
+                    },
+                    category: "debug",
+                    name: `${_t("Activate debug mode")} (${debugKey})`,
+                });
+                result.push({
+                    action() {
                         router.pushState({ debug: "assets" }, { reload: true });
                     },
                     category: "debug",


### PR DESCRIPTION
Before this commit, you could only enable debug=assets, which incurs extra cost and does not serve the same purpose. Now, you can choose between light mode or the more costly mode.
