### PR TITLE
[FIX] hr_holidays: fix delete button on dashboard 

### DIFF
--- a/addons/hr_holidays/static/src/views/view_dialog/form_view_dialog.js
+++ b/addons/hr_holidays/static/src/views/view_dialog/form_view_dialog.js
@@ -2,13 +2,13 @@
 
 import { FormViewDialog } from "@web/views/view_dialogs/form_view_dialog";
 
-import { registry } from '@web/core/registry';
+import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 
-import { formView } from '@web/views/form/form_view';
-import { FormController } from '@web/views/form/form_controller';
+import { formView } from "@web/views/form/form_view";
+import { FormController } from "@web/views/form/form_controller";
 
-import { useLeaveCancelWizard } from '../hooks';
+import { useLeaveCancelWizard } from "../hooks";
 
 export class TimeOffDialogFormController extends FormController {
     static props = {
@@ -30,21 +30,34 @@ export class TimeOffDialogFormController extends FormController {
     }
 
     async onClick(action) {
-        const args = (action === 'action_approve') ? [this.record.resId, false] : [this.record.resId];
+        const args = action === "action_approve" ? [this.record.resId, false] : [this.record.resId];
         await this.orm.call("hr.leave", action, args);
         this.props.onLeaveUpdated();
     }
 
     get canApprove() {
-        return !this.model.root.isNew && (this.record.data.can_approve && ['confirm', 'refuse',].includes(this.record.data.state));
+        return (
+            !this.model.root.isNew &&
+            this.record.data.can_approve &&
+            ["confirm", "refuse"].includes(this.record.data.state)
+        );
     }
 
     get canValidate() {
-        return !this.model.root.isNew && (this.record.data.can_approve && this.record.data.state === 'validate1');
+        return (
+            !this.model.root.isNew &&
+            this.record.data.can_approve &&
+            this.record.data.state === "validate1"
+        );
     }
 
     get canRefuse() {
-        return !this.model.root.isNew && (this.record.data.can_approve && this.record.data.state && ['confirm', 'validate1', 'validate'].includes(this.record.data.state));
+        return (
+            !this.model.root.isNew &&
+            this.record.data.can_approve &&
+            this.record.data.state &&
+            ["confirm", "validate1", "validate"].includes(this.record.data.state)
+        );
     }
 
     deleteRecord() {
@@ -64,18 +77,19 @@ export class TimeOffDialogFormController extends FormController {
     }
 
     get canDelete() {
-        return !this.canCancel
-            && !this.model.root.isNew
-            && this.record.data.state
-            && !['validate', 'refuse', 'cancel'].includes(this.record.data.state);
+        return (
+            !this.canCancel &&
+            !this.model.root.isNew &&
+            this.record.data.state &&
+            !["validate", "refuse", "cancel"].includes(this.record.data.state)
+        );
     }
 }
 
-registry.category('views').add('timeoff_dialog_form', {
+registry.category("views").add("timeoff_dialog_form", {
     ...formView,
     Controller: TimeOffDialogFormController,
 });
-
 
 export class TimeOffFormViewDialog extends FormViewDialog {
     static props = {
@@ -89,7 +103,7 @@ export class TimeOffFormViewDialog extends FormViewDialog {
 
         this.viewProps = Object.assign(this.viewProps, {
             jsClass: "timeoff_dialog_form",
-            buttonTemplate: 'hr_holidays.FormViewDialog.buttons',
+            buttonTemplate: "hr_holidays.FormViewDialog.buttons",
             onCancelLeave: () => {
                 this.props.close();
             },
@@ -98,9 +112,9 @@ export class TimeOffFormViewDialog extends FormViewDialog {
                 this.props.close();
             },
             onRecordDeleted: (record) => {
-                this.props.onRecordDeleted(record)
+                this.props.onRecordDeleted(record);
             },
             onLeaveCancelled: this.props.onLeaveCancelled.bind(this),
-        })
+        });
     }
 }

--- a/addons/hr_holidays/static/src/views/view_dialog/form_view_dialog.js
+++ b/addons/hr_holidays/static/src/views/view_dialog/form_view_dialog.js
@@ -65,6 +65,7 @@ export class TimeOffDialogFormController extends FormController {
 
     get canDelete() {
         return !this.canCancel
+            && !this.model.root.isNew
             && this.record.data.state
             && !['validate', 'refuse', 'cancel'].includes(this.record.data.state);
     }


### PR DESCRIPTION
This commit reintroduces a condition that was accidentally removed in
https://github.com/odoo/odoo/pull/169391
This removal made the "delete" button appear on new records, leading
to a traceback upon click.