### PR TITLE
[FIX] html_editor: remove format of tag with attribute

### DIFF
--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -358,6 +358,7 @@ function getOrCreateSpan(node, ancestors) {
     }
 }
 function removeFormat(node, formatSpec) {
+    const document = node.ownerDocument;
     node = closestElement(node);
     if (formatSpec.hasStyle(node)) {
         formatSpec.removeStyle(node);
@@ -372,7 +373,7 @@ function removeFormat(node, formatSpec) {
         });
         if (attributesNames.length) {
             // Change tag name
-            const newNode = this.document.createElement("span");
+            const newNode = document.createElement("span");
             while (node.firstChild) {
                 newNode.appendChild(node.firstChild);
             }

--- a/addons/html_editor/static/tests/format/remove_format.test.js
+++ b/addons/html_editor/static/tests/format/remove_format.test.js
@@ -530,6 +530,13 @@ test("should remove multiple format (3)", async () => {
         contentAfter: "<div><p><b>a</b>[bc</p><p>de<br>fg<br></p><p>ijsd]fsf</p></div>",
     });
 });
+test("should remove format and keep attribute in a span", async () => {
+    await testEditor({
+        contentBefore: '<p><strong some-attr="1">[abc]</strong></p>',
+        stepFunction: (editor) => editor.dispatch("FORMAT_REMOVE_FORMAT"),
+        contentAfter: '<p><span some-attr="1">[abc]</span></p>',
+    });
+});
 test("should remove multiple color (1)", async () => {
     await testEditor({
         contentBefore:


### PR DESCRIPTION
Before this commit, removing the format of a tag with an attribute would lead to a traceback, as `removeFormat` is called as a standalone function (not a method) and `this` is thus undefined.
