### PR TITLE
[IMP] pos_*: payment terminal based methods in point of sale

### DIFF
--- a/addons/point_of_sale/models/pos_payment_method.py
+++ b/addons/point_of_sale/models/pos_payment_method.py
@@ -1,6 +1,19 @@
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError, ValidationError
 
+POS_PAYMENT_TERMINALS = [
+    ('adyen', 'Adyen'),
+    ('mercado_pago', 'Mercado Pago'),
+    ('paytm', 'PayTM'),
+    ('razorpay', 'Razorpay'),
+    ('six', 'SIX'),
+    ('stripe', 'Stripe'),
+    ('viva_wallet', 'Viva Wallet'),
+    ('ingenico', 'Ingenico'),
+    ('worldline', 'Worldline'),
+    ('iot_six', 'SIX IoT'),
+]
+
 
 class PosPaymentMethod(models.Model):
     _name = 'pos.payment.method'
@@ -8,14 +21,16 @@ class PosPaymentMethod(models.Model):
     _order = "sequence, id"
     _inherit = ['pos.load.mixin']
 
-    def _get_payment_terminal_selection(self):
-        return []
-
     def _get_payment_method_type(self):
-        selection = [('none', 'None required'), ('terminal', 'Terminal')]
+        selection = [('none', 'None required'), ('terminal', 'Terminal'), ('online', 'Online')]
         if self.env['res.partner.bank'].get_available_qr_methods_in_sequence():
             selection.append(('qr_code', 'Bank App (QR Code)'))
         return selection
+
+    def _get_default_journal(self):
+        return self.env['account.journal'].search([
+            *self.env['account.journal']._check_company_domain(self.env.company),
+            ('type', '=', 'bank')], limit=1)
 
     name = fields.Char(string="Method", required=True, translate=True, help='Defines the name of the payment method that will be displayed in the Point of Sale when the payments are selected.')
     sequence = fields.Integer(copy=False)
@@ -34,6 +49,7 @@ class PosPaymentMethod(models.Model):
         string='Journal',
         domain=['|', '&', ('type', '=', 'cash'), ('pos_payment_method_ids', '=', False), ('type', '=', 'bank')],
         ondelete='restrict',
+        default=_get_default_journal,
         help='Leave empty to use the receivable account of customer.\n'
              'Defines the journal where to book the accumulated payments (or individual payment if Identify Customer is true) after closing the session.\n'
              'For cash journal, we directly write to the default account in the journal via statement lines.\n'
@@ -46,7 +62,9 @@ class PosPaymentMethod(models.Model):
     open_session_ids = fields.Many2many('pos.session', string='Pos Sessions', compute='_compute_open_session_ids', help='Open PoS sessions that are using this payment method.')
     config_ids = fields.Many2many('pos.config', string='Point of Sale')
     company_id = fields.Many2one('res.company', string='Company', default=lambda self: self.env.company)
-    use_payment_terminal = fields.Selection(selection=lambda self: self._get_payment_terminal_selection(), string='Use a Payment Terminal', help='Record payments with a terminal on this journal.')
+    use_payment_terminal = fields.Selection(
+        POS_PAYMENT_TERMINALS,
+        string='Use a Payment Terminal', help='Record payments with a terminal on this journal.')
     # used to hide use_payment_terminal when no payment interfaces are installed
     hide_use_payment_terminal = fields.Boolean(compute='_compute_hide_use_payment_terminal')
     active = fields.Boolean(default=True)
@@ -60,6 +78,8 @@ class PosPaymentMethod(models.Model):
         help='Type of QR-code to be generated for this payment method.',
     )
     hide_qr_code_method = fields.Boolean(compute='_compute_hide_qr_code_method')
+    module_id = fields.Many2one('ir.module.module', compute='_compute_module_id')
+    is_terminal_installed = fields.Boolean(compute='_compute_is_terminal_installed')
 
     @api.model
     def _load_pos_data_domain(self, data):
@@ -69,11 +89,15 @@ class PosPaymentMethod(models.Model):
     def _load_pos_data_fields(self, config_id):
         return ['id', 'name', 'is_cash_count', 'use_payment_terminal', 'split_transactions', 'type', 'image', 'sequence', 'payment_method_type', 'default_qr']
 
+    @api.constrains('use_payment_terminal')
+    def _check_use_payment_terminal(self):
+        if any(record.use_payment_terminal in ['razorpay', 'paytm'] and record.company_id.currency_id.name != 'INR' for record in self):
+            raise UserError(_('This Payment Terminal is only valid for INR Currency'))
+
     @api.depends('type', 'payment_method_type')
     def _compute_hide_use_payment_terminal(self):
-        no_terminals = not bool(self._fields['use_payment_terminal'].selection(self))
         for payment_method in self:
-            payment_method.hide_use_payment_terminal = no_terminals or payment_method.type in ('cash', 'pay_later') or payment_method.payment_method_type != 'terminal'
+            payment_method.hide_use_payment_terminal = payment_method.type in ('cash', 'pay_later') or payment_method.payment_method_type != 'terminal'
 
     @api.depends('payment_method_type')
     def _compute_hide_qr_code_method(self):
@@ -118,6 +142,22 @@ class PosPaymentMethod(models.Model):
         for pm in self:
             pm.is_cash_count = pm.type == 'cash'
 
+    @api.depends('use_payment_terminal')
+    def _compute_module_id(self):
+        for record in self:
+            search_name = f'pos_{record.use_payment_terminal}'
+            if record.use_payment_terminal in ('ingenico', 'worldline'):
+                search_name = 'pos_iot'
+            record.module_id = self.env['ir.module.module'].search([('name', '=', search_name)])
+
+    @api.depends('module_id')
+    def _compute_is_terminal_installed(self):
+        for record in self:
+            if not record.use_payment_terminal or record.module_id.state == 'installed':
+                record.is_terminal_installed = True
+            else:
+                record.is_terminal_installed = False
+
     def _is_write_forbidden(self, fields):
         whitelisted_fields = {'sequence'}
         return bool(fields - whitelisted_fields and self.open_session_ids)
@@ -127,12 +167,26 @@ class PosPaymentMethod(models.Model):
         for vals in vals_list:
             if vals.get('payment_method_type', False):
                 self._force_payment_method_type_values(vals, vals['payment_method_type'])
+
+            if vals.get('config_ids'):
+                pos_configs_vals = vals.get('config_ids')
+                config_ids = [config[1] for config in pos_configs_vals]
+                pos_sessions = {config.id: config.current_session_id for config in self.env['pos.config'].search([('id', 'in', config_ids)])}
+                pos_configs = [config for config in pos_configs_vals if not pos_sessions.get(config[1])]
+                vals.update({'config_ids': pos_configs})
         return super().create(vals_list)
 
     def write(self, vals):
         if self._is_write_forbidden(set(vals.keys())):
             raise UserError(_('Please close and validate the following open PoS Sessions before modifying this payment method.\n'
                             'Open sessions: %s', (' '.join(self.open_session_ids.mapped('name')),)))
+
+        if vals.get('config_ids'):
+            pos_configs_vals = vals.get('config_ids')
+            config_ids = [config[1] for config in pos_configs_vals]
+            pos_sessions = {config.id: config.current_session_id for config in self.env['pos.config'].search([('id', 'in', config_ids)])}
+            pos_configs = [config for config in pos_configs_vals if not pos_sessions.get(config[1])]
+            vals.update({'config_ids': pos_configs})
 
         if 'payment_method_type' in vals:
             self._force_payment_method_type_values(vals, vals['payment_method_type'])
@@ -217,3 +271,17 @@ class PosPaymentMethod(models.Model):
 
         return payment_bank.with_context(is_online_qr=True).build_qr_code_base64(
             float(amount), free_communication, structured_communication, currency, debtor_partner, self.qr_code_method, silent_errors=False)
+
+    def button_immediate_install(self):
+        """ Install the module and reload the page.
+        Note: `self.ensure_one()`
+        :return: The action to reload the page.
+        :rtype: dict
+        """
+        self.ensure_one()
+        if self.module_id and self.module_id.state != 'installed':
+            self.module_id.button_immediate_install()
+            return {
+                'type': 'ir.actions.client',
+                'tag': 'reload',
+            }

--- a/addons/point_of_sale/models/res_config_settings.py
+++ b/addons/point_of_sale/models/res_config_settings.py
@@ -31,13 +31,6 @@ class ResConfigSettings(models.TransientModel):
 
     pos_config_id = fields.Many2one('pos.config', string="Point of Sale", default=lambda self: self._default_pos_config())
     sale_tax_id = fields.Many2one('account.tax', string="Default Sale Tax", related='company_id.account_sale_tax_id', readonly=False, check_company=True)
-    module_pos_adyen = fields.Boolean(string="Adyen Payment Terminal", help="The transactions are processed by Adyen. Set your Adyen credentials on the related payment method.")
-    module_pos_stripe = fields.Boolean(string="Stripe Payment Terminal", help="The transactions are processed by Stripe. Set your Stripe credentials on the related payment method.")
-    module_pos_six = fields.Boolean(string="Six Payment Terminal", help="The transactions are processed by Six. Set the IP address of the terminal on the related payment method.")
-    module_pos_viva_wallet = fields.Boolean(string="Viva Wallet Payment Terminal", help="The transactions are processed by Viva Wallet on terminal or tap on phone.")
-    module_pos_paytm = fields.Boolean(string="PayTM Payment Terminal", help="The transactions are processed by PayTM. Set your PayTM credentials on the related payment method.")
-    module_pos_razorpay = fields.Boolean(string="Razorpay Payment Terminal", help="The transactions are processed by Razorpay. Set your Razorpay credentials on the related payment method.")
-    module_pos_mercado_pago = fields.Boolean(string="Mercado Pago Payment Terminal", help="The transactions are processed by Mercado Pago. Set your Mercado Pago credentials on the related payment method.")
     module_pos_preparation_display = fields.Boolean(string="Preparation Display", help="Show orders on the preparation display screen.")
     module_pos_pricer = fields.Boolean(string="Pricer electronic price tags", help="Display the price of your products through electronic price tags")
     update_stock_quantities = fields.Selection(related="company_id.point_of_sale_update_stock_quantities", readonly=False)

--- a/addons/point_of_sale/tests/common.py
+++ b/addons/point_of_sale/tests/common.py
@@ -79,6 +79,7 @@ class TestPointOfSaleCommon(ValuationReconciliationTestCommon):
         })
         cls.credit_payment_method = cls.env['pos.payment.method'].create({
             'name': 'Credit',
+            'journal_id': False,
             'receivable_account_id': cls.company_data['default_account_receivable'].id,
             'split_transactions': True,
             'company_id': cls.env.company.id,
@@ -277,7 +278,7 @@ class TestPoSCommon(ValuationReconciliationTestCommon):
             'name': 'Split (Bank) PM',
             'split_transactions': True,
         })
-        cls.pay_later_pm = cls.env['pos.payment.method'].create({'name': 'Pay Later', 'split_transactions': True})
+        cls.pay_later_pm = cls.env['pos.payment.method'].create({'name': 'Pay Later', 'split_transactions': True, 'journal_id': False})
         config.write({'payment_method_ids': [(4, cls.cash_split_pm1.id), (4, cls.bank_split_pm1.id), (4, cls.cash_pm1.id), (4, cls.bank_pm1.id), (4, cls.pay_later_pm.id)]})
         return config
 

--- a/addons/point_of_sale/views/pos_payment_method_views.xml
+++ b/addons/point_of_sale/views/pos_payment_method_views.xml
@@ -18,26 +18,24 @@
                     </div>
                     <group name="Payment methods">
                         <group>
+                            <field name="config_ids" widget="many2many_tags"/>
                             <field name="split_transactions"/>
                             <field name="journal_id" required="not split_transactions" placeholder="Leave empty to use the receivable account of customer" />
                             <field name="outstanding_account_id" groups="account.group_account_readonly" invisible="type != 'bank'" required="type == 'bank'" placeholder="Selection of outstanding account is required" />
                             <field name="receivable_account_id" groups="account.group_account_readonly" invisible="split_transactions" placeholder="Leave empty to use the default account from the company setting" />
-                            <field name="company_id" readonly="1" groups="base.group_multi_company" />
+                            <field name="company_id" readonly="1" groups="base.group_multi_company" invisible="1"/>
                         </group>
                         <group>
                             <field name="hide_use_payment_terminal" invisible="1"/>
                             <field name="hide_qr_code_method" invisible="1"/>
+                            <field name="is_terminal_installed" invisible="1"/>
                             <field name="payment_method_type"/>
-                            <field name="use_payment_terminal" string="Integrate with" invisible="hide_use_payment_terminal" />
-                            <field name="qr_code_method" invisible="hide_qr_code_method" required="payment_method_type == 'qr_code'"/>
-                            <div name="tips" colspan="2" invisible="not hide_use_payment_terminal or payment_method_type != 'terminal'">
-                                <h2>Tips:</h2>
-                                <p>
-                                    Go to <a href="#" name="%(action_pos_configuration)d" type="action" class="btn-link o_form_uri" role="button">Configurations > Settings</a>
-                                    <strong> > Payment Terminals</strong>
-                                    in order to install a Payment Terminal and make a fully integrated payment method.
-                                </p>
+                            <label for="use_payment_terminal" invisible="hide_use_payment_terminal"/>
+                            <div class="o_row payment_terminal_div" invisible="hide_use_payment_terminal">
+                                <field name="use_payment_terminal" string="Integrate with"  />
+                                <button type="object" class="btn btn-primary" name="button_immediate_install" string="Activate" invisible="is_terminal_installed"/>
                             </div>
+                            <field name="qr_code_method" invisible="hide_qr_code_method" required="payment_method_type == 'qr_code'"/>
                         </group>
                     </group>
                 </sheet>

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -54,7 +54,7 @@
                                 <span>Please note that the kiosk only works with Adyen &amp; Stripe terminals</span>
                             </div>
                             <setting id="payment_methods_new" string="Payment Methods" help="Payment methods available" documentation="/applications/sales/point_of_sale/payment_methods.html">
-                                <field name="pos_payment_method_ids" colspan="4" widget="many2many_tags" readonly="pos_has_active_session" required="pos_company_has_template" options="{'no_create': True}" />
+                                <field name="pos_payment_method_ids" colspan="4" widget="many2many_tags" readonly="pos_has_active_session" required="pos_company_has_template" options="{'no_quick_create': True}" context="{'default_config_ids': [pos_config_id]}"/>
                                 <div>
                                     <button name="%(action_payment_methods_tree)d" icon="oi-arrow-right" type="action" string="Payment Methods" class="btn-link"/>
                                 </div>
@@ -312,31 +312,6 @@
                             </setting>
                             <setting help="Print basic ticket without prices. Can be used for gifts.">
                                 <field name="pos_basic_receipt"/>
-                            </setting>
-                        </block>
-
-                        <block title="Payment Terminals" help="Those settings are common to all PoS." id="pos_payment_terminals_section">
-                            <setting id="adyen_payment_terminal_setting" title="The transactions are processed by Adyen. Set your Adyen credentials on the related payment method." string="Adyen" help="Accept payments with an Adyen payment terminal"
-                                     documentation="/applications/sales/point_of_sale/payment_methods/terminals/adyen.html">
-                                <field name="module_pos_adyen"/>
-                            </setting>
-                            <setting id="stripe_payment_terminal_setting" title="The transactions are processed by Stripe. Set your Stripe credentials on the related payment method." string="Stripe" help="Accept payments with a Stripe payment terminal" documentation="applications/sales/point_of_sale/payment_methods/terminals/stripe.html">
-                                <field name="module_pos_stripe"/>
-                            </setting>
-                            <setting title="The transactions are processed by Six. Set the IP address of the terminal on the related payment method." string="Six" documentation="/applications/sales/point_of_sale/payment_methods/terminals/six.html" help="Accept payments with a Six payment terminal">
-                                <field name="module_pos_six"/>
-                            </setting>
-                            <setting title="The transactions are processed by Viva Wallet on terminal or tap on phone." string="Viva Wallet" help="Accept payments with Viva Wallet on a terminal or tap on phone">
-                                <field name="module_pos_viva_wallet"/>
-                            </setting>
-                            <setting title="The transactions are processed by PayTM. Set your PayTM credentials on the related payment method." string="PayTM" help="Accept payments with a PayTM payment terminal">
-                                <field name="module_pos_paytm"/>
-                            </setting>
-                            <setting id="pos_razorpay_setting" title="The transactions are processed by Razorpay. Set your Razorpay credentials on the related payment method." string="Razorpay" help="Accept payments with a Razorpay payment terminal">
-                                <field name="module_pos_razorpay"/>
-                            </setting>
-                            <setting title="The transactions are processed by Mercado Pago on terminal" string="Mercado Pago" help="Accept payments with Mercado Pago on a terminal">
-                                <field name="module_pos_mercado_pago"/>
                             </setting>
                         </block>
 

--- a/addons/pos_adyen/models/pos_payment_method.py
+++ b/addons/pos_adyen/models/pos_payment_method.py
@@ -18,9 +18,6 @@ UNPREDICTABLE_ADYEN_DATA = object() # sentinel
 class PosPaymentMethod(models.Model):
     _inherit = 'pos.payment.method'
 
-    def _get_payment_terminal_selection(self):
-        return super(PosPaymentMethod, self)._get_payment_terminal_selection() + [('adyen', 'Adyen')]
-
     # Adyen
     adyen_api_key = fields.Char(string="Adyen API key", help='Used when connecting to Adyen: https://docs.adyen.com/user-management/how-to-get-the-api-key/#description', copy=False, groups='base.group_erp_manager')
     adyen_terminal_identifier = fields.Char(help='[Terminal model]-[Serial number], for example: P400Plus-123456789', copy=False)
@@ -59,6 +56,14 @@ class PosPaymentMethod(models.Model):
                                              terminal=payment_method.adyen_terminal_identifier,
                                              company=existing_payment_method.company_id.name,
                                              payment_method=existing_payment_method.display_name))
+
+    @api.onchange('use_payment_terminal')
+    def _onchange_use_payment_terminal(self):
+        super()._onchange_use_payment_terminal()
+        if self.use_payment_terminal == 'adyen' and not self.adyen_api_key:
+            existing_payment_method = self.search([('use_payment_terminal', '=', 'adyen'), ('adyen_api_key', '!=', False)], limit=1)
+            if existing_payment_method:
+                self.adyen_api_key = existing_payment_method.adyen_api_key
 
     def _get_adyen_endpoints(self):
         return {

--- a/addons/pos_adyen/views/pos_payment_method_views.xml
+++ b/addons/pos_adyen/views/pos_payment_method_views.xml
@@ -5,12 +5,12 @@
         <field name="model">pos.payment.method</field>
         <field name="inherit_id" ref="point_of_sale.pos_payment_method_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='use_payment_terminal']" position="after">
+            <xpath expr="//div[hasclass('payment_terminal_div')]" position="after">
                 <!-- Adyen -->
-                <field name="adyen_api_key" invisible="use_payment_terminal != 'adyen'" required="use_payment_terminal == 'adyen'" password="True"/>
-                <field name="adyen_terminal_identifier" invisible="use_payment_terminal != 'adyen'" required="use_payment_terminal == 'adyen'"/>
-                <field name="adyen_event_url" invisible="use_payment_terminal != 'adyen'" widget="CopyClipboardChar"/>
-                <field name="adyen_test_mode" invisible="use_payment_terminal != 'adyen'" required="use_payment_terminal == 'adyen'"/>
+                <field name="adyen_api_key" invisible="hide_use_payment_terminal or use_payment_terminal != 'adyen'" required="use_payment_terminal == 'adyen'" password="True"/>
+                <field name="adyen_terminal_identifier" invisible="hide_use_payment_terminal or use_payment_terminal != 'adyen'" required="use_payment_terminal == 'adyen'"/>
+                <field name="adyen_event_url" invisible="hide_use_payment_terminal or use_payment_terminal != 'adyen'" widget="CopyClipboardChar"/>
+                <field name="adyen_test_mode" invisible="hide_use_payment_terminal or use_payment_terminal != 'adyen'" required="use_payment_terminal == 'adyen'"/>
             </xpath>
         </field>
     </record>

--- a/addons/pos_mercado_pago/views/pos_payment_method_views.xml
+++ b/addons/pos_mercado_pago/views/pos_payment_method_views.xml
@@ -5,12 +5,12 @@
         <field name="model">pos.payment.method</field>
         <field name="inherit_id" ref="point_of_sale.pos_payment_method_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='use_payment_terminal']" position="after">
+            <xpath expr="//div[hasclass('payment_terminal_div')]" position="after">
                 <!-- MercadoPago -->
-                <field name="mp_bearer_token" placeholder="APP_USR-..." invisible="use_payment_terminal != 'mercado_pago'" required="use_payment_terminal == 'mercado_pago'"/>
-                <field name="mp_webhook_secret_key" placeholder="c2f3662..." invisible="use_payment_terminal != 'mercado_pago'" required="use_payment_terminal == 'mercado_pago'"/>
-                <field name="mp_id_point_smart" placeholder="1494126963" invisible="use_payment_terminal != 'mercado_pago'" required="use_payment_terminal == 'mercado_pago'"/>
-                <button string="Force PDV" type="object" name="force_pdv" groups="base.group_no_one" class="oe_highlight" invisible="use_payment_terminal != 'mercado_pago'" required="use_payment_terminal == 'mercado_pago'"/>
+                <field name="mp_bearer_token" placeholder="APP_USR-..." invisible="hide_use_payment_terminal or use_payment_terminal != 'mercado_pago'" required="use_payment_terminal == 'mercado_pago'"/>
+                <field name="mp_webhook_secret_key" placeholder="c2f3662..." invisible="hide_use_payment_terminal or use_payment_terminal != 'mercado_pago'" required="use_payment_terminal == 'mercado_pago'"/>
+                <field name="mp_id_point_smart" placeholder="1494126963" invisible="hide_use_payment_terminal or use_payment_terminal != 'mercado_pago'" required="use_payment_terminal == 'mercado_pago'"/>
+                <button string="Force PDV" type="object" name="force_pdv" groups="base.group_no_one" class="oe_highlight" invisible="hide_use_payment_terminal or use_payment_terminal != 'mercado_pago'" required="use_payment_terminal == 'mercado_pago'"/>
             </xpath>
         </field>
     </record>

--- a/addons/pos_online_payment/models/pos_config.py
+++ b/addons/pos_online_payment/models/pos_config.py
@@ -14,7 +14,7 @@ class PosConfig(models.Model):
         for config in self:
             opm_amount = 0
             for pm in config.payment_method_ids:
-                if pm.is_online_payment:
+                if pm.payment_method_type == 'online':
                     opm_amount += 1
                     if opm_amount > 1:
                         raise ValidationError(_("A POS config cannot have more than one online payment method."))
@@ -23,4 +23,4 @@ class PosConfig(models.Model):
 
     def _get_cashier_online_payment_method(self):
         self.ensure_one()
-        return self.payment_method_ids.filtered('is_online_payment')[:1]
+        return self.payment_method_ids.filtered(lambda pm: pm.payment_method_type == 'online')[:1]

--- a/addons/pos_online_payment/static/src/app/models/pos_payment.js
+++ b/addons/pos_online_payment/static/src/app/models/pos_payment.js
@@ -4,7 +4,7 @@ import { patch } from "@web/core/utils/patch";
 patch(PosPayment.prototype, {
     //@override
     canBeAdjusted() {
-        if (this.payment_method_id.is_online_payment) {
+        if (this.payment_method_id.payment_method_type === "online") {
             return false;
         } else {
             return super.canBeAdjusted();

--- a/addons/pos_online_payment/static/src/app/services/pos_store.js
+++ b/addons/pos_online_payment/static/src/app/services/pos_store.js
@@ -48,7 +48,7 @@ patch(PosStore.prototype, {
 
         if (opData["deleted"] === true) {
             const onlinePm = order.payment_ids.filter(
-                (line) => line.payment_method_id.is_online_payment
+                (line) => line.payment_method_id.payment_method_type === "online"
             );
 
             for (const line of onlinePm) {
@@ -62,7 +62,7 @@ patch(PosStore.prototype, {
 
         const opLinesToUpdate = order.payment_ids.filter(
             (line) =>
-                line.payment_method_id.is_online_payment &&
+                line.payment_method_id.payment_method_type === "online" &&
                 ["waiting", "done"].includes(line.getPaymentStatus())
         );
         for (const op of opData.online_payments) {

--- a/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
@@ -8,7 +8,10 @@ import { ask } from "@point_of_sale/app/utils/make_awaitable_dialog";
 
 patch(PaymentScreen.prototype, {
     async addNewPaymentLine(paymentMethod) {
-        if (paymentMethod.is_online_payment && typeof this.currentOrder.id === "string") {
+        if (
+            paymentMethod.payment_method_type === "online" &&
+            typeof this.currentOrder.id === "string"
+        ) {
             this.currentOrder.date_order = luxon.DateTime.now().toFormat("yyyy-MM-dd HH:mm:ss");
             this.pos.addPendingOrder([this.currentOrder.id]);
             await this.pos.syncAllOrders();
@@ -17,7 +20,9 @@ patch(PaymentScreen.prototype, {
     },
     getRemainingOnlinePaymentLines() {
         return this.paymentLines.filter(
-            (line) => line.payment_method_id.is_online_payment && line.getPaymentStatus() !== "done"
+            (line) =>
+                line.payment_method_id.payment_method_type === "online" &&
+                line.getPaymentStatus() !== "done"
         );
     },
     checkRemainingOnlinePaymentLines(unpaidAmount) {
@@ -58,7 +63,7 @@ patch(PaymentScreen.prototype, {
             return false;
         }
 
-        if (!this.payment_methods_from_config.some((pm) => pm.is_online_payment)) {
+        if (!this.payment_methods_from_config.some((pm) => pm.payment_method_type === "online")) {
             return true;
         }
 

--- a/addons/pos_online_payment/tests/test_frontend.py
+++ b/addons/pos_online_payment/tests/test_frontend.py
@@ -83,7 +83,7 @@ class TestUi(AccountTestInvoicingCommon, OnlinePaymentCommon):
 
         cls.online_payment_method = cls.env['pos.payment.method'].create({
             'name': 'Online payment',
-            'is_online_payment': True,
+            'payment_method_type': 'online',
             'online_payment_provider_ids': [Command.set([cls.payment_provider.id])],
         })
 

--- a/addons/pos_online_payment/views/pos_payment_method_views.xml
+++ b/addons/pos_online_payment/views/pos_payment_method_views.xml
@@ -7,40 +7,30 @@
         <field name="arch" type="xml">
             <xpath expr="//form/sheet" position="before">
                 <field name="has_an_online_payment_provider" invisible="1"/>
-                <div class="alert alert-danger" role="alert" invisible="not is_online_payment or has_an_online_payment_provider">
+                <div class="alert alert-danger" role="alert" invisible="payment_method_type != 'online' or has_an_online_payment_provider">
                     You have not activated any <bold><a type="action" name="%(payment.action_payment_provider)d" class="alert-link" role="button">payment provider</a></bold> to allow online payments.
                 </div>
             </xpath>
-            <xpath expr="//form/sheet/group/group/field[@name='split_transactions']" position="before">
-                <field name="is_online_payment"/>
-            </xpath>
             <xpath expr="//form/sheet/group/group/field[@name='split_transactions']" position="attributes">
-                <attribute name="invisible">is_online_payment</attribute>
-            </xpath>
-            <xpath expr="//form/sheet/group/group/field[@name='payment_method_type']" position="attributes">
-                <attribute name="invisible">is_online_payment</attribute>
+                <attribute name="invisible">payment_method_type == 'online'</attribute>
             </xpath>
             <xpath expr="//form/sheet/group/group/field[@name='qr_code_method']" position="attributes">
-                <attribute name="invisible">is_online_payment or hide_qr_code_method</attribute>
+                <attribute name="invisible">hide_qr_code_method or payment_method_type == 'online'</attribute>
             </xpath>
-            <xpath expr="//form/sheet/group/group/div[@name='tips']" position="attributes">
-                <attribute name="invisible">is_online_payment or not hide_use_payment_terminal or payment_method_type != 'terminal'</attribute>
-            </xpath>
+
             <xpath expr="//form/sheet/group/group/field[@name='journal_id']" position="attributes">
-                <attribute name="invisible">is_online_payment</attribute>
-                <attribute name="required">not is_online_payment and not split_transactions</attribute>
+                <attribute name="invisible">payment_method_type == 'online'</attribute>
+                <attribute name="required">payment_method_type != 'online' and not split_transactions</attribute>
             </xpath>
             <xpath expr="//form/sheet/group/group/field[@name='receivable_account_id']" position="attributes">
-                <attribute name="invisible">is_online_payment or split_transactions</attribute>
+                <attribute name="invisible">payment_method_type == 'online' or split_transactions</attribute>
             </xpath>
-            <xpath expr="//form/sheet/group[@name='Payment methods']/group" position="after">
-                <group invisible="not is_online_payment">
-                    <div colspan="2">
-                        <label for="online_payment_provider_ids"/>
-                        <field name="online_payment_provider_ids" widget="many2many_tags" options="{'no_create': True}" placeholder="All available providers" />
-                        <button name="%(payment.action_payment_provider)d" icon="fa-arrow-right" type="action" string="Payment Providers" class="btn-link" />
-                    </div>
-                </group>
+            <xpath expr="//field[@name='payment_method_type']" position="after">
+                <div colspan="2" invisible="payment_method_type != 'online'">
+                    <label for="online_payment_provider_ids"/>
+                    <field name="online_payment_provider_ids" widget="many2many_tags" options="{'no_create': True}" placeholder="All available providers" />
+                    <button name="%(payment.action_payment_provider)d" icon="fa-arrow-right" type="action" string="Payment Providers" class="btn-link" />
+                </div>
             </xpath>
         </field>
     </record>
@@ -51,10 +41,9 @@
         <field name="inherit_id" ref="point_of_sale.pos_payment_method_view_tree"/>
         <field name="arch" type="xml">
             <xpath expr="//list" position="attributes">
-                <attribute name="decoration-danger">is_online_payment and not has_an_online_payment_provider</attribute>
+                <attribute name="decoration-danger">payment_method_type == 'online' and not has_an_online_payment_provider</attribute>
             </xpath>
             <xpath expr="//list" position="inside">
-                <field name="is_online_payment" optional="hide"/>
                 <field name="has_an_online_payment_provider" column_invisible="True"/>
             </xpath>
         </field>

--- a/addons/pos_online_payment_self_order/models/pos_config.py
+++ b/addons/pos_online_payment_self_order/models/pos_config.py
@@ -8,7 +8,7 @@ from odoo.exceptions import ValidationError
 class PosConfig(models.Model):
     _inherit = 'pos.config'
 
-    self_order_online_payment_method_id = fields.Many2one('pos.payment.method', string='Self Online Payment', help="The online payment method to use when a customer pays a self-order online.", domain=[('is_online_payment', '=', True)], store=True, readonly=False)
+    self_order_online_payment_method_id = fields.Many2one('pos.payment.method', string='Self Online Payment', help="The online payment method to use when a customer pays a self-order online.", domain=[('payment_method_type', '=', 'online')], store=True, readonly=False)
 
     @api.constrains('self_order_online_payment_method_id')
     def _check_self_order_online_payment_method_id(self):

--- a/addons/pos_online_payment_self_order/models/pos_payment_method.py
+++ b/addons/pos_online_payment_self_order/models/pos_payment_method.py
@@ -9,7 +9,7 @@ class PosPaymentMethod(models.Model):
     def _load_pos_self_data_domain(self, data):
         if data['pos.config']['data'][0]['self_ordering_mode'] == 'kiosk':
             domain = super()._load_pos_self_data_domain(data)
-            domain = expression.OR([[('is_online_payment', '=', True)], domain])
+            domain = expression.OR([[('payment_method_type', '=', 'online')], domain])
             return domain
         else:
-            return [('is_online_payment', '=', True)]
+            return [('payment_method_type', '=', 'online')]

--- a/addons/pos_online_payment_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_online_payment_self_order/static/src/app/services/self_order_service.js
@@ -47,7 +47,7 @@ patch(SelfOrder.prototype, {
     },
     filterPaymentMethods(pms) {
         const pm = super.filterPaymentMethods(...arguments);
-        const online_pms = pms.filter((rec) => rec.is_online_payment);
+        const online_pms = pms.filter((rec) => rec.payment_method_type === "online");
         return [...new Set([...pm, ...online_pms])];
     },
 });

--- a/addons/pos_online_payment_self_order/static/src/components/order_widget/order_widget.js
+++ b/addons/pos_online_payment_self_order/static/src/components/order_widget/order_widget.js
@@ -8,7 +8,7 @@ patch(OrderWidget.prototype, {
         const type = this.selfOrder.config.self_ordering_mode;
         const mode = this.selfOrder.config.self_ordering_pay_after;
         const isOnlinePayment = this.selfOrder.models["pos.payment.method"].find(
-            (p) => p.is_online_payment
+            (p) => p.payment_method_type === "online"
         );
         const order = this.selfOrder.currentOrder;
         const takeAway = order.takeaway;

--- a/addons/pos_online_payment_self_order/static/src/pages/payment_page/payment_page.js
+++ b/addons/pos_online_payment_self_order/static/src/pages/payment_page/payment_page.js
@@ -8,7 +8,7 @@ patch(PaymentPage.prototype, {
         const pm = this.selectedPaymentMethod;
         const device = this.selfOrder.config.self_ordering_mode;
 
-        if (!pm || !pm.is_online_payment) {
+        if (!pm || pm.payment_method_type !== "online") {
             return super.startPayment(...arguments);
         } else {
             order = await this.selfOrder.sendDraftOrderToServer();
@@ -23,7 +23,7 @@ patch(PaymentPage.prototype, {
     },
     get selectedPaymentIsOnline() {
         const paymentMethods = this.selectedPaymentMethod;
-        return paymentMethods && paymentMethods.is_online_payment;
+        return paymentMethods && paymentMethods.payment_method_type === "online";
     },
     generateQrcodeImg(url) {
         const codeWriter = new window.ZXing.BrowserQRCodeSvgWriter();

--- a/addons/pos_paytm/views/pos_payment_method_views.xml
+++ b/addons/pos_paytm/views/pos_payment_method_views.xml
@@ -5,14 +5,14 @@
         <field name="model">pos.payment.method</field>
         <field name="inherit_id" ref="point_of_sale.pos_payment_method_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='use_payment_terminal']" position="after">
-                <field name="paytm_mid" invisible="use_payment_terminal != 'paytm'" required="use_payment_terminal == 'paytm'"/>
-                <field name="paytm_tid" invisible="use_payment_terminal != 'paytm'" required="use_payment_terminal == 'paytm'"/>
-                <field name="paytm_merchant_key" invisible="use_payment_terminal != 'paytm'" required="use_payment_terminal == 'paytm'"/>
-                <field name="channel_id" groups="base.group_no_one" invisible="use_payment_terminal != 'paytm'" required="use_payment_terminal == 'paytm'"/>
-                <field name="accept_payment" invisible="use_payment_terminal != 'paytm'" required="use_payment_terminal == 'paytm'"/>
-                <field name="allowed_payment_modes" invisible="use_payment_terminal != 'paytm'" required="use_payment_terminal == 'paytm'"/>
-                <field name="paytm_test_mode" invisible="use_payment_terminal != 'paytm'" required="use_payment_terminal == 'paytm'"/>
+            <xpath expr="//div[hasclass('payment_terminal_div')]" position="after">
+                <field name="paytm_mid" invisible="hide_use_payment_terminal or use_payment_terminal != 'paytm'" required="use_payment_terminal == 'paytm'"/>
+                <field name="paytm_tid" invisible="hide_use_payment_terminal or use_payment_terminal != 'paytm'" required="use_payment_terminal == 'paytm'"/>
+                <field name="paytm_merchant_key" invisible="hide_use_payment_terminal or use_payment_terminal != 'paytm'" required="use_payment_terminal == 'paytm'"/>
+                <field name="channel_id" groups="base.group_no_one" invisible="hide_use_payment_terminal or use_payment_terminal != 'paytm'" required="use_payment_terminal == 'paytm'"/>
+                <field name="accept_payment" invisible="hide_use_payment_terminal or use_payment_terminal != 'paytm'" required="use_payment_terminal == 'paytm'"/>
+                <field name="allowed_payment_modes" invisible="hide_use_payment_terminal or use_payment_terminal != 'paytm'" required="use_payment_terminal == 'paytm'"/>
+                <field name="paytm_test_mode" invisible="hide_use_payment_terminal or use_payment_terminal != 'paytm'" required="use_payment_terminal == 'paytm'"/>
             </xpath>
         </field>
     </record>

--- a/addons/pos_razorpay/models/pos_payment_method.py
+++ b/addons/pos_razorpay/models/pos_payment_method.py
@@ -1,4 +1,3 @@
-from odoo.exceptions import UserError
 from odoo import fields, models, api, _
 
 from .razorpay_pos_request import RazorpayPosRequest
@@ -12,9 +11,6 @@ class PosPaymentMethod(models.Model):
     razorpay_username = fields.Char(string='Razorpay Username', help='Username(Device Login) \n ex: 1234500121')
     razorpay_api_key = fields.Char(string='Razorpay API Key', help='Used when connecting to Razorpay: https://razorpay.com/docs/payments/dashboard/account-settings/api-keys/')
     razorpay_test_mode = fields.Boolean(string='Razorpay Test Mode', default=False, help='Turn it on when in Test Mode')
-
-    def _get_payment_terminal_selection(self):
-        return super()._get_payment_terminal_selection() + [('razorpay', 'Razorpay')]
 
     def razorpay_make_payment_request(self, data):
         razorpay = RazorpayPosRequest(self)
@@ -76,7 +72,14 @@ class PosPaymentMethod(models.Model):
         errorMessage = response.get('errorMessage') or default_error_msg
         return {'errorMessage': str(errorMessage)}
 
-    @api.constrains('use_payment_terminal')
-    def _check_razorpay_terminal(self):
-        if any(record.use_payment_terminal == 'razorpay' and record.company_id.currency_id.name != 'INR' for record in self):
-            raise UserError(_('This Payment Terminal is only valid for INR Currency'))
+    @api.onchange('use_payment_terminal')
+    def _onchange_use_payment_terminal(self):
+        super()._onchange_use_payment_terminal()
+        if self.use_payment_terminal == 'razorpay' and not self.razorpay_api_key:
+            existing_payment_method = self.search([('use_payment_terminal', '=', 'razorpay'), ('razorpay_api_key', '!=', False)], limit=1)
+            if existing_payment_method:
+                self.update({
+                    'razorpay_allowed_payment_modes': existing_payment_method.razorpay_allowed_payment_modes,
+                    'razorpay_username': existing_payment_method.razorpay_username,
+                    'razorpay_api_key': existing_payment_method.razorpay_api_key,
+                })

--- a/addons/pos_razorpay/views/pos_payment_method_views.xml
+++ b/addons/pos_razorpay/views/pos_payment_method_views.xml
@@ -5,12 +5,12 @@
         <field name="model">pos.payment.method</field>
         <field name="inherit_id" ref="point_of_sale.pos_payment_method_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='use_payment_terminal']" position="after">
-                <field name="razorpay_username" invisible="use_payment_terminal != 'razorpay'" required="use_payment_terminal == 'razorpay'"/>
-                <field name="razorpay_tid" invisible="use_payment_terminal != 'razorpay'" required="use_payment_terminal == 'razorpay'"/>
-                <field name="razorpay_api_key" invisible="use_payment_terminal != 'razorpay'" required="use_payment_terminal == 'razorpay'"/>
-                <field name="razorpay_test_mode" invisible="use_payment_terminal != 'razorpay'" required="use_payment_terminal == 'razorpay'"/>
-                <field name="razorpay_allowed_payment_modes" invisible="use_payment_terminal != 'razorpay'" required="use_payment_terminal == 'razorpay'"/>
+            <xpath expr="//div[hasclass('payment_terminal_div')]" position="after">
+                <field name="razorpay_username" invisible="hide_use_payment_terminal or use_payment_terminal != 'razorpay'" required="use_payment_terminal == 'razorpay'"/>
+                <field name="razorpay_tid" invisible="hide_use_payment_terminal or use_payment_terminal != 'razorpay'" required="use_payment_terminal == 'razorpay'"/>
+                <field name="razorpay_api_key" invisible="hide_use_payment_terminal or use_payment_terminal != 'razorpay'" required="use_payment_terminal == 'razorpay'"/>
+                <field name="razorpay_test_mode" invisible="hide_use_payment_terminal or use_payment_terminal != 'razorpay'" required="use_payment_terminal == 'razorpay'"/>
+                <field name="razorpay_allowed_payment_modes" invisible="hide_use_payment_terminal or use_payment_terminal != 'razorpay'" required="use_payment_terminal == 'razorpay'"/>
             </xpath>
         </field>
     </record>

--- a/addons/pos_restaurant_adyen/models/pos_payment_method.py
+++ b/addons/pos_restaurant_adyen/models/pos_payment_method.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models, api
+from odoo import api, fields, models
 
 
 class PosPaymentMethod(models.Model):
@@ -15,6 +15,14 @@ class PosPaymentMethod(models.Model):
             'adjust': 'https://pal-%s.adyen.com/pal/servlet/Payment/v52/adjustAuthorisation',
             'capture': 'https://pal-%s.adyen.com/pal/servlet/Payment/v52/capture',
         }
+
+    @api.onchange('use_payment_terminal')
+    def _onchange_use_payment_terminal(self):
+        super()._onchange_use_payment_terminal()
+        if self.use_payment_terminal == 'adyen' and not self.adyen_merchant_account:
+            existing_payment_method = self.search([('use_payment_terminal', '=', 'adyen'), ('adyen_merchant_account', '!=', False)], limit=1)
+            if existing_payment_method:
+                self.adyen_merchant_account = existing_payment_method.adyen_merchant_account
 
     @api.model
     def _load_pos_data_fields(self, config_id):

--- a/addons/pos_restaurant_adyen/views/pos_payment_method_views.xml
+++ b/addons/pos_restaurant_adyen/views/pos_payment_method_views.xml
@@ -6,7 +6,7 @@
       <field name="inherit_id" ref="pos_adyen.pos_payment_method_view_form_inherit_pos_adyen"/>
       <field name="arch" type="xml">
           <xpath expr="//field[@name='adyen_terminal_identifier']" position="after">
-                <field name="adyen_merchant_account" invisible="use_payment_terminal != 'adyen'" required="use_payment_terminal == 'adyen'"/>
+                <field name="adyen_merchant_account" invisible="hide_use_payment_terminal or use_payment_terminal != 'adyen'" required="use_payment_terminal == 'adyen'"/>
           </xpath>
       </field>
     </record>

--- a/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.js
+++ b/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.js
@@ -77,7 +77,7 @@ export class ConfirmationPage extends Component {
         this.confirmedOrder = order;
 
         const paymentMethods = this.selfOrder.models["pos.payment.method"].filter(
-            (p) => p.is_online_payment
+            (p) => p.payment_method_type === "online"
         );
 
         if (

--- a/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.xml
@@ -23,7 +23,7 @@
             </div>
         </div>
         <div class="px-3 py-4 d-flex gap-1 justify-content-center">
-            <button class="btn btn-primary btn-lg" t-if="state.selection || selectedPaymentMethod.is_online_payment || this.selfOrder.paymentError" t-on-click="() => this.router.back()">Back</button>
+            <button class="btn btn-primary btn-lg" t-if="state.selection || selectedPaymentMethod.payment_method_type == 'online' || this.selfOrder.paymentError" t-on-click="() => this.router.back()">Back</button>
             <button class="btn btn-info btn-lg" t-if="!state.selection and selfOrder.paymentError" t-on-click="startPayment">Retry</button>
         </div>
     </t>

--- a/addons/pos_six/models/pos_payment_method.py
+++ b/addons/pos_six/models/pos_payment_method.py
@@ -7,9 +7,6 @@ from odoo import fields, models, api
 class PosPaymentMethod(models.Model):
     _inherit = 'pos.payment.method'
 
-    def _get_payment_terminal_selection(self):
-        return super(PosPaymentMethod, self)._get_payment_terminal_selection() + [('six', 'SIX')]
-
     six_terminal_ip = fields.Char('Six Terminal IP')
 
     @api.model

--- a/addons/pos_six/views/pos_payment_method_views.xml
+++ b/addons/pos_six/views/pos_payment_method_views.xml
@@ -5,9 +5,9 @@
         <field name="model">pos.payment.method</field>
         <field name="inherit_id" ref="point_of_sale.pos_payment_method_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='use_payment_terminal']" position="after">
+            <xpath expr="//div[hasclass('payment_terminal_div')]" position="after">
                 <field name="six_terminal_ip"
-                    invisible="use_payment_terminal != 'six'"
+                    invisible="hide_use_payment_terminal or use_payment_terminal != 'six'"
                     required="use_payment_terminal == 'six'"/>
             </xpath>
         </field>

--- a/addons/pos_stripe/models/pos_payment_method.py
+++ b/addons/pos_stripe/models/pos_payment_method.py
@@ -14,9 +14,6 @@ TIMEOUT = 10
 class PosPaymentMethod(models.Model):
     _inherit = 'pos.payment.method'
 
-    def _get_payment_terminal_selection(self):
-        return super()._get_payment_terminal_selection() + [('stripe', 'Stripe')]
-
     # Stripe
     stripe_serial_number = fields.Char(help='[Serial number of the stripe terminal], for example: WSC513105011295', copy=False)
 

--- a/addons/pos_stripe/views/pos_payment_method_views.xml
+++ b/addons/pos_stripe/views/pos_payment_method_views.xml
@@ -5,10 +5,10 @@
         <field name="model">pos.payment.method</field>
         <field name="inherit_id" ref="point_of_sale.pos_payment_method_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='use_payment_terminal']" position="after">
+            <xpath expr="//div[hasclass('payment_terminal_div')]" position="after">
                 <!-- Stripe -->
-                <field name="stripe_serial_number" invisible="use_payment_terminal != 'stripe'" required="use_payment_terminal == 'stripe'"/>
-                <div colspan="2" class="mt16" invisible="use_payment_terminal != 'stripe'" required="use_payment_terminal == 'stripe'">
+                <field name="stripe_serial_number" invisible="hide_use_payment_terminal or use_payment_terminal != 'stripe'" required="use_payment_terminal == 'stripe'"/>
+                <div colspan="2" class="mt16" invisible="hide_use_payment_terminal or use_payment_terminal != 'stripe'" required="use_payment_terminal == 'stripe'">
                     <button name="action_stripe_key" type="object" icon="oi-arrow-right" string="Don't forget to complete Stripe connect before using this payment method." class="btn-link"/>
                 </div>
             </xpath>

--- a/addons/pos_viva_wallet/views/pos_payment_method_views.xml
+++ b/addons/pos_viva_wallet/views/pos_payment_method_views.xml
@@ -5,15 +5,15 @@
         <field name="model">pos.payment.method</field>
         <field name="inherit_id" ref="point_of_sale.pos_payment_method_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='use_payment_terminal']" position="after">
+            <xpath expr="//div[hasclass('payment_terminal_div')]" position="after">
                 <!-- Viva Wallet -->
-                <field name="viva_wallet_merchant_id" invisible="use_payment_terminal != 'viva_wallet'" required="use_payment_terminal == 'viva_wallet'"/>
-                <field name="viva_wallet_api_key" invisible="use_payment_terminal != 'viva_wallet'" required="use_payment_terminal == 'viva_wallet'"/>
-                <field name="viva_wallet_client_id" invisible="use_payment_terminal != 'viva_wallet'" required="use_payment_terminal == 'viva_wallet'"/>
-                <field name="viva_wallet_client_secret" invisible="use_payment_terminal != 'viva_wallet'" required="use_payment_terminal == 'viva_wallet'"/>
-                <field name="viva_wallet_test_mode" invisible="use_payment_terminal != 'viva_wallet'" required="use_payment_terminal == 'viva_wallet'"/>
-                <field name="viva_wallet_terminal_id" invisible="use_payment_terminal != 'viva_wallet'" required="use_payment_terminal == 'viva_wallet'"/>
-                <field name="viva_wallet_webhook_endpoint" invisible="use_payment_terminal != 'viva_wallet' or not id" required="use_payment_terminal == 'viva_wallet'" widget="CopyClipboardChar"/>
+                <field name="viva_wallet_merchant_id" invisible="hide_use_payment_terminal or use_payment_terminal != 'viva_wallet'" required="use_payment_terminal == 'viva_wallet'"/>
+                <field name="viva_wallet_api_key" invisible="hide_use_payment_terminal or use_payment_terminal != 'viva_wallet'" required="use_payment_terminal == 'viva_wallet'"/>
+                <field name="viva_wallet_client_id" invisible="hide_use_payment_terminal or use_payment_terminal != 'viva_wallet'" required="use_payment_terminal == 'viva_wallet'"/>
+                <field name="viva_wallet_client_secret" invisible="hide_use_payment_terminal or use_payment_terminal != 'viva_wallet'" required="use_payment_terminal == 'viva_wallet'"/>
+                <field name="viva_wallet_test_mode" invisible="hide_use_payment_terminal or use_payment_terminal != 'viva_wallet'" required="use_payment_terminal == 'viva_wallet'"/>
+                <field name="viva_wallet_terminal_id" invisible="hide_use_payment_terminal or use_payment_terminal != 'viva_wallet'" required="use_payment_terminal == 'viva_wallet'"/>
+                <field name="viva_wallet_webhook_endpoint" invisible="hide_use_payment_terminal or use_payment_terminal != 'viva_wallet' or not id" required="use_payment_terminal == 'viva_wallet'" widget="CopyClipboardChar"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
pos_*: point_of_sale, pos_adyen, pos_mercado_pago, pos_online_payment, pos_paytm, pos_razorpay, pos_six, pos_stripe, pos_viva_wallet

Before this commit:
==========
- Users had to add common field values for the same provider-based method multiple times, which was time-consuming.
- There is a boolean field called `is_online_payment` used to indicate whether an online payment method is being created.

After this commit:
==========
- Users only need to add common field values once. After that, common field values are automatically populated, saving time 
  when creating payment methods.
- The `is_online_payment` field has been removed from `pos.payment.method`. The selection value `Online` has been added to create an online payment method.

Related PR:
Enterprise: https://github.com/odoo/enterprise/pull/67699
Upgrade: https://github.com/odoo/upgrade/pull/6329

task-3506646
