### PR TITLE
[FIX] quality_mrp: avoid traceback when sending to fail location

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1896,7 +1896,7 @@ class MrpProduction(models.Model):
             ml_by_move = []
             product_uom = initial_move.product_id.uom_id
             if not initial_move.picked:
-                for move_line in initial_move.move_line_ids:
+                for move_line in initial_move.move_line_ids.sorted(key=lambda ml: ml._sorting_move_lines()):
                     available_qty = move_line.product_uom_id._compute_quantity(move_line.quantity, product_uom, rounding_method="HALF-UP")
                     if float_compare(available_qty, 0, precision_rounding=product_uom.rounding) <= 0:
                         continue

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -513,6 +513,9 @@ class StockMoveLine(models.Model):
             moves.with_prefetch()._recompute_state()
         return res
 
+    def _sorting_move_lines(self):
+        return (self.id,)
+
     def _action_done(self):
         """ This method is called during a move's `action_done`. It'll actually move a quant from
         the source location to the destination location, and unreserve if needed in the source


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1” with BoM: - Component: C1

- Create a quality point: - Product: P1 - Operation: Manufacturing - Control per: Quantity - Control Frequency: All

- Create a manufacturing order: - Product: P1 - Quantity: 20

- Confirm the MO
- Set the qty producing 12
- click on the quality check: - Button Fail - Quantity: 5

- Valide the Mo and create a backorder
- click on the quality check: - Button Fail - Quantity: 1

Problem:
A traceback is triggered:
```
  File "/home/odoo/odoo V16/enterprise/quality_control/models/quality.py", line 370, in _move_line_to_failure_location
    if not check._can_move_line_to_failure_location():
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/odoo V16/enterprise/quality_mrp/models/quality.py", line 49, in _can_move_line_to_failure_location
    self.move_line_id = self.production_id.finished_move_line_ids.filtered(
    ^^^^^^^^^^^^^^^^^
  File "/home/odoo/odoo V16/odoo/odoo/fields.py", line 1321, in __set__
    write_value = self.convert_to_write(value, records)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/odoo V16/odoo/odoo/fields.py", line 3118, in convert_to_write
    return value.id
           ^^^^^^^^
  File "/home/odoo/odoo V16/odoo/odoo/fields.py", line 5154, in __get__
    raise ValueError("Expected singleton: %s" % record)
ValueError: Expected singleton: stock.move.line(96, 98)
```

When we validate the MO to create the backorder, the `_split_productions`
function is called. This results in two move lines:
https://github.com/odoo/odoo/blob/4be8cac644c9471f98bf16e82825af0e9439e697/addons/mrp/models/mrp_production.py#L1837
The first one has a quantity of 15, which is the remaining quantity
to be processed, and the second line has a quantity of 5, which is the
quantity that has definitely failed. However, these two move lines are
supposed to be ordered first by the failed ones and then by the others.
Because, in the current situation, we take the move line with the
quantity of 15, reduce it by the 12 units processed in this MO,
leaving 3. As a result, we will have two remaining move lines:
3 + 5 (already failed), and both will be used in the backorder.
But if they were ordered by the failed ones first, we would subtract
12 from 5, resulting in -7, and then reduce the line with 15 - 7 = 8
in the move line that will be used in the backorder."
https://github.com/odoo/odoo/blob/4be8cac644c9471f98bf16e82825af0e9439e697/addons/mrp/models/mrp_production.py#L1848-L1858
opw-4064656
