### PR TITLE
[FIX] html_editor: history steps ids att in BR element

### DIFF
--- a/addons/html_editor/static/src/others/collaboration/collaboration_odoo_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_odoo_plugin.js
@@ -83,6 +83,8 @@ export class CollaborationOdooPlugin extends Plugin {
             // Wait until editor is focused to join the peer to peer network.
             this.editable.addEventListener("focus", this.joinPeerToPeer);
         }
+
+        this.removeHistoryIds(this.editable);
     }
     destroy() {
         this.collaborationStopBus && this.collaborationStopBus();
@@ -105,8 +107,7 @@ export class CollaborationOdooPlugin extends Plugin {
             case "STEP_ADDED":
                 this.ptp?.notifyAllPeers("oe_history_step", payload.step, { transport: "rtc" });
                 break;
-            case "CLEAN":
-                // TODO @phoenix: evaluate if this should be cleanforsave instead
+            case "CLEAN_FOR_SAVE":
                 this.attachHistoryIds(payload.root);
                 break;
             case "HISTORY_RESET":
@@ -596,6 +597,7 @@ export class CollaborationOdooPlugin extends Plugin {
         content = content || "<p><br></p>";
         // content here is trusted
         this.editable.innerHTML = content;
+        this.removeHistoryIds(this.editable);
         this.dispatch("NORMALIZE", { node: this.editable });
         this.shared.reset(content);
 
@@ -777,12 +779,12 @@ export class CollaborationOdooPlugin extends Plugin {
         );
         return record;
     }
-    attachHistoryIds(editable) {
-        // clean existig 'data-last-history-steps' attributes
+    removeHistoryIds(editable) {
         editable
             .querySelectorAll("[data-last-history-steps]")
             .forEach((el) => el.removeAttribute("data-last-history-steps"));
-
+    }
+    attachHistoryIds(editable) {
         const historyIds = this.shared.getBranchIds().join(",");
         const firstChild = editable.children[0];
         if (firstChild) {


### PR DESCRIPTION
Step to reproduce:
- Press "enter" on an empty paragraph.

Result:
  The new paragraph resulting from the block split has:
  - no hint displayed;
  - a BR element with the "data-last-history-steps" attribute.

A similar result is obtained by any call to SplitPlugin's splitElement method (splitting a block, formatting a selection etc.), having the mentioned attribute added to the first child of the split element.

The reason for this was the CollaborationOdooPlugin's attachHistoryIds method being called on the element about to be split, when this method is actually meant to be called on the editable when about to send the document to the server.

This commit, other than fixing the moment in which attachHistoryIds gets called (on CLEAN_FOR_SAVE instead of CLEAN), removes the "data-last-history-steps" attribute from the DOM for edition, as it has no use after the information it contained has been stored.
