### PR TITLE
[FIX] account_edi_ubl_cii: use company_registry for the PartyLegalEntity

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -90,8 +90,11 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
                     'company_id': endpoint,
                     'company_id_attrs': {'schemeID': scheme},
                 })
-            if partner.country_id.code == "LU" and 'l10n_lu_peppol_identifier' in partner._fields and partner.l10n_lu_peppol_identifier:
-                vals['company_id'] = partner.l10n_lu_peppol_identifier
+            if partner.country_id.code == "LU":
+                if 'l10n_lu_peppol_identifier' in partner._fields and partner.l10n_lu_peppol_identifier:
+                    vals['company_id'] = partner.l10n_lu_peppol_identifier
+                elif partner.company_registry:
+                    vals['company_id'] = partner.company_registry
             if partner.country_id.code == 'DK':
                 # DK-R-014: For Danish Suppliers it is mandatory to specify schemeID as "0184" (DK CVR-number) when
                 # PartyLegalEntity/CompanyID is used for AccountingSupplierParty


### PR DESCRIPTION
In Luxembourg, the "Société national des chemins de Fer Luxembourgeois" expects the `PartyLegalEntity/CompanyID` to be filled with the "Registre de Commerce et des Sociétés" (RCS), which is normally filled on the `company_registry` of the supplier company.

Before this commit, we filled this tag with the VAT (which is also filled in the `PartyTaxScheme/CompanyID`).

The peppol official documentation states:

1. `PartyTaxScheme/CompanyID`: "The Seller's VAT identifier (also known as Seller VAT identification number) or the local identification (defined by the Seller’s address) of the Seller for tax purposes or a reference that enables the Seller to state his registered tax status." [1]

2. `PartyLegalEntity/CompanyID`: "An identifier issued by an official registrar that identifies the Seller as a legal entity or person." [2]

Consequently, it is not certain whether the company_registry should always be used to fill the element `PartyLegalEntity/CompanyID` or not, hence we only use it in Luxembourg for now.

[1] https://docs.peppol.eu/poacc/billing/3.0/syntax/ubl-invoice/cac-AccountingSupplierParty/cac-Party/cac-PartyTaxScheme/cbc-CompanyID/
[2] https://docs.peppol.eu/poacc/billing/3.0/syntax/ubl-invoice/cac-AccountingSupplierParty/cac-Party/cac-PartyLegalEntity/cbc-CompanyID/

opw-4075457
