### PR TITLE
[FIX] pos_self_order: make self_ordering_default_user required

### DIFF
--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -68,6 +68,7 @@ class PosConfig(models.Model):
         string="Default User",
         help="Access rights of this user will be used when visiting self order website when no session is open.",
         default=_self_order_default_user,
+        required=True,
     )
     self_ordering_pay_after = fields.Selection(
         selection=lambda self: self._compute_selection_pay_after(),


### PR DESCRIPTION
If no default user is set and you open the self ordering while not being connected you get an access error.

Steps to reproduce:
-------------------
* Remove default user from self ordering
* Open the self ordering in an incognito window
> Observation: You get an access error

opw-4076798
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
