### PR TITLE
[FIX] sale, purchase: missing line name on invoices

### DIFF
--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -2,7 +2,6 @@
 from datetime import datetime, time
 from dateutil.relativedelta import relativedelta
 from pytz import UTC
-import re
 
 from odoo import api, fields, models, _
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT, get_lang
@@ -557,18 +556,9 @@ class PurchaseOrderLine(models.Model):
         aml_currency = move and move.currency_id or self.currency_id
         date = move and move.date or fields.Date.today()
 
-        # Compatibility fix for creating invoices from a SO since the computation of the line name has been changed in the account module.
-        # Has to be removed as soon as the new behavior for the line name has been implemented in the sale module.
-        line_name = self.name
-        if self.product_id.display_name:
-            line_name = re.sub(re.escape(self.product_id.display_name), '', line_name)
-            line_name = re.sub(r'^\n', '', line_name)
-            line_name = re.sub(r'(?<=\n) ', '', line_name)
-            line_name = re.sub(r'P(\d+):(\s*)$', r'P\1', '%s: %s' % (self.order_id.name, line_name))
-
         res = {
             'display_type': self.display_type or 'product',
-            'name': line_name,
+            'name': self.name,
             'product_id': self.product_id.id,
             'product_uom_id': self.product_uom.id,
             'quantity': self.qty_to_invoice,

--- a/addons/purchase/tests/test_purchase_invoice.py
+++ b/addons/purchase/tests/test_purchase_invoice.py
@@ -328,12 +328,12 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
         self.assertInvoiceValues(move, [
             {
                 'display_type': 'product',
-                'amount_currency': 1000,
-                'balance': 1000,
-            }, {
-                'display_type': 'product',
                 'amount_currency': 500,
                 'balance': 500,
+            }, {
+                'display_type': 'product',
+                'amount_currency': 1000,
+                'balance': 1000,
             }, {
                 'display_type': 'payment_term',
                 'amount_currency': -1500,

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1,7 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import re
-
 from collections import defaultdict
 from datetime import timedelta
 
@@ -1176,17 +1174,10 @@ class SaleOrderLine(models.Model):
         """
         self.ensure_one()
 
-        # Compatibility fix for creating invoices from a SO since the computation of the line name has been changed in the account module.
-        # Has to be removed as soon as the new behavior for the line name has been implemented in the sale module.
-        line_name = self.name
-        if self.product_id.display_name:
-            line_name = re.sub(re.escape(self.product_id.display_name), '', line_name)
-            line_name = re.sub(r'^\n', '', line_name)
-            line_name = re.sub(r'(?<=\n) ', '', line_name)
         res = {
             'display_type': self.display_type or 'product',
             'sequence': self.sequence,
-            'name': line_name,
+            'name': self.name,
             'product_id': self.product_id.id,
             'product_uom_id': self.product_uom.id,
             'quantity': self.qty_to_invoice,


### PR DESCRIPTION
Description of the issue this commit addresses:

When the new product/label widget was designed on the invoice form, a compatibility patch was applied to the sale and the purchase app to make sure the line name contained what was needed. Since then a redesign of the feature was made and the line name contains the product name again. It's only in the Invoice Lines tab that the name is removed from the name attribute so it isn't displayed twice. The regexes that removed the product name from the label for invoices coming from the Sales and the Purchase apps are therefore causing a discordance in the behaviors from the accounting app and from those two.

---

Desired behavior after this commit is merged:

After this commit, creating an invoice from a Sale or a Purchase creates invoices lines with the product name inside the name attribute to keep the same behavior everywhere.

---

sale PR commit: https://github.com/odoo/odoo/pull/152869/commits/dc33e2f10b44dd957836650c775840dd79f5b8bd
purchase PR commit: https://github.com/odoo/odoo/pull/152869/commits/82064d84da04fca373637b37b710a6f6e02da81a

no task-feedback

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
