### PR TITLE
[FIX] base_import_module: fix test_import_zip

### DIFF
--- a/addons/base_import_module/tests/test_import_module.py
+++ b/addons/base_import_module/tests/test_import_module.py
@@ -64,9 +64,9 @@ class TestImportModule(odoo.tests.TransactionCase):
             """),
         ]
         self.env['res.lang']._activate_lang('fr_FR')
-        with self.assertLogs('odoo.addons.base_import_module.models.ir_module') as log_catcher:
+        with self.assertLogs('odoo.addons.base.models.ir_module') as log_catcher:
             self.import_zipfile(files)
-            self.assertIn('module foo: no translation for language fr_FR', log_catcher.output[5])
+            self.assertIn('module foo: no translation for language fr_FR', log_catcher.output[1])
         self.assertEqual(self.env.ref('foo.foo')._name, 'res.partner')
         self.assertEqual(self.env.ref('foo.foo').name, 'foo')
         self.assertEqual(self.env.ref('foo.bar')._name, 'res.partner')


### PR DESCRIPTION
This test uses a log catcher on "odoo.addons.base_import_module.models.ir_module" however, the log it tries to catch is now emitted from "odoo.addons.base.models.ir_module"

After this commit, the log is now properly caught by the test


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
