### PR TITLE
[FIX] account: Avoid singleton error on send mail option

### DIFF
--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -290,7 +290,7 @@ class AccountMoveSend(models.TransientModel):
     def _compute_mail_partner_ids(self):
         for wizard in self:
             if wizard.mode == 'invoice_single' and wizard.mail_template_id:
-                wizard.mail_partner_ids = self._get_default_mail_partner_ids(self.move_ids, wizard.mail_template_id, wizard.mail_lang)
+                wizard.mail_partner_ids = wizard._get_default_mail_partner_ids(wizard.move_ids, wizard.mail_template_id, wizard.mail_lang)
             else:
                 wizard.mail_partner_ids = None
 


### PR DESCRIPTION
Fixed error on compute method when more of one wizard is created and tried to get the `mail_partner_ids`.

This section is for `invoice_single` records, so, if you send multiple move_ids a singleton error is returned because you send the moves of all the wizards.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
