### PR TITLE
[FIX] sale_timesheet: correct the domain of task's sale order item

### DIFF
--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -131,13 +131,13 @@
                         column_invisible="not parent.allow_billable"
                         readonly="readonly_timesheet"
                         context="{'with_remaining_hours': True, 'with_price_unit': True}" options="{'no_create': True, 'no_open': True}"
-                        domain="[('is_service', '=', True), ('order_partner_id', 'child_of', parent.partner_id), ('is_expense', '=', False), ('state', '=', 'sale'), ('is_downpayment', '=', False)]"
+                        domain="[('is_service', '=', True), ('order_partner_id.commercial_partner_id.id', 'parent_of', parent.partner_id), ('is_expense', '=', False), ('state', '=', 'sale'), ('is_downpayment', '=', False)]"
                         optional="hide"/>
                     <field name="so_line" widget="so_line_field" groups="sales_team.group_sale_salesman"
                         column_invisible="not parent.allow_billable"
                         readonly="readonly_timesheet"
                         context="{'with_remaining_hours': True, 'with_price_unit': True}" options="{'no_create': True, 'no_open': True}"
-                        domain="[('is_service', '=', True), ('order_partner_id', 'child_of', parent.partner_id), ('is_expense', '=', False), ('state', '=', 'sale'), ('is_downpayment', '=', False)]"
+                        domain="[('is_service', '=', True), ('order_partner_id.commercial_partner_id.id', 'parent_of', parent.partner_id), ('is_expense', '=', False), ('state', '=', 'sale'), ('is_downpayment', '=', False)]"
                         optional="hide"/>
                 </xpath>
                 <xpath expr="//field[@name='remaining_hours']" position="after">


### PR DESCRIPTION
Steps:
- Create a contact with two sub-contacts: Sub1 and Sub2.
- Create a service product that generates a project upon order.
- Create a quotation for Sub1 with the created product and confirm it.
- Go to the created project and create a task.
- Edit the task and change the customer to Sub2.
- Add a line in timesheet tab
- Click on the dropdown of the sale order item.

Issue:
- The sale order item does not appear in the dropdown list.

Cause:
- The domain on `sale_line` is incorrect in the timesheet tab in the project task.

Solution:
- Correct the domain to link project timesheets to any sale order related to the company or its children.

task-4081462

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
