### PR TITLE
[FIX] web_tour: skip show pointer if not anchor

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_compilers.js
+++ b/addons/web_tour/static/src/tour_service/tour_compilers.js
@@ -642,7 +642,7 @@ export function compileStepAuto(stepIndex, step, options) {
                 browser.clearTimeout(tourTimeout);
                 tourState.set(tour.name, "currentIndex", stepIndex + 1);
 
-                if (showPointerDuration > 0) {
+                if (showPointerDuration > 0 && stepEl !== true) {
                     // Useful in watch mode.
                     pointer.pointTo(stepEl, step);
                     await new Promise((r) => browser.setTimeout(r, showPointerDuration));


### PR DESCRIPTION
When a step is not active, we return true to bypass the trigger search. As a result, it is then true (instead of the element) that is passed to pointer.pointTo() which triggers the bug.
In order to overcome this problem, we avoid going into this part of the code in the case where stepEl is true.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
