### PR TITLE
[FIX] sale: fix traceback when user removes the UOM from SO

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -518,7 +518,7 @@ class SaleOrderLine(models.Model):
         price = self.pricelist_item_id._compute_price(
             product=self.product_id.with_context(**self._get_product_price_context()),
             quantity=self.product_uom_qty or 1.0,
-            uom=self.product_uom,
+            uom=self.product_uom or self.product_id.uom_id,
             date=self.order_id.date_order,
             currency=self.currency_id,
         )


### PR DESCRIPTION
Currently, a traceback occurs when the user removes the UMO from the Sale Order Line.

To reproduce this issue:

1) Install `sale`
2) Enable `UOM`, and `Pricelist` with advanced rules from sales configuration 
3) Create a new pricelist with a `price rule` of `discount` and make sure to change
   the `discount policy` to `without_discount` from the pricelist configuration
4) Now create a new `Quotation` with the pricelist
5) Remove the `UOM` from the Order Lines and update the Quantity

Error:- 
```
ValueError: Expected singleton: uom.uom()
```

When the user removes UOM from the SOL it triggers a compute method `_compute_discount`
through which another method `_get_pricelist_price`.

https://github.com/odoo/odoo/blob/d83bd4f8970e5495205cf2fa583d9343368b5d70/addons/sale/models/sale_order_line.py#L518-L522

In the second method, UMO is used to compute the price for the `pricelist item`, 
but in that `_compute_price`, `uom.ensure_one()` is used. 
Which leads to the above traceback.

https://github.com/odoo/odoo/blob/d83bd4f8970e5495205cf2fa583d9343368b5d70/addons/product/models/product_pricelist_item.py#L362-L364

By applying this commit will resolve this issue by taking UOM from product, which is a required field in product.

sentry-5537497781

