### PR TITLE
[IMP] sale_mrp: make the forecast widget appear for kits in sales orders

### DIFF
--- a/addons/sale_mrp/models/sale_order_line.py
+++ b/addons/sale_mrp/models/sale_order_line.py
@@ -13,18 +13,6 @@ class SaleOrderLine(models.Model):
         """The inventory widget should now be visible in more cases if the product is consumable."""
         super(SaleOrderLine, self)._compute_qty_to_deliver()
         for line in self:
-            # Hide the widget for kits since forecast doesn't support them.
-            boms = self.env['mrp.bom']
-            if line.state == 'sale':
-                boms = line.move_ids.mapped('bom_line_id.bom_id')
-            elif line.state in ['draft', 'sent'] and line.product_id:
-                boms = boms._bom_find(line.product_id, company_id=line.company_id.id, bom_type='phantom')[line.product_id]
-            relevant_bom = boms.filtered(lambda b: b.type == 'phantom' and
-                    (b.product_id == line.product_id or
-                    (b.product_tmpl_id == line.product_id.product_tmpl_id and not b.product_id)))
-            if relevant_bom:
-                line.display_qty_widget = False
-                continue
             if line.state == 'draft' and line.product_type == 'consu':
                 components = line.product_id.get_components()
                 if components and components != [line.product_id.id]:


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Forecast widget on kits not showing for sales orders.

Current behavior before PR: The forecasting widget in the quotations view does not apply to kits even though it's logically expected. It's already displayed in the manufacturing order view.

Desired behavior after PR is merged: The widget is now visible for kits as well.

Task ID: [4086277](https://www.odoo.com/odoo/project/966/tasks/4086277)

Edit: Awaiting spec.