### PR TITLE
[FIX] website_event_sale: restore cart after login

### DIFF
--- a/addons/website_event_sale/views/website_event_templates.xml
+++ b/addons/website_event_sale/views/website_event_templates.xml
@@ -86,10 +86,10 @@
     <!-- Change 'continue' button to use the website login settings -->
     <xpath expr="//div[hasclass('modal-footer')]//button[hasclass('btn-primary')]" position="replace">
         <t t-if="website.account_on_checkout == 'mandatory' and website.is_public_user()">
-            <a class="btn btn-primary" t-attf-href="/web/login?redirect=/event/#{slug(event)}">
+            <button class="btn btn-primary" type="submit">
                 <span>Sign In</span>
                 <span class="fa fa-sign-in"/>
-            </a>
+            </button>
         </t>
         <t t-else="">
             <t t-set="has_paying_ticket" t-value="any(ticket.get('price', 0) > 0 for ticket in tickets)"/>


### PR DESCRIPTION
Steps to reproduce
====================

- Say logging is mandatory to order (website settings).
- Log in as a visitor, pick some tickets, and fill in the attendee details.
- ​Try to confirm.
- You are redirected to the login page and then to the event.
- Your tickets are lost and you need to start again.

After this PR
==================

The cart will be restored with the ticket picked up, after login.

Task-4039974

