### PR TITLE
[IMP] pos_restaurant: snap tables to grid lines

### DIFF
--- a/addons/pos_restaurant/static/tests/tours/floor_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/floor_screen_tour.js
@@ -61,7 +61,6 @@ registry.category("web_tour.tours").add("FloorScreenTour", {
             NumberPopup.enterValue("100"),
             NumberPopup.isShown("100"),
             Dialog.confirm(),
-            FloorScreen.clickTable("100"),
             FloorScreen.selectedTableIs("100"),
 
             // test duplicate table
@@ -73,7 +72,6 @@ registry.category("web_tour.tours").add("FloorScreenTour", {
             NumberPopup.enterValue("1111"),
             NumberPopup.isShown("1111"),
             Dialog.confirm(),
-            FloorScreen.clickTable("1111"),
             FloorScreen.selectedTableIs("1111"),
 
             // switch floor, switch back and check if
@@ -119,7 +117,6 @@ registry.category("web_tour.tours").add("FloorScreenTour", {
             FloorScreen.table({ name: "4", numOfSeats: "9" }),
 
             // change number of seat when the input is already selected
-            FloorScreen.clickTable("4"),
             FloorScreen.selectedTableIs("4"),
             FloorScreen.clickEditButton("Seats"),
             NumberPopup.enterValue("15"),
@@ -128,7 +125,6 @@ registry.category("web_tour.tours").add("FloorScreenTour", {
             FloorScreen.table({ name: "4", numOfSeats: "15" }),
 
             // change shape
-            FloorScreen.clickTable("4"),
             FloorScreen.clickEditButton("MakeRound"),
 
             // Opening product screen in main floor should go back to main floor


### PR DESCRIPTION
When editing the position or the size of tables in floors without background images in pos_restaurant a grid is superimposed to guide the user.

In this commit we make it such that tables snap on these grid lines.

In addition, we make it such that when a user clicks on a selected table, the table will be deselected.

Task: 4087047





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
