### PR TITLE
[FIX] l10n_it: wrongly assigned attachment as main attachment

### DIFF
--- a/addons/l10n_it/models/__init__.py
+++ b/addons/l10n_it/models/__init__.py
@@ -2,3 +2,4 @@
 from . import template_it
 from . import account_report
 from . import account_tax
+from . import account_move

--- a/addons/l10n_it/models/account_move.py
+++ b/addons/l10n_it/models/account_move.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    def _message_set_main_attachment_id(self, attachments, force=False, filter_xml=False):
+        if self.message_main_attachment_id.mimetype == "application/pkcs7-mime":
+            force = True
+        super()._message_set_main_attachment_id(attachments, force, filter_xml)


### PR DESCRIPTION
Before this commit:
Sometimes attachments with extension 'p7m' were incorrectly assigned
as the main attachment. This caused the attachment viewer to treat these
attachments as previews that could be displayed.

After this commit:
Attachments with mimetype 'p7m' will no longer be considered as the
main attachment, preventing them from appearing in the attachment viewer.

task-3669465

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
