### PR TITLE
[FIX] mail: ensure user existence before usage

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2133,7 +2133,7 @@ class MailThread(models.AbstractModel):
 
         # Find the message's author
         guest = self.env['mail.guest']._get_guest_from_context()
-        if self.env.user._is_public() and guest:
+        if self.env.user and self.env.user._is_public() and guest:
             author_guest_id = guest.id
             author_id, email_from = False, False
         else:


### PR DESCRIPTION
Record creation from an automation rule can be triggered without a user, that can lead to error for message author.

Steps:
- Create an automation rule (webhook)
- Add an action to run code (create a "crm.lead")
- Via a server action, send a webhook notification

Actual result:
- Webhook failing due to "no user"

Expected result:
- Webhook create the record as expected

opw-4077936

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
