### PR TITLE
[REF] account,*: partial payment method domain for manual adding in Journal

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -317,8 +317,12 @@ class AccountJournal(models.Model):
         method_information_mapping = results['method_information_mapping']
         providers_per_code = results['providers_per_code']
 
-        # Compute the candidates for each journal.
-        for journal in self:
+        journal_bank_cash = self.filtered(lambda j: j.type in ('bank', 'cash'))
+        journal_other = self - journal_bank_cash
+        journal_other.available_payment_method_ids = False
+
+        # Compute the candidates for each bank/cash journal.
+        for journal in journal_bank_cash:
             commands = [Command.clear()]
             company = journal.company_id
 
@@ -334,12 +338,11 @@ class AccountJournal(models.Model):
                             protected_provider_ids.add(line.payment_provider_id.id)
 
             for pay_method in pay_methods:
-                values = method_information_mapping[pay_method.id]
-
-                # Get the domain of the journals on which the current method is usable.
-                method_domain = pay_method._get_payment_method_domain(pay_method.code)
-                if not journal.filtered_domain(method_domain):
+                # Check the partial domain of the payment method to make sure the type matches the current journal
+                if not journal._is_payment_method_available(pay_method.code, complete_domain=False):
                     continue
+
+                values = method_information_mapping[pay_method.id]
 
                 if values['mode'] == 'unique':
                     # 'unique' are linked to a single journal per company.
@@ -1000,10 +1003,15 @@ class AccountJournal(models.Model):
         else:
             return self.outbound_payment_method_line_ids
 
-    def _is_payment_method_available(self, payment_method_code):
+    def _is_payment_method_available(self, payment_method_code, complete_domain=True):
         """ Check if the payment method is available on this journal. """
         self.ensure_one()
-        return self.filtered_domain(self.env['account.payment.method']._get_payment_method_domain(payment_method_code))
+        method_domain = self.env['account.payment.method']._get_payment_method_domain(
+            code=payment_method_code,
+            with_country=complete_domain,
+            with_currency=complete_domain,
+        )
+        return self.filtered_domain(method_domain)
 
     def _process_reference_for_sale_order(self, order_reference):
         '''

--- a/addons/account/models/account_payment_method.py
+++ b/addons/account/models/account_payment_method.py
@@ -37,26 +37,25 @@ class AccountPaymentMethod(models.Model):
         return payment_methods
 
     @api.model
-    def _get_payment_method_domain(self, code):
+    def _get_payment_method_domain(self, code, with_currency=True, with_country=True):
         """
-        :return: The domain specyfying which journal can accomodate this payment method.
+        :param code: string of the payment method line code to check.
+        :param with_currency: if False (default True), ignore the currency_id domain if it exists.
+        :return: The domain specifying which journal can accommodate this payment method.
         """
         if not code:
             return []
         information = self._get_payment_method_information().get(code)
+        journal_types = information.get('type', ('bank', 'cash'))
+        domains = [[('type', 'in', journal_types)]]
 
-        currency_ids = information.get('currency_ids')
-        country_id = information.get('country_id')
-        default_domain = [('type', 'in', ('bank', 'cash'))]
-        domains = [information.get('domain', default_domain)]
-
-        if currency_ids:
+        if with_currency and (currency_ids := information.get('currency_ids')):
             domains += [expression.OR([
                 [('currency_id', '=', False), ('company_id.currency_id', 'in', currency_ids)],
-                [('currency_id', 'in', currency_ids)]],
-            )]
+                [('currency_id', 'in', currency_ids)],
+            ])]
 
-        if country_id:
+        if with_country and (country_id := information.get('country_id')):
             domains += [[('company_id.account_fiscal_country_id', '=', country_id)]]
 
         return expression.AND(domains)
@@ -66,16 +65,17 @@ class AccountPaymentMethod(models.Model):
         """
         Contains details about how to initialize a payment method with the code x.
         The contained info are:
-            mode: Either unique if we only want one of them at a single time (payment providers for example)
-                   or multi if we want the method on each journal fitting the domain.
-            domain: The domain defining the eligible journals.
-            currency_id: The id of the currency necessary on the journal (or company) for it to be eligible.
-            country_id: The id of the country needed on the company for it to be eligible.
-            hidden: If set to true, the method will not be automatically added to the journal,
-                    and will not be selectable by the user.
+
+        - ``mode``: One of the following:
+          "unique" if the method cannot be used twice on the same company,
+          "electronic" if the method cannot be used twice on the same company for the same 'payment_provider_id',
+          "multi" if the method can be duplicated on the same journal.
+        - ``type``: Tuple containing one or both of these items: "bank" and "cash"
+        - ``currency_ids``: The ids of the currency necessary on the journal (or company) for it to be eligible.
+        - ``country_id``: The id of the country needed on the company for it to be eligible.
         """
         return {
-            'manual': {'mode': 'multi', 'domain': [('type', 'in', ('bank', 'cash'))]},
+            'manual': {'mode': 'multi', 'type': ('bank', 'cash')},
         }
 
     @api.model

--- a/addons/account/tests/test_account_journal.py
+++ b/addons/account/tests/test_account_journal.py
@@ -104,7 +104,7 @@ class TestAccountJournal(AccountTestInvoicingCommon):
 
         def _get_payment_method_information(self):
             res = Method_get_payment_method_information(self)
-            res['multi'] = {'mode': 'multi', 'domain': [('type', '=', 'bank')]}
+            res['multi'] = {'mode': 'multi', 'type': ('bank',)}
             return res
 
         with patch.object(AccountPaymentMethod, '_get_payment_method_information', _get_payment_method_information):

--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -117,7 +117,7 @@
                             </page>
                             <page id="outbound_payment_settings" string="Outgoing Payments" name="page_outgoing_payments" invisible="type not in ['cash', 'bank']">
                                     <field name="outbound_payment_method_line_ids" nolabel="1" context="{'default_payment_type': 'outbound'}">
-                                        <tree string="Payment Methods" editable="bottom" nolabel="1">
+                                        <tree string="Payment Methods" editable="bottom">
                                             <field name="available_payment_method_ids" column_invisible="True"/>
                                             <field name="payment_type" column_invisible="True"/>
                                             <field name="company_id" column_invisible="True"/>

--- a/addons/account_check_printing/models/account_payment_method.py
+++ b/addons/account_check_printing/models/account_payment_method.py
@@ -10,5 +10,5 @@ class AccountPaymentMethod(models.Model):
     @api.model
     def _get_payment_method_information(self):
         res = super()._get_payment_method_information()
-        res['check_printing'] = {'mode': 'multi', 'domain': [('type', '=', 'bank')]}
+        res['check_printing'] = {'mode': 'multi', 'type': ('bank',)}
         return res

--- a/addons/account_payment/models/account_payment_method.py
+++ b/addons/account_payment/models/account_payment_method.py
@@ -15,6 +15,6 @@ class AccountPaymentMethod(models.Model):
                 continue
             res[code] = {
                 'mode': 'electronic',
-                'domain': [('type', '=', 'bank')],
+                'type': ('bank',),
             }
         return res

--- a/addons/account_payment/tests/common.py
+++ b/addons/account_payment/tests/common.py
@@ -54,7 +54,7 @@ class AccountPaymentCommon(PaymentCommon, AccountTestInvoicingCommon):
 
         def _get_payment_method_information(*args, **kwargs):
             res = Method_get_payment_method_information()
-            res['none'] = {'mode': 'electronic', 'domain': [('type', '=', 'bank')]}
+            res['none'] = {'mode': 'electronic', 'type': ('bank',)}
             return res
 
         with patch.object(self.env.registry['account.payment.method'], '_get_payment_method_information', _get_payment_method_information):

--- a/addons/l10n_latam_check/models/account_payment_method.py
+++ b/addons/l10n_latam_check/models/account_payment_method.py
@@ -7,8 +7,8 @@ class AccountPaymentMethod(models.Model):
     @api.model
     def _get_payment_method_information(self):
         res = super()._get_payment_method_information()
-        res['new_third_party_checks'] = {'mode': 'multi', 'domain': [('type', '=', 'cash')]}
-        res['in_third_party_checks'] = {'mode': 'multi', 'domain': [('type', '=', 'cash')]}
-        res['out_third_party_checks'] = {'mode': 'multi', 'domain': [('type', '=', 'cash')]}
-        res['own_checks'] = {'mode': 'multi', 'domain': [('type', '=', 'bank')]}
+        res['new_third_party_checks'] = {'mode': 'multi', 'type': ('cash',)}
+        res['in_third_party_checks'] = {'mode': 'multi', 'type': ('cash',)}
+        res['out_third_party_checks'] = {'mode': 'multi', 'type': ('cash',)}
+        res['own_checks'] = {'mode': 'multi', 'type': ('bank',)}
         return res

--- a/addons/pos_online_payment/tests/test_frontend.py
+++ b/addons/pos_online_payment/tests/test_frontend.py
@@ -33,7 +33,7 @@ class TestUi(AccountTestInvoicingCommon, OnlinePaymentCommon):
 
         def _get_payment_method_information(self):
             res = Method_get_payment_method_information(self)
-            res['none'] = {'mode': 'multi', 'domain': [('type', '=', 'bank')]}
+            res['none'] = {'mode': 'multi', 'type': ('bank',)}
             return res
 
         with patch.object(AccountPaymentMethod, '_get_payment_method_information', _get_payment_method_information):


### PR DESCRIPTION
This commit refactors the restriction set on the tree view of Journal's
Inbound/Outbound payment method lines so that it's possible to manually
add method that were initially restricted.

In other words, if a payment method is available (and some partial rules
are met), we will now be able to add them manually in the journal. The
alleviated restriction will be from the currency and country domain, but
the mode (unique / electronic) restriction and journal type will stay.

Purpose: Sometimes, the user might want to manually add a payment method
even when it doesn't meet the method's criteria. For example: an
european company wants to create ISO20022 files for his bank that only
accepts this type of payment files. Because the bank account is an IBAN,
ISO20022 is not available because the journal currency is EUR.

This commit will not change the current behavior of generation of
default inbound/outbound payment method lines. By default, the domains
in the payment methods are considered when adding to the default lines.

To make it performance friendly, in the compute for available payment
method in journal, we will filter the non bank/cash journal and keep
them outside the loop, since payment method are useless for them.

task-id: [4058440](https://www.odoo.com/odoo/project/967/tasks/4058440?cids=1)
related enterprise PR: https://github.com/odoo/enterprise/pull/67816