### PR TITLE
[FIX] purchase_stock: handle view replacement in action_add_from_catalog

### DIFF
--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -106,7 +106,7 @@ class PurchaseOrder(models.Model):
         # Replaces the product's kanban view by the purchase specific one.
         action = super().action_add_from_catalog()
         kanban_view_id = self.env.ref('purchase_stock.product_view_kanban_catalog_purchase_only').id
-        action['views'][0] = (kanban_view_id, 'kanban')
+        action['views'] = [(kanban_view_id, view_type) if view_type == 'kanban' else (view_id, view_type) for (view_id, view_type) in action['views']]
         return action
 
     def button_approve(self, force=False):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The method action_add_from_catalog in purchase_stock replaces the product's kanban view with a purchase-specific one. This method directly replaces the first view in the list, which could be wrong if another module changes the default view of the catalog.

This commit updates the method to replace only the kanban view, ensuring that other view types are preserved correctly.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
