### PR TITLE
[ADD] l10n_in_gstin_status: check GSTIN status

### DIFF
--- a/addons/l10n_in/__manifest__.py
+++ b/addons/l10n_in/__manifest__.py
@@ -23,6 +23,7 @@ Sheet, now only Vertical format has been permitted Which is Supported By Odoo.
         'base_vat',
         'account_debit_note',
         'account',
+        'iap',
     ],
     'auto_install': ['account'],
     'data': [

--- a/addons/l10n_in/models/__init__.py
+++ b/addons/l10n_in/models/__init__.py
@@ -4,6 +4,7 @@ from . import account_invoice
 from . import account_move_line
 from . import account_tax
 from . import company
+from . import iap_account
 from . import product_template
 from . import port_code
 from . import res_config_settings

--- a/addons/l10n_in/models/company.py
+++ b/addons/l10n_in/models/company.py
@@ -16,6 +16,11 @@ class ResCompany(models.Model):
         store=True,
         readonly=False,
     )
+    l10n_in_edi_production_env = fields.Boolean(
+        string="Indian Production Environment",
+        help="Enable the use of production credentials",
+        groups="base.group_system",
+    )
 
     @api.depends('vat')
     def _compute_l10n_in_hsn_code_digit(self):

--- a/addons/l10n_in/models/iap_account.py
+++ b/addons/l10n_in/models/iap_account.py
@@ -1,0 +1,27 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+from odoo.addons.iap import jsonrpc
+
+DEFAULT_IAP_ENDPOINT = "https://l10n-in-edi.api.odoo.com"
+DEFAULT_IAP_TEST_ENDPOINT = "https://l10n-in-edi-demo.api.odoo.com"
+IAP_SERVICE_NAME = 'l10n_in_edi'
+
+
+class IapAccount(models.Model):
+    _inherit = 'iap.account'
+
+    @api.model
+    def _l10n_in_connect_to_server(self, is_production, params, url_path, config_parameter, timeout=25):
+        user_token = self.get(IAP_SERVICE_NAME)
+        params.update({
+            "dbuuid": self.env["ir.config_parameter"].sudo().get_param("database.uuid"),
+            "account_token": user_token.account_token,
+        })
+        if is_production:
+            default_endpoint = DEFAULT_IAP_ENDPOINT
+        else:
+            default_endpoint = DEFAULT_IAP_TEST_ENDPOINT
+        endpoint = self.env["ir.config_parameter"].sudo().get_param(config_parameter, default_endpoint)
+        url = "%s%s" % (endpoint, url_path)
+        return jsonrpc(url, params=params, timeout=timeout)

--- a/addons/l10n_in/models/res_config_settings.py
+++ b/addons/l10n_in/models/res_config_settings.py
@@ -1,13 +1,33 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
+from odoo import _, fields, models
+from odoo.exceptions import ValidationError
+from odoo.addons.l10n_in.models.iap_account import IAP_SERVICE_NAME
 
 
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
     group_l10n_in_reseller = fields.Boolean(implied_group='l10n_in.group_l10n_in_reseller', string="Manage Reseller(E-Commerce)")
+    l10n_in_edi_production_env = fields.Boolean(
+        string="Indian Production Environment",
+        related="company_id.l10n_in_edi_production_env",
+        readonly=False
+    )
     module_l10n_in_edi = fields.Boolean('Indian Electronic Invoicing')
     module_l10n_in_edi_ewaybill = fields.Boolean('Indian Electronic Waybill')
+    module_l10n_in_gstin_status = fields.Boolean('Check GST Number Status')
     l10n_in_hsn_code_digit = fields.Selection(related='company_id.l10n_in_hsn_code_digit', readonly=False)
+
+    def l10n_in_edi_buy_iap(self):
+        if not self.l10n_in_edi_production_env or not (self.module_l10n_in_edi or self.module_l10n_in_gstin_status):
+            raise ValidationError(_(
+                "Please ensure that at least one Indian service and production environment is enabled,"
+                " and save the configuration to proceed with purchasing credits."
+            ))
+        return {
+            'type': 'ir.actions.act_url',
+            'url': self.env["iap.account"].get_credits_url(service_name=IAP_SERVICE_NAME),
+            'target': '_new'
+        }

--- a/addons/l10n_in/views/res_config_settings_views.xml
+++ b/addons/l10n_in/views/res_config_settings_views.xml
@@ -9,17 +9,48 @@
                 <setting help="Use this if setup with Reseller(E-Commerce)." name="ecommerce_reseller_setting" title="Manage Reseller(E-Commerce)" invisible="country_code != 'IN'">
                     <field name="group_l10n_in_reseller"/>
                 </setting>
-                <setting help="Connect to NIC (National Informatics Center) to submit invoices on posting." name="electronic_invoices_in" invisible="country_code != 'IN'" documentation="/applications/finance/accounting/fiscal_localizations/localizations/india.html#indian-e-invoicing">
-                    <field name="module_l10n_in_edi" class="oe_inline" widget="upgrade_boolean"/>
-                </setting>
-                <setting help="Connect to NIC (National Informatics Center) to submit e-waybill on posting." name="electronic_waybill_in" invisible="country_code != 'IN'" documentation="/applications/finance/accounting/fiscal_localizations/localizations/india.html#indian-e-waybill">
-                    <field name="module_l10n_in_edi_ewaybill" class="oe_inline" widget="upgrade_boolean"/>
-                </setting>
             </block>
             <xpath expr="//app[@name='account']" position="inside">
-                <div id="india_integration_section" invisible="1">
+                <div id="india_integration_section">
                     <block title="Indian Integration" id="india_localization" invisible="country_code != 'IN'">
+                        <setting name="india_production_setting"
+                                 string="Production Environment"
+                                 help="Activate this to start using Indian services in the production environment.">
+                            <field name="l10n_in_edi_production_env"/>
+                            <div class='mt8'
+                                 invisible="not l10n_in_edi_production_env or (not module_l10n_in_edi and not module_l10n_in_gstin_status and not module_l10n_in_edi_ewaybill)">
+                                <button name="l10n_in_edi_buy_iap"
+                                        title="Costs 1 credit per transaction. Free 200 credits will be available for the first time."
+                                        icon="fa-arrow-right"
+                                        type="object"
+                                        string="Buy credits"
+                                        class="btn-link"/>
+                            </div>
+                        </setting>
+                        <setting/>
+                        <setting name="electronic_invoices_in"
+                                 help="Connect to NIC (National Informatics Center) to submit invoices on posting."
+                                 company_dependent="1"
+                                 invisible="country_code != 'IN'"
+                                 documentation="/applications/finance/fiscal_localizations/india.html#india-e-invoicing">
+                            <field name="module_l10n_in_edi"/>
+                        </setting>
+                        <setting name="electronic_waybill_in"
+                                 help="Connect to NIC (National Informatics Center) to submit e-waybill on posting."
+                                 company_dependent="1"
+                                 
+                                 invisible="country_code != 'IN'"
+                                 documentation="/applications/finance/fiscal_localizations/india.html#indian-e-waybill">
+                            <field name="module_l10n_in_edi_ewaybill" class="oe_inline" widget="upgrade_boolean"/>
+                        </setting>
+                        <setting name="india_gstin_status_api_settings"
+                                 string="Check GST Number Status"
+                                 help="Enable this to check the GST Number status"
+                                 invisible="country_code != 'IN'">
+                            <field name="module_l10n_in_gstin_status" class="oe_inline"/>
+                        </setting>
                     </block>
+
                 </div>
             </xpath>
             <app name="account" position="inside">

--- a/addons/l10n_in_edi/__manifest__.py
+++ b/addons/l10n_in_edi/__manifest__.py
@@ -8,7 +8,6 @@
     "depends": [
         "account_edi",
         "l10n_in",
-        "iap",
     ],
     "description": """
 Indian - E-invoicing

--- a/addons/l10n_in_edi/models/res_company.py
+++ b/addons/l10n_in_edi/models/res_company.py
@@ -11,11 +11,6 @@ class ResCompany(models.Model):
     l10n_in_edi_password = fields.Char("E-invoice (IN) Password", groups="base.group_system")
     l10n_in_edi_token = fields.Char("E-invoice (IN) Token", groups="base.group_system")
     l10n_in_edi_token_validity = fields.Datetime("E-invoice (IN) Valid Until", groups="base.group_system")
-    l10n_in_edi_production_env = fields.Boolean(
-        string="E-invoice (IN) Is production OSE environment",
-        help="Enable the use of production credentials",
-        groups="base.group_system",
-    )
 
     def _l10n_in_edi_token_is_valid(self):
         self.ensure_one()

--- a/addons/l10n_in_edi/models/res_config_settings.py
+++ b/addons/l10n_in_edi/models/res_config_settings.py
@@ -10,11 +10,6 @@ class ResConfigSettings(models.TransientModel):
 
     l10n_in_edi_username = fields.Char("Indian EDI username", related="company_id.l10n_in_edi_username", readonly=False)
     l10n_in_edi_password = fields.Char("Indian EDI password", related="company_id.l10n_in_edi_password", readonly=False)
-    l10n_in_edi_production_env = fields.Boolean(
-        string="Indian EDI Testing Environment",
-        related="company_id.l10n_in_edi_production_env",
-        readonly=False
-    )
 
     def l10n_in_check_gst_number(self):
         if not self.company_id.vat:
@@ -41,12 +36,3 @@ class ResConfigSettings(models.TransientModel):
                   'message': _("API credentials validated successfully"),
               }
           }
-
-    def l10n_in_edi_buy_iap(self):
-        if not self.l10n_in_edi_production_env:
-            raise UserError(_("You must enable production environment to buy credits"))
-        return {
-            'type': 'ir.actions.act_url',
-            'url': self.env["iap.account"].get_credits_url(service_name="l10n_in_edi", base_url=''),
-            'target': '_new'
-        }

--- a/addons/l10n_in_edi/views/res_config_settings_views.xml
+++ b/addons/l10n_in_edi/views/res_config_settings_views.xml
@@ -5,12 +5,8 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <div id="india_integration_section" position="attributes">
-                <attribute name="invisible">0</attribute>
-            </div>
-            <xpath expr="//block[@id='india_localization']" position="inside">
-                <setting id="gsp_setting" string="Setup E-invoice" help="Check the documentation to get credentials" documentation="/applications/finance/fiscal_localizations/india.html" company_dependent="1" >
-                    <div class="content-group">
+            <xpath expr="//setting[@name='electronic_invoices_in']" position="inside">
+                    <div class="content-group" invisible="not module_l10n_in_edi">
                         <div class="mt16 row">
                             <label for="l10n_in_edi_username" string="Username" class="col-3 col-lg-3 o_light_label"/>
                             <field name="l10n_in_edi_username" nolabel="1"/>
@@ -19,18 +15,10 @@
                             <label for="l10n_in_edi_password" string="Password" class="col-3 col-lg-3 o_light_label"/>
                             <field name="l10n_in_edi_password" password="True" nolabel="1"/>
                         </div>
-                        <div class="row">
-                            <label for="l10n_in_edi_production_env" string="Production Environment" class="col-3 col-lg-3 o_light_label"/>
-                            <field name="l10n_in_edi_production_env" nolabel="1"/>
-                        </div>
                     </div>
-                    <div class='mt8'>
+                    <div class='mt8' invisible="not module_l10n_in_edi">
                         <button name="l10n_in_edi_test" icon="oi-arrow-right" type="object" string="Verify Username and Password" class="btn-link"/>
                     </div>
-                    <div class='mt8'>
-                        <button name="l10n_in_edi_buy_iap" title="Costs 1 credit per transaction. Free 200 credits will be available for the first time." icon="fa-arrow-right" type="object" string="Buy credits" class="btn-link"/>
-                    </div>
-                </setting>
             </xpath>
         </field>
     </record>

--- a/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
+++ b/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
@@ -9,8 +9,6 @@ from markupsafe import Markup
 from odoo import models, fields, api, _
 from odoo.tools import html_escape
 from odoo.exceptions import AccessError
-from odoo.addons.iap import jsonrpc
-from odoo.addons.l10n_in_edi.models.account_edi_format import DEFAULT_IAP_ENDPOINT, DEFAULT_IAP_TEST_ENDPOINT
 
 from .error_codes import ERROR_CODES
 
@@ -586,21 +584,18 @@ class AccountEdiFormat(models.Model):
 
     @api.model
     def _l10n_in_edi_ewaybill_connect_to_server(self, company, url_path, params):
-        user_token = self.env["iap.account"].get("l10n_in_edi")
         params.update({
-            "account_token": user_token.account_token,
-            "dbuuid": self.env["ir.config_parameter"].sudo().get_param("database.uuid"),
             "username": company.sudo().l10n_in_edi_ewaybill_username,
             "gstin": company.vat,
         })
-        if company.sudo().l10n_in_edi_production_env:
-            default_endpoint = DEFAULT_IAP_ENDPOINT
-        else:
-            default_endpoint = DEFAULT_IAP_TEST_ENDPOINT
-        endpoint = self.env["ir.config_parameter"].sudo().get_param("l10n_in_edi_ewaybill.endpoint", default_endpoint)
-        url = "%s%s" % (endpoint, url_path)
         try:
-            response = jsonrpc(url, params=params, timeout=70)
+            response = self.env['iap.account']._l10n_in_connect_to_server(
+                is_production=company.sudo().l10n_in_edi_production_env,
+                params=params,
+                url_path=url_path,
+                config_parameter="l10n_in_edi_ewaybill.endpoint",
+                timeout=70
+            )
             return self._l10n_in_set_missing_error_message(response)
         except AccessError as e:
             _logger.warning("Connection error: %s", e.args[0])

--- a/addons/l10n_in_edi_ewaybill/views/res_config_settings_views.xml
+++ b/addons/l10n_in_edi_ewaybill/views/res_config_settings_views.xml
@@ -5,32 +5,20 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <div id="india_integration_section" position="attributes">
-                <attribute name="invisible">0</attribute>
-            </div>
-            <xpath expr="//block[@id='india_localization']" position="inside">
-                <setting id="l10n_in_eway_iap" string="Setup Electronic Waybill" help="Check the documentation to get credentials." documentation="/applications/finance/fiscal_localizations/india.html" company_dependent="1" >
-                    <div class="content-group">
-                        <div class="mt16 row">
-                            <label for="l10n_in_edi_ewaybill_username" string="Username" class="col-3 col-lg-3 o_light_label"/>
-                            <field name="l10n_in_edi_ewaybill_username" nolabel="1"/>
-                        </div>
-                        <div class="row">
-                            <label for="l10n_in_edi_ewaybill_password" string="Password" class="col-3 col-lg-3 o_light_label"/>
-                            <field name="l10n_in_edi_ewaybill_password" password="True" nolabel="1"/>
-                        </div>
-                        <div class="row">
-                            <label for="l10n_in_edi_production_env" string="Production Environment" class="col-3 col-lg-3 o_light_label"/>
-                            <field name="l10n_in_edi_production_env" nolabel="1"/>
-                        </div>
+            <xpath expr="//setting[@name='electronic_waybill_in']" position="inside">
+                <div class="content-group" invisible="not module_l10n_in_edi_ewaybill or not module_l10n_in_edi">
+                    <div class="mt16 row">
+                        <label for="l10n_in_edi_ewaybill_username" string="Username" class="col-3 col-lg-3 o_light_label"/>
+                        <field name="l10n_in_edi_ewaybill_username" nolabel="1"/>
                     </div>
-                    <div class='mt8'>
-                        <button name="l10n_in_edi_ewaybill_test" icon="oi-arrow-right" type="object" string="Verify Username and Password" class="btn-link"/>
+                    <div class="row">
+                        <label for="l10n_in_edi_ewaybill_password" string="Password" class="col-3 col-lg-3 o_light_label"/>
+                        <field name="l10n_in_edi_ewaybill_password" password="True" nolabel="1"/>
                     </div>
-                    <div class='mt8'>
-                        <button name="l10n_in_edi_buy_iap" title="Costs 1 credit per transaction. Free 200 credits will be available for the first time." icon="fa-arrow-right" type="object" string="Buy credits" class="btn-link"/>
-                    </div>
-                </setting>
+                </div>
+                <div class='mt8' invisible="not module_l10n_in_edi_ewaybill or not module_l10n_in_edi">
+                    <button name="l10n_in_edi_ewaybill_test" icon="oi-arrow-right" type="object" string="Verify Username and Password" class="btn-link"/>
+                </div>
             </xpath>
         </field>
     </record>

--- a/addons/l10n_in_gstin_status/__init__.py
+++ b/addons/l10n_in_gstin_status/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/l10n_in_gstin_status/__manifest__.py
+++ b/addons/l10n_in_gstin_status/__manifest__.py
@@ -1,0 +1,15 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    "name": "Indian - Check GST Number Status",
+    'countries': ['in'],
+    "category": "Accounting/Localizations",
+    "depends": [
+        "l10n_in",
+    ],
+    "data": [
+        "views/account_move_views.xml",
+        "views/res_partner_views.xml",
+    ],
+    "installable": True,
+    "license": "LGPL-3",
+}

--- a/addons/l10n_in_gstin_status/models/__init__.py
+++ b/addons/l10n_in_gstin_status/models/__init__.py
@@ -1,0 +1,4 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import account_move
+from . import res_partner

--- a/addons/l10n_in_gstin_status/models/account_move.py
+++ b/addons/l10n_in_gstin_status/models/account_move.py
@@ -1,0 +1,40 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import api, fields, models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    l10n_in_partner_gstin_status = fields.Boolean(
+        string="GST Status",
+        compute="_compute_l10n_in_partner_gstin_status_and_date",
+    )
+    l10n_in_show_gstin_status = fields.Boolean(compute="_compute_l10n_in_show_gstin_status")
+    l10n_in_gstin_verified_date = fields.Date(compute="_compute_l10n_in_partner_gstin_status_and_date")
+
+    @api.depends('partner_id', 'state', 'payment_state', 'l10n_in_gst_treatment')
+    def _compute_l10n_in_show_gstin_status(self):
+        indian_moves = self.filtered(lambda m: m.country_code == 'IN')
+        (self - indian_moves).l10n_in_show_gstin_status = False
+        for move in indian_moves:
+            move.l10n_in_show_gstin_status = (
+                move.partner_id
+                and move.state == 'posted'
+                and move.move_type != 'entry'
+                and move.payment_state not in ['paid', 'reversed']
+                and move.l10n_in_gst_treatment in ['regular', 'composition', 'special_economic_zone', 'deemed_export', 'uin_holders']
+            )
+
+    @api.depends('partner_id')
+    def _compute_l10n_in_partner_gstin_status_and_date(self):
+        for move in self:
+            if move.country_code == 'IN' and move.payment_state not in ['paid', 'reversed'] and move.state != 'cancel':
+                move.l10n_in_partner_gstin_status = move.partner_id.l10n_in_gstin_verified_status
+                move.l10n_in_gstin_verified_date = move.partner_id.l10n_in_gstin_verified_date
+            else:
+                move.l10n_in_partner_gstin_status = False
+                move.l10n_in_gstin_verified_date = False
+
+    def l10n_in_verify_partner_gstin_status(self):
+        self.ensure_one()
+        return self.with_company(self.company_id).partner_id.action_l10n_in_verify_gstin_status()

--- a/addons/l10n_in_gstin_status/models/res_partner.py
+++ b/addons/l10n_in_gstin_status/models/res_partner.py
@@ -1,0 +1,115 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import logging
+import re
+
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError, AccessError, ValidationError
+from odoo.addons.l10n_in.models.iap_account import IAP_SERVICE_NAME
+
+_logger = logging.getLogger(__name__)
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    l10n_in_gstin_verified_status = fields.Boolean(
+        string="GST Status",
+        tracking=True,
+    )
+    l10n_in_gstin_verified_date = fields.Date(
+        string="GSTIN Verified Date",
+        tracking=True,
+    )
+
+    @api.onchange('vat')
+    def _onchange_l10n_in_gst_status(self):
+        """
+        Reset GST Status Whenever the `vat` of partner changes
+        """
+        for partner in self:
+            if partner.country_code == 'IN':
+                partner.l10n_in_gstin_verified_status = False
+                partner.l10n_in_gstin_verified_date = False
+
+    def action_l10n_in_verify_gstin_status(self):
+        self.ensure_one()
+        if not self.vat:
+            raise ValidationError(_("Please enter the GSTIN"))
+        is_production = self.env.company.sudo().l10n_in_edi_production_env
+        params = {
+            "gstin_to_search": self.vat,
+        }
+        try:
+            response = self.env['iap.account']._l10n_in_connect_to_server(
+                is_production,
+                params,
+                '/iap/l10n_in_reports/1/public/search',
+                "l10n_in_gstin_status.endpoint"
+            )
+        except AccessError:
+            raise UserError(_("Unable to connect with GST network"))
+        if response.get('error') and any(e.get('code') == 'no-credit' for e in response['error']):
+            return self.env["bus.bus"]._sendone(self.env.user.partner_id, "iap_notification",
+                {
+                    "type": "no_credit",
+                    "title": _("Not enough credits to check GSTIN status"),
+                    "get_credits_url": self.env["iap.account"].get_credits_url(service_name=IAP_SERVICE_NAME),
+                },
+            )
+        gst_status = response.get('data', {}).get('sts', "")
+        if gst_status.casefold() == 'active':
+            l10n_in_gstin_verified_status = True
+        elif gst_status:
+            l10n_in_gstin_verified_status = False
+            date_from = response.get("data", {}).get("cxdt", '')
+            if date_from and re.search(r'\d', date_from):
+                message = _(
+                    "GSTIN %(vat)s is %(status)s and Effective from %(date_from)s.",
+                    vat=self.vat,
+                    status=gst_status,
+                    date_from=date_from,
+                )
+            else:
+                message = _(
+                    "GSTIN %(vat)s is %(status)s, effective date is not available.",
+                    vat=self.vat,
+                    status=gst_status
+                )
+            if not is_production:
+                message += _(" Warning: You are currently in a test environment. The result is a dummy.")
+            self.message_post(body=message)
+        else:
+            _logger.info("GST status check error %s", response)
+            if response.get('error') and any(e.get('code') == 'SWEB_9035' for e in response['error']):
+                raise UserError(
+                    _("The provided GSTIN is invalid. Please check the GSTIN and try again.")
+                )
+            default_error_message = _(
+                "Something went wrong while fetching the GST status."
+                "Please Contact Support if the error persists with"
+                "Response: %(response)s",
+                response=response
+            )
+            error_messages = [
+                f"[{error.get('code') or _('Unknown')}] {error.get('message') or default_error_message}"
+                for error in response.get('error')
+            ]
+            raise UserError(
+                error_messages
+                and '\n'.join(error_messages)
+                or default_error_message
+            )
+        self.write({
+            "l10n_in_gstin_verified_status": l10n_in_gstin_verified_status,
+            "l10n_in_gstin_verified_date": fields.Date.today(),
+        })
+        return {
+            "type": "ir.actions.client",
+            "tag": "display_notification",
+            "params": {
+                "type": "info",
+                "message": _("GSTIN Status Updated Successfully"),
+                "next": {"type": "ir.actions.act_window_close"},
+            },
+        }

--- a/addons/l10n_in_gstin_status/tests/__init__.py
+++ b/addons/l10n_in_gstin_status/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_check_status

--- a/addons/l10n_in_gstin_status/tests/test_check_status.py
+++ b/addons/l10n_in_gstin_status/tests/test_check_status.py
@@ -1,0 +1,85 @@
+from unittest.mock import patch
+from freezegun import freeze_time
+
+from odoo.tests.common import TransactionCase, tagged
+from odoo.exceptions import UserError
+from odoo.tools import mute_logger
+from datetime import date
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestGSTStatusFeature(TransactionCase):
+    def setUp(self):
+        self.partner1 = self.env["res.partner"].create(
+            {"name": "Active GSTIN", "vat": "36AAACM4154G1ZO"}
+        )
+        self.partner2 = self.env["res.partner"].create(
+            {"name": "Cancelled GSTIN", "vat": "19AABCT1332L2ZD"}
+        )
+        self.partner3 = self.env["res.partner"].create(
+            {"name": "Invalid GSTIN", "vat": "19AACCT6304M1ZB"}
+        )
+        self.partner4 = self.env["res.partner"].create(
+            {"name": "No Records GSTIN", "vat": "19AACCT6304M1DB"}
+        )
+        self.partner5 = self.env["res.partner"].create(
+            {
+                "name": "Partner Vat Reset",
+                "vat": "36AAACM4154G1ZO",
+                "country_id": self.env.ref('base.in').id,
+                "l10n_in_gstin_verified_status": "active",
+                "l10n_in_gstin_verified_date": "2024-06-01",
+            }
+        )
+        self.mock_responses = {
+            "active": {
+                "data": {"sts": "Active"}
+            },
+            "cancelled": {
+                "data": {"sts": "Cancelled"}
+            },
+            "invalid": {
+                "error": [{"code": "SWEB_9035", "message": "Invalid GSTIN / UID"}],
+            },
+            "no_records": {
+                "error": [{"code": "FO8000", "message": "No records found for the provided GSTIN."}],
+            },
+        }
+
+    @freeze_time('2024-05-20')
+    @mute_logger('odoo.addons.l10n_in_gstin_status.models.res_partner')
+    def check_gstin_status(self, partner, expected_status, mock_response, raises_exception=False):
+        with patch("odoo.addons.l10n_in.models.iap_account.jsonrpc") as mock_jsonrpc:
+            mock_jsonrpc.return_value = mock_response
+            if raises_exception:
+                with self.assertRaises(UserError):
+                    partner.action_l10n_in_verify_gstin_status()
+            else:
+                partner.action_l10n_in_verify_gstin_status()
+                self.assertEqual(partner.l10n_in_gstin_verified_status, expected_status)
+                self.assertEqual(partner.l10n_in_gstin_verified_date, date(2024, 5, 20))
+
+    def test_gstin_status(self):
+        """Test GSTIN status for various cases"""
+        self.check_gstin_status(
+            self.partner1,
+            expected_status=True,
+            mock_response=self.mock_responses["active"]
+        )
+        self.check_gstin_status(
+            self.partner2,
+            expected_status=False,
+            mock_response=self.mock_responses["cancelled"]
+        )
+        self.check_gstin_status(
+            self.partner3,
+            expected_status=False,
+            raises_exception=True,
+            mock_response=self.mock_responses["invalid"],
+        )
+        self.check_gstin_status(
+            self.partner4,
+            expected_status=False,
+            raises_exception=True,
+            mock_response=self.mock_responses["no_records"],
+        )

--- a/addons/l10n_in_gstin_status/views/account_move_views.xml
+++ b/addons/l10n_in_gstin_status/views/account_move_views.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="move_form_inherit_l10n_in_gst_verification" model="ir.ui.view">
+        <field name="name">account.move.form.inherit.l10n.in.gst.verification</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='ref']" position="after">
+                <field name="l10n_in_show_gstin_status" invisible="1"/>
+                <label for="l10n_in_partner_gstin_status"
+                    invisible="not l10n_in_show_gstin_status"/>
+                <div name="status_date_container"
+                    invisible="not l10n_in_show_gstin_status">
+                    <field name="l10n_in_partner_gstin_status" class="d-none"/>
+                    <span class="text-nowrap" readonly="1">
+                        <span invisible="not l10n_in_partner_gstin_status"
+                            class="oe_inline text-success">Active</span>
+                        <span invisible="not l10n_in_gstin_verified_date or l10n_in_partner_gstin_status"
+                            class="oe_inline text-danger">Inactive</span>
+                        <span class="text-muted oe_inline">
+                            <span invisible="l10n_in_gstin_verified_date">Not Checked</span>
+                            <span invisible="not l10n_in_gstin_verified_date" class="ps-3">Checked: </span>
+                            <field name="l10n_in_gstin_verified_date" class="oe_inline" widget="remaining_days"/>
+                            <button name="l10n_in_verify_partner_gstin_status"
+                                type="object" icon="fa-refresh"
+                                class="oe_link p-0 ps-3" title="Verify GSTIN status" />
+                        </span>
+                    </span>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_in_gstin_status/views/res_partner_views.xml
+++ b/addons/l10n_in_gstin_status/views/res_partner_views.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="l10n_in_view_partner_base_vat_form" model="ir.ui.view">
+            <field name="name">l10n.in.gstin.status.view.partner.inherit</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="base_vat.view_partner_base_vat_form" />
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='vies_valid']" position="after">
+                    <span invisible="country_code != 'IN' or not vat">
+                        <span invisible="not l10n_in_gstin_verified_date or not l10n_in_gstin_verified_status"
+                            class="oe_inline text-success">Active</span>
+                        <span invisible="not l10n_in_gstin_verified_date or l10n_in_gstin_verified_status"
+                            class="oe_inline text-danger">Inactive</span>
+                        <span invisible="not l10n_in_gstin_verified_date and not l10n_in_gstin_verified_status" class="text-muted">
+                            (
+                            <field name="l10n_in_gstin_verified_date" widget="remaining_days" class="oe_inline" readonly="1" />
+                            <button name="action_l10n_in_verify_gstin_status" type="object" icon="fa-refresh"
+                                class="oe_link p-0 ps-2" title="Reverify GSTIN status" />
+                            )
+                        </span>
+                        <button string="Check Status" name="action_l10n_in_verify_gstin_status" type="object"
+                            icon="fa-check" class="oe_link p-0" title="Check GSTIN status"
+                            invisible="l10n_in_gstin_verified_date" />
+                    </span>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
This commit introduces a new module enabling users to check the GSTIN status of vendors. We can install it manually or with 'GST Status API Service' in the 'Customer Invoices' section in the Accounting settings.

After installation, Users will find a 'Check Status'  button on the partner form. By clicking, the system retrieves the latest GSTIN status from the service provider, displaying the GSTIN status, and the date of the last verification. Now the 'Re Verify' button is shown on partner form, vendor bills, customer invoices, credit notes, and debit notes to re verify the status. This enhancement ensures users have up-to-date information regarding vendor compliance directly within Odoo.

task-3707122

see https://github.com/odoo/enterprise/pull/67787
see https://github.com/odoo/upgrade/pull/6335

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
