### PR TITLE
[IMP] project: show project name if there is only one company

### DIFF
--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -213,7 +213,6 @@
             <field name="arch" type="xml">
                 <list decoration-muted="active == False" string="Projects" multi_edit="1" sample="1" default_order="is_favorite desc, sequence, name, id" js_class="project_project_list">
                     <field name="sequence" column_invisible="True"/>
-                    <field name="name" column_invisible="1"/>
                     <field name="message_needaction" column_invisible="True"/>
                     <field name="active" column_invisible="True"/>
                     <field name="is_milestone_exceeded" column_invisible="True"/>
@@ -221,7 +220,7 @@
                     <field name="is_milestone_deadline_exceeded" column_invisible="1"/>
                     <field name="allow_milestones" column_invisible="True"/>
                     <field name="is_favorite" string="Favorite" nolabel="1" widget="project_is_favorite" optional="hide"/>
-                    <field name="display_name" string="Name" class="fw-bold"/>
+                    <field name="name" class="fw-bold"/>
                     <field name="partner_id" optional="show" string="Customer"/>
                     <field name="company_id" optional="show" groups="base.group_multi_company" options="{'no_create': True, 'no_open': True}"/>
                     <field name="company_id" column_invisible="True"/>


### PR DESCRIPTION
In the project list view, instead of displaying the name, we use the display_name so that we can show the company name for fsm projects.
However, since it is a computed field, it has the drawback of not being sortable.

To alleviate this, this PR will use the name instead if there is only one company in the context or if Field Service is not installed.

Task-3942760
