### PR TITLE
[IMP] mrp, repair: b2b improvements

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1199,7 +1199,8 @@ class MrpProduction(models.Model):
     def _set_qty_producing(self, pick_manual_consumption_moves=True):
         if self.product_id.tracking == 'serial':
             qty_producing_uom = self.product_uom_id._compute_quantity(self.qty_producing, self.product_id.uom_id, rounding_method='HALF-UP')
-            if qty_producing_uom != 1:
+            # allow changing a non-zero value to a 0 to not block mass produce feature
+            if qty_producing_uom != 1 and not (qty_producing_uom == 0 and self._origin.qty_producing != self.qty_producing):
                 self.qty_producing = self.product_id.uom_id._compute_quantity(1, self.product_uom_id, rounding_method='HALF-UP')
         for move in (self.move_raw_ids | self.move_finished_ids.filtered(lambda m: m.product_id != self.product_id)):
             # picked + manual means the user set the quantity manually

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -1589,6 +1589,33 @@ class TestMrpOrder(TestMrpCommon):
         mo.action_confirm()
         self.assertEqual(len(mo.move_raw_ids), 2)
 
+    def test_change_sn_tracked_qty_produced(self):
+        """ Checks if qty_producing can be set to 0 after being set to non-zero value """
+        mo_with_serial, _, _, _, _ = self.generate_mo(tracking_final='serial')
+        mo_without_serial, _, _, _, _ = self.generate_mo()
+
+        self.assertEqual(mo_with_serial.qty_producing, 0)
+        self.assertEqual(mo_without_serial.qty_producing, 0)
+
+        mo_form_with_serial = Form(mo_with_serial)
+        mo_form_without_serial = Form(mo_without_serial)
+
+        mo_form_with_serial.qty_producing = 3
+        mo_form_without_serial.qty_producing = 3
+        mo_with_serial = mo_form_with_serial.save()
+        mo_without_serial = mo_form_without_serial.save()
+        self.assertEqual(mo_with_serial.qty_producing, 1)
+        self.assertEqual(mo_without_serial.qty_producing, 3)
+
+        mo_form_with_serial = Form(mo_with_serial)
+        mo_form_without_serial = Form(mo_without_serial)
+        mo_form_with_serial.qty_producing = 0
+        mo_form_without_serial.qty_producing = 0
+        mo_with_serial = mo_form_with_serial.save()
+        mo_without_serial = mo_form_without_serial.save()
+        self.assertEqual(mo_with_serial.qty_producing, 0)
+        self.assertEqual(mo_without_serial.qty_producing, 0)
+
     def test_product_produce_uom(self):
         """ Produce a finished product tracked by serial number. Set another
         UoM on the bom. The produce wizard should keep the UoM of the product (unit)

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -509,7 +509,8 @@
                                     <field name="move_lines_count" column_invisible="True"/>
                                     <field name="state" column_invisible="True" force_save="1"/>
                                     <field name="product_uom_qty" string="To Produce" force_save="1" readonly="parent.state != 'draft' and ((parent.state not in ('confirmed', 'progress', 'to_close') and not parent.is_planned) or parent.is_locked)"/>
-                                    <field name="quantity" string="Produced" column_invisible="parent.state == 'draft'" readonly="has_tracking != 'none'"/>
+                                    <field name="quantity" column_invisible="parent.state == 'draft'" readonly="has_tracking != 'none'"/>
+                                    <field name="picked" string="Produced" column_invisible="parent.state == 'draft'" optional="show"/>
                                     <field name="product_uom" groups="uom.group_uom"/>
                                     <field name="cost_share" optional="hide"/>
                                     <field name="show_details_visible" column_invisible="True"/>

--- a/addons/mrp/views/product_views.xml
+++ b/addons/mrp/views/product_views.xml
@@ -57,6 +57,25 @@
             </field>
         </record>
 
+        <record id="product_view_search_catalog" model="ir.ui.view">
+            <field name="name">product.view.search.catalog.inherit.mrp</field>
+            <field name="inherit_id" ref="product.product_view_search_catalog"/>
+            <field name="model">product.product</field>
+            <field name="arch" type="xml">
+                <filter name="goods" position="after">
+                    <filter string="In the BoM"
+                            invisible="context.get('active_model') != 'mrp.bom.line'"
+                            name="products_in_bom"
+                            domain="[('product_catalog_product_is_in_bom', '=', True)]"/>
+                    <filter string="In the MO"
+                            invisible="context.get('active_model') != 'stock.move' or
+                                       context.get('product_catalog_order_model') != 'mrp.production'"
+                            name="products_in_mo"
+                            domain="[('product_catalog_product_is_in_mo', '=', True)]"/>
+                </filter>
+            </field>
+        </record>
+
         <menuitem id="menu_mrp_product_form"
             name="Products"
             action="product_template_action"

--- a/addons/mrp/wizard/mrp_batch_produce.py
+++ b/addons/mrp/wizard/mrp_batch_produce.py
@@ -30,7 +30,9 @@ class MrpBatchProduct(models.TransientModel):
         for wizard in self:
             if wizard.lot_name:
                 continue
-            wizard.lot_name = self.env['stock.lot']._get_next_serial(self.production_id.company_id, self.production_id.product_id)
+            wizard.lot_name = self.production_id.lot_producing_id.name
+            if not wizard.lot_name:
+                wizard.lot_name = self.env['stock.lot']._get_next_serial(self.production_id.company_id, self.production_id.product_id)
 
     @api.depends('production_id')
     def _compute_lot_qty(self):

--- a/addons/repair/models/product.py
+++ b/addons/repair/models/product.py
@@ -1,11 +1,33 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import fields, models, _
+from odoo.exceptions import UserError
 
 
 class Product(models.Model):
     _inherit = "product.product"
+
+    product_catalog_product_is_in_repair = fields.Boolean(
+        compute='_compute_product_is_in_repair',
+        search='_search_product_is_in_repair',
+    )
+
+    def _compute_product_is_in_repair(self):
+        # Just to enable the _search method
+        self.product_catalog_product_is_in_repair = False
+
+    def _search_product_is_in_repair(self, operator, value):
+        if operator not in ['=', '!='] or not isinstance(value, bool):
+            raise UserError(_("Operation not supported"))
+        product_ids = self.env['repair.order'].search([
+            ('id', 'in', [self.env.context.get('order_id', '')]),
+        ]).move_ids.product_id.ids
+        if (operator == '!=' and value is True) or (operator == '=' and value is False):
+            domain_operator = 'not in'
+        else:
+            domain_operator = 'in'
+        return [('id', domain_operator, product_ids)]
 
     def _count_returned_sn_products_domain(self, sn_lot, or_domains):
         or_domains.append([

--- a/addons/repair/views/product_views.xml
+++ b/addons/repair/views/product_views.xml
@@ -19,10 +19,14 @@
         <field name="inherit_id" ref="product.product_view_search_catalog"/>
         <field name="arch" type="xml">
             <xpath expr="//filter[@name='goods']" position="after">
+                <filter string="In the Repair Order"
+                    invisible="context.get('active_model') != 'stock.move' or
+                                context.get('product_catalog_order_model') != 'repair.order'"
+                    name="products_in_repair"
+                    domain="[('product_catalog_product_is_in_repair', '=', True)]"/>
                 <separator />
                 <filter name="bom_parts" string="BoM Components" domain="[('id', 'in', context.get('catalog_bom_product_ids'))]"/>
             </xpath>
         </field>
     </record>
-
 </odoo>


### PR DESCRIPTION
That's a splited version of this PR -> https://github.com/odoo/odoo/pull/162264

## mrp: add product catalog filters for if product qty > 0

Default filters have been added to the product catalog,
similar to the 'In the Order' filter in sales orders.
The following filters have been added to the product catalogs for:
. In the BOM
. In the MO
. In the Repair Order
When any of these filters are selected, the catalog will
display only the products that are included in the
respective BoM/MO/Repair Order.

## allow sn tracked products to change qty_producing back to 0

Now, users can specify the production quantity as 0
on a MO when the product is tracked by serial. Prior
to this commit, once the qty_producing was set to 1, it
could not be changed. Additionaly, if the MO was in progress,
it is now possible to conduct mass production by simply changing
the quantity to 0, the mass produce feature is accessible even
after the qty_producing has been changed to any other value whereas
it was unavailable before.
Here are the steps to test this feature:
. Create an MO for a SN tracked product
. Input 5 product_qty (qty to produce) and save it
. Input 1 in the quantity being produced
. Save and attempt to input 0 in the same quantity being
produced
After following the above steps, the new value should be 0,
and users are no longer blocked at the 1 value. Furthermore,
with the state set to 'in progress', users can generate a
serial number, and the 'Produce All' button will be hidden.
However, users can input 0 again in the production quantity,
and that button should reappear, allowing mass production in
the 'in progress' state.

## mrp: ensure consistent component

Before this commit, the consumed in operation setting was not
functioning properly because the products were only consumed
when the operation was processed via the Shop Floor. Now,
these products will be consumed via two methods:
1. WO in the MO form:
. Go to the work orders tab
. Start and complete the operation, and the product will be
consumed.
2. WO in the operation tab on the Manufacturing app:
. Select the operations
. Click 'Done', and the product will be consumed as well