### PR TITLE
[IMP] core: test complement domains (partial)

### DIFF
--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -717,7 +717,7 @@ class TestExpression(SavepointCaseWithUserDemo, TransactionExpressionCase):
         # Special =? operator mean "is equal if right is set, otherwise always True"
         users = self._search(Users, [('name', 'like', 'test'), ('parent_id', '=?', False)])
         self.assertEqual(users, a + b1 + b2, '(x =? False) failed')
-        users = self._search(Users, [('name', 'like', 'test'), ('parent_id', '=?', b1.partner_id.id)], test_complement=False)  # FIXME complement
+        users = self._search(Users, [('name', 'like', 'test'), ('parent_id', '=?', b1.partner_id.id)])
         self.assertEqual(users, b2, '(x =? id) failed')
 
     def test_30_normalize_domain(self):

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -883,6 +883,20 @@ class TestExpression(SavepointCaseWithUserDemo, TransactionExpressionCase):
         countries = self._search(Country, [('name', '=ilike', 'z%')])
         self.assertTrue(len(countries) == 2, "Must match only countries with names starting with Z (currently 2)")
 
+    def test_like_filtered(self):
+        Model = self.env['res.partner.category']
+        record = Model.create({'name': '[default] _*%'})
+        record_pct = Model.create({'name': '5%'})
+
+        self.assertIn(record, self._search(Model, [('name', 'like', r'[default]')]))
+        self.assertIn(record, self._search(Model, [('name', 'like', r'\_*')]))
+        self.assertIn(record, self._search(Model, [('name', 'like', r'[_ef')]))
+        self.assertIn(record, self._search(Model, [('name', 'like', r'[%]')]))
+        self.assertIn(record, self._search(Model, [('name', 'ilike', r'DEF')]))
+
+        self.assertIn(record, self._search(Model, [('name', '=like', r'%\%')]))
+        self.assertIn(record_pct, self._search(Model, [('name', '=like', r'%\%')]))
+
     def test_like_cast(self):
         Model = self.env['res.partner.category']
         record = Model.create({'name': 'XY', 'color': 42})

--- a/odoo/addons/test_new_api/tests/test_indexed_translation.py
+++ b/odoo/addons/test_new_api/tests/test_indexed_translation.py
@@ -25,13 +25,11 @@ class TestIndexedTranslation(TransactionExpressionCase):
 
         # escaped and unescaped PG wildcards
         self.assertEqual(self._search(record_en, [('name', 'ilike', r'class%class')]), record_en)
-        self.assertEqual(record_en.search([('name', 'ilike', r'class="m_\_class')]), record_en)  # FIXME complement
-        # self.assertEqual(self._search(record_en, [('name', 'ilike', r'class="m_\_class')]), record_en)
+        self.assertEqual(self._search(record_en, [('name', 'ilike', r'class="m_\_class')]), record_en)
         self.assertEqual(self._search(record_en, [('name', 'ilike', 'bonjour')]), record_en.browse())
         self.assertEqual(self._search(record_en, [('name', 'ilike', '</div>\n<div/>')]), record_en)
         self.assertEqual(self._search(record_fr, [('name', 'ilike', '</div>\a<div/>')]), record_fr)
-        self.assertEqual(record_fr.search([('name', 'ilike', r'\%bonjour\\')]), record_fr)  # FIXME complement
-        # self.assertEqual(self._search(record_fr, [('name', 'ilike', r'\%bonjour\\')]), record_fr)
+        self.assertEqual(self._search(record_fr, [('name', 'ilike', r'\%bonjour\\')]), record_fr)
 
         self.assertEqual(
             self._search(record_en, [('name', '=', '<div class="my_class">hello</div>\n<div/>')]),

--- a/odoo/addons/test_new_api/tests/test_indexed_translation.py
+++ b/odoo/addons/test_new_api/tests/test_indexed_translation.py
@@ -1,11 +1,10 @@
-# -*- coding: utf-8 -*-
-
 import odoo.tests
+from odoo.addons.base.tests.test_expression import TransactionExpressionCase
 from odoo.addons.base.tests.test_translate import SPECIAL_CHARACTERS
 
 
 @odoo.tests.tagged('post_install', '-at_install')
-class TestIndexedTranslation(odoo.tests.TransactionCase):
+class TestIndexedTranslation(TransactionExpressionCase):
 
     @classmethod
     def setUpClass(cls):
@@ -22,22 +21,24 @@ class TestIndexedTranslation(odoo.tests.TransactionCase):
         self.assertEqual(record_fr.name, '<div class="my_class">%bonjour\\</div>\a<div/>')
 
         # matching double quotes
-        self.assertEqual(record_en.search([('name', 'ilike', 'class="my_class')]), record_en)
+        self.assertEqual(self._search(record_en, [('name', 'ilike', 'class="my_class')]), record_en)
 
         # escaped and unescaped PG wildcards
-        self.assertEqual(record_en.search([('name', 'ilike', 'class%class')]), record_en)
-        self.assertEqual(record_en.search([('name', 'ilike', r'class="m_\_class')]), record_en)
-        self.assertEqual(record_en.search([('name', 'ilike', 'bonjour')]), record_en.browse())
-        self.assertEqual(record_en.search([('name', 'ilike', '</div>\n<div/>')]), record_en)
-        self.assertEqual(record_fr.search([('name', 'ilike', '</div>\a<div/>')]), record_fr)
-        self.assertEqual(record_fr.search([('name', 'ilike', r'\%bonjour\\')]), record_fr)
+        self.assertEqual(self._search(record_en, [('name', 'ilike', r'class%class')]), record_en)
+        self.assertEqual(record_en.search([('name', 'ilike', r'class="m_\_class')]), record_en)  # FIXME complement
+        # self.assertEqual(self._search(record_en, [('name', 'ilike', r'class="m_\_class')]), record_en)
+        self.assertEqual(self._search(record_en, [('name', 'ilike', 'bonjour')]), record_en.browse())
+        self.assertEqual(self._search(record_en, [('name', 'ilike', '</div>\n<div/>')]), record_en)
+        self.assertEqual(self._search(record_fr, [('name', 'ilike', '</div>\a<div/>')]), record_fr)
+        self.assertEqual(record_fr.search([('name', 'ilike', r'\%bonjour\\')]), record_fr)  # FIXME complement
+        # self.assertEqual(self._search(record_fr, [('name', 'ilike', r'\%bonjour\\')]), record_fr)
 
         self.assertEqual(
-            record_en.search([('name', '=', '<div class="my_class">hello</div>\n<div/>')]),
+            self._search(record_en, [('name', '=', '<div class="my_class">hello</div>\n<div/>')]),
             record_en,
         )
         self.assertEqual(
-            record_fr.search([('name', '=', '<div class="my_class">%bonjour\\</div>\a<div/>')]),
+            self._search(record_fr, [('name', '=', '<div class="my_class">%bonjour\\</div>\a<div/>')]),
             record_fr,
         )
 
@@ -78,18 +79,18 @@ class TestIndexedTranslation(odoo.tests.TransactionCase):
         record_en.name = name_en
         record_fr.name = name_fr
 
-        self.assertEqual(record_en.search([('name', 'ilike', name_en)]), record_en)
-        self.assertEqual(record_en.search([('name', '=', name_en)]), record_en)
-        self.assertEqual(record_en.search([('name', 'in', [name_en])]), record_en)
+        self.assertEqual(self._search(record_en, [('name', 'ilike', name_en)]), record_en)
+        self.assertEqual(self._search(record_en, [('name', '=', name_en)]), record_en)
+        self.assertEqual(self._search(record_en, [('name', 'in', [name_en])]), record_en)
 
-        self.assertEqual(record_fr.search([('name', 'ilike', name_fr)]), record_en)
-        self.assertEqual(record_fr.search([('name', '=', name_fr)]), record_en)
-        self.assertEqual(record_fr.search([('name', 'in', [name_fr])]), record_en)
+        self.assertEqual(self._search(record_fr, [('name', 'ilike', name_fr)]), record_en)
+        self.assertEqual(self._search(record_fr, [('name', '=', name_fr)]), record_en)
+        self.assertEqual(self._search(record_fr, [('name', 'in', [name_fr])]), record_en)
 
-        self.assertFalse(record_fr.search([('name', 'ilike', name_en)]))
-        self.assertFalse(record_fr.search([('name', '=', name_en)]))
-        self.assertFalse(record_fr.search([('name', 'in', [name_en])]))
+        self.assertFalse(self._search(record_fr, [('name', 'ilike', name_en)]))
+        self.assertFalse(self._search(record_fr, [('name', '=', name_en)]))
+        self.assertFalse(self._search(record_fr, [('name', 'in', [name_en])]))
 
-        self.assertFalse(record_en.search([('name', 'ilike', name_fr)]))
-        self.assertFalse(record_en.search([('name', '=', name_fr)]))
-        self.assertFalse(record_en.search([('name', 'in', [name_fr])]))
+        self.assertFalse(self._search(record_en, [('name', 'ilike', name_fr)]))
+        self.assertFalse(self._search(record_en, [('name', '=', name_fr)]))
+        self.assertFalse(self._search(record_en, [('name', 'in', [name_fr])]))

--- a/odoo/addons/test_new_api/tests/test_one2many.py
+++ b/odoo/addons/test_new_api/tests/test_one2many.py
@@ -1,13 +1,12 @@
-# -*- coding: utf-8 -*-
-from odoo.tests.common import TransactionCase
-from odoo.exceptions import MissingError, UserError
 from odoo import Command
+from odoo.addons.base.tests.test_expression import TransactionExpressionCase
+from odoo.exceptions import MissingError, UserError
 from odoo.tools import mute_logger
 
 
-class One2manyCase(TransactionCase):
+class One2manyCase(TransactionExpressionCase):
     def setUp(self):
-        super(One2manyCase, self).setUp()
+        super().setUp()
         self.Line = self.env["test_new_api.multi.line"]
         self.multi = self.env["test_new_api.multi"].create({
             "name": "What is up?"
@@ -127,28 +126,28 @@ class One2manyCase(TransactionCase):
         movie_editions = movies_with_edition.editions
         one_movie_edition = movie_editions[0]
 
-        res_movies_without_edition = self.Movie.search([('editions', '=', False)])
+        res_movies_without_edition = self._search(self.Movie, [('editions', '=', False)])
         self.assertItemsEqual(t(res_movies_without_edition), t(movies_without_edition))
 
-        res_movies_with_edition = self.Movie.search([('editions', '!=', False)])
+        res_movies_with_edition = self._search(self.Movie, [('editions', '!=', False)])
         self.assertItemsEqual(t(res_movies_with_edition), t(movies_with_edition))
 
-        res_books_with_movie_edition = self.Book.search([('editions', 'in', movie_editions.ids)])
+        res_books_with_movie_edition = self._search(self.Book, [('editions', 'in', movie_editions.ids)])
         self.assertFalse(t(res_books_with_movie_edition))
 
-        res_books_without_movie_edition = self.Book.search([('editions', 'not in', movie_editions.ids)])
+        res_books_without_movie_edition = self._search(self.Book, [('editions', 'not in', movie_editions.ids)])
         self.assertItemsEqual(t(res_books_without_movie_edition), t(books))
 
-        res_books_without_one_movie_edition = self.Book.search([('editions', 'not in', movie_editions[:1].ids)])
+        res_books_without_one_movie_edition = self._search(self.Book, [('editions', 'not in', movie_editions[:1].ids)])
         self.assertItemsEqual(t(res_books_without_one_movie_edition), t(books))
 
-        res_books_with_one_movie_edition_name = self.Book.search([('editions', '=', movie_editions[:1].name)])
+        res_books_with_one_movie_edition_name = self._search(self.Book, [('editions', '=', movie_editions[:1].name)])
         self.assertFalse(t(res_books_with_one_movie_edition_name))
 
-        res_books_without_one_movie_edition_name = self.Book.search([('editions', '!=', movie_editions[:1].name)])
+        res_books_without_one_movie_edition_name = self._search(self.Book, [('editions', '!=', movie_editions[:1].name)])
         self.assertItemsEqual(t(res_books_without_one_movie_edition_name), t(books))
 
-        res_movies_not_of_edition_name = self.Movie.search([('editions', '!=', one_movie_edition.name)])
+        res_movies_not_of_edition_name = self._search(self.Movie, [('editions', '!=', one_movie_edition.name)])
         self.assertItemsEqual(t(res_movies_not_of_edition_name), t(movies.filtered(lambda r: one_movie_edition not in r.editions)))
 
     def test_merge_partner(self):
@@ -453,8 +452,8 @@ class One2manyCase(TransactionCase):
         # Also, test a simple infinite loop if record is marked as a parent of itself
         team1.parent_id = team1.id
         # Check that the search is not stuck in the loop
-        Team.search([('id', 'parent_of', team1.id)])
-        Team.search([('id', 'child_of', team1.id)])
+        self._search(Team, [('id', 'parent_of', team1.id)])
+        self._search(Team, [('id', 'child_of', team1.id)])
 
     @mute_logger('odoo.osv.expression')
     def test_create_one2many_with_unsearchable_field(self):

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 import collections
 import contextlib
 import datetime
-import fnmatch
 import functools
 import inspect
 import itertools
@@ -6362,9 +6361,29 @@ class BaseModel(metaclass=MetaModel):
                     else:
                         def unaccent(x):
                             return str(x) if x else ''
-                    value_esc = unaccent(value).replace('_', '?').replace('%', '*').replace('[', '?')
-                    if not comparator.startswith('='):
-                        value_esc = f'*{value_esc}*'
+
+                    # build a regex that matches the SQL-like expression
+                    # note that '\' is used for escaping in SQL
+                    def build_like_regex(value: str, exact: bool):
+                        yield '^' if exact else '.*'
+                        escaped = False
+                        for char in value:
+                            if escaped:
+                                escaped = False
+                                yield re.escape(char)
+                            elif char == '\\':
+                                escaped = True
+                            elif char == '%':
+                                yield '.*'
+                            elif char == '_':
+                                yield '.'
+                            else:
+                                yield re.escape(char)
+                        if exact:
+                            yield '$'
+                        # no need to match r'.*' in else because we only use .match()
+
+                    like_regex = re.compile("".join(build_like_regex(unaccent(value), comparator.startswith("="))))
                 if comparator in ('=', '!=') and field.type in ('char', 'text', 'html') and not value:
                     # use the comparator 'in' for falsy comparison of strings
                     comparator = 'in' if comparator == '=' else 'not in'
@@ -6419,8 +6438,7 @@ class BaseModel(metaclass=MetaModel):
                     elif comparator == '>=':
                         ok = any(x is not None and x >= value for x in data)
                     elif comparator in ('like', 'ilike', '=like', '=ilike', 'not ilike', 'not like'):
-                        # use fnmatchcase to avoid relying on file path case normalization
-                        ok = any(fnmatch.fnmatchcase(unaccent(x), value_esc) for x in data)
+                        ok = any(like_regex.match(unaccent(x)) for x in data)
                         if comparator.startswith('not'):
                             ok = not ok
                     elif comparator == 'any':

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -420,6 +420,13 @@ def _tree_from_domain(domain):
 
 def _tree_not(tree):
     """ Negate a tree node. """
+    if tree[0] == '=?':
+        # already update operator '=?' here, so that '!' is distributed correctly
+        assert len(tree) == 3
+        if tree[2]:
+            tree = ('=', tree[1], tree[2])
+        else:
+            return ('?', False)
     if tree[0] == '?':
         return ('?', not tree[1])
     if tree[0] == '!':


### PR DESCRIPTION
Add tests for complementary domains: given a domain the result of `['!', *normalized_domain]` should return all other objects.

This defines the tests and adds TODO comments for found issues.
The PR to follow-up is #171291

task-4017289


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
