### PR TITLE
[FIX] pos_hr: prevent error on backspace in empty password popup

### DIFF
--- a/addons/pos_hr/static/src/app/select_cashier_mixin.js
+++ b/addons/pos_hr/static/src/app/select_cashier_mixin.js
@@ -42,7 +42,7 @@ export function useCashierSelector(
     async function checkPin(employee) {
         const employee_security = pos.employee_security;
         const inputPin = await makeAwaitable(dialog, NumberPopup, {
-            formatDisplayedValue: (x) => x.replace(/./g, "•"),
+            formatDisplayedValue: (x) => (x ? x.replace(/./g, "•") : ""),
             title: _t("Password?"),
         });
         if (!inputPin || employee_security[employee.id].pin !== Sha1.hash(inputPin)) {


### PR DESCRIPTION
Before this commit, pressing backspace in the cashier selection password number popup when it was empty would cause an error.

opw-4089617

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
