### PR TITLE
[FIX] website: fix redirect when clicking on new button in form editor

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -561,6 +561,7 @@ options.registry.WebsiteFormEditor = FormEditor.extend({
                             reject();
                         },
                     });
+                    resolve();
                 },
                 cancel: () => resolve(),
             });


### PR DESCRIPTION
Commit [1] replaced the dialogs from legacy to OWL ones, but also created a deadlock by not resolving the promise set by the dialog.

This commit fixes that by properly resolving the promise regardless of the user's answer.

[1]: https://github.com/odoo/odoo/commit/00c9a7919768df71e79b5d34e21064729443c5fe
