### PR TITLE
[FIX] account_edi_ubl_cii: German document context was wrong

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
@@ -181,6 +181,7 @@ class AccountEdiXmlCII(models.AbstractModel):
             'purchase_order_reference': invoice.purchase_order_reference if 'purchase_order_reference' in invoice._fields
                 and invoice.purchase_order_reference else invoice.ref or invoice.name,
             'contract_reference': invoice.contract_reference if 'contract_reference' in invoice._fields and invoice.contract_reference else '',
+            'document_context_id': "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended",
         }
 
         # data used for IncludedSupplyChainTradeLineItem / SpecifiedLineTradeSettlement
@@ -203,8 +204,6 @@ class AccountEdiXmlCII(models.AbstractModel):
                 date_range = self._get_invoicing_period(invoice)
                 template_values['billing_start'] = min(date_range)
                 template_values['billing_end'] = max(date_range)
-
-        template_values['document_context_id'] = "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
 
         # Fixed taxes: add them as charges on the invoice lines
         for line_vals in template_values['invoice_line_vals_list']:

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
@@ -204,13 +204,7 @@ class AccountEdiXmlCII(models.AbstractModel):
                 template_values['billing_start'] = min(date_range)
                 template_values['billing_end'] = max(date_range)
 
-        # One of the difference between XRechnung and Facturx is the following. Submitting a Facturx to XRechnung
-        # validator raises a warning, but submitting a XRechnung to Facturx raises an error.
-        supplier = invoice.company_id.partner_id.commercial_partner_id
-        if supplier.country_id.code == 'DE':
-            template_values['document_context_id'] = "urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.2"
-        else:
-            template_values['document_context_id'] = "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
+        template_values['document_context_id'] = "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
 
         # Fixed taxes: add them as charges on the invoice lines
         for line_vals in template_values['invoice_line_vals_list']:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Germany currently has two competing EDI Invoice XML Standards: ZUGPFeRD 2.2, which is identical to Factur-X 1.0.06 (https://www.ferd-net.de/standards/zugferd-2.2/zugferd-2.2.html) and the KoSIT 3.0.2 XRechnung (https://xeinkauf.de/xrechnung/), which are not interoperable. A Factur-X XML generated in Germany should not falsely claim to be complaint to the KoSIT XRechnung.
Current behavior before PR:
A Factur-X XML generated from a German company uses the document context "urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.2", which claims compliance with the wrong Standard (KoSIT XRechnung instead of ZUGPFeRD/Factur-X) in also an outdated version.
Desired behavior after PR is merged:
Even when generated in Germany, the Factur-X XML correctly uses the document context indicating compliance to Factur-X 1.0


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
