### PR TITLE
[IMP] web_tour: alternative trigger in tour tour_interactive

### DIFF
--- a/addons/web_tour/static/tests/tour_service.test.js
+++ b/addons/web_tour/static/tests/tour_service.test.js
@@ -1085,6 +1085,59 @@ test("automatic tour with alternative trigger", async () => {
     expect.verifySteps(["on step", "on step", "on step", "on step", "succeeded"]);
 });
 
+test("manual tour with alternative trigger", async () => {
+    patchWithCleanup(browser.console, {
+        log: (s) => {
+            !s.includes("═") ? expect.step(s) : "";
+        },
+    });
+    registry.category("web_tour.tours").add("tour_des_flandres_2", {
+        test: false,
+        sequence: 93,
+        steps: () => [
+            {
+                trigger: ".button1, .button2",
+                run: "click",
+            },
+            {
+                trigger: "body:not(:visible), .button4, .button3",
+                run: "click",
+            },
+            {
+                trigger: ".interval1, .interval2, .button5",
+                run: "click",
+            },
+            {
+                trigger: "button:contains(0, hello):enabled, button:contains(2, youpi)",
+                run: "click",
+            },
+        ],
+    });
+    class Root extends Component {
+        static components = {};
+        static template = xml/*html*/ `
+            <t>
+                <div class="container">
+                    <button class="button0">0, hello</button>
+                    <button class="button1">Button 1</button>
+                    <button class="button2">2, youpi</button>
+                    <button class="button3">Button 3</button>
+                    <button class="button4">Button 4</button>
+                    <button class="button5">Button 5</button>
+                </div>
+            </t>
+        `;
+        static props = ["*"];
+    }
+    await mountWithCleanup(Root);
+    getService("tour_service").startTour("tour_des_flandres_2", { mode: "manual" });
+    await contains(".button2").click();
+    await contains(".button3").click();
+    await contains(".button5").click();
+    await contains(".button2").click();
+    expect.verifySteps(["click", "click", "click", "click", "tour succeeded"]);
+});
+
 test("Tour backward when the pointed element disappear", async () => {
     registry.category("web_tour.tours").add("tour1", {
         sequence: 10,


### PR DESCRIPTION
Before this commit, the interactive tour did not take into account the possibility of having an alternative trigger. That is to say that, in case of a selector with a comma ( e.g: .button1, .button2 ), the tooltip is displayed on the first element found in the DOM and listens exclusively on this element. So, if we click on the other element, the step will not be resolved.
In this commit, we add the fact that when there is a comma selector, we listen on each element of the trigger. The tooltip is only displayed on the first of the elements of the trigger, but if we trigger the event on another element, the step will also be resolved.

task~4009134

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
