### PR TITLE
[IMP] account: Per payment method granularity sequencing

### DIFF
--- a/addons/account/models/account_payment_method.py
+++ b/addons/account/models/account_payment_method.py
@@ -121,6 +121,11 @@ class AccountPaymentMethodLine(models.Model):
     payment_type = fields.Selection(related='payment_method_id.payment_type')
     company_id = fields.Many2one(related='journal_id.company_id')
     available_payment_method_ids = fields.Many2many(related='journal_id.available_payment_method_ids')
+    payment_sequence = fields.Boolean(
+        string='Dedicated Payment Sequence',
+        default=True,
+        help="Check this box if you don't want to share the same sequence on payments and bank transactions posted on this journal",
+    )
 
     @api.depends('journal_id')
     @api.depends_context('show_payment_journal_id')

--- a/addons/account/tests/test_sequence_mixin.py
+++ b/addons/account/tests/test_sequence_mixin.py
@@ -640,7 +640,9 @@ class TestSequenceMixin(TestSequenceMixinCommon):
 
     def test_resequence_payment_and_non_payment_without_payment_sequence(self):
         """Resequence wizard could be open for different move type if the payment sequence is set to False on the journal."""
-        journal = self.company_data['default_journal_bank'].copy({'payment_sequence': False})
+        journal = self.company_data['default_journal_bank'].copy()
+        journal.outbound_payment_method_line_ids.write({'payment_sequence': False})
+        journal.inbound_payment_method_line_ids.write({'payment_sequence': False})
         bsl = self.env['account.bank.statement.line'].create({'name': 'test', 'amount': 100, 'journal_id': journal.id})
         payment = self.env['account.payment'].create({
             'payment_type': 'inbound',

--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -84,7 +84,6 @@
                                         <field name="profit_account_id" invisible="type not in ('cash', 'bank')"/>
                                         <field name="loss_account_id" invisible="type not in ('cash', 'bank')"/>
                                         <field name="refund_sequence" invisible="type not in ['sale', 'purchase']"/>
-                                        <field name="payment_sequence" invisible="type not in ('bank', 'cash')"/>
                                         <field name="code" placeholder="e.g. INV"/>
                                         <field name="currency_id" options="{'no_create': True}" groups="base.group_multi_currency"/>
                                     </group>
@@ -112,6 +111,7 @@
                                                optional="hide"
                                                options="{'no_quick_create': True}"
                                                groups="account.group_account_readonly"/>
+                                        <field name="payment_sequence"/>
                                     </tree>
                                 </field>
                             </page>
@@ -130,6 +130,7 @@
                                                    optional="hide"
                                                    options="{'no_quick_create': True}"
                                                    groups="account.group_account_readonly"/>
+                                            <field name="payment_sequence"/>
                                         </tree>
                                     </field>
                                     <field name="selected_payment_method_codes" invisible="1"/>

--- a/addons/account/wizard/account_resequence.py
+++ b/addons/account/wizard/account_resequence.py
@@ -41,7 +41,7 @@ class ReSequenceWizard(models.TransientModel):
             raise UserError(_('The sequences of this journal are different for Invoices and Refunds but you selected some of both types.'))
         is_payment = set(active_move_ids.mapped(lambda x: bool(x.payment_id)))
         if (
-            active_move_ids.journal_id.payment_sequence
+            active_move_ids.journal_id._has_dedicated_payment_sequence()
             and len(is_payment) > 1
         ):
             raise UserError(_('The sequences of this journal are different for Payments and non-Payments but you selected some of both types.'))


### PR DESCRIPTION
Currently, the sequencing ganularity for payments is set at journal level.

With this commit, the granularity is moved down to the payment method of a journal. Now, one journal can have several sequences (1 for each payment method and a default one for the journal itself).

odoo/enterprise/pull/67796
odoo/upgrade/pull/6334
task-3925608

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
