### PR TITLE
[IMP] mrp: shop floor register component consumption

### DIFF
--- a/addons/mrp/views/stock_move_views.xml
+++ b/addons/mrp/views/stock_move_views.xml
@@ -14,6 +14,10 @@
             <field name="mode">primary</field>
             <field name="inherit_id" ref="stock.view_stock_move_operations" />
             <field name="arch" type="xml">
+                <xpath expr="//field[@name='move_line_ids']" position="attributes">
+                    <attribute name="widget">quality_sml_x2_many</attribute>
+                </xpath>
+
                 <xpath expr="//label[@for='product_uom_qty']" position="attributes">
 		            <attribute name="string">Total To Consume</attribute>
                 </xpath>


### PR DESCRIPTION
In this commit:
=====================
- Currently, there are two ways of registering component consumption in the shop floor interface: component moves (manual consumption) and component consumption steps.
- Now we use the move mechanism (manual consumption) for the register component consumption type step.

task-3976734
