### PR TITLE
[IMP] *: use .translate to translate props whenever possible

### DIFF
--- a/addons/base_import/static/src/import_data_content/import_data_content.js
+++ b/addons/base_import/static/src/import_data_content/import_data_content.js
@@ -23,10 +23,6 @@ export class ImportDataContent extends Component {
         previewError: { type: String, optional: true },
     };
 
-    setup() {
-        this.searchPlaceholder = _t("Search a field...");
-    }
-
     getGroups(column) {
         const groups = [
             { choices: this.makeChoices(column.fields.basic) },

--- a/addons/base_import/static/src/import_data_content/import_data_content.xml
+++ b/addons/base_import/static/src/import_data_content/import_data_content.xml
@@ -63,7 +63,7 @@
                                     value="column.fieldInfo ? column.fieldInfo.fieldPath : undefined"
                                     groups="getGroups(column)"
                                     onSelect="(fieldPath) => this.onFieldChanged(column, fieldPath)"
-                                    searchPlaceholder="searchPlaceholder"
+                                    searchPlaceholder.translate="Search a field..."
                                     togglerClass="column.fieldInfo ? 'ps-1' : ''"
                                 >
                                     <t t-if="column.fieldInfo">

--- a/addons/html_editor/static/src/main/media/media_dialog/icon_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/icon_selector.js
@@ -1,4 +1,3 @@
-import { _t } from "@web/core/l10n/translation";
 import { SearchMedia } from "./search_media";
 import { fonts } from "@html_editor/utils/fonts";
 
@@ -28,8 +27,6 @@ export class IconSelector extends Component {
             fonts: this.props.fonts,
             needle: "",
         });
-
-        this.searchPlaceholder = _t("Search a pictogram");
     }
 
     get selectedMediaIds() {

--- a/addons/html_editor/static/src/main/media/media_dialog/icon_selector.xml
+++ b/addons/html_editor/static/src/main/media/media_dialog/icon_selector.xml
@@ -2,7 +2,7 @@
 <t t-name="html_editor.IconSelector">
     <div>
         <div class="o_we_file_selector_control_panel sticky-top d-flex gap-2 align-items-center mb-1 py-4 px-3">
-            <SearchMedia searchPlaceholder="searchPlaceholder"
+            <SearchMedia searchPlaceholder.translate="Search a pictogram"
                 search.bind="this.search"
                 needle="state.needle"/>
         </div>

--- a/addons/mail/static/src/core/common/message_seen_indicator.js
+++ b/addons/mail/static/src/core/common/message_seen_indicator.js
@@ -23,10 +23,6 @@ class MessageSeenIndicatorDialog extends Component {
             true
         );
     }
-
-    get SEEN_BY() {
-        return _t("Seen by:");
-    }
 }
 
 /**

--- a/addons/mail/static/src/core/common/message_seen_indicator.xml
+++ b/addons/mail/static/src/core/common/message_seen_indicator.xml
@@ -20,7 +20,7 @@
     </t>
 
     <t t-name="mail.MessageSeenIndicatorDialog">
-        <Dialog size="'sm'" title="SEEN_BY" footer="false" withBodyPadding="false">
+        <Dialog size="'sm'" title.translate="Seen by:" footer="false" withBodyPadding="false">
             <ul class="list-group list-group-flush list-unstyled py-1" t-ref="content">
                 <li class="list-group-item py-2" t-foreach="props.message.channelMemberHaveSeen" t-as="member" t-key="member.id">
                     <t t-call="mail.MessageSeenIndicatorPopover.card"/>

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -129,8 +129,4 @@ export class ChannelInvitation extends Component {
         }
         return _t("Invite");
     }
-
-    get title() {
-        return _t("Invite people");
-    }
 }

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.ChannelInvitation">
-        <ActionPanel title="title" resizable="false">
+        <ActionPanel title.translate="Invite people" resizable="false">
             <div t-att-class="{ 'o-discuss-ChannelInvitation-has-size-constraints': props.hasSizeConstraints }">
                 <t t-if="store.self.type === 'partner'">
                     <input class="o-discuss-ChannelInvitation-search border form-control" t-ref="input" placeholder="Type the name of a person" t-on-input="onInput"/>

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.js
@@ -3,7 +3,6 @@ import { ActionPanel } from "@mail/discuss/core/common/action_panel";
 
 import { Component, onWillUpdateProps, onWillStart, useState } from "@odoo/owl";
 
-import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 
 export class ChannelMemberList extends Component {
@@ -41,9 +40,5 @@ export class ChannelMemberList extends Component {
             return;
         }
         this.store.openChat({ partnerId: member.persona.id });
-    }
-
-    get title() {
-        return _t("Member List");
     }
 }

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.ChannelMemberList">
-        <ActionPanel title="title">
+        <ActionPanel title.translate="Member List">
             <button t-on-click="() => props.openChannelInvitePanel({ keepPrevious: env.inChatWindow })" class="btn btn-secondary m-3 mt-0">Invite a User</button>
             <t t-if="props.thread.onlineMembers.length > 0">
                 <h6 class="mx-3 text-700">

--- a/addons/mail/static/src/discuss/message_pin/common/pinned_messages_panel.js
+++ b/addons/mail/static/src/discuss/message_pin/common/pinned_messages_panel.js
@@ -40,8 +40,4 @@ export class PinnedMessagesPanel extends Component {
             return _t("This conversation doesn't have any pinned messages.");
         }
     }
-
-    get title() {
-        return _t("Pinned Messages");
-    }
 }

--- a/addons/mail/static/src/discuss/message_pin/common/pinned_messages_panel.xml
+++ b/addons/mail/static/src/discuss/message_pin/common/pinned_messages_panel.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="discuss.PinnedMessagesPanel">
-        <ActionPanel title="title">
+        <ActionPanel title.translate="Pinned Messages">
             <MessageCardList emptyText="emptyText" messages="props.thread.pinnedMessages" thread="props.thread" mode="'pin'"/>
         </ActionPanel>
     </t>

--- a/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.js
@@ -8,7 +8,7 @@ export class ActionpadWidget extends Component {
     static components = { SelectPartnerButton };
     static props = {
         partner: { type: [Object, { value: null }], optional: true },
-        actionName: Object,
+        actionName: String,
         actionType: String,
         isActionButtonHighlighted: { type: Boolean, optional: true },
         onClickMore: { type: Function, optional: true },

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -41,7 +41,6 @@ export class ProductScreen extends Component {
         ProductCard,
         CameraBarcodeScanner,
     };
-    static numpadActionName = _t("Payment");
     static props = {};
 
     setup() {

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
@@ -10,7 +10,7 @@
                     <div class="subpads d-flex">
                         <ActionpadWidget
                             partner="currentOrder?.get_partner()"
-                            actionName="constructor.numpadActionName"
+                            actionName.translate="Payment"
                             actionType="'payment'"
                             onClickMore.bind="displayAllControlPopup" />
                         <Numpad t-if="pos.get_order().uiState.selected_orderline_uuid" buttons="getNumpadButtons()" onClick.bind="onNumpadClick"/>

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/search_bar/search_bar.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/search_bar/search_bar.js
@@ -27,7 +27,7 @@ export class SearchBar extends Component {
     static template = "point_of_sale.SearchBar";
     static props = {
         config: Object,
-        placeholder: Object,
+        placeholder: String,
         onSearch: Function,
         onFilterSelected: Function,
     };

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -54,8 +54,6 @@ export class TicketScreen extends Component {
         reuseSavedUIState: false,
         ui: {},
     };
-    static numpadActionName = _t("Refund");
-    static searchPlaceholder = _t("Search Orders...");
 
     setup() {
         this.pos = usePos();

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -28,7 +28,7 @@
                         </t>
                         <SearchBar
                             config="getSearchBarConfig()"
-                            placeholder="constructor.searchPlaceholder"
+                            placeholder.translate="Search Orders..."
                             onSearch.bind="onSearch"
                             onFilterSelected.bind="onFilterSelected" />
                         <div t-if="getNbrPages()" class="item">
@@ -173,7 +173,7 @@
                                 <div class="subpads d-flex">
                                     <ActionpadWidget
                                         partner="getSelectedOrder()?.get_partner()"
-                                        actionName="constructor.numpadActionName"
+                                        actionName.translate="Refund"
                                         actionType="'refund'"
                                         actionToTrigger.bind="onDoRefund"
                                         isActionButtonHighlighted="getHasItemsToRefund()" />

--- a/addons/point_of_sale/static/src/app/store/cash_opening_popup/cash_opening_popup.js
+++ b/addons/point_of_sale/static/src/app/store/cash_opening_popup/cash_opening_popup.js
@@ -65,8 +65,4 @@ export class CashOpeningPopup extends Component {
         }
         this.state.notes = "";
     }
-
-    get inputPlaceholder() {
-        return _t("Opening Balance Eg: 123");
-    }
 }

--- a/addons/point_of_sale/static/src/app/store/cash_opening_popup/cash_opening_popup.xml
+++ b/addons/point_of_sale/static/src/app/store/cash_opening_popup/cash_opening_popup.xml
@@ -14,7 +14,7 @@
                         isValid.bind="env.utils.isValidFloat"
                         callback.bind="handleInputChange"
                         autofocus="true"
-                        placeholder="inputPlaceholder"/>
+                        placeholder.translate="Opening Balance Eg: 123"/>
                     <div class="button icon btn btn-secondary" t-on-click="openDetailsPopup">
                         <i class="fa fa-money fa-2x" role="img" title="Open the money details popup"/>
                     </div>

--- a/addons/product_matrix/static/src/js/product_matrix_dialog.js
+++ b/addons/product_matrix/static/src/js/product_matrix_dialog.js
@@ -1,6 +1,3 @@
-/** @odoo-module **/
-
-import { _t } from "@web/core/l10n/translation";
 import { Dialog } from '@web/core/dialog/dialog';
 import { formatMonetary } from "@web/views/fields/formatters";
 import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
@@ -20,7 +17,6 @@ export class ProductMatrixDialog extends Component {
 
     setup() {
         this.size = 'xl';
-        this.title = _t("Choose Product Variants");
 
         const productMatrixRef = useRef('productMatrix');
         useHotkey("enter", () => this._onConfirm(), {

--- a/addons/product_matrix/static/src/xml/product_matrix_dialog.xml
+++ b/addons/product_matrix/static/src/xml/product_matrix_dialog.xml
@@ -1,6 +1,6 @@
 <templates>
     <t t-name="product_matrix.dialog">
-        <Dialog size="size" title="title" withBodyPadding="false">
+        <Dialog size="size" title.translate="Choose Product Variants" withBodyPadding="false">
             <t t-call="product_matrix.matrix">
                 <t t-set="header" t-value="props.header"/>
                 <t t-set="rows" t-value="props.rows"/>

--- a/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
+++ b/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
@@ -1,6 +1,3 @@
-/** @odoo-module **/
-
-import { _t } from "@web/core/l10n/translation";
 import { Component, onWillStart, useState, useSubEnv } from "@odoo/owl";
 import { Dialog } from '@web/core/dialog/dialog';
 import { rpc } from "@web/core/network/rpc";
@@ -36,7 +33,6 @@ export class ProductConfiguratorDialog extends Component {
     }
 
     setup() {
-        this.title = _t("Configure your product");
         this.state = useState({
             products: [],
             optionalProducts: [],

--- a/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.xml
+++ b/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-name="sale.ProductConfiguratorDialog">
-        <Dialog size="size" title="title" contentClass="'o_sale_product_configurator_dialog'">
+        <Dialog size="size" title.translate="Configure your product" contentClass="'o_sale_product_configurator_dialog'">
             <ProductList t-if="this.state.products.length" products="this.state.products"/>
             <ProductList
                 t-if="this.state.optionalProducts.length"

--- a/addons/snailmail/static/src/core_ui/snailmail_error.js
+++ b/addons/snailmail/static/src/core_ui/snailmail_error.js
@@ -1,9 +1,6 @@
-/* @odoo-module */
-
 import { Component } from "@odoo/owl";
 import { Dialog } from "@web/core/dialog/dialog";
 
-import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 
 export class SnailmailError extends Component {
@@ -13,7 +10,6 @@ export class SnailmailError extends Component {
 
     setup() {
         this.orm = useService("orm");
-        this.title = _t("Failed letter");
     }
 
     async fetchSnailmailCreditsUrl() {

--- a/addons/snailmail/static/src/core_ui/snailmail_error.xml
+++ b/addons/snailmail/static/src/core_ui/snailmail_error.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="snailmail.SnailmailError">
-        <Dialog contentClass="'o-snailmail-SnailmailError'" title="title">
+        <Dialog contentClass="'o-snailmail-SnailmailError'" title.translate="Failed letter">
             <t t-if="props.failureType === 'sn_credit'">
                 <p class="mx-3 mb-3">
                     The letter could not be sent due to insufficient credits on your IAP account.

--- a/addons/spreadsheet/static/src/global_filters/components/filter_date_from_to_value/filter_date_from_to_value.js
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_date_from_to_value/filter_date_from_to_value.js
@@ -1,7 +1,6 @@
 /** @ts-check */
 
 import { Component } from "@odoo/owl";
-import { _t } from "@web/core/l10n/translation";
 import { DateTimeInput } from "@web/core/datetime/datetime_input";
 import { serializeDate, deserializeDate } from "@web/core/l10n/dates";
 
@@ -13,8 +12,6 @@ export class DateFromToValue extends Component {
         from: { type: String, optional: true },
         to: { type: String, optional: true },
     };
-    fromPlaceholder = _t("Date from...");
-    toPlaceholder = _t("Date to...");
 
     onDateFromChanged(dateFrom) {
         this.props.onFromToChanged({

--- a/addons/spreadsheet/static/src/global_filters/components/filter_date_from_to_value/filter_date_from_to_value.xml
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_date_from_to_value/filter_date_from_to_value.xml
@@ -4,14 +4,14 @@
         <DateTimeInput
             value="dateFrom"
             type="'date'"
-            placeholder="fromPlaceholder"
+            placeholder.translate="Date from..."
             onChange.bind="onDateFromChanged"
         />
         <i class="oi oi-arrow-right"></i>
         <DateTimeInput
             value="dateTo"
             type="'date'"
-            placeholder="toPlaceholder"
+            placeholder.translate="Date to..."
             onChange.bind="onDateToChanged"
         />
     </div>

--- a/addons/web/static/src/core/debug/debug_menu_items.xml
+++ b/addons/web/static/src/core/debug/debug_menu_items.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.DebugMenu.SetDefaultDialog">
-        <Dialog title="title">
+        <Dialog title.translate="Set Defaults">
             <table style="width: 100%">
                 <tr>
                     <td>
@@ -62,7 +62,7 @@
     </t>
 
     <t t-name="web.DebugMenu.GetMetadataDialog">
-        <Dialog title="title">
+        <Dialog title.translate="View Metadata">
             <table class="table table-sm table-striped">
                 <tr>
                     <th>ID:</th>
@@ -114,7 +114,7 @@
     </t>
 
     <t t-name="web.DebugMenu.GetViewDialog">
-        <Dialog title="title">
+        <Dialog title.translate="Get View">
             <pre t-esc="props.arch"/>
             <t t-set-slot="footer">
                 <button class="btn btn-primary o-default-button" t-on-click="() => props.close()">Close</button>

--- a/addons/web/static/src/core/errors/error_dialogs.js
+++ b/addons/web/static/src/core/errors/error_dialogs.js
@@ -46,7 +46,6 @@ export const odooExceptionTitleMap = new Map(
 export class ErrorDialog extends Component {
     static template = "web.ErrorDialog";
     static components = { Dialog };
-    static dialogTitle = _t(`Oops!`);
     static title = _t("Odoo Error");
     static showTracebackButtonText = _t("See technical details");
     static hideTracebackButtonText = _t("Hide technical details");
@@ -200,7 +199,6 @@ export class RedirectWarningDialog extends Component {
 export class Error504Dialog extends Component {
     static template = "web.Error504Dialog";
     static components = { Dialog };
-    static title = _t("Request timeout");
     static props = { ...standardErrorDialogProps };
 }
 
@@ -210,7 +208,6 @@ export class Error504Dialog extends Component {
 export class SessionExpiredDialog extends Component {
     static template = "web.SessionExpiredDialog";
     static components = { Dialog };
-    static title = _t("Odoo Session Expired");
     static props = { ...standardErrorDialogProps };
 
     onClick() {

--- a/addons/web/static/src/core/errors/error_dialogs.xml
+++ b/addons/web/static/src/core/errors/error_dialogs.xml
@@ -25,7 +25,7 @@
     </t>
 
     <t t-name="web.Error504Dialog">
-        <Dialog title="this.constructor.title" size="'xl'" contentClass="'o_error_dialog'">
+        <Dialog title.translate="Request timeout" size="'xl'" contentClass="'o_error_dialog'">
             <div role="alert">
                 <p class="text-prewrap">
                     The operation was interrupted. This usually means that the current operation is taking too much time.
@@ -38,7 +38,7 @@
     </t>
 
     <t t-name="web.SessionExpiredDialog">
-        <Dialog title="this.constructor.title" size="'xl'" contentClass="'o_error_dialog'">
+        <Dialog title.translate="Odoo Session Expired" size="'xl'" contentClass="'o_error_dialog'">
             <div role="alert">
                 <p class="text-prewrap">
                     Your Odoo session expired. The current page is about to be refreshed.
@@ -51,7 +51,7 @@
     </t>
 
     <t t-name="web.ErrorDialog">
-        <Dialog title="this.constructor.dialogTitle" size="'xl'" contentClass="'o_error_dialog'">
+        <Dialog title.translate="Oops!" size="'xl'" contentClass="'o_error_dialog'">
             <div role="alert">
                 <p class="text-prewrap">
                     Something went wrong... If you really are stuck, share the report with your friendly support service

--- a/addons/web/static/src/core/model_selector/model_selector.js
+++ b/addons/web/static/src/core/model_selector/model_selector.js
@@ -39,10 +39,6 @@ export class ModelSelector extends Component {
         });
     }
 
-    get placeholder() {
-        return _t("Type a model here...");
-    }
-
     get sources() {
         return [this.optionsSource];
     }

--- a/addons/web/static/src/core/model_selector/model_selector.xml
+++ b/addons/web/static/src/core/model_selector/model_selector.xml
@@ -13,7 +13,7 @@
                 id="props.id"
                 value="props.value || ''"
                 sources="sources"
-                placeholder="placeholder"
+                placeholder.translate="Type a model here..."
                 autoSelect="props.autoSelect"
                 onSelect.bind="onSelect"
             />

--- a/addons/web/static/src/core/signature/signature_dialog.js
+++ b/addons/web/static/src/core/signature/signature_dialog.js
@@ -1,4 +1,3 @@
-import { _t } from "@web/core/l10n/translation";
 import { Dialog } from "@web/core/dialog/dialog";
 import { NameAndSignature } from "./name_and_signature";
 
@@ -18,7 +17,6 @@ export class SignatureDialog extends Component {
     };
 
     setup() {
-        this.title = _t("Adopt Your Signature");
         this.signature = useState({
             name: this.props.defaultName,
             isSignatureEmpty: true,

--- a/addons/web/static/src/core/signature/signature_dialog.xml
+++ b/addons/web/static/src/core/signature/signature_dialog.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.SignatureDialog">
-      <Dialog title="title">
+      <Dialog title.translate="Adopt Your Signature">
          <div>
             <NameAndSignature t-props="nameAndSignatureProps"/>
             <div class="mt16 small">By clicking Adopt &amp; Sign, I agree that the chosen signature/initials will be a valid electronic representation of my hand-written signature/initials for all purposes when it is used on documents, including legally binding contracts.</div>

--- a/addons/web/static/src/views/debug_items.js
+++ b/addons/web/static/src/views/debug_items.js
@@ -30,10 +30,6 @@ class GetViewDialog extends Component {
         arch: { type: String },
         close: { type: Function },
     };
-
-    setup() {
-        this.title = _t("Get View");
-    }
 }
 
 export function getView({ component, env }) {
@@ -247,7 +243,6 @@ class SetDefaultDialog extends Component {
 
     setup() {
         this.orm = useService("orm");
-        this.title = _t("Set Defaults");
         this.state = {
             fieldToSet: "",
             condition: "",

--- a/addons/web/static/src/views/kanban/kanban_column_examples_dialog.js
+++ b/addons/web/static/src/views/kanban/kanban_column_examples_dialog.js
@@ -1,6 +1,5 @@
 import { Dialog } from "@web/core/dialog/dialog";
 import { Notebook } from "@web/core/notebook/notebook";
-import { _t } from "@web/core/l10n/translation";
 
 import { Component, useRef } from "@odoo/owl";
 
@@ -36,7 +35,7 @@ export class KanbanColumnExamplesDialog extends Component {
     static template = "web.KanbanColumnExamplesDialog";
     static components = { Dialog, Notebook };
     static props = ["*"];
-    static title = _t("Kanban Examples");
+
     setup() {
         this.navList = useRef("navList");
         this.pages = [];

--- a/addons/web/static/src/views/kanban/kanban_column_examples_dialog.xml
+++ b/addons/web/static/src/views/kanban/kanban_column_examples_dialog.xml
@@ -19,7 +19,7 @@
 
     <!-- Note: this dialog isn't responsive, but it is not accessible on mobile -->
     <t t-name="web.KanbanColumnExamplesDialog">
-        <Dialog contentClass="'o_kanban_examples_dialog'" title="this.constructor.title">
+        <Dialog contentClass="'o_kanban_examples_dialog'" title.translate="Kanban Examples">
             <Notebook orientation="'vertical'" pages="pages" onPageUpdate.bind="onPageUpdate" />
             <t t-set-slot="footer">
                 <button class="btn btn-primary" t-on-click="applyExamples" t-esc="props.applyExamplesText"/>

--- a/addons/web/static/src/views/view_dialogs/export_data_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/export_data_dialog.js
@@ -116,7 +116,6 @@ export class ExportDataDialog extends Component {
             disabled: false,
         });
 
-        this.title = _t("Export Data");
         this.newTemplateText = _t("New template");
         this.removeFieldText = _t("Remove field");
 

--- a/addons/web/static/src/views/view_dialogs/export_data_dialog.xml
+++ b/addons/web/static/src/views/view_dialogs/export_data_dialog.xml
@@ -29,7 +29,7 @@
     </t>
 
     <t t-name="web.ExportDataDialog">
-        <Dialog contentClass="'o_export_data_dialog'" title="title" size="'lg'">
+        <Dialog contentClass="'o_export_data_dialog'" title.translate="Export Data" size="'lg'">
             <div class="row w-100">
                 <div class="o_left_panel col-12 col-md-6 h-100 d-flex flex-column flex-nowrap">
                     <div class="o_import_compat">

--- a/addons/web/static/src/webclient/barcode/barcode_scanner.js
+++ b/addons/web/static/src/webclient/barcode/barcode_scanner.js
@@ -92,10 +92,6 @@ export class BarcodeDialog extends Component {
         return this.detector && this.detector.__proto__.constructor.name === "ZXingBarcodeDetector";
     }
 
-    get title() {
-        return _t("Barcode Scanner");
-    }
-
     /**
      * Check for camera preview element readiness
      *

--- a/addons/web/static/src/webclient/barcode/barcode_scanner.xml
+++ b/addons/web/static/src/webclient/barcode/barcode_scanner.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="web.BarcodeDialog">
-        <Dialog title="this.title" fullscreen="true" footer="false" contentClass="'o-barcode-modal'">
+        <Dialog title.translate="Barcode Scanner" fullscreen="true" footer="false" contentClass="'o-barcode-modal'">
             <CropOverlay onResize.bind="this.onResize" isReady="state.isReady">
                 <video t-ref="videoPreview" muted="true" autoplay="true" playsinline="true" class="w-100 h-100"/>
             </CropOverlay>

--- a/addons/web_editor/static/src/components/media_dialog/icon_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/icon_selector.js
@@ -1,6 +1,3 @@
-/** @odoo-module **/
-
-import { _t } from "@web/core/l10n/translation";
 import fonts from '@web_editor/js/wysiwyg/fonts';
 import { SearchMedia } from './search_media';
 
@@ -30,8 +27,6 @@ export class IconSelector extends Component {
             fonts: this.props.fonts,
             needle: '',
         });
-
-        this.searchPlaceholder = _t("Search a pictogram");
     }
 
     get selectedMediaIds() {

--- a/addons/web_editor/static/src/components/media_dialog/icon_selector.xml
+++ b/addons/web_editor/static/src/components/media_dialog/icon_selector.xml
@@ -3,7 +3,7 @@
 <t t-name="web_editor.IconSelector">
     <div>
         <div class="o_we_file_selector_control_panel sticky-top d-flex gap-2 align-items-center mb-1 py-4 px-3">
-            <SearchMedia searchPlaceholder="searchPlaceholder"
+            <SearchMedia searchPlaceholder.translate="Search a pictogram"
                 search.bind="this.search"
                 needle="state.needle"/>
         </div>

--- a/addons/web_editor/static/src/components/media_dialog/media_dialog.js
+++ b/addons/web_editor/static/src/components/media_dialog/media_dialog.js
@@ -1,6 +1,3 @@
-/** @odoo-module **/
-
-import { _t } from "@web/core/l10n/translation";
 import { useService, useChildRef } from '@web/core/utils/hooks';
 import { Mutex } from "@web/core/utils/concurrency";
 import { Dialog } from '@web/core/dialog/dialog';
@@ -50,7 +47,6 @@ export class MediaDialog extends Component {
     setup() {
         this.size = 'xl';
         this.contentClass = 'o_select_media_dialog h-100';
-        this.title = _t("Select a media");
         this.modalRef = useChildRef();
 
         this.orm = useService('orm');

--- a/addons/web_editor/static/src/components/media_dialog/media_dialog.xml
+++ b/addons/web_editor/static/src/components/media_dialog/media_dialog.xml
@@ -3,7 +3,7 @@
 <t t-name="web_editor.MediaDialog">
     <Dialog contentClass="contentClass"
         size="size"
-        title="title"
+        title.translate="Select a media"
         modalRef="modalRef">
         <Notebook pages="tabs" onPageUpdate.bind="onTabChange" defaultPage="state.activeTab"/>
         <t t-set-slot="footer">

--- a/addons/web_editor/static/src/js/editor/add_snippet_dialog.js
+++ b/addons/web_editor/static/src/js/editor/add_snippet_dialog.js
@@ -1,4 +1,3 @@
-/** @odoo-module **/
 import { isBrowserFirefox } from "@web/core/browser/feature_detection";
 import { Dialog } from "@web/core/dialog/dialog";
 import { _t } from "@web/core/l10n/translation";
@@ -23,7 +22,6 @@ export class RenameCustomSnippetDialog extends Component {
         Dialog,
     };
     setup() {
-        this.title = _t("Rename the block");
         this.renameInputRef = useRef("renameInput");
     }
     onClickConfirm() {
@@ -53,7 +51,6 @@ export class AddSnippetDialog extends Component {
     };
 
     setup() {
-        this.title = _t("Insert a block");
         this.iframeRef = useRef("iframe");
         this.snippetGroups = this.getSnippetGroups();
 

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_prompt_dialog.xml
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_prompt_dialog.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
 
 <t t-name="web_editor.ChatGPTPromptDialog">
-    <Dialog size="'lg'" title="'Generate Text with AI'">
+    <Dialog size="'lg'" title.translate="Generate Text with AI">
         <div t-foreach="state.messages" t-as="message" t-key="message_index"
             class="position-relative py-1 px-3"
             t-att-class="message_index ? 'mt-2' : 'mt-0'">

--- a/addons/web_editor/static/src/xml/add_snippet_dialog.xml
+++ b/addons/web_editor/static/src/xml/add_snippet_dialog.xml
@@ -3,7 +3,7 @@
 
 <t t-name="web_editor.AddSnippetDialog">
     <Dialog
-        title="title"
+        title.translate="Insert a block"
         contentClass="'o_add_snippet_dialog h-100'"
         footer="false"
         size="'xl'">
@@ -36,7 +36,7 @@
 </t>
 
 <t t-name="web_editor.RenameCustomSnippetDialog">
-    <Dialog title="this.title" contentClass="'o_rename_custom_snippet_dialog'" size="'md'">
+    <Dialog title.translate="Rename the block" contentClass="'o_rename_custom_snippet_dialog'" size="'md'">
         <div class="mb-3 row">
             <label class="col-form-label col-md-2" for="customSnippetName">Name</label>
             <div class="col-md-10">

--- a/addons/web_tour/static/src/debug/tour_dialog_component.js
+++ b/addons/web_tour/static/src/debug/tour_dialog_component.js
@@ -1,5 +1,3 @@
-/** @odoo-module **/
-
 import { useService } from "@web/core/utils/hooks";
 import { Dialog } from "@web/core/dialog/dialog";
 import { _t } from "@web/core/l10n/translation";
@@ -14,7 +12,6 @@ export default class ToursDialog extends Component {
         close: Function,
     };
     setup() {
-        this.title = _t("Tours");
         this.tourService = useService("tour_service");
         this.notification = useService("notification");
         this.onboardingTours = this.tourService.getSortedTours().filter((tour) => !tour.test);

--- a/addons/web_tour/static/src/debug/tour_dialog_component.xml
+++ b/addons/web_tour/static/src/debug/tour_dialog_component.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
 
 <t t-name="web_tour.ToursDialog">
-    <Dialog title="title">
+    <Dialog title.translate="Tours">
         <t t-call="web_tour.ToursDialog.Table">
             <t t-set="caption">Onboarding tours</t>
             <t t-set="tours" t-value="onboardingTours"/>

--- a/addons/website/static/src/components/dialog/add_page_dialog.js
+++ b/addons/website/static/src/components/dialog/add_page_dialog.js
@@ -1,5 +1,3 @@
-/** @odoo-module **/
-
 import { isBrowserFirefox } from "@web/core/browser/feature_detection";
 import { rpc } from "@web/core/network/rpc";
 import { Deferred } from "@web/core/utils/concurrency";
@@ -40,9 +38,6 @@ export class AddPageConfirmDialog extends Component {
         super.setup();
         useAutofocus();
 
-        this.title = _t("New Page");
-        this.primaryTitle = _t("Create");
-        this.switchLabel = _t("Add to menu");
         this.website = useService('website');
         this.http = useService('http');
         this.action = useService('action');
@@ -403,7 +398,6 @@ export class AddPageDialog extends Component {
         super.setup();
         useAutofocus();
 
-        this.title = _t("New Page");
         this.primaryTitle = _t("Create");
         this.switchLabel = _t("Add to menu");
         this.website = useService('website');

--- a/addons/website/static/src/components/dialog/add_page_dialog.xml
+++ b/addons/website/static/src/components/dialog/add_page_dialog.xml
@@ -2,8 +2,8 @@
 <templates xml:space="preserve">
 <t t-name="website.AddPageConfirmDialog">
     <WebsiteDialog
-        title="title"
-        primaryTitle="primaryTitle"
+        title.translate="New Page"
+        primaryTitle.translate="Create"
         primaryClick="() => this.addPage()"
         close="props.close">
         <div class="row gy-4">
@@ -13,7 +13,7 @@
             <div class="col-md-9">
                 <input type="text" t-model="state.name" class="form-control" required="required" t-ref="autofocus"/>
             </div>
-            <Switch extraClasses="'offset-md-3 col-md-9 text-start'" label="switchLabel" value="state.addMenu" onChange="(value) => this.onChangeAddMenu(value)"/>
+            <Switch extraClasses="'offset-md-3 col-md-9 text-start'" label.translate="Add to menu" value="state.addMenu" onChange="(value) => this.onChangeAddMenu(value)"/>
         </div>
     </WebsiteDialog>
 </t>
@@ -112,7 +112,7 @@
 
 <t t-name="website.AddPageDialog">
     <WebsiteDialog
-        title="title"
+        title.translate="New Page"
         contentClass="'o_website_page_templates_dialog h-100'"
         showFooter="false"
         footer="false"

--- a/addons/website/static/src/components/dialog/edit_menu.js
+++ b/addons/website/static/src/components/dialog/edit_menu.js
@@ -1,6 +1,3 @@
-/** @odoo-module **/
-
-import { _t } from "@web/core/l10n/translation";
 import { useService, useAutofocus } from '@web/core/utils/hooks';
 import { useNestedSortable } from "@web/core/utils/nested_sortable";
 import wUtils from '@website/js/utils';
@@ -44,7 +41,6 @@ export class MenuDialog extends Component {
 
     setup() {
         this.website = useService('website');
-        this.title = _t("Add a menu item");
         useAutofocus();
 
         this.name = useControlledInput(this.props.name, value => !!value);
@@ -112,9 +108,6 @@ export class EditMenuDialog extends Component {
         this.orm = useService('orm');
         this.website = useService('website');
         this.dialogs = useService('dialog');
-
-        this.title = _t("Edit Menu");
-        this.saveButton = _t("Save");
 
         this.menuEditor = useRef('menu-editor');
 

--- a/addons/website/static/src/components/dialog/edit_menu.xml
+++ b/addons/website/static/src/components/dialog/edit_menu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
 <t t-name="website.MenuDialog">
-    <WebsiteDialog title="title" closeOnClick="false" primaryClick.bind="this.onClickOk" secondaryClick="props.close">
+    <WebsiteDialog title.translate="Add a menu item" closeOnClick="false" primaryClick.bind="this.onClickOk" secondaryClick="props.close">
         <div class="o_menu_dialog_form mb-3 row">
             <label class="col-form-label col-md-3">
                 Name
@@ -45,7 +45,7 @@
 </t>
 
 <t t-name="website.EditMenuDialog">
-    <WebsiteDialog close="props.close" title="title" primaryTitle="saveButton" primaryClick="() => this.onClickSave()">
+    <WebsiteDialog close="props.close" title.translate="Edit Menu" primaryTitle.translate="Save" primaryClick="() => this.onClickSave()">
         <ul t-ref="menu-editor" class="oe_menu_editor list-unstyled">
             <t t-foreach="state.rootMenu.children" t-as="menu" t-key="menu.fields['id']">
                 <MenuRow menu="menu" edit="(id) => this.editMenu(id)" delete="(id) => this.deleteMenu(id)"/>

--- a/addons/website/static/src/components/dialog/page_properties.js
+++ b/addons/website/static/src/components/dialog/page_properties.js
@@ -1,5 +1,3 @@
-/** @odoo-module **/
-
 import {CheckBox} from '@web/core/checkbox/checkbox';
 import { _t } from "@web/core/l10n/translation";
 import {useService, useAutofocus} from "@web/core/utils/hooks";
@@ -83,9 +81,6 @@ export class DeletePageDialog extends Component {
 
     setup() {
         this.website = useService('website');
-        this.title = _t("Delete Page");
-        this.deleteButton = _t("Ok");
-        this.cancelButton = _t("Cancel");
 
         this.state = useState({
             confirm: false,

--- a/addons/website/static/src/components/dialog/page_properties.xml
+++ b/addons/website/static/src/components/dialog/page_properties.xml
@@ -64,7 +64,7 @@
 </t>
 
 <t t-name="website.DeletePageDialog">
-    <WebsiteDialog title="title" close="props.close">
+    <WebsiteDialog title.translate="Delete Page" close="props.close">
         <p t-if="props.resIds.length > 1">Are you sure you want to delete those pages?</p>
         <p t-else="">Are you sure you want to delete this page?</p>
         <p t-if="props.hasNewPageTemplate" class="text-warning">

--- a/addons/website/static/src/xml/website.editor.xml
+++ b/addons/website/static/src/xml/website.editor.xml
@@ -66,11 +66,10 @@
                             <div class="text-muted">Explore on <a target="_blank" href="https://fonts.google.com">fonts.google.com</a>.</div>
                         </div>
                         <div class="col-form-label col-md-8 o_field_widget">
-                            <t t-set="googleFontPlaceholderText">Select a Google Font...</t>
                             <div class="o_input_dropdown">
                                 <GoogleFontAutoComplete
                                     value="state.googleFontFamily"
-                                    placeholder="googleFontPlaceholderText"
+                                    placeholder.translate="Select a Google Font..."
                                     sources="getGoogleFontList"
                                     onSelect.bind="onGoogleFontSelect"
                                 />

--- a/addons/website_slides/static/src/js/public/components/course_tag_add_dialog/course_tag_add_dialog.js
+++ b/addons/website_slides/static/src/js/public/components/course_tag_add_dialog/course_tag_add_dialog.js
@@ -1,5 +1,3 @@
-/** @odoo-module **/
-
 import { Component, useState } from "@odoo/owl";
 import { Dialog } from "@web/core/dialog/dialog";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
@@ -20,7 +18,6 @@ export class CourseTagAddDialog extends Component {
 
     async setup() {
         super.setup();
-        this.title = _t("Add Tag");
         this.choices = useState({
             tagIds: [],
             tagGroupIds: [],

--- a/addons/website_slides/static/src/js/public/components/course_tag_add_dialog/course_tag_add_dialog.xml
+++ b/addons/website_slides/static/src/js/public/components/course_tag_add_dialog/course_tag_add_dialog.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
   <t t-name="website_slides.CourseTagAddDialog">
-    <Dialog size="'md'" title="title">
+    <Dialog size="'md'" title.translate="Add Tag">
         <t t-set-slot="footer">
             <a role="button" class="btn btn-primary me-1" t-on-click.prevent="onClickFormSubmit">
                 <span>Add</span>


### PR DESCRIPTION
To make it translatable, the content of some props was sometimes placed in the JavaScript code of the component to be wrapped in a call to gettext.

With the introduction of the .translate modifier for props, this indirection by the JS code is no longer necessary.

This commit converts the code to use .translate as much as possible. It is believed that avoiding indirection is better for code readability, and less prone to result in dead code.

Enterprise: https://github.com/odoo/enterprise/pull/67821