### PR TITLE
[I18N] l10n_din5008{_repair,_stock}: update translations

### DIFF
--- a/addons/l10n_din5008/i18n/de.po
+++ b/addons/l10n_din5008/i18n/de.po
@@ -78,14 +78,16 @@ msgid ""
 ";\n"
 "                            }\n"
 "                            .page {\n"
-"                                [name=invoice_line_table], [name=stock_move_table], .o_main_table {\n"
+"                                [name=invoice_line_table], "
+"[name=stock_move_table], .o_main_table {\n"
 "                                    th {\n"
 "                                        color:"
 msgstr ""
 ";\n"
 "                            }\n"
 "                            .page {\n"
-"                                [name=invoice_line_table], [name=stock_move_table], .o_main_table {\n"
+"                                [name=invoice_line_table], "
+"[name=stock_move_table], .o_main_table {\n"
 "                                    th {\n"
 "                                        color:"
 
@@ -302,14 +304,25 @@ msgid "Street2"
 msgstr "Straße 2"
 
 #. module: l10n_din5008
+#: model_terms:ir.ui.view,arch_db:l10n_din5008.external_layout_din5008
+msgid "Tax ID"
+msgstr "USt-IdNr."
+
+#. module: l10n_din5008
 #: model:ir.model.fields,help:l10n_din5008.field_base_document_layout__account_fiscal_country_id
 msgid "The country to use the tax reports from for this company"
-msgstr "Das Land, aus dem die Steuerberichte für dieses Unternehmen zu verwenden sind"
+msgstr ""
+"Das Land, aus dem die Steuerberichte für dieses Unternehmen zu verwenden sind"
 
 #. module: l10n_din5008
 #: model:ir.model.fields,help:l10n_din5008.field_base_document_layout__company_registry
-msgid "The registry number of the company. Use it if it is different from the Tax ID. It must be unique across all partners of a same country"
-msgstr "Die Registernummer des Unternehmens. Verwenden Sie diese, wenn sie sich von der Steuer-ID unterscheidet. Sie muss für alle Partner desselben Landes eindeutig sein."
+msgid ""
+"The registry number of the company. Use it if it is different from the Tax "
+"ID. It must be unique across all partners of a same country"
+msgstr ""
+"Die Registernummer des Unternehmens. Verwenden Sie diese, wenn sie sich von "
+"der Steuer-ID unterscheidet. Sie muss für alle Partner desselben Landes "
+"eindeutig sein."
 
 #. module: l10n_din5008
 #. odoo-python

--- a/addons/l10n_din5008/i18n/fr.po
+++ b/addons/l10n_din5008/i18n/fr.po
@@ -58,7 +58,8 @@ msgid ""
 ";\n"
 "                            }\n"
 "                            .page {\n"
-"                                [name=invoice_line_table], [name=stock_move_table], .o_main_table {\n"
+"                                [name=invoice_line_table], "
+"[name=stock_move_table], .o_main_table {\n"
 "                                    th {\n"
 "                                        color:"
 msgstr ""
@@ -98,7 +99,7 @@ msgstr "Ville"
 #. module: l10n_din5008
 #: model:ir.model.fields,field_description:l10n_din5008.field_base_document_layout__company_details
 msgid "Company Details"
-msgstr ""
+msgstr "Détails de la société"
 
 #. module: l10n_din5008
 #: model:ir.model,name:l10n_din5008.model_base_document_layout
@@ -148,22 +149,22 @@ msgstr "Pays d'imposition"
 #. module: l10n_din5008
 #: model:ir.model.fields,help:l10n_din5008.field_base_document_layout__report_footer
 msgid "Footer text displayed at the bottom of all reports."
-msgstr ""
+msgstr "Pied de page de tous les rapports."
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.external_layout_din5008
 msgid "HRB Nr:"
-msgstr ""
+msgstr "N° HRB:"
 
 #. module: l10n_din5008
 #: model:ir.model.fields,help:l10n_din5008.field_base_document_layout__company_details
 msgid "Header text displayed at the top of all reports."
-msgstr ""
+msgstr "Texte d'en-tête affiché en haut de tous les rapports."
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.external_layout_din5008
 msgid "IBAN:"
-msgstr ""
+msgstr "IBAN:"
 
 #. module: l10n_din5008
 #. odoo-python
@@ -249,14 +250,14 @@ msgstr "Référence"
 #. module: l10n_din5008
 #: model:ir.model.fields,field_description:l10n_din5008.field_base_document_layout__report_footer
 msgid "Report Footer"
-msgstr ""
+msgstr "Pied de page de rapport"
 
 #. module: l10n_din5008
 #. odoo-python
 #: code:addons/l10n_din5008/models/account_move.py:0
 #, python-format
 msgid "Shipping Address:"
-msgstr ""
+msgstr "Adresse de livraison:"
 
 #. module: l10n_din5008
 #. odoo-python
@@ -276,14 +277,25 @@ msgid "Street2"
 msgstr "Rue 2"
 
 #. module: l10n_din5008
+#: model_terms:ir.ui.view,arch_db:l10n_din5008.external_layout_din5008
+msgid "Tax ID"
+msgstr "N° TVA"
+
+#. module: l10n_din5008
 #: model:ir.model.fields,help:l10n_din5008.field_base_document_layout__account_fiscal_country_id
 msgid "The country to use the tax reports from for this company"
-msgstr "Le pays à partir duquel utiliser les déclarations fiscales pour cette société"
+msgstr ""
+"Le pays à partir duquel utiliser les déclarations fiscales pour cette société"
 
 #. module: l10n_din5008
 #: model:ir.model.fields,help:l10n_din5008.field_base_document_layout__company_registry
-msgid "The registry number of the company. Use it if it is different from the Tax ID. It must be unique across all partners of a same country"
-msgstr "Le numéro de registre de la société. Utilisez-le s'il est différent du numéro d'identification fiscale. Il doit être unique parmi tous les partenaires d'un même pays"
+msgid ""
+"The registry number of the company. Use it if it is different from the Tax "
+"ID. It must be unique across all partners of a same country"
+msgstr ""
+"Le numéro de registre de la société. Utilisez-le s'il est différent du "
+"numéro d'identification fiscale. Il doit être unique parmi tous les "
+"partenaires d'un même pays"
 
 #. module: l10n_din5008
 #. odoo-python

--- a/addons/l10n_din5008/i18n/it.po
+++ b/addons/l10n_din5008/i18n/it.po
@@ -58,7 +58,8 @@ msgid ""
 ";\n"
 "                            }\n"
 "                            .page {\n"
-"                                [name=invoice_line_table], [name=stock_move_table], .o_main_table {\n"
+"                                [name=invoice_line_table], "
+"[name=stock_move_table], .o_main_table {\n"
 "                                    th {\n"
 "                                        color:"
 msgstr ""
@@ -98,7 +99,7 @@ msgstr "Città"
 #. module: l10n_din5008
 #: model:ir.model.fields,field_description:l10n_din5008.field_base_document_layout__company_details
 msgid "Company Details"
-msgstr ""
+msgstr "Dettagli azienda"
 
 #. module: l10n_din5008
 #: model:ir.model,name:l10n_din5008.model_base_document_layout
@@ -148,7 +149,7 @@ msgstr "Paese fiscale"
 #. module: l10n_din5008
 #: model:ir.model.fields,help:l10n_din5008.field_base_document_layout__report_footer
 msgid "Footer text displayed at the bottom of all reports."
-msgstr ""
+msgstr "Piè di pagina visualizzato in fondo a tutti i documenti."
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.external_layout_din5008
@@ -158,7 +159,7 @@ msgstr "No HRB:"
 #. module: l10n_din5008
 #: model:ir.model.fields,help:l10n_din5008.field_base_document_layout__company_details
 msgid "Header text displayed at the top of all reports."
-msgstr ""
+msgstr "Testo di intestazione visualizzato all'inizio di tutti i rapporti."
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.external_layout_din5008
@@ -249,7 +250,7 @@ msgstr "Riferimento"
 #. module: l10n_din5008
 #: model:ir.model.fields,field_description:l10n_din5008.field_base_document_layout__report_footer
 msgid "Report Footer"
-msgstr ""
+msgstr "Piè di pagina documento"
 
 #. module: l10n_din5008
 #. odoo-python
@@ -276,14 +277,23 @@ msgid "Street2"
 msgstr "Strada 2"
 
 #. module: l10n_din5008
+#: model_terms:ir.ui.view,arch_db:l10n_din5008.external_layout_din5008
+msgid "Tax ID"
+msgstr "Partita IVA"
+
+#. module: l10n_din5008
 #: model:ir.model.fields,help:l10n_din5008.field_base_document_layout__account_fiscal_country_id
 msgid "The country to use the tax reports from for this company"
 msgstr "Il paese da cui utilizzare i report fiscali per questa società"
 
 #. module: l10n_din5008
 #: model:ir.model.fields,help:l10n_din5008.field_base_document_layout__company_registry
-msgid "The registry number of the company. Use it if it is different from the Tax ID. It must be unique across all partners of a same country"
-msgstr "Il numero di registro dell'azienda. Inseriscilo se è diverso dalla partita IVA. Deve essere unico per tutti i partner di una stessa nazione"
+msgid ""
+"The registry number of the company. Use it if it is different from the Tax "
+"ID. It must be unique across all partners of a same country"
+msgstr ""
+"Il numero di registro dell'azienda. Inseriscilo se è diverso dalla partita "
+"IVA. Deve essere unico per tutti i partner di una stessa nazione"
 
 #. module: l10n_din5008
 #. odoo-python

--- a/addons/l10n_din5008/i18n/l10n_din5008.pot
+++ b/addons/l10n_din5008/i18n/l10n_din5008.pot
@@ -275,6 +275,11 @@ msgid "Street2"
 msgstr ""
 
 #. module: l10n_din5008
+#: model_terms:ir.ui.view,arch_db:l10n_din5008.external_layout_din5008
+msgid "Tax ID"
+msgstr ""
+
+#. module: l10n_din5008
 #: model:ir.model.fields,help:l10n_din5008.field_base_document_layout__account_fiscal_country_id
 msgid "The country to use the tax reports from for this company"
 msgstr ""

--- a/addons/l10n_din5008/i18n/nl.po
+++ b/addons/l10n_din5008/i18n/nl.po
@@ -58,7 +58,8 @@ msgid ""
 ";\n"
 "                            }\n"
 "                            .page {\n"
-"                                [name=invoice_line_table], [name=stock_move_table], .o_main_table {\n"
+"                                [name=invoice_line_table], "
+"[name=stock_move_table], .o_main_table {\n"
 "                                    th {\n"
 "                                        color:"
 msgstr ""
@@ -98,7 +99,7 @@ msgstr "Plaats"
 #. module: l10n_din5008
 #: model:ir.model.fields,field_description:l10n_din5008.field_base_document_layout__company_details
 msgid "Company Details"
-msgstr ""
+msgstr "Bedrijfsgegevens"
 
 #. module: l10n_din5008
 #: model:ir.model,name:l10n_din5008.model_base_document_layout
@@ -148,17 +149,17 @@ msgstr "Fiscale land"
 #. module: l10n_din5008
 #: model:ir.model.fields,help:l10n_din5008.field_base_document_layout__report_footer
 msgid "Footer text displayed at the bottom of all reports."
-msgstr ""
+msgstr "Voettekst, weergegeven aan de onderzijde van alle rapportages."
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.external_layout_din5008
 msgid "HRB Nr:"
-msgstr "Kvk nr.:"
+msgstr "HRB nr.:"
 
 #. module: l10n_din5008
 #: model:ir.model.fields,help:l10n_din5008.field_base_document_layout__company_details
 msgid "Header text displayed at the top of all reports."
-msgstr ""
+msgstr "Koptekst weergegeven boven aan alle rapportages."
 
 #. module: l10n_din5008
 #: model_terms:ir.ui.view,arch_db:l10n_din5008.external_layout_din5008
@@ -249,7 +250,7 @@ msgstr "Referentie"
 #. module: l10n_din5008
 #: model:ir.model.fields,field_description:l10n_din5008.field_base_document_layout__report_footer
 msgid "Report Footer"
-msgstr ""
+msgstr "Rapport voettekst"
 
 #. module: l10n_din5008
 #. odoo-python
@@ -276,14 +277,25 @@ msgid "Street2"
 msgstr "Straat2"
 
 #. module: l10n_din5008
+#: model_terms:ir.ui.view,arch_db:l10n_din5008.external_layout_din5008
+msgid "Tax ID"
+msgstr "Btw nr."
+
+#. module: l10n_din5008
 #: model:ir.model.fields,help:l10n_din5008.field_base_document_layout__account_fiscal_country_id
 msgid "The country to use the tax reports from for this company"
-msgstr "Het land waaruit de belastingrapporten voor dit bedrijf moeten worden gebruikt"
+msgstr ""
+"Het land waaruit de belastingrapporten voor dit bedrijf moeten worden "
+"gebruikt"
 
 #. module: l10n_din5008
 #: model:ir.model.fields,help:l10n_din5008.field_base_document_layout__company_registry
-msgid "The registry number of the company. Use it if it is different from the Tax ID. It must be unique across all partners of a same country"
-msgstr "Het registratienummer van het bedrijf. Gebruik het als het verschilt van het BTW nummer. Het moet uniek zijn voor alle partners van hetzelfde land"
+msgid ""
+"The registry number of the company. Use it if it is different from the Tax "
+"ID. It must be unique across all partners of a same country"
+msgstr ""
+"Het registratienummer van het bedrijf. Gebruik het als het verschilt van het "
+"btw-nummer. Het moet uniek zijn voor alle partners van hetzelfde land"
 
 #. module: l10n_din5008
 #. odoo-python

--- a/addons/l10n_din5008_repair/i18n/de.po
+++ b/addons/l10n_din5008_repair/i18n/de.po
@@ -62,10 +62,3 @@ msgstr "Reparaturauftrag"
 #, python-format
 msgid "Repair Quotation"
 msgstr "Kostenvoranschlag"
-
-#. module: l10n_din5008_repair
-#. odoo-python
-#: code:addons/l10n_din5008_repair/models/repair.py:0
-#, python-format
-msgid "Warranty"
-msgstr "Garantie"

--- a/addons/l10n_din5008_repair/i18n/fr.po
+++ b/addons/l10n_din5008_repair/i18n/fr.po
@@ -62,10 +62,3 @@ msgstr "Ordre de réparation"
 #, python-format
 msgid "Repair Quotation"
 msgstr "Devis de réparation"
-
-#. module: l10n_din5008_repair
-#. odoo-python
-#: code:addons/l10n_din5008_repair/models/repair.py:0
-#, python-format
-msgid "Warranty"
-msgstr "Garantie"

--- a/addons/l10n_din5008_repair/i18n/it.po
+++ b/addons/l10n_din5008_repair/i18n/it.po
@@ -62,10 +62,3 @@ msgstr "Ordine di riparazione"
 #, python-format
 msgid "Repair Quotation"
 msgstr "Preventivo riparazione"
-
-#. module: l10n_din5008_repair
-#. odoo-python
-#: code:addons/l10n_din5008_repair/models/repair.py:0
-#, python-format
-msgid "Warranty"
-msgstr "Garanzia"

--- a/addons/l10n_din5008_repair/i18n/l10n_din5008_repair.pot
+++ b/addons/l10n_din5008_repair/i18n/l10n_din5008_repair.pot
@@ -60,10 +60,3 @@ msgstr ""
 #, python-format
 msgid "Repair Quotation"
 msgstr ""
-
-#. module: l10n_din5008_repair
-#. odoo-python
-#: code:addons/l10n_din5008_repair/models/repair.py:0
-#, python-format
-msgid "Warranty"
-msgstr ""

--- a/addons/l10n_din5008_repair/i18n/nl.po
+++ b/addons/l10n_din5008_repair/i18n/nl.po
@@ -62,10 +62,3 @@ msgstr "Reparatieorder"
 #, python-format
 msgid "Repair Quotation"
 msgstr "Reparatieofferte"
-
-#. module: l10n_din5008_repair
-#. odoo-python
-#: code:addons/l10n_din5008_repair/models/repair.py:0
-#, python-format
-msgid "Warranty"
-msgstr "Garantie"

--- a/addons/l10n_din5008_stock/i18n/de.po
+++ b/addons/l10n_din5008_stock/i18n/de.po
@@ -25,6 +25,13 @@ msgid "Customer Address:"
 msgstr "Kundenadresse:"
 
 #. module: l10n_din5008_stock
+#. odoo-python
+#: code:addons/l10n_din5008_stock/models/stock.py:0
+#, python-format
+msgid "Delivery Address:"
+msgstr "Lieferadresse:"
+
+#. module: l10n_din5008_stock
 #: model:ir.model.fields,field_description:l10n_din5008_stock.field_stock_picking__l10n_din5008_addresses
 msgid "L10N Din5008 Addresses"
 msgstr "L10N Din5008 Adressen"

--- a/addons/l10n_din5008_stock/i18n/fr.po
+++ b/addons/l10n_din5008_stock/i18n/fr.po
@@ -25,6 +25,13 @@ msgid "Customer Address:"
 msgstr "Adresse du client:"
 
 #. module: l10n_din5008_stock
+#. odoo-python
+#: code:addons/l10n_din5008_stock/models/stock.py:0
+#, python-format
+msgid "Delivery Address:"
+msgstr "Adresse de livraison:"
+
+#. module: l10n_din5008_stock
 #: model:ir.model.fields,field_description:l10n_din5008_stock.field_stock_picking__l10n_din5008_addresses
 msgid "L10N Din5008 Addresses"
 msgstr "Adresses L10N Din5008"

--- a/addons/l10n_din5008_stock/i18n/it.po
+++ b/addons/l10n_din5008_stock/i18n/it.po
@@ -25,6 +25,13 @@ msgid "Customer Address:"
 msgstr "Indirizzo cliente:"
 
 #. module: l10n_din5008_stock
+#. odoo-python
+#: code:addons/l10n_din5008_stock/models/stock.py:0
+#, python-format
+msgid "Delivery Address:"
+msgstr "Indirizzo di consegna:"
+
+#. module: l10n_din5008_stock
 #: model:ir.model.fields,field_description:l10n_din5008_stock.field_stock_picking__l10n_din5008_addresses
 msgid "L10N Din5008 Addresses"
 msgstr "Indirizzi L10N Din5008"

--- a/addons/l10n_din5008_stock/i18n/nl.po
+++ b/addons/l10n_din5008_stock/i18n/nl.po
@@ -25,6 +25,13 @@ msgid "Customer Address:"
 msgstr "Klantadres:"
 
 #. module: l10n_din5008_stock
+#. odoo-python
+#: code:addons/l10n_din5008_stock/models/stock.py:0
+#, python-format
+msgid "Delivery Address:"
+msgstr "Afleveradres:"
+
+#. module: l10n_din5008_stock
 #: model:ir.model.fields,field_description:l10n_din5008_stock.field_stock_picking__l10n_din5008_addresses
 msgid "L10N Din5008 Addresses"
 msgstr "L10N Din5008 Adressen"


### PR DESCRIPTION
Some translations were missing in the DIN5008 modules. This commit updates the terms and completes missing translations.

[opw-3961574](https://www.odoo.com/odoo/project.task/3961574?cids=1)