### PR TITLE
[FIX] web: align records button

### DIFF
--- a/addons/web/static/src/legacy/scss/fields.scss
+++ b/addons/web/static/src/legacy/scss/fields.scss
@@ -543,7 +543,6 @@
             position: relative;
 
             > .o_field_domain_panel {
-                @include o-position-absolute(0, 0);
                 margin-top: 0;
             }
         }


### PR DESCRIPTION
The position of the records button was set to absolute with top: 0 and right: 0, which caused it to always hide the text and/or button of the selection (all/any). The fix applied is to show it in the same position as in version 17.0 (at the bottom of the conditions)

Steps to reproduce:

- Switch to French

- Go to data cleaning - model data_merge.model

- Edit the domain by adding one other condition

- Try to switch between ALL and ANY for the conditions

opw-3890382

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr