### PR TITLE
[FIX] point_of_sale: show tax base amount instead of NAN

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -705,7 +705,7 @@ export class PosOrder extends Base {
                         tax_percentage: taxData.amount,
                     });
                 }
-                taxDetails[taxId].base += taxData.base;
+                taxDetails[taxId].base += taxData.base_amount;
                 taxDetails[taxId].amount += taxData.tax_amount;
             }
         }


### PR DESCRIPTION
### Steps to reproduce
- Install PoS
- Open a new session
- Add a product
- In the receipt, the base amount of the tax is shown as NAN

### Investigation
- The error happens due to the use of non existing key `base` to reference the base amount inside `taxDetails` instead of `base_amount`, that's why it return `NAN`