### PR TITLE
[IMP] website_sale: skip signature request for e-commerce orders

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -80,6 +80,11 @@ class SaleOrder(models.Model):
             else:
                 order.is_abandoned_cart = False
 
+    def _compute_require_signature(self):
+        website_orders = self.filtered('website_id')
+        website_orders.require_signature = False
+        super(SaleOrder, self - website_orders)._compute_require_signature()
+
     def _compute_payment_term_id(self):
         super()._compute_payment_term_id()
         website_orders = self.filtered(


### PR DESCRIPTION
Prior this commit:
-The setting 'portal_confirmation_sign' is true by default and invisible if only ecommerce is installed.
-Customers could receive an email to sign the quote, confirming it and triggering delivery without payment.

Post this commit:
-Ecommerce orders will no longer require a signature.

task:4075358

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
