### PR TITLE
[FIX] stock: fixed domain error when locations are None

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -317,7 +317,7 @@ class Product(models.Model):
         if self.env.context.get('strict'):
             loc_domain = [('location_id', 'in', locations.ids)]
             dest_loc_domain = [('location_dest_id', 'in', locations.ids)]
-        else:
+        elif locations:
             paths_domain = expression.OR([[('parent_path', '=like', loc.parent_path + '%')] for loc in locations])
             loc_domain = [('location_id', 'any', paths_domain)]
             dest_loc_domain = [('location_dest_id', 'any', paths_domain)]


### PR DESCRIPTION
Issue Summary:

During the upgrade from Odoo version 16.0 to 17.0, a discrepancy has emerged in the product configuration, specifically with the "Buy" route.
The problem arises when computing the available quantity using the _compute_quantities_dict function.

see:
 https://github.com/odoo/odoo/commit/6d8f184f09c213be068f911dd327ffe84fde8bab

Problem Description:

In version 17.0, when fetching the domain_Quant using the _get_domain_locations function, the domain returned is ('location_id', 'any', [(0, '=', 1)])
 if no locations are found.
In version 16.0, it returns an empty list [] if no locations are found. This change results in the domain_quant in version 17.0 being
 [('product_id', 'in', [2684, 5474, 5475, 5478, 5487, 5522]), ('location_id', 'any', [(0, '=', 1)])],
 which leads to {} values, whereas in version 16.0, the domain
 would be [('product_id', 'in', [2684, 5474, 5475, 5478, 5487, 5522])], which returns actual values.

Impact:

The inconsistency in the domain operation between versions results in incorrect or missing quantity data after the upgrade, affecting the accuracy of product availability.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
