### PR TITLE
[FIX] purchase: fix product display name

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -465,7 +465,7 @@ class ProductProduct(models.Model):
         return super()._search(domain, offset, limit, order, access_rights_uid)
 
     @api.depends('name', 'default_code', 'product_tmpl_id')
-    @api.depends_context('display_default_code', 'seller_id', 'company_id', 'partner_id')
+    @api.depends_context('display_default_code', 'seller_id', 'company_id', 'partner_id', 'use_partner_name')
     def _compute_display_name(self):
 
         def get_display_name(name, code):
@@ -473,7 +473,7 @@ class ProductProduct(models.Model):
                 return f'[{code}] {name}'
             return name
 
-        partner_id = self._context.get('partner_id')
+        partner_id = self._context.get('partner_id') if self.env.context.get('use_partner_name', True) else self.env['res.partner']
         if partner_id:
             partner_ids = [partner_id, self.env['res.partner'].browse(partner_id).commercial_partner_id.id]
         else:

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -235,7 +235,7 @@
                                         readonly="state in ('purchase', 'to approve', 'done', 'cancel')"
                                         required="not display_type"
                                         width="35%"
-                                        context="{'partner_id':parent.partner_id, 'quantity':product_qty, 'company_id': parent.company_id}"
+                                        context="{'partner_id': parent.partner_id, 'quantity': product_qty, 'company_id': parent.company_id, 'use_partner_name': False}"
                                         force_save="1" domain="[('purchase_ok', '=', True)]"/>
                                     <field name="name" widget="section_and_note_text"/>
                                     <field name="date_planned" optional="hide" required="not display_type" force_save="1"/>


### PR DESCRIPTION
Combining purchase order line and product supplier info for orders with multiple pages results in inconsistent behavior:
- products on first page shows the internal references and names
- subsequent pages shows the supplier's codes and names. It is better to display the internals for the product field and keep the supplier codes and names for the description field.

Therefore, the search has also been fixed accordingly.

task: 4040598 (see also 3893787)

see also https://github.com/odoo/odoo/pull/113527

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
