### PR TITLE
[FIX] web: ButtonBox alignment on mobile

### DIFF
--- a/addons/web/static/src/views/form/button_box/button_box.scss
+++ b/addons/web/static/src/views/form/button_box/button_box.scss
@@ -165,12 +165,15 @@
     --button-box-gap: 1px;
     --button-box-per-row: 2;
     --button-box-border-color: #{map-get(map-get($o-btns-bs-outline-override, 'secondary'), 'border')};
+    --button-box-spacing: #{map-get($spacers, 3)};
 
     display: grid;
     grid-template-columns: repeat(var(--button-box-per-row), minmax(0, 1fr));
     overflow: hidden;
-    inset-inline-end: $spacer;
     gap: var(--button-box-gap);
+    width: calc(100vw - var(--button-box-spacing) * 2) !important;
+    left: var(--button-box-spacing) !important;
+    right: var(--button-box-spacing) !important;
 
     > span .o_field_widget, .o_stat_info, .o_stat_value {
         @include text-truncate;


### PR DESCRIPTION
Since commit [1], the ButtonBox's dropdown wasn't properly aligned and
didn't toke advantage of the viewport's width.

This commit fixes it by forcing the dropdown to take most of the
viewport width, independently from the `usePosition()` hook horizontal
positioning.

Note: the issue is fundamentally bound to the way `usePosition()` hook
bahave on mobile ; a refactor should happen at some point to have a more
sensible behavior on smaller screens.

task-3336242

[1]: https://github.com/odoo/odoo/commit/e74b2084830fb1fee34fb822cf61f4e8f5394dbd