### PR TITLE
[FIX] point_of_sale,pos_loyalty: allow gift card with 0 points

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -697,7 +697,7 @@ export class PosStore extends Reactive {
         }
 
         // Handle price unit
-        if (!values.product_id.isCombo() && !vals.price_unit) {
+        if (!values.product_id.isCombo() && vals.price_unit === undefined) {
             values.price_unit = values.product_id.get_price(order.pricelist_id, values.qty);
         }
 

--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -375,7 +375,7 @@ patch(PosStore.prototype, {
         }
 
         // move price_unit from opt to vals
-        if (opt.price_unit) {
+        if (opt.price_unit !== undefined) {
             vals.price_unit = opt.price_unit;
             delete opt.price_unit;
         }


### PR DESCRIPTION
Problem:
For a gift card with 0 points,there price is ignored and is set to the product price

Steps to reproduce:
- Install "point_of_sale" app and "pos_loyalty" module
- Select "Scan existing cards" in the promotions settings
- Generate a gift card with a value of 0.00 $ and copy its code
- Start a shop session
- Select the gift card product and enter the code
- The price of the gift card is $50.00 instead of $0.00

Cause:
0 is interpreted as false in conditions

Note:
Implement a fix for this PR: https://github.com/odoo/odoo/pull/175232
See the PR for the test

opw-3909019


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
