### PR TITLE
[FIX] base remove `embedded_parent_res_id` in vals if there is no embedded action

### DIFF
--- a/odoo/addons/base/models/ir_filters.py
+++ b/odoo/addons/base/models/ir_filters.py
@@ -117,7 +117,7 @@ class IrFilters(models.Model):
     def create_or_replace(self, vals):
         action_id = vals.get('action_id')
         embedded_action_id = vals.get('embedded_action_id')
-        if not embedded_action_id and vals.get('embedded_parent_res_id'):
+        if not embedded_action_id and 'embedded_parent_res_id' in vals:
             del vals['embedded_parent_res_id']
         embedded_parent_res_id = vals.get('embedded_parent_res_id')
         current_filters = self.get_filters(vals['model_id'], action_id, embedded_action_id, embedded_parent_res_id)

--- a/odoo/addons/base/tests/test_ir_filters.py
+++ b/odoo/addons/base/tests/test_ir_filters.py
@@ -373,3 +373,26 @@ class TestEmbeddedFilters(FiltersCase):
         # If embedded_action_id and embedded_parent_res_id are not set, should return no filters
         filters = self.env['ir.filters'].with_user(self.USER_ID).get_filters('ir.filters')
         self.assertItemsEqual(noid(filters), [])
+
+    def test_global_filters_with_no_embedded_action(self):
+        Filters = self.env['ir.filters'].with_user(self.USER_ID)
+        filter_a = Filters.create_or_replace({
+            'name': 'a',
+            'model_id': 'ir.filters',
+            'user_id': False,
+            'is_default': True,
+            'embedded_action_id': False,
+            'embedded_parent_res_id': 0,
+        })
+        filter_b = Filters.create_or_replace({
+            'name': 'b',
+            'model_id': 'ir.filters',
+            'user_id': self.USER_ID,
+            'is_default': True,
+            'embedded_action_id': False,
+            'embedded_parent_res_id': 1,
+        })
+        self.assertFalse(filter_a.embedded_action_id)
+        self.assertFalse(filter_a.embedded_parent_res_id)
+        self.assertFalse(filter_b.embedded_action_id)
+        self.assertFalse(filter_b.embedded_parent_res_id)


### PR DESCRIPTION
Before this commit, the user can no longer save as favorite his filters
when the action contains no embedded actions.

This commit removes `embedded_parent_res_id` field in `vals` given to
`create_or_replace` method if `embedded_action_id` in the vals is falsy
(or not given in the `vals`) to avoid triggering the constraint
(`check_res_id_only_when_embedded_action`) saying
`embedded_parent_res_id` cannot be set without `embedded_action_id` set.

Steps to reproduce:
==================
1. install project
2. go to project app
3. try to save a filter as favorite

Current Behavior
================
A traceback is occured because the constraint
`check_res_id_only_when_embedded_action` is not respected when the
filter is created. The reason is because the `embedded_parent_res_id`
field is an integer and so if that field is given in the vals with value
equals to false for instance, the value will be given to the create
method and so the ORM will convert false into 0 as the field is a
integer. Becuase of that, `embedded_parent_res_id` is not null and
`embedded_action_id` is null in SQL.

Expected Behavior
=================
The filter should be saved as favorite.