### PR TITLE
[FIX] website_sale: align product configurator columns mobile

### DIFF
--- a/addons/website_sale/static/src/scss/product_configurator.scss
+++ b/addons/website_sale/static/src/scss/product_configurator.scss
@@ -250,6 +250,12 @@ label.css_attribute_color.css_not_available {
     padding: 0.075rem 0.75rem;
 }
 
+@include media-breakpoint-down(md) {
+    .oe_advanced_configurator_modal th.td-img + th {
+        display: none;
+    }
+}
+
 .js_product {
 
     .td-product_name {


### PR DESCRIPTION
Steps to reproduce:
/!\ on mobile
- Sale > Any Product > Sales tab
- Add an optional product
- Website > Shop > Select product
- Add to cart

Columns are misaligned with their data, the style that dictates which elements should display depending on screen width only applied to the table body, meaning we had 4 columns with only three data points to fill them, hence why everything is shifted over to the left.

opw-4067850

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
