### PR TITLE
[FIX] point_of_sale: Interrupted PoS Orders without session get new one

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -123,7 +123,7 @@ class PosOrder(models.Model):
         """
         order = order['data']
         pos_session = self.env['pos.session'].browse(order['pos_session_id'])
-        if pos_session.state == 'closing_control' or pos_session.state == 'closed':
+        if not pos_session.exists() or pos_session.state == 'closing_control' or pos_session.state == 'closed':
             order['pos_session_id'] = self._get_valid_session(order).id
 
         pos_order = False


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
In the PoS we can start buying and then come back to the backend, or simply close the window of the PoS. In this case, the session for the PoS is still opened so when the UI is used again, the items that were added to the PoS screen are still there to continue with the shopping.

In very rare cases, it could be that the pos.session is deleted, and what happens in this case is that, in the method create_from_ui() https://github.com/odoo/odoo/blob/4ee576f/addons/point_of_sale/models/pos_order.py#L938-L940, it first checks that the PoS Order with the PoS reference still exists. It then iterates over the existing orders found, using all(). What happens is that all() in Python returns True if the argument is an empty iterable, so all([]) is True. This makes that the condition for the if is evaluated as true and then _process_order() is executed.

The problem with this is that, eventually, a check will be made on the pos.session that was linked to the order we had interrupted, and an access to a deleted record will trigger as a result of https://github.com/odoo/odoo/blob/4ee576f/addons/point_of_sale/models/pos_order.py#L126. Before doing the checks on the fields for the (possibly deleted) PoS Session, we first check if it still exists, and if it doesn't then a new rescue session is created.

**Current behavior before PR:**
Pop-up showing a 'Missing Record' error appears. The pop-up is not blocking, but is annoying.

**Desired behavior after PR is merged:**
No pop-up appears.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
