### PR TITLE
[FIX] ir_sequence: prevent an error when generate a sequences

### DIFF
--- a/odoo/addons/base/models/ir_sequence.py
+++ b/odoo/addons/base/models/ir_sequence.py
@@ -232,7 +232,7 @@ class IrSequence(models.Model):
         try:
             interpolated_prefix = _interpolate(self.prefix, d)
             interpolated_suffix = _interpolate(self.suffix, d)
-        except (ValueError, TypeError):
+        except (ValueError, TypeError, KeyError):
             raise UserError(_('Invalid prefix or suffix for sequence \'%s\'') % self.name)
         return interpolated_prefix, interpolated_suffix
 

--- a/odoo/addons/base/tests/test_ir_sequence.py
+++ b/odoo/addons/base/tests/test_ir_sequence.py
@@ -192,6 +192,21 @@ class TestIrSequenceGenerate(BaseCase):
             with self.assertRaises(UserError):
                 env['ir.sequence'].next_by_code('test_sequence_type_7')
 
+    def test_ir_sequence_suffix(self):
+        """ test whether the raise a user error for an invalid sequence """
+
+        # try to create a sequence with invalid suffix
+        with environment() as env:
+            seq = env['ir.sequence'].create({
+                'code': 'test_sequence_type_8',
+                'name': 'Test sequence',
+                'prefix': '',
+                'suffix': '/%(Y)s',
+            })
+            self.assertTrue(seq)
+            with self.assertRaises(UserError):
+                env['ir.sequence'].next_by_code('test_sequence_type_8')
+
     @classmethod
     def tearDownClass(cls):
         drop_sequence('test_sequence_type_5')


### PR DESCRIPTION
Currently, an error occurs when generating a sequence with an invalid prefix or suffix.

Step to produce:

- Install the `mrp` module as an example (ensure developer mode is enabled).
- Go to Settings / Technical / Sequences & Identifiers / Sequences, Open 'stock.lot.serial', and add '/%(Y)s' as a suffix.
- Create a new product by lots, Open 'Manufacturing Orders'  and create an order with that new product.
- Confirm this order, And then click on mark as done and apply immediate production.


Traceback On Sentry:
```
KeyError: 'Y'
  File "odoo/http.py", line 2248, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1823, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1843, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1821, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1828, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2053, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 220, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 756, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 38, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 34, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 458, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/web/models/models.py", line 73, in web_save
    self = self.create(vals)
  File "<decorator-gen-247>", line 2, in create
  File "odoo/api.py", line 420, in _model_create_multi
    return create(self, [arg])
  File "addons/sale/models/sale_order.py", line 807, in create
    vals['name'] = self.env['ir.sequence'].next_by_code(
  File "odoo/addons/base/models/ir_sequence.py", line 292, in next_by_code
    return seq_id._next(sequence_date=sequence_date)
  File "odoo/addons/base/models/ir_sequence.py", line 265, in _next
    return self._next_do()
  File "odoo/addons/base/models/ir_sequence.py", line 207, in _next_do
    return self.get_next_char(number_next)
  File "odoo/addons/base/models/ir_sequence.py", line 242, in get_next_char
    interpolated_prefix, interpolated_suffix = self._get_prefix_suffix()
  File "odoo/addons/base/models/ir_sequence.py", line 236, in _get_prefix_suffix
    interpolated_suffix = _interpolate(self.suffix, d)
  File "odoo/addons/base/models/ir_sequence.py", line 211, in _interpolate
    return (s % d) if s else ''

```

An error occurs when the user provides an invalid suffix in ir_sequence and the system tries to generate that sequence at [1].

link [1]: https://github.com/odoo/odoo/blob/27ba460e4051e4045ff1e93dcaa94293ab5706d5/odoo/addons/base/models/ir_sequence.py#L232

To resolve the issue, raise a user error for an invalid sequence.

Sentry-5656428786, 6187435365, 6330909193

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
