### PR TITLE
[FIX] sale_management: re-computation of optional produce price is skipped

### DIFF
--- a/addons/sale_management/models/sale_order_line.py
+++ b/addons/sale_management/models/sale_order_line.py
@@ -38,7 +38,7 @@ class SaleOrderLine(models.Model):
 
     def _lines_without_price_recomputation(self):
         """ Hook to allow filtering the lines to avoid the recomputation of the price. """
-        return self.filtered('sale_order_option_ids')
+        return self.env['sale.order.line']
 
     #=== TOOLING ===#
 


### PR DESCRIPTION
Issue
----

When an optional product line is added to cart (becomes a normal order line by either
pressing the cart icon from the DB or from the portal by a user), its price is not updated
if the product quantity is changed. If a pricelist is chosen which gives lower prices to
higher quantities of the optional product, the user can add that product with an initially
high quantity but then decrease that quantity and the price would be the same.

Steps
-----

 - Create a pricelist for a product A where 6 or more of A is 10.0 each and 3 or more of A is 15.0 each.
 - Create a sales order with A as an optional product where the quantity is 6.
 - Click the cart icon (Add to order lines) on the optional product.
 - Try to decrease the quantity from the added order line.
 - Price is still 10.0 as if there's 6 or more of A.

Cause
-----

`sale_management` adds a hook `_lines_without_price_recomputation` to `sale.order.line` for filtering
out order lines whose price need not be updated. It currently returns lines that have optional products,
so they won't get their price updated.

opw-4078525