### PR TITLE
[FIX] account: fix account_id domain on account_move_line

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3760,7 +3760,7 @@ class AccountMoveLine(models.Model):
         help='Utility field to express amount currency')
     account_id = fields.Many2one('account.account', string='Account',
         index=True, ondelete="cascade",
-        domain="[('deprecated', '=', False), ('company_id', '=', 'company_id'),('is_off_balance', '=', False)]",
+        domain="[('deprecated', '=', False), ('company_id', '=', company_id),('is_off_balance', '=', False)]",
         check_company=True,
         tracking=True)
     account_internal_type = fields.Selection(related='account_id.user_type_id.type', string="Internal Type", readonly=True)

--- a/doc/cla/individual/AxeldelosReyes.md
+++ b/doc/cla/individual/AxeldelosReyes.md
@@ -1,0 +1,11 @@
+Mexico, 2024-08-01
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Axel Eduardo de los Reyes Berrones axel9410clash@gmail.com https://github.com/AxeldelosReyes


### PR DESCRIPTION
While it doesnt affect odoo invoicing operation, this bug can cause problems for developers extending the model or creating other account.move.line views.

**Impacted versions:**
    15.0

**Description of the issue/feature this PR addresses:**

- No account results found when editing account_id on account.move.line.

**Current behavior before PR:**
- No account results found when editing account_id on account.move.line.

**Desired behavior after PR is merged:**

- when editing account_id in many2one should find results




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
