### PR TITLE
[FIX] l10n_fr_invoice_addr: fix legal invoice elements' visibility

### DIFF
--- a/addons/l10n_fr_invoice_addr/views/report_invoice.xml
+++ b/addons/l10n_fr_invoice_addr/views/report_invoice.xml
@@ -1,13 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="report_invoice_document" inherit_id="account.report_invoice_document">
-        <xpath expr="//address" position="after">
+        <xpath expr="//t[@t-set='information_block']/div[@name='shipping_address_block']" position="attributes">
+            <attribute name="groups"/>
+            <attribute name="t-if">(o.l10n_fr_is_company_french and o.move_type.startswith('out_')) or o.env.user.has_group('account.group_delivery_invoice_address')</attribute>
+        </xpath>
+
+        <xpath expr="//div[@name='address_not_same_as_shipping']//address[@t-field='o.partner_id']" position="after">
             <div class="mb-3" t-if="o.l10n_fr_is_company_french and o.partner_id.commercial_partner_id.siret">
                 SIRET: <t t-esc="o.partner_id.commercial_partner_id.siret"/>
             </div>
         </xpath>
 
-        <xpath expr="//address" position="attributes">
+        <xpath expr="//div[@name='address_not_same_as_shipping']//address[@t-field='o.partner_id']" position="attributes">
+            <attribute name="t-attf-class">{{'mb-0' if o.l10n_fr_is_company_french and o.partner_id.commercial_partner_id.siret else ''}}</attribute>
+        </xpath>
+
+        <xpath expr="//div[@name='address_same_as_shipping']//address[@t-field='o.partner_id']" position="after">
+            <div class="mb-3" t-if="o.l10n_fr_is_company_french and o.partner_id.commercial_partner_id.siret">
+                SIRET: <t t-esc="o.partner_id.commercial_partner_id.siret"/>
+            </div>
+        </xpath>
+
+        <xpath expr="//div[@name='address_same_as_shipping']//address[@t-field='o.partner_id']" position="attributes">
+            <attribute name="t-attf-class">{{'mb-0' if o.l10n_fr_is_company_french and o.partner_id.commercial_partner_id.siret else ''}}</attribute>
+        </xpath>
+
+        <xpath expr="//div[@name='no_shipping']//address[@t-field='o.partner_id']" position="after">
+            <div class="mb-3" t-if="o.l10n_fr_is_company_french and o.partner_id.commercial_partner_id.siret">
+                SIRET: <t t-esc="o.partner_id.commercial_partner_id.siret"/>
+            </div>
+        </xpath>
+
+        <xpath expr="//div[@name='no_shipping']//address[@t-field='o.partner_id']" position="attributes">
             <attribute name="t-attf-class">{{'mb-0' if o.l10n_fr_is_company_french and o.partner_id.commercial_partner_id.siret else ''}}</attribute>
         </xpath>
 


### PR DESCRIPTION
This fixes 3 different issues:
- On invoice preview: The shipping address doesn't appear when the "Shipping Address" setting is off even when the company is french
- On invoice preview: The SIRET sometimes doesn't appear on the invoice. There are 3 instances of the same address that can be shown and only 1 was modified
- On account move: The condition for the shipping address to appear was wrong as it should only be visible for outgoing account moves as long as it's not expected to be already present (aka. when the user is already part of the `account.group_delivery_invoice_address` group)

See: #172497

task-4083172