### PR TITLE
[IMP] point_of_sale: add tab navigation for orders

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -1057,6 +1057,9 @@ export class PosOrder extends Base {
             change: this.get_change() && formatCurrency(this.get_change()),
         };
     }
+    getFloatingOrderName() {
+        return this.note || this.tracking_number;
+    }
 }
 
 registry.category("pos_available_models").add(PosOrder.pythonModel, PosOrder);

--- a/addons/point_of_sale/static/src/app/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.js
@@ -22,6 +22,8 @@ import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { deduceUrl } from "@point_of_sale/utils";
 import { PaymentScreen } from "@point_of_sale/app/screens/payment_screen/payment_screen";
 import { user } from "@web/core/user";
+import { TextInputPopup } from "@point_of_sale/app/utils/input_popups/text_input_popup";
+import { ListContainer } from "@point_of_sale/app/generic_components/list_container/list_container";
 
 export class Navbar extends Component {
     static template = "point_of_sale.Navbar";
@@ -34,6 +36,7 @@ export class Navbar extends Component {
         Dropdown,
         DropdownItem,
         SyncPopup,
+        ListContainer,
     };
     static props = {};
     setup() {
@@ -60,6 +63,36 @@ export class Navbar extends Component {
     }
     get showCashMoveButton() {
         return Boolean(this.pos.config.cash_control && this.pos.session._has_cash_move_perm);
+    }
+    showTabs() {
+        return true;
+    }
+    newFloatingOrder() {
+        this.pos.add_new_order();
+        this.pos.showScreen("ProductScreen");
+    }
+    selectFloatingOrder(order) {
+        this.pos.set_order(order);
+        this.pos.showScreen("ProductScreen");
+    }
+    getFloatingOrders() {
+        return this.pos.get_open_orders();
+    }
+    editOrderNote(order) {
+        this.dialog.add(TextInputPopup, {
+            title: _t("Edit order note"),
+            placeholder: _t("Emma's Birthday Party"),
+            startingValue: order.note || "",
+            getPayload: async (newName) => {
+                if (typeof order.id == "number") {
+                    this.pos.data.write("pos.order", [order.id], {
+                        note: newName,
+                    });
+                } else {
+                    order.note = newName;
+                }
+            },
+        });
     }
     onCashMoveButtonClick() {
         this.hardwareProxy.openCashbox(_t("Cash in / out"));

--- a/addons/point_of_sale/static/src/app/navbar/navbar.xml
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.xml
@@ -9,6 +9,20 @@
             <button t-if="pos.showBackButton()" class="back-button btn d-flex align-items-center" t-on-click="onClickBackButton">
                 <i class="fa fa-2x fa-angle-left pb-1" role="img" aria-label="Go Back" title="Go Back" />
             </button>
+            <div class="my-2 d-flex overflow-hidden">
+                <t t-if="showTabs()">
+                    <button class="btn btn-primary mx-2" t-on-click="newFloatingOrder">
+                        <i class="fa fa-plus-circle" aria-hidden="true"/>
+                    </button>
+                    <ListContainer items="getFloatingOrders()" t-slot-scope="scope">
+                        <t t-set="order" t-value="scope.item"/>
+                        <button t-if="pos.get_order()?.id === order.id" class="btn tab btn-secondary active d-flex align-items-center" t-on-click="() => this.editOrderNote(this.pos.get_order())">
+                            <i class="fa fa-pencil-square-o me-1" aria-hidden="true" /><t t-esc="pos.get_order().getFloatingOrderName()"/>
+                        </button>
+                        <button t-else="" t-esc="order.getFloatingOrderName()" class="btn btn-secondary" t-on-click="() => this.selectFloatingOrder(order)"/>
+                    </ListContainer>
+                </t>
+            </div>
             <div class="pos-rightheader d-flex ms-auto h-100 px-1" t-if="pos.shouldShowNavbarButtons()">
                 <div class="status-buttons d-flex flex-grow-1  justify-content-end h-100">
                     <button class="btn btn-outline my-2" t-if="isBarcodeScannerSupported() and pos.mainScreen.component.name == 'ProductScreen'" t-on-click="onClickScan">

--- a/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
@@ -2,8 +2,6 @@ import { Navbar } from "@point_of_sale/app/navbar/navbar";
 import { ProductScreen } from "@point_of_sale/app/screens/product_screen/product_screen";
 import { TipScreen } from "@pos_restaurant/app/tip_screen/tip_screen";
 import { patch } from "@web/core/utils/patch";
-import { ListContainer } from "@point_of_sale/app/generic_components/list_container/list_container";
-import { TextInputPopup } from "@point_of_sale/app/utils/input_popups/text_input_popup";
 import { _t } from "@web/core/l10n/translation";
 import { makeAwaitable } from "@point_of_sale/app/store/make_awaitable_dialog";
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
@@ -15,9 +13,6 @@ import {
     BACKSPACE,
 } from "@point_of_sale/app/generic_components/numpad/numpad";
 
-patch(Navbar, {
-    components: { ...Navbar.components, ListContainer },
-});
 patch(Navbar.prototype, {
     async onClickBackButton() {
         if (this.pos.orderToTransferUuid) {
@@ -61,6 +56,9 @@ patch(Navbar.prototype, {
                   ?.table_id
             : this.pos.selectedTable;
     },
+    showTabs() {
+        return !this.pos.selectedTable;
+    },
     get showTableIcon() {
         return typeof this.getTable()?.table_number === "number" && this.pos.showBackButton();
     },
@@ -68,33 +66,6 @@ patch(Navbar.prototype, {
         const mode = this.pos.floorPlanStyle === "kanban" ? "default" : "kanban";
         localStorage.setItem("floorPlanStyle", mode);
         this.pos.floorPlanStyle = mode;
-    },
-    newFloatingOrder() {
-        this.pos.add_new_order();
-        this.pos.showScreen("ProductScreen");
-    },
-    getFloatingOrders() {
-        return this.pos.get_open_orders().filter((order) => !order.table_id);
-    },
-    selectFloatingOrder(order) {
-        this.pos.set_order(order);
-        this.pos.showScreen("ProductScreen");
-    },
-    editOrderNote(order) {
-        this.dialog.add(TextInputPopup, {
-            title: _t("Edit order note"),
-            placeholder: _t("Emma's Birthday Party"),
-            startingValue: order.note,
-            getPayload: async (newName) => {
-                if (typeof order.id == "number") {
-                    this.pos.data.write("pos.order", [order.id], {
-                        note: newName,
-                    });
-                } else {
-                    order.note = newName;
-                }
-            },
-        });
     },
     get showEditPlanButton() {
         return true;

--- a/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.xml
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.xml
@@ -19,19 +19,7 @@
                     class="table-name text-white fw-bolder px-3 my-2 me-1 py-1 d-flex align-items-center" 
                     t-on-click="() => this.switchTable()"/>
                 <button t-else="" class="btn btn-secondary mx-2" t-on-click="() => this.switchTable()">Go to...</button>
-                <t t-if="!pos.orderToTransferUuid">
-                    <button t-if="!pos.selectedOrderUuid" class="btn btn-primary mx-2" t-on-click="newFloatingOrder">
-                        <i class="fa fa-plus-circle" aria-hidden="true"/>
-                    </button>
-                    <ListContainer t-if="!pos.selectedOrderUuid and !pos.selectedTable" items="getFloatingOrders()" t-slot-scope="scope">
-                        <t t-set="order" t-value="scope.item"/>
-                        <button t-esc="order.getFloatingOrderName()" class="btn btn-secondary tab" t-on-click="() => this.selectFloatingOrder(order)"/>
-                    </ListContainer>
-                    <button t-if="pos.get_order() and !pos.get_order()?.table_id" class="btn btn-secondary ms-2" t-on-click="() => this.editOrderNote(this.pos.get_order())">
-                        <i class="fa fa-pencil-square-o me-1" aria-hidden="true" /><t t-if="!ui.isSmall" t-esc="pos.get_order().getFloatingOrderName()"/>
-                    </button>
-                </t>
-                <div class="d-flex align-items-center" t-else="">
+                <div class="d-flex align-items-center" t-if="pos.orderToTransferUuid">
                     <strong class="ms-2">
                         Select table to transfer order
                     </strong>

--- a/addons/pos_restaurant/static/src/overrides/models/pos_order.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_order.js
@@ -35,7 +35,4 @@ patch(PosOrder.prototype, {
     setBooked(booked) {
         this.uiState.booked = booked;
     },
-    getFloatingOrderName() {
-        return this.note || this.tracking_number;
-    },
 });


### PR DESCRIPTION
In this commit we add in pos the possibility to navigate from one draft order to another using tabs. ( the system is the one previously used for "floating orders" in pos_restaurant.

Task: 4082885





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
