### PR TITLE
[FIX] sale_project: fix multiple sale order cancel from list view

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -315,7 +315,7 @@ class SaleOrder(models.Model):
         res = super().write(values)
         if 'state' in values and values['state'] == 'cancel':
             # Remove sale line field reference from all projects
-            self.env['project.project'].sudo().search([('sale_line_id.order_id', '=', self.id)]).sale_line_id = False
+            self.env['project.project'].sudo().search([('sale_line_id.order_id', 'in', self.ids)]).sale_line_id = False
         return res
 
     def _prepare_analytic_account_data(self, prefix=None):


### PR DESCRIPTION
Version:
 - saas-17.4

steps to reproduce:
- when `sale_project` module is installed
- open list view in sale/subscription
- select multiple orders
- click on 'cancel quotation' button from Actions

Issue:
- it will give traceback when cancel multiple order at once.

cause:
- singleton error occurred while attempting to set sale_line_id to False for multiple records. It only handled a single order_id at a time, resulting in failure when self.id contained multiple values.

solution:
- by using 'in' and self.ids, the code now clears sale_line_id for all related project.project records without causing an error.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
