### PR TITLE
[FIX] l10n_mx: fix readonly traceback when deactivating the res_config_settings_view_form in get_view

### DIFF
--- a/addons/l10n_mx/models/res_config_settings.py
+++ b/addons/l10n_mx/models/res_config_settings.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from odoo import api, fields, models
+from odoo import api, fields, models, modules
 
 
 class ResConfigSettings(models.TransientModel):
@@ -14,6 +14,6 @@ class ResConfigSettings(models.TransientModel):
         # However, we don't want to force the upgrade of the module.
         # 'module_l10n_mx_edi' will be removed in master.
         mx_view = self.env.ref('l10n_mx.res_config_settings_view_form', raise_if_not_found=False).sudo()
-        if mx_view.active:
+        if mx_view.active and not modules.module.current_test:
             mx_view.active = False
         return super().get_views(views, options)

--- a/addons/l10n_mx/views/res_config_settings_views.xml
+++ b/addons/l10n_mx/views/res_config_settings_views.xml
@@ -3,6 +3,7 @@
     <record id="res_config_settings_view_form" model="ir.ui.view">
         <field name="name">res.config.settings.view.form.inherit.l10n.mx</field>
         <field name="model">res.config.settings</field>
+        <field name="active">False</field>
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
             <xpath expr=".//block[@id='invoicing_settings']" position="inside">


### PR DESCRIPTION
To reproduce:
- Launch Odoo instance with the option --db_replica_host=''
- Install l10n_mx
- access Settings > Accounting
- You'll get the error in the log

The Issue
During testing, attempting to modify a field's state using the 'get_views' function, which is marked as read-only, results in a read-only error.

The Fix:
To resolve this, apply changes only when we are not in test mode and ensure the view is initially imported as inactive.

runbot-60422