### PR TITLE
[IMP] point_of_sale: add dialog animation

### DIFF
--- a/addons/point_of_sale/static/src/app/pos_app.scss
+++ b/addons/point_of_sale/static/src/app/pos_app.scss
@@ -68,6 +68,9 @@ input::-webkit-inner-spin-button {
 }
 
 @media screen and (max-width: 575px) {
+    .modal{
+        animation: addOpacity 0.2s ease-in-out forwards;
+    }
     .pos .modal-dialog{
         margin: 0;
         max-height: 92dvh;
@@ -86,12 +89,43 @@ input::-webkit-inner-spin-button {
         min-height: unset;
     }
 }
-
+@keyframes addOpacity {
+    0% {
+        background-color: rgba(0, 0, 0, 0);
+    }
+    100% {
+        background-color: rgba(0, 0, 0, 0.5);
+    }
+}
 @keyframes popUp {
     0% {
         transform: translateY(100%);
+        background-color: rgba(0, 0, 0, 0) !important;
     }
     100% {
         transform: translateY(0);
+        background-color: rgba(0, 0, 0, 0.5) !important;
+    }
+}
+.isClosing {
+    animation: popDown 0.2s ease-in-out forwards;
+}
+@keyframes popDown {
+    0% {
+        transform: translateY(0);
+    }
+    100% {
+        transform: translateY(100%);
+    }
+}
+.closing-modal-bg {
+    animation: removeOpacity 0.2s ease-in-out;
+}
+@keyframes removeOpacity {
+    0% {
+        background-color: rgba(0, 0, 0, 0.5);
+    }
+    100% {
+        background-color: rgba(0, 0, 0, 0);
     }
 }

--- a/addons/point_of_sale/static/src/overrides/dialog.js
+++ b/addons/point_of_sale/static/src/overrides/dialog.js
@@ -1,0 +1,34 @@
+import { useExternalListener } from "@odoo/owl";
+import { Dialog } from "@web/core/dialog/dialog";
+import { patch } from "@web/core/utils/patch";
+import { SIZES, utils } from "@web/core/ui/ui_service";
+
+patch(Dialog.prototype, {
+    setup() {
+        super.setup();
+        if (utils.getSize() <= SIZES.SM) {
+            useExternalListener(window, "touchstart", (ev) => {
+                if (ev.target.classList.contains("modal")) {
+                    this.dismiss();
+                }
+            });
+        }
+    },
+    async dismiss() {
+        if (utils.getSize() > SIZES.SM) {
+            return super.dismiss();
+        }
+        if (odoo.test_mode_enabled) {
+            // in tours we must close the popup instantly, as the tour will not wait for
+            // the closing before going to the next step
+            return super.dismiss();
+        }
+        this.modalRef.el.classList.add("closing-modal-bg");
+        this.modalRef.el.children[0].classList.add("isClosing");
+        this.modalRef.el.style.background = "rgba(0, 0, 0, 0)";
+        const CLOSING_ANIMATION_DURATION = 200;
+        setTimeout(() => {
+            super.dismiss();
+        }, CLOSING_ANIMATION_DURATION);
+    },
+});

--- a/addons/point_of_sale/views/pos_assets_index.xml
+++ b/addons/point_of_sale/views/pos_assets_index.xml
@@ -22,6 +22,7 @@
                 'pos_config_id': pos_config_id,
                 'access_token': access_token,
                 'debug': debug,
+                'test_mode_enabled': test_mode_enabled,
             })"/>;
             // Prevent the menu_service to load anything. In an ideal world, POS assets would only contain
             // what is genuinely necessary, and not the whole backend.


### PR DESCRIPTION
In mobile screens, the dialogs slide from the bottom of the screen when opening, but when closing they just disappear.

In this commit we add the sliding down animation when closing the dialogs.

Additionally, dialogs will now automatically close on mobile when clicking outside.

Task: 4087143




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
