### PR TITLE
[FIX] website: avoid failing during wysiwyg adapter's destroy

### DIFF
--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -361,7 +361,8 @@ export class WysiwygAdapterComponent extends Wysiwyg {
      * @returns {HTMLElement}
      */
     get editable() {
-        return this.websiteService.pageDocument.getElementById('wrapwrap');
+        // Page document might become unavailable when leaving the page.
+        return this.websiteService.pageDocument?.getElementById('wrapwrap');
     }
     /**
      * @see {editable} jQuery wrapped editable.
@@ -427,7 +428,8 @@ export class WysiwygAdapterComponent extends Wysiwyg {
         const formOptionsMod = await odoo.loader.modules.get('@website/snippets/s_website_form/options')[Symbol.for('default')];
         formOptionsMod.clearAllFormsInfo();
 
-        this.$editable[0].removeEventListener("click", this.__onPageClick, { capture: true });
+        // Editable might become unavailable when leaving the page.
+        this.editable?.removeEventListener("click", this.__onPageClick, { capture: true });
         return super.destroy(...arguments);
     }
 


### PR DESCRIPTION
Since [1] when routing was changed to path-based, the website service's `pageDocument` can be reset before the wysiwyg adapter is destroyed. Because of this, the `destroy` might fail - leading to further errors.

Steps to reproduce:
- Be logged in.
- Access the visitor view of the Home page.
- Click on the "Editor" link to reach the back-end view.
- Click on "Edit".
- Click on the back button of the browser.

=> An error dialog appears.

[1]: https://github.com/odoo/odoo/commit/c63d14a0485a553b74a8457aee158384e9ae6d3f

opw-4074988
