### PR TITLE
[FIX] website: fix hoverable dropdowns if header searchbar

### DIFF
--- a/addons/website/static/src/js/content/menu.js
+++ b/addons/website/static/src/js/content/menu.js
@@ -661,7 +661,10 @@ publicWidget.registry.hoverableDropdown = animations.Animation.extend({
         if (focusedEl) {
             focusedEl.focus();
         } else {
-            ev.currentTarget.querySelector(".dropdown-toggle").blur();
+            const dropdownToggleEl = ev.currentTarget.querySelector(".dropdown-toggle");
+            if (dropdownToggleEl) {
+                dropdownToggleEl.blur();
+            }
         }
     },
     /**


### PR DESCRIPTION
Steps to reproduce:

- In website edit mode.
- Click on the header.
- Select the "Vertical" template in the "Header" options.
- Drag and drop a "Search" block from the inner content section into the header.
- Click on the header.
- Select "On Hover" for the "Sub Menus" option of the "Navbar".
- Save the page.
- Enter a letter (e.g., "a") in the search input.
- Click outside the page to lose the focus on the input.
- Hover over the search results with the mouse.
- Traceback: "Cannot read properties of null (reading 'blur')"

The bug occurred after commit [1], which didn't account for a dropdown missing a "dropdown-toggle" element.

[1]: https://github.com/odoo/odoo/commit/0f7cbf2969b3c4b6c496e5b54814c4a9b3081af4

opw-4012850