### PR TITLE
[FIX] html_editor: youtube shorts not getting added

### DIFF
--- a/addons/html_editor/tools.py
+++ b/addons/html_editor/tools.py
@@ -14,7 +14,7 @@ valid_url_regex = r'^(http://|https://|//)[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{
 
 # Regex for few of the widely used video hosting services
 player_regexes = {
-    'youtube': r'^(?:(?:https?:)?//)?(?:www\.)?(?:youtu\.be/|youtube(-nocookie)?\.com/(?:embed/|v/|watch\?v=|watch\?.+&v=))((?:\w|-){11})\S*$',
+    'youtube': r'^(?:(?:https?:)?//)?(?:www\.)?(?:youtu\.be/|youtube(-nocookie)?\.com/(?:embed/|v/|shorts/|live/|watch\?v=|watch\?.+&v=))((?:\w|-){11})\S*$',
     'vimeo': r'//(player.)?vimeo.com/([a-z]*/)*([0-9]{6,11})[?]?.*',
     'dailymotion': r'(https?:\/\/)(www\.)?(dailymotion\.com\/(embed\/video\/|embed\/|video\/|hub\/.*#video=)|dai\.ly\/)(?P<id>[A-Za-z0-9]{6,7})',
     'instagram': r'(?:(.*)instagram.com|instagr\.am)/p/(.[a-zA-Z0-9-_\.]*)',


### PR DESCRIPTION
Steps to Reproduce: 

1. Go to Website --> Drag and drop an Image snippet(here Image - text).
2. Double click on the image --> Add a youtube shorts link in the video tab.
3. It will say the provided url is invalid.

Issue reason:
Commit [[1]] added youtube shorts feature to video selector dialog. But this issue is introduced by new implementation of `html_editor` intended to replace the `web_editor`. `player_regexes` for youtube didn't support youtube shorts.

Solution:
Updating the `player_regexes` for youtube to add youtube shorts as well as added part to support youtube live videos.

This commit ensures the youtube shorts are getting added and working.

[1]: https://github.com/odoo/odoo/commit/d890f7b

task-4082384

