### PR TITLE
[FIX] pos_restaurant: resize table constraint

### DIFF
--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
@@ -37,14 +37,13 @@ export function constrain(num, min, max) {
  * @returns {{ minX: number, maxX: number, minY: number, maxY: number }} limits
  */
 export function getLimits(el, limitEl) {
-    const { width, height } = el.getBoundingClientRect();
     const limitRect = limitEl.getBoundingClientRect();
     const offsetParentRect = el.offsetParent.getBoundingClientRect();
     return {
         minX: limitRect.left - offsetParentRect.left,
-        maxX: limitRect.left - offsetParentRect.left + limitRect.width - width,
+        maxX: limitRect.left - offsetParentRect.left + limitRect.width,
         minY: limitRect.top - offsetParentRect.top,
-        maxY: limitRect.top - offsetParentRect.top + limitRect.height - height,
+        maxY: limitRect.top - offsetParentRect.top + limitRect.height,
     };
 }
 const useDraggable = makeDraggableHook({


### PR DESCRIPTION
Limits of the table size shouldn't be dependent on its current size.

**Before:**

https://github.com/user-attachments/assets/8f9864c3-4857-4dfe-be48-046461a26764

**After:**

https://github.com/user-attachments/assets/119548bd-8428-4b85-b5cc-5cc8da2b98b9

