### PR TITLE
[FIX] hw_drivers: fix serial filtering windows

### DIFF
--- a/addons/hw_drivers/iot_handlers/interfaces/SerialInterface.py
+++ b/addons/hw_drivers/iot_handlers/interfaces/SerialInterface.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import serial.tools.list_ports
+import platform
+from serial.tools.list_ports import comports
 
 from odoo.addons.hw_drivers.interface import Interface
 
@@ -10,11 +11,10 @@ class SerialInterface(Interface):
     connection_type = 'serial'
 
     def get_devices(self):
-        serial_ports = serial.tools.list_ports.comports()
         serial_devices = {
             port.device: {'identifier': port.device}
-            for port in serial_ports
-            if port.subsystem != 'amba'
+            for port in comports()
+            if platform.system() == 'Windows' or port.subsystem != 'amba'
             # RPI 5 uses ttyAMA10 as a console serial port for system messages: odoo interprets it as scale -> avoid it
         }
         return serial_devices


### PR DESCRIPTION
We filter `amba` subystem on serial devices to avoid having a fake scale being detected by Odoo.   
Problem was that Windows serial Python package does not have a subsystem attribute: we are now making the distinction between Linux and Windows IoT.