### PR TITLE
[FIX] purchase_stock: allow decreasing demand on picking with lead time

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -25,7 +25,7 @@ class StockMove(models.Model):
 
     @api.model
     def _prepare_merge_negative_moves_excluded_distinct_fields(self):
-        excluded_fields = super()._prepare_merge_negative_moves_excluded_distinct_fields() + ['created_purchase_line_id']
+        excluded_fields = super()._prepare_merge_negative_moves_excluded_distinct_fields() + ['created_purchase_line_id', 'date_deadline']
         if self.env['ir.config_parameter'].sudo().get_param('purchase_stock.merge_different_procurement'):
             excluded_fields += ['procure_method']
         return excluded_fields


### PR DESCRIPTION
### Steps to reproduce:

- Enable "Multi-steps" route and "Security Lead Time for Purchase" in the settings and add a lead time of 2 days
- Go to Inventory / Configuration / Warehouse Management / Warehouses
- Put you warehouse in 2 steps Incoming Shipments
- Create a storable product using the buy route and with a set vendor
- Create an order point min 50, max 50 for that product and Order Once
- Go on and confirm the associated PO
> 2 pickings were created
- Change the demand of the demand to 35 units on the PO
> The first picking from Vendor to Input was correctly updated, however
> The picking from Input to Stock **was not updated** and a picking from
> Stock to Input was created for 15 units.

### Cause of the issue:

Decreasing the quantity on the PO will generate and confirm a stock move with negative quantities of -15 units to propagate the decrease of quantity from one picking to an other. On the first picking the negative move is correctly merged to the already existing one updating the `product_qty` to 35 units. However, the negative move of -15 Units created from Input to Stock does not have the same `date_deadline` as the already exiting move on our second picking due to the leadtime on purchase order, and since the `date_deadline` is not excluded here: https://github.com/odoo/odoo/blob/8ff2381901e4920434eaee73f8c265fc67271c99/addons/stock/models/stock_move.py#L1029-L1030 from the field keys used to create the `moves_by_neg_key` dictionnary, the keys of the two moves will not match one an other and the moves will not be merged as they should be because the second loop will be done on an empty list:
https://github.com/odoo/odoo/blob/8ff2381901e4920434eaee73f8c265fc67271c99/addons/stock/models/stock_move.py#L1051-L1053

opw-4075649
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
