### PR TITLE
[FIX] web: autofocus the first input on the empty login form

### DIFF
--- a/addons/web/static/src/core/user_switch/user_switch.js
+++ b/addons/web/static/src/core/user_switch/user_switch.js
@@ -16,6 +16,7 @@ export class UserSwitch extends Component {
         });
         this.form = document.querySelector("form.oe_login_form");
         this.form.classList.toggle("d-none", users.length);
+        this.form.querySelector(":placeholder-shown")?.focus();
         useEffect(
             (el) => el?.querySelector("button.list-group-item-action")?.focus(),
             () => [this.root.el]


### PR DESCRIPTION
it occurs when you are on the empty login form and no user saved on the
quick login form.

this issues was introduced in commit odoo/odoo@ce71c5d17f093db195d7a212fe610d55824f6fbc

task-3953707
