### PR TITLE
[FIX] web_tour: fix missing step in warn step

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_interactive.js
+++ b/addons/web_tour/static/src/tour_service/tour_interactive.js
@@ -201,6 +201,7 @@ export class TourInteractive {
         const actions = [];
         if (!step.run || typeof step.run === "function") {
             actions.push({
+                step,
                 event: "warn",
                 anchor: step.trigger,
             });


### PR DESCRIPTION
The warn step (the ones with no run or function in the run) didn't have the variable "step" set. So when the backward went on this step the step.active was undefined.

Task-ID: 4089134