### PR TITLE
[FIX] l10n_in: enable payslip unlink with cnl am

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -116,13 +116,13 @@ class AccountMove(models.Model):
     @api.ondelete(at_uninstall=False)
     def _unlink_l10n_in_except_once_post(self):
         # Prevent deleting entries once it's posted for Indian Company only
-        if any(m.country_code == 'IN' and m.posted_before for m in self) and not self._context.get('force_delete'):
+        if any(m.country_code == 'IN' and m.state == 'posted' for m in self) and not self._context.get('force_delete'):
             raise UserError(_("To keep the audit trail, you can not delete journal entries once they have been posted.\nInstead, you can cancel the journal entry."))
 
     def unlink(self):
         # Add logger here becouse in api ondelete account.move.line is deleted and we can't get total amount
         logger_msg = False
-        if any(m.country_code == 'IN' and m.posted_before for m in self):
+        if any(m.country_code == 'IN' and m.state == 'posted' for m in self):
             if self._context.get('force_delete'):
                 moves_details = ", ".join("{entry_number} ({move_id}) amount {amount_total} {currency} and partner {partner_name}".format(
                     entry_number=m.name,


### PR DESCRIPTION
Before this commit, the user would get a UserError when cancelling a payslip :
- if an entry has been posted -> Error + advise to cancel the entry (ok)
- if the entry is then cancelled following the advise -> same error (ko)

After this commit, the user will be able to unlink payslips if the accounting entry is not posted (in draft or cancelled)

Steps to reproduce:
- requirement modules: l10n_in_hr_payroll_account, be in indian company
1. Go to Payroll > Configuration > Structure > choose any (e.g. worker pay)
2. Set its Salary Journal (e.g. Bank)
3. Go to Payslips > All payslips > NEW > fill the form with chosen structure
4. Click on Compute sheet > Create Draft Entry > Confirm
5. Go to Other Info tab > Click on Draft Entry > fill the form (e.g. bank:100:credit and salary_expense:100:debit) > post it
6. Go back to the payslip > click on CANCEL > User Error (ok)
7. Go back to the posted entry > reset to draft > cancel entry
8. Back to the payslip > Click on CANCEL again > User Error (not ok)

Note:
It is ambigious to know wether this is an intended behavior.

1.
https://github.com/odoo/odoo/commit/1c07fa7ef4c879cf85667e658273ae40904e3569 The commit message of this commit suggests that Users can't delete journal entries after posting "once". Does "after posting" mean "after ever being posted" or "while in posted state"?

2.
https://github.com/odoo/odoo/commit/6c4a92f5e93932cb154db7b735ba5b012100fa4b This commit add clarification to the raised error message by adding: "Instead, you can cancel the journal entry", advising the user to cancel the journal entry before unlinking something.

Cause:
UserError is being raised if any present account move is being unlinked while being posted_before.

Solution:
Raise UserError if any present account move is being unlinked while being in a state of posted.

opw-4075244
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
