### PR TITLE
[FIX] base_automation: prevent crash when writing on tracked fields

### DIFF
--- a/addons/base_automation/controllers/main.py
+++ b/addons/base_automation/controllers/main.py
@@ -3,7 +3,7 @@ from odoo.addons.base_automation.models.base_automation import get_webhook_reque
 
 class BaseAutomationController(Controller):
 
-    @route(['/web/hook/<string:rule_uuid>'], type='http', auth='none', methods=['GET', 'POST'], csrf=False, save_session=False)
+    @route(['/web/hook/<string:rule_uuid>'], type='http', auth='public', methods=['GET', 'POST'], csrf=False, save_session=False)
     def call_webhook_http(self, rule_uuid, **kwargs):
         """ Execute an automation webhook """
         rule = request.env['base.automation'].sudo().search([('webhook_uuid', '=', rule_uuid)])

--- a/addons/test_base_automation/__manifest__.py
+++ b/addons/test_base_automation/__manifest__.py
@@ -13,6 +13,7 @@ tests independently to functional aspects of other models.""",
     'depends': ['base_automation'],
     'data': [
         'security/ir.model.access.csv',
+        'data/mail_template_data.xml',
     ],
     'assets': {
         'web.assets_tests': [

--- a/addons/test_base_automation/data/mail_template_data.xml
+++ b/addons/test_base_automation/data/mail_template_data.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="test_base_automation.test_tracking_template" model="mail.template">
+        <field name="name">Test</field>
+        <field name="subject">Test Template</field>
+        <field name="partner_to">test</field>
+        <field name="body_html" type="html"><p>Hello <t t-out="object.state"></t></p></field>
+        <field name="model_id" ref="test_base_automation.model_test_base_automation_task"/>
+        <field name="auto_delete" eval="True"/>
+    </record>
+
+</odoo>

--- a/addons/test_base_automation/models/test_base_automation.py
+++ b/addons/test_base_automation/models/test_base_automation.py
@@ -100,6 +100,7 @@ class Project(models.Model):
 
 class Task(models.Model):
     _name = _description = 'test_base_automation.task'
+    _inherit = ['mail.thread']
 
     name = fields.Char()
     parent_id = fields.Many2one('test_base_automation.task')
@@ -107,12 +108,18 @@ class Task(models.Model):
         'test_base_automation.project',
         compute='_compute_project_id', recursive=True, store=True, readonly=False,
     )
+    state = fields.Boolean(tracking=True)
 
     @api.depends('parent_id.project_id')
     def _compute_project_id(self):
         for task in self:
             if not task.project_id:
                 task.project_id = task.parent_id.project_id
+
+    def _track_template(self, changes):
+        if 'state' in changes:
+            return {'state': (self.env.ref("test_base_automation.test_tracking_template"), {})}
+        return {}
 
 
 class Stage(models.Model):


### PR DESCRIPTION
Steps to reproduce
==================

- Install web_studio,helpdesk
- Go to Helpdesk > Tickets > All tickets
- Open studio
- Webhooks > New
  * model: Helpdesk Ticket 
  * target record: `model.browse(int(payload.get('_id')))` 
  * action: code: `record.write({"stage_id": payload.get("stage_id")})`

- Copy the url and execute the webhook with the following body:

```json
{
    "_id": 2,
    "stage_id": 2
}
```

=> 500 Internal Server Error

Cause of the issue
==================

stage_id is a tracked field. We check the current user with `self.env.user._is_public()`.

This crashes because the route is annotated with auth=None

Solution
========

Use a public auth. This is already the case in 17.1+

opw-4074124