### PR TITLE
[FIX] base_import_module: Make test_import_zip more resilient

### DIFF
--- a/addons/base_import_module/tests/test_import_module.py
+++ b/addons/base_import_module/tests/test_import_module.py
@@ -66,7 +66,7 @@ class TestImportModule(odoo.tests.TransactionCase):
         self.env['res.lang']._activate_lang('fr_FR')
         with self.assertLogs('odoo.addons.base_import_module.models.ir_module') as log_catcher:
             self.import_zipfile(files)
-            self.assertIn('module foo: no translation for language fr_FR', log_catcher.output[5])
+            self.assertIn('INFO:odoo.addons.base_import_module.models.ir_module:module foo: no translation for language fr_FR', log_catcher.output)
         self.assertEqual(self.env.ref('foo.foo')._name, 'res.partner')
         self.assertEqual(self.env.ref('foo.foo').name, 'foo')
         self.assertEqual(self.env.ref('foo.bar')._name, 'res.partner')


### PR DESCRIPTION
In some cases, this test can fail if the logs are not exactly in the expected order. 
See some examples here:
https://runbot.odoo.com/runbot/build/66341605
https://runbot.odoo.com/runbot/build/66320898
https://runbot.odoo.com/runbot/build/66320884

After this commit, the order of the logs does not matter for the test.
Also, in case the test does fail, the logs are visible in the traceback (instead of being suppressed by the log catcher)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
