### PR TITLE
[FIX] sale_project: prevent singleton error when cancelling multiple quotations

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -315,7 +315,7 @@ class SaleOrder(models.Model):
         res = super().write(values)
         if 'state' in values and values['state'] == 'cancel':
             # Remove sale line field reference from all projects
-            self.env['project.project'].sudo().search([('sale_line_id.order_id', '=', self.id)]).sale_line_id = False
+            self.env['project.project'].sudo().search([('sale_line_id.order_id', 'in', self.ids)]).sale_line_id = False
         return res
 
     def _prepare_analytic_account_data(self, prefix=None):

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -876,3 +876,21 @@ class TestSaleProject(HttpCase, TestSaleProjectCommon):
         })
 
         self.assertTrue(sale_order.analytic_account_id)
+
+    def test_cancel_multiple_quotations(self):
+        quotations = self.env['sale.order'].create([
+            {
+                'partner_id': self.partner.id,
+                'order_line': [
+                    Command.create({'product_id': self.product.id}),
+                ],
+            },
+            {
+                'partner_id': self.partner.id,
+                'order_line': [
+                    Command.create({'product_id': self.product.id}),
+                ],
+            }
+        ])
+        quotations._action_cancel()
+        self.assertEqual(set(quotations.mapped('state')), {'cancel'}, "Both quotations are in 'cancel' state.")


### PR DESCRIPTION
When user tries to cancel the multiple quotations at once,
a traceback will appear.

Steps to reproduce the error:
- Install ```sale_project```
- Go to Sales > Orders > Quotations > Select multiple quotations
- Actions > Cancel quotations > Cancel quotations

Traceback:
```
ValueError: Expected singleton: sale.order(1, 2)
  File "odoo/http.py", line 2373, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1903, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1966, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1933, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2177, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 223, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 754, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 40, in call_button
    action = call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 459, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/sale/wizard/mass_cancel_orders.py", line 32, in action_mass_cancel
    self.sale_order_ids._action_cancel()
  File "home/odoo/src/enterprise/saas-17.4/sale_planning/models/sale_order.py", line 62, in _action_cancel
    result = super()._action_cancel()
  File "addons/sale_purchase/models/sale_order.py", line 27, in _action_cancel
    result = super()._action_cancel()
  File "addons/sale/models/sale_order.py", line 1138, in _action_cancel
    return self.write({'state': 'cancel'})
  File "addons/sale_project/models/sale_order.py", line 318, in write
    self.env['project.project'].sudo().search([('sale_line_id.order_id', '=', self.id)]).sale_line_id = False
  File "odoo/fields.py", line 5216, in __get__
    raise ValueError("Expected singleton: %s" % record)
```

https://github.com/odoo/odoo/blob/5a7e83a4340aeee3c0208cea72c200e998e26ecd/addons/sale_project/models/sale_order.py#L318
Here, ```self.id``` is used instead of ```self.ids```.

sentry-5659311816

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
