### PR TITLE
[FIX] website_hr_recruitment: fix `s_features` snippet background

### DIFF
--- a/addons/website_hr_recruitment/data/hr_job_demo.xml
+++ b/addons/website_hr_recruitment/data/hr_job_demo.xml
@@ -166,7 +166,7 @@
                 </div>
             </section>
             <!-- What we offer -->
-            <section class="s_features pt64 pb64 bg-200" data-name="Features" data-snippet="s_features">
+            <section class="s_features pt64 pb64" data-name="Features" data-snippet="s_features">
                 <div class="container">
                     <div class="col-lg-12">
                         <h3>What We Offer</h3>
@@ -406,7 +406,7 @@
                 </div>
             </section>
             <!-- What we offer -->
-            <section class="s_features pt64 pb64 bg-200" data-name="Features" data-snippet="s_features">
+            <section class="s_features pt64 pb64" data-name="Features" data-snippet="s_features">
                 <div class="container">
                     <div class="col-lg-12">
                         <h3>What We Offer</h3>
@@ -646,7 +646,7 @@
                 </div>
             </section>
             <!-- What we offer -->
-            <section class="s_features pt64 pb64 bg-200" data-name="Features" data-snippet="s_features">
+            <section class="s_features pt64 pb64" data-name="Features" data-snippet="s_features">
                 <div class="container">
                     <div class="col-lg-12">
                         <h3>What We Offer</h3>
@@ -885,7 +885,7 @@
                 </div>
             </section>
             <!-- What we offer -->
-            <section class="s_features pt64 pb64 bg-200" data-name="Features" data-snippet="s_features">
+            <section class="s_features pt64 pb64" data-name="Features" data-snippet="s_features">
                 <div class="container">
                     <div class="col-lg-12">
                         <h3>What We Offer</h3>
@@ -1124,7 +1124,7 @@
                 </div>
             </section>
             <!-- What we offer -->
-            <section class="s_features pt64 pb64 bg-200" data-name="Features" data-snippet="s_features">
+            <section class="s_features pt64 pb64" data-name="Features" data-snippet="s_features">
                 <div class="container">
                     <div class="col-lg-12">
                         <h3>What We Offer</h3>
@@ -1363,7 +1363,7 @@
                 </div>
             </section>
             <!-- What we offer -->
-            <section class="s_features pt64 pb64 bg-200" data-name="Features" data-snippet="s_features">
+            <section class="s_features pt64 pb64" data-name="Features" data-snippet="s_features">
                 <div class="container">
                     <div class="col-lg-12">
                         <h3>What We Offer</h3>
@@ -1602,7 +1602,7 @@
                 </div>
             </section>
             <!-- What we offer -->
-            <section class="s_features pt64 pb64 bg-200" data-name="Features" data-snippet="s_features">
+            <section class="s_features pt64 pb64" data-name="Features" data-snippet="s_features">
                 <div class="container">
                     <div class="col-lg-12">
                         <h3>What We Offer</h3>

--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -534,7 +534,7 @@
         </div>
     </section>
     <!-- What we offer -->
-    <section class="s_features pt64 pb64 bg-200" data-name="Features" data-snippet="s_features">
+    <section class="s_features pt64 pb64" data-name="Features" data-snippet="s_features">
         <div class="container" itemprop="employerOverview">
             <div class="col-lg-12">
                 <h3>What We Offer</h3>


### PR DESCRIPTION
| Master | This PR |
|--------|--------|
| <img alt="image" src="https://github.com/user-attachments/assets/085054cf-d7ae-4ad2-b7be-e8ccf9377de9"> | <img alt="image" src="https://github.com/user-attachments/assets/b5099e47-9033-4c15-b01e-1dd515962b90"> | 


Commit[1], which is part of the Odoo 18 snippets redesign aimed to align all the occurrences of the s_call_to_action snippet across the front-end.

It appears that this commit did not take into account the fact that the background of the snippet was a light gray in the `website_hr_recruitment` module, resulting in a visual vibration and a bad visual result.

To handle the issue, we remove the gray background from the section.

Commit[1]: bca923658372c7c7319b18c05455ad837fe06a15

task-4084989

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
