### PR TITLE
[FIX] html_editor: protect cleanTrailingBR

### DIFF
--- a/addons/html_editor/static/src/utils/dom.js
+++ b/addons/html_editor/static/src/utils/dom.js
@@ -201,15 +201,15 @@ export function fillShrunkPhrasingParent(el) {
  * @returns {HTMLElement|undefined} the removed br, if any
  */
 export function cleanTrailingBR(el) {
-    let br;
-    const candidate = el.lastChild;
-    if (candidate && candidate.tagName === "BR" && !isEmptyBlock(el)) {
-        if (candidate.previousSibling?.tagName !== "BR") {
-            br = candidate;
-            candidate.remove();
-        }
+    const candidate = el?.lastChild;
+    if (
+        candidate?.nodeName === "BR" &&
+        candidate.previousSibling?.nodeName !== "BR" &&
+        !isEmptyBlock(el)
+    ) {
+        candidate.remove();
+        return candidate;
     }
-    return br;
 }
 
 export function toggleClass(node, className) {

--- a/addons/html_editor/static/tests/insert/html.test.js
+++ b/addons/html_editor/static/tests/insert/html.test.js
@@ -467,4 +467,19 @@ describe("not collapsed selection", () => {
             contentAfter: `<p><span class="a">TEST</span>[]</p>`,
         });
     });
+    test("should insert html containing ZWNBSP", async () => {
+        await testEditor({
+            contentBefore: "<p>[]<br></p>",
+            stepFunction: async (editor) => {
+                editor.shared.domInsert(
+                    parseHTML(
+                        editor.document,
+                        '<p>\uFEFF<a href="#">\uFEFFlink\uFEFF</a>\uFEFF</p><p>\uFEFF<a href="#">\uFEFFlink\uFEFF</a>\uFEFF</p>'
+                    )
+                );
+                editor.dispatch("ADD_STEP");
+            },
+            contentAfter: '<p><a href="#">link</a></p><p><a href="#">link</a>[]<br></p>',
+        });
+    });
 });


### PR DESCRIPTION
Certain HTML contents, specifically those containing zero-width non-breaking spaces (unicode FEFF), could cause `domInsert` to call `cleanTrailingBR` with a null argument.  This commit ensures that the function is protected against such cases.
