### PR TITLE
[FIX] web, website: scroll to dynamic snippet on drop

### DIFF
--- a/addons/web/static/src/legacy/js/core/dom.js
+++ b/addons/web/static/src/legacy/js/core/dom.js
@@ -168,7 +168,9 @@ const dom = Object.assign({}, minimalDom, {
                 return $scrollable[0].scrollHeight - $scrollable[0].clientHeight;
             }
 
+            el.classList.add("o_check_scroll_position");
             let offsetTop = $el.offset().top;
+            el.classList.remove("o_check_scroll_position");
             if (el.classList.contains('d-none')) {
                 el.classList.remove('d-none');
                 offsetTop = $el.offset().top;

--- a/addons/website/static/src/snippets/s_dynamic_snippet/000.scss
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/000.scss
@@ -1,5 +1,5 @@
 .s_dynamic {
-    &.o_dynamic_empty {
+    &.o_dynamic_empty:not(.o_check_scroll_position) {
         display: none !important;
     }
     [data-url] {


### PR DESCRIPTION
Steps to reproduce the bug:

- In Website edit mode.
- Drag and drop enough snippets to have a vertical scrollbar.
- Scroll the page to the top.
- Drag and drop a dynamic snippet (e.g. Products) at the bottom of the viewport.
- Bug: The page doesn't scroll to the dynanmic snippet.

The bug was due to the fact that we needed to know the top position of the snippet to set the scroll value. However, it wasn't possible to get the offset of the element because the dynamic snippets were set to "display: none" when this calculation was made.

It's a bug we had before and fixed with this commit [1]. It worked. But since this other commit [2] where dynamic snippets are no longer hidden with the Bootstrap class "d-none" but with the class "o_dynamic_empty", the fix no longer works.

[1]: https://github.com/odoo/odoo/commit/963f0ed02eba929fcbc65fe51bef95c2a1dcf2ea
[2]: https://github.com/odoo/odoo/commit/63def9c87305dd7773e0592a28fe19d0b63c0878

task-4072655