### PR TITLE
[IMP] point_of_sale: add ActionScreen

### DIFF
--- a/addons/point_of_sale/static/src/app/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.js
@@ -22,6 +22,7 @@ import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { deduceUrl } from "@point_of_sale/utils";
 import { PaymentScreen } from "@point_of_sale/app/screens/payment_screen/payment_screen";
 import { user } from "@web/core/user";
+import { ActionScreen } from "@point_of_sale/app/screens/action_screen";
 
 export class Navbar extends Component {
     static template = "point_of_sale.Navbar";
@@ -74,7 +75,7 @@ export class Navbar extends Component {
             }
         } else if (
             this.pos.mobile_pane == "left" ||
-            this.pos.mainScreen.component === PaymentScreen
+            [PaymentScreen, ActionScreen].includes(this.pos.mainScreen.component)
         ) {
             this.pos.mobile_pane = "right";
             this.pos.showScreen("ProductScreen");

--- a/addons/point_of_sale/static/src/app/screens/action_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/action_screen.js
@@ -1,0 +1,12 @@
+import { Component, xml } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+import { ActionContainer } from "@web/webclient/actions/action_container";
+
+export class ActionScreen extends Component {
+    static components = { ActionContainer };
+    static props = {};
+    static template = xml`
+        <ActionContainer/>
+    `;
+}
+registry.category("pos_screens").add("ActionScreen", ActionScreen);

--- a/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
@@ -14,6 +14,7 @@ import {
     ZERO,
     BACKSPACE,
 } from "@point_of_sale/app/generic_components/numpad/numpad";
+import { ActionScreen } from "@point_of_sale/app/screens/action_screen";
 
 patch(Navbar, {
     components: { ...Navbar.components, ListContainer },
@@ -34,7 +35,8 @@ patch(Navbar.prototype, {
             if (
                 (this.pos.mainScreen.component === ProductScreen &&
                     this.pos.mobile_pane == "right") ||
-                this.pos.mainScreen.component === TipScreen
+                this.pos.mainScreen.component === TipScreen ||
+                this.pos.mainScreen.component === ActionScreen
             ) {
                 this.pos.showScreen("FloorScreen", { floor: this.floor });
             } else {


### PR DESCRIPTION
In this commit we add a mechanism that allows us to open actions with `target: "current"`. This means that we can now have action that occupy an entire screen, not just a dialog.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
