### PR TITLE
[IMP] mail: adapt imstatus to use channel member

### DIFF
--- a/addons/hr_holidays/static/src/im_status_patch.xml
+++ b/addons/hr_holidays/static/src/im_status_patch.xml
@@ -2,9 +2,9 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.ImStatus" t-inherit-mode="extension">
         <xpath expr="//*[@name='icon']" position="replace">
-            <i t-if="props.persona.im_status === 'leave_online'" class="fa fa-plane text-success" title="Online" role="img" aria-label="User is online"/>
-            <i t-elif="props.persona.im_status === 'leave_away'" class="fa fa-plane o-away" title="Idle" role="img" aria-label="User is idle"/>
-            <i t-elif="props.persona.im_status === 'leave_offline'" class="fa fa-plane text-700" title="Out of office" role="img" aria-label="User is out of office"/>
+            <i t-if="persona.im_status === 'leave_online'" class="fa fa-plane text-success" title="Online" role="img" aria-label="User is online"/>
+            <i t-elif="persona.im_status === 'leave_away'" class="fa fa-plane o-away" title="Idle" role="img" aria-label="User is idle"/>
+            <i t-elif="persona.im_status === 'leave_offline'" class="fa fa-plane text-700" title="Out of office" role="img" aria-label="User is out of office"/>
             <t t-else="">$0</t>
         </xpath>
     </t>

--- a/addons/hr_homeworking/static/src/im_status_patch.xml
+++ b/addons/hr_homeworking/static/src/im_status_patch.xml
@@ -2,11 +2,11 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.ImStatus" t-inherit-mode="extension">
         <xpath expr="//*[@name='icon']" position="replace">
-            <t t-if="props.persona.im_status">
-                <t t-if="props.persona.im_status.split('_').length == 2">
-                    <t t-set="location" t-value="props.persona.im_status.split('_')[0]"/>
+            <t t-if="persona.im_status">
+                <t t-if="persona.im_status.split('_').length == 2">
+                    <t t-set="location" t-value="persona.im_status.split('_')[0]"/>
                     <t t-if="location == 'home' || location == 'office' || location == 'other'">
-                        <t t-set="status" t-value="props.persona.im_status.split('_')[1]"/>
+                        <t t-set="status" t-value="persona.im_status.split('_')[1]"/>
                         <t t-set="location_map" t-value="{'home': 'fa-home', 'office': 'fa-building', 'other': 'fa-map-marker'}"/>
                         <t t-set="status_map" t-value="{'online': 'text-success', 'away': 'o-away', 'offline': 'text-7000'}"/>
                         <t t-set="icon" t-value="location_map[location]"/>

--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -14,7 +14,7 @@
         <button class="o-mail-ChatBubble" t-att-name="props.chatWindow.displayName" t-att-class="{ 'o-bouncing': state.bouncing, 'position-fixed': env.embedLivechat, 'position-relative': !env.embedLivechat, 'o-active': preview.isOpen }" t-att-style="env.embedLivechat ? `top: ${ position.top }; left: ${ position.left };` : ''" t-on-click="() => props.chatWindow.open()" t-on-animationend="() => state.bouncing = false" t-ref="root">
             <div t-if="thread?.importantCounter > 0" class="o-mail-ChatBubble-counter position-absolute badge rounded-pill fw-bold o-discuss-badge shadow" t-out="thread?.importantCounter"/>
             <button t-if="state.showClose and !env.embedLivechat" class="o-mail-ChatBubble-close position-absolute shadow rounded-circle fw-bold bg-view" title="Close Chat Window" t-on-click.stop="() => this.props.chatWindow.close()"><i class="oi oi-close"/></button>
-            <ImStatus t-if="thread?.correspondent?.persona?.im_status and thread?.correspondent?.persona?.im_status != 'offline'" className="'o-mail-ChatBubble-status position-absolute o-mail-brighter'" persona="thread.correspondent.persona" thread="thread"/>
+            <ImStatus t-if="thread?.correspondent?.persona?.im_status and thread?.correspondent?.persona?.im_status != 'offline'" className="'o-mail-ChatBubble-status position-absolute o-mail-brighter'" member="thread.correspondent" thread="thread"/>
             <button class="o-mail-ChatHub-bubbleBtn btn">
                 <img class="o-mail-ChatBubble-avatar rounded-circle" t-att-class="{ 'o-big': env.embedLivechat }" t-att-src="thread?.avatarUrl" alt="Thread image" draggable="false"/>
             </button>

--- a/addons/mail/static/src/core/common/im_status.js
+++ b/addons/mail/static/src/core/common/im_status.js
@@ -2,8 +2,12 @@ import { Component } from "@odoo/owl";
 import { Typing } from "@mail/discuss/typing/common/typing";
 
 export class ImStatus extends Component {
-    static props = ["persona", "className?", "style?", "thread?"];
+    static props = ["persona?", "className?", "style?", "member?"];
     static template = "mail.ImStatus";
     static defaultProps = { className: "", style: "" };
     static components = { Typing };
+
+    get persona() {
+        return this.props.persona ?? this.props.member?.persona;
+    }
 }

--- a/addons/mail/static/src/core/common/im_status.xml
+++ b/addons/mail/static/src/core/common/im_status.xml
@@ -4,14 +4,14 @@
     <t t-name="mail.ImStatus">
         <div class="o-mail-ImStatus d-flex justify-content-center flex-shrink-0 align-items-center rounded-circle bg-inherit" t-att-class="props.className" t-att-style="props.style">
             <span class="d-flex flex-column" name="icon">
-                <t t-if="!props.thread or !props.thread.hasOtherMembersTyping">
-                    <i t-if="props.persona.im_status === 'online'" class="fa fa-circle text-success" title="Online" role="img" aria-label="User is online"/>
-                    <i t-elif="props.persona.im_status === 'away'" class="fa fa-circle o-away" title="Idle" role="img" aria-label="User is idle"/>
-                    <i t-elif="props.persona.im_status === 'offline'" class="fa fa-circle-o text-700" title="Offline" role="img" aria-label="User is offline"/>
-                    <i t-elif="props.persona.im_status === 'bot'" class="fa fa-heart text-success" title="Bot" role="img" aria-label="User is a bot"/>
+                <t t-if="(!props.member or !props.member.isTyping) and persona">
+                    <i t-if="persona.im_status === 'online'" class="fa fa-circle text-success" title="Online" role="img" aria-label="User is online"/>
+                    <i t-elif="persona.im_status === 'away'" class="fa fa-circle o-away" title="Idle" role="img" aria-label="User is idle"/>
+                    <i t-elif="persona.im_status === 'offline'" class="fa fa-circle-o text-700" title="Offline" role="img" aria-label="User is offline"/>
+                    <i t-elif="persona.im_status === 'bot'" class="fa fa-heart text-success" title="Bot" role="img" aria-label="User is a bot"/>
                     <i t-else="" class="fa fa-fw fa-question-circle" title="No IM status available"/>
                 </t>
-                <Typing t-if="props.thread" channel="props.thread" size="'medium'" displayText="false" />
+                <Typing t-if="props.member?.isTyping" member="props.member" channel="props.member.threadAsTyping" size="'medium'" displayText="false" />
             </span>
         </div>
     </t>

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -19,7 +19,7 @@
                     <t t-else="">
                         <ThreadIcon className="'me-2 align-self-center'" size="'large'" thread="thread"/>
                     </t>
-                    <ImStatus t-if="thread.channel_type === 'chat' and thread.correspondent" className="'me-1'" persona="thread.correspondent.persona" thread="thread" />
+                    <ImStatus t-if="thread.channel_type === 'chat' and thread.correspondent" className="'me-1'" member="thread.correspondent" />
                     <div class="d-flex flex-grow-1 align-self-center align-items-center h-100 py-2">
                         <AutoresizeInput
                             className="'o-mail-Discuss-threadName lead fw-bold flex-shrink-1 text-dark py-0'"

--- a/addons/mail/static/src/core/web/messaging_menu.xml
+++ b/addons/mail/static/src/core/web/messaging_menu.xml
@@ -106,7 +106,7 @@
                     onSwipeLeft="hasTouch() and thread.canUnpin ? { action: () => thread.unpin(), icon: 'fa-times-circle', bgColor: 'bg-danger' } : undefined"
                 >
                     <t t-set-slot="icon">
-                        <ImStatus t-if="thread.channel_type === 'chat' and thread.correspondent" persona="thread.correspondent.persona" thread="thread" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'"/>
+                        <ImStatus t-if="thread.channel_type === 'chat' and thread.correspondent" member="thread.correspondent" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'"/>
                     </t>
                     <t t-if="message" t-set-slot="body-icon">
                         <t t-call="mail.message_preview_prefix">

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -31,7 +31,7 @@
             <div class="bg-inherit o-discuss-ChannelMember-avatar position-relative d-flex ms-4 flex-shrink-0">
                 <img class="w-100 h-100 rounded o_object_fit_cover"
                      t-att-src="member.persona.avatarUrl"/>
-                <ImStatus persona="member.persona" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'"/>
+                <ImStatus member="member" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'"/>
             </div>
             <span t-ref="displayName" class="ms-2 text-truncate" t-esc="member.name"/>
             <span class="ms-auto">

--- a/addons/mail/static/src/discuss/typing/common/typing.js
+++ b/addons/mail/static/src/discuss/typing/common/typing.js
@@ -14,12 +14,14 @@ export class Typing extends Component {
         size: "small",
         displayText: true,
     };
-    static props = ["channel", "size?", "displayText?"];
+    static props = ["channel?", "size?", "displayText?", "member?"];
     static template = "discuss.Typing";
 
     /** @returns {string} */
     get text() {
-        const typingMemberNames = this.props.channel.otherTypingMembers.map(({ name }) => name);
+        const typingMemberNames = this.props.member
+            ? [this.props.member.name]
+            : this.props.channel.otherTypingMembers.map(({ name }) => name);
         if (typingMemberNames.length === 1) {
             return _t("%s is typing...", typingMemberNames[0]);
         }

--- a/addons/mail/static/src/discuss/typing/common/typing.xml
+++ b/addons/mail/static/src/discuss/typing/common/typing.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.Typing">
-        <t t-if="props.channel.hasOtherMembersTyping">
+        <t t-if="props.member ? props.member.isTyping : props.channel.hasOtherMembersTyping">
             <div class="o-discuss-Typing-icon d-flex align-items-center" t-attf-class="{{ className }}" t-att-title="text">
                 <span class="o-discuss-Typing-dot d-flex flex-shrink-0 rounded-pill bg-500"
                       t-att-class="{


### PR DESCRIPTION
`ImStatus` currently uses `thread` to display the typing status.Which doesn't allow you to display member specific typing statuses in member list.

This PR adapts `ImStatus` to use `ChannelMember` instead of `Thread` to display typing status. Which enables use to display member specific typing statuses.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
