### PR TITLE
[FIX] point_of_sale: prevent connection of exempted fields on load

### DIFF
--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -764,13 +764,14 @@ export function createRelatedModels(modelDefs, modelClasses = {}, indexes = {}) 
                                     const toConnect = records[field.relation].get(id);
                                     if (toConnect) {
                                         connect(field, recorded, toConnect);
-                                    } else if (this[field.relation]) {
-                                        if (!isFieldExemptedAutoLoad(field)) {
-                                            if (!missingRecords[field.relation]) {
-                                                missingRecords[field.relation] = new Set([id]);
-                                            } else {
-                                                missingRecords[field.relation].add(id);
-                                            }
+                                    } else if (
+                                        this[field.relation] &&
+                                        !isFieldExemptedAutoLoad(field)
+                                    ) {
+                                        if (!missingRecords[field.relation]) {
+                                            missingRecords[field.relation] = new Set([id]);
+                                        } else {
+                                            missingRecords[field.relation].add(id);
                                         }
                                         const key = `${field.relation}_${id}`;
                                         if (!missingFields[key]) {
@@ -788,13 +789,11 @@ export function createRelatedModels(modelDefs, modelClasses = {}, indexes = {}) 
                             const toConnect = records[field.relation].get(id);
                             if (toConnect) {
                                 connect(field, recorded, toConnect);
-                            } else if (this[field.relation]) {
-                                if (!isFieldExemptedAutoLoad(field)) {
-                                    if (!missingRecords[field.relation]) {
-                                        missingRecords[field.relation] = new Set([id]);
-                                    } else {
-                                        missingRecords[field.relation].add(id);
-                                    }
+                            } else if (this[field.relation] && !isFieldExemptedAutoLoad(field)) {
+                                if (!missingRecords[field.relation]) {
+                                    missingRecords[field.relation] = new Set([id]);
+                                } else {
+                                    missingRecords[field.relation].add(id);
                                 }
                                 const key = `${field.relation}_${id}`;
                                 if (!missingFields[key]) {


### PR DESCRIPTION
Before this commit, exempted fields were being connected upon loading, which could lead to issues.

opw-4088809

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
