### PR TITLE
[FIX] hw_drivers: fix error updating status of electronic scale

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/SerialBaseDriver.py
+++ b/addons/hw_drivers/iot_handlers/drivers/SerialBaseDriver.py
@@ -57,6 +57,7 @@ class SerialDriver(Driver):
     STATUS_CONNECTED = 'connected'
     STATUS_ERROR = 'error'
     STATUS_CONNECTING = 'connecting'
+    STATUS_DISCONNECTED = 'disconnected'
 
     def __init__(self, identifier, device):
         """ Attributes initialization method for `SerialDriver`.
@@ -137,6 +138,8 @@ class SerialDriver(Driver):
                 while not self._stopped.is_set():
                     self._take_measure()
                     time.sleep(self._protocol.newMeasureDelay)
+                self._status['status'] = self.STATUS_DISCONNECTED
+                self._push_status()
         except Exception:
             msg = _('Error while reading %s', self.device_name)
             _logger.exception(msg)


### PR DESCRIPTION
**Before commit**
  - When the electronic scale is disconnected, its connection status is not updated.

**After commit**
  - When the electronic scale is disconnected, the status of the electronic scale will be updated.

**Error Description**
  - If you have a digital scale that is connected and selected for use in POS.
  - The status of IoT devices is updated via the router `/hw_proxy/status_json` and the function `get_status()`
  - However, the status of the digital scale is not updated when it is disconnected. This leads to the scale still reporting that it is connected when calling the `get_status()` function.
 
The scale status is updated via `self._status`
https://github.com/odoo/odoo/blob/8ff2381901e4920434eaee73f8c265fc67271c99/addons/hw_drivers/iot_handlers/drivers/SerialScaleDriver.py#L110-L114

However `self._status` is not updated when disconnected.
https://github.com/odoo/odoo/blob/8ff2381901e4920434eaee73f8c265fc67271c99/addons/hw_drivers/iot_handlers/drivers/SerialBaseDriver.py#L129-L144

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
