### PR TITLE
[IMP] sale_project: copy the company of the project template

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -130,6 +130,16 @@ class SaleOrder(models.Model):
             # Orders from different companies are confirmed together
             for order in self:
                 order.order_line.sudo().with_company(order.company_id)._timesheet_service_generation()
+
+        # If the order has exactly one project and that project comes from a template, set the company of the template
+        # on the project.
+        for order in self:
+            if len(order.project_ids) == 1:
+                project = order.project_ids[0]
+                for sol in order.order_line:
+                    if project == sol.project_id and (project_template := sol.product_template_id.project_template_id):
+                        project.sudo().company_id = project_template.sudo().company_id
+                        break
         return super()._action_confirm()
 
     def action_view_task(self):

--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -196,7 +196,7 @@ class SaleOrderLine(models.Model):
     def _timesheet_create_project(self):
         """ Generate project for the given so line, and link it.
             :param project: record of project.project in which the task should be created
-            :return task: record of the created task
+            :return: record of the created project
         """
         self.ensure_one()
         values = self._timesheet_create_project_prepare_values()


### PR DESCRIPTION
When a product in a sales order creates a project, we set the company of the sales order on the project.
However, it would make sense to use the company of the project template, if there is one, so that we can for instance use a template with no company to make all the generated projects public to all companies.
With this PR, we now set the company of the template on the generated project whenever possible.

Task-3940637