### PR TITLE
[FIX] mass_mailing: fix template compressed mode

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -463,7 +463,10 @@ export class MassMailingHtmlField extends HtmlField {
 
             $themeSelectorNew.remove();
 
-            this.wysiwyg.setSnippetsMenuFolded(uiUtils.isSmall() || themeName === 'basic');
+            const isSnippetsFolded = uiUtils.isSmall() || themeName === 'basic';
+            this.wysiwyg.setSnippetsMenuFolded(isSnippetsFolded);
+            // Inform the iframe content of the snippets menu visibility
+            this.wysiwyg.$iframeBody.closest('body').toggleClass("has_snippets_sidebar", !isSnippetsFolded);
 
             this._switchImages(themeParams, $snippets);
 

--- a/addons/mass_mailing/static/src/scss/mass_mailing.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.scss
@@ -25,6 +25,17 @@
     border: none;
 }
 
+body.editor_has_snippets .o_field_mass_mailing_html div.d-flex:has(iframe) {
+    // Forcing the iframe to have the correct display mode (mobile vs desktop) by making it
+    // take all the available horizontal space so that the theme lg rules are correctly applied.
+    position: relative;
+    justify-content: end;
+    iframe {
+        position: absolute !important;
+        height: 100%;
+    }
+}
+
 .o_form_view.o_mass_mailing_mailing_form .o_form_renderer {
     &.o_form_readonly .o_mass_mailing_subject {
         // Place the favorite button without breaking the emoji widget

--- a/addons/mass_mailing/static/src/scss/mass_mailing.ui.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.ui.scss
@@ -208,6 +208,11 @@ html:not(.o_mass_mailing_iframe), body:not(.o_mass_mailing_iframe), html.o_fulls
     }
 }
 
+// Prevent the website snippets sidebar from overlapping the template
+body.has_snippets_sidebar .o_layout {
+    padding-right: $o-we-sidebar-width !important;
+}
+
 body.o_force_mail_theme_choice {
     #oe_snippets {
         width: 100%;


### PR DESCRIPTION
Purpose
=======
Fix the theme templates which are displayed in compressed mode
on large screen sizes.

Specification
=============
Following the extension of the chatter's width, the iframe width became
too small to be considered as a large viewport meaning all the bootstrap
lg rules aren't correctly applied.

Making sure the iframe width is large enough by making it position absolute
so that it takes the full form width.
Preventing the website snippets from overlapping the template by adding a
padding right to the layout.

Choosing the iframe to be position absolute instead of the website snippets
to make sure the snippets drag to scroll feature still works.

related commits:
https://github.com/odoo/odoo/commit/916ac1712c7fae4623ec176e688ba13af01be015
https://github.com/odoo/odoo/commit/cf6cd5ef46287f4e71fe96ad6b404ba9b08c1066

Task-4086474

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
