### PR TITLE
[FIX] account: cannot search by analytic

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1323,7 +1323,7 @@ class AccountMoveLine(models.Model):
         order = (order or self._order) + ', id'
         # Add the domain and order by in order to compute the cumulated balance in _compute_cumulated_balance
         contextualized = self.with_context(
-            domain_cumulated_balance=to_tuple(domain or []),
+            domain_cumulated_balance=to_tuple(self._apply_analytic_distribution_domain(domain or [])),
             order_cumulated_balance=order,
         )
         return super(AccountMoveLine, contextualized).search_read(domain, fields, offset, limit, order)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Cannot search by analytic because analytic_distribution is a non-store compute field, we need to pass the domain through the method _apply_analytic_distribution_domain to reprocess the domain so we can find the correct data.

Current behavior before PR:
Cannot search by analytic

Desired behavior after PR is merged:
Can search by analytic



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
