### PR TITLE
[IMP] web: simplify kanban archs

### DIFF
--- a/addons/web/static/tests/core/domain_field.test.js
+++ b/addons/web/static/tests/core/domain_field.test.js
@@ -699,12 +699,9 @@ test.tags("desktop")("domain field in kanban view", async function () {
         resId: 1,
         arch: `
             <kanban>
-                <field name="bar" />
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo" widget="domain" options="{'model': 'partner.type'}" />
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo" widget="domain" options="{'model': 'partner.type'}" />
                     </t>
                 </templates>
             </kanban>`,

--- a/addons/web/static/tests/legacy/mobile/views/fields/many2one_barcode_field_tests.js
+++ b/addons/web/static/tests/legacy/mobile/views/fields/many2one_barcode_field_tests.js
@@ -68,12 +68,10 @@ QUnit.module("Fields", (hooks) => {
             },
             views: {
                 "product.product,false,kanban": `
-                    <kanban><templates><t t-name="kanban-box">
-                        <div>
-                            <field name="id"/>
-                            <field name="name"/>
-                            <field name="barcode"/>
-                        </div>
+                    <kanban><templates><t t-name="kanban-card">
+                        <field name="id"/>
+                        <field name="name"/>
+                        <field name="barcode"/>
                     </t></templates></kanban>
                 `,
                 "product.product,false,search": "<search></search>",

--- a/addons/web/static/tests/legacy/mobile/views/form_view_tests.js
+++ b/addons/web/static/tests/legacy/mobile/views/form_view_tests.js
@@ -355,10 +355,8 @@ QUnit.module("Mobile Views", ({ beforeEach }) => {
                 "partner,false,kanban": `
                     <kanban>
                         <templates>
-                            <t t-name="kanban-box">
-                                <div>
-                                    <field name="display_name" />
-                                </div>
+                            <t t-name="kanban-card">
+                                <field name="display_name" />
                             </t>
                         </templates>
                     </kanban>

--- a/addons/web/static/tests/legacy/mobile/views/kanban_view_tests.js
+++ b/addons/web/static/tests/legacy/mobile/views/kanban_view_tests.js
@@ -72,10 +72,9 @@ QUnit.module("Views", (hooks) => {
             arch: `
                 <kanban>
                     <progressbar field="foo" colors='{"yop": "success", "blip": "danger"}'/>
-                    <field name="product_id"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div><field name="foo"/></div>
+                        <t t-name="kanban-card">
+                            <field name="foo"/>
                         </t>
                     </templates>
                 </kanban>`,

--- a/addons/web/static/tests/legacy/mobile/views/view_dialog/select_create_dialog_tests.js
+++ b/addons/web/static/tests/legacy/mobile/views/view_dialog/select_create_dialog_tests.js
@@ -41,18 +41,14 @@ QUnit.module("ViewDialogs", (hooks) => {
             },
             views: {
                 "product,false,kanban": `
-                    <kanban><templates><t t-name="kanban-box">
-                        <div>
-                            <field name="id"/>
-                            <field name="name"/>
-                        </div>
+                    <kanban><templates><t t-name="kanban-card">
+                        <field name="id"/>
+                        <field name="name"/>
                     </t></templates></kanban>
                 `,
                 "sale_order_line,false,kanban": `
-                    <kanban><templates><t t-name="kanban-box">
-                        <div>
-                            <field name="id"/>
-                        </div>
+                    <kanban><templates><t t-name="kanban-card">
+                        <field name="id"/>
                     </t></templates></kanban>
                 `,
                 "product,false,search": "<search></search>",
@@ -109,7 +105,7 @@ QUnit.module("ViewDialogs", (hooks) => {
         serverData.views["product,false,kanban"] = `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
+                    <t t-name="kanban-card">
                          <div class="o_primary" t-if="!selection_mode">
                             <a type="object" name="some_action">
                                 <field name="name"/>

--- a/addons/web/static/tests/legacy/mobile/webclient/window_action_tests.js
+++ b/addons/web/static/tests/legacy/mobile/webclient/window_action_tests.js
@@ -31,10 +31,8 @@ QUnit.module("ActionManager", (hooks) => {
                 "project,false,kanban": `
                 <kanban>
                     <templates>
-                        <t t-name='kanban-box'>
-                            <div class='oe_kanban_card'>
-                                <field name='foo' />
-                            </div>
+                        <t t-name='kanban-card'>
+                            <field name='foo' />
                         </t>
                     </templates>
                 </kanban>

--- a/addons/web/static/tests/legacy/webclient/helpers.js
+++ b/addons/web/static/tests/legacy/webclient/helpers.js
@@ -336,8 +336,8 @@ export function getActionManagerServerData() {
     const archs = {
         // kanban views
         "partner,1,kanban":
-            '<kanban><templates><t t-name="kanban-box">' +
-            '<div><field name="foo"/></div>' +
+            '<kanban><templates><t t-name="kanban-card">' +
+            '<field name="foo"/>' +
             "</t></templates></kanban>",
         // list views
         "partner,false,list": '<tree><field name="foo"/></tree>',

--- a/addons/web/static/tests/search/control_panel.test.js
+++ b/addons/web/static/tests/search/control_panel.test.js
@@ -18,7 +18,7 @@ class Foo extends models.Model {
     _views = {
         search: `<search/>`,
         list: `<list/>`,
-        kanban: `<kanban><t t-name="kanban-box"></t></kanban>`,
+        kanban: `<kanban><t t-name="kanban-card"></t></kanban>`,
     };
 }
 defineModels([Foo]);

--- a/addons/web/static/tests/search/search_panel_desktop.test.js
+++ b/addons/web/static/tests/search/search_panel_desktop.test.js
@@ -131,7 +131,7 @@ class Partner extends models.Model {
         kanban: /* xml */ `
             <kanban>
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field name="foo"/>
                     </div>
                 </templates>

--- a/addons/web/static/tests/views/fields/boolean_favorite_field.test.js
+++ b/addons/web/static/tests/views/fields/boolean_favorite_field.test.js
@@ -31,10 +31,8 @@ test("FavoriteField in kanban view", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="bar" widget="boolean_favorite"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="bar" widget="boolean_favorite"/>
                     </t>
                 </templates>
             </kanban>
@@ -70,10 +68,8 @@ test("FavoriteField saves changes by default", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="bar" widget="boolean_favorite"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="bar" widget="boolean_favorite"/>
                     </t>
                 </templates>
             </kanban>
@@ -103,10 +99,8 @@ test("FavoriteField does not save if autosave option is set to false", async () 
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="bar" widget="boolean_favorite" options="{'autosave': False}"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="bar" widget="boolean_favorite" options="{'autosave': False}"/>
                     </t>
                 </templates>
             </kanban>
@@ -235,10 +229,8 @@ test("FavoriteField in kanban view with readonly attribute", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="bar" widget="boolean_favorite" readonly="1"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="bar" widget="boolean_favorite" readonly="1"/>
                     </t>
                 </templates>
             </kanban>

--- a/addons/web/static/tests/views/fields/float_toggle_field.test.js
+++ b/addons/web/static/tests/views/fields/float_toggle_field.test.js
@@ -71,10 +71,8 @@ test("kanban view (readonly) with option force_button", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="float_field" widget="float_toggle" options="{'force_button': true}"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="float_field" widget="float_toggle" options="{'force_button': true}"/>
                     </t>
                 </templates>
             </kanban>`,

--- a/addons/web/static/tests/views/fields/gauge_field.test.js
+++ b/addons/web/static/tests/views/fields/gauge_field.test.js
@@ -20,10 +20,8 @@ test("GaugeField in kanban view", async () => {
         <kanban>
             <field name="another_int_field"/>
             <templates>
-                <t t-name="kanban-box">
-                    <div>
-                        <field name="int_field" widget="gauge" options="{'max_field': 'another_int_field'}"/>
-                    </div>
+                <t t-name="kanban-card">
+                    <field name="int_field" widget="gauge" options="{'max_field': 'another_int_field'}"/>
                 </t>
             </templates>
         </kanban>`,

--- a/addons/web/static/tests/views/fields/html_field.test.js
+++ b/addons/web/static/tests/views/fields/html_field.test.js
@@ -119,10 +119,8 @@ test("html fields are correctly rendered in kanban view", async () => {
         arch: /* xml */ `
             <kanban class="o_kanban_test">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="txt"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="txt"/>
                     </t>
                 </templates>
             </kanban>`,

--- a/addons/web/static/tests/views/fields/image_field.test.js
+++ b/addons/web/static/tests/views/fields/image_field.test.js
@@ -542,14 +542,9 @@ test("ImageField in subviews is loaded correctly", async () => {
                 <field name="document" widget="image" options="{'size': [90, 90]}" />
                 <field name="timmy" widget="many2many" mode="kanban">
                     <kanban>
-                        <field name="name" />
                         <templates>
-                            <t t-name="kanban-box">
-                                <div>
-                                    <span>
-                                        <t t-esc="record.name.value" />
-                                    </span>
-                                </div>
+                            <t t-name="kanban-card">
+                                <field name="name" />
                             </t>
                         </templates>
                     </kanban>

--- a/addons/web/static/tests/views/fields/image_url_field.test.js
+++ b/addons/web/static/tests/views/fields/image_url_field.test.js
@@ -80,12 +80,9 @@ test("ImageUrlField in subviews are loaded correctly", async () => {
                 <field name="foo" widget="image_url" options="{'size': [90, 90]}"/>
                 <field name="timmy" widget="many2many" mode="kanban">
                     <kanban>
-                        <field name="display_name"/>
                         <templates>
-                            <t t-name="kanban-box">
-                                <div>
-                                    <span><t t-esc="record.display_name.value"/></span>
-                                </div>
+                            <t t-name="kanban-card">
+                                <field name="display_name"/>
                             </t>
                         </templates>
                     </kanban>
@@ -155,10 +152,8 @@ test("image url fields in kanban don't stop opening record", async () => {
         arch: /* xml */ `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo" widget="image_url"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo" widget="image_url"/>
                     </t>
                 </templates>
             </kanban>

--- a/addons/web/static/tests/views/fields/journal_dashboard_graph_field.test.js
+++ b/addons/web/static/tests/views/fields/journal_dashboard_graph_field.test.js
@@ -92,10 +92,8 @@ test.tags("desktop")("JournalDashboardGraphField is rendered correctly", async (
             <kanban>
                 <field name="graph_type"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="graph_data" t-att-graph_type="record.graph_type.raw_value" widget="dashboard_graph"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="graph_data" t-att-graph_type="record.graph_type.raw_value" widget="dashboard_graph"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -129,10 +127,8 @@ test("rendering of a JournalDashboardGraphField in an updated grouped kanban vie
             <kanban>
                 <field name="graph_type"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="graph_data" t-att-graph_type="record.graph_type.raw_value" widget="dashboard_graph"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="graph_data" t-att-graph_type="record.graph_type.raw_value" widget="dashboard_graph"/>
                     </t>
                 </templates>
             </kanban>`,

--- a/addons/web/static/tests/views/fields/many2many_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_field.test.js
@@ -240,18 +240,15 @@ test.tags("desktop")("many2many kanban: edition", async () => {
             <form>
                 <field name="timmy">
                     <kanban>
-                        <field name="name" />
                         <templates>
-                            <t t-name="kanban-box">
+                            <t t-name="kanban-card">
                                 <div>
                                     <a
                                         t-if="!read_only_mode"
                                         type="delete"
                                         class="fa fa-times float-end delete_icon"
                                     />
-                                    <span>
-                                        <t t-esc="record.name.value" />
-                                    </span>
+                                    <field name="name"/>
                                 </div>
                             </t>
                         </templates>
@@ -344,10 +341,8 @@ test("many2many kanban(editable): properly handle add-label node attribute", asy
                     <field name="timmy" add-label="Add timmy" mode="kanban">
                         <kanban>
                             <templates>
-                                <t t-name="kanban-box">
-                                    <div class="oe_kanban_details">
-                                        <field name="name"/>
-                                    </div>
+                                <t t-name="kanban-card">
+                                    <field name="name"/>
                                 </t>
                             </templates>
                         </kanban>
@@ -414,12 +409,11 @@ test("many2many kanban: create action disabled", async () => {
             <form>
                 <field name="timmy">
                     <kanban create="0">
-                        <field name="name"/>
                         <templates>
-                            <t t-name="kanban-box">
+                            <t t-name="kanban-card">
                                 <div>
                                     <a t-if="!read_only_mode" type="delete" class="fa fa-times float-end delete_icon"/>
-                                    <span><t t-esc="record.name.value"/></span>
+                                    <field name="name"/>
                                 </div>
                             </t>
                         </templates>
@@ -452,12 +446,9 @@ test("many2many kanban: conditional create/delete actions", async () => {
                 <field name="color"/>
                 <field name="timmy" options="{'create': [('color', '=', 'red')], 'delete': [('color', '=', 'red')]}">
                     <kanban>
-                        <field name="name"/>
                         <templates>
-                            <t t-name="kanban-box">
-                                <div>
-                                    <span><t t-esc="record.name.value"/></span>
-                                </div>
+                            <t t-name="kanban-card">
+                                <field name="name"/>
                             </t>
                         </templates>
                     </kanban>
@@ -996,8 +987,8 @@ test("many2many field with link option (kanban)", async () => {
                 <field name="timmy" options="{'link': [('color', '=', 'red')]}">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-box">
-                                <div><field name="name"/></div>
+                            <t t-name="kanban-card">
+                                <field name="name"/>
                             </t>
                         </templates>
                     </kanban>
@@ -1037,8 +1028,8 @@ test('many2many field with link option (kanban, create="0")', async () => {
                 <field name="timmy" options="{'link': [('color', '=', 'red')]}">
                     <kanban create="0">
                         <templates>
-                            <t t-name="kanban-box">
-                                <div><field name="name"/></div>
+                            <t t-name="kanban-card">
+                                <field name="name"/>
                             </t>
                         </templates>
                     </kanban>
@@ -1371,10 +1362,9 @@ test("onchange with 40+ commands for a many2many", async () => {
                 <field name="foo"/>
                 <field name="timmy">
                     <kanban>
-                        <field name="name"/>
                         <templates>
-                            <t t-name="kanban-box">
-                                <div><t t-esc="record.name.value"/></div>
+                            <t t-name="kanban-card">
+                                <field name="name"/>
                             </t>
                         </templates>
                     </kanban>
@@ -1431,10 +1421,9 @@ test.tags("desktop")("onchange with 40+ commands for a many2many on desktop", as
                 <field name="foo"/>
                 <field name="timmy">
                     <kanban>
-                        <field name="name"/>
                         <templates>
-                            <t t-name="kanban-box">
-                                <div><t t-esc="record.name.value"/></div>
+                            <t t-name="kanban-card">
+                                <field name="name"/>
                             </t>
                         </templates>
                     </kanban>
@@ -1601,10 +1590,8 @@ test("many2many kanban: action/type attribute", async () => {
                 <field name="timmy">
                     <kanban action="a1" type="object">
                         <templates>
-                            <t t-name="kanban-box">
-                                <div>
-                                    <field name="name"/>
-                                </div>
+                            <t t-name="kanban-card">
+                                <field name="name"/>
                             </t>
                         </templates>
                     </kanban>

--- a/addons/web/static/tests/views/fields/many2many_tags_avatar_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_avatar_field.test.js
@@ -238,17 +238,11 @@ test("widget many2many_tags_avatar in kanban view", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="name"/>
-                            <div class="oe_kanban_footer">
-                                <div class="o_kanban_record_bottom">
-                                    <div class="oe_kanban_bottom_right">
-                                        <field name="partner_ids" widget="many2many_tags_avatar"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="name"/>
+                        <footer>
+                            <field name="partner_ids" widget="many2many_tags_avatar"/>
+                        </footer>
                     </t>
                 </templates>
             </kanban>`,
@@ -327,17 +321,11 @@ test("widget many2many_tags_avatar add/remove tags in kanban view", async () => 
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="name"/>
-                            <div class="oe_kanban_footer">
-                                <div class="o_kanban_record_bottom">
-                                    <div class="oe_kanban_bottom_right">
-                                        <field name="partner_ids" widget="many2many_tags_avatar"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="name"/>
+                        <footer>
+                            <field name="partner_ids" widget="many2many_tags_avatar"/>
+                        </footer>
                     </t>
                 </templates>
             </kanban>`,
@@ -380,17 +368,11 @@ test("widget many2many_tags_avatar quick add tags and close in kanban view with 
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="name"/>
-                            <div class="oe_kanban_footer">
-                                <div class="o_kanban_record_bottom">
-                                    <div class="oe_kanban_bottom_right">
-                                        <field name="partner_ids" widget="many2many_tags_avatar"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="name"/>
+                        <footer>
+                            <field name="partner_ids" widget="many2many_tags_avatar"/>
+                        </footer>
                     </t>
                 </templates>
             </kanban>`,
@@ -412,17 +394,11 @@ test("widget many2many_tags_avatar in kanban view missing access rights", async 
         arch: `
             <kanban edit="0" create="0">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="name"/>
-                            <div class="oe_kanban_footer">
-                                <div class="o_kanban_record_bottom">
-                                    <div class="oe_kanban_bottom_right">
-                                        <field name="partner_ids" widget="many2many_tags_avatar"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="name"/>
+                        <footer>
+                            <field name="partner_ids" widget="many2many_tags_avatar"/>
+                        </footer>
                     </t>
                 </templates>
             </kanban>`,

--- a/addons/web/static/tests/views/fields/many2one_avatar_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_avatar_field.test.js
@@ -324,16 +324,10 @@ test.tags("desktop")("widget many2one_avatar in kanban view (load more dialog)",
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <div class="oe_kanban_footer">
-                                <div class="o_kanban_record_bottom">
-                                    <div class="oe_kanban_bottom_right">
-                                        <field name="user_id" widget="many2one_avatar"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                    <t t-name="kanban-card">
+                        <footer>
+                            <field name="user_id" widget="many2one_avatar"/>
+                        </footer>
                     </t>
                 </templates>
             </kanban>`,
@@ -361,16 +355,10 @@ test("widget many2one_avatar in kanban view", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <div class="oe_kanban_footer">
-                                <div class="o_kanban_record_bottom">
-                                    <div class="oe_kanban_bottom_right">
-                                        <field name="user_id" widget="many2one_avatar"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                    <t t-name="kanban-card">
+                        <footer>
+                            <field name="user_id" widget="many2one_avatar"/>
+                        </footer>
                     </t>
                 </templates>
             </kanban>`,
@@ -404,16 +392,10 @@ test("widget many2one_avatar in kanban view without access rights", async () => 
         arch: `
             <kanban edit="0" create="0">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <div class="oe_kanban_footer">
-                                <div class="o_kanban_record_bottom">
-                                    <div class="oe_kanban_bottom_right">
-                                        <field name="user_id" widget="many2one_avatar"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                    <t t-name="kanban-card">
+                        <footer>
+                            <field name="user_id" widget="many2one_avatar"/>
+                        </footer>
                     </t>
                 </templates>
             </kanban>`,

--- a/addons/web/static/tests/views/fields/one2many_field.test.js
+++ b/addons/web/static/tests/views/fields/one2many_field.test.js
@@ -2296,10 +2296,9 @@ test("one2many field when using the pager", async () => {
             <form>
                 <field name="p">
                     <kanban>
-                        <field name="name"/>
                         <templates>
-                            <t t-name="kanban-box">
-                                <div><t t-esc="record.name"/></div>
+                            <t t-name="kanban-card">
+                                <field name="name"/>
                             </t>
                         </templates>
                     </kanban>
@@ -2394,12 +2393,11 @@ test("edition of one2many field with pager", async () => {
             <form>
                 <field name="p">
                     <kanban>
-                        <field name="name"/>
                         <templates>
-                            <t t-name="kanban-box">
+                            <t t-name="kanban-card">
                                 <div>
                                     <a t-if="!read_only_mode" type="delete" class="fa fa-times float-end delete_icon"/>
-                                    <span><t t-esc="record.name.value"/></span>
+                                    <field name="name"/>
                                 </div>
                             </t>
                         </templates>
@@ -2530,12 +2528,11 @@ test.tags("desktop")("edition of one2many field with pager on desktop", async ()
             <form>
                 <field name="p">
                     <kanban>
-                        <field name="name"/>
                         <templates>
-                            <t t-name="kanban-box">
+                            <t t-name="kanban-card">
                                 <div>
                                     <a t-if="!read_only_mode" type="delete" class="fa fa-times float-end delete_icon"/>
-                                    <span><t t-esc="record.name.value"/></span>
+                                    <field name="name"/>
                                 </div>
                             </t>
                         </templates>
@@ -2611,12 +2608,9 @@ test("When viewing one2many records in an embedded kanban, the delete button sho
             <form>
                 <field name="turtles">
                     <kanban>
-                        <field name="name"/>
                         <templates>
-                            <t t-name="kanban-box">
-                                <div>
-                                    <h3>Record 1</h3>
-                                </div>
+                            <t t-name="kanban-card">
+                                <h3>Record 1</h3>
                             </t>
                         </templates>
                     </kanban>
@@ -2645,12 +2639,9 @@ test("open a record in a one2many kanban (mode 'readonly')", async () => {
             <form edit="0">
                 <field name="turtles">
                     <kanban>
-                        <field name="name"/>
                         <templates>
-                            <t t-name="kanban-box">
-                                <div>
-                                    <t t-esc="record.name.value"/>
-                                </div>
+                            <t t-name="kanban-card">
+                                <field name="name"/>
                             </t>
                         </templates>
                     </kanban>
@@ -2681,12 +2672,9 @@ test("open a record in a one2many kanban (mode 'edit')", async () => {
             <form>
                 <field name="turtles">
                     <kanban>
-                        <field name="name"/>
                         <templates>
-                            <t t-name="kanban-box">
-                                <div>
-                                    <t t-esc="record.name.value"/>
-                                </div>
+                            <t t-name="kanban-card">
+                                <field name="name"/>
                             </t>
                         </templates>
                     </kanban>
@@ -2767,12 +2755,9 @@ test("open a record in a one2many kanban with an x2m in the form", async () => {
             <form>
                 <field name="p">
                     <kanban>
-                        <field name="name"/>
                         <templates>
-                            <t t-name="kanban-box">
-                                <div>
-                                    <t t-esc="record.name.value"/>
-                                </div>
+                            <t t-name="kanban-card">
+                                <field name="name"/>
                             </t>
                         </templates>
                     </kanban>
@@ -2812,12 +2797,9 @@ test("one2many in kanban: add a line custom control create editable", async () =
                         <control>
                             <create string="Add pasta" context="{'default_name': 'pasta'}"/>
                         </control>
-                        <field name="name"/>
                         <templates>
-                            <t t-name="kanban-box">
-                                <div>
-                                    <t t-esc="record.name.value"/>
-                                </div>
+                            <t t-name="kanban-card">
+                                <field name="name"/>
                             </t>
                         </templates>
                     </kanban>
@@ -2867,12 +2849,9 @@ test("one2many in kanban: add a line custom control create editable (2)", async 
                             <create string="Create" context="{}" />
                             <button string="Action Button" name="do_something" type="object" context="{'parent_id': parent.id}"/>
                         </control>
-                        <field name="name"/>
                         <templates>
-                            <t t-name="kanban-box">
-                                <div>
-                                    <t t-esc="record.name.value"/>
-                                </div>
+                            <t t-name="kanban-card">
+                                <field name="name"/>
                             </t>
                         </templates>
                     </kanban>
@@ -3393,14 +3372,12 @@ test("one2many kanban: edition", async () => {
             <form>
                 <field name="p">
                     <kanban>
-                        <field name="color"/>
-                        <field name="name"/>
                         <templates>
-                            <t t-name="kanban-box">
+                            <t t-name="kanban-card">
                                 <div>
                                     <a t-if="!read_only_mode" type="delete" class="fa fa-times float-end delete_icon"/>
-                                    <span><t t-esc="record.name.value"/></span>
-                                    <span><t t-esc="record.color.value"/></span>
+                                    <field name="name"/>
+                                    <field name="color"/>
                                 </div>
                             </t>
                         </templates>
@@ -3471,7 +3448,7 @@ test("one2many kanban (editable): properly handle add-label node attribute", asy
                 <field name="turtles" add-label="Add turtle" mode="kanban">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-box">
+                            <t t-name="kanban-card">
                                 <field name="name"/>
                             </t>
                         </templates>
@@ -3497,12 +3474,11 @@ test("one2many kanban: create action disabled", async () => {
             <form>
                 <field name="p">
                     <kanban create="0">
-                        <field name="name"/>
                         <templates>
-                            <t t-name="kanban-box">
+                            <t t-name="kanban-card">
                                 <div>
                                     <a t-if="!read_only_mode" type="delete" class="fa fa-times float-end delete_icon"/>
-                                    <span><t t-esc="record.name.value"/></span>
+                                    <field name="name"/>
                                 </div>
                             </t>
                         </templates>
@@ -3527,12 +3503,9 @@ test("one2many kanban: conditional create/delete actions", async () => {
                 <field name="bar"/>
                 <field name="p" options="{'create': [('bar', '=', True)], 'delete': [('bar', '=', True)]}">
                     <kanban>
-                        <field name="name"/>
                         <templates>
-                            <t t-name="kanban-box">
-                                <div>
-                                    <span><t t-esc="record.name.value"/></span>
-                                </div>
+                            <t t-name="kanban-card">
+                                <field name="name"/>
                             </t>
                         </templates>
                     </kanban>
@@ -5742,13 +5715,10 @@ test("one2many kanban with action button", async () => {
             <form>
                 <field name="p">
                     <kanban>
-                        <field name="foo"/>
                         <templates>
-                            <t t-name="kanban-box">
-                                <div>
-                                    <span><t t-esc="record.foo.value"/></span>
-                                    <button name="method_name" type="object" class="fa fa-plus"/>
-                                </div>
+                            <t t-name="kanban-card">
+                                <field name="foo"/>
+                                <button name="method_name" type="object" class="fa fa-plus"/>
                             </t>
                         </templates>
                     </kanban>
@@ -6443,13 +6413,9 @@ test("one2many field with virtual ids", async () => {
                                 <field name="p" mode="kanban">
                                     <kanban>
                                         <templates>
-                                            <t t-name="kanban-box">
-                                                <div class="o_test_id">
-                                                    <field name="id"/>
-                                                </div>
-                                                <div class="o_test_foo">
-                                                    <field name="foo"/>
-                                                </div>
+                                            <t t-name="kanban-card">
+                                                <field name="id" class="o_test_id"/>
+                                                <field name="foo" class="o_test_foo"/>
                                             </t>
                                         </templates>
                                     </kanban>
@@ -6538,13 +6504,10 @@ test("one2many field with virtual ids with kanban button", async () => {
                 <field name="p" mode="kanban">
                     <kanban>
                         <templates>
-                            <field name="foo"/>
-                            <t t-name="kanban-box">
-                                <div>
-                                    <span><t t-esc="record.foo.value"/></span>
-                                    <button type="object" class="btn btn-link fa fa-shopping-cart" name="button_warn" string="button_warn" warn="warn" />
-                                    <button type="object" class="btn btn-link fa fa-shopping-cart" name="button_disabled" string="button_disabled" />
-                                </div>
+                            <t t-name="kanban-card">
+                                <field name="foo"/>
+                                <button type="object" class="btn btn-link fa fa-shopping-cart" name="button_warn" string="button_warn" warn="warn" />
+                                <button type="object" class="btn btn-link fa fa-shopping-cart" name="button_disabled" string="button_disabled" />
                             </t>
                         </templates>
                     </kanban>
@@ -6838,10 +6801,8 @@ test('x2many fields use their "mode" attribute', async () => {
                         </tree>
                         <kanban>
                             <templates>
-                                <t t-name="kanban-box">
-                                    <div>
-                                        <field name="turtle_int"/>
-                                    </div>
+                                <t t-name="kanban-card">
+                                    <field name="turtle_int"/>
                                 </t>
                             </templates>
                         </kanban>
@@ -9526,12 +9487,10 @@ test("field context is correctly passed to x2m subviews", async () => {
                 <field name="turtles" context="{'some_key': 1}">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-box">
-                                <div>
-                                    <t t-if="context.some_key">
-                                        <field name="turtle_foo"/>
-                                    </t>
-                                </div>
+                            <t t-name="kanban-card">
+                                <t t-if="context.some_key">
+                                    <field name="turtle_foo"/>
+                                </t>
                             </t>
                         </templates>
                     </kanban>
@@ -9564,10 +9523,8 @@ test.tags("desktop")("one2many kanban with widget handle", async () => {
                     <kanban>
                         <field name="turtle_int" widget="handle"/>
                         <templates>
-                            <t t-name="kanban-box">
-                                <div>
-                                    <field name="turtle_foo"/>
-                                </div>
+                            <t t-name="kanban-card">
+                                <field name="turtle_foo"/>
                             </t>
                         </templates>
                     </kanban>
@@ -11437,10 +11394,9 @@ test("one2many can delete a new record", async () => {
             <form>
                 <field name="p">
                     <kanban>
-                        <field name="foo"/>
                         <templates>
-                            <t t-name="kanban-box">
-                                <div><t t-esc="record.foo.value"/></div>
+                            <t t-name="kanban-card">
+                                <field name="foo"/>
                             </t>
                         </templates>
                     </kanban>
@@ -11863,10 +11819,9 @@ test("kanban one2many in opened view form", async () => {
                     <form>
                         <field name="p">
                             <kanban class="o-custom-class" can_open="0">
-                                <field name="name"/>
                                 <templates>
-                                    <t t-name="kanban-box">
-                                        <div><t t-esc="record.name.value"/></div>
+                                    <t t-name="kanban-card">
+                                        <field name="name"/>
                                     </t>
                                 </templates>
                             </kanban>
@@ -11893,10 +11848,9 @@ test("kanban one2many in opened view form (with _view_ref)", async () => {
     Partner._views = {
         [["kanban", 1234]]: /* xml */ `
             <kanban class="o-custom-class" can_open="0">
-                <field name="name"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><t t-esc="record.name.value"/></div>
+                    <t t-name="kanban-card">
+                        <field name="name"/>
                     </t>
                 </templates>
             </kanban>
@@ -11942,10 +11896,8 @@ test("kanban one2many (with widget) in opened view form", async () => {
                 <field name="p">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-box">
-                                <div>
-                                    <field name="name" widget="char"/>
-                                </div>
+                            <t t-name="kanban-card">
+                                <field name="name" widget="char"/>
                             </t>
                         </templates>
                     </kanban>
@@ -12752,12 +12704,9 @@ test("x2many kanban with float field in form (non inline) but not in kanban", as
                 <field name="bar"/>
                 <field name="turtles" invisible="not bar">
                     <kanban>
-                        <field name="name"/>
                         <templates>
-                            <t t-name="kanban-box">
-                                <div>
-                                    <t t-esc="record.name.raw_value"/>
-                                </div>
+                            <t t-name="kanban-card">
+                                <field name="name"/>
                             </t>
                         </templates>
                     </kanban>

--- a/addons/web/static/tests/views/fields/priority_field.test.js
+++ b/addons/web/static/tests/views/fields/priority_field.test.js
@@ -183,10 +183,8 @@ test("PriorityField can write after adding a record -- kanban", async () => {
         arch: /* xml */ `
             <kanban on_create="quick_create" quick_create_view="myquickview">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="selection" widget="priority"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="selection" widget="priority"/>
                     </t>
                 </templates>
             </kanban>`,

--- a/addons/web/static/tests/views/fields/progress_bar_field.test.js
+++ b/addons/web/static/tests/views/fields/progress_bar_field.test.js
@@ -215,10 +215,8 @@ test("ProgressBarField: field is editable in kanban", async () => {
         arch: /* xml */ `
                 <kanban>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div>
-                                <field name="int_field" title="ProgressBarTitle" widget="progressbar" options="{'editable': true, 'max_value': 'float_field'}" />
-                            </div>
+                        <t t-name="kanban-card">
+                            <field name="int_field" title="ProgressBarTitle" widget="progressbar" options="{'editable': true, 'max_value': 'float_field'}" />
                         </t>
                     </templates>
                 </kanban>`,
@@ -256,10 +254,8 @@ test("force readonly in kanban", async (assert) => {
         arch: /* xml */ `
         <kanban>
             <templates>
-                <t t-name="kanban-box">
-                    <div>
-                        <field name="int_field" widget="progressbar" options="{'editable': true, 'max_value': 'float_field', 'readonly': True}" />
-                    </div>
+                <t t-name="kanban-card">
+                    <field name="int_field" widget="progressbar" options="{'editable': true, 'max_value': 'float_field', 'readonly': True}" />
                 </t>
             </templates>
         </kanban>`,
@@ -281,12 +277,10 @@ test("ProgressBarField: readonly and editable attrs/options in kanban", async ()
         arch: /* xml */ `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="int_field" readonly="1" widget="progressbar" options="{'max_value': 'float_field'}" />
-                            <field name="int_field2" widget="progressbar" options="{'max_value': 'float_field'}" />
-                            <field name="int_field3" widget="progressbar" options="{'editable': true, 'max_value': 'float_field'}" />
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="int_field" readonly="1" widget="progressbar" options="{'max_value': 'float_field'}" />
+                        <field name="int_field2" widget="progressbar" options="{'max_value': 'float_field'}" />
+                        <field name="int_field3" widget="progressbar" options="{'editable': true, 'max_value': 'float_field'}" />
                     </t>
                 </templates>
             </kanban>`,

--- a/addons/web/static/tests/views/fields/properties_field.test.js
+++ b/addons/web/static/tests/views/fields/properties_field.test.js
@@ -1382,12 +1382,10 @@ test("properties: kanban view", async () => {
         arch: /* xml */ `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="company_id"/> <hr/>
-                            <field name="display_name"/> <hr/>
-                            <field name="properties" widget="properties"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="company_id"/> <hr/>
+                        <field name="display_name"/> <hr/>
+                        <field name="properties" widget="properties"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1437,12 +1435,10 @@ test("properties: kanban view with date and datetime property fields", async () 
         arch: /* xml */ `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="company_id"/> <hr/>
-                            <field name="display_name"/> <hr/>
-                            <field name="properties" widget="properties"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="company_id"/> <hr/>
+                        <field name="display_name"/> <hr/>
+                        <field name="properties" widget="properties"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1487,12 +1483,10 @@ test("properties: kanban view with multiple sources of properties definitions", 
         arch: /* xml */ `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="company_id"/> <hr/>
-                            <field name="display_name"/> <hr/>
-                            <field name="properties" widget="properties"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="company_id"/> <hr/>
+                        <field name="display_name"/> <hr/>
+                        <field name="properties" widget="properties"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1562,12 +1556,10 @@ test("properties: kanban view with label and border", async () => {
         arch: /* xml */ `
                 <kanban>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div>
-                                <field name="company_id"/> <hr/>
-                                <field name="display_name"/> <hr/>
-                                <field name="properties" widget="properties"/>
-                            </div>
+                        <t t-name="kanban-card">
+                            <field name="company_id"/> <hr/>
+                            <field name="display_name"/> <hr/>
+                            <field name="properties" widget="properties"/>
                         </t>
                     </templates>
                 </kanban>`,
@@ -1611,12 +1603,10 @@ test("properties: kanban view without properties", async () => {
         arch: /* xml */ `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="company_id"/> <hr/>
-                            <field name="display_name"/> <hr/>
-                            <field name="properties" widget="properties"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="company_id"/> <hr/>
+                        <field name="display_name"/> <hr/>
+                        <field name="properties" widget="properties"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1631,12 +1621,10 @@ test.tags("desktop")("properties: switch view on desktop", async () => {
     Partner._views[["search", false]] = /* xml */ `<search/>`;
     Partner._views[["kanban", 99]] = /* xml */ `<kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="company_id"/> <hr/>
-                            <field name="display_name"/> <hr/>
-                            <field name="properties" widget="properties"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="company_id"/> <hr/>
+                        <field name="display_name"/> <hr/>
+                        <field name="properties" widget="properties"/>
                     </t>
                 </templates>
             </kanban>`;
@@ -1666,12 +1654,10 @@ test.tags("mobile")("properties: switch view on mobile", async () => {
     Partner._views[["search", false]] = /* xml */ `<search/>`;
     Partner._views[["kanban", 99]] = /* xml */ `<kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="company_id"/> <hr/>
-                            <field name="display_name"/> <hr/>
-                            <field name="properties" widget="properties"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="company_id"/> <hr/>
+                        <field name="display_name"/> <hr/>
+                        <field name="properties" widget="properties"/>
                     </t>
                 </templates>
             </kanban>`;

--- a/addons/web/static/tests/views/fields/selection_field.test.js
+++ b/addons/web/static/tests/views/fields/selection_field.test.js
@@ -315,10 +315,8 @@ test("SelectionField in kanban view", async () => {
         arch: /* xml */ `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="color" widget="selection" />
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="color" widget="selection" />
                     </t>
                 </templates>
             </kanban>`,
@@ -348,10 +346,8 @@ test("SelectionField - auto save record in kanban view", async () => {
         arch: /* xml */ `
                 <kanban>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div>
-                                <field name="color" widget="selection" />
-                            </div>
+                        <t t-name="kanban-card">
+                            <field name="color" widget="selection" />
                         </t>
                     </templates>
                 </kanban>`,
@@ -370,10 +366,8 @@ test("SelectionField don't open form view on click in kanban view", async functi
         arch: /* xml */ `
                 <kanban>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div>
-                                <field name="color" widget="selection" />
-                            </div>
+                        <t t-name="kanban-card">
+                            <field name="color" widget="selection" />
                         </t>
                     </templates>
                 </kanban>`,
@@ -405,10 +399,8 @@ test("SelectionField is disabled if field readonly", async () => {
         arch: /* xml */ `
                 <kanban>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div>
-                                <field name="color" widget="selection" />
-                            </div>
+                        <t t-name="kanban-card">
+                            <field name="color" widget="selection" />
                         </t>
                     </templates>
                 </kanban>
@@ -428,10 +420,8 @@ test("SelectionField is disabled with a readonly attribute", async () => {
         arch: /* xml */ `
                 <kanban>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div>
-                                <field name="color" widget="selection" readonly="1" />
-                            </div>
+                        <t t-name="kanban-card">
+                            <field name="color" widget="selection" readonly="1" />
                         </t>
                     </templates>
                 </kanban>
@@ -455,12 +445,9 @@ test("SelectionField in kanban view with handle widget", async () => {
         resModel: "partner",
         arch: /* xml */ `
                 <kanban>
-                    <field name="int_field" widget="handle"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div>
-                                <field name="color" widget="selection"/>
-                            </div>
+                        <t t-name="kanban-card">
+                            <field name="color" widget="selection"/>
                         </t>
                     </templates>
                 </kanban>`,

--- a/addons/web/static/tests/views/fields/state_selection_field.test.js
+++ b/addons/web/static/tests/views/fields/state_selection_field.test.js
@@ -413,10 +413,8 @@ test("works when required in a readonly view", async () => {
         arch: /* xml */ `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="selection" widget="state_selection" required="1"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="selection" widget="state_selection" required="1"/>
                     </t>
                 </templates>
             </kanban>

--- a/addons/web/static/tests/views/form/auto_save.test.js
+++ b/addons/web/static/tests/views/form/auto_save.test.js
@@ -278,11 +278,8 @@ test.tags("desktop")(`save when action changed`, async () => {
         search: `<search/>`,
         kanban: `
             <kanban>
-                <field name="name"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div></div>
-                    </t>
+                    <t t-name="kanban-card"/>
                 </templates>
             </kanban>
         `,

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -904,7 +904,7 @@ test(`Form and subview with _view_ref contexts`, async () => {
         kanban: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
+                    <t t-name="kanban-card">
                         <field name="color"/>
                     </t>
                 </templates>
@@ -969,7 +969,7 @@ test(`Form and subsubview with only _view_ref contexts`, async () => {
         kanban: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
+                    <t t-name="kanban-card">
                         <field name="name"/>
                     </t>
                 </templates>
@@ -983,7 +983,7 @@ test(`Form and subsubview with only _view_ref contexts`, async () => {
         kanban: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
+                    <t t-name="kanban-card">
                         <field name="name"/>
                     </t>
                 </templates>
@@ -6966,8 +6966,8 @@ test(`non inline subview and create=0 in action context`, async () => {
     Product._views = {
         kanban: `
             <kanban>
-                <templates><t t-name="kanban-box">
-                    <div><field name="name"/></div>
+                <templates><t t-name="kanban-card">
+                    <field name="name"/>
                 </t></templates>
             </kanban>
         `,
@@ -9493,10 +9493,8 @@ test.tags("desktop")(`discard after a failed save (and close notifications)`, as
         kanban: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo" />
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo" />
                     </t>
                 </templates>
             </kanban>
@@ -9540,7 +9538,7 @@ test(`one2many create record dialog shouldn't have a 'remove' button`, async () 
                 <field name="child_ids">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-box">
+                            <t t-name="kanban-card">
                                 <field name="foo"/>
                             </t>
                         </templates>
@@ -10329,8 +10327,8 @@ test.tags("desktop")(`empty x2manys when coming form a list with sample data`, a
                 <field name="child_ids">
                     <kanban>
                         <templates>
-                            <t t-name="kanban-box">
-                                <div><field name="name"/></div>
+                            <t t-name="kanban-card">
+                                <field name="name"/>
                             </t>
                         </templates>
                     </kanban>

--- a/addons/web/static/tests/views/kanban/kanban_compiler.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_compiler.test.js
@@ -13,12 +13,10 @@ test("bootstrap dropdowns with kanban_ignore_dropdown class should be left as is
     const arch = `
         <kanban>
             <templates>
-                <t t-name="kanban-box">
-                    <div>
-                        <button name="dropdown" class="kanban_ignore_dropdown" type="button" data-bs-toggle="dropdown">Boostrap dropdown</button>
-                        <div class="dropdown-menu kanban_ignore_dropdown" role="menu">
-                            <span>Dropdown content</span>
-                        </div>
+                <t t-name="kanban-card">
+                    <button name="dropdown" class="kanban_ignore_dropdown" type="button" data-bs-toggle="dropdown">Boostrap dropdown</button>
+                    <div class="dropdown-menu kanban_ignore_dropdown" role="menu">
+                        <span>Dropdown content</span>
                     </div>
                 </t>
             </templates>
@@ -27,12 +25,10 @@ test("bootstrap dropdowns with kanban_ignore_dropdown class should be left as is
         <t t-translation="off">
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <button name="dropdown" class="kanban_ignore_dropdown" type="button" data-bs-toggle="dropdown">Boostrap dropdown</button>
-                            <div class="dropdown-menu kanban_ignore_dropdown" role="menu">
-                                <span>Dropdown content</span>
-                            </div>
+                    <t t-name="kanban-card">
+                        <button name="dropdown" class="kanban_ignore_dropdown" type="button" data-bs-toggle="dropdown">Boostrap dropdown</button>
+                        <div class="dropdown-menu kanban_ignore_dropdown" role="menu">
+                            <span>Dropdown content</span>
                         </div>
                     </t>
                 </templates>

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -70,7 +70,6 @@ import {
 import { currencies } from "@web/core/currency";
 import { registry } from "@web/core/registry";
 import { user } from "@web/core/user";
-import { getOrigin } from "@web/core/utils/urls";
 import { RelationalModel } from "@web/model/relational_model/relational_model";
 import { SampleServer } from "@web/model/sample_server";
 import { KanbanCompiler } from "@web/views/kanban/kanban_compiler";
@@ -233,7 +232,6 @@ test("basic ungrouped rendering", async () => {
             <kanban class="o_kanban_test">
             <templates>
                 <t t-name="kanban-card">
-                    <t t-esc="record.foo.value"/>
                     <field name="foo"/>
                 </t>
             </templates>
@@ -432,7 +430,7 @@ test("display full is supported on fields", async () => {
         arch: `
         <kanban class="o_kanban_test">
             <templates>
-                <t t-name="kanban-box">
+                <t t-name="kanban-card">
                     <field name="foo" display="full"/>
                 </t>
             </templates>
@@ -465,12 +463,9 @@ test.tags("desktop")("basic grouped rendering", async () => {
         resModel: "partner",
         arch: `
             <kanban class="o_kanban_test">
-                <field name="bar" />
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo" />
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo" />
                     </t>
                 </templates>
             </kanban>`,
@@ -517,12 +512,9 @@ test("basic grouped rendering with no record", async () => {
         resModel: "partner",
         arch: `
             <kanban class="o_kanban_test">
-                <field name="bar" />
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo" />
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo" />
                     </t>
                 </templates>
             </kanban>`,
@@ -545,13 +537,9 @@ test("grouped rendering with active field (archivable by default)", async () => 
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="active"/>
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -586,11 +574,9 @@ test("grouped rendering with active field (archivable true)", async () => {
         resModel: "partner",
         arch: `
             <kanban archivable="true">
-                <field name="active"/>
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -626,10 +612,8 @@ test.tags("desktop")("empty group when grouped by date", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `<kanban>
-            <field name="bar"/>
-            <field name="date"/>
             <templates>
-                <t t-name="kanban-box">
+                <t t-name="kanban-card">
                     <field name="foo"/>
                 </t>
             </templates>
@@ -659,11 +643,9 @@ test("grouped rendering with active field (archivable false)", async () => {
         resModel: "partner",
         arch: `
             <kanban archivable="false">
-                <field name="active"/>
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -690,11 +672,9 @@ test.tags("desktop")("m2m grouped rendering with active field (archivable true)"
         resModel: "partner",
         arch: `
             <kanban archivable="true">
-                <field name="active"/>
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -730,10 +710,9 @@ test("kanban grouped by date field", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="date"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -750,12 +729,8 @@ test("context can be used in kanban template", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                    <div>
-                        <t t-if="context.some_key">
-                            <field name="foo"/>
-                        </t>
-                    </div>
+                    <t t-name="kanban-card">
+                        <field t-if="context.some_key" name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -776,7 +751,7 @@ test("user context can be used in kanban template", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field t-if="user_context.some_key" name="foo"/>
                     </div>
                 </templates>
@@ -795,13 +770,11 @@ test("kanban with sub-template", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <t t-call="another-template"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <t t-call="another-template"/>
                     </t>
                     <t t-name="another-template">
-                        <span><field name="foo"/></span>
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -823,7 +796,7 @@ test("kanban with t-set outside card", async () => {
             <kanban>
                 <field name="int_field"/>
                 <templates>
-                    <t t-name="kanban-box">
+                    <t t-name="kanban-card">
                         <t t-set="x" t-value="record.int_field.value"/>
                         <div>
                             <t t-esc="x"/>
@@ -843,11 +816,9 @@ test("kanban with t-if/t-else on field", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field t-if="record.int_field.value > -1" name="int_field"/>
-                            <t t-else="">Negative value</t>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field t-if="record.int_field.value > -1" name="int_field"/>
+                        <t t-else="">Negative value</t>
                     </t>
                 </templates>
             </kanban>`,
@@ -868,11 +839,9 @@ test("kanban with t-if/t-else on field with widget", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field t-if="record.int_field.value > -1" name="int_field" widget="integer"/>
-                            <t t-else="">Negative value</t>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field t-if="record.int_field.value > -1" name="int_field" widget="integer"/>
+                        <t t-else="">Negative value</t>
                     </t>
                 </templates>
             </kanban>`,
@@ -908,15 +877,13 @@ test("field with widget and dynamic attributes in kanban", async () => {
             <kanban>
                 <field name="foo"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="int_field" widget="my_field"
-                                t-att-dyn-bool="record.foo.value.length > 3"
-                                t-attf-interp-str="hello {{record.foo.value}}"
-                                t-attf-interp-str2="hello #{record.foo.value} !"
-                                t-attf-interp-str3="hello {{record.foo.value}} }}"
-                            />
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="int_field" widget="my_field"
+                            t-att-dyn-bool="record.foo.value.length > 3"
+                            t-attf-interp-str="hello {{record.foo.value}}"
+                            t-attf-interp-str2="hello #{record.foo.value} !"
+                            t-attf-interp-str3="hello {{record.foo.value}} }}"
+                        />
                     </t>
                 </templates>
             </kanban>`,
@@ -944,14 +911,12 @@ test("view button and string interpolated attribute in kanban", async () => {
             <kanban>
                 <field name="foo"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <a name="one" type="object" class="hola"/>
-                            <a name="two" type="object" class="hola" t-attf-class="hello"/>
-                            <a name="sri" type="object" class="hola" t-attf-class="{{record.foo.value}}"/>
-                            <a name="foa" type="object" class="hola" t-attf-class="{{record.foo.value}} olleh"/>
-                            <a name="fye" type="object" class="hola" t-attf-class="hello {{record.foo.value}}"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <a name="one" type="object" class="hola"/>
+                        <a name="two" type="object" class="hola" t-attf-class="hello"/>
+                        <a name="sri" type="object" class="hola" t-attf-class="{{record.foo.value}}"/>
+                        <a name="foa" type="object" class="hola" t-attf-class="{{record.foo.value}} olleh"/>
+                        <a name="fye" type="object" class="hola" t-attf-class="hello {{record.foo.value}}"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -986,12 +951,9 @@ test("pager should be hidden in grouped mode", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1010,8 +972,8 @@ test("there should be no limit on the number of fetched groups", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1034,10 +996,8 @@ test("pager, ungrouped, with default limit", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1053,10 +1013,8 @@ test.tags("desktop")("pager, ungrouped, with default limit on desktop", async ()
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1078,8 +1036,8 @@ test("pager, ungrouped, with limit given in options", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1094,8 +1052,8 @@ test.tags("desktop")("pager, ungrouped, with limit given in options on desktop",
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1119,8 +1077,8 @@ test("pager, ungrouped, with limit set on arch and given in options", async () =
         arch: `
             <kanban limit="3">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1138,8 +1096,8 @@ test.tags("desktop")(
             arch: `
             <kanban limit="3">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1162,8 +1120,8 @@ test.tags("desktop")("pager, ungrouped, with count limit reached", async () => {
         arch: `
             <kanban limit="2">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1198,8 +1156,8 @@ test("pager, ungrouped, with count limit reached, click next", async () => {
         arch: `
             <kanban limit="2">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1230,8 +1188,8 @@ test.tags("desktop")(
             arch: `
             <kanban limit="2">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1260,8 +1218,8 @@ test("pager, ungrouped, with count limit reached, click next (2)", async () => {
         arch: `
             <kanban limit="2">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1299,8 +1257,8 @@ test.tags("desktop")(
             arch: `
             <kanban limit="2">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1334,8 +1292,8 @@ test("pager, ungrouped, with count limit reached, click previous", async () => {
         arch: `
             <kanban limit="2">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1368,8 +1326,8 @@ test.tags("desktop")(
             arch: `
             <kanban limit="2">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1397,8 +1355,8 @@ test.tags("desktop")("pager, ungrouped, with count limit reached, edit pager", a
         arch: `
             <kanban limit="2">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1440,8 +1398,8 @@ test.tags("desktop")("count_limit attrs set in arch", async () => {
         arch: `
             <kanban limit="2" count_limit="3">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1472,11 +1430,9 @@ test.tags("desktop")("pager, ungrouped, deleting all records from last page", as
         arch: `
             <kanban limit="3">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <div><a role="menuitem" type="delete" class="dropdown-item">Delete</a></div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <a role="menuitem" type="delete" class="dropdown-item">Delete</a>
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1526,8 +1482,8 @@ test.tags("desktop")("pager, update calls onUpdatedPager", async () => {
         arch: `
             <kanban js_class="test_kanban_view">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1549,11 +1505,9 @@ test("click on a button type='delete' to delete a record in a column", async () 
         arch: `
             <kanban limit="3">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <div><a role="menuitem" type="delete" class="dropdown-item o_delete">Delete</a></div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <a role="menuitem" type="delete" class="dropdown-item o_delete">Delete</a>
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1584,11 +1538,9 @@ test("click on a button type='archive' to archive a record in a column", async (
         arch: `
             <kanban limit="3">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <div><a role="menuitem" type="archive" class="dropdown-item o_archive">archive</a></div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <a role="menuitem" type="archive" class="dropdown-item o_archive">archive</a>
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1619,11 +1571,9 @@ test("click on a button type='unarchive' to unarchive a record in a column", asy
         arch: `
             <kanban limit="3">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <div><a role="menuitem" type="unarchive" class="dropdown-item o_unarchive">unarchive</a></div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <a role="menuitem" type="unarchive" class="dropdown-item o_unarchive">unarchive</a>
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1656,8 +1606,8 @@ test.tags("desktop")("kanban with an action id as on_create attrs", async () => 
         arch: `
             <kanban on_create="some.action">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1682,10 +1632,9 @@ test.tags("desktop")("grouped kanban with quick_create attrs set to false", asyn
         resModel: "partner",
         arch: `
             <kanban quick_create="false" on_create="quick_create">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1708,10 +1657,9 @@ test.tags("desktop")("create in grouped on m2o", async () => {
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1734,10 +1682,9 @@ test("create in grouped on char", async () => {
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1760,11 +1707,9 @@ test("prevent deletion when grouped by many2many field", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                            <t t-if="widget.deletable"><span class="thisisdeletable">delete</span></t>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
+                        <t t-if="widget.deletable"><span class="thisisdeletable">delete</span></t>
                     </t>
                 </templates>
             </kanban>`,
@@ -1792,8 +1737,8 @@ test.tags("desktop")("kanban grouped by many2one: false column is folded by defa
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1824,10 +1769,9 @@ test.tags("desktop")("quick created records in grouped kanban are on displayed t
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="display_name"/></div>
+                    <t t-name="kanban-card">
+                        <field name="display_name"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1879,10 +1823,9 @@ test.tags("desktop")("quick create record without quick_create_view", async () =
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -1943,10 +1886,9 @@ test.tags("desktop")("quick create record with quick_create_view", async () => {
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -2012,12 +1954,9 @@ test.tags("desktop")("quick create record flickering", async () => {
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -2062,12 +2001,9 @@ test.tags("desktop")("quick create record flickering (load more)", async () => {
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -2100,10 +2036,9 @@ test.tags("desktop")("quick create record should focus default field", async fun
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -2128,10 +2063,9 @@ test.tags("desktop")("quick create record should focus first field input", async
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -2154,10 +2088,9 @@ test.tags("desktop")("quick_create_view without quick_create option", async () =
         resModel: "partner",
         arch: `
             <kanban quick_create_view="some_view_ref">
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -2197,10 +2130,9 @@ test.tags("desktop")("quick create record in grouped on m2o (no quick_create_vie
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -2258,10 +2190,9 @@ test.tags("desktop")("quick create record in grouped on m2o (with quick_create_v
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -2310,10 +2241,9 @@ test("quick create record in grouped on m2m (no quick_create_view)", async () =>
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="category_ids"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -2355,10 +2285,9 @@ test.tags("desktop")("quick create record in grouped on m2m in the None column",
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="category_ids"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -2412,8 +2341,8 @@ test("quick create record in grouped on m2m (field not in template)", async () =
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -2466,8 +2395,8 @@ test("quick create record in grouped on m2m (field in the form view)", async () 
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -2511,10 +2440,9 @@ test.tags("desktop")("quick create record validation: stays open when invalid", 
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -2565,10 +2493,9 @@ test.tags("desktop")("quick create record with default values and onchanges", as
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -2615,10 +2542,9 @@ test("quick create record with quick_create_view: modifiers", async () => {
         resModel: "partner",
         arch: `
             <kanban quick_create_view="some_view_ref">
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -2662,12 +2588,9 @@ test("quick create record with onchange of field marked readonly", async () => {
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -2709,11 +2632,11 @@ test("quick create record and change state in grouped mode", async () => {
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field name="foo"/>
-                        <div class="oe_kanban_bottom_right">
+                        <footer>
                             <field name="kanban_state" widget="state_selection"/>
-                        </div>
+                        </footer>
                     </div>
                 </templates>
             </kanban>`,
@@ -2739,10 +2662,9 @@ test("window resize should not change quick create form size", async () => {
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -2766,10 +2688,9 @@ test("quick create record: cancel and validate without using the buttons", async
         resModel: "partner",
         arch: `
             <kanban quick_create_view="some_view_ref" on_create="quick_create">
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -2833,10 +2754,9 @@ test("quick create record: validate with ENTER", async () => {
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -2872,10 +2792,9 @@ test("quick create record: prevent multiple adds with ENTER", async () => {
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -2922,10 +2841,9 @@ test("quick create record: prevent multiple adds with Add clicked", async () => 
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -2967,12 +2885,9 @@ test.tags("desktop")("save a quick create record and create a new one simultaneo
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="display_name"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="display_name"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -3035,10 +2950,9 @@ test("quick create record: prevent multiple adds with ENTER, with onchange", asy
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -3116,10 +3030,10 @@ test("quick create record: click Add to create, with delayed onchange", async ()
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/><field name="int_field"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
+                        <field name="int_field"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -3167,10 +3081,9 @@ test.tags("desktop")("quick create when first column is folded", async () => {
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -3206,10 +3119,9 @@ test("quick create record: cancel when not dirty", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -3298,8 +3210,8 @@ test.tags("desktop")("quick create record: cancel when modal is opened", async (
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -3338,10 +3250,9 @@ test("quick create record: cancel when dirty", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -3409,10 +3320,9 @@ test("quick create record and edit in grouped mode", async () => {
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -3446,10 +3356,9 @@ test.tags("desktop")("quick create several records in a row", async () => {
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -3497,10 +3406,9 @@ test("quick create is disabled until record is created and read", async () => {
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -3553,10 +3461,9 @@ test.tags("desktop")("quick create record fail in grouped by many2one", async ()
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -3586,10 +3493,9 @@ test.tags("desktop")("quick create record fail in grouped by many2one", async ()
 test("quick create record and click Edit, name_create fails", async () => {
     Partner._views["kanban,false"] = `
         <kanban sample="1">
-            <field name="product_id"/>
             <templates>
-                <t t-name="kanban-box">
-                    <div><field name="foo"/></div>
+                <t t-name="kanban-card">
+                    <field name="foo"/>
                 </t>
             </templates>
         </kanban>`;
@@ -3654,10 +3560,9 @@ test.tags("desktop")("quick create record is re-enabled after discard on failure
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -3706,8 +3611,8 @@ test("quick create record fails in grouped by char", async () => {
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -3754,8 +3659,8 @@ test("quick create record fails in grouped by selection", async () => {
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="state"/></div>
+                    <t t-name="kanban-card">
+                        <field name="state"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -3803,10 +3708,9 @@ test.tags("desktop")("quick create record in empty grouped kanban", async () => 
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -3830,8 +3734,8 @@ test.tags("desktop")("quick create record in grouped on date(time) field", async
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="display_name"/></div>
+                    <t t-name="kanban-card">
+                        <field name="display_name"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -3878,8 +3782,8 @@ test("quick create record feature is properly enabled/disabled at reload", async
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="display_name"/></div>
+                    <t t-name="kanban-card">
+                        <field name="display_name"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -3924,8 +3828,8 @@ test("quick create record in grouped by char field", async () => {
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="display_name"/></div>
+                    <t t-name="kanban-card">
+                        <field name="display_name"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -3955,8 +3859,8 @@ test("quick create record in grouped by boolean field", async () => {
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="display_name"/></div>
+                    <t t-name="kanban-card">
+                        <field name="display_name"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -3986,8 +3890,8 @@ test("quick create record in grouped on selection field", async () => {
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="display_name"/></div>
+                    <t t-name="kanban-card">
+                        <field name="display_name"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -4026,8 +3930,8 @@ test("quick create record in grouped by char field (within quick_create_view)", 
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -4062,8 +3966,8 @@ test("quick create record in grouped by boolean field (within quick_create_view)
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="bar"/></div>
+                    <t t-name="kanban-card">
+                        <field name="bar"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -4101,8 +4005,8 @@ test("quick create record in grouped by selection field (within quick_create_vie
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="state"/></div>
+                    <t t-name="kanban-card">
+                        <field name="state"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -4142,8 +4046,8 @@ test.tags("desktop")("quick create record while adding a new column", async () =
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -4203,8 +4107,8 @@ test.tags("desktop")("close a column while quick creating a record", async () =>
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -4250,8 +4154,8 @@ test("quick create record: open on a column while another column has already one
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -4294,12 +4198,10 @@ test("many2many_tags in kanban views", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="category_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
-                            <field name="foo"/>
-                            <field name="state" widget="priority"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="category_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                        <field name="foo"/>
+                        <field name="state" widget="priority"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -4357,11 +4259,9 @@ test("priority field should not be editable when missing access rights", async (
         arch: `
             <kanban edit="0">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                            <field name="state" widget="priority"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
+                        <field name="state" widget="priority"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -4392,13 +4292,9 @@ test("Do not open record when clicking on `a` with `href`", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                            <div>
-                                <a class="o_test_link" href="#">test link</a>
-                            </div>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
+                        <a class="o_test_link" href="#">test link</a>
                     </t>
                 </templates>
             </kanban>`,
@@ -4443,10 +4339,8 @@ test("Open record when clicking on widget field", async function (assert) {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="salary" widget="monetary"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="salary" widget="monetary"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -4483,12 +4377,9 @@ test("o2m loaded in only one batch", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="subtask_ids" widget="many2many_tags"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="subtask_ids" widget="many2many_tags"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -4517,12 +4408,9 @@ test.tags("desktop")("kanban with many2many, load and reload", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="category_ids" widget="many2many_tags"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="category_ids" widget="many2many_tags"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -4558,12 +4446,9 @@ test.tags("desktop")("kanban with reference field", async () => {
         groupBy: ["product_id"],
         arch: `
             <kanban>
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                    <div>
+                    <t t-name="kanban-card">
                         <field name="ref_product"/>
-                    </div>
                     </t>
                 </templates>
             </kanban>`,
@@ -4593,8 +4478,8 @@ test.tags("desktop")("drag and drop a record with load more", async () => {
         arch: `
             <kanban limit="1">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="id"/></div>
+                    <t t-name="kanban-card">
+                        <field name="id"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -4621,15 +4506,12 @@ test.tags("desktop")("can drag and drop a record from one column to the next", a
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                            <t t-if="widget.editable">
-                                <span class="thisiseditable">edit</span>
-                            </t>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
+                        <t t-if="widget.editable">
+                            <span class="thisiseditable">edit</span>
+                        </t>
                     </t>
                 </templates>
             </kanban>`,
@@ -4668,10 +4550,8 @@ test.tags("desktop")(
             arch: `
                 <kanban>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div>
-                                <field name="foo"/>
-                            </div>
+                        <t t-name="kanban-card">
+                            <field name="foo"/>
                         </t>
                     </templates>
                 </kanban>`,
@@ -4704,10 +4584,8 @@ test.tags("desktop")(
             arch: `
                 <kanban>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div>
-                                <field name="foo"/>
-                            </div>
+                        <t t-name="kanban-card">
+                            <field name="foo"/>
                         </t>
                     </templates>
                 </kanban>`,
@@ -4740,10 +4618,9 @@ test.tags("desktop")("drag and drop highlight on hover", async () => {
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -4769,10 +4646,9 @@ test("drag and drop outside of a column", async () => {
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -4807,8 +4683,8 @@ test.tags("desktop")("drag and drop a record, grouped by selection", async () =>
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="state"/></div>
+                    <t t-name="kanban-card">
+                        <field name="state"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -4857,7 +4733,7 @@ test.tags("desktop")("prevent drag and drop of record if grouped by readonly", a
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
+                    <t t-name="kanban-card">
                         <div>
                             <field name="foo"/>
                             <field name="product_id" readonly="0" invisible="1"/>
@@ -4977,11 +4853,9 @@ test("prevent drag and drop if grouped by date/datetime field", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="date"/>
-                <field name="datetime"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -5048,10 +4922,9 @@ test.tags("desktop")("prevent drag and drop if grouped by many2many field", asyn
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -5134,9 +5007,9 @@ test("Ensuring each progress bar has some space", async () => {
             <kanban>
                 <progressbar field="state" colors='{"abc": "success", "def": "warning", "ghi": "danger"}' />
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field name="state" widget="state_selection" />
-                        <div><field name="foo" /></div>
+                        <field name="foo" />
                     </div>
                 </templates>
             </kanban>`,
@@ -5152,10 +5025,9 @@ test("completely prevent drag and drop if records_draggable set to false", async
         resModel: "partner",
         arch: `
             <kanban records_draggable="false">
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -5207,13 +5079,10 @@ test.tags("desktop")("prevent drag and drop of record if save fails", async () =
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                            <field name="product_id"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
+                        <field name="product_id"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -5258,10 +5127,9 @@ test("kanban view with default_group_by", async () => {
         resModel: "partner",
         arch: `
             <kanban default_group_by="bar">
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -5296,10 +5164,9 @@ test.tags("desktop")("kanban view not groupable", async () => {
         resModel: "partner",
         arch: `
             <kanban default_group_by="bar">
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -5328,8 +5195,8 @@ test("kanban view with create=False", async () => {
         arch: `
             <kanban create="0">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -5345,8 +5212,8 @@ test("kanban view with create=False and groupby", async () => {
         arch: `
             <kanban create="0">
                 <templates>
-                    <t t-name="kanban-box">>
-                        <div><field name="foo"/></div>>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -5365,8 +5232,8 @@ test("clicking on a link triggers correct event", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><a type="edit">Edit</a></div>
+                    <t t-name="kanban-card">
+                        <a type="edit">Edit</a>
                     </t>
                 </templates>
             </kanban>`,
@@ -5384,10 +5251,9 @@ test.tags("desktop")("environment is updated when (un)folding groups", async () 
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="id"/></div>
+                    <t t-name="kanban-card">
+                        <field name="id"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -5425,10 +5291,9 @@ test.tags("desktop")("create a column in grouped on m2o", async () => {
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -5515,10 +5380,9 @@ test("create a column in grouped on m2o without sequence field on view model", a
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -5561,10 +5425,9 @@ test.tags("desktop")("auto fold group when reach the limit", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -5625,10 +5488,9 @@ test.tags("desktop")("auto fold group when reach the limit (2)", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -5670,10 +5532,9 @@ test.tags("desktop")("show/hide help message (ESC) in quick create [REQUIRE FOCU
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -5710,12 +5571,9 @@ test.tags("desktop")("delete a column in grouped on m2o", async () => {
         resModel: "partner",
         arch: `
             <kanban class="o_kanban_test" on_create="quick_create">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -5854,10 +5712,9 @@ test("create a column, delete it and create another one", async () => {
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -5913,10 +5770,9 @@ test("delete an empty column, then a column with records.", async () => {
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -5963,10 +5819,9 @@ test.tags("desktop")("edit a column in grouped on m2o", async () => {
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -6041,10 +5896,9 @@ test("edit a column propagates right context", async () => {
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -6061,10 +5915,9 @@ test("quick create column should be opened if there is no column", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -6085,10 +5938,9 @@ test("quick create column should not be closed on window click if there is no co
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -6114,10 +5966,9 @@ test("quick create several columns in a row", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -6165,10 +6016,9 @@ test.tags("desktop")("quick create column with enter", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -6208,10 +6058,9 @@ test.tags("desktop")("quick create column and examples", async () => {
         resModel: "partner",
         arch: `
             <kanban examples="test">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -6289,10 +6138,9 @@ test("quick create column with x_name as _rec_name", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -6329,9 +6177,8 @@ test.tags("desktop")("count of folded groups in empty kanban with sample data", 
         type: "kanban",
         arch: `
             <kanban sample="1">
-                <field name="product_id"/>
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field name="foo"/>
                     </div>
                 </templates>
@@ -6378,10 +6225,9 @@ test.tags("desktop")("quick create column and examples: with folded columns", as
         resModel: "partner",
         arch: `
             <kanban examples="test">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -6433,10 +6279,9 @@ test.tags("desktop")("quick create column's apply button's display text", async 
         resModel: "partner",
         arch: `
             <kanban examples="test">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -6478,10 +6323,9 @@ test.tags("desktop")("create column and examples background with ghostColumns ti
         resModel: "partner",
         arch: `
             <kanban examples="test">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -6513,10 +6357,9 @@ test("create column and examples background without ghostColumns titles", async 
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -6559,11 +6402,10 @@ test("nocontent helper after adding a record (kanban with progressbar)", async (
         resModel: "partner",
         arch: `
             <kanban >
-                <field name="product_id"/>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -6609,10 +6451,9 @@ test.tags("desktop")("ungrouped kanban view can be grouped, then ungrouped", asy
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -6645,11 +6486,9 @@ test("no content helper when archive all records in kanban group", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="active"/>
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -6680,11 +6519,8 @@ test.tags("desktop")("no content helper when no data", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <t t-esc="record.foo.value"/>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -6723,10 +6559,9 @@ test("no nocontent helper for grouped kanban with empty groups", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -6747,8 +6582,8 @@ test("no nocontent helper for grouped kanban with no records", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -6775,8 +6610,8 @@ test("no nocontent helper is shown when no longer creating column", async () => 
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -6825,8 +6660,8 @@ test("no nocontent helper is hidden when quick creating a column", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -6865,8 +6700,8 @@ test("remove nocontent helper after adding a record", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -6907,8 +6742,8 @@ test("remove nocontent helper when adding a record", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -6948,8 +6783,8 @@ test("nocontent helper is displayed again after canceling quick create", async (
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -6975,8 +6810,8 @@ test("nocontent helper for grouped kanban (on m2o field) with no records with no
         arch: `
             <kanban group_create="false">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -7003,8 +6838,8 @@ test("nocontent helper for grouped kanban (on date field) with no records with n
         arch: `
             <kanban group_create="false">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -7025,9 +6860,8 @@ test("empty grouped kanban with sample data and no columns", async () => {
     await mountView({
         arch: `
             <kanban sample="1">
-                <field name="product_id"/>
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field name="foo"/>
                     </div>
                 </templates>
@@ -7072,12 +6906,9 @@ test("empty kanban with sample data grouped by date range (fill temporal)", asyn
     await mountView({
         arch: `
             <kanban sample="1">
-                <field name="date"/>
-                <field name="state"/>
-                <field name="int_field"/>
                 <progressbar field="state" sum_field="int_field" help="progress" colors="{}"/>
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field name="foo"/>
                         <field name="int_field"/>
                     </div>
@@ -7112,10 +6943,9 @@ test("empty grouped kanban with sample data and click quick create", async () =>
         resModel: "partner",
         arch: `
             <kanban sample="1">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -7161,10 +6991,9 @@ test.tags("desktop")("quick create record in grouped kanban with sample data", a
         resModel: "partner",
         arch: `
             <kanban sample="1" on_create="quick_create">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -7204,10 +7033,9 @@ test("empty grouped kanban with sample data and cancel quick create", async () =
         resModel: "partner",
         arch: `
             <kanban sample="1">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -7246,9 +7074,8 @@ test.tags("desktop")("empty grouped kanban with sample data: keynav", async () =
         type: "kanban",
         arch: `
             <kanban sample="1">
-                <field name="product_id"/>
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field name="foo"/>
                         <field name="state" widget="priority"/>
                     </div>
@@ -7274,10 +7101,9 @@ test.tags("desktop")("empty kanban with sample data", async () => {
         resModel: "partner",
         arch: `
             <kanban sample="1">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -7320,13 +7146,10 @@ test("empty grouped kanban with sample data and many2many_tags", async () => {
         resModel: "partner",
         arch: `
             <kanban sample="1">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="int_field"/>
-                            <field name="category_ids" widget="many2many_tags"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="int_field"/>
+                        <field name="category_ids" widget="many2many_tags"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -7353,10 +7176,9 @@ test("empty grouped kanban with sample data and many2many_tags", async () => {
 test.tags("desktop")("sample data does not change after reload with sample data", async () => {
     Partner._views["kanban,false"] = `
         <kanban sample="1">
-            <field name="product_id"/>
             <templates>
-                <t t-name="kanban-box">
-                    <div><field name="int_field"/></div>
+                <t t-name="kanban-card">
+                    <field name="int_field"/>
                 </t>
             </templates>
         </kanban>`;
@@ -7406,10 +7228,9 @@ test.tags("desktop")("non empty kanban with sample data", async () => {
         resModel: "partner",
         arch: `
             <kanban sample="1">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -7448,9 +7269,8 @@ test("empty grouped kanban with sample data: add a column", async () => {
     await mountView({
         arch: `
             <kanban sample="1">
-                <field name="product_id"/>
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field name="foo"/>
                     </div>
                 </templates>
@@ -7493,9 +7313,8 @@ test.tags("desktop")("empty grouped kanban with sample data: cannot fold a colum
         type: "kanban",
         arch: `
             <kanban sample="1">
-                <field name="product_id"/>
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field name="foo"/>
                     </div>
                 </templates>
@@ -7540,9 +7359,8 @@ test("empty grouped kanban with sample data: delete a column", async () => {
         type: "kanban",
         arch: `
             <kanban sample="1">
-                <field name="product_id"/>
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field name="foo"/>
                     </div>
                 </templates>
@@ -7585,9 +7403,8 @@ test("empty grouped kanban with sample data: add a column and delete it right aw
         type: "kanban",
         arch: `
             <kanban sample="1">
-                <field name="product_id"/>
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field name="foo"/>
                     </div>
                 </templates>
@@ -7645,7 +7462,7 @@ test.tags("desktop")("kanban with sample data: do an on_create action", async ()
         arch: `
             <kanban sample="1" on_create="myCreateAction">
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field name="foo"/>
                     </div>
                 </templates>
@@ -7689,7 +7506,7 @@ test("kanban with sample data grouped by m2o and existing groups", async () => {
         arch: `
             <kanban sample="1">
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field name="product_id"/>
                     </div>
                 </templates>
@@ -7711,11 +7528,8 @@ test.tags("desktop")("bounce create button when no data and click on empty area"
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                    <div>
-                        <t t-esc="record.foo.value"/>
+                    <t t-name="kanban-card">
                         <field name="foo"/>
-                    </div>
                     </t>
                 </templates>
             </kanban>`,
@@ -7748,7 +7562,7 @@ test("buttons with modifiers", async () => {
                 <field name="bar"/>
                 <field name="state"/>
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <button class="o_btn_test_1" type="object" name="a1" invisible="foo != 'yop'"/>
                         <button class="o_btn_test_2" type="object" name="a2" invisible="bar and state not in ['abc', 'def']"/>
                     </div>
@@ -7777,7 +7591,7 @@ test("support styling of anchor tags with action type", async function (assert) 
         arch: `
             <kanban>
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field name="foo"/>
                         <a type="action" name="42" class="btn-primary" style="margin-left: 10px"><i class="oi oi-arrow-right"/> Click me !</a>
                     </div>
@@ -7807,7 +7621,7 @@ test("button executes action and reloads", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field name="foo"/>
                         <button type="object" name="a1" class="a1"/>
                     </div>
@@ -7850,9 +7664,8 @@ test("button executes action and check domain", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="active"/>
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field name="foo"/>
                         <button type="object" name="a1" />
                         <button type="object" name="toggle_active" class="toggle-active" />
@@ -7877,10 +7690,8 @@ test("field tag with modifiers but no widget", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo" invisible="id == 1"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo" invisible="id == 1"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -7897,10 +7708,8 @@ test("field tag with widget and class attributes", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo" widget="char" class="hi"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo" widget="char" class="hi"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -7918,14 +7727,10 @@ test("rendering date and datetime (value)", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="date"/>
-                <field name="datetime"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <span class="date" t-esc="record.date.value"/>
-                            <span class="datetime" t-esc="record.datetime.value"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field class="date" name="date"/>
+                        <field class="datetime" name="datetime"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -7949,11 +7754,9 @@ test("rendering date and datetime (raw value)", async () => {
                 <field name="date"/>
                 <field name="datetime"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <span class="date" t-esc="record.date.raw_value"/>
-                            <span class="datetime" t-esc="record.datetime.raw_value"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <span class="date" t-esc="record.date.raw_value"/>
+                        <span class="datetime" t-esc="record.datetime.raw_value"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -7975,15 +7778,12 @@ test("rendering many2one (value)", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-            <field name="product_id"/>
-            <templates>
-                <t t-name="kanban-box">
-                    <div>
-                        <span class="product_id" t-esc="record.product_id.value"/>
-                    </div>
-                </t>
-            </templates>
-        </kanban>`,
+                <templates>
+                    <t t-name="kanban-card">
+                        <field name="product_id" class="product_id"/>
+                    </t>
+                </templates>
+            </kanban>`,
     });
 
     expect(getKanbanRecordTexts()).toEqual(["hello", "", "hello", "xmo"]);
@@ -7999,10 +7799,8 @@ test("rendering many2one (raw value)", async () => {
             <kanban>
                 <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <span class="product_id" t-esc="record.product_id.raw_value"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <span class="product_id" t-esc="record.product_id.raw_value"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -8022,11 +7820,9 @@ test("evaluate conditions on relational fields", async () => {
                 <field name="product_id"/>
                 <field name="category_ids"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <button t-if="!record.product_id.raw_value" class="btn_a">A</button>
-                            <button t-if="!record.category_ids.raw_value.length" class="btn_b">B</button>
-                        </div>
+                    <t t-name="kanban-card">
+                        <button t-if="!record.product_id.raw_value" class="btn_a">A</button>
+                        <button t-if="!record.category_ids.raw_value.length" class="btn_b">B</button>
                     </t>
                 </templates>
             </kanban>`,
@@ -8051,11 +7847,9 @@ test.tags("desktop")("resequence columns in grouped by m2o", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="bar" />
-                <field name="product_id" readonly="not bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="id"/></div>
+                    <t t-name="kanban-card">
+                        <field name="id"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -8104,10 +7898,9 @@ test.tags("desktop")("resequence all when creating new record + partial resequen
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="id"/></div>
+                    <t t-name="kanban-card">
+                        <field name="id"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -8148,10 +7941,9 @@ test("prevent resequence columns if groups_draggable=false", async () => {
         resModel: "partner",
         arch: `
             <kanban groups_draggable='0'>
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                    <div><field name="id"/></div>
+                    <t t-name="kanban-card">
+                        <field name="id"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -8184,10 +7976,9 @@ test("open config dropdown on kanban with records and groups draggable off", asy
         resModel: "partner",
         arch: `
             <kanban groups_draggable='0' records_draggable='0'>
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                    <div><field name="id"/></div>
+                    <t t-name="kanban-card">
+                        <field name="id"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -8208,15 +7999,12 @@ test("properly evaluate more complex domains", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="foo"/>
                 <field name="bar"/>
                 <field name="category_ids"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                            <button type="object" invisible="bar or category_ids" class="btn btn-primary float-end" name="arbitrary">Join</button>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
+                        <button type="object" invisible="bar or category_ids" class="btn btn-primary float-end" name="arbitrary">Join</button>
                     </t>
                 </templates>
             </kanban>`,
@@ -8386,10 +8174,8 @@ test("load more records in column", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="id"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="id"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -8439,11 +8225,9 @@ test("load more records in column with x2many", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                    <div>
+                    <t t-name="kanban-card">
                         <field name="category_ids"/>
                         <field name="foo"/>
-                    </div>
                     </t>
                 </templates>
             </kanban>`,
@@ -8479,8 +8263,8 @@ test("update buttons after column creation", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -8510,11 +8294,10 @@ test.tags("desktop")("group_by_tooltip option when grouping on a many2one", asyn
         resModel: "partner",
         arch: `
             <kanban default_group_by="bar">
-                <field name="bar"/>
                 <field name="product_id" options='{"group_by_tooltip": {"name": "Kikou"}}'/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -8579,11 +8362,10 @@ test.tags("desktop")("asynchronous tooltips when grouped", async () => {
         resModel: "partner",
         arch: `
             <kanban default_group_by="product_id">
-                <field name="bar"/>
                 <field name="product_id" options='{"group_by_tooltip": {"name": "Name"}}'/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -8622,11 +8404,10 @@ test.tags("desktop")("loads data tooltips only when first opening", async () => 
         resModel: "partner",
         arch: `
             <kanban default_group_by="product_id">
-                <field name="bar"/>
-                <field name="product_id"  options='{"group_by_tooltip": {"name": "Name"}}'/>
+                <field name="product_id" options='{"group_by_tooltip": {"name": "Name"}}'/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -8657,10 +8438,9 @@ test.tags("desktop")("move a record then put it again in the same column", async
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="display_name"/></div>
+                    <t t-name="kanban-card">
+                        <field name="display_name"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -8708,10 +8488,9 @@ test.tags("desktop")("resequence a record twice", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="display_name"/></div>
+                    <t t-name="kanban-card">
+                        <field name="display_name"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -8777,13 +8556,10 @@ test("basic support for widgets (being Owl Components)", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="foo"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <t t-esc="record.foo.value"/>
-                            <widget name="test"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
+                        <widget name="test"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -8813,13 +8589,10 @@ test("kanban card: record value should be updated", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="foo"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <div class="foo" t-esc="record.foo.value"/>
-                            <widget name="test"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo" class="foo"/>
+                        <widget name="test"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -8842,14 +8615,10 @@ test("column progressbars properly work", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="bar"/>
-                <field name="int_field"/>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -8882,11 +8651,10 @@ test("filter on progressbar in new groups", async () => {
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
-                <field name="bar"/>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -8934,14 +8702,10 @@ test('column progressbars: "false" bar is clickable', async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="bar"/>
-                <field name="int_field"/>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -8995,15 +8759,10 @@ test('column progressbars: "false" bar with sum_field', async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="bar"/>
-                <field name="int_field"/>
-                <field name="foo"/>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -9043,14 +8802,10 @@ test("column progressbars should not crash in non grouped views", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="bar"/>
-                <field name="int_field"/>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -9081,13 +8836,10 @@ test("column progressbars: creating a new column should create a new progressbar
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="product_id"/>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -9127,10 +8879,8 @@ test("column progressbars on quick create properly update counter", async () => 
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -9176,10 +8926,8 @@ test("column progressbars are working with load more", async () => {
             <kanban limit="1">
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="id"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="id"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -9220,10 +8968,9 @@ test("column progressbars with an active filter are working with load more", asy
         arch: `
             <kanban limit="1">
                 <progressbar field="foo" colors='{"blork": "success"}'/>
-                <field name="foo"/>
                 <templates>
-                    <t t-name="kanban-box">
-                    <div><field name="id"/></div>
+                    <t t-name="kanban-card">
+                        <field name="id"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -9263,15 +9010,10 @@ test("column progressbars on archiving records update counter", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="active"/>
-                <field name="bar"/>
-                <field name="int_field"/>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -9318,15 +9060,10 @@ test("kanban with progressbars: correctly update env when archiving records", as
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="active"/>
-                <field name="bar"/>
-                <field name="int_field"/>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="id"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="id"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -9364,14 +9101,10 @@ test("RPCs when (re)loading kanban view progressbars", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-            <field name="bar"/>
-            <field name="int_field"/>
             <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
             <templates>
-                <t t-name="kanban-box">
-                    <div>
-                        <field name="foo"/>
-                    </div>
+                <t t-name="kanban-card">
+                    <field name="foo"/>
                 </t>
             </templates>
         </kanban>`,
@@ -9408,12 +9141,10 @@ test("RPCs when (de)activating kanban view progressbar filters", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="bar"/>
-                <field name="int_field"/>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -9471,10 +9202,8 @@ test.tags("desktop")("drag & drop records grouped by m2o with progressbar", asyn
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="int_field"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="int_field"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -9551,10 +9280,8 @@ test.tags("desktop")("d&d records grouped by date with progressbar with aggregat
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="int_field"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="int_field"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -9595,10 +9322,8 @@ test("progress bar subgroup count recompute", async () => {
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -9633,10 +9358,8 @@ test.tags("desktop")("progress bar recompute after d&d to and from other column"
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -9682,10 +9405,8 @@ test("progress bar recompute after filter selection", async () => {
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -9737,10 +9458,8 @@ test("progress bar recompute after filter selection (aggregates)", async () => {
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -9799,10 +9518,8 @@ test("progress bar with aggregates: activate bars (grouped by boolean)", async (
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -9837,10 +9554,8 @@ test("progress bar with aggregates: activate bars (grouped by many2one)", async 
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -9875,10 +9590,8 @@ test("progress bar with aggregates: activate bars (grouped by date)", async () =
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -9917,10 +9630,8 @@ test("progress bar with aggregates: Archive All in a column", async () => {
         arch: `
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
-                <templates><t t-name="kanban-box">
-                    <div>
+                <templates><t t-name="kanban-card">
                         <field name="foo"/>
-                    </div>
                 </t></templates>
             </kanban>`,
         groupBy: ["bar"],
@@ -9955,14 +9666,9 @@ test.tags("desktop")("load more should load correct records after drag&drop even
         resModel: "partner",
         arch: `
             <kanban limit="1">
-                <field name="id"/>
-                <field name="foo"/>
-                <field name="sequence"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="id"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="id"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -9995,11 +9701,10 @@ test.tags("desktop")("column progressbars on quick create with quick_create_view
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
-                <field name="int_field"/>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -10047,12 +9752,10 @@ test.tags("desktop")("progressbars and active filter with quick_create_view", as
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create" quick_create_view="some_view_ref">
-                <field name="int_field"/>
-                <field name="foo"/>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -10126,12 +9829,9 @@ test.tags("desktop")("quickcreate in first column after moving a record from it"
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="int_field"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -10152,199 +9852,6 @@ test.tags("desktop")("quickcreate in first column after moving a record from it"
     );
 });
 
-test("test displaying image (URL, image field not set)", async () => {
-    patchWithCleanup(KanbanCompiler.prototype, {
-        compileImage(el) {
-            el.setAttribute("t-att-data-src", el.getAttribute("t-att-src"));
-            el.removeAttribute("t-att-src");
-            return super.compileImage(el);
-        },
-    });
-    await mountView({
-        type: "kanban",
-        resModel: "partner",
-        arch: `
-            <kanban>
-                <field name="id"/>
-                <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <img t-att-src="kanban_image('partner', 'image', record.id.raw_value)"/>
-                        </div>
-                    </t>
-                </templates>
-            </kanban>`,
-    });
-
-    // since the field image is not set, kanban_image will generate an URL
-    expect(queryAll(`.o_kanban_record img`).map((img) => img.dataset.src.split("?")[0])).toEqual([
-        `${getOrigin()}/web/image/partner/1/image`,
-        `${getOrigin()}/web/image/partner/2/image`,
-        `${getOrigin()}/web/image/partner/3/image`,
-        `${getOrigin()}/web/image/partner/4/image`,
-    ]);
-    expect(queryFirst(".o_kanban_record img").loading).toBe("lazy");
-});
-
-test("test displaying image (write_date field)", async () => {
-    // the presence of write_date field ensures that the image is reloaded when necessary
-    expect.assertions(2);
-
-    patchWithCleanup(KanbanCompiler.prototype, {
-        compileImage(el) {
-            el.setAttribute("t-att-data-src", el.getAttribute("t-att-src"));
-            el.removeAttribute("t-att-src");
-            return super.compileImage(el);
-        },
-    });
-
-    const rec = Partner._records.find((r) => r.id === 1);
-    rec.write_date = "2022-08-05 08:37:00";
-
-    onRpc("web_search_read", ({ kwargs }) => {
-        expect(kwargs.specification).toEqual({ id: {}, write_date: {} });
-    });
-
-    await mountView({
-        type: "kanban",
-        resModel: "partner",
-        arch: `
-            <kanban>
-                <field name="id"/>
-                <templates>
-                    <t t-name="kanban-box"><div>
-                    <img t-att-src="kanban_image('partner', 'image', record.id.raw_value)"/>
-                    </div></t>
-                </templates>
-            </kanban>`,
-        domain: [["id", "in", [1]]],
-    });
-
-    expect(
-        `.o_kanban_record img[data-src='${getOrigin()}/web/image/partner/1/image?unique=1659688620000']`
-    ).toHaveCount(1);
-});
-
-test("test displaying image (binary & placeholder)", async () => {
-    patchWithCleanup(KanbanCompiler.prototype, {
-        compileImage(el) {
-            el.setAttribute("t-att-data-src", el.getAttribute("t-att-src"));
-            el.removeAttribute("t-att-src");
-            return super.compileImage(el);
-        },
-    });
-
-    Partner._fields.image = fields.Binary();
-    Partner._records[0].image = "R0lGODlhAQABAAD/ACwAAAAAAQABAAACAA==";
-
-    await mountView({
-        type: "kanban",
-        resModel: "partner",
-        arch: `
-            <kanban>
-                <field name="id"/>
-                <field name="image"/>
-                <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <img t-att-src="kanban_image('partner', 'image', record.id.raw_value)"/>
-                        </div>
-                    </t>
-                </templates>
-            </kanban>`,
-    });
-
-    expect(queryAll(`.o_kanban_record img`).map((img) => img.dataset.src.split("?")[0])).toEqual([
-        "data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACAA==",
-        `${getOrigin()}/web/image/partner/2/image`,
-        `${getOrigin()}/web/image/partner/3/image`,
-        `${getOrigin()}/web/image/partner/4/image`,
-    ]);
-});
-
-test("test displaying image (for another record)", async () => {
-    patchWithCleanup(KanbanCompiler.prototype, {
-        compileImage(el) {
-            el.setAttribute("t-att-data-src", el.getAttribute("t-att-src"));
-            el.removeAttribute("t-att-src");
-            return super.compileImage(el);
-        },
-    });
-
-    Partner._fields.image = fields.Binary();
-    Partner._records[0].image = "R0lGODlhAQABAAD/ACwAAAAAAQABAAACAA==";
-
-    await mountView({
-        type: "kanban",
-        resModel: "partner",
-        arch: `
-            <kanban>
-                <field name="id"/>
-                <field name="image"/>
-                <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <img t-att-src="kanban_image('partner', 'image', 1)"/>
-                        </div>
-                    </t>
-                </templates>
-            </kanban>`,
-    });
-
-    // the field image is set, but we request the image for a specific id
-    // -> for the record matching the ID, the base64 should be returned
-    // -> for all the other records, the image should be displayed by url
-    expect(queryAll(`.o_kanban_record img`).map((img) => img.dataset.src.split("?")[0])).toEqual([
-        "data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACAA==",
-        `${getOrigin()}/web/image/partner/1/image`,
-        `${getOrigin()}/web/image/partner/1/image`,
-        `${getOrigin()}/web/image/partner/1/image`,
-    ]);
-});
-
-test("test displaying image from m2o field (m2o field not set)", async () => {
-    patchWithCleanup(KanbanCompiler.prototype, {
-        compileImage(el) {
-            el.setAttribute("t-att-data-src", el.getAttribute("t-att-src"));
-            el.removeAttribute("t-att-src");
-            return super.compileImage(el);
-        },
-    });
-
-    class FooPartner extends models.Model {
-        _name = "foo.partner";
-
-        name = fields.Char();
-        partner_id = fields.Many2one({ relation: "partner" });
-
-        _records = [
-            { id: 1, name: "foo_with_partner_image", partner_id: 1 },
-            { id: 2, name: "foo_no_partner" },
-        ];
-    }
-    defineModels([FooPartner]);
-
-    await mountView({
-        type: "kanban",
-        resModel: "foo.partner",
-        arch: `
-            <kanban>
-                <templates>
-                    <div t-name="kanban-box">
-                        <field name="name"/>
-                        <field name="partner_id"/>
-                        <img t-att-src="kanban_image('partner', 'image', record.partner_id.raw_value)"/>
-                    </div>
-                </templates>
-            </kanban>`,
-    });
-
-    expect(queryAll(`.o_kanban_record img`).map((img) => img.dataset.src.split("?")[0])).toEqual([
-        `${getOrigin()}/web/image/partner/1/image`,
-        `${getOrigin()}/web/image/partner/null/image`,
-    ]);
-});
-
 test.tags("desktop")("grouped kanban: clear groupby when reloading", async () => {
     // in this test, we simulate that clearing the domain is slow, so that
     // clearing the groupby does not corrupt the data handled while
@@ -10363,12 +9870,9 @@ test.tags("desktop")("grouped kanban: clear groupby when reloading", async () =>
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -10406,10 +9910,8 @@ test.tags("desktop")("quick_create on grouped kanban without column", async () =
         arch: `
             <kanban group_create="0" on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -10430,11 +9932,8 @@ test("keynav: right/left", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <t t-esc="record.foo.value"/>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -10457,12 +9956,9 @@ test("keynav: down, with focus is inside a card", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <t t-esc="record.foo.value"/>
-                            <field name="foo"/>
-                            <a href="#" class="o-this-is-focussable">ho! this is focussable</a>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
+                        <a href="#" class="o-this-is-focussable">ho! this is focussable</a>
                     </t>
                 </templates>
             </kanban>`,
@@ -10480,12 +9976,9 @@ test.tags("desktop")("keynav: grouped kanban", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -10561,12 +10054,9 @@ test.tags("desktop")("keynav: grouped kanban with empty columns", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -10613,10 +10103,8 @@ test.tags("desktop")("keynav: no global_click, press ENTER on card with a link",
         arch: `
             <kanban can_open="0">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <a type="archive">Archive</a>
-                        </div>
+                    <t t-name="kanban-card">
+                        <a type="archive">Archive</a>
                     </t>
                 </templates>
             </kanban>`,
@@ -10644,10 +10132,8 @@ test.tags("desktop")("keynav: kanban with global_click", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                         <a name="action_test" type="object" />
                     </t>
                 </templates>
@@ -10702,13 +10188,9 @@ test.tags("desktop")("set cover image", async () => {
                     <t t-name="kanban-menu">
                         <a type="set_cover" data-field="displayed_image_id" class="dropdown-item">Set Cover Image</a>
                     </t>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                            <div>
-                                <field name="displayed_image_id" widget="attachment_image"/>
-                            </div>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
+                        <field name="displayed_image_id" widget="attachment_image"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -10788,13 +10270,9 @@ test.tags("desktop")("open file explorer if no cover image", async () => {
                     <t t-name="kanban-menu">
                         <a type="set_cover" data-field="displayed_image_id" class="dropdown-item">Set Cover Image</a>
                     </t>
-                    <t t-name="kanban-box">
-                        <div class="oe_kanban_global_click">
-                            <field name="foo"/>
-                            <div>
-                                <field name="displayed_image_id" widget="attachment_image"/>
-                            </div>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
+                        <field name="displayed_image_id" widget="attachment_image"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -10857,13 +10335,9 @@ test.tags("desktop")("unset cover image", async () => {
                     <t t-name="kanban-menu">
                         <a type="set_cover" data-field="displayed_image_id" class="dropdown-item">Set Cover Image</a>
                     </t>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                            <div>
-                                <field name="displayed_image_id" widget="attachment_image"/>
-                            </div>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
+                        <field name="displayed_image_id" widget="attachment_image"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -10925,10 +10399,8 @@ test.tags("desktop")("ungrouped kanban with handle field", async () => {
             <kanban>
                 <field name="int_field" widget="handle" />
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -10953,10 +10425,8 @@ test("ungrouped kanban without handle field", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -10982,10 +10452,8 @@ test("click on image field in kanban (with default global_click)", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="image" widget="image"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="image" widget="image"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -11008,8 +10476,8 @@ test("kanban view with boolean field", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="bar"/></div>
+                    <t t-name="kanban-card">
+                        <field name="bar"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -11027,8 +10495,8 @@ test("kanban view with boolean widget", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="bar" widget="boolean"/></div>
+                    <t t-name="kanban-card">
+                        <field name="bar" widget="boolean"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -11046,8 +10514,8 @@ test("kanban view with boolean toggle widget", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="bar" widget="boolean_toggle"/></div>
+                    <t t-name="kanban-card">
+                        <field name="bar" widget="boolean_toggle"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -11076,8 +10544,8 @@ test("kanban view with monetary and currency fields without widget", async () =>
             <kanban>
                 <field name="currency_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="salary"/></div>
+                    <t t-name="kanban-card">
+                        <field name="salary"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -11095,9 +10563,8 @@ test.tags("desktop")("quick create: keyboard navigation to buttons", async () =>
     await mountView({
         arch: `
             <kanban on_create="quick_create">
-                <field name="bar"/>
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field name="display_name"/>
                     </div>
                 </templates>
@@ -11137,15 +10604,12 @@ test("kanban with isHtmlEmpty method", async () => {
         resModel: "product",
         arch: `
             <kanban>
-                <field name="description"/>
                 <templates>
-                    <t t-name="kanban-box">
-                    <div>
+                    <t t-name="kanban-card">
                         <field name="display_name"/>
                         <div class="test" t-if="!widget.isHtmlEmpty(record.description.raw_value)">
-                            <t t-out="record.description.value"/>
+                            <field name="description"/>
                         </div>
-                    </div>
                     </t>
                 </templates>
             </kanban>`,
@@ -11172,14 +10636,10 @@ test("progressbar filter state is kept unchanged when domain is updated (records
         arch: `
             <kanban default_group_by="bar">
                 <progressbar field="foo" colors='{"yop": "success", "blip": "danger"}'/>
-                <field name="foo"/>
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="id"/>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="id"/>
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -11250,10 +10710,8 @@ test("progressbar filter state is kept unchanged when domain is updated (emptyin
         arch: `
             <kanban default_group_by="bar">
                 <progressbar field="foo" colors='{"yop": "success", "blip": "danger"}'/>
-                <field name="foo"/>
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
+                    <t t-name="kanban-card">
                         <div>
                             <field name="id"/>
                             <field name="foo"/>
@@ -11339,10 +10797,8 @@ test.tags("desktop")("filtered column counters when dropping in non-matching rec
         arch: `
             <kanban default_group_by="bar">
                 <progressbar field="foo" colors='{"yop": "success", "blip": "danger"}'/>
-                <field name="foo"/>
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
+                    <t t-name="kanban-card">
                         <div>
                             <field name="id"/>
                             <field name="foo"/>
@@ -11409,10 +10865,8 @@ test.tags("desktop")("filtered column is reloaded when dragging out its last rec
         arch: `
             <kanban default_group_by="bar">
                 <progressbar field="foo" colors='{"yop": "success", "blip": "danger"}'/>
-                <field name="foo"/>
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
+                    <t t-name="kanban-card">
                         <div>
                             <field name="id"/>
                             <field name="foo"/>
@@ -11492,10 +10946,8 @@ test("kanban widget can extract props from attrs", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <widget name="widget_test_option" title="Widget with Option"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <widget name="widget_test_option" title="Widget with Option"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -11523,10 +10975,8 @@ test("action/type attributes on kanban arch, type='object'", async () => {
         arch: `
             <kanban action="a1" type="object">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <p>some value</p><field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <p>some value</p><field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -11558,10 +11008,8 @@ test("action/type attributes on kanban arch, type='action'", async () => {
         arch: `
             <kanban action="a1" type="action">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <p>some value</p><field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <p>some value</p><field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -11586,7 +11034,7 @@ test("Missing t-key is automatically filled with a warning", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
+                    <t t-name="kanban-card">
                         <div>
                             <span t-foreach="[1, 2, 3]" t-as="i" t-esc="i" />
                         </div>
@@ -11616,10 +11064,8 @@ test("Quick created record is rendered after load", async () => {
                 <field name="category_ids" />
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <span t-esc="record.category_ids.raw_value.length" />
-                        </div>
+                    <t t-name="kanban-card">
+                        <span t-esc="record.category_ids.raw_value.length" />
                     </t>
                 </templates>
             </kanban>`,
@@ -11650,7 +11096,7 @@ test("Allow use of 'editable'/'deletable' in ungrouped kanban", async () => {
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <button t-if="widget.editable">EDIT</button>
                         <button t-if="widget.deletable">DELETE</button>
                     </div>
@@ -11671,10 +11117,8 @@ test.tags("desktop")("folded groups kept when leaving/coming back", async () => 
         "kanban,false": `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="int_field"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="int_field"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -11722,10 +11166,8 @@ test.tags("desktop")("filter groups kept when leaving/coming back", async () => 
             <kanban>
                 <progressbar field="state" colors='{"abc": "success", "def": "warning", "ghi": "danger"}' />
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="id" />
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="id" />
                     </t>
                 </templates>
             </kanban>`,
@@ -11782,10 +11224,8 @@ test.tags("desktop")("folded groups kept when leaving/coming back (grouped by da
         "kanban,false": `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="int_field"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="int_field"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -11831,10 +11271,8 @@ test.tags("desktop")("loaded records kept when leaving/coming back", async () =>
         "kanban,false": `
             <kanban limit="1">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="int_field"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="int_field"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -11880,10 +11318,8 @@ test("basic rendering with 2 groupbys", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo" />
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo" />
                     </t>
                 </templates>
             </kanban>`,
@@ -11919,10 +11355,8 @@ test("basic rendering with a date groupby with a granularity", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo" />
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo" />
                     </t>
                 </templates>
             </kanban>`,
@@ -11949,12 +11383,9 @@ test.tags("desktop")("quick create record and click outside (no dirty input)", a
         resModel: "partner",
         arch: `
             <kanban limit="2">
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -12008,12 +11439,9 @@ test.tags("desktop")("quick create record and click outside (with dirty input)",
         resModel: "partner",
         arch: `
             <kanban limit="2">
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -12076,12 +11504,9 @@ test("quick create record and click on 'Load more'", async () => {
         resModel: "partner",
         arch: `
             <kanban limit="2">
-                <field name="bar"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -12114,7 +11539,7 @@ test("dropdown is closed on item click", async () => {
                     <t t-name="kanban-menu">
                         <a role="menuitem" class="dropdown-item">Item</a>
                     </t>
-                    <t t-name="kanban-box">
+                    <t t-name="kanban-card">
                         <div/>
                     </t>
                 </templates>
@@ -12142,7 +11567,7 @@ test("can use JSON in kanban template", async () => {
             <kanban>
                 <field name="foo"/>
                 <templates>
-                    <t t-name="kanban-box">
+                    <t t-name="kanban-card">
                         <div>
                             <span t-foreach="JSON.parse(record.foo.raw_value)" t-as="v" t-key="v_index" t-esc="v"/>
                         </div>
@@ -12166,14 +11591,10 @@ test("Color '200' (gray) can be used twice (for false value and another value) i
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="bar"/>
-                <field name="foo"/>
                 <progressbar field="foo" colors='{"yop": "200", "gnap": "warning", "blip": "danger"}'/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="state"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="state"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -12236,7 +11657,7 @@ test("update field on which progress bars are computed", async () => {
             <kanban>
                 <progressbar field="state" colors='{"abc": "success", "def": "warning", "ghi": "danger"}' />
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field name="state" widget="state_selection" />
                         <field name="id" />
                     </div>
@@ -12332,7 +11753,7 @@ test("load more button shouldn't be visible when unfiltering column", async () =
             <kanban>
                 <progressbar field="state" colors='{"abc": "success", "def": "warning", "ghi": "danger"}' />
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field name="state" widget="state_selection" />
                         <field name="id" />
                     </div>
@@ -12389,7 +11810,7 @@ test("click on the progressBar of a new column", async () => {
             <kanban on_create="quick_create">
                 <progressbar field="state" colors='{"abc": "success", "def": "warning", "ghi": "danger"}' />
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field name="state" widget="state_selection" />
                         <field name="id" />
                     </div>
@@ -12427,10 +11848,8 @@ test.tags("desktop")("keep focus in cp when pressing arrowdown and no kanban car
         arch: `
             <kanban on_create="quick_create">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="display_name"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="display_name"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -12482,12 +11901,9 @@ test.tags("desktop")("no leak of TransactionInProgress (grouped case)", async ()
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="state"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -12557,10 +11973,8 @@ test.tags("desktop")("no leak of TransactionInProgress (not grouped case)", asyn
             <kanban records_draggable="1">
                 <field name="int_field" widget="handle" />
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -12629,7 +12043,7 @@ test("renders banner_route", async () => {
         arch: `
             <kanban banner_route="/mybody/isacage">
                 <templates>
-                    <t t-name="kanban-box">
+                    <t t-name="kanban-card">
                         <div/>
                     </t>
                 </templates>
@@ -12658,10 +12072,8 @@ test("fieldDependencies support for fields", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo" widget="custom_field"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo" widget="custom_field"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -12689,10 +12101,8 @@ test("fieldDependencies support for fields: dependence on a relational field", a
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo" widget="custom_field"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo" widget="custom_field"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -12714,10 +12124,8 @@ test("column quick create - title and placeholder", async function (assert) {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="int_field"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="int_field"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -12740,7 +12148,7 @@ test.tags("desktop")("fold a column and drag record on it should not unfold it",
         arch: `
             <kanban>
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field name="id"/>
                     </div>
                 </templates>
@@ -12782,7 +12190,7 @@ test.tags("desktop")("drag record on initially folded column should not unfold i
         arch: `
             <kanban>
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field name="id"/>
                     </div>
                 </templates>
@@ -12815,7 +12223,7 @@ test.tags("desktop")("drag record to folded column, with progressbars", async ()
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field" />
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field name="id" />
                     </div>
                 </templates>
@@ -12874,13 +12282,10 @@ test.tags("desktop")("quick create record in grouped kanban in a form view dialo
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
+                    <t t-name="kanban-card">
                         <t t-if="record.foo.raw_value" t-set="foo"/>
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -12942,7 +12347,7 @@ test.tags("desktop")("no sample data when all groups are folded then one is unfo
         arch: `
             <kanban sample="1">
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field name="id"/>
                     </div>
                 </templates>
@@ -12974,7 +12379,7 @@ test.tags("desktop")("no content helper, all groups folded with (unloaded) recor
         arch: `
             <kanban>
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field name="id"/>
                     </div>
                 </templates>
@@ -12997,7 +12402,7 @@ test.tags("desktop")("Move multiple records in different columns simultaneously"
         arch: `
             <kanban>
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field name="id" />
                     </div>
                 </templates>
@@ -13034,7 +12439,7 @@ test.tags("desktop")("drag & drop: content scrolls when reaching the edges", asy
         arch: `
             <kanban>
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field name="id" />
                     </div>
                 </templates>
@@ -13110,7 +12515,7 @@ test("attribute default_order", async () => {
         arch: `
             <kanban default_order="int">
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field name="int" />
                     </div>
                 </templates>
@@ -13134,10 +12539,8 @@ test.tags("desktop")("d&d records grouped by m2o with m2o displayed in records",
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="product_id" widget="many2one"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="product_id" widget="many2one"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -13173,7 +12576,7 @@ test("Can't use KanbanRecord implementation details in arch", async () => {
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
+                    <t t-name="kanban-card">
                         <div>
                             <t t-esc="__owl__"/>
                             <t t-esc="props"/>
@@ -13216,10 +12619,8 @@ test.tags("desktop")("rerenders only once after resequencing records", async () 
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -13319,7 +12720,7 @@ test("sample server: _mockWebReadGroup API", async () => {
         arch: `
             <kanban sample="1">
                 <templates>
-                    <div t-name="kanban-box">
+                    <div t-name="kanban-card">
                         <field name="display_name"/>
                     </div>
                 </templates>
@@ -13359,7 +12760,7 @@ test.tags("desktop")("scroll on group unfold and progressbar click", async () =>
             <kanban>
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}' sum_field="int_field" />
                 <templates>
-                    <t t-name="kanban-box">Record</t>
+                    <t t-name="kanban-card">Record</t>
                 </templates>
             </kanban>`,
         groupBy: ["product_id"],
@@ -13461,12 +12862,9 @@ test.tags("desktop")("action button in controlPanel with display='always'", asyn
                     <button name="display" type="object" class="display_invisible_2" string="invisible context" display="always" invisible="context.get('a')"/>
                     <button name="default-selection" type="object" class="default-selection" string="default-selection"/>
                 </header>
-                <field name="bar" />
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo" />
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo" />
                     </t>
                 </templates>
             </kanban>`,
@@ -13492,7 +12890,7 @@ test.tags("desktop")("Keep scrollTop when loading records with load more", async
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
+                    <t t-name="kanban-card">
                         <div style="height:1000px;"><field name="id"/></div>
                     </t>
                 </templates>
@@ -13516,12 +12914,9 @@ test("Kanban: no reset of the groupby when a non-empty column is deleted", async
         resModel: "partner",
         arch: `
             <kanban default_group_by="product_id">
-                <field name="foo"/>
-                <field name="product_id"/>
-                <field name="category_ids"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -13571,10 +12966,9 @@ test.tags("desktop")("searchbar filters are displayed directly", async () => {
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="foo"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -13607,10 +13001,9 @@ test("searchbar filters are displayed directly (with progressbar)", async () => 
         arch: `
             <kanban>
                 <progressbar field="state" colors='{"abc": "success", "def": "warning", "ghi": "danger"}' />
-                <field name="foo"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -13744,13 +13137,10 @@ test.tags("desktop")("group by properties and drag and drop", async () => {
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                            <field name="properties"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
+                        <field name="properties"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -13807,7 +13197,7 @@ test("kanbans with basic and custom compiler, same arch", async () => {
     Partner._views["kanban,false"] = `
         <kanban js_class="my_kanban">
             <templates>
-                <t t-name="kanban-box">
+                <t t-name="kanban-card">
                     <div><field name="foo"/></div>
                 </t>
             </templates>
@@ -13846,10 +13236,8 @@ test("grouped on field with readonly expression depending on context", async () 
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="product_id" readonly="context.get('abc')" />
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="product_id" readonly="context.get('abc')" />
                     </t>
                 </templates>
             </kanban>`,
@@ -13879,11 +13267,9 @@ test.tags("desktop")("grouped on field with readonly expression depending on fie
         arch: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo" />
-                            <field name="product_id" readonly="foo == 'yop'" />
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo" />
+                        <field name="product_id" readonly="foo == 'yop'" />
                     </t>
                 </templates>
             </kanban>`,
@@ -13907,10 +13293,9 @@ test.tags("desktop")("quick create a column by pressing enter when input is focu
         resModel: "partner",
         arch: `
             <kanban>
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -13942,10 +13327,9 @@ test("Correct values for progress bar with toggling filter and slow RPC", async 
         arch: `
             <kanban>
                 <progressbar field="state" colors='{"abc": "success", "def": "warning", "ghi": "danger"}' />
-                <field name="foo"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -14002,10 +13386,9 @@ test.tags("desktop")("click on empty kanban must shake the NEW button", async ()
         resModel: "partner",
         arch: `
             <kanban on_create="quick_create">
-                <field name="product_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,

--- a/addons/web/static/tests/views/kanban/kanban_view_legacy.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view_legacy.test.js
@@ -1,0 +1,2258 @@
+import { after, beforeEach, expect, test } from "@odoo/hoot";
+import {
+    click,
+    dblclick,
+    queryAll,
+    queryAllTexts,
+    queryFirst,
+    queryOne,
+    queryText,
+    setInputFiles,
+} from "@odoo/hoot-dom";
+import { FileInput } from "@web/core/file_input/file_input";
+import { Deferred, animationFrame } from "@odoo/hoot-mock";
+import { Component, onRendered, xml } from "@odoo/owl";
+import {
+    contains,
+    defineModels,
+    fields,
+    getDropdownMenu,
+    getKanbanColumn,
+    getKanbanColumnDropdownMenu,
+    getKanbanRecord,
+    getKanbanRecordTexts,
+    getService,
+    mockService,
+    models,
+    mountView,
+    mountWithCleanup,
+    onRpc,
+    patchWithCleanup,
+    stepAllNetworkCalls,
+    toggleKanbanColumnActions,
+    toggleKanbanRecordDropdown,
+    validateSearch,
+    webModels,
+} from "@web/../tests/web_test_helpers";
+
+import { currencies } from "@web/core/currency";
+import { registry } from "@web/core/registry";
+import { user } from "@web/core/user";
+import { getOrigin } from "@web/core/utils/urls";
+import { KanbanCompiler } from "@web/views/kanban/kanban_compiler";
+import { KanbanRecord } from "@web/views/kanban/kanban_record";
+import { KanbanRenderer } from "@web/views/kanban/kanban_renderer";
+import { kanbanView } from "@web/views/kanban/kanban_view";
+import { ViewButton } from "@web/views/view_button/view_button";
+import { AnimatedNumber } from "@web/views/view_components/animated_number";
+import { WebClient } from "@web/webclient/webclient";
+
+const { IrAttachment } = webModels;
+
+const fieldRegistry = registry.category("fields");
+const viewRegistry = registry.category("views");
+const viewWidgetRegistry = registry.category("view_widgets");
+
+async function createFileInput({ mockPost, mockAdd, props }) {
+    mockService("notification", {
+        add: mockAdd || (() => {}),
+    });
+    mockService("http", {
+        post: mockPost || (() => {}),
+    });
+    await mountWithCleanup(FileInput, { props });
+}
+
+class Partner extends models.Model {
+    _name = "partner";
+    _rec_name = "foo";
+
+    foo = fields.Char();
+    bar = fields.Boolean();
+    sequence = fields.Integer();
+    int_field = fields.Integer({ aggregator: "sum", sortable: true });
+    float_field = fields.Float({ aggregator: "sum" });
+    product_id = fields.Many2one({ relation: "product" });
+    category_ids = fields.Many2many({ relation: "category" });
+    date = fields.Date();
+    datetime = fields.Datetime();
+    state = fields.Selection({
+        type: "selection",
+        selection: [
+            ["abc", "ABC"],
+            ["def", "DEF"],
+            ["ghi", "GHI"],
+        ],
+    });
+    salary = fields.Monetary({ aggregator: "sum", currency_field: this.currency_id });
+    currency_id = fields.Many2one({ relation: "res.currency" });
+
+    _records = [
+        {
+            id: 1,
+            foo: "yop",
+            bar: true,
+            int_field: 10,
+            float_field: 0.4,
+            product_id: 3,
+            category_ids: [],
+            state: "abc",
+            salary: 1750,
+            currency_id: 1,
+        },
+        {
+            id: 2,
+            foo: "blip",
+            bar: true,
+            int_field: 9,
+            float_field: 13,
+            product_id: 5,
+            category_ids: [6],
+            state: "def",
+            salary: 1500,
+            currency_id: 1,
+        },
+        {
+            id: 3,
+            foo: "gnap",
+            bar: true,
+            int_field: 17,
+            float_field: -3,
+            product_id: 3,
+            category_ids: [7],
+            state: "ghi",
+            salary: 2000,
+            currency_id: 2,
+        },
+        {
+            id: 4,
+            foo: "blip",
+            bar: false,
+            int_field: -4,
+            float_field: 9,
+            product_id: 5,
+            category_ids: [],
+            state: "ghi",
+            salary: 2222,
+            currency_id: 1,
+        },
+    ];
+}
+
+class Product extends models.Model {
+    _name = "product";
+
+    name = fields.Char();
+
+    _records = [
+        { id: 3, name: "hello" },
+        { id: 5, name: "xmo" },
+    ];
+}
+
+class Category extends models.Model {
+    _name = "category";
+
+    name = fields.Char();
+    color = fields.Integer();
+
+    _records = [
+        { id: 6, name: "gold", color: 2 },
+        { id: 7, name: "silver", color: 5 },
+    ];
+}
+
+class Currency extends models.Model {
+    _name = "res.currency";
+
+    name = fields.Char();
+    symbol = fields.Char();
+    position = fields.Selection({
+        selection: [
+            ["after", "A"],
+            ["before", "B"],
+        ],
+    });
+
+    _records = [
+        { id: 1, name: "USD", symbol: "$", position: "before" },
+        { id: 2, name: "EUR", symbol: "€", position: "after" },
+    ];
+}
+
+defineModels([Partner, Product, Category, Currency, IrAttachment]);
+
+beforeEach(() => {
+    patchWithCleanup(AnimatedNumber, { enableAnimations: false });
+});
+
+test("display full is supported on fields", async () => {
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+        <kanban class="o_kanban_test">
+            <templates>
+                <t t-name="kanban-box">
+                    <field name="foo" display="full"/>
+                </t>
+            </templates>
+        </kanban>`,
+    });
+
+    expect(".o_kanban_record span.o_text_block").toHaveCount(4);
+    expect(queryFirst("span.o_text_block").textContent).toBe("yop");
+});
+
+test.tags("desktop")("basic grouped rendering", async () => {
+    expect.assertions(16);
+
+    patchWithCleanup(KanbanRenderer.prototype, {
+        setup() {
+            super.setup(...arguments);
+            onRendered(() => {
+                expect.step("rendered");
+            });
+        },
+    });
+
+    onRpc("web_read_group", ({ kwargs }) => {
+        // the lazy option is important, so the server can fill in the empty groups
+        expect(kwargs.lazy).toBe(true, { message: "should use lazy read_group" });
+    });
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban class="o_kanban_test">
+                <field name="bar" />
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <field name="foo" />
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+        groupBy: ["bar"],
+    });
+
+    expect(".o_kanban_view").toHaveClass("o_kanban_test");
+    expect(".o_kanban_renderer").toHaveClass("o_kanban_grouped");
+    expect(".o_control_panel_main_buttons button.o-kanban-button-new").toHaveCount(1);
+    expect(".o_kanban_group").toHaveCount(2);
+    expect(".o_kanban_group:first-child .o_kanban_record").toHaveCount(1);
+    expect(".o_kanban_group:nth-child(2) .o_kanban_record").toHaveCount(3);
+    expect.verifySteps(["rendered"]);
+
+    await toggleKanbanColumnActions(0);
+
+    // check available actions in kanban header's config dropdown
+    expect(".o-dropdown--menu .o_kanban_toggle_fold").toHaveCount(1);
+    expect(".o_kanban_header:first-child .o_kanban_config .o_column_edit").toHaveCount(0);
+    expect(".o_kanban_header:first-child .o_kanban_config .o_column_delete").toHaveCount(0);
+    expect(".o_kanban_header:first-child .o_kanban_config .o_column_archive_records").toHaveCount(
+        0
+    );
+    expect(".o_kanban_header:first-child .o_kanban_config .o_column_unarchive_records").toHaveCount(
+        0
+    );
+
+    // focuses the search bar and closes the dropdown
+    click(".o_searchview input");
+
+    // the next line makes sure that reload works properly.  It looks useless,
+    // but it actually test that a grouped local record can be reloaded without
+    // changing its result.
+    await validateSearch();
+    expect(".o_kanban_group:nth-child(2) .o_kanban_record").toHaveCount(3);
+    expect.verifySteps(["rendered"]);
+});
+
+test("basic grouped rendering with no record", async () => {
+    Partner._records = [];
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban class="o_kanban_test">
+                <field name="bar" />
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <field name="foo" />
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+        groupBy: ["bar"],
+    });
+    expect(".o_kanban_grouped").toHaveCount(1);
+    expect(".o_view_nocontent").toHaveCount(1);
+    expect(".o_control_panel_main_buttons button.o-kanban-button-new").toHaveCount(1, {
+        message:
+            "There should be a 'New' button even though there is no column when groupby is not a many2one",
+    });
+});
+
+test("grouped rendering with active field (archivable by default)", async () => {
+    // add active field on partner model and make all records active
+    Partner._fields.active = fields.Boolean({ default: true });
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <field name="active"/>
+                <field name="bar"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <field name="foo"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+        groupBy: ["bar"],
+    });
+
+    const clickColumnAction = await toggleKanbanColumnActions(1);
+
+    // check archive/restore all actions in kanban header's config dropdown
+    expect(".o_column_archive_records").toHaveCount(1, { root: getKanbanColumnDropdownMenu(0) });
+    expect(".o_column_unarchive_records").toHaveCount(1, { root: getKanbanColumnDropdownMenu(0) });
+    expect(".o_kanban_group").toHaveCount(2);
+    expect(queryAll(".o_kanban_record", { root: getKanbanColumn(0) })).toHaveCount(1);
+    expect(queryAll(".o_kanban_record", { root: getKanbanColumn(1) })).toHaveCount(3);
+
+    await clickColumnAction("Archive All");
+    expect(".o_dialog").toHaveCount(1);
+
+    await contains(".o_dialog footer .btn-primary").click();
+
+    expect(".o_kanban_group").toHaveCount(2);
+    expect(queryAll(".o_kanban_record", { root: getKanbanColumn(0) })).toHaveCount(1);
+    expect(queryAll(".o_kanban_record", { root: getKanbanColumn(1) })).toHaveCount(0);
+});
+
+test("context can be used in kanban template", async () => {
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="kanban-box">
+                    <div>
+                        <t t-if="context.some_key">
+                            <field name="foo"/>
+                        </t>
+                    </div>
+                    </t>
+                </templates>
+            </kanban>`,
+        context: { some_key: 1 },
+        domain: [["id", "=", 1]],
+    });
+
+    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(1);
+    expect(".o_kanban_record span:contains(yop)").toHaveCount(1);
+});
+
+test("user context can be used in kanban template", async () => {
+    patchWithCleanup(user, { context: { some_key: true } });
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <div t-name="kanban-box">
+                        <field t-if="user_context.some_key" name="foo"/>
+                    </div>
+                </templates>
+            </kanban>`,
+        domain: [["id", "=", 1]],
+    });
+
+    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(1);
+    expect(".o_kanban_record span:contains(yop)").toHaveCount(1);
+});
+
+test("kanban with sub-template", async () => {
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <t t-call="another-template"/>
+                        </div>
+                    </t>
+                    <t t-name="another-template">
+                        <span><field name="foo"/></span>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    expect(queryAllTexts(".o_kanban_record:not(.o_kanban_ghost)")).toEqual([
+        "yop",
+        "blip",
+        "gnap",
+        "blip",
+    ]);
+});
+
+test("kanban with t-set outside card", async () => {
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <field name="int_field"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <t t-set="x" t-value="record.int_field.value"/>
+                        <div>
+                            <t t-esc="x"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    expect(queryAllTexts(".o_kanban_record:not(.o_kanban_ghost)")).toEqual(["10", "9", "17", "-4"]);
+});
+
+test("kanban with t-if/t-else on field", async () => {
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <field t-if="record.int_field.value > -1" name="int_field"/>
+                            <t t-else="">Negative value</t>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    expect(queryAllTexts(".o_kanban_record:not(.o_kanban_ghost)")).toEqual([
+        "10",
+        "9",
+        "17",
+        "Negative value",
+    ]);
+});
+
+test("kanban with t-if/t-else on field with widget", async () => {
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <field t-if="record.int_field.value > -1" name="int_field" widget="integer"/>
+                            <t t-else="">Negative value</t>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    expect(queryAllTexts(".o_kanban_record:not(.o_kanban_ghost)")).toEqual([
+        "10",
+        "9",
+        "17",
+        "Negative value",
+    ]);
+});
+
+test("field with widget and dynamic attributes in kanban", async () => {
+    const myField = {
+        component: class MyField extends Component {
+            static template = xml`<span/>`;
+            static props = ["*"];
+        },
+        extractProps: ({ attrs }) => {
+            expect.step(
+                `${attrs["dyn-bool"]}/${attrs["interp-str"]}/${attrs["interp-str2"]}/${attrs["interp-str3"]}`
+            );
+        },
+    };
+    fieldRegistry.add("my_field", myField);
+    after(() => fieldRegistry.remove("my_field"));
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <field name="foo"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <field name="int_field" widget="my_field"
+                                t-att-dyn-bool="record.foo.value.length > 3"
+                                t-attf-interp-str="hello {{record.foo.value}}"
+                                t-attf-interp-str2="hello #{record.foo.value} !"
+                                t-attf-interp-str3="hello {{record.foo.value}} }}"
+                            />
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+    expect.verifySteps([
+        "false/hello yop/hello yop !/hello yop }}",
+        "true/hello blip/hello blip !/hello blip }}",
+        "true/hello gnap/hello gnap !/hello gnap }}",
+        "true/hello blip/hello blip !/hello blip }}",
+    ]);
+});
+
+test("view button and string interpolated attribute in kanban", async () => {
+    patchWithCleanup(ViewButton.prototype, {
+        setup() {
+            super.setup();
+            expect.step(`[${this.props.clickParams["name"]}] className: '${this.props.className}'`);
+        },
+    });
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <field name="foo"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <a name="one" type="object" class="hola"/>
+                            <a name="two" type="object" class="hola" t-attf-class="hello"/>
+                            <a name="sri" type="object" class="hola" t-attf-class="{{record.foo.value}}"/>
+                            <a name="foa" type="object" class="hola" t-attf-class="{{record.foo.value}} olleh"/>
+                            <a name="fye" type="object" class="hola" t-attf-class="hello {{record.foo.value}}"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+    expect.verifySteps([
+        "[one] className: 'hola oe_kanban_action oe_kanban_action_a'",
+        "[two] className: 'hola oe_kanban_action oe_kanban_action_a hello'",
+        "[sri] className: 'hola oe_kanban_action oe_kanban_action_a yop'",
+        "[foa] className: 'hola oe_kanban_action oe_kanban_action_a yop olleh'",
+        "[fye] className: 'hola oe_kanban_action oe_kanban_action_a hello yop'",
+        "[one] className: 'hola oe_kanban_action oe_kanban_action_a'",
+        "[two] className: 'hola oe_kanban_action oe_kanban_action_a hello'",
+        "[sri] className: 'hola oe_kanban_action oe_kanban_action_a blip'",
+        "[foa] className: 'hola oe_kanban_action oe_kanban_action_a blip olleh'",
+        "[fye] className: 'hola oe_kanban_action oe_kanban_action_a hello blip'",
+        "[one] className: 'hola oe_kanban_action oe_kanban_action_a'",
+        "[two] className: 'hola oe_kanban_action oe_kanban_action_a hello'",
+        "[sri] className: 'hola oe_kanban_action oe_kanban_action_a gnap'",
+        "[foa] className: 'hola oe_kanban_action oe_kanban_action_a gnap olleh'",
+        "[fye] className: 'hola oe_kanban_action oe_kanban_action_a hello gnap'",
+        "[one] className: 'hola oe_kanban_action oe_kanban_action_a'",
+        "[two] className: 'hola oe_kanban_action oe_kanban_action_a hello'",
+        "[sri] className: 'hola oe_kanban_action oe_kanban_action_a blip'",
+        "[foa] className: 'hola oe_kanban_action oe_kanban_action_a blip olleh'",
+        "[fye] className: 'hola oe_kanban_action oe_kanban_action_a hello blip'",
+    ]);
+});
+
+test("click on a button type='delete' to delete a record in a column", async () => {
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban limit="3">
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <div><a role="menuitem" type="delete" class="dropdown-item o_delete">Delete</a></div>
+                            <field name="foo"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+        groupBy: ["product_id"],
+    });
+    expect(queryAll(".o_kanban_record", { root: getKanbanColumn(0) })).toHaveCount(2);
+    expect(queryAll(".o_kanban_load_more", { root: getKanbanColumn(0) })).toHaveCount(0);
+
+    click(queryFirst(".o_kanban_record .o_delete", { root: getKanbanColumn(0) }));
+    await animationFrame();
+    expect(".modal").toHaveCount(1);
+
+    await contains(".modal .btn-primary").click();
+
+    expect(queryAll(".o_kanban_record", { root: getKanbanColumn(0) })).toHaveCount(1);
+    expect(queryAll(".o_kanban_load_more", { root: getKanbanColumn(0) })).toHaveCount(0);
+});
+
+test("click on a button type='archive' to archive a record in a column", async () => {
+    onRpc("action_archive", ({ args }) => {
+        expect.step(`archive:${args[0]}`);
+        return true;
+    });
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban limit="3">
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <div><a role="menuitem" type="archive" class="dropdown-item o_archive">archive</a></div>
+                            <field name="foo"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+        groupBy: ["product_id"],
+    });
+
+    expect(queryAll(".o_kanban_record", { root: getKanbanColumn(0) })).toHaveCount(2);
+
+    await contains(".o_kanban_record .o_archive").click();
+
+    expect(".modal").toHaveCount(1);
+    expect.verifySteps([]);
+
+    await contains(".modal .btn-primary").click();
+
+    expect.verifySteps(["archive:1"]);
+});
+
+test("click on a button type='unarchive' to unarchive a record in a column", async () => {
+    onRpc("action_unarchive", ({ args }) => {
+        expect.step(`unarchive:${args[0]}`);
+        return true;
+    });
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban limit="3">
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <div><a role="menuitem" type="unarchive" class="dropdown-item o_unarchive">unarchive</a></div>
+                            <field name="foo"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+        groupBy: ["product_id"],
+    });
+
+    expect(queryAll(".o_kanban_record", { root: getKanbanColumn(0) })).toHaveCount(2);
+
+    await contains(".o_kanban_record .o_unarchive").click();
+
+    expect.verifySteps(["unarchive:1"]);
+});
+
+test("many2many_tags in kanban views", async () => {
+    Partner._records[0].category_ids = [6, 7];
+    Partner._records[1].category_ids = [7, 8];
+    Category._records.push({
+        id: 8,
+        name: "hello",
+        color: 0,
+    });
+
+    stepAllNetworkCalls();
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <field name="category_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                            <field name="foo"/>
+                            <field name="state" widget="priority"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+        selectRecord: (resId) => {
+            expect(resId).toBe(1, {
+                message: "should trigger an event to open the clicked record in a form view",
+            });
+        },
+    });
+
+    expect(
+        queryAll(".o_field_many2many_tags .o_tag", { root: getKanbanRecord({ index: 0 }) })
+    ).toHaveCount(2, {
+        message: "first record should contain 2 tags",
+    });
+    expect(queryAll(".o_tag.o_tag_color_2", { root: getKanbanRecord({ index: 0 }) })).toHaveCount(
+        1,
+        {
+            message: "first tag should have color 2",
+        }
+    );
+    expect.verifySteps([
+        "/web/webclient/translations",
+        "/web/webclient/load_menus",
+        "get_views",
+        "web_search_read",
+    ]);
+
+    // Checks that second records has only one tag as one should be hidden (color 0)
+    expect(".o_kanban_record:nth-child(2) .o_tag").toHaveCount(1, {
+        message: "there should be only one tag in second record",
+    });
+    const tag = queryFirst(".o_kanban_record:nth-child(2) .o_tag");
+    expect(tag.innerText).toBe("silver");
+
+    // Write on the record using the priority widget to trigger a re-render in readonly
+    await contains(".o_kanban_record:first-child .o_priority_star:first-child").click();
+
+    expect.verifySteps(["web_save"]);
+    expect(".o_kanban_record:first-child .o_field_many2many_tags .o_tag").toHaveCount(2, {
+        message: "first record should still contain only 2 tags",
+    });
+    const tags = queryAll(".o_kanban_record:first-child .o_tag");
+    expect(tags[0].innerText).toBe("gold");
+    expect(tags[1].innerText).toBe("silver");
+
+    // click on a tag (should trigger switch_view)
+    await contains(".o_kanban_record:first-child .o_tag:first-child").click();
+});
+
+test("priority field should not be editable when missing access rights", async () => {
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban edit="0">
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <field name="foo"/>
+                            <field name="state" widget="priority"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+    // Try to fill one star in the priority field of the first record
+    await contains(".o_kanban_record:first-child .o_priority_star:first-child").click();
+    expect(".o_kanban_record:first-child .o_priority .fa-star-o").toHaveCount(2, {
+        message: "first record should still contain 2 empty stars",
+    });
+});
+
+test("Do not open record when clicking on `a` with `href`", async () => {
+    expect.assertions(6);
+
+    Partner._records = [{ id: 1, foo: "yop" }];
+
+    mockService("action", {
+        async switchView() {
+            // when clicking on a record in kanban view,
+            // it switches to form view.
+            expect.step("switchView");
+        },
+    });
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <field name="foo"/>
+                            <div>
+                                <a class="o_test_link" href="#">test link</a>
+                            </div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(1);
+    expect(".o_kanban_record a").toHaveCount(1);
+
+    const testLink = queryFirst(".o_kanban_record a");
+    expect(!!testLink.href).toBe(true, {
+        message: "link inside kanban record should have non-empty href",
+    });
+
+    // Prevent the browser default behaviour when clicking on anything.
+    // This includes clicking on a `<a>` with `href`, so that it does not
+    // change the URL in the address bar.
+    // Note that we should not specify a click listener on 'a', otherwise
+    // it may influence the kanban record global click handler to not open
+    // the record.
+    testLink.addEventListener("click", (ev) => {
+        expect(ev.defaultPrevented).toBe(false, {
+            message: "should not prevented browser default behaviour beforehand",
+        });
+        expect(ev.target).toBe(testLink, {
+            message: "should have clicked on the test link in the kanban record",
+        });
+        ev.preventDefault();
+    });
+
+    click(testLink);
+    expect.verifySteps([]);
+});
+
+test("Open record when clicking on widget field", async function (assert) {
+    expect.assertions(2);
+
+    Product._views["form,false"] = `<form string="Product"><field name="display_name"/></form>`;
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <field name="salary" widget="monetary"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+        selectRecord: (resId) => {
+            expect(resId).toBe(1, { message: "should trigger an event to open the form view" });
+        },
+    });
+
+    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(4);
+
+    click(queryFirst(".o_field_monetary[name=salary]"));
+});
+
+test("clicking on a link triggers correct event", async () => {
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div><a type="edit">Edit</a></div>
+                    </t>
+                </templates>
+            </kanban>`,
+        selectRecord: (resId, { mode }) => {
+            expect(resId).toBe(1);
+            expect(mode).toBe("edit");
+        },
+    });
+    await contains("a", { root: getKanbanRecord({ index: 0 }) }).click();
+});
+
+test("empty grouped kanban with sample data and many2many_tags", async () => {
+    onRpc("web_read_group", function ({ kwargs, parent }) {
+        const result = parent();
+        // override read_group to return empty groups, as this is
+        // the case for several models (e.g. project.task grouped
+        // by stage_id)
+        result.groups.forEach((group) => {
+            group[`${kwargs.groupby[0]}_count`] = 0;
+        });
+        return result;
+    });
+    stepAllNetworkCalls();
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban sample="1">
+                <field name="product_id"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <field name="int_field"/>
+                            <field name="category_ids" widget="many2many_tags"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+        groupBy: ["product_id"],
+    });
+
+    expect(".o_kanban_group").toHaveCount(2, { message: "there should be 2 'real' columns" });
+    expect(queryFirst(".o_content")).toHaveClass("o_view_sample_data");
+    expect(queryAll(".o_kanban_record").length >= 1).toBe(true, {
+        message: "there should be sample records",
+    });
+    expect(queryAll(".o_field_many2many_tags .o_tag").length >= 1).toBe(true, {
+        message: "there should be tags",
+    });
+    // should not read the tags
+    expect.verifySteps([
+        "/web/webclient/translations",
+        "/web/webclient/load_menus",
+        "get_views",
+        "web_read_group",
+    ]);
+});
+
+test("buttons with modifiers", async () => {
+    Partner._records[1].bar = false; // so that test is more complete
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <field name="foo"/>
+                <field name="bar"/>
+                <field name="state"/>
+                <templates>
+                    <div t-name="kanban-box">
+                        <button class="o_btn_test_1" type="object" name="a1" invisible="foo != 'yop'"/>
+                        <button class="o_btn_test_2" type="object" name="a2" invisible="bar and state not in ['abc', 'def']"/>
+                    </div>
+                </templates>
+            </kanban>`,
+    });
+
+    expect(".o_btn_test_1").toHaveCount(1, { message: "kanban should have one buttons of type 1" });
+    expect(".o_btn_test_2").toHaveCount(3, {
+        message: "kanban should have three buttons of type 2",
+    });
+});
+
+test("support styling of anchor tags with action type", async function (assert) {
+    expect.assertions(3);
+
+    mockService("action", {
+        doActionButton(action) {
+            expect(action.name).toBe("42");
+        },
+    });
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <div t-name="kanban-box">
+                        <field name="foo"/>
+                        <a type="action" name="42" class="btn-primary" style="margin-left: 10px"><i class="oi oi-arrow-right"/> Click me !</a>
+                    </div>
+                </templates>
+            </kanban>`,
+    });
+
+    await click(queryFirst("a[type='action']"));
+    expect(queryFirst("a[type='action']")).toHaveClass("btn-primary");
+    expect(queryFirst("a[type='action']").style.marginLeft).toBe("10px");
+});
+
+test("button executes action and reloads", async () => {
+    stepAllNetworkCalls();
+
+    let count = 0;
+    mockService("action", {
+        doActionButton({ onClose }) {
+            count++;
+            onClose();
+        },
+    });
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <div t-name="kanban-box">
+                        <field name="foo"/>
+                        <button type="object" name="a1" class="a1"/>
+                    </div>
+                </templates>
+            </kanban>`,
+    });
+
+    expect.verifySteps([
+        "/web/webclient/translations",
+        "/web/webclient/load_menus",
+        "get_views",
+        "web_search_read",
+    ]);
+    expect("button.a1").toHaveCount(4);
+
+    click(queryFirst("button.a1"));
+    expect(!!queryFirst("button.a1").disabled).toBe(true);
+    await animationFrame();
+
+    expect(count).toBe(1, { message: "should have triggered an execute action only once" });
+    // the records should be reloaded after executing a button action
+    expect.verifySteps(["web_search_read"]);
+});
+
+test("button executes action and check domain", async () => {
+    Partner._fields.active = fields.Boolean({ default: true });
+    for (let i = 0; i < Partner.length; i++) {
+        Partner._records[i].active = true;
+    }
+
+    mockService("action", {
+        doActionButton({ onClose }) {
+            Partner._records[0].active = false;
+            onClose();
+        },
+    });
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <field name="active"/>
+                <templates>
+                    <div t-name="kanban-box">
+                        <field name="foo"/>
+                        <button type="object" name="a1" />
+                        <button type="object" name="toggle_active" class="toggle-active" />
+                    </div>
+                </templates>
+            </kanban>`,
+    });
+
+    expect(queryText("span", { root: getKanbanRecord({ index: 0 }) })).toBe("yop", {
+        message: "should display 'yop' record",
+    });
+    await contains("button.toggle-active", { root: getKanbanRecord({ index: 0 }) }).click();
+    expect(queryText("span", { root: getKanbanRecord({ index: 0 }) })).not.toBe("yop", {
+        message: "should have removed 'yop' record from the view",
+    });
+});
+
+test("field tag with modifiers but no widget", async () => {
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <field name="foo" invisible="id == 1"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    expect(".o_kanban_record:first").toHaveText("");
+    expect(".o_kanban_record:eq(1)").toHaveText("blip");
+});
+
+test("field tag with widget and class attributes", async () => {
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <field name="foo" widget="char" class="hi"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    expect(".o_field_widget.hi").toHaveCount(4);
+});
+
+test("rendering date and datetime (value)", async () => {
+    Partner._records[0].date = "2017-01-25";
+    Partner._records[1].datetime = "2016-12-12 10:55:05";
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <field name="date"/>
+                <field name="datetime"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <span class="date" t-esc="record.date.value"/>
+                            <span class="datetime" t-esc="record.datetime.value"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    expect(getKanbanRecord({ index: 0 }).querySelector(".date").innerText).toBe("01/25/2017");
+    expect(getKanbanRecord({ index: 1 }).querySelector(".datetime").innerText).toBe(
+        "12/12/2016 11:55:05"
+    );
+});
+
+test("rendering date and datetime (raw value)", async () => {
+    Partner._records[0].date = "2017-01-25";
+    Partner._records[1].datetime = "2016-12-12 10:55:05";
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <field name="date"/>
+                <field name="datetime"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <span class="date" t-esc="record.date.raw_value"/>
+                            <span class="datetime" t-esc="record.datetime.raw_value"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    expect(getKanbanRecord({ index: 0 }).querySelector(".date").innerText).toBe(
+        "2017-01-25T00:00:00.000+01:00"
+    );
+    expect(getKanbanRecord({ index: 1 }).querySelector(".datetime").innerText).toBe(
+        "2016-12-12T11:55:05.000+01:00"
+    );
+});
+
+test("rendering many2one (value)", async () => {
+    Partner._records[1].product_id = false;
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+            <field name="product_id"/>
+            <templates>
+                <t t-name="kanban-box">
+                    <div>
+                        <span class="product_id" t-esc="record.product_id.value"/>
+                    </div>
+                </t>
+            </templates>
+        </kanban>`,
+    });
+
+    expect(getKanbanRecordTexts()).toEqual(["hello", "", "hello", "xmo"]);
+});
+
+test("rendering many2one (raw value)", async () => {
+    Partner._records[1].product_id = false;
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <field name="product_id"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <span class="product_id" t-esc="record.product_id.raw_value"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    expect(getKanbanRecordTexts()).toEqual(["3", "false", "3", "5"]);
+});
+
+test("evaluate conditions on relational fields", async () => {
+    Partner._records[0].product_id = false;
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <field name="product_id"/>
+                <field name="category_ids"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <button t-if="!record.product_id.raw_value" class="btn_a">A</button>
+                            <button t-if="!record.category_ids.raw_value.length" class="btn_b">B</button>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(4, {
+        message: "there should be 4 records",
+    });
+    expect(".o_kanban_record:not(.o_kanban_ghost) .btn_a").toHaveCount(1, {
+        message: "only 1 of them should have the 'Action' button",
+    });
+    expect(".o_kanban_record:not(.o_kanban_ghost) .btn_b").toHaveCount(2, {
+        message: "only 2 of them should have the 'Action' button",
+    });
+});
+
+test("properly evaluate more complex domains", async () => {
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <field name="foo"/>
+                <field name="bar"/>
+                <field name="category_ids"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <field name="foo"/>
+                            <button type="object" invisible="bar or category_ids" class="btn btn-primary float-end" name="arbitrary">Join</button>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    expect("button.float-end.oe_kanban_action_button").toHaveCount(1, {
+        message: "only one button should be visible",
+    });
+});
+
+test("basic support for widgets (being Owl Components)", async () => {
+    class MyComponent extends Component {
+        static template = xml`<div t-att-class="props.class" t-esc="value"/>`;
+        static props = ["*"];
+        get value() {
+            return JSON.stringify(this.props.record.data);
+        }
+    }
+    const myComponent = {
+        component: MyComponent,
+    };
+    viewWidgetRegistry.add("test", myComponent);
+    after(() => viewWidgetRegistry.remove("test"));
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <field name="foo"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <t t-esc="record.foo.value"/>
+                            <widget name="test"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    expect(getKanbanRecord({ index: 2 }).querySelector(".o_widget").innerText).toBe(
+        '{"foo":"gnap"}'
+    );
+});
+
+test("kanban card: record value should be updated", async () => {
+    class MyComponent extends Component {
+        static template = xml`<div><button t-on-click="onClick">CLick</button></div>`;
+        static props = ["*"];
+        onClick() {
+            this.props.record.update({ foo: "yolo" });
+        }
+    }
+    const myComponent = {
+        component: MyComponent,
+    };
+    viewWidgetRegistry.add("test", myComponent);
+    after(() => viewWidgetRegistry.remove("test"));
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <field name="foo"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <div class="foo" t-esc="record.foo.value"/>
+                            <widget name="test"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    expect(queryText(".foo", { root: getKanbanRecord({ index: 0 }) })).toBe("yop");
+
+    click(queryOne("button", { root: getKanbanRecord({ index: 0 }) }));
+    await animationFrame();
+    await animationFrame();
+
+    expect(queryText(".foo", { root: getKanbanRecord({ index: 0 }) })).toBe("yolo");
+});
+
+test("test displaying image (URL, image field not set)", async () => {
+    patchWithCleanup(KanbanCompiler.prototype, {
+        compileImage(el) {
+            el.setAttribute("t-att-data-src", el.getAttribute("t-att-src"));
+            el.removeAttribute("t-att-src");
+            return super.compileImage(el);
+        },
+    });
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <field name="id"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <img t-att-src="kanban_image('partner', 'image', record.id.raw_value)"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    // since the field image is not set, kanban_image will generate an URL
+    expect(queryAll(`.o_kanban_record img`).map((img) => img.dataset.src.split("?")[0])).toEqual([
+        `${getOrigin()}/web/image/partner/1/image`,
+        `${getOrigin()}/web/image/partner/2/image`,
+        `${getOrigin()}/web/image/partner/3/image`,
+        `${getOrigin()}/web/image/partner/4/image`,
+    ]);
+    expect(queryFirst(".o_kanban_record img").loading).toBe("lazy");
+});
+
+test("test displaying image (write_date field)", async () => {
+    // the presence of write_date field ensures that the image is reloaded when necessary
+    expect.assertions(2);
+
+    patchWithCleanup(KanbanCompiler.prototype, {
+        compileImage(el) {
+            el.setAttribute("t-att-data-src", el.getAttribute("t-att-src"));
+            el.removeAttribute("t-att-src");
+            return super.compileImage(el);
+        },
+    });
+
+    const rec = Partner._records.find((r) => r.id === 1);
+    rec.write_date = "2022-08-05 08:37:00";
+
+    onRpc("web_search_read", ({ kwargs }) => {
+        expect(kwargs.specification).toEqual({ id: {}, write_date: {} });
+    });
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <field name="id"/>
+                <templates>
+                    <t t-name="kanban-box"><div>
+                    <img t-att-src="kanban_image('partner', 'image', record.id.raw_value)"/>
+                    </div></t>
+                </templates>
+            </kanban>`,
+        domain: [["id", "in", [1]]],
+    });
+
+    expect(
+        `.o_kanban_record img[data-src='${getOrigin()}/web/image/partner/1/image?unique=1659688620000']`
+    ).toHaveCount(1);
+});
+
+test("test displaying image (binary & placeholder)", async () => {
+    patchWithCleanup(KanbanCompiler.prototype, {
+        compileImage(el) {
+            el.setAttribute("t-att-data-src", el.getAttribute("t-att-src"));
+            el.removeAttribute("t-att-src");
+            return super.compileImage(el);
+        },
+    });
+
+    Partner._fields.image = fields.Binary();
+    Partner._records[0].image = "R0lGODlhAQABAAD/ACwAAAAAAQABAAACAA==";
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <field name="id"/>
+                <field name="image"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <img t-att-src="kanban_image('partner', 'image', record.id.raw_value)"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    expect(queryAll(`.o_kanban_record img`).map((img) => img.dataset.src.split("?")[0])).toEqual([
+        "data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACAA==",
+        `${getOrigin()}/web/image/partner/2/image`,
+        `${getOrigin()}/web/image/partner/3/image`,
+        `${getOrigin()}/web/image/partner/4/image`,
+    ]);
+});
+
+test("test displaying image (for another record)", async () => {
+    patchWithCleanup(KanbanCompiler.prototype, {
+        compileImage(el) {
+            el.setAttribute("t-att-data-src", el.getAttribute("t-att-src"));
+            el.removeAttribute("t-att-src");
+            return super.compileImage(el);
+        },
+    });
+
+    Partner._fields.image = fields.Binary();
+    Partner._records[0].image = "R0lGODlhAQABAAD/ACwAAAAAAQABAAACAA==";
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <field name="id"/>
+                <field name="image"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <img t-att-src="kanban_image('partner', 'image', 1)"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    // the field image is set, but we request the image for a specific id
+    // -> for the record matching the ID, the base64 should be returned
+    // -> for all the other records, the image should be displayed by url
+    expect(queryAll(`.o_kanban_record img`).map((img) => img.dataset.src.split("?")[0])).toEqual([
+        "data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACAA==",
+        `${getOrigin()}/web/image/partner/1/image`,
+        `${getOrigin()}/web/image/partner/1/image`,
+        `${getOrigin()}/web/image/partner/1/image`,
+    ]);
+});
+
+test("test displaying image from m2o field (m2o field not set)", async () => {
+    patchWithCleanup(KanbanCompiler.prototype, {
+        compileImage(el) {
+            el.setAttribute("t-att-data-src", el.getAttribute("t-att-src"));
+            el.removeAttribute("t-att-src");
+            return super.compileImage(el);
+        },
+    });
+
+    class FooPartner extends models.Model {
+        _name = "foo.partner";
+
+        name = fields.Char();
+        partner_id = fields.Many2one({ relation: "partner" });
+
+        _records = [
+            { id: 1, name: "foo_with_partner_image", partner_id: 1 },
+            { id: 2, name: "foo_no_partner" },
+        ];
+    }
+    defineModels([FooPartner]);
+
+    await mountView({
+        type: "kanban",
+        resModel: "foo.partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <div t-name="kanban-box">
+                        <field name="name"/>
+                        <field name="partner_id"/>
+                        <img t-att-src="kanban_image('partner', 'image', record.partner_id.raw_value)"/>
+                    </div>
+                </templates>
+            </kanban>`,
+    });
+
+    expect(queryAll(`.o_kanban_record img`).map((img) => img.dataset.src.split("?")[0])).toEqual([
+        `${getOrigin()}/web/image/partner/1/image`,
+        `${getOrigin()}/web/image/partner/null/image`,
+    ]);
+});
+
+test.tags("desktop")("set cover image", async () => {
+    expect.assertions(9);
+
+    IrAttachment._records = [
+        {
+            id: 1,
+            name: "1.png",
+            mimetype: "image/png",
+            res_model: "partner",
+            res_id: 1,
+        },
+        {
+            id: 2,
+            name: "2.png",
+            mimetype: "image/png",
+            res_model: "partner",
+            res_id: 2,
+        },
+    ];
+    Partner._fields.displayed_image_id = fields.Many2one({
+        string: "Cover",
+        relation: "ir.attachment",
+    });
+
+    onRpc(({ model, method, args }) => {
+        if (model === "partner" && method === "web_save") {
+            expect.step(String(args[0][0]));
+        }
+    });
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="kanban-menu">
+                        <a type="set_cover" data-field="displayed_image_id" class="dropdown-item">Set Cover Image</a>
+                    </t>
+                    <t t-name="kanban-box">
+                        <div>
+                            <field name="foo"/>
+                            <div>
+                                <field name="displayed_image_id" widget="attachment_image"/>
+                            </div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    mockService("action", {
+        switchView(_viewType, { mode, resModel, res_id, view_type }) {
+            expect({ mode, resModel, res_id, view_type }).toBe({
+                mode: "readonly",
+                resModel: "partner",
+                res_id: 1,
+                view_type: "form",
+            });
+        },
+    });
+
+    await toggleKanbanRecordDropdown(0);
+    await contains(".oe_kanban_action", {
+        root: getDropdownMenu(getKanbanRecord({ index: 0 })),
+    }).click();
+
+    expect(queryAll("img", { root: getKanbanRecord({ index: 0 }) })).toHaveCount(0, {
+        message: "Initially there is no image.",
+    });
+
+    await contains(".modal .o_kanban_cover_image img").click();
+    await contains(".modal .btn-primary:first-child").click();
+
+    expect('img[data-src*="/web/image/1"]').toHaveCount(1);
+
+    await toggleKanbanRecordDropdown(1);
+    const coverButton = getDropdownMenu(getKanbanRecord({ index: 1 })).querySelector("a");
+    expect(queryText(coverButton)).toBe("Set Cover Image");
+    await contains(coverButton).click();
+
+    expect(".modal .o_kanban_cover_image").toHaveCount(1);
+    expect(".modal .btn:contains(Select)").toHaveCount(1);
+    expect(".modal .btn:contains(Discard)").toHaveCount(1);
+    expect(".modal .btn:contains(Remove Cover Image)").toHaveCount(0);
+
+    dblclick(".modal .o_kanban_cover_image img"); // doesn't work
+    await animationFrame();
+
+    expect('img[data-src*="/web/image/2"]').toHaveCount(1);
+
+    await contains(".o_kanban_record:first-child .o_attachment_image").click(); //Not sure, to discuss
+
+    // should writes on both kanban records
+    expect.verifySteps(["1", "2"]);
+});
+
+test.tags("desktop")("open file explorer if no cover image", async () => {
+    expect.assertions(2);
+
+    Partner._fields.displayed_image_id = fields.Many2one({
+        string: "Cover",
+        relation: "ir.attachment",
+    });
+
+    const uploadedPromise = new Deferred();
+    await createFileInput({
+        mockPost: async (route) => {
+            if (route === "/web/binary/upload_attachment") {
+                await uploadedPromise;
+            }
+            return "[]";
+        },
+        props: {},
+    });
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="kanban-menu">
+                        <a type="set_cover" data-field="displayed_image_id" class="dropdown-item">Set Cover Image</a>
+                    </t>
+                    <t t-name="kanban-box">
+                        <div class="oe_kanban_global_click">
+                            <field name="foo"/>
+                            <div>
+                                <field name="displayed_image_id" widget="attachment_image"/>
+                            </div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    await toggleKanbanRecordDropdown(0);
+    await contains(".oe_kanban_action", {
+        root: getDropdownMenu(getKanbanRecord({ index: 0 })),
+    }).click();
+    setInputFiles([]);
+    await animationFrame();
+
+    expect(`.o_file_input input`).not.toBeEnabled({
+        message: "the upload button should be disabled on upload",
+    });
+    uploadedPromise.resolve();
+    await animationFrame();
+
+    expect(`.o_file_input input`).toBeEnabled({
+        message: "the upload button should be enabled for upload",
+    });
+});
+
+test.tags("desktop")("unset cover image", async () => {
+    IrAttachment._records = [
+        {
+            id: 1,
+            name: "1.png",
+            mimetype: "image/png",
+            res_model: "partner",
+            res_id: 1,
+        },
+        {
+            id: 2,
+            name: "2.png",
+            mimetype: "image/png",
+            res_model: "partner",
+            res_id: 2,
+        },
+    ];
+    Partner._fields.displayed_image_id = fields.Many2one({
+        string: "Cover",
+        relation: "ir.attachment",
+    });
+    Partner._records[0].displayed_image_id = 1;
+    Partner._records[1].displayed_image_id = 2;
+
+    onRpc(({ model, method, args }) => {
+        if (model === "partner" && method === "web_save") {
+            expect.step(String(args[0][0]));
+            expect(args[1].displayed_image_id).toBe(false);
+        }
+    });
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="kanban-menu">
+                        <a type="set_cover" data-field="displayed_image_id" class="dropdown-item">Set Cover Image</a>
+                    </t>
+                    <t t-name="kanban-box">
+                        <div>
+                            <field name="foo"/>
+                            <div>
+                                <field name="displayed_image_id" widget="attachment_image"/>
+                            </div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    await toggleKanbanRecordDropdown(0);
+    await contains(".oe_kanban_action", {
+        root: getDropdownMenu(getKanbanRecord({ index: 0 })),
+    }).click();
+
+    expect(
+        queryAll('img[data-src*="/web/image/1"]', { root: getKanbanRecord({ index: 0 }) })
+    ).toHaveCount(1);
+    expect(
+        queryAll('img[data-src*="/web/image/2"]', { root: getKanbanRecord({ index: 1 }) })
+    ).toHaveCount(1);
+
+    expect(".modal .o_kanban_cover_image").toHaveCount(1);
+    expect(".modal .btn:contains(Select)").toHaveCount(1);
+    expect(".modal .btn:contains(Discard)").toHaveCount(1);
+    expect(".modal .btn:contains(Remove Cover Image)").toHaveCount(1);
+
+    await contains(".modal .btn-secondary").click(); // click on "Remove Cover Image" button
+
+    expect(queryAll("img", { root: getKanbanRecord({ index: 0 }) })).toHaveCount(0, {
+        message: "The cover image should be removed.",
+    });
+
+    await toggleKanbanRecordDropdown(1);
+    const coverButton = getDropdownMenu(getKanbanRecord({ index: 1 })).querySelector("a");
+    expect(queryText(coverButton)).toBe("Set Cover Image");
+    await contains(coverButton).click();
+
+    dblclick(".modal .o_kanban_cover_image img"); // doesn't work
+    await animationFrame();
+
+    expect(queryAll("img", { root: getKanbanRecord({ index: 1 }) })).toHaveCount(0, {
+        message: "The cover image should be removed.",
+    });
+    // should writes on both kanban records
+    expect.verifySteps(["1", "2"]);
+});
+
+test.tags("desktop")("ungrouped kanban with handle field", async () => {
+    expect.assertions(3);
+
+    onRpc("/web/dataset/resequence", async (request) => {
+        const { params } = await request.json();
+        expect(params.ids).toEqual([2, 1, 3, 4], {
+            message: "should write the sequence in correct order",
+        });
+        return true;
+    });
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <field name="int_field" widget="handle" />
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <field name="foo"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    expect(getKanbanRecordTexts()).toEqual(["blip", "blip", "yop", "gnap"]);
+
+    await contains(".o_kanban_record").dragAndDrop(queryFirst(".o_kanban_record:nth-child(4)"));
+
+    expect(getKanbanRecordTexts()).toEqual(["blip", "yop", "gnap", "blip"]);
+});
+
+test("ungrouped kanban without handle field", async () => {
+    onRpc("/web/dataset/resequence", () => {
+        expect.step("resequence");
+        return true;
+    });
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <field name="foo"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    expect(getKanbanRecordTexts()).toEqual(["yop", "blip", "gnap", "blip"]);
+
+    await contains(".o_kanban_record").dragAndDrop(queryFirst(".o_kanban_record:nth-child(4)"));
+
+    expect(getKanbanRecordTexts()).toEqual(["yop", "blip", "gnap", "blip"]);
+    expect.verifySteps([]);
+});
+
+test("click on image field in kanban (with default global_click)", async () => {
+    expect.assertions(2);
+
+    Partner._fields.image = fields.Binary();
+    Partner._records[0].image = "R0lGODlhAQABAAD/ACwAAAAAAQABAAACAA==";
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <field name="image" widget="image"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+        selectRecord(recordId) {
+            expect(recordId).toBe(1, {
+                message: "should call its selectRecord prop with the clicked record",
+            });
+        },
+    });
+
+    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(4);
+
+    await contains(".o_field_image").click();
+});
+
+test("kanban view with boolean field", async () => {
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div><field name="bar"/></div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    expect(".o_kanban_record input:disabled").toHaveCount(4);
+    expect(".o_kanban_record input:checked").toHaveCount(3);
+    expect(".o_kanban_record input:not(:checked)").toHaveCount(1);
+});
+
+test("kanban view with boolean widget", async () => {
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div><field name="bar" widget="boolean"/></div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    expect(
+        queryAll("div.o_field_boolean .o-checkbox", { root: getKanbanRecord({ index: 0 }) })
+    ).toHaveCount(1);
+});
+
+test("kanban view with boolean toggle widget", async () => {
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div><field name="bar" widget="boolean_toggle"/></div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+    expect(getKanbanRecord({ index: 0 }).querySelector("[name='bar'] input")).toBeChecked();
+    expect(getKanbanRecord({ index: 1 }).querySelector("[name='bar'] input")).toBeChecked();
+
+    click(queryOne("[name='bar'] input", { root: getKanbanRecord({ index: 1 }) }));
+    await animationFrame();
+
+    expect(getKanbanRecord({ index: 0 }).querySelector("[name='bar'] input")).toBeChecked();
+    expect(getKanbanRecord({ index: 1 }).querySelector("[name='bar'] input")).not.toBeChecked();
+});
+
+test("kanban view with monetary and currency fields without widget", async () => {
+    const mockedCurrencies = {};
+    for (const record of Currency._records) {
+        mockedCurrencies[record.id] = record;
+    }
+    patchWithCleanup(currencies, mockedCurrencies);
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <field name="currency_id"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div><field name="salary"/></div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    expect(getKanbanRecordTexts()).toEqual([
+        `$ 1,750.00`,
+        `$ 1,500.00`,
+        `2,000.00 €`,
+        `$ 2,222.00`,
+    ]);
+});
+
+test("kanban with isHtmlEmpty method", async () => {
+    Product._fields.description = fields.Html();
+    Product._records.push({
+        id: 11,
+        name: "product 11",
+        description: "<span class='text-info'>hello</hello>",
+    });
+    Product._records.push({
+        id: 12,
+        name: "product 12",
+        description: "<p class='a'><span style='color:red;'/><br/></p>",
+    });
+
+    await mountView({
+        type: "kanban",
+        resModel: "product",
+        arch: `
+            <kanban>
+                <field name="description"/>
+                <templates>
+                    <t t-name="kanban-box">
+                    <div>
+                        <field name="display_name"/>
+                        <div class="test" t-if="!widget.isHtmlEmpty(record.description.raw_value)">
+                            <t t-out="record.description.value"/>
+                        </div>
+                    </div>
+                    </t>
+                </templates>
+            </kanban>`,
+        domain: [["id", "in", [11, 12]]],
+    });
+    expect(".o_kanban_record:first-child div.test").toHaveCount(1, {
+        message: "the container is displayed if description have actual content",
+    });
+    expect(queryText("span.text-info", { root: getKanbanRecord({ index: 0 }) })).toBe("hello", {
+        message: "the inner html content is rendered properly",
+    });
+    expect(".o_kanban_record:last-child div.test").toHaveCount(0, {
+        message:
+            "the container is not displayed if description just have formatting tags and no actual content",
+    });
+});
+
+test("kanban widget can extract props from attrs", async () => {
+    class TestWidget extends Component {
+        static template = xml`<div class="o-test-widget-option" t-esc="props.title"/>`;
+        static props = ["*"];
+    }
+    const testWidget = {
+        component: TestWidget,
+        extractProps: ({ attrs }) => {
+            return {
+                title: attrs.title,
+            };
+        },
+    };
+    viewWidgetRegistry.add("widget_test_option", testWidget);
+    after(() => viewWidgetRegistry.remove("widget_test_option"));
+
+    await mountView({
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <widget name="widget_test_option" title="Widget with Option"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+        resModel: "partner",
+        type: "kanban",
+    });
+
+    expect(".o-test-widget-option").toHaveCount(4);
+    expect(queryFirst(".o-test-widget-option").textContent).toBe("Widget with Option");
+});
+
+test("action/type attributes on kanban arch, type='object'", async () => {
+    mockService("action", {
+        doActionButton(params) {
+            expect.step(`doActionButton type ${params.type} name ${params.name}`);
+            params.onClose();
+        },
+    });
+
+    stepAllNetworkCalls();
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban action="a1" type="object">
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <p>some value</p><field name="foo"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    expect.verifySteps([
+        "/web/webclient/translations",
+        "/web/webclient/load_menus",
+        "get_views",
+        "web_search_read",
+    ]);
+    await contains(".o_kanban_record p").click();
+    expect.verifySteps(["doActionButton type object name a1", "web_search_read"]);
+});
+
+test("action/type attributes on kanban arch, type='action'", async () => {
+    mockService("action", {
+        doActionButton(params) {
+            expect.step(`doActionButton type ${params.type} name ${params.name}`);
+            params.onClose();
+        },
+    });
+
+    stepAllNetworkCalls();
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban action="a1" type="action">
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <p>some value</p><field name="foo"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    expect.verifySteps([
+        "/web/webclient/translations",
+        "/web/webclient/load_menus",
+        "get_views",
+        "web_search_read",
+    ]);
+    await contains(".o_kanban_record p").click();
+    expect.verifySteps(["doActionButton type action name a1", "web_search_read"]);
+});
+
+test("Missing t-key is automatically filled with a warning", async () => {
+    patchWithCleanup(console, { warn: () => expect.step("warning") });
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <span t-foreach="[1, 2, 3]" t-as="i" t-esc="i" />
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    expect.verifySteps(["warning"]);
+    expect(getKanbanRecord({ index: 0 }).innerText).toBe("123");
+});
+
+test("Allow use of 'editable'/'deletable' in ungrouped kanban", async () => {
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban on_create="quick_create">
+                <templates>
+                    <div t-name="kanban-box">
+                        <button t-if="widget.editable">EDIT</button>
+                        <button t-if="widget.deletable">DELETE</button>
+                    </div>
+                </templates>
+            </kanban>`,
+    });
+
+    expect(getKanbanRecordTexts()).toEqual([
+        "EDITDELETE",
+        "EDITDELETE",
+        "EDITDELETE",
+        "EDITDELETE",
+    ]);
+});
+
+test("can use JSON in kanban template", async () => {
+    Partner._records = [{ id: 1, foo: '["g", "e", "d"]' }];
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <field name="foo"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <span t-foreach="JSON.parse(record.foo.raw_value)" t-as="v" t-key="v_index" t-esc="v"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(1);
+    expect(".o_kanban_record span").toHaveCount(3);
+    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveText("ged");
+});
+
+test("Can't use KanbanRecord implementation details in arch", async () => {
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div>
+                            <t t-esc="__owl__"/>
+                            <t t-esc="props"/>
+                            <t t-esc="env"/>
+                            <t t-esc="render"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+    expect(queryFirst(".o_kanban_record").innerHTML).toBe("<div></div>");
+});
+
+test("kanbans with basic and custom compiler, same arch", async () => {
+    // In this test, the exact same arch will be rendered by 2 different kanban renderers:
+    // once with the basic one, and once with a custom renderer having a custom compiler. The
+    // purpose of the test is to ensure that the template is compiled twice, once by each
+    // compiler, even though the arch is the same.
+    class MyKanbanCompiler extends KanbanCompiler {
+        setup() {
+            super.setup();
+            this.compilers.push({ selector: "div", fn: this.compileDiv });
+        }
+
+        compileDiv(node, params) {
+            const compiledNode = this.compileGenericNode(node, params);
+            compiledNode.setAttribute("class", "my_kanban_compiler");
+            return compiledNode;
+        }
+    }
+    class MyKanbanRecord extends KanbanRecord {}
+    MyKanbanRecord.Compiler = MyKanbanCompiler;
+    class MyKanbanRenderer extends KanbanRenderer {}
+    MyKanbanRenderer.components = {
+        ...KanbanRenderer.components,
+        KanbanRecord: MyKanbanRecord,
+    };
+    viewRegistry.add("my_kanban", {
+        ...kanbanView,
+        Renderer: MyKanbanRenderer,
+    });
+    after(() => viewRegistry.remove("my_kanban"));
+
+    Partner._fields.one2many = fields.One2many({ relation: "partner" });
+    Partner._records[0].one2many = [1];
+    Partner._views["form,false"] = `<form><field name="one2many" mode="kanban"/></form>`;
+    Partner._views["search,false"] = `<search/>`;
+    Partner._views["kanban,false"] = `
+        <kanban js_class="my_kanban">
+            <templates>
+                <t t-name="kanban-box">
+                    <div><field name="foo"/></div>
+                </t>
+            </templates>
+        </kanban>`;
+
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction({
+        res_model: "partner",
+        type: "ir.actions.act_window",
+        views: [
+            [false, "kanban"],
+            [false, "form"],
+        ],
+    });
+
+    // main kanban, custom view
+    expect(".o_kanban_view").toHaveCount(1);
+    expect(".o_my_kanban_view").toHaveCount(1);
+    expect(".my_kanban_compiler").toHaveCount(4);
+
+    // switch to form
+    await contains(".o_kanban_record").click();
+    await animationFrame();
+    expect(".o_form_view").toHaveCount(1);
+    expect(".o_form_view .o_field_widget[name=one2many]").toHaveCount(1);
+
+    // x2many kanban, basic renderer
+    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(1);
+    expect(".my_kanban_compiler").toHaveCount(0);
+});

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -5306,10 +5306,8 @@ test(`Navigate between the list and kanban view using the command palette`, asyn
         list: `<list><field name="display_name"/></list>`,
         kanban: `
             <kanban class="o_kanban_test">
-                <templates><t t-name="kanban-box">
-                    <div>
-                        <field name="foo"/>
-                    </div>
+                <templates><t t-name="kanban-card">
+                    <field name="foo"/>
                 </t></templates>
             </kanban>
         `,
@@ -13061,8 +13059,8 @@ test(`change the viewType of the current action`, async () => {
         "kanban,1": `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>

--- a/addons/web/static/tests/webclient/actions/client_action.test.js
+++ b/addons/web/static/tests/webclient/actions/client_action.test.js
@@ -50,10 +50,8 @@ class Partner extends models.Model {
         "kanban,false": `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="display_name"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="display_name"/>
                     </t>
                 </templates>
             </kanban>`,

--- a/addons/web/static/tests/webclient/actions/close_action.test.js
+++ b/addons/web/static/tests/webclient/actions/close_action.test.js
@@ -36,10 +36,8 @@ class Partner extends models.Model {
         "kanban,1": `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="display_name"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="display_name"/>
                     </t>
                 </templates>
             </kanban>`,

--- a/addons/web/static/tests/webclient/actions/concurrency.test.js
+++ b/addons/web/static/tests/webclient/actions/concurrency.test.js
@@ -51,10 +51,8 @@ class Partner extends models.Model {
         "kanban,1": `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="display_name"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="display_name"/>
                     </t>
                 </templates>
             </kanban>`,

--- a/addons/web/static/tests/webclient/actions/effect.test.js
+++ b/addons/web/static/tests/webclient/actions/effect.test.js
@@ -38,10 +38,8 @@ class Partner extends models.Model {
         "kanban,1": `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="display_name"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="display_name"/>
                     </t>
                 </templates>
             </kanban>`,

--- a/addons/web/static/tests/webclient/actions/embedded_action.test.js
+++ b/addons/web/static/tests/webclient/actions/embedded_action.test.js
@@ -65,10 +65,8 @@ class Partner extends models.Model {
         "kanban,1": `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -90,10 +88,8 @@ class Pony extends models.Model {
         "list,false": `<tree><field name="name"/></tree>`,
         "kanban,false": `<kanban>
                             <templates>
-                                <t t-name="kanban-box">
-                                    <div>
-                                        <field name="name"/>
-                                    </div>
+                                <t t-name="kanban-card">
+                                    <field name="name"/>
                                 </t>
                             </templates>
                         </kanban>`,

--- a/addons/web/static/tests/webclient/actions/error_handling.test.js
+++ b/addons/web/static/tests/webclient/actions/error_handling.test.js
@@ -32,10 +32,8 @@ class Partner extends models.Model {
         "kanban,1": `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="display_name"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="display_name"/>
                     </t>
                 </templates>
             </kanban>`,

--- a/addons/web/static/tests/webclient/actions/load_state.test.js
+++ b/addons/web/static/tests/webclient/actions/load_state.test.js
@@ -161,8 +161,8 @@ class Partner extends models.Model {
         kanban: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>

--- a/addons/web/static/tests/webclient/actions/misc.test.js
+++ b/addons/web/static/tests/webclient/actions/misc.test.js
@@ -59,10 +59,8 @@ class Partner extends models.Model {
         "kanban,1": `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="display_name"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="display_name"/>
                     </t>
                 </templates>
             </kanban>`,

--- a/addons/web/static/tests/webclient/actions/push_state.test.js
+++ b/addons/web/static/tests/webclient/actions/push_state.test.js
@@ -111,8 +111,8 @@ class Partner extends models.Model {
         kanban: `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="foo"/></div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>

--- a/addons/web/static/tests/webclient/actions/report_action.test.js
+++ b/addons/web/static/tests/webclient/actions/report_action.test.js
@@ -42,10 +42,8 @@ class Partner extends models.Model {
         "kanban,1": `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="display_name"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="display_name"/>
                     </t>
                 </templates>
             </kanban>`,

--- a/addons/web/static/tests/webclient/actions/server_action.test.js
+++ b/addons/web/static/tests/webclient/actions/server_action.test.js
@@ -32,10 +32,8 @@ class Partner extends models.Model {
         "kanban,1": `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="display_name"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="display_name"/>
                     </t>
                 </templates>
             </kanban>`,

--- a/addons/web/static/tests/webclient/actions/target.test.js
+++ b/addons/web/static/tests/webclient/actions/target.test.js
@@ -45,10 +45,8 @@ class Partner extends models.Model {
         "kanban,1": `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="display_name"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="display_name"/>
                     </t>
                 </templates>
             </kanban>`,

--- a/addons/web/static/tests/webclient/actions/window_action.test.js
+++ b/addons/web/static/tests/webclient/actions/window_action.test.js
@@ -93,10 +93,8 @@ class Partner extends models.Model {
         "kanban,1": `
             <kanban>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div>
-                            <field name="foo"/>
-                        </div>
+                    <t t-name="kanban-card">
+                        <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
@@ -319,10 +317,8 @@ test.tags("desktop")("switching into a view with mode=edit lands in edit mode", 
     Partner._views["kanban,1"] = `
         <kanban on_create="quick_create" default_group_by="m2o">
             <templates>
-                <t t-name="kanban-box">
-                    <div>
-                        <field name="foo"/>
-                    </div>
+                <t t-name="kanban-card">
+                    <field name="foo"/>
                 </t>
             </templates>
         </kanban>`;
@@ -2517,8 +2513,8 @@ test.tags("desktop")("sample server: populate groups", async () => {
         "kanban,false": `
             <kanban sample="1" default_group_by="write_date:month">
                 <templates>
-                    <t t-name="kanban-box">
-                        <div><field name="display_name"/></div>
+                    <t t-name="kanban-card">
+                        <field name="display_name"/>
                     </t>
                 </templates>
             </kanban>`,

--- a/addons/web/static/tests/webclient/clickbot.test.js
+++ b/addons/web/static/tests/webclient/clickbot.test.js
@@ -46,10 +46,8 @@ class Foo extends models.Model {
         `,
         kanban: /* xml */ `
             <kanban class="o_kanban_test">
-                <templates><t t-name="kanban-box">
-                    <div>
-                        <field name="foo"/>
-                    </div>
+                <templates><t t-name="kanban-card">
+                    <field name="foo"/>
                 </t></templates>
             </kanban>
         `,


### PR DESCRIPTION
In this commit we have simplified the kanban arch for the web module test cases. the goal is to simplify them, make them easier to read and use bootstrap utility classnames.

- Previously, we used kanban-box, but now we are using kanban-card instead.
- Deprecated oe_kanban_global_click and oe_kanban_global_click_edit.
- More use of <field/> tags
- Removed the oe_kanban_colorpicker class and replaced it with the kanban_color_picker widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- kanban_image from rendering context, is deprecated so we use <field name=... widget=image/> instead
- kanban_color, kanban_getcolor and kanban_getcolorname are deprecated use new attribute highlight_color=color_field_name on root node

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
