### PR TITLE
[FIX] l10n_be_pos_sale:traceback when invoicing with l10n_be installed

### DIFF
--- a/addons/l10n_be_pos_sale/static/src/js/PaymentScreen.js
+++ b/addons/l10n_be_pos_sale/static/src/js/PaymentScreen.js
@@ -9,7 +9,7 @@ patch(PaymentScreen.prototype, {
     async toggleIsToInvoice() {
         const orderLines = this.currentOrder.get_orderlines();
         const has_origin_order = orderLines.some(line => line.sale_order_origin_id);
-        const has_intracom_taxes = orderLines.some(line=>line.tax_ids?.some(tax=>this.pos.intracom_tax_ids.includes(tax)));
+        const has_intracom_taxes = orderLines.some(line=>line.tax_ids?.some(tax=>this.pos.intracom_tax_ids?.includes(tax)));
         if(this.currentOrder.is_to_invoice() && this.pos.company.country?.code === "BE" && has_origin_order && has_intracom_taxes){
             this.popup.add(ErrorPopup, {
                 title: _t('This order needs to be invoiced'),

--- a/addons/l10n_be_pos_sale/static/tests/tours/l10n_be_pos_sale_tour.js
+++ b/addons/l10n_be_pos_sale/static/tests/tours/l10n_be_pos_sale_tour.js
@@ -22,3 +22,17 @@ registry.category("web_tour.tours").add("PosSettleOrderIsInvoice", {
             ErrorPopup.clickConfirm(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("PosSettleOrderTryInvoice", {
+    test: true,
+    url: "/pos/ui",
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.clickQuotationButton(),
+            ProductScreen.selectFirstOrder(),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickInvoiceButton(),
+            PaymentScreen.isInvoiceButtonChecked(),
+        ].flat(),
+});

--- a/addons/l10n_be_pos_sale/tests/test_l10n_be_pos_sale.py
+++ b/addons/l10n_be_pos_sale/tests/test_l10n_be_pos_sale.py
@@ -59,3 +59,28 @@ class TestPoSSaleL10NBe(TestPointOfSaleHttpCommon):
         sale_order.action_confirm()
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosSettleOrderIsInvoice', login="accountman")
+
+
+@odoo.tests.tagged('post_install_l10n', 'post_install', '-at_install')
+class TestPoSSaleL10NBeNormalCompany(TestPointOfSaleHttpCommon):
+    def test_settle_order_can_invoice(self):
+        """This test makes sure that you can invoice a settled order when l10n_be is installed"""
+        self.product_a = self.env['product.product'].create({
+            'name': 'Product A',
+            'type': 'product',
+            'list_price': 10,
+            'taxes_id': False,
+            'available_in_pos': True,
+        })
+
+        self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'product_id': self.product_a.id,
+                'product_uom_qty': 10,
+                'product_uom': self.product_a.uom_id.id,
+                'price_unit': 10,
+            })],
+        })
+        self.main_pos_config.open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosSettleOrderTryInvoice', login="accountman")


### PR DESCRIPTION
If the module l10n_be was installed and you tried to invoice a settled order, you got a traceback

Steps to reproduce:
-------------------
* Install l10n_be_pos_sale module
* Open PoS in a non belgian company
* Import an order from sales in PoS
* Try to invoice it
> Observation: You get a traceback

Why the fix:
------------
Intracom taxes where not set and was causing a traceback.

opw-4089625
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
