### PR TITLE
[FIX] l10n_in: traceback when sell product with hsn code

### DIFF
--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -27,7 +27,7 @@ export const accountTaxHelpers = {
      */
     batch_for_taxes_computation(taxes, { special_mode = null } = {}) {
         function sort_key(taxes) {
-            return taxes.sort((t1, t2) => t1.sequence - t2.sequence || t1.id - t2.id);
+            return taxes ? taxes.sort((t1, t2) => t1.sequence - t2.sequence || t1.id - t2.id) : [];
         }
 
         const results = {

--- a/addons/l10n_in/models/account_tax.py
+++ b/addons/l10n_in/models/account_tax.py
@@ -50,7 +50,7 @@ class AccountTax(models.Model):
             quantity = base_line['quantity']
             product = base_line['product']
             uom = base_line['uom']
-            taxes = base_line['taxes']
+            taxes = base_line['taxes_data']
 
             final_price_unit = price_unit * (1 - (discount / 100))
 

--- a/addons/l10n_in/static/src/helpers/hsn_summary.js
+++ b/addons/l10n_in/static/src/helpers/hsn_summary.js
@@ -21,7 +21,7 @@ patch(accountTaxHelpers, {
             const quantity = base_line.quantity;
             const product = base_line.product;
             const uom = base_line.uom || {};
-            const taxes = base_line.taxes;
+            const taxes = base_line.taxes_data;
 
             const final_price_unit = price_unit * (1 - discount / 100);
 

--- a/addons/l10n_in/tests/test_hsn_summary.py
+++ b/addons/l10n_in/tests/test_hsn_summary.py
@@ -63,7 +63,7 @@ class TestHSNsummary(TestTaxCommon):
         new_base_lines = []
         for base_line in base_lines:
             base_line = dict(base_line)
-            taxes = base_line['taxes']
+            taxes = base_line['taxes_data']
             base_line['taxes'] = [self._jsonify_tax(tax) for tax in taxes]
             base_line['product'] = self._jsonify_product(base_line['product'], taxes)
             base_line['uom'] = self._jsonify_uom(base_line['uom'])
@@ -97,7 +97,7 @@ class TestHSNsummary(TestTaxCommon):
             'discount': discount,
             'product': product,
             'uom': uom,
-            'taxes': taxes or self.env['account.tax'],
+            'taxes_data': taxes or self.env['account.tax'],
         }
 
     def test_l10n_in_hsn_summary_1(self):


### PR DESCRIPTION
Steps:
===
Install point_of_sale and l10n_in module.
Create a product and add the HSN code.
Open POS and sell the newly created product.
Confirm Payment at the time of payment throws a traceback.

Issue:
===
Error occurs while payment.

Cause:
===
Instead of fetching taxes_data, it's fetching taxes.

FIX:
===
Fetch correct taxes_data.

task-4085939
