### PR TITLE
[FIX] l10n_gcc_invoice: prioritize line label over product display name

### DIFF
--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -281,7 +281,7 @@
                                         <span t-field="line.product_uom_id" groups="uom.group_uom"/>
                                     </td>
                                     <td name="account_invoice_line_name">
-                                        <t t-set="line_name" t-value="line.with_context(lang=o.partner_id.lang).product_id.display_name or line.name"/>
+                                        <t t-set="line_name" t-value="line.name or line.with_context(lang=o.partner_id.lang).product_id.display_name"/>
                                         <span t-out="line_name" t-options="{'widget': 'text'}" t-att-dir="o.env['res.lang']._lang_get_direction(o.partner_id.lang)"/>
                                     </td>
 


### PR DESCRIPTION
### Steps to reproduce

* install `l10n_sa`
* create a new invoice and add a line with a product and a custom label.
* print the invoice

You will see in the 'Description' column that the product's display name is shown instead of the label you set

opw-4071925