### PR TITLE
[FIX] l10n_mx_edi : CFDI payment cancellation

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -1150,7 +1150,7 @@ class AccountPayment(models.Model):
         self.move_id.button_cancel()
 
     def button_request_cancel(self):
-        self.move_id.button_request_cancel()
+        return self.move_id.button_request_cancel()
 
     def action_draft(self):
         ''' posted -> draft '''


### PR DESCRIPTION
Missing return in the function, as now there is a wizard, without the return the wizard doesn't appear.

linked:https://github.com/odoo/enterprise/pull/67630

task-3894308