### PR TITLE
[FIX] base: fix get_field_translations

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3130,7 +3130,9 @@ class BaseModel(metaclass=MetaModel):
         # We don't forbid reading inactive/non-existing languages,
         langs = set(langs or [l[0] for l in self.env['res.lang'].get_installed()])
         val_en = self.with_context(lang='en_US')[field_name]
-        if not callable(field.translate):
+        if not field.translate:
+            translations = []
+        elif field.translate is True:
             translations = [{
                 'lang': lang,
                 'source': val_en,


### PR DESCRIPTION
return emtpy translations list when the field is not translatable to be consistent with the api's definition

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
