### PR TITLE
Add shipping policy to picking type for internal transfers

### DIFF
--- a/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
+++ b/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
@@ -787,3 +787,19 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
             else:
                 self.assertEqual(len(picking.move_ids_without_package), 2, "Should have 2 moves for: Comp1 and Comp2")
                 self.assertEqual([move.product_id for move in picking.move_ids_without_package.sorted('product_id')], [comp1, comp2])
+
+    def test_pick_components_uses_shipping_policy_from_picking_type(self):
+        self.warehouse.manufacture_steps = "pbm"
+        pick_components_type = self.warehouse.pbm_type_id
+
+        for move_type in ["direct", "one"]:
+            pick_components_type.move_type = move_type
+
+            mo = self.env["mrp.production"].create({
+                "bom_id": self.bom.id,
+                "location_src_id": self.warehouse.pbm_loc_id.id,
+            })
+            mo.action_confirm()
+
+            self.assertEqual(mo.picking_ids[0].picking_type_id, pick_components_type)
+            self.assertEqual(mo.picking_ids[0].move_type, move_type)

--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -17,15 +17,6 @@ class StockMove(models.Model):
     sale_line_id = fields.Many2one('sale.order.line', 'Sale Line', index='btree_not_null')
 
     @api.model
-    def default_get(self, fields_list):
-        defaults = super().default_get(fields_list)
-        model = self.env.context.get('active_model')
-        so_id = self.env.context.get('active_id')
-        if model == 'sale.order' and so_id:
-            defaults['group_id'] = self.env[model].browse(so_id).procurement_group_id.id
-        return defaults
-
-    @api.model
     def _prepare_merge_moves_distinct_fields(self):
         distinct_fields = super(StockMove, self)._prepare_merge_moves_distinct_fields()
         distinct_fields.append('sale_line_id')

--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -1233,36 +1233,6 @@ class TestSaleStock(TestSaleStockCommon, ValuationReconciliationTestCommon):
         # Check that the remaining quantity is set on the retrun
         self.assertEqual(return_wizard.product_return_moves.quantity, 8)
 
-    def test_create_picking_from_so(self):
-        sale_order = self._get_new_sale_order()
-        sale_order.action_confirm()
-        self.assertEqual(len(sale_order.picking_ids), 1)
-        context = {
-            'active_model': 'sale.order',
-            'active_id': sale_order.id
-        }
-        self.env['stock.picking'].with_context(context).create({
-            'picking_type_id': sale_order.picking_ids.picking_type_id.id,
-            'move_ids': [(0, 0, {
-                'name': 'test move',
-                'product_id': self.company_data['product_delivery_no'].id,
-                'product_uom_qty': 1,
-                'location_id': sale_order.picking_ids.location_id.id,
-                'location_dest_id': sale_order.picking_ids.location_dest_id.id,
-            })]
-        })
-        self.assertEqual(len(sale_order.picking_ids), 2)
-        self.env['stock.picking'].with_context(context).create({
-            'name': 'test move line',
-            'picking_type_id': sale_order.picking_ids.picking_type_id.id,
-            'move_line_ids': [(0, 0, {
-                'product_id': self.company_data['product_delivery_no'].id,
-                'location_id': sale_order.picking_ids.location_id.id,
-                'location_dest_id': sale_order.picking_ids.location_dest_id.id,
-            })]
-        })
-        self.assertEqual(len(sale_order.picking_ids), 3)
-
     def test_return_with_mto_and_multisteps(self):
         """
         Suppose a product P and a 3-steps delivery.

--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -1999,3 +1999,16 @@ class TestSaleStock(TestSaleStockCommon, ValuationReconciliationTestCommon):
         ship02.move_ids.write({'quantity': 7, 'picked': True})
         ship02.button_validate()
         self.assertEqual(so.delivery_status, 'full')
+
+    def test_so_delivery_ignores_shipping_policy_from_picking_type(self):
+        picking_type_out = self.company_data['default_warehouse'].out_type_id
+        picking_type_out.move_type = "direct"
+
+        so = self._get_new_sale_order()
+        # Ignore picking_type_out, use the value from SO
+        so.picking_policy = "one"
+        so.action_confirm()
+
+        self.assertEqual(so.procurement_group_id.move_type, "one")
+        self.assertEqual(so.picking_ids[0].picking_type_id, picking_type_out)
+        self.assertEqual(so.picking_ids[0].move_type, "one")

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1425,7 +1425,7 @@ Please change the quantity done or the rounding precision of your unit of measur
             'origin': origin,
             'company_id': self.mapped('company_id').id,
             'user_id': False,
-            'move_type': self.mapped('group_id').move_type or 'direct',
+            'group_id': self.mapped('group_id').id,
             'partner_id': partner,
             'picking_type_id': self.mapped('picking_type_id').id,
             'location_id': self.mapped('location_id').id,

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -436,10 +436,10 @@ class ProcurementGroup(models.Model):
         'Reference',
         default=lambda self: self.env['ir.sequence'].next_by_code('procurement.group') or '',
         required=True)
-    move_type = fields.Selection([
-        ('direct', 'Partial'),
-        ('one', 'All at once')], string='Delivery Type', default='direct',
-        required=True)
+    move_type = fields.Selection(
+        [('direct', 'Partial'), ('one', 'All at once')],
+        string='Delivery Type'
+    )
     stock_move_ids = fields.One2many('stock.move', 'group_id', string="Related Stock Moves")
 
     @api.model

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -6851,3 +6851,15 @@ class StockMove(TransactionCase):
         })
         receipt.action_confirm()
         self.assertNotEqual(old_reference, receipt.move_ids.reference)
+
+    def test_internal_picking_uses_shipping_policy_from_picking_type(self):
+        picking_type_internal = self.env.ref('stock.picking_type_internal')
+
+        for move_type in ["direct", "one"]:
+            picking_type_internal.move_type = move_type
+
+            picking = self.env['stock.picking'].create({
+                'picking_type_id': picking_type_internal.id,
+            })
+
+            self.assertEqual(picking.move_type, move_type)

--- a/addons/stock/views/stock_picking_type_views.xml
+++ b/addons/stock/views/stock_picking_type_views.xml
@@ -105,6 +105,7 @@
                                     <field invisible="code not in ['incoming', 'outgoing', 'internal']" name="return_picking_type_id" string="Returns Type"/>
                                     <field name="default_location_return_id" invisible="code not in ['incoming', 'outgoing', 'internal']" groups="stock.group_stock_multi_locations"/>
                                     <field name="create_backorder"/>
+                                    <field name="move_type" help="Unless previously specified by the source document, this will be the default picking policy for this operation type." invisible="code != 'internal'"/>
                                 </group>
                             </group>
                             <group name="second">


### PR DESCRIPTION
* add shipping policy to picking type for internal transfers
* make the move type in picking and procurement group non-required
* if procurement group's move type is defined, use it as picking's move type
* otherwise use picking type's shipping policy

task  4080756