### PR TITLE
[FIX] website: fix viewref return type when called from RPC

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1064,6 +1064,7 @@ class Website(models.Model):
         return request.env.user.id == request.website._get_cached('user_id')
 
     @api.model
+    @api.returns("ir.ui.view")
     def viewref(self, view_id, raise_if_not_found=True):
         ''' Given an xml_id or a view_id, return the corresponding view record.
             In case of website context, return the most specific one.


### PR DESCRIPTION
When calling this method from RPC, it returns `"ir.ui.view(1,)"` as a string, instead of just `1` as an int.

@moduon MT-6944


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
