### PR TITLE
[FIX] stock_{fleet, picking_batch}: prepare batch and wave button

### DIFF
--- a/addons/stock_fleet/views/stock_picking_type.xml
+++ b/addons/stock_fleet/views/stock_picking_type.xml
@@ -7,11 +7,6 @@
             <field name="inherit_id" ref="stock.stock_picking_type_kanban"/>
             <field name="arch" type="xml">
                 <data>
-                    <xpath expr="//div[hasclass('col-6') and hasclass('o_kanban_card_manage_section') and hasclass('o_kanban_manage_new')]" position="inside">
-                        <div role="menuitem">
-                            <a name="action_batch" type="object" context="{'view_mode':'form'}">Prepare Batches</a>
-                        </div>
-                    </xpath>
                     <xpath expr="//div[hasclass('col-6') and hasclass('o_kanban_card_manage_section') and hasclass('o_kanban_manage_new')]" position="after">
                         <t t-if="record.code.raw_value == 'incoming' or record.code.raw_value == 'outgoing'">
                             <div class="col-6 o_kanban_card_manage_section o_kanban_manage_new">

--- a/addons/stock_picking_batch/views/stock_picking_wave_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_wave_views.xml
@@ -51,6 +51,18 @@
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="stock.stock_picking_type_kanban"/>
         <field name="arch" type="xml">
+            <xpath expr="//div[hasclass('col-6') and hasclass('o_kanban_card_manage_section') and hasclass('o_kanban_manage_new')]" position="inside">
+                <div role="menuitem">
+                    <a name="action_batch" type="object" context="{'view_mode':'form'}">
+                        Prepare Batches
+                    </a>
+                </div>
+                <div role="menuitem" groups="stock.group_stock_picking_wave">
+                    <a name="get_action_picking_type_operations" type="object">
+                        Prepare Waves
+                    </a>
+                </div>
+            </xpath>
             <xpath expr="//button[@name='get_action_picking_tree_ready']" position="before">
                 <button t-if="record.count_picking_batch.raw_value > 0" class="btn btn-primary mr8 mb4 align-top" name="action_batch" type="object">
                     <field name="count_picking_batch"/> Batches


### PR DESCRIPTION
This commit bring back the 'prepare wave' button removed in 6fb0ae5fa9d16e74594dbf6bad43756ae2ffe8e2. Also move the 'prepare batch' button introduced in 202c021e2890e15d392aee0b776a0f130afa0dc3 from `stock_fleet` to `stock_picking_batch` in order to have a coherent view

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
