### PR TITLE
[IMP] web: ControlPanel buttons styling in mobile

### DIFF
--- a/addons/web/static/src/search/cog_menu/cog_menu.xml
+++ b/addons/web/static/src/search/cog_menu/cog_menu.xml
@@ -2,10 +2,10 @@
 <templates xml:space="preserve">
 
     <t t-name="web.CogMenu">
-        <div t-if="hasItems" class="o_cp_action_menus d-flex align-items-center pe-2 gap-1">
+        <div t-if="hasItems" class="o_cp_action_menus d-flex align-items-center gap-1" t-att-class="{'pe-2': !env.isSmall}">
             <div class="lh-1">
                 <Dropdown menuClass="'lh-base'" beforeOpen.bind="loadPrintItems">
-                    <button class="d-print-none btn p-0 ms-1 lh-sm border-0" data-hotkey="u" data-tooltip="Actions">
+                    <button class="d-print-none btn" t-att-class="env.isSmall ? 'btn-secondary' : 'lh-sm p-0 border-0'" data-hotkey="u" data-tooltip="Actions">
                         <i class="fa fa-cog"/>
                     </button>
 

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -19,7 +19,7 @@
                     <t t-call="web.embeddedActionsDropdown" />
                 </div>
             </Transition>
-            <div class="o_control_panel_main d-flex flex-wrap flex-lg-nowrap justify-content-between align-items-lg-start gap-3 flex-grow-1">
+            <div class="o_control_panel_main d-flex flex-wrap flex-lg-nowrap justify-content-between align-items-lg-start gap-1 gap-lg-3 flex-grow-1">
                 <div class="o_control_panel_breadcrumbs d-flex align-items-center gap-1 order-0 h-lg-100">
                     <div class="o_control_panel_main_buttons d-flex gap-1 d-empty-none d-print-none" t-ref="mainButtons" t-on-keydown="onMainButtonsKeydown">
                         <div t-if="env.isSmall" class="btn-group o_control_panel_collapsed_create">

--- a/addons/web/static/src/views/form/button_box/button_box.xml
+++ b/addons/web/static/src/views/form/button_box/button_box.xml
@@ -8,7 +8,7 @@
             <Dropdown position="!env.isSmall ? 'bottom-end' : ''" menuClass="'o-form-buttonbox p-0 border-0 ' + (!env.isSmall ? 'o_dropdown_more' : 'o-form-buttonbox-small')">
                 <button class="o_button_more btn d-flex justify-content-center align-items-center" t-att-class="!env.isSmall ? 'o-dropdown-caret btn-outline-secondary' : 'btn-secondary'">
                     <span t-if="!env.isSmall">More</span>
-                    <i t-else="" class="fa fa-bolt" aria-hidden="true"/>
+                    <i t-else="" class="fa fa-bolt lh-base" aria-hidden="true"/>
                 </button>
                 <t t-set-slot="content">
                     <DropdownItem t-foreach="additionalButtons" t-as="button" t-key="button_value" class="'d-flex flex-column p-0'">

--- a/addons/web/static/src/views/form/form_controller.xml
+++ b/addons/web/static/src/views/form/form_controller.xml
@@ -23,13 +23,16 @@
                     </t>
 
                     <t t-set-slot="layout-actions">
-                        <t t-if="buttonBoxTemplate">
+                        <t t-if="!env.isSmall and buttonBoxTemplate">
                             <t t-call="{{ buttonBoxTemplate }}" t-call-context="{ __comp__: Object.assign(Object.create(this), { this, props: { ...this.props, record: this.model.root } }) }"/>
                         </t>
                     </t>
 
                     <t t-set-slot="control-panel-additional-actions">
                         <CogMenu t-props="this.cogMenuProps"/>
+                        <t t-if="env.isSmall and buttonBoxTemplate">
+                            <t t-call="{{ buttonBoxTemplate }}" t-call-context="{ __comp__: Object.assign(Object.create(this), { this, props: { ...this.props, record: this.model.root } }) }"/>
+                        </t>
                     </t>
 
                     <t t-set-slot="control-panel-status-indicator">


### PR DESCRIPTION
This commit adapts the ControlPanel buttons' styling (CogMenu,
ButtonBox) to look like actual buttons and improves their readability
for smaller screens.

task-3336242