### PR TITLE
[FIX] web: tree editor's within operator traceback

### DIFF
--- a/addons/web/static/src/core/tree_editor/condition_tree.js
+++ b/addons/web/static/src/core/tree_editor/condition_tree.js
@@ -868,6 +868,10 @@ export function removeWithinOperators(tree) {
         }
         const { negate, path, value } = tree;
         const fieldType = value[2];
+
+        // Prevent invalid tokens
+        value[0] = parseInt(value[0]);
+
         const dateExpressions = {
             today: expression(DATE_TODAY_STRING_EXPRESSION),
             delta: expression(


### PR DESCRIPTION
The within operator expects 2 values:
- An integer
- A period range (selection field)

Those 2 values are then injected into a string that gets turned to an Expression. If some garbage is passed to the integer part, a traceback would occur.

Waiting for a more robust error handling system, we can use the parseInt function that will either get rid of unwanted characters or returns a NaN value, which wouldn't crash as it would created a valid expression.

task id 4086413
