### PR TITLE
[FIX] analytic: Allow `analytic_distribution` in filtered_domain

### DIFF
--- a/addons/analytic/models/analytic_mixin.py
+++ b/addons/analytic/models/analytic_mixin.py
@@ -3,6 +3,7 @@
 from odoo import models, fields, api, _
 from odoo.tools import SQL
 from odoo.tools.float_utils import float_round, float_compare
+from odoo.tools.misc import flatten
 from odoo.exceptions import UserError, ValidationError
 
 class AnalyticMixin(models.AbstractModel):
@@ -87,6 +88,17 @@ class AnalyticMixin(models.AbstractModel):
         domain = self._apply_analytic_distribution_domain(domain)
         return super().read_group(domain, fields, groupby, offset, limit, orderby, lazy)
 
+    def mapped(self, func):
+        # Get the related analytic accounts as a recordset instead of the distribution
+        if func == 'analytic_distribution' and self.env.context.get('distribution_ids'):
+            return self.env['account.analytic.account'].browse(flatten(record._get_analytic_account_ids() for record in self))
+        return super().mapped(func)
+
+    def filtered_domain(self, domain):
+        # Filter based on the accounts used (i.e. allowing a name_search) instead of the distribution
+        # A domain on a binary field doesn't make sense anymore outside of set or not; and it is still doable.
+        return super(AnalyticMixin, self.with_context(distribution_ids=True)).filtered_domain(domain)
+
     def write(self, vals):
         """ Format the analytic_distribution float value, so equality on analytic_distribution can be done """
         decimal_precision = self.env['decimal.precision'].precision_get('Percentage Analytic')
@@ -134,4 +146,4 @@ class AnalyticMixin(models.AbstractModel):
     def _get_analytic_account_ids(self) -> list[int]:
         """ Get the analytic account ids from the analytic_distribution dict """
         self.ensure_one()
-        return [int(account_id) for ids in self.analytic_distribution for account_id in ids.split(',')]
+        return [int(account_id) for ids in (self.analytic_distribution or {}) for account_id in ids.split(',')]

--- a/addons/analytic/tests/__init__.py
+++ b/addons/analytic/tests/__init__.py
@@ -2,3 +2,4 @@
 
 from . import test_analytic_account
 from . import test_plan_operations
+from . import test_analytic_mixin

--- a/addons/analytic/tests/test_analytic_mixin.py
+++ b/addons/analytic/tests/test_analytic_mixin.py
@@ -1,0 +1,116 @@
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged('post_install', '-at_install')
+class TestAnalyticMixin(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.analytic_plan = cls.env['account.analytic.plan'].create({
+            'name': 'Plan',
+        })
+
+        cls.sales_aa = cls.env['account.analytic.account'].create({'name': 'Sales', 'plan_id': cls.analytic_plan.id})
+        cls.administrative_aa = cls.env['account.analytic.account'].create({'name': 'Administrative', 'plan_id': cls.analytic_plan.id})
+        cls.rd_aa = cls.env['account.analytic.account'].create({'name': 'Research & Development', 'plan_id': cls.analytic_plan.id})
+        cls.commercial_aa = cls.env['account.analytic.account'].create({'name': 'Commercial', 'plan_id': cls.analytic_plan.id})
+        cls.marketing_aa = cls.env['account.analytic.account'].create({'name': 'Marketing', 'plan_id': cls.analytic_plan.id})
+        cls.com_marketing_aa = cls.env['account.analytic.account'].create({'name': 'Commercial & Marketing', 'plan_id': cls.analytic_plan.id})
+
+        cls.product_a = cls.env['product.product'].create({
+            'name': 'product_a',
+            'lst_price': 1000.0,
+        })
+
+    def test_filtered_domain(self):
+        """
+            This test covers the filtered_domain override on analytic.mixin.
+            It is supposed to handle the use of analytic_distribution with the following operators
+            with a string representing the analytic account name :
+                - `=`
+                - `!=`
+                - `ilike`,
+                - `not ilike`,
+            and the "in" operator used to directly indicate a tuple/list of analytic account ids.
+            This test verifies that the public method handles all these operators.
+        """
+        self.move = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'date': '2023-02-01',
+            'invoice_date': '2023-02-01',
+            'invoice_line_ids': []
+        })
+
+        self.aml_sales_admin_ad = self.env['account.move.line'].create({
+            'product_id': self.product_a.id,
+            'price_unit': 1000.0,
+            'analytic_distribution': {
+                self.sales_aa.id: 50,
+                self.administrative_aa.id: 50
+            },
+            'move_id': self.move.id
+        })
+
+        self.aml_rd_ad = self.env['account.move.line'].create({
+            'product_id': self.product_a.id,
+            'price_unit': 1000.0,
+            'analytic_distribution': {
+                self.rd_aa.id: 100,
+            },
+            'move_id': self.move.id
+        })
+
+        self.aml_commercial_ad = self.env['account.move.line'].create({
+            'product_id': self.product_a.id,
+            'price_unit': 1000.0,
+            'analytic_distribution': {
+                self.commercial_aa.id: 100,
+            },
+            'move_id': self.move.id
+        })
+
+        self.aml_com_marketing_ad = self.env['account.move.line'].create({
+            'product_id': self.product_a.id,
+            'price_unit': 1000.0,
+            'analytic_distribution': {
+                self.com_marketing_aa.id: 100,
+            },
+            'move_id': self.move.id
+        })
+
+        self.aml_without_ad = self.env['account.move.line'].create({
+            'product_id': self.product_a.id,
+            'price_unit': 100.0,
+            'move_id': self.move.id
+        })
+
+        self.aml_without_ad_1 = self.env['account.move.line'].create({
+            'product_id': self.product_a.id,
+            'price_unit': 100.0,
+            'move_id': self.move.id
+        })
+
+        def filter_domain(comparator, value):
+            return self.move.invoice_line_ids.filtered_domain([('analytic_distribution', comparator, value)])
+
+        self.assertEqual(filter_domain('=', 'Research & Development'), self.aml_rd_ad)
+        self.assertEqual(filter_domain('=', 'Sales'), self.aml_sales_admin_ad)
+        self.assertEqual(filter_domain('=', 'Administrative'), self.aml_sales_admin_ad)
+        self.assertEqual(filter_domain('=', 'Commercial'), self.aml_commercial_ad)
+        self.assertFalse(filter_domain('=', ''))  # Should returns an empty recordset
+        self.assertEqual(filter_domain('=', self.commercial_aa.id), self.aml_commercial_ad)
+
+        self.assertEqual(filter_domain('ilike', 'Commercial'), self.aml_commercial_ad | self.aml_com_marketing_ad)
+        self.assertEqual(filter_domain('ilike', ''), self.move.invoice_line_ids - self.aml_without_ad - self.aml_without_ad_1)
+
+        self.assertEqual(filter_domain('not ilike', 'Commercial'), self.move.invoice_line_ids - self.aml_com_marketing_ad - self.aml_commercial_ad)
+        self.assertEqual(filter_domain('not ilike', ''), self.aml_without_ad + self.aml_without_ad_1)  # Should returns an AML without analytic_distribution
+
+        self.assertEqual(filter_domain('!=', 'Commercial & Marketing'), self.move.invoice_line_ids - self.aml_com_marketing_ad)
+        self.assertEqual(filter_domain('!=', ''), self.move.invoice_line_ids)  # Should returns an every AML
+        self.assertEqual(filter_domain('!=', self.commercial_aa.id), self.move.invoice_line_ids - self.aml_commercial_ad)
+
+        self.assertEqual(filter_domain('in', [self.commercial_aa.id]), self.aml_commercial_ad)
+        self.assertEqual(filter_domain('in', (self.sales_aa + self.rd_aa).ids), self.aml_sales_admin_ad + self.aml_rd_ad)


### PR DESCRIPTION
This commit adapts the `analytic_distribution` field with `filtered_domain` method.

Since the `analytic_distribution` field is a JSON field, it is not natively supported by the methods (search, filtered_domain, etc.). The `analytic.mixin` mixin already handles `search` and `read_group` by applying its own logic in overrides of these.

This fix is therefore similar and overrides `filtered_domain` and `mapped` (which is used by the latter).

An example of a flow where this case is problematic is when adding an approval rule via studio (a feature enabling, for example, some methods/buttons to be clickable only if the user is authorized).

To do this, the user must enter a domain, thus filtering the records on which he wishes to apply the approval rule.

In our case, using “analytic_distribution” in a domain doesn't work, because studio uses a `filtered_domain` to find out whether the current record corresponds to the condition set by the domain.

But once in `filtered_domain` we arrive here

https://github.com/odoo/odoo/blob/b527b8643400f4bca74aeb397cde9e5d260f01ff/odoo/models.py#L6203-L6204

`record.mapped(key)` where key is `analytic_distribution` returns the entire JSON object, in the form of an object array containing as key a comma-separated list of ids whose value is a float, for example: `{“16,17”: 100.0}`.

Since our domain in this case looks something like `[“analytic_distribution”, “=”, “Administrative”]`

we compare `Administrative` with `{“16,17”: 100.0}` and `filtered_domain` returns False and our record is never detected.

So this fix is in two parts,

first, we make sure that mapped doesn't return the whole `analytic_distribution` object, but just the values we're interested in: the ids. To do this, we use the method already available in `analytic.mixin`: `_get_analytic_account_ids`.

So instead of comparing `Administrative` with `{“16,17”: 100.0}`, we'll compare the id directly, so something like comparing `Administrative` with `[16,17]`.

Now that we have a clean list of ids, we can replace the display name `Administrative` with its id to compare ids with ids.

To do this, we'll override `filtered_domain` so that if we call it with the following domain `[“analytic_distribution”, “=”, “Administrative”]`, we'll rewrite the domain to facilitate the final call of the real `filtered_domain` method. The result is: `[“analytic_distribution”, “=”, [17]]`.

Proceed in the same way as in `_search_analytic_distribution` to retrieve the id using a `name_search`.

https://github.com/odoo/odoo/blob/d6bdb05771fd29a79f2e8087b92a438fec28afaa/addons/analytic/models/analytic_mixin.py#L51-L58

opw-4002202