### PR TITLE
[IMP] account: hotkey added to upload button

### DIFF
--- a/addons/account/static/src/components/bills_upload/bills_upload.xml
+++ b/addons/account/static/src/components/bills_upload/bills_upload.xml
@@ -150,7 +150,7 @@
         <!-- No record is available so rely on the action context to contain the default_move_type -->
         <AccountFileUploader>
             <t t-set-slot="toggler">
-                <button type="button" class="btn btn-secondary o_button_upload_bill">
+                <button type="button" class="btn btn-secondary o_button_upload_bill" data-hotkey="b">
                     Upload
                 </button>
             </t>


### PR DESCRIPTION
This PR will add a hotkey to the upload button(ALT + B) in the `account` module.

related enterprise PR: https://github.com/odoo/enterprise/pull/67840
**task**-4079684