### PR TITLE
[FIX] mrp,stock: account for removal strategy when editing mo qty

### DIFF
--- a/addons/mrp/static/tests/tours/mrp_sm_sml_synchronization.js
+++ b/addons/mrp/static/tests/tours/mrp_sm_sml_synchronization.js
@@ -55,10 +55,10 @@ registry.category("web_tour.tours").add('test_manufacturing_and_byproduct_sm_to_
         { trigger: ".o_data_row > td:contains('10')" },
         {
             trigger: ".o_field_widget[name=quantity] input",
-            run: 'text 7',
+            run: 'text 8',
         },
         { trigger: ".fa-list" },
-        { trigger: ".o_list_footer .o_list_number > span:contains('7')" },
+        { trigger: ".o_list_footer .o_list_number > span:contains('8')" },
         { trigger: ".o_form_button_save" },
         ...stepUtils.saveForm(),
     ]

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -4175,5 +4175,5 @@ class TestMrpSynchronization(HttpCase):
         self.start_tour(url, "test_manufacturing_and_byproduct_sm_to_sml_synchronization", login="admin", timeout=100)
         self.assertEqual(mo.move_raw_ids.quantity, 7)
         self.assertEqual(mo.move_raw_ids.move_line_ids.quantity, 7)
-        self.assertEqual(mo.move_byproduct_ids.quantity, 7)
+        self.assertEqual(mo.move_byproduct_ids.quantity, 8)
         self.assertEqual(len(mo.move_byproduct_ids.move_line_ids), 2)

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -359,7 +359,7 @@ class StockMove(models.Model):
     def _set_quantity(self):
         def _process_decrease(move, quantity):
             mls_to_unlink = set()
-            for ml in move.move_line_ids:
+            for ml in reversed(move.move_line_ids):
                 if float_is_zero(quantity, precision_rounding=move.product_uom.rounding):
                     break
                 qty_ml_dec = min(ml.quantity, ml.product_uom_id._compute_quantity(quantity, ml.product_uom_id, round=False))


### PR DESCRIPTION
Steps
---
1. Create a product category with a FIFO removal strategy
2. Create 2 products in this category, both tracked by lot: * a storable component C * a manufactured product P whose bom uses the component
3. Create 5 lots (L1,...,L5) of the component of 10 units each, in such a way that the dates are chronological
4. Create an MO for 30 P -> confirm it 
   * => in moves lines of the component draw we **correctly** have: [L1: 10, L2: 10, L3: 10]

=== Bug 1 ===

6. Leave the form view and reopen it
7. Without ever clicking the button to see the sml, set the qty producing to 15 and save 
   * to respect fifo we want: [ L1: 10, L2: 5 ] 
   * but we have: [ L2: 5, L3: 10 ]

=== Bug 2 ===

8. Now set the qty producing to 25: 
   * the moves lines are: [ L2: 5, L3: 10, \<No lot\>: 10 ]

=== Bug 3 ===

10. cancel the MO and exit the form view
11. create a new MO as in step 4.
12. set the qty_producing to 15
13. **then** the lot id (producing) to whatever -> *save*
    * =>  Now the move lines are: [ \<No lot\>: 15 ]

Cause and Fix
---
Bug 1:
* When we set the `qty_producing`, we call the corresponding onchange, which calls `set_quantity_done` appropriately, however since the moves lines were never loaded in the view, the onchange won't affect them
* Later, because `set_quantity_done` did properly set the overall move quantity, we call the `_set_quantity` inverse of `stock.move`s, where the process decrease function take quantity away from sml in the order they were set.
* => Fix: in `_set_quantity` take quantity away in the reverse creation order. Do not rely on the onchange to set the sml, instead set the raw quantity and let the inverse handle it.

Bug 2:
* in case of increasing quantity, `_set_quantity` does not apply removal strategy logic
* Fix: use `_action_assign` which has the logic we want

Bug 3:
* on step 10. we call the onchange for `qty_producing` thus in the cache the sml as after step 6.,
* then when we set the lot id, when we try to apply the values in the cache to the new temporary record for onchanges, since these sml are represented as update commands, they will be applied to the real record instead of the temporary one and the onchange will see no sml
* then bug2 applies
* Fix: fix1 gives use this one for free since the first onchange won't have affected the move lines.

opw-4074174
