### PR TITLE
[FIX] sale_management: translate default quotation template

### DIFF
--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -90,7 +90,7 @@ class SaleOrder(models.Model):
         self.sale_order_option_ids._update_price_and_discount()
         return res
 
-    @api.onchange('sale_order_template_id')
+    @api.onchange('sale_order_template_id', 'partner_id')
     def onchange_sale_order_template_id(self):
 
         if not self.sale_order_template_id:


### PR DESCRIPTION
Problem: When the user sets a default quotation template in Sales > Settings and creates a quotation with a customer whose language preference is not English, the products' description is not translated accordingly for all sale order lines.

Solution: When the user changes the customer on the quotation, the quotation template should recreate the sale order lines according to the new customer's language.

Steps to Reproduce on Runbot:
1. Install Sales
2. Set a default quotation template in Sales > Settings
3. Create a new quotation
4. Set a customer whose language is not English on the quotation
5. Print the quotation
6. Observe that the products' description on each line is not translated, whilst the entire report is translated

opw-3957417

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
