### PR TITLE
[FIX] hw_driver: avoid sending 'distant_display' to db

### DIFF
--- a/addons/hw_drivers/main.py
+++ b/addons/hw_drivers/main.py
@@ -61,7 +61,12 @@ class Manager(Thread):
                     'manufacturer': iot_devices[device].device_manufacturer,
                     'connection': iot_devices[device].device_connection,
                 }
-            data = {'params': {'iot_box': iot_box, 'devices': devices_list,}}
+            data = {
+                'params': {
+                    'iot_box': iot_box,
+                    'devices': [d for d in devices_list if d.name != 'distant_display'],
+                }  # Don't send distant_display to the db
+            }
             # disable certifiacte verification
             urllib3.disable_warnings()
             http = urllib3.PoolManager(cert_reqs='CERT_NONE')


### PR DESCRIPTION
We use a "distant_display" if no display is connected to the IoT, in order to use the customer display on another computer. We don't need to send it to the database though, as it could confuse users.

Task: 4061443