### PR TITLE
[IMP] account: New journal type and internal transfer reconciliation

### DIFF
--- a/addons/account/data/template/account.account-generic_coa.csv
+++ b/addons/account/data/template/account.account-generic_coa.csv
@@ -41,3 +41,4 @@
 "expense_rd","RD Expenses","9610","expense","account.account_tag_investing","False"
 "expense_sales","Sales Expenses","9620","expense","account.account_tag_investing","False"
 "pos_receivable","Account Receivable (PoS)","1013","asset_receivable","","True"
+"credit_card","Credit Card","201100","liability_credit_card","","False"

--- a/addons/account/demo/account_demo.py
+++ b/addons/account/demo/account_demo.py
@@ -295,6 +295,13 @@ class AccountChartTemplate(models.AbstractModel):
             ],
             limit=1,
         )
+        ccd_journal = self.env['account.journal'].search(
+            domain=[
+                *self.env['account.journal']._check_company_domain(cid),
+                ('type', '=', 'credit'),
+            ],
+            limit=1,
+        )
         return {
             'demo_bank_statement_1': {
                 'name': f'{bnk_journal.name} - {time.strftime("%Y")}-01-01/1',
@@ -313,6 +320,19 @@ class AccountChartTemplate(models.AbstractModel):
                         'amount': 1275.0,
                         'date': time.strftime('%Y-01-01'),
                         'partner_id': 'base.res_partner_12',
+                    }),
+                ]
+            },
+            'demo_credit_statement_1': {
+                'name': f'{ccd_journal.name} - {time.strftime("%Y")}-01-01/1',
+                'balance_end_real': -1055.0,
+                'balance_start': 0.0,
+                'line_ids': [
+                    Command.create({
+                        'journal_id': ccd_journal.id,
+                        'payment_ref': 'Initial balance',
+                        'amount': -1055.0,
+                        'date': time.strftime('%Y-01-01'),
                     }),
                 ]
             },

--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -68,7 +68,7 @@ class account_journal(models.Model):
 
     @api.depends('current_statement_balance')
     def _kanban_dashboard_graph(self):
-        bank_cash_journals = self.filtered(lambda journal: journal.type in ('bank', 'cash'))
+        bank_cash_journals = self.filtered(lambda journal: journal.type in ('bank', 'cash', 'credit'))
         bank_cash_graph_datas = bank_cash_journals._get_bank_cash_graph_data()
         for journal in bank_cash_journals:
             journal.kanban_dashboard_graph = json.dumps(bank_cash_graph_datas[journal.id])
@@ -232,6 +232,8 @@ class account_journal(models.Model):
             return ['', _('Cash: Balance')]
         elif self.type == 'bank':
             return ['', _('Bank: Balance')]
+        elif self.type == 'credit':
+            return ['', _('Credit Card: Balance')]
 
     def _get_bank_cash_graph_data(self):
         """Computes the data used to display the graph for bank and cash journals in the accounting dashboard"""
@@ -414,7 +416,7 @@ class account_journal(models.Model):
 
     def _fill_bank_cash_dashboard_data(self, dashboard_data):
         """Populate all bank and cash journal's data dict with relevant information for the kanban card."""
-        bank_cash_journals = self.filtered(lambda journal: journal.type in ('bank', 'cash'))
+        bank_cash_journals = self.filtered(lambda journal: journal.type in ('bank', 'cash', 'credit'))
         if not bank_cash_journals:
             return
 
@@ -493,7 +495,7 @@ class account_journal(models.Model):
             accessible = journal.company_id.id in journal.company_id._accessible_branches().ids
             nb_direct_payments, direct_payments_balance = direct_payment_balances[journal.id]
             drag_drop_settings = {
-                'image': '/account/static/src/img/bank.svg' if journal.type == 'bank' else '/web/static/img/rfq.svg',
+                'image': '/account/static/src/img/bank.svg' if journal.type in ('bank', 'credit') else '/web/static/img/rfq.svg',
                 'text': _('Drop to import transactions'),
             }
 
@@ -946,6 +948,8 @@ class account_journal(models.Model):
             return self._context.get('action_name')
         elif self.type == 'bank':
             return 'action_bank_statement_tree'
+        elif self.type == 'credit':
+            return 'action_credit_statement_tree'
         elif self.type == 'cash':
             return 'action_view_bank_statement_tree'
         elif self.type == 'sale':

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -768,7 +768,7 @@ class AccountMove(models.Model):
         elif self.is_purchase_document(include_receipts=True):
             return ['purchase']
         elif self.payment_id or self.statement_line_id or self.env.context.get('is_payment') or self.env.context.get('is_statement_line'):
-            return ['bank', 'cash']
+            return ['bank', 'cash', 'credit']
         return ['general']
 
     def _search_default_journal(self):
@@ -3149,7 +3149,7 @@ class AccountMove(models.Model):
                 year_part = "%s-%s" % ((self.date + relativedelta(years=-1)).strftime('%y'), self.date.strftime('%y'))
         # Arbitrarily use annual sequence for sales documents, but monthly
         # sequence for other documents
-        if self.journal_id.type in ['sale', 'bank', 'cash']:
+        if self.journal_id.type in ['sale', 'bank', 'cash', 'credit']:
             # We reduce short code to 4 characters (0000) in case of staggered
             # year to avoid too long sequences (see Indian GST rule 46(b) for
             # example). Note that it's already the case for monthly sequences.

--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -127,7 +127,7 @@ class AccountPayment(models.Model):
     destination_journal_id = fields.Many2one(
         comodel_name='account.journal',
         string='Destination Journal',
-        domain="[('type', 'in', ('bank','cash')), ('id', '!=', journal_id)]",
+        domain="[('type', 'in', ('bank', 'cash', 'credit')), ('id', '!=', journal_id)]",
         check_company=True,
     )
 
@@ -522,7 +522,7 @@ class AccountPayment(models.Model):
             '|',
             ('company_id', 'parent_of', self.env.company.id),
             ('company_id', 'child_of', self.env.company.id),
-            ('type', 'in', ('bank', 'cash')),
+            ('type', 'in', ('bank', 'cash', 'credit')),
         ])
         for pay in self:
             if pay.payment_type == 'inbound':
@@ -992,8 +992,8 @@ class AccountPayment(models.Model):
             payment_vals_to_write = {}
 
             if 'journal_id' in changed_fields:
-                if pay.journal_id.type not in ('bank', 'cash'):
-                    raise UserError(_("A payment must always belongs to a bank or cash journal."))
+                if pay.journal_id.type not in ('bank', 'cash', 'credit'):
+                    raise UserError(_("A payment must always belongs to a bank, cash or credit journal."))
 
             if 'line_ids' in changed_fields:
                 all_lines = move.line_ids

--- a/addons/account/models/account_payment_method.py
+++ b/addons/account/models/account_payment_method.py
@@ -46,7 +46,7 @@ class AccountPaymentMethod(models.Model):
         if not code:
             return []
         information = self._get_payment_method_information().get(code)
-        journal_types = information.get('type', ('bank', 'cash'))
+        journal_types = information.get('type', ('bank', 'cash', 'credit'))
         domains = [[('type', 'in', journal_types)]]
 
         if with_currency and (currency_ids := information.get('currency_ids')):
@@ -75,7 +75,7 @@ class AccountPaymentMethod(models.Model):
         - ``country_id``: The id of the country needed on the company for it to be eligible.
         """
         return {
-            'manual': {'mode': 'multi', 'type': ('bank', 'cash')},
+            'manual': {'mode': 'multi', 'type': ('bank', 'cash', 'credit')},
         }
 
     @api.model

--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -232,7 +232,7 @@ class AccountReconcileModel(models.Model):
         tracking=True,
     )
     match_journal_ids = fields.Many2many('account.journal', string='Journals Availability',
-        domain="[('type', 'in', ('bank', 'cash'))]",
+        domain="[('type', 'in', ('bank', 'cash', 'credit'))]",
         check_company=True,
         help='The reconciliation model will only be available from the selected journals.')
     match_nature = fields.Selection(selection=[

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -616,7 +616,7 @@ class AccountChartTemplate(models.AbstractModel):
         company.get_unaffected_earnings_account()
 
         # Set newly created Cash difference and Suspense accounts to the Cash and Bank journals
-        for journal in [self.ref(kind, raise_if_not_found=False) for kind in ('bank', 'cash')]:
+        for journal in [self.ref(kind, raise_if_not_found=False) for kind in ('bank', 'cash', 'credit')]:
             if journal:
                 journal.suspense_account_id = journal.suspense_account_id or company.account_journal_suspense_account_id
                 journal.profit_account_id = journal.profit_account_id or company.default_cash_difference_income_account_id
@@ -980,7 +980,7 @@ class AccountChartTemplate(models.AbstractModel):
                 'type': 'general',
                 'code': _('MISC'),
                 'show_on_dashboard': False,
-                'sequence': 8,
+                'sequence': 9,
             },
             "exch": {
                 'name': _('Exchange Difference'),
@@ -999,6 +999,12 @@ class AccountChartTemplate(models.AbstractModel):
                 'type': 'bank',
                 'show_on_dashboard': True,
                 'sequence': 7,
+            },
+            "credit": {
+                'name': _('Credit Card'),
+                'type': 'credit',
+                'show_on_dashboard': True,
+                'sequence': 8,
             },
             "cash": {
                 'name': _('Cash'),

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -661,6 +661,11 @@ class AccountChartTemplate(models.AbstractModel):
             if value and field in self.env[model]._fields:
                 self.env['ir.property']._set_default(field, model, self.ref(value).id, company=company)
 
+        # Set default transfer account on the internal transfer reconciliation model
+        reco = self.ref('internal_transfer_reco', raise_if_not_found=False)
+        if reco:
+            reco.line_ids.write({'account_id': company.transfer_account_id.id})
+
     def _get_chart_template_data(self, template_code):
         template_data = defaultdict(lambda: defaultdict(dict))
         template_data['res.company']  # ensure it's the first property when iterating
@@ -1047,6 +1052,17 @@ class AccountChartTemplate(models.AbstractModel):
                     Command.create({
                         'amount_type': 'percentage_st_line',
                         'amount_string': '100',
+                    }),
+                ],
+            },
+            'internal_transfer_reco': {
+                'name': _('Internal Transfers'),
+                'rule_type': 'writeoff_button',
+                'line_ids': [
+                    Command.create({
+                        'amount_type': 'percentage',
+                        'amount_string': '100',
+                        'label': _('Internal Transfers'),
                     }),
                 ],
             },

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -299,6 +299,10 @@ class AccountTestInvoicingCommon(ProductCommon):
                     ('company_id', '=', company.id),
                     ('type', '=', 'cash')
                 ], limit=1),
+            'default_journal_credit': cls.env['account.journal'].search([
+                    ('company_id', '=', company.id),
+                    ('type', '=', 'credit')
+                ], limit=1),
             'default_tax_sale': company.account_sale_tax_id,
             'default_tax_purchase': company.account_purchase_tax_id,
         }

--- a/addons/account/views/account_bank_statement_views.xml
+++ b/addons/account/views/account_bank_statement_views.xml
@@ -29,15 +29,15 @@
             <field name="name">account.bank.statement.search</field>
             <field name="model">account.bank.statement</field>
             <field name="arch" type="xml">
-                <search string="Search Bank Statements">
-                    <field name="name" string="Bank Statement"/>
+                <search string="Search Statements">
+                    <field name="name" string="Statement"/>
                     <field name="date"/>
                     <filter string="Empty" name="empty" domain="[('line_ids','=',False)]"/>
                     <filter name="invalid" string="Invalid"
                             domain="['|', ('is_valid', '=', False),('is_complete', '=', False)]"/>
                     <separator/>
                     <filter name="filter_date" date="date"/>
-                    <field name="journal_id" domain="[('type', 'in', ('bank', 'cash'))]" />
+                    <field name="journal_id" domain="[('type', 'in', ('bank', 'cash', 'credit'))]" />
                     <group expand="0" string="Group By">
                         <filter string="Journal" name="journal" context="{'group_by': 'journal_id'}"/>
                         <filter string="Date" name="date" context="{'group_by': 'date'}"/>
@@ -51,7 +51,7 @@
             <field name="name">Bank Statements</field>
             <field name="res_model">account.bank.statement</field>
             <field name="view_mode">tree,pivot,graph,form</field>
-            <field name="domain">['|', ('journal_id', '=', False), ('journal_id.type', '=', 'bank')]</field>
+            <field name="domain">[('journal_id.type', '=', 'bank')]</field>
             <field name="context">{'journal_type':'bank'}</field>
             <field name="search_view_id" ref="view_bank_statement_search"/>
             <field name="help" type="html">
@@ -67,6 +67,28 @@
               </p>
             </field>
         </record>
+
+        <record id="action_credit_statement_tree" model="ir.actions.act_window">
+            <field name="name">Credit Statements</field>
+            <field name="res_model">account.bank.statement</field>
+            <field name="view_mode">tree,pivot,graph</field>
+            <field name="domain">[('journal_id.type', '=', 'credit')]</field>
+            <field name="context">{'journal_type': 'credit'}</field>
+            <field name="search_view_id" ref="view_bank_statement_search"/>
+            <field name="help" type="html">
+              <p class="o_view_nocontent_smiling_face">
+                Register a bank statement
+              </p><p>
+                A credit statement is a summary of all financial transactions
+                occurring over a given period of time on a credit account. You
+                should receive this periodically from your bank.
+              </p><p>
+                Odoo allows you to reconcile a statement line directly with
+                the related sale or purchase invoices.
+              </p>
+            </field>
+        </record>
+
         <record model="ir.actions.act_window.view" id="action_bank_statement_tree_bank">
             <field name="sequence" eval="1"/>
             <field name="view_mode">tree</field>
@@ -105,7 +127,7 @@
             <field name="view_mode">tree,pivot,graph</field>
             <field name="view_id" ref="view_bank_statement_tree"/>
             <field name="search_view_id" ref="view_bank_statement_search"/>
-            <field name="domain">['|', ('journal_id', '=', False), ('journal_id.type', '=', 'cash')]</field>
+            <field name="domain">[('journal_id.type', '=', 'cash')]</field>
             <field name="context">{'journal_type':'cash'}</field>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">

--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -22,19 +22,19 @@
                             <t t-value="JSON.parse(record.kanban_dashboard.raw_value)" t-set="dashboard"/>
                             <t t-value="record.type.raw_value" t-set="journal_type"/>
                             <t t-value="!record.has_entries.raw_value" t-set="journal_is_empty"/>
-                            <t t-set="bank_unconfigured" t-value="journal_type == 'bank'
+                            <t t-set="bank_unconfigured" t-value="(journal_type == 'bank' or journal_type == 'credit')
                                                                   and ['undefined', 'online_sync'].includes(dashboard.bank_statements_source)
                                                                   and journal_is_empty"/>
                             <t t-call="JournalTop"/>
                             <div t-att-class="'container o_kanban_card_content' + (dashboard.is_sample_data ? ' o_sample_data' : '')">
                                 <div class="row">
-                                    <t t-if="journal_type == 'bank'" t-call="JournalBodyBank"/>
+                                    <t t-if="journal_type == 'bank' || journal_type == 'credit'" t-call="JournalBodyBank"/>
                                     <t t-if="journal_type == 'cash'" t-call="JournalBodyBankCash"/>
                                     <t t-if="journal_type == 'sale' || journal_type == 'purchase'" t-call="JournalBodySalePurchase"/>
                                     <t t-if="journal_type == 'general'" t-call="JournalMiscelaneous"/>
                                 </div>
                                 <div class="row mt-auto">
-                                    <t t-if="['bank', 'cash', 'sale'].includes(journal_type)
+                                    <t t-if="['bank', 'cash', 'credit', 'sale'].includes(journal_type)
                                              and !bank_unconfigured
                                              or (journal_type == 'purchase' and !journal_is_empty)"
                                        t-call="JournalBodyGraph"/>
@@ -68,14 +68,15 @@
                         <t t-value="JSON.parse(record.kanban_dashboard.raw_value)" t-set="dashboard"/>
                         <t t-value="record.type.raw_value" t-set="journal_type"/>
                         <div class="container">
-                            <!-- For bank and cash -->
-                            <div t-if="journal_type == 'bank' || journal_type == 'cash'" class="row" id="bank_and_cash_container">
+                            <!-- For bank, cash and credit -->
+                            <div t-if="journal_type == 'bank' || journal_type == 'cash' || journal_type == 'credit'" class="row" id="bank_and_cash_container">
                                 <div class="col-4 o_kanban_card_manage_section o_kanban_manage_view">
                                     <h5 id="card_action_view_menus" class="o_kanban_card_manage_title">
                                         <span role="separator">View</span>
                                     </h5>
                                     <div id="action_card_statements">
                                         <a t-if="journal_type == 'bank'" role="menuitem" type="object" name="open_action_with_context" context="{'action_name': 'action_bank_statement_tree', 'search_default_journal': True}">Statements</a>
+                                        <a t-if="journal_type == 'credit'" role="menuitem" type="object" name="open_action_with_context" context="{'action_name': 'action_credit_statement_tree', 'search_default_journal': True}">Statements</a>
                                         <a t-if="journal_type == 'cash'" role="menuitem" type="object" name="open_action_with_context" context="{'action_name': 'action_view_bank_statement_tree', 'search_default_journal': True}">Cash Registers</a>
                                     </div>
                                     <div>
@@ -254,7 +255,7 @@
                         <div id="dashboard_bank_cash_left" class="col mb-3 mb-sm-0 o_kanban_primary_left">
                             <div name="bank_cash_buttons" class="clearfix">
                                 <t t-set="bank_requires_setup" t-value="!record.bank_account_id.raw_value and ['undefined', 'online_sync'].includes(dashboard.bank_statements_source)"/>
-                                <div name="setup_bank_btn" class="float-start me-1" t-if="journal_type == 'bank' and bank_requires_setup">
+                                <div name="setup_bank_btn" class="float-start me-1" t-if="(journal_type == 'bank' or journal_type == 'credit') and bank_requires_setup">
                                     <button name="action_configure_bank_journal" type="object" class="btn btn-primary" groups="account.group_account_basic">Setup Bank</button>
                                 </div>
                                 <div name="transactions_btn" class="float-start me-1">
@@ -392,7 +393,7 @@
                         </div>
                     </t>
                     <t t-name="JournalBodyGraph">
-                        <field name="kanban_dashboard_graph" t-att-graph_type="['cash','bank'].includes(journal_type) ? 'line' : 'bar'" widget="dashboard_graph"/>
+                        <field name="kanban_dashboard_graph" t-att-graph_type="['cash', 'bank', 'credit'].includes(journal_type) ? 'line' : 'bar'" widget="dashboard_graph"/>
                     </t>
             </templates>
             </kanban>

--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -86,6 +86,7 @@
                                         <field name="profit_account_id" invisible="type not in ('cash', 'bank')"/>
                                         <field name="loss_account_id" invisible="type not in ('cash', 'bank')"/>
                                         <field name="refund_sequence" invisible="type not in ['sale', 'purchase']"/>
+                                        <field name="payment_sequence" invisible="type not in ('bank', 'cash', 'credit')"/>
                                         <field name="code" placeholder="e.g. INV"/>
                                         <field name="currency_id" options="{'no_create': True}" groups="base.group_multi_currency"/>
                                     </group>

--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -62,6 +62,8 @@
                                         <field name="default_account_type" invisible="1"/>
                                         <label for="default_account_id" string="Bank Account"
                                                invisible="type != 'bank'" groups="account.group_account_readonly"/>
+                                        <label for="default_account_id" string="Journal Account"
+                                               invisible="type != 'credit'" groups="account.group_account_readonly"/>
                                         <label for="default_account_id" string="Cash Account"
                                                invisible="type != 'cash'" groups="account.group_account_readonly"/>
                                         <label for="default_account_id" string="Default Income Account"
@@ -73,18 +75,17 @@
                                                invisible="type != 'general'" groups="account.group_account_readonly"/>
                                         <field name="default_account_id" nolabel="1"
                                                invisible="not type"
-                                               required="(id and type in ('bank', 'cash')) or type in ('sale', 'purchase')"
+                                               required="(id and type in ('bank', 'cash', 'credit')) or type in ('sale', 'purchase')"
                                                options="{'no_quick_create': True}"
                                                groups="account.group_account_readonly"/>
                                         <field name="suspense_account_id"
-                                               invisible="type not in ('bank', 'cash')"
-                                               required="type in ('bank', 'cash')"
+                                               invisible="type not in ('bank', 'cash', 'credit')"
+                                               required="type in ('bank', 'cash', 'credit')"
                                                options="{'no_quick_create': True}"
                                                groups="account.group_account_readonly"/>
                                         <field name="profit_account_id" invisible="type not in ('cash', 'bank')"/>
                                         <field name="loss_account_id" invisible="type not in ('cash', 'bank')"/>
                                         <field name="refund_sequence" invisible="type not in ['sale', 'purchase']"/>
-                                        <field name="payment_sequence" invisible="type not in ('bank', 'cash')"/>
                                         <field name="code" placeholder="e.g. INV"/>
                                         <field name="currency_id" options="{'no_create': True}" groups="base.group_multi_currency"/>
                                     </group>
@@ -94,9 +95,13 @@
                                         <field name="bank_id" invisible="not bank_account_id"/>
                                         <field name="bank_statements_source" widget="radio" required="type == 'bank'"  groups="account.group_account_basic"/>
                                     </group>
+                                    <group name="bank_source" string="" invisible="type != 'credit'">
+                                        <label for="bank_statements_source" string="Transaction Feeds" invisible="type != 'credit'" groups="account.group_account_readonly"/>
+                                        <field name="bank_statements_source" nolabel="1" widget="radio" required="type != 'credit'" groups="account.group_account_basic"/>
+                                    </group>
                                 </group>
                             </page>
-                            <page id="inbound_payment_settings" string="Incoming Payments" name="page_incoming_payments" invisible="type not in ['cash', 'bank']">
+                            <page id="inbound_payment_settings" string="Incoming Payments" name="page_incoming_payments" invisible="type not in ['cash', 'bank', 'credit']">
                                 <field name="available_payment_method_ids" invisible="1"/>
                                 <field name="inbound_payment_method_line_ids" nolabel="1" context="{'default_payment_type': 'inbound'}">
                                     <tree string="Payment Methods" editable="bottom">
@@ -109,13 +114,12 @@
                                         <field name="payment_account_id"
                                                placeholder="Leave empty to use the default outstanding account"
                                                string="Outstanding Receipts accounts"
-                                               optional="hide"
                                                options="{'no_quick_create': True}"
                                                groups="account.group_account_readonly"/>
                                     </tree>
                                 </field>
                             </page>
-                            <page id="outbound_payment_settings" string="Outgoing Payments" name="page_outgoing_payments" invisible="type not in ['cash', 'bank']">
+                            <page id="outbound_payment_settings" string="Outgoing Payments" name="page_outgoing_payments" invisible="type not in ['cash', 'bank', 'credit']">
                                     <field name="outbound_payment_method_line_ids" nolabel="1" context="{'default_payment_type': 'outbound'}">
                                         <tree string="Payment Methods" editable="bottom">
                                             <field name="available_payment_method_ids" column_invisible="True"/>
@@ -127,7 +131,6 @@
                                             <field name="payment_account_id"
                                                    placeholder="Leave empty to use the default outstanding account"
                                                    string="Outstanding Payments accounts"
-                                                   optional="hide"
                                                    options="{'no_quick_create': True}"
                                                    groups="account.group_account_readonly"/>
                                         </tree>
@@ -217,8 +220,8 @@
                     <separator/>
                     <filter name="sales" string="Sales" domain="[('type', '=', 'sale')]"/>
                     <filter name="purchases" string="Purchases" domain="[('type', '=', 'purchase')]"/>
-                    <filter name="liquidity" string="Liquidity" domain="['|', ('type', '=', 'cash'), ('type', '=', 'bank')]"/>
-                    <filter name="miscellaneous" string="Miscellaneous" domain="[('type', 'not in', ['sale', 'purchase', 'cash', 'bank'])]"/>
+                    <filter name="liquidity" string="Liquidity" domain="['|', ('type', '=', 'cash'), ('type', '=', 'bank'), ('type', '=', 'credit')]"/> 
+                    <filter name="miscellaneous" string="Miscellaneous" domain="[('type', 'not in', ['sale', 'purchase', 'cash', 'bank', 'credit'])]"/>
                     <separator/>
                     <filter name="inactive" string="Archived" domain="[('active', '=', False)]"/>
                 </search>

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -178,7 +178,7 @@ class AccountPaymentRegister(models.TransientModel):
         company = batch_result['lines'].company_id
         journals = self.env['account.journal'].search([
             *self.env['account.journal']._check_company_domain(company),
-            ('type', 'in', ('bank', 'cash')),
+            ('type', 'in', ('bank', 'cash', 'credit')),
         ])
         if payment_type == 'inbound':
             return journals.filtered('inbound_payment_method_line_ids')
@@ -204,7 +204,7 @@ class AccountPaymentRegister(models.TransientModel):
 
         default_domain = [
             *self.env['account.journal']._check_company_domain(company),
-            ('type', 'in', ('bank', 'cash')),
+            ('type', 'in', ('bank', 'cash', 'credit')),
             ('id', 'in', self.available_journal_ids.ids)
         ]
 
@@ -463,7 +463,7 @@ class AccountPaymentRegister(models.TransientModel):
             else:
                 wizard.journal_id = self.env['account.journal'].search([
                     *self.env['account.journal']._check_company_domain(wizard.company_id),
-                    ('type', 'in', ('bank', 'cash')),
+                    ('type', 'in', ('bank', 'cash', 'credit')),
                     ('id', 'in', self.available_journal_ids.ids)
                 ], limit=1)
 
@@ -786,7 +786,7 @@ class AccountPaymentRegister(models.TransientModel):
 
             if 'journal_id' in res and not self.env['account.journal'].browse(res['journal_id']).filtered_domain([
                 *self.env['account.journal']._check_company_domain(lines.company_id),
-                ('type', 'in', ('bank', 'cash')),
+                ('type', 'in', ('bank', 'cash', 'credit')),
             ]):
                 # default can be inherited from the list view, should be computed instead
                 del res['journal_id']

--- a/addons/l10n_be/models/template_be.py
+++ b/addons/l10n_be/models/template_be.py
@@ -79,19 +79,4 @@ class AccountChartTemplate(models.AbstractModel):
                 'name@nl': 'Bankkosten (Geen BTW)',
                 'name@de': 'Bankgebühren (Ohne MwSt.)',
             },
-            'virements_internes_template': {
-                'name': 'Internal Transfers',
-                'to_check': False,
-                'line_ids': [
-                    Command.create({
-                        'account_id': 'a58',
-                        'amount_type': 'percentage',
-                        'amount_string': '100',
-                        'label': 'Internal Transfers',
-                    }),
-                ],
-                'name@fr': 'Virements internes',
-                'name@nl': 'Interne overboekingen',
-                'name@de': 'Interne Überweisungen',
-            },
         }


### PR DESCRIPTION
Create a new credit card journal type that is similar to a bank journal,
streamlining the configuration and avoiding useless fields.

---

The Belgian localization added the possibility to perform internal
transfer during the reconciliation; this option has been made general.

odoo/enterprise/pull/67786
task-3925608

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
