### PR TITLE
[FIX] web: update record if input field set to default

### DIFF
--- a/addons/web/static/src/views/fields/input_field_hook.js
+++ b/addons/web/static/src/views/fields/input_field_hook.js
@@ -71,15 +71,12 @@ export function useInputField(params) {
             }
 
             if (!isInvalid) {
-                if (val !== component.props.record.data[component.props.name]) {
-                    lastSetValue = inputRef.el.value;
-                    pendingUpdate = true;
-                    await component.props.record.update({ [component.props.name]: val });
-                    pendingUpdate = false;
-                    component.props.record.model.bus.trigger("FIELD_IS_DIRTY", isDirty);
-                } else {
-                    inputRef.el.value = params.getValue();
-                }
+                lastSetValue = inputRef.el.value;
+                pendingUpdate = true;
+                await component.props.record.update({ [component.props.name]: val });
+                pendingUpdate = false;
+                component.props.record.model.bus.trigger("FIELD_IS_DIRTY", isDirty);
+                inputRef.el.value = params.getValue();
             }
         }
     }

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -14871,4 +14871,33 @@ QUnit.module("Views", (hooks) => {
             assert.verifySteps(["web_save"]);
         }
     );
+
+    QUnit.test("onchange should be triggered if the value of a field is set to its default value", async function (assert) {
+        let edited = false;
+        serverData.models.partner.onchanges = {
+            qux(record) {
+                if (edited) {
+                    record.display_name = "new value";
+                }
+            }
+        };
+
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `<form>
+                <field name="display_name" required="1"/>
+                <field name="qux"/>
+            </form>`,
+        });
+
+        edited = true;
+        await editInput(target, "[name='qux'] input", 0);
+
+        assert.strictEqual(
+            target.querySelector("[name='display_name'] input").value,
+            "new value"
+        );
+    });
 });


### PR DESCRIPTION
Steps
-----
1. Inventory > Operations > Adjustments > Physical inventory
2. On a line with a positive on hand quantity but no counted quantity set, enter a value of 0. Click outside of the input field so it loses focus.
-> The difference stays at 0 (should be negative). Works as excepted if the value entered is any other than 0.

Cause
-----
Commit dcba2a87b7ab15b357d57c410868f19e829a8db0 made it so the record is not updated if the value entered by the user is the same than the value present in the record.
https://github.com/odoo/odoo/blob/dcba2a87b7ab15b357d57c410868f19e829a8db0/addons/web/static/src/views/fields/input_field_hook.js#L74 As a result, there's no onchange sent and the "Difference" isn't computed. We revert that while keeping the formating issue change.

opw-4063994
opw-4064858
