### PR TITLE
[CLN] *: replace all t-esc in qweb templates by t-out

### DIFF
--- a/addons/hr_recruitment/data/mail_templates.xml
+++ b/addons/hr_recruitment/data/mail_templates.xml
@@ -2,7 +2,7 @@
 <odoo><data noupdate="1">
 
     <template id="applicant_hired_template">
-Employee created: <a href="#" t-att-data-oe-id="applicant.emp_id.id" data-oe-model="hr.employee"><t t-esc="applicant.emp_id.name"/></a>
+Employee created: <a href="#" t-att-data-oe-id="applicant.emp_id.id" data-oe-model="hr.employee"><t t-out="applicant.emp_id.name"/></a>
     </template>
 
     <template id="mail_notification_light_without_background" inherit_id="mail.mail_notification_light">

--- a/addons/iap_mail/data/mail_templates.xml
+++ b/addons/iap_mail/data/mail_templates.xml
@@ -2,12 +2,12 @@
 <odoo>
 
     <template id="enrich_company">
-        <p t-esc="flavor_text" />
+        <p t-out="flavor_text" />
         <div class="o_partner_autocomplete_enrich_info p-3 mt-3 mb-3 me-5">
             <div class="row p-0 m-0">
             <div class="col-sm-10 p-0">
                 <h4>
-                    <span class="me-3 align-middle" t-esc="name"/>
+                    <span class="me-3 align-middle" t-out="name"/>
                     <a t-if="twitter" class="ms-2" target="_blank" t-attf-href="http://www.twitter.com/{{twitter}}">
                         <img src="/web_editor/font_to_img/61569/rgb(0,132,180)/22"/>
                     </a>
@@ -21,7 +21,7 @@
                         <img width="19px" height="19px" src="/partner_autocomplete/static/img/crunchbase.ico"/>
                     </a>
                 </h4>
-                <p t-esc="description"/>
+                <p t-out="description"/>
             </div>
             <div t-if="logo" class="col-sm-2 p-0 text-center text-md-end order-first order-md-last">
                 <img t-attf-src="{{logo}}" alt="" style="max-width: 80px;"/>
@@ -34,12 +34,12 @@
                     <i class="fa fa-fw me-2 fa-building text-primary"/>
                     <b>Company type</b>
                 </div>
-                <div t-if="company_type" class="my-1 col-sm-9" t-esc="company_type" />
+                <div t-if="company_type" class="my-1 col-sm-9" t-out="company_type" />
                 <div t-if="founded_year" class="d-flex my-1 p-0 col-sm-3">
                     <i class="fa fa-fw me-2 fa-calendar text-primary"/>
                     <b>Founded</b>
                 </div>
-                <div t-if="founded_year" class="my-1 col-sm-9" t-esc="founded_year" />
+                <div t-if="founded_year" class="my-1 col-sm-9" t-out="founded_year" />
                 <t t-set="sectors" t-value="[]" />
                 <t t-if="sector_primary" t-set="sectors" t-value="sectors + [sector_primary]" />
                 <t t-if="industry" t-set="sectors" t-value="sectors + [industry]" />
@@ -51,20 +51,20 @@
                 </div>
                 <div t-if="sectors" class="my-1 col-sm-9">
                     <t t-foreach="sectors" t-as="inner_sector">
-                        <label t-esc="inner_sector" class="o_tag o_tag_color_7" style="font-weight:normal; padding: 2px 10px; margin: 1px 0px; border-radius: 13px; display: inline-block;"/>
+                        <label t-out="inner_sector" class="o_tag o_tag_color_7" style="font-weight:normal; padding: 2px 10px; margin: 1px 0px; border-radius: 13px; display: inline-block;"/>
                     </t>
                 </div>
                 <div t-if="employees" class="d-flex my-1 p-0 col-sm-3">
                     <i class="fa fa-fw me-2 fa-users text-primary"/>
                     <b>Employees</b>
                 </div>
-                <div t-if="employees" class="my-1 col-sm-9" t-esc="'%.0f' % employees" />
+                <div t-if="employees" class="my-1 col-sm-9" t-out="'%.0f' % employees" />
                 <div t-if="estimated_annual_revenue" class="d-flex my-1 p-0 col-sm-3">
                     <i class="fa fa-fw me-2 fa-money text-primary"/>
                     <b>Estimated revenue</b>
                 </div>
                 <div t-if="estimated_annual_revenue" class="my-1 col-sm-9">
-                    <span t-esc="estimated_annual_revenue" /><span> per year</span>
+                    <span t-out="estimated_annual_revenue" /><span> per year</span>
                 </div>
                 <div t-if="phone_numbers" class="d-flex my-1 p-0 col-sm-3">
                     <i class="fa fa-fw me-2 fa-phone text-primary"/>
@@ -72,7 +72,7 @@
                 </div>
                 <div t-if="phone_numbers" class="col-sm-9">
                     <t t-foreach="phone_numbers" t-as="phone_number">
-                        <a t-attf-href="tel:{{phone_number}}" t-esc="phone_number" class="o_tag o_tag_color_7"  style="font-weight:normal; padding: 2px 10px; margin: 1px 0px; border-radius: 13px; display: inline-block;"/>
+                        <a t-attf-href="tel:{{phone_number}}" t-out="phone_number" class="o_tag o_tag_color_7"  style="font-weight:normal; padding: 2px 10px; margin: 1px 0px; border-radius: 13px; display: inline-block;"/>
                     </t>
                 </div>
                 <div t-if="email" class="d-flex my-1 p-0 col-sm-3">
@@ -81,21 +81,21 @@
                 </div>
                 <div t-if="email" class="col-sm-9">
                     <t t-foreach="email" t-as="email_item">
-                        <a target="_top" t-attf-href="mailto:{{email_item}}" t-esc="email_item" class="o_tag o_tag_color_7"  style="font-weight:normal; padding: 2px 10px; margin: 1px 0px; border-radius: 13px; display: inline-block;"/>
+                        <a target="_top" t-attf-href="mailto:{{email_item}}" t-out="email_item" class="o_tag o_tag_color_7"  style="font-weight:normal; padding: 2px 10px; margin: 1px 0px; border-radius: 13px; display: inline-block;"/>
                     </t>
                 </div>
                 <div t-if="timezone" class="d-flex my-1 p-0 col-sm-3">
                     <i class="fa fa-fw me-2 fa-globe text-primary"/>
                     <b>Timezone</b>
                 </div>
-                <div t-if="timezone" class="my-1 col-sm-9" t-esc="timezone.replace('_', ' ')" />
+                <div t-if="timezone" class="my-1 col-sm-9" t-out="timezone.replace('_', ' ')" />
                 <div t-if="tech" class="d-flex my-1 p-0 col-sm-3">
                     <i class="fa fa-fw me-2 fa-cube text-primary"/>
                     <b>Technologies Used</b>
                 </div>
                 <div t-if="tech" class="my-1 col-sm-9">
                     <t t-foreach="tech" t-as="tech_item">
-                        <label t-esc="tech_item.replace('_', ' ').title()" class="o_tag o_tag_color_7"  style="font-weight:normal; padding: 2px 10px; margin: 1px 0px; border-radius: 13px; display: inline-block;"/>
+                        <label t-out="tech_item.replace('_', ' ').title()" class="o_tag o_tag_color_7"  style="font-weight:normal; padding: 2px 10px; margin: 1px 0px; border-radius: 13px; display: inline-block;"/>
                     </t>
                 </div>
                 <div t-if="twitter_bio" class="d-flex my-1 p-0 col-sm-3">
@@ -105,12 +105,12 @@
                 <div t-if="twitter_bio" class="my-1 col-sm-9">
                     <div class="d-flex gap-2">
                         <a t-if="twitter" target="_blank" t-attf-href="http://www.twitter.com/{{twitter}}">
-                            http://www.twitter.com/<t t-esc="twitter"/>
+                            http://www.twitter.com/<t t-out="twitter"/>
                         </a>
                         <span t-if="twitter"> • </span>
-                        <div t-if="twitter_followers"><t t-esc="twitter_followers"/> followers</div>
+                        <div t-if="twitter_followers"><t t-out="twitter_followers"/> followers</div>
                     </div>
-                    <div t-esc="twitter_bio" />
+                    <div t-out="twitter_bio" />
                 </div>
             </div>
         </div>

--- a/addons/mail/data/mail_templates_chatter.xml
+++ b/addons/mail/data/mail_templates_chatter.xml
@@ -3,9 +3,9 @@
     <data>
         <!-- Discuss utility templates for notifications -->
         <template id="message_user_assigned">
-    <span>Dear <t t-esc="object.user_id.sudo().name"/>,</span>
+    <span>Dear <t t-out="object.user_id.sudo().name"/>,</span>
     <br/><br/>
-    <span style="margin-top: 8px;">You have been assigned to the <t t-esc="model_description or 'document'"/> <t t-esc="object.display_name"/>.</span>
+    <span style="margin-top: 8px;">You have been assigned to the <t t-out="model_description or 'document'"/> <t t-out="object.display_name"/>.</span>
     <br/>
         </template>
 
@@ -23,7 +23,7 @@
     <div t-if="feedback">
         <div class="fw-bold">Feedback:</div>
         <t t-foreach="feedback.split('\n')" t-as="feedback_line">
-            <t t-esc="feedback_line"/>
+            <t t-out="feedback_line"/>
             <br t-if="not feedback_line_last"/>
         </t>
     </div>
@@ -37,8 +37,8 @@
     <p>
         <span t-field="activity.create_uid.name"/> has just assigned you the following activity:
         <ul>
-            <li>Document: "<t t-esc="activity.res_name"/>"
-                <t t-if="model_description"> (<t t-esc="model_description"/>)</t>
+            <li>Document: "<t t-out="activity.res_name"/>"
+                <t t-if="model_description"> (<t t-out="model_description"/>)</t>
             </li>
             <li t-if="activity.summary">Summary: <span t-field="activity.summary"/></li>
             <li>Deadline: <span t-field="activity.date_deadline"/></li>
@@ -49,10 +49,10 @@
 
         <template id="message_origin_link">
             <p>
-                <t t-if="edit">This <t t-esc="self.env['ir.model']._get(self._name).name.lower()"/> has been modified from:</t>
-                <t t-else="">This <t t-esc="self.env['ir.model']._get(self._name).name.lower()"/> has been created from:</t>
+                <t t-if="edit">This <t t-out="self.env['ir.model']._get(self._name).name.lower()"/> has been modified from:</t>
+                <t t-else="">This <t t-out="self.env['ir.model']._get(self._name).name.lower()"/> has been created from:</t>
                 <t t-foreach="origin" t-as="o">
-                    <a href="#" t-att-data-oe-model="o._name" t-att-data-oe-id="o.id"> <t t-esc="o.display_name"/></a><span t-if="origin.ids[-1:] != o.ids">, </span>
+                    <a href="#" t-att-data-oe-model="o._name" t-att-data-oe-id="o.id"> <t t-out="o.display_name"/></a><span t-if="origin.ids[-1:] != o.ids">, </span>
                 </t>
             </p>
         </template>

--- a/addons/mail/data/mail_templates_mailgateway.xml
+++ b/addons/mail/data/mail_templates_mailgateway.xml
@@ -4,7 +4,7 @@
         <template id="message_notification_limit_email">
             <p>Dear Sender,</p>
             <p>
-                The message below could not be accepted by the address <t t-esc="email"/> because you have
+                The message below could not be accepted by the address <t t-out="email"/> because you have
                 contacted it too many times in the last few minutes.
                 <br/>
                 Please try again later.
@@ -14,14 +14,14 @@
 
         <template id="mail_bounce_catchall">
 <div>
-    <p>Hello <t t-esc="message['email_from']"/>,</p>
-    <p>The email sent to <t t-esc="message['to']"/> cannot be processed. This address
-    is used to collect replies and should not be used to directly contact <t t-esc="res_company.name"/>.</p>
-    <p>Please contact us instead using <a t-att-href="'mailto:%s' % res_company.email"><t t-esc="res_company.email"/></a></p>
+    <p>Hello <t t-out="message['email_from']"/>,</p>
+    <p>The email sent to <t t-out="message['to']"/> cannot be processed. This address
+    is used to collect replies and should not be used to directly contact <t t-out="res_company.name"/>.</p>
+    <p>Please contact us instead using <a t-att-href="'mailto:%s' % res_company.email"><t t-out="res_company.email"/></a></p>
     <p>Regards,</p>
-    <p>The <t t-esc="res_company.name"/> team.</p>
+    <p>The <t t-out="res_company.name"/> team.</p>
 </div>
-<blockquote><t t-esc="message['body']"/></blockquote>
+<blockquote><t t-out="message['body']"/></blockquote>
         </template>
 
         <!-- Mail bounce alias mail template -->

--- a/addons/project/data/mail_template_data.xml
+++ b/addons/project/data/mail_template_data.xml
@@ -118,9 +118,9 @@
         <!-- You have been assigned email -->
         <template id="project_message_user_assigned">
 <div>
-    Dear <t t-esc="assignee_name"/>,
+    Dear <t t-out="assignee_name"/>,
     <br/><br/>
-    <span style="margin-top: 8px;">You have been assigned to the <t t-esc="model_description or 'document'"/> <t t-esc="object.display_name"/>.</span>
+    <span style="margin-top: 8px;">You have been assigned to the <t t-out="model_description or 'document'"/> <t t-out="object.display_name"/>.</span>
 </div>
         </template>
 

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -13,7 +13,7 @@
             <head>
                 <meta charset="utf-8"/>
                 <meta name="viewport" content="initial-scale=1"/>
-                <title><t t-esc="title or 'Odoo Report'"/></title>
+                <title><t t-out="title or 'Odoo Report'"/></title>
                 <t t-call-assets="web.report_assets_common"/>
                 <!-- Temporary code: only used to maintain CSS for legacy HTML reports (full width...) -->
                 <!-- Should be removed once the reports are fully converted. -->
@@ -47,7 +47,7 @@
             <head>
                 <meta charset="utf-8"/>
                 <meta name="viewport" content="initial-scale=1"/>
-                <title><t t-esc="title or 'Odoo Report'"/></title>
+                <title><t t-out="title or 'Odoo Report'"/></title>
                 <t t-call-assets="web.report_assets_common" t-js="false"/>
                 <style>
                     <t t-out="preview_css"/>
@@ -273,7 +273,7 @@
             </t>
 
             <div name="address" t-att-class="not custom_layout_address and colclass or information_block and colclass">
-                <t t-esc="address or None">
+                <t t-out="address or None">
                     <div class="bg-light border-1 rounded h-100 d-flex flex-column align-items-center justify-content-center p-4 opacity-75 text-muted text-center">
                         <strong>Address block</strong>
                         <div>Usually contains the address of the document's recipient.</div>
@@ -311,8 +311,8 @@
                         </li>
                         <li t-if="not forced_vat"/>
                         <li t-else="">
-                            <t t-esc="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
-                            <span t-esc="forced_vat">US12345671</span>
+                            <t t-out="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
+                            <span t-out="forced_vat">US12345671</span>
                         </li>
                     </ul>
                 </div>
@@ -366,8 +366,8 @@
                             </li>
                             <li t-if="not forced_vat"/>
                             <li t-else="">
-                                <t t-esc="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
-                                <span t-esc="forced_vat">US12345671</span>
+                                <t t-out="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
+                                <span t-out="forced_vat">US12345671</span>
                             </li>
                         </ul>
                     </div>
@@ -426,8 +426,8 @@
                         </li>
                         <li t-if="not forced_vat"/>
                         <li t-else="">
-                            <t t-esc="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
-                            <span t-esc="forced_vat">US12345671</span>
+                            <t t-out="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
+                            <span t-out="forced_vat">US12345671</span>
                         </li>
                     </ul>
                 </div>
@@ -486,8 +486,8 @@
                         </li>
                         <li t-if="not forced_vat"/>
                         <li t-else="">
-                            <t t-esc="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
-                            <span t-esc="forced_vat">US12345671</span>
+                            <t t-out="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
+                            <span t-out="forced_vat">US12345671</span>
                         </li>
                     </ul>
                 </div>
@@ -561,8 +561,8 @@
                         </li>
                         <li t-if="not forced_vat"/>
                         <li t-else="">
-                            <t t-esc="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
-                            <span t-esc="forced_vat">US12345671</span>
+                            <t t-out="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
+                            <span t-out="forced_vat">US12345671</span>
                         </li>
                     </ul>
                 </div>
@@ -627,8 +627,8 @@
                         </li>
                         <li t-if="not forced_vat"/>
                         <li t-else="">
-                            <t t-esc="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
-                            <span t-esc="forced_vat">US12345671</span>
+                            <t t-out="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
+                            <span t-out="forced_vat">US12345671</span>
                         </li>
                     </ul>
                 </div>
@@ -691,8 +691,8 @@
                         </li>
                         <li t-if="not forced_vat"/>
                         <li t-else="">
-                            <t t-esc="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
-                            <span t-esc="forced_vat">US12345671</span>
+                            <t t-out="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
+                            <span t-out="forced_vat">US12345671</span>
                         </li>
                     </ul>
                 </div>
@@ -770,10 +770,10 @@
         <div class="header">
             <div class="row">
                 <div class="col-3">
-                    <span t-esc="context_timestamp(datetime.datetime.now()).strftime('%Y-%m-%d %H:%M')"/>
+                    <span t-out="context_timestamp(datetime.datetime.now()).strftime('%Y-%m-%d %H:%M')"/>
                 </div>
                 <div class="col-2 offset-2 text-center">
-                    <span t-esc="company.name"/>
+                    <span t-out="company.name"/>
                 </div>
                 <div class="col-2 offset-3 text-end">
                     <ul class="list-inline">
@@ -847,31 +847,31 @@
                     }
                 }
 
-                .o_company_<t t-esc='company.id'/>_layout {
-                    font-family: <t t-esc="font" />;
+                .o_company_<t t-out='company.id'/>_layout {
+                    font-family: <t t-out="font" />;
 
                     h2 {
-                        color: <t t-esc='primary'/>;
+                        color: <t t-out='primary'/>;
                     }
 
                     #informations strong {
-                        color: <t t-esc='secondary'/>;
+                        color: <t t-out='secondary'/>;
                     }
 
                     .o_total strong {
-                        color: <t t-esc='primary'/>;
+                        color: <t t-out='primary'/>;
                     }
 
                     .o_company_tagline {
-                        color: <t t-esc='primary'/>
+                        color: <t t-out='primary'/>
                     }
             <t t-if="layout == 'web.external_layout_boxed'">
                 &amp;.o_report_layout_boxed {
                     #total .o_total td {
-                        background-color: <t t-esc='primary'/>;
+                        background-color: <t t-out='primary'/>;
 
                         strong {
-                            color: preview-color-contrast(<t t-esc='primary'/>);
+                            color: preview-color-contrast(<t t-out='primary'/>);
                         }
                     }
                 }
@@ -880,11 +880,11 @@
                 &amp;.o_report_layout_bold {
                     .o_main_table {
                         thead th {
-                            border-top: 3px solid <t t-esc='secondary'/>;
+                            border-top: 3px solid <t t-out='secondary'/>;
                         }
 
                         tbody tr:last-child td {
-                            border-bottom: 3px solid <t t-esc='secondary'/>;
+                            border-bottom: 3px solid <t t-out='secondary'/>;
                         }
                     }
                 }
@@ -892,35 +892,35 @@
             <t t-elif="layout == 'web.external_layout_folder'">
                 &amp; .o_folder_header_container {
                     rect, path {
-                        fill: mix(white, <t t-esc='primary'/>, 92%);
+                        fill: mix(white, <t t-out='primary'/>, 92%);
                     }
                 }
 
                 &amp;.o_report_layout_folder_footer {
-                    border-top: 1px solid <t t-esc='secondary'/>;
+                    border-top: 1px solid <t t-out='secondary'/>;
                 }
             </t>
             <t t-elif="layout == 'web.external_layout_wave'">
                 &amp;.o_report_layout_wave {
                     #informations {
-                        border-color: <t t-esc='secondary'/>;
-                        background-color: mix(white, <t t-esc='secondary'/>, 92%);
+                        border-color: <t t-out='secondary'/>;
+                        background-color: mix(white, <t t-out='secondary'/>, 92%);
                     }
                 }
             </t>
             <t t-elif="layout == 'web.external_layout_bubble'">
                 &amp;.o_report_layout_bubble {
                     #informations {
-                        border-color: <t t-esc='secondary'/>;
-                        background-color: mix(white, <t t-esc='secondary'/>, 92%);
+                        border-color: <t t-out='secondary'/>;
+                        background-color: mix(white, <t t-out='secondary'/>, 92%);
                     }
 
                     thead th, #total .o_total td {
-                        background-color: <t t-esc='primary'/>;
-                        color: preview-color-contrast(<t t-esc='primary'/>);
+                        background-color: <t t-out='primary'/>;
+                        color: preview-color-contrast(<t t-out='primary'/>);
 
                         strong {
-                            color: preview-color-contrast(<t t-esc='primary'/>);
+                            color: preview-color-contrast(<t t-out='primary'/>);
                         }
                     }
                 }

--- a/addons/website/views/snippets/s_call_to_action.xml
+++ b/addons/website/views/snippets/s_call_to_action.xml
@@ -11,7 +11,7 @@
                 </div>
                 <div class="col-lg-3">
                     <p style="text-align: right;">
-                        <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg"><t t-esc="cta_btn_text">Contact us</t></a>
+                        <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg"><t t-out="cta_btn_text">Contact us</t></a>
                     </p>
                 </div>
             </div>

--- a/addons/website/views/snippets/s_cover.xml
+++ b/addons/website/views/snippets/s_cover.xml
@@ -9,8 +9,8 @@
             <h1 class="display-3" style="text-align: center;">Your journey starts here</h1>
             <p class="lead" style="text-align: center;">Write one or two paragraphs describing your product, services or a specific feature.<br/> To be successful your content needs to be useful to your readers.</p>
             <p style="text-align: center;">
-                <a t-att-href="cta_btn_href" class="btn btn-secondary"><t t-esc="cta_btn_text">Discover more</t></a>
-                <a t-att-href="cta_btn_href" class="btn btn-outline-secondary"><t t-esc="cta_btn_text">Contact us</t></a>
+                <a t-att-href="cta_btn_href" class="btn btn-secondary"><t t-out="cta_btn_text">Discover more</t></a>
+                <a t-att-href="cta_btn_href" class="btn btn-outline-secondary"><t t-out="cta_btn_text">Contact us</t></a>
             </p>
         </div>
     </section>

--- a/addons/website/views/snippets/s_dynamic_snippet.xml
+++ b/addons/website/views/snippets/s_dynamic_snippet.xml
@@ -26,7 +26,7 @@
             <we-select string="Template" data-name="template_opt" data-attribute-name="templateKey" data-no-preview="true">
             </we-select>
             <we-select string="Fetched Elements" data-name="number_of_records_opt" data-attribute-name="numberOfRecords" data-no-preview="true">
-                <we-button t-foreach="range(1, 17)" t-as="value" t-att-data-select-data-attribute="value" t-esc="value"/>
+                <we-button t-foreach="range(1, 17)" t-as="value" t-att-data-select-data-attribute="value" t-out="value"/>
             </we-select>
             <t t-out="0"/>
         </div>

--- a/addons/website/views/snippets/s_mega_menu_big_icons_subtitles.xml
+++ b/addons/website/views/snippets/s_mega_menu_big_icons_subtitles.xml
@@ -73,8 +73,8 @@
         <div class="d-flex align-items-center">
             <i t-attf-class="fa rounded rounded-circle me-3 #{_icon_classes}"/>
             <div class="flex-grow-1">
-                <h4 class="mt-0 mb-0" t-esc="_title"/>
-                <span class="small"><t t-esc="_text"/></span>
+                <h4 class="mt-0 mb-0" t-out="_title"/>
+                <span class="small"><t t-out="_text"/></span>
             </div>
         </div>
     </a>

--- a/addons/website/views/snippets/s_mega_menu_cards.xml
+++ b/addons/website/views/snippets/s_mega_menu_cards.xml
@@ -57,8 +57,8 @@
     <div class="col-12 col-sm-6 col-md" data-name="Menu Item">
         <a href="#" class="nav-link o_default_snippet_text rounded text-wrap text-center p-3">
             <img t-att-src="_img_src" class="mb-3 rounded shadow img-fluid" alt=""/>
-            <h4 t-esc="_title"/>
-            <p class="o_default_snippet_text mb-0 small"><t t-esc="_text"/></p>
+            <h4 t-out="_title"/>
+            <p class="o_default_snippet_text mb-0 small"><t t-out="_text"/></p>
         </a>
     </div>
 </template>

--- a/addons/website/views/snippets/s_mega_menu_images_subtitles.xml
+++ b/addons/website/views/snippets/s_mega_menu_images_subtitles.xml
@@ -61,8 +61,8 @@
         <div class="d-flex">
             <img t-att-src="_img_src" class="me-3 rounded shadow" alt=""/>
             <div class="flex-grow-1">
-                <h4 class="mt-0 mb-0" t-esc="_title"/>
-                <span class="small"><t t-esc="_text"/></span>
+                <h4 class="mt-0 mb-0" t-out="_title"/>
+                <span class="small"><t t-out="_text"/></span>
             </div>
         </div>
     </a>

--- a/addons/website/views/snippets/s_mega_menu_menu_image_menu.xml
+++ b/addons/website/views/snippets/s_mega_menu_menu_image_menu.xml
@@ -12,7 +12,7 @@
                             <t t-set="text">Menu Item %s</t>
                             <t t-set="text" t-value="text % (i + 1)"/>
                             <a href="#" class="nav-link o_default_snippet_text" data-name="Menu Item"
-                                t-esc="text"/>
+                                t-out="text"/>
                         </t>
                     </nav>
                 </div>
@@ -26,7 +26,7 @@
                             <t t-set="text">Menu Item %s</t>
                             <t t-set="text" t-value="text % (i + 1)"/>
                             <a href="#" class="nav-link o_default_snippet_text" data-name="Menu Item"
-                                t-esc="text"/>
+                                t-out="text"/>
                         </t>
                     </nav>
                 </div>

--- a/addons/website/views/snippets/s_mega_menu_multi_menus.xml
+++ b/addons/website/views/snippets/s_mega_menu_multi_menus.xml
@@ -11,13 +11,13 @@
                 <t t-set="menu4_title">Last Menu</t>
                 <t t-foreach="[menu1_title, menu2_title, menu3_title, menu4_title]" t-as="menu_title">
                     <div class="col-12 col-sm py-2 text-center">
-                        <h4 class="o_default_snippet_text" t-esc="menu_title"/>
+                        <h4 class="o_default_snippet_text" t-out="menu_title"/>
                         <nav class="nav flex-column">
                             <t t-foreach="3" t-as="i">
                                 <t t-set="text">Menu Item %s</t>
                                 <t t-set="text" t-value="text % (i + 1)"/>
                                 <a href="#" class="nav-link o_default_snippet_text" data-name="Menu Item"
-                                   t-esc="text"/>
+                                   t-out="text"/>
                             </t>
                         </nav>
                     </div>

--- a/addons/website/views/snippets/s_mega_menu_thumbnails.xml
+++ b/addons/website/views/snippets/s_mega_menu_thumbnails.xml
@@ -98,7 +98,7 @@
             <br/>
             <span class="d-block p-2 small">
                 <b>
-                    <t t-esc="_text"/>
+                    <t t-out="_text"/>
                 </b>
             </span>
         </a>

--- a/addons/website/views/snippets/s_product_catalog.xml
+++ b/addons/website/views/snippets/s_product_catalog.xml
@@ -49,8 +49,8 @@
 <template id="s_product_catalog_dish">
     <li class="s_product_catalog_dish" data-name="Product">
         <p class="s_product_catalog_dish_title d-flex align-items-baseline pb-2">
-            <span t-esc="name" class="s_product_catalog_dish_name s_product_catalog_dish_dot_leaders"/>
-            <span t-esc="price" class="s_product_catalog_dish_price ms-auto ps-2"/>
+            <span t-out="name" class="s_product_catalog_dish_name s_product_catalog_dish_dot_leaders"/>
+            <span t-out="price" class="s_product_catalog_dish_price ms-auto ps-2"/>
         </p>
     </li>
 </template>

--- a/addons/website/views/snippets/s_text_cover.xml
+++ b/addons/website/views/snippets/s_text_cover.xml
@@ -8,7 +8,7 @@
                 <div class="o_grid_item g-height-10 g-col-lg-5 col-lg-5 o_colored_level o_cc o_cc1" style="z-index: 1; grid-area: 2 / 3 / 11 / 8; --grid-item-padding-x: 24px; --grid-item-padding-y: 24px;">
                     <h1 class="display-3">Sell Online. <br/>Easily.</h1>
                     <p class="lead"><br/>Sell online easily with a user-friendly platform that streamlines all the steps, including setup, inventory management, and payment processing.<br/></p>
-                    <a t-att-href="cta_btn_href" class="btn btn-lg btn-primary"><t t-esc="cta_btn_text">Contact us</t></a>
+                    <a t-att-href="cta_btn_href" class="btn btn-lg btn-primary"><t t-out="cta_btn_text">Contact us</t></a>
                 </div>
                 <div class="o_grid_item o_grid_item_image g-height-12 g-col-lg-6 col-lg-6 o_colored_level o_cc o_cc1 pt160 pb160 oe_img_bg d-none d-md-block" style="grid-area: 1 / 7 / 12 / 13; --grid-item-padding-x: 0px; --grid-item-padding-y: 0px;">
                     <img src="/web/image/website.s_text_cover_default_image" class="img img-fluid mx-auto" alt=""/>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -948,7 +948,7 @@
                        data-select-class="o_header_standard"
                        data-customize-website-views="website.header_visibility_standard"
                        data-img="/website/static/src/img/snippets_options/header_effect_standard.png">
-                <span t-esc='header_effect_standard_label'/>
+                <span t-out='header_effect_standard_label'/>
             </we-button>
             <we-button id="option_header_effect_scroll"
                        t-att-data-select-label="header_effect_scroll_label"
@@ -958,7 +958,7 @@
                        data-select-class=""
                        data-customize-website-views=""
                        data-img="/website/static/src/img/snippets_options/header_effect_scroll.png">
-                <span t-esc='header_effect_scroll_label'/>
+                <span t-out='header_effect_scroll_label'/>
             </we-button>
             <we-button id="option_header_effect_fixed"
                        t-att-data-select-label="header_effect_fixed_label"
@@ -968,7 +968,7 @@
                        data-select-class="o_header_fixed"
                        data-customize-website-views="website.header_visibility_fixed"
                        data-img="/website/static/src/img/snippets_options/header_effect_fixed.png">
-                <span t-esc='header_effect_fixed_label'/>
+                <span t-out='header_effect_fixed_label'/>
             </we-button>
             <we-button id="option_header_effect_disappears"
                        t-att-data-select-label="header_effect_disappears_label"
@@ -978,7 +978,7 @@
                        data-select-class="o_header_disappears"
                        data-customize-website-views="website.header_visibility_disappears"
                        data-img="/website/static/src/img/snippets_options/header_effect_disappears.png">
-                <span t-esc="header_effect_disappears_label" />
+                <span t-out="header_effect_disappears_label" />
             </we-button>
             <we-button id="option_header_effect_fade_out"
                        t-att-data-select-label="header_effect_fadeout_label"
@@ -988,7 +988,7 @@
                        data-select-class="o_header_fade_out"
                        data-customize-website-views="website.header_visibility_fade_out"
                        data-img="/website/static/src/img/snippets_options/header_effect_fade_out.png">
-               <span t-esc='header_effect_fadeout_label'/>
+               <span t-out='header_effect_fadeout_label'/>
             </we-button>
         </we-select>
     </div>

--- a/addons/website/views/website_pages_views.xml
+++ b/addons/website/views/website_pages_views.xml
@@ -103,7 +103,7 @@
                             <span class="fs-3">
                                 <i t-if="record.is_homepage.raw_value" class="fa fa-home pe-2"
                                     title="Home page of the current website"/>
-                                <t t-esc="record.name.value"/>
+                                <t t-out="record.name.value"/>
                             </span>
                             <div class="text-muted">
                                 <t t-if="record.website_id.value">
@@ -111,7 +111,7 @@
                                     <field name="website_id" groups="website.group_multi_website"/>
                                 </t>
                             </div>
-                            <span class="text-primary" t-esc="record.website_url.value"/>
+                            <span class="text-primary" t-out="record.website_url.value"/>
                         </div>
                         <div><field name="is_in_menu" widget="boolean"/> In Main Menu</div>
                         <div><field name="is_seo_optimized" widget="boolean"/> SEO Optimized</div>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -201,7 +201,7 @@
                 window.dataLayer = window.dataLayer || [];
                 function gtag(){dataLayer.push(arguments);}
                 gtag('js', new Date());
-                gtag('config', '<t t-esc="website.google_analytics_key"/>');
+                gtag('config', '<t t-out="website.google_analytics_key"/>');
             </script>
         </t>
         <t t-if="website.plausible_shared_key and not editable">
@@ -237,7 +237,7 @@
             <div class="o_frontend_to_backend_buttons d-flex">
                 <a href="#" title="Go to your Odoo Apps" class="o_frontend_to_backend_apps_btn fa fa-th d-flex align-items-center justify-content-center text-decoration-none" data-bs-toggle="dropdown"/>
                 <div class="dropdown-menu o_frontend_to_backend_apps_menu" role="menu">
-                    <a role="menuitem" class="dropdown-item" t-esc="menu['name']"
+                    <a role="menuitem" class="dropdown-item" t-out="menu['name']"
                        t-as="menu" t-foreach="env['ir.ui.menu'].with_context(force_action=True).load_menus_root()['children']"
                        t-attf-href="/web#menu_id=#{menu['id']}&amp;action=#{menu['action'] and menu['action'].split(',')[1] or ''}"/>
                 </div>
@@ -1618,7 +1618,7 @@
                                 <li><a href="#">Legal</a></li>
                                 <t t-set="configurator_footer_links" t-value="[]"/>
                                 <li t-foreach="configurator_footer_links" t-as="link">
-                                    <a t-att-href="link['href']" t-esc="link['text']"/>
+                                    <a t-att-href="link['href']" t-out="link['text']"/>
                                 </li>
                                 <li><a href="/contactus">Contact us</a></li>
                             </ul>
@@ -1757,7 +1757,7 @@
                                 <li class="list-item py-1"><a href="#">Blog</a></li>
                                 <t t-set="configurator_footer_links" t-value="[]"/>
                                 <li t-foreach="configurator_footer_links" t-as="link" class="list-item py-1">
-                                    <a t-att-href="link['href']" t-esc="link['text']"/>
+                                    <a t-att-href="link['href']" t-out="link['text']"/>
                                 </li>
                             </ul>
                         </div>
@@ -1816,7 +1816,7 @@
                                 <li class="list-inline-item"><a href="#">Services</a></li>
                                 <t t-set="configurator_footer_links" t-value="[]"/>
                                 <li t-foreach="configurator_footer_links" t-as="link" class="list-inline-item">
-                                    <a t-att-href="link['href']" t-esc="link['text']"/>
+                                    <a t-att-href="link['href']" t-out="link['text']"/>
                                 </li>
                             </ul>
                         </div>
@@ -1906,7 +1906,7 @@
                                 <t t-set="configurator_footer_links" t-value="[]"/>
                                 <t t-foreach="configurator_footer_links" t-as="link" class="list-inline-item">
                                     <li class="list-inline-item">•</li>
-                                    <li class="list-inline-item"><a t-att-href="link['href']" t-esc="link['text']"/></li>
+                                    <li class="list-inline-item"><a t-att-href="link['href']" t-out="link['text']"/></li>
                                 </t>
                             </ul>
                         </div>
@@ -1982,7 +1982,7 @@
                                 <li><a href="/contactus">Contact us</a></li>
                                 <t t-set="configurator_footer_links" t-value="[]"/>
                                 <li t-foreach="configurator_footer_links" t-as="link">
-                                    <a t-att-href="link['href']" t-esc="link['text']"/>
+                                    <a t-att-href="link['href']" t-out="link['text']"/>
                                 </li>
                             </ul>
                         </div>
@@ -2305,11 +2305,11 @@
     <xpath expr="//div[@id='wrap']" position="inside">
         <div class="oe_structure">
             <section class="container">
-                <h1><t t-esc="res_company.name"/>
+                <h1><t t-out="res_company.name"/>
                     <small groups='base.group_no_one'>Odoo Version <t t-out="version.get('server_version')"/></small>
                 </h1>
                 <p>
-                    Information about the <t t-esc="res_company.name"/> instance of Odoo, the <a target="_blank" href="https://www.odoo.com">Open Source ERP</a>.
+                    Information about the <t t-out="res_company.name"/> instance of Odoo, the <a target="_blank" href="https://www.odoo.com">Open Source ERP</a>.
                 </p>
 
                 <div class="alert alert-warning alert-dismissable mt16" groups="website.group_website_restricted_editor" role="status">
@@ -2535,13 +2535,13 @@
         <div class="container" t-if="view and editable">
             <div class="alert alert-danger" role="alert">
                 <h4>Template fallback</h4>
-                <p>An error occurred while rendering the template <code t-esc="qweb_exception.name"/>.</p>
+                <p>An error occurred while rendering the template <code t-out="qweb_exception.name"/>.</p>
                 <p>If this error is caused by a change of yours in the templates, you have the possibility to reset the template to its <strong>factory settings</strong>.</p>
                 <form action="#" method="post" id="reset_templates_form">
                     <ul>
                         <li>
                             <label>
-                                <t t-esc="view.name"/>
+                                <t t-out="view.name"/>
                             </label>
                         </li>
                     </ul>
@@ -2561,10 +2561,10 @@
 User-agent: *
 <t t-if="website.domain and not website._is_indexable_url(url_root)">
 Disallow: /
-Sitemap: <t t-esc="website.domain"/>/sitemap.xml
+Sitemap: <t t-out="website.domain"/>/sitemap.xml
 </t>
 <t t-else="">
-Sitemap: <t t-esc="url_root"/>sitemap.xml
+Sitemap: <t t-out="url_root"/>sitemap.xml
 
 
 ##############
@@ -2578,10 +2578,10 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
 
 <template id="sitemap_locs">
     <url t-foreach="locs" t-as="page">
-        <loc><t t-esc="url_root"/><t t-esc="page['loc']"/></loc><t t-if="page.get('lastmod', False)">
-        <lastmod t-esc="page['lastmod']"/></t><t t-if="page.get('priority', False)">
-        <priority t-esc="page['priority']"/></t><t t-if="page.get('changefreq', False)">
-        <changefreq t-esc="page['changefreq']"/></t>
+        <loc><t t-out="url_root"/><t t-out="page['loc']"/></loc><t t-if="page.get('lastmod', False)">
+        <lastmod t-out="page['lastmod']"/></t><t t-if="page.get('priority', False)">
+        <priority t-out="page['priority']"/></t><t t-if="page.get('changefreq', False)">
+        <changefreq t-out="page['changefreq']"/></t>
     </url>
 </template>
 
@@ -2594,7 +2594,7 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
 <template id="sitemap_index_xml"><t t-translation="off">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 <sitemapindex t-attf-xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap t-translation="off" t-foreach="pages" t-as="page">
-    <loc><t t-esc="url_root"/>sitemap-<t t-esc="page"/>.xml</loc>
+    <loc><t t-out="url_root"/>sitemap-<t t-out="page"/>.xml</loc>
   </sitemap>
 </sitemapindex>
 </t>
@@ -2614,7 +2614,7 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
 </template>
 
 <template id="search_text_with_highlight" name="Website Searchbox item highlight">
-    <span t-foreach="enumerate(parts)" t-as="part" t-att-class="'text-primary' if part[0] % 2 else None" t-esc="part[1]"/>
+    <span t-foreach="enumerate(parts)" t-as="part" t-att-class="'text-primary' if part[0] % 2 else None" t-out="part[1]"/>
 </template>
 
 <template id="list_website_public_pages" name="Website Pages">
@@ -2630,20 +2630,20 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
                 <h3 class="mt16">Pages</h3>
                 <t t-if="not pages">
                     <div t-if="search" class="alert alert-warning mt8" role="alert">
-                        Your search '<t t-esc="search" />' did not match any pages.
+                        Your search '<t t-out="search" />' did not match any pages.
                     </div>
                     <div t-else="" class="alert alert-warning mt8" role="alert">
                         There are currently no pages for this website.
                     </div>
                 </t>
                 <div t-elif="original_search" class="alert alert-warning mt8" role="alert">
-                    No results found for '<span t-esc="original_search"/>'. Showing results for '<span t-esc="search"/>'.
+                    No results found for '<span t-out="original_search"/>'. Showing results for '<span t-out="search"/>'.
                 </div>
                 <div t-if="pages" class="table-responsive">
                     <table class="table table-hover">
                         <tbody>
                             <tr t-foreach="pages" t-as="page">
-                                <td><a t-att-href="page.url"><t t-esc="page.name"/></a></td>
+                                <td><a t-att-href="page.url"><t t-out="page.name"/></a></td>
                             </tr>
                         </tbody>
                     </table>
@@ -2669,7 +2669,7 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
                 <t t-if="not results">
                     <div class="alert alert-warning mt8" role="alert">
                         <t t-if="search">
-                            Your search '<t t-esc="search" />' did not match anything.
+                            Your search '<t t-out="search" />' did not match anything.
                         </t>
                         <t t-else="">
                             Specify a search term.
@@ -2678,8 +2678,8 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
                 </t>
                 <t t-elif="fuzzy_search">
                     <div class="alert alert-warning mt8" role="alert">
-                        Your search '<t t-esc="search" />' did not match anything.
-                        Results are displayed for '<t t-esc="fuzzy_search"/>'.
+                        Your search '<t t-out="search" />' did not match anything.
+                        Results are displayed for '<t t-out="fuzzy_search"/>'.
                     </div>
                 </t>
                 <div t-if="results" class="table-responsive">

--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -265,10 +265,10 @@
                             </div>
                             <div class="o_theme_preview_bottom clearfix">
                                 <h5 t-if="record.summary.value" class="text-uppercase float-start">
-                                    <b><t t-esc="record.summary.value.split(',')[0]"/></b>
+                                    <b><t t-out="record.summary.value.split(',')[0]"/></b>
                                 </h5>
                                 <h6 t-if="record.display_name.value" class="text-muted float-end">
-                                    <b><t t-esc="record.display_name.value.replace('Theme', '').replace('theme', '')"/></b>
+                                    <b><t t-out="record.display_name.value.replace('Theme', '').replace('theme', '')"/></b>
                                 </h6>
                             </div>
                         </div>

--- a/odoo/addons/base/views/ir_qweb_widget_templates.xml
+++ b/odoo/addons/base/views/ir_qweb_widget_templates.xml
@@ -3,10 +3,10 @@
 <template id="contact_name">
     <div t-if="'name' in fields">
         <t t-if="object.name">
-            <span itemprop="name" t-esc="name"/>
+            <span itemprop="name" t-out="name"/>
         </t>
         <t t-if="not object.name and object.parent_name">
-            <span itemprop="name" t-esc="object.parent_name"/>
+            <span itemprop="name" t-out="object.parent_name"/>
         </t>
         <t t-if="options.get('country_image') and 'country_id' in fields and object.country_id and object.country_id.image_url">
             <span t-field="object.country_id.image_url" t-options='{"widget": "image_url", "class": "country_flag"}'/>
@@ -17,7 +17,7 @@
 <template id="contact">
     <address t-ignore="true" class="o_portal_address mb-0">
         <div t-if="not (('name' in fields) or (address and 'address' in fields) or (city and 'city' in fields) or (mobile and 'mobile' in fields) or (website and 'website' in fields) or (email and 'email' in fields))" class="css_non_editable_mode_hidden">
-            --<span class="text-muted" t-esc="name"/>--
+            --<span class="text-muted" t-out="name"/>--
         </div>
         <t t-if="object.country_id.name_position != 'after'">
             <t t-call="base.contact_name"/>
@@ -26,30 +26,30 @@
 
             <div t-if="address and 'address' in fields" t-attf-class="d-flex align-items-baseline gap-1">
                 <i t-if="not options.get('no_marker')" class="fa fa-map-marker fa-fw" role="img" aria-label="Address" title="Address"/>
-                <span class="w-100 lh-sm text-truncate" itemprop="streetAddress" t-esc="address"/>
+                <span class="w-100 lh-sm text-truncate" itemprop="streetAddress" t-out="address"/>
             </div>
             <div t-if="city and 'city' in fields" t-attf-class="d-flex align-items-baseline gap-1">
                 <i t-if="not options.get('no_marker')" class="fa fa-map-marker fa-fw" role="img" aria-label="Address" title="Address"/>
                 <span>
                     <div>
-                        <span itemprop="addressLocality" t-esc="city"/>,
-                        <span itemprop="addressCountry" t-esc="country_id"/>
+                        <span itemprop="addressLocality" t-out="city"/>,
+                        <span itemprop="addressCountry" t-out="country_id"/>
                     </div>
                 </span>
             </div>
             <div class="d-flex align-items-center gap-1" t-if="phone and 'phone' in fields">
-                <i t-if="not options.get('no_marker') or options.get('phone_icons')" class='fa fa-phone fa-fw' role="img" aria-label="Phone" title="Phone"/> <span class="o_force_ltr" itemprop="telephone" t-esc="phone"/>
+                <i t-if="not options.get('no_marker') or options.get('phone_icons')" class='fa fa-phone fa-fw' role="img" aria-label="Phone" title="Phone"/> <span class="o_force_ltr" itemprop="telephone" t-out="phone"/>
             </div>
             <div class="d-flex align-items-center gap-1" t-if="mobile and 'mobile' in fields">
-                <i t-if="not options.get('no_marker') or options.get('phone_icons')" class='fa fa-mobile fa-fw' role="img" aria-label="Mobile" title="Mobile"/> <span class="o_force_ltr" itemprop="telephone" t-esc="mobile"/>
+                <i t-if="not options.get('no_marker') or options.get('phone_icons')" class='fa fa-mobile fa-fw' role="img" aria-label="Mobile" title="Mobile"/> <span class="o_force_ltr" itemprop="telephone" t-out="mobile"/>
             </div>
             <div class="d-flex align-items-center gap-1" t-if="website and 'website' in fields">
                 <i t-if="not options.get('no_marker')" class='fa fa-globe fa-fw' role="img" aria-label="Website" title="Website"/>
-                <a t-att-href="website and '%s%s' % ('http://' if '://' not in website else '',website)"><span itemprop="website" t-esc="website"/></a>
+                <a t-att-href="website and '%s%s' % ('http://' if '://' not in website else '',website)"><span itemprop="website" t-out="website"/></a>
             </div>
-            <div class="d-flex align-items-baseline gap-1" t-if="email and 'email' in fields"><i t-if="not options.get('no_marker')" class='fa fa-envelope fa-fw' role="img" aria-label="Email" title="Email"/> <span class="text-break w-100" itemprop="email" t-esc="email"/></div>
+            <div class="d-flex align-items-baseline gap-1" t-if="email and 'email' in fields"><i t-if="not options.get('no_marker')" class='fa fa-envelope fa-fw' role="img" aria-label="Email" title="Email"/> <span class="text-break w-100" itemprop="email" t-out="email"/></div>
         </div>
-        <div t-if="vat and 'vat' in fields"><span t-esc="vat_label"/>: <span itemprop="vatID" t-esc="vat"/></div>
+        <div t-if="vat and 'vat' in fields"><span t-out="vat_label"/>: <span itemprop="vatID" t-out="vat"/></div>
         <t t-if="object.country_id and object.country_id.name_position == 'after'">
             <t t-call="base.contact_name"/>
         </t>


### PR DESCRIPTION
For every dev's sanity that uses the '--log-handler odoo.tools.convert:DEBUG' and sees hundreds of lines of warning,
we replaced the deprecated t-esc by t-out in qweb templates.

Some may still be hiding, but with perseverance, we will prevail.

Task: 4081513