### PR TITLE
[IMP] spreadsheet_dashboard: Add edit icon next to dashboard name

### DIFF
--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.js
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.js
@@ -32,6 +32,7 @@ export class SpreadsheetDashboardAction extends Component {
         this.Status = Status;
         this.controlPanelDisplay = {};
         this.orm = useService("orm");
+        this.actionService = useService("action");
         // Use the non-protected orm service (`this.env.services.orm` instead of `useService("orm")`)
         // because spreadsheets models are preserved across multiple components when navigating
         // with the breadcrumb
@@ -126,6 +127,19 @@ export class SpreadsheetDashboardAction extends Component {
      */
     openDashboard(dashboardId) {
         this.state.activeDashboard = this.loader.getDashboard(dashboardId);
+    }
+
+    /**
+     * @param {number} id - The ID of the dashboard to be edited.
+     * @returns {Promise<void>}
+     */
+    async editDashboard(id) {
+        const action = await this.env.services.orm.call(
+            "spreadsheet.dashboard",
+            "action_edit_dashboard",
+            [id]
+        );
+        this.actionService.doAction(action);
     }
 
     async shareSpreadsheet(data, excelExport) {

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.scss
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.scss
@@ -4,21 +4,37 @@
     align-items: center;
 
     ul {
-        padding-inline-start: 0px
+        padding-inline-start: 0px;
     }
 
     li {
         padding: 4px 8px 4px 12px;
         list-style-type: none;
         white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
 
         &:hover:not(.active) {
             background-color: $o-gray-100;
         }
+
+        .o_dashboard_name {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            padding-right: 8px;
+        }
+
+        .o_edit_dashboard {
+            padding: 0;
+            visibility: hidden;
+            opacity: 0;
+            transition: visibility 0.2s, opacity 0.2s ease-in-out;
+        }
     }
 
+    .o_search_panel_category_value:hover .o_edit_dashboard,
+    .o_search_panel_category_value:focus-within .o_edit_dashboard {
+        visibility: visible;
+        opacity: 1;
+    }
 }
 
 .o_spreadsheet_dashboard_action {
@@ -73,7 +89,7 @@
             .o_multi_record_selector {
                 width: 100%;
 
-                .o_input{
+                .o_input {
                     flex: 1 0 1rem;
                 }
             }

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
@@ -78,10 +78,22 @@
                 <ul class="list-group d-block o_search_panel_field">
                     <li t-foreach="group.dashboards" t-as="dashboard" t-key="dashboard.id"
                         t-on-click="() => this.openDashboard(dashboard.id)"
-                        t-esc="dashboard.displayName"
                         t-att-data-name="dashboard.displayName"
-                        class="o_search_panel_category_value list-group-item cursor-pointer border-0"
-                        t-att-class="{'active': dashboard.id === state.activeDashboard.id}"/>
+                        class="o_search_panel_category_value list-group-item cursor-pointer border-0 d-flex justify-content-between align-items-center"
+                        t-att-class="{'active': dashboard.id === state.activeDashboard.id}">
+                        <div class="o_dashboard_name">
+                            <t t-esc="dashboard.displayName" />
+                        </div>
+                        <button
+                            type="button"
+                            class="btn btn-link o_edit_dashboard oi oi-arrow-right"
+                            tabindex="-1"
+                            draggable="false"
+                            aria-label="Edit"
+                            data-tooltip="Edit"
+                            t-on-click.stop="() => this.editDashboard(dashboard.id)"
+                        />
+                    </li>
                 </ul>
             </section>
         </div>


### PR DESCRIPTION
# Description

Previously, users had to navigate to the configuration menu and select the appropriate dashboard section to `Edit` a dashboard.

This PR introduces a new edit icon next to the dashboard name in the dashboard view, enabling users to edit the dashboard directly from the view.

Task: [4066015](https://www.odoo.com/odoo/project/2328/tasks/4066015?cids=2)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
