### PR TITLE
[IMP] web: make company selector inheritable

### DIFF
--- a/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.js
+++ b/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.js
@@ -8,7 +8,7 @@ import { Component, useChildSubEnv, useState } from "@odoo/owl";
 import { debounce } from "@web/core/utils/timing";
 import { useService } from "@web/core/utils/hooks";
 
-class CompanySelector {
+export class CompanySelector {
     constructor(companyService, toggleDelay) {
         this.companyService = companyService;
         this.selectedCompaniesIds = companyService.activeCompanyIds.slice();
@@ -154,12 +154,13 @@ export class SwitchCompanyMenu extends Component {
     static components = { Dropdown, DropdownItem, SwitchCompanyItem };
     static props = {};
     static toggleDelay = 1000;
+    static CompanySelector = CompanySelector;
 
     setup() {
         this.companyService = useService("company");
 
         this.companySelector = useState(
-            new CompanySelector(this.companyService, this.constructor.toggleDelay)
+            new this.constructor.CompanySelector(this.companyService, this.constructor.toggleDelay)
         );
         useChildSubEnv({ companySelector: this.companySelector });
     }


### PR DESCRIPTION
Currently, it is not possible to inherit the company selector widget.
To modify the behavior of the widget, developers need to create a new
one instead of inheriting it, which is not ideal. This commit introduces
changes that allow inheriting the company selector widget and also makes
it easier to replace or extend the CompanySelector class within the
SwitchCompanyMenu.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
