### PR TITLE
[FIX] mail: scrollable message content inside message bubble

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -91,7 +91,7 @@
                                                     <Composer t-if="state.isEditing" autofocus="true" composer="message.composer" messageComponent="constructor" onDiscardCallback.bind="exitEditMode" onPostCallback.bind="exitEditMode" mode="env.inChatter ? 'extended' : 'compact'" sidebar="false"/>
                                                     <t t-else="">
                                                         <em t-if="message.subject and !message.isSubjectSimilarToOriginThreadName and !message.isSubjectDefault" class="mb-1 me-2">Subject: <t t-out="props.messageSearch?.highlight(message.subject) ?? message.subject"/></em>
-                                                        <div t-if="message.type and message.type.includes('email')" t-ref="shadowBody"/>
+                                                        <div class="overflow-x-auto" t-if="message.type and message.type.includes('email')" t-ref="shadowBody"/>
                                                         <t t-elif="state.showTranslation" t-out="message.translationValue"/>
                                                         <t t-elif="message.body" t-out="props.messageSearch?.highlight(message.body) ?? message.body"/>
                                                         <p class="fst-italic text-muted small" t-if="state.showTranslation">


### PR DESCRIPTION
**Current behavior before PR:**

When an email template is posted inside the chatter, the content overflows
in the x-direction, causing a UI issue where the message bubble does not
handle the overflow properly.
![image](https://github.com/user-attachments/assets/c838caa5-5424-41ac-9aff-2c78a8e96f12)


**Desired behavior after PR is merged:**

The issue has been fixed, making the message content scrollable inside the
message bubble, preventing overflow and maintaining proper UI appearance.

**Task**-4083373


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
