### PR TITLE
[FIX] website_hr_recruitment: linkedin logo overlap with rtl lang

### DIFF
--- a/addons/website_hr_recruitment/static/src/scss/website_hr_recruitment.scss
+++ b/addons/website_hr_recruitment/static/src/scss/website_hr_recruitment.scss
@@ -60,12 +60,15 @@
 
 .o_linkedin_icon {
     position: absolute;
-    height: 100%;
-    padding: 2px 5px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 38px;
+    width: 38px;
     margin: 0!important;
-    border-radius: 0.25rem;
-    background-color: #f5993c;
-    filter: invert(1);
+    border-radius: 0.4rem 0 0 0.4rem;
+    color: #fcf9f2;
+    background-color: #0a66c2;
 }
 
 .o_apply_description_link:hover {

--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -251,12 +251,12 @@
                                             <label class="col-4 col-sm-auto s_website_form_label" style="width: 200px" for="recruitment4">
                                                 <span class="s_website_form_label_content">LinkedIn Profile</span>
                                             </label>
-                                            <div class="col-sm" style="position: relative">
-                                                <i class="fa fa-linkedin fa-2x m-1 o_linkedin_icon" style="max-height: 37px;"></i>
+                                            <div class="col-sm" >
+                                                <i class="fa fa-linkedin fa-2x o_linkedin_icon"></i>
                                                 <input id="recruitment4" type="text"
                                                     class="form-control s_website_form_input pl64"
-                                                    placeholder="e.g. https://www.linkedin.com/in/fpodoo/"
-                                                    style="padding-left: 40px"
+                                                    placeholder="e.g. https://www.linkedin.com/in/fpodoo"
+                                                    style="padding-inline-start: calc(40px + 0.375rem)"
                                                     name="linkedin_profile"
                                                     data-fill-with="linkedin_profile"/>
                                                 <div class="alert alert-warning mt-2 d-none" id="linkedin-message"></div>


### PR DESCRIPTION
The LinkedIn logo on the /jobs/apply page, where applicants input their LinkedIn profile URL, was previously overlapping the link when using RTL languages (like Arabic or Hebrew). This issue was resolved by replacing padding-left with padding-inline-start. Additionally, CSS for the logo was slightly refactored as it had some conflicting declarations.

task-4087165

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
