### PR TITLE
[FIX] website_mail: recaptcha check was missing on contact creation

### DIFF
--- a/addons/website_mail/controllers/main.py
+++ b/addons/website_mail/controllers/main.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo import http
+from odoo import http, _
 from odoo.http import request
+from odoo.exceptions import UserError
 
 
 class WebsiteMail(http.Controller):
@@ -9,6 +10,8 @@ class WebsiteMail(http.Controller):
     @http.route(['/website_mail/follow'], type='json', auth="public", website=True)
     def website_message_subscribe(self, id=0, object=None, message_is_follower="on", email=False, **post):
         # TDE FIXME: check this method with new followers
+        if not request.env['ir.http']._verify_request_recaptcha_token('website_mail_follow'):
+            raise UserError(_("Suspicious activity detected by Google reCaptcha."))
         res_id = int(id)
         is_follower = message_is_follower == 'on'
         record = request.env[object].browse(res_id).exists()


### PR DESCRIPTION
The route `/website_mail/follow` can create new contacts, for that reason, it should be protected with recaptcha similar to `/website/form/<string:model_name>` and `/website_mass_mailing/subscribe`

This PR adds the Recaptcha check on the endpoint: `/website_mail/follow`

Before this PR it was possible to create as much dummy contact as you wanted as an attacker with a simple script

opw-4023724
