### PR TITLE
[FIX] pos_self_order: make sure default_user is set when needed

### DIFF
--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -24,7 +24,7 @@ class PosConfig(models.Model):
         return self.env["res.lang"].get_installed()
 
     def _self_order_default_user(self):
-        users = self.env["res.users"].search(['|', ('company_id', '=', self.env.company.id), ('company_id', '=', False)])
+        users = self.env["res.users"].search(['|', ('company_ids', 'in', self.env.company.id), ('company_id', '=', False)])
         for user in users:
             if (user.sudo().has_group("point_of_sale.group_pos_user")
                     or user.sudo().has_group("point_of_sale.group_pos_manager")):
@@ -163,10 +163,11 @@ class PosConfig(models.Model):
     def _check_default_user(self):
         for record in self:
             if (
-                record.self_ordering_mode == 'mobile'
-                and record.self_ordering_default_user_id
+                record.self_ordering_mode != 'nothing' and (
+                not record.self_ordering_default_user_id or (
+                record.self_ordering_default_user_id
                 and not record.self_ordering_default_user_id.sudo().has_group("point_of_sale.group_pos_user")
-                and not record.self_ordering_default_user_id.sudo().has_group("point_of_sale.group_pos_manager")
+                and not record.self_ordering_default_user_id.sudo().has_group("point_of_sale.group_pos_manager")))
             ):
                 raise UserError(_("The Self-Order default user must be a POS user"))
 

--- a/addons/pos_self_order/tests/test_self_order_common.py
+++ b/addons/pos_self_order/tests/test_self_order_common.py
@@ -5,6 +5,8 @@ import odoo.tests
 from odoo.addons.point_of_sale.tests.common_setup_methods import setup_pos_combo_items
 from odoo.addons.pos_self_order.tests.self_order_common_test import SelfOrderCommonTest
 
+from odoo.exceptions import UserError
+
 
 @odoo.tests.tagged("post_install", "-at_install")
 class TestSelfOrderCommon(SelfOrderCommonTest):
@@ -51,3 +53,10 @@ class TestSelfOrderCommon(SelfOrderCommonTest):
         for mode in ("mobile", "consultation", "kiosk"):
             self.pos_config.write({"self_ordering_mode": mode})
             self.start_tour(self_route, "self_order_pos_is_closed")
+
+    def test_self_order_config_default_user(self):
+        self.pos_config.payment_method_ids = self.pos_config.payment_method_ids.filtered(lambda pm: not pm.is_cash_count)
+        for mode in ("mobile", "consultation", "kiosk"):
+            self.pos_config.write({"self_ordering_mode": mode})
+            with self.assertRaises(UserError):
+                self.pos_config.write({"self_ordering_default_user_id": False})

--- a/addons/pos_self_order/views/res_config_settings_views.xml
+++ b/addons/pos_self_order/views/res_config_settings_views.xml
@@ -28,7 +28,7 @@
                             <label for="pos_self_ordering_service_mode" class="col-lg-4" string="Service at" />
                             <field name="pos_self_ordering_service_mode" readonly="not pos_module_pos_restaurant and pos_self_ordering_mode != 'kiosk'" />
                         </div>
-                        <div class="content-group row" groups="base.group_no_one" invisible="not pos_self_ordering_mode in ['kiosk', 'mobile']">
+                        <div class="content-group row" groups="base.group_no_one" invisible="pos_self_ordering_mode == 'nothing'">
                             <label for="pos_self_ordering_default_user_id" class="col-lg-4" string="Default User"/>
                             <field name="pos_self_ordering_default_user_id" />
                         </div>


### PR DESCRIPTION
When self ordering is enabled, default user should always be set. If it is not the case, self ordering pages would return access error

Steps to reproduce:
-------------------
* Enable self order (kiosk/menu/menu+ordering)
* Remove default user from pos config
* Try to open the self order page
> Observation: you get an access error

opw-4076798
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
