### PR TITLE
[FIX] website: support redirect from URL with query string

### DIFF
--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -304,13 +304,14 @@ class Http(models.AbstractModel):
     @classmethod
     def _serve_redirect(cls):
         req_page = request.httprequest.path
+        req_page_with_qs = request.httprequest.environ['REQUEST_URI']
         domain = [
             ('redirect_type', 'in', ('301', '302')),
             # trailing / could have been removed by server_page
-            '|', ('url_from', '=', req_page.rstrip('/')), ('url_from', '=', req_page + '/')
+            ('url_from', 'in', [req_page_with_qs, req_page.rstrip('/'), req_page + '/'])
         ]
         domain += request.website.website_domain()
-        return request.env['website.rewrite'].sudo().search(domain, limit=1)
+        return request.env['website.rewrite'].sudo().search(domain, order='url_from DESC', limit=1)
 
     @classmethod
     def _serve_fallback(cls):


### PR DESCRIPTION
Previously, there was no clean way to redirect old URLs like /xx.asp?id=xx with the correct HTTP status code.

This update adds support for such redirects, allowing people to migrate to Odoo more easily.

fiximp-realife





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
