### PR TITLE
[REF] google_calendar: allow external credentials

### DIFF
--- a/addons/google_account/controllers/main.py
+++ b/addons/google_account/controllers/main.py
@@ -20,11 +20,9 @@ class GoogleAuth(http.Controller):
             raise BadRequest()
 
         if kw.get('code'):
-            base_url = request.httprequest.url_root.strip('/') or request.env.user.get_base_url()
             access_token, refresh_token, ttl = request.env['google.service']._get_google_tokens(
                 kw['code'],
                 service,
-                redirect_uri=f'{base_url}/google_account/authentication'
             )
             service_field = 'res_users_settings_id'
             if service_field in request.env.user:

--- a/addons/google_calendar/models/res_users.py
+++ b/addons/google_calendar/models/res_users.py
@@ -163,10 +163,9 @@ class User(models.Model):
     @api.model
     def check_calendar_credentials(self):
         res = super().check_calendar_credentials()
-        get_param = self.env['ir.config_parameter'].sudo().get_param
-        client_id = get_param('google_calendar_client_id')
-        client_secret = get_param('google_calendar_client_secret')
-        res['google_calendar'] = bool(client_id and client_secret)
+        has_setup_credentials = self.env['google.service']._has_setup_credentials()
+        has_external_credentials = self.env['google.service']._has_external_credentials_provider()
+        res['google_calendar'] = bool(has_setup_credentials or has_external_credentials)
         return res
 
     def check_synchronization_status(self):

--- a/addons/google_calendar/models/res_users_settings.py
+++ b/addons/google_calendar/models/res_users_settings.py
@@ -50,9 +50,8 @@ class ResUsersSettings(models.Model):
 
     def _refresh_google_calendar_token(self):
         self.ensure_one()
-        get_param = self.env['ir.config_parameter'].sudo().get_param
-        client_id = get_param('google_calendar_client_id')
-        client_secret = get_param('google_calendar_client_secret')
+        client_id = self.env['google.service']._get_client_id('calendar')
+        client_secret = self.env['google.service']._get_client_secret('calendar')
 
         if not client_id or not client_secret:
             raise UserError(_("The account for the Google Calendar service is not configured."))

--- a/addons/google_calendar/utils/google_calendar.py
+++ b/addons/google_calendar/utils/google_calendar.py
@@ -125,11 +125,10 @@ class GoogleCalendarService():
             's': 'calendar',
             'f': from_url
         }
-        base_url = self.google_service._context.get('base_url') or self.google_service.get_base_url()
         return self.google_service._get_authorize_uri(
             'calendar',
             self._get_calendar_scope(),
-            base_url + '/google_account/authentication',
+            self.google_service._get_redirect_uri(),
             state=json.dumps(state),
             approval_prompt='force',
             access_type='offline'


### PR DESCRIPTION
Refactor Google Calendar credential functions to consolidate them within the Google Service class. This improves organization
and makes it easier to locate all credential-related functions. Each credential type is now handled by a dedicated private 'get'
function for easier overriding. Additionally, an overridable function to indicate the use of external credentials is included.

task-3864685