### PR TITLE
[IMP] base: allow sending datetime objects over XMLRPC

### DIFF
--- a/odoo/addons/base/controllers/rpc.py
+++ b/odoo/addons/base/controllers/rpc.py
@@ -135,7 +135,7 @@ class RPC(Controller):
         """Common method to handle an XML-RPC request."""
         _check_request()
         data = request.httprequest.get_data()
-        params, method = xmlrpc.client.loads(data)
+        params, method = xmlrpc.client.loads(data, use_datetime=True)
         result = dispatch_rpc(service, method, params)
         return dumps((result,))
 

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1789,7 +1789,7 @@ class HttpCase(TransactionCase):
 
         self.xmlrpc_common = xmlrpclib.ServerProxy(self.xmlrpc_url + 'common', transport=Transport(self.cr))
         self.xmlrpc_db = xmlrpclib.ServerProxy(self.xmlrpc_url + 'db', transport=Transport(self.cr))
-        self.xmlrpc_object = xmlrpclib.ServerProxy(self.xmlrpc_url + 'object', transport=Transport(self.cr))
+        self.xmlrpc_object = xmlrpclib.ServerProxy(self.xmlrpc_url + 'object', transport=Transport(self.cr), use_datetime=True)
         # setup an url opener helper
         self.opener = Opener(self.cr)
 


### PR DESCRIPTION
Odoo has supported setting fields to datetime values since #25624 / 960360afe478a8f7b9c456721b5591154952a37d (merged in 12.0). However this ability was never extended to xmlrpc: by default xmlrpc will decode `dateTime.iso8601` values to a special [`xmlrpc.client.DateTime`] object which Odoo doesn't support.

We can make such code work by just enabling datetime unmarshalling,
this is backward compatible because currently sending datetime objects
over xmlrpc just doesn't work (or worse is silently broken).

While at it, remove the monkeypatching / replacement of `xmlrpc.client.Marshaller`: this monkeypatching causes issues with the XMLRPC testing, since those run in process after loading base they use the monkeypatched marshaller and thus perform non-standard calls / marshalling.

This patching does not seem at all necessary as as far as I can tell we're only dumping to xmlrpc in this specific location, and so can just use the custom marshaller directly. It's also very weird to monkeypatch from a controller submodule in the depth of base.