### PR TITLE
[IMP] website_sale: product page improve carousel and grid

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -539,20 +539,14 @@ class Website(models.Model):
             '100_pc': (12, 12),
         }.get(self.product_page_image_width)
 
-    def _get_product_page_grid_image_classes(self):
+    def _get_product_page_grid_image_spacing_classes(self):
         spacing_map = {
-            'none': 'p-0',
-            'small': 'p-2',
-            'medium': 'p-3',
-            'big': 'p-4',
+            'none': 'm-0',
+            'small': 'm-1',
+            'medium': 'm-2',
+            'big': 'm-3',
         }
-        columns_map = {
-            1: 'col-12',
-            2: 'col-6',
-            3: 'col-4',
-        }
-        return spacing_map.get(self.product_page_image_spacing) + ' ' +\
-                columns_map.get(self.product_page_grid_columns)
+        return spacing_map.get(self.product_page_image_spacing)
 
     @api.model
     def _send_abandoned_cart_email(self):

--- a/addons/website_sale/static/src/js/components/website_sale_image_viewer.js
+++ b/addons/website_sale/static/src/js/components/website_sale_image_viewer.js
@@ -21,7 +21,7 @@ export class ProductImageViewer extends Dialog {
         this.images = [...this.props.images].map(image => {
             return {
                 src: image.dataset.zoomImage || image.src,
-                thumbnailSrc: image.src.replace('/image_1024/', '/image_128/'),
+                thumbnailSrc: image.src.replace('/image_1024/', '/image_256/'),
             };
         });
         this.state = useState({

--- a/addons/website_sale/static/src/js/website_sale.editor.js
+++ b/addons/website_sale/static/src/js/website_sale.editor.js
@@ -701,13 +701,21 @@ options.registry.WebsiteSaleProductPage = options.Class.extend({
     async _computeWidgetVisibility(widgetName, params) {
         const hasImages = this.productDetailMain.dataset.image_width != 'none';
         const isFullImage = this.productDetailMain.dataset.image_width == '100_pc';
+        const multipleImages = hasImages && this.productDetailMain.querySelector(
+            '.o_wsale_product_images'
+        ).dataset.imageAmount > 1;
+        const isGrid = !!this.productDetailMain.querySelector('#o-grid-product');
         switch (widgetName) {
             case 'o_wsale_thumbnail_pos':
                 return Boolean(this.productPageCarousel) && hasImages;
             case 'o_wsale_grid_spacing':
+                return isGrid && multipleImages;
             case 'o_wsale_grid_columns':
-                return Boolean(this.productPageGrid) && hasImages;
+                return Boolean(this.productPageGrid) && hasImages && isGrid && multipleImages;
             case 'o_wsale_image_layout':
+                return multipleImages;
+            case "o_wsale_image_ratio":
+                return !isGrid && multipleImages;
             case 'o_wsale_zoom_click':
             case 'o_wsale_zoom_none':
             case 'o_wsale_replace_main_image':

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -410,17 +410,36 @@ a.no-decoration {
         opacity: 0.2;
     }
 
-    .carousel-outer {
-        height: 400px;
-        max-height: 90vh;
-        display: flex;
-        align-items: center;
-        .carousel-inner {
-            img {
-                object-fit: contain;
-            }
+    .carousel-inner {
+        img {
+            object-fit: contain;
         }
     }
+
+    &.o_carousel_not_single .carousel-outer {
+        aspect-ratio: 1 / 1;
+
+        &.o_wsale_carousel_ratio_4x3 {
+            aspect-ratio: 4 / 3;
+        }
+
+        &.o_wsale_carousel_ratio_4x5 {
+            aspect-ratio: 4 / 5;
+        }
+
+        &.o_wsale_carousel_ratio_16x9 {
+            aspect-ratio: 16 / 9;
+        }
+
+        &.o_wsale_carousel_ratio_21x9 {
+            aspect-ratio: 21 / 9;
+        }
+
+        .product_detail_img {
+            width: auto !important;
+        }
+    }
+
 
     .carousel-control-prev .fa {
         padding-right: 2px;
@@ -545,14 +564,6 @@ a.no-decoration {
         }
 
         &.o_carousel_product_left_indicators {
-            .carousel-outer {
-                height: 500px;
-            }
-
-            .o_carousel_product_indicators {
-                max-height: 500px;
-            }
-
             .carousel-indicators li {
                 margin: 0;
 

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -440,47 +440,6 @@ a.no-decoration {
         }
     }
 
-
-    .carousel-control-prev .fa {
-        padding-right: 2px;
-    }
-    .carousel-control-next .fa {
-        padding-left: 2px;
-    }
-
-    .carousel-control-prev, .carousel-control-next {
-        top: auto;
-        bottom: auto;
-        opacity: 0.5;
-        cursor: pointer;
-        transition: opacity 0.8s;
-
-        &:focus {
-            opacity: 0.65;
-        }
-        &:hover {
-            opacity: 0.8;
-        }
-        > span {
-            width: 2.5rem;
-            height: 2.5rem;
-            line-height: 2.5rem;
-            color: map-get($grays, '900');
-            background: white;
-            @include font-size(1.15rem);
-            border: 1px solid map-get($grays, '400');
-            border-radius: 50%;
-        }
-        @include media-breakpoint-down(lg) {
-            > span {
-                width: 2rem;
-                height: 2rem;
-                line-height: 2rem;
-                font-size: 1rem;
-            }
-        }
-    }
-
     @include media-breakpoint-up(xl) {
         &:not(:hover) {
             .carousel-control-prev, .carousel-control-next {
@@ -570,6 +529,41 @@ a.no-decoration {
                 &:not(:first-child) {
                     margin-top: 10px;
                 }
+            }
+        }
+    }
+}
+
+#o-carousel-product, .o_wsale_image_viewer {
+    .carousel-control-prev, .carousel-control-next {
+        top: auto;
+        bottom: auto;
+        opacity: 0.5;
+        cursor: pointer;
+        transition: opacity 0.8s;
+
+        &:focus {
+            opacity: 0.65;
+        }
+
+        &:hover {
+            opacity: 0.8;
+        }
+
+        > i {
+            width: 2.5rem;
+            height: 2.5rem;
+            line-height: 2.5rem;
+            @include font-size(1.15rem);
+            border-radius: var(--btn-border-radius);
+        }
+
+        @include media-breakpoint-down(lg) {
+            > i {
+                width: 2rem;
+                height: 2rem;
+                line-height: 2rem;
+                font-size: 1rem;
             }
         }
     }

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -564,6 +564,17 @@ a.no-decoration {
     }
 }
 
+// Customization of the grid on /product page.
+.o_wsale_product_page_grid_column div {
+    &:first-child {
+        margin-top: 0 !important;
+    }
+
+    &:last-child {
+        margin-bottom: 0 !important;
+    }
+}
+
 .ecom-zoomable {
     &[data-ecom-zoom-click] {
         img.product_detail_img {

--- a/addons/website_sale/static/src/scss/website_sale_frontend.scss
+++ b/addons/website_sale/static/src/scss/website_sale_frontend.scss
@@ -27,8 +27,8 @@
             list-style: none;
 
             .o_wsale_image_viewer_thumbnail {
+                aspect-ratio: 1/1;
                 width: 128px;
-                height: 128px;
             }
 
             li img{

--- a/addons/website_sale/static/src/scss/website_sale_frontend.scss
+++ b/addons/website_sale/static/src/scss/website_sale_frontend.scss
@@ -40,22 +40,4 @@
             }
         }
     }
-
-    .o_wsale_image_viewer_control {
-        z-index: 1;
-        width: 40px;
-        height: 40px;
-
-        &:hover {
-            background-color: rgba($gray-400, 0.1);
-        }
-
-        &.o_wsale_image_viewer_previous {
-            margin: 1px 1px 0 0; // not correctly centered for some reasons
-        }
-
-        &.o_wsale_image_viewer_next {
-            margin: 1px 0 0 1px; // not correctly centered for some reasons
-        }
-    }
 }

--- a/addons/website_sale/static/src/xml/website_sale_image_viewer.xml
+++ b/addons/website_sale/static/src/xml/website_sale_image_viewer.xml
@@ -37,11 +37,35 @@
                             </ol>
                         </div>
                         <!-- Controls -->
-                        <div class="o_wsale_image_viewer_control o_wsale_image_viewer_previous btn btn-dark position-absolute top-0 bottom-0 start-0 align-items-center justify-content-center d-flex my-auto ms-3 rounded-circle" t-on-click="previousImage" title="Previous (Left-Arrow)" role="button">
-                            <span class="oi oi-chevron-left" role="img"/>
+                        <div class="o_wsale_image_viewer_control position-absolute d-flex align-items-center me-2 h-100 w-100">
+                            <a
+                                class="carousel-control-prev"
+                                t-on-click="previousImage"
+                                title="Previous (Left-Arrow)"
+                                role="button"
+                            >
+                                <i
+                                    class="oi oi-chevron-left border bg-white text-900"
+                                    role="img"
+                                    aria-label="Previous"
+                                    title="Previous"
+                                />
+                            </a>
                         </div>
-                        <div class="o_wsale_image_viewer_control o_wsale_image_viewer_next btn btn-dark position-absolute top-0 bottom-0 end-0 align-items-center justify-content-center d-flex my-auto me-3 rounded-circle" t-on-click="nextImage" title="Next (Right-Arrow)" role="button">
-                            <span class="oi oi-chevron-right" role="img"/>
+                        <div class="o_wsale_image_viewer_control position-absolute d-flex align-items-center me-2 h-100 w-100">
+                            <a
+                                class="carousel-control-next"
+                                t-on-click="nextImage"
+                                title="Next (Right-Arrow)"
+                                role="button"
+                            >
+                                <i
+                                    class="oi oi-chevron-right border bg-white text-900"
+                                    role="img"
+                                    aria-label="Next"
+                                    title="Next"
+                                />
+                            </a>
                         </div>
                     </t>
                 </div>

--- a/addons/website_sale/static/src/xml/website_sale_image_viewer.xml
+++ b/addons/website_sale/static/src/xml/website_sale_image_viewer.xml
@@ -24,7 +24,13 @@
                                 <t t-foreach="images" t-as="image" t-key="image.thumbnailSrc">
                                     <li t-attf-class="align-top position-relative px-1 pb-1 {{image === selectedImage ? 'active' : ''}}" t-on-click="() => this.selectedImage = image">
                                         <div>
-                                            <img t-att-src="image.thumbnailSrc" t-attf-class="img o_wsale_image_viewer_thumbnail {{image === selectedImage ? 'active' : ''}}" t-att-alt="props.title" loading="lazy"/>
+                                            <img
+                                                t-att-src="image.thumbnailSrc"
+                                                class="img o_wsale_image_viewer_thumbnail bg-body object-fit-contain"
+                                                t-att-class="{'active': image === selectedImage}"
+                                                t-att-alt="props.title"
+                                                loading="lazy"
+                                            />
                                         </div>
                                     </li>
                                 </t>

--- a/addons/website_sale/views/snippets/snippets.xml
+++ b/addons/website_sale/views/snippets/snippets.xml
@@ -295,6 +295,28 @@
                 <we-button data-set-image-layout="carousel">Carousel</we-button>
                 <we-button data-set-image-layout="grid">Grid</we-button>
             </we-select>
+            <we-select
+                string="Images Ratio"
+                data-name="o_wsale_image_ratio"
+                class="o_we_sublevel_1"
+                data-reload="/"
+            >
+                <we-button data-customize-website-views="">
+                    Default (1x1)
+                </we-button>
+                <we-button data-customize-website-views="website_sale.products_carousel_4x3">
+                    Landscape (4/3)
+                </we-button>
+                <we-button data-customize-website-views="website_sale.products_carousel_4x5">
+                    Portrait (4/5)
+                </we-button>
+                <we-button data-customize-website-views="website_sale.products_carousel_16x9">
+                    Wide (16/9)
+                </we-button>
+                <we-button data-customize-website-views="website_sale.products_carousel_21x9">
+                    Wider (21/9)
+                </we-button>
+            </we-select>
             <we-select string="Image Zoom" class="o_we_sublevel_1" data-name="o_wsale_zoom_mode" data-no-preview="true" data-reload="/">
                 <we-button data-name="o_wsale_zoom_hover" data-customize-website-views="website_sale.product_picture_magnify_hover">Magnifier on hover</we-button>
                 <we-button data-name="o_wsale_zoom_click" data-customize-website-views="website_sale.product_picture_magnify_click">Pop-up on Click</we-button>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1225,7 +1225,11 @@
                         t-att-data-image_width="website.product_page_image_width"
                         t-att-data-image_layout="website.product_page_image_layout">
                         <t t-set="image_cols" t-value="website._get_product_page_proportions()"/>
-                        <div t-attf-class="col-lg-#{image_cols[0]} mt-lg-4 o_wsale_product_images position-relative" t-if="website.product_page_image_width != 'none'">
+                        <div
+                            t-attf-class="col-lg-#{image_cols[0]} mt-lg-4 o_wsale_product_images position-relative"
+                            t-if="website.product_page_image_width != 'none'"
+                            t-att-data-image-amount="len(product_variant._get_images() if product_variant else product._get_images())"
+                        >
                             <t t-call="website_sale.shop_product_images"/>
                         </div>
                         <div t-attf-class="col-lg-#{image_cols[1]} mt-md-4" id="product_details">
@@ -2951,17 +2955,25 @@
         <div t-if="product_image._name == 'product.image' and product_image.embed_code" t-att-class="image_classes + ' ratio ratio-16x9'">
             <t t-out="product_image.embed_code"/>
         </div>
-        <div t-elif="len(product_images) == 1 and website.product_page_image_layout != 'grid'"
-             class="position-relative d-inline-flex overflow-hidden m-auto h-100"
+        <div
+            t-elif="len(product_images) == 1 and website.product_page_image_layout != 'grid'"
+            class="position-relative d-inline-flex overflow-hidden m-auto w-100"
         >
             <span t-attf-class="o_ribbon #{ribbon._get_position_class()} z-1"
                   t-attf-style="#{text_color and ('color: %s; ' % text_color)}#{bg_color and 'background-color:' + bg_color}"
                   t-out="ribbon['name'] or ''"
             />
-            <div t-field="product_image.image_1920"
-                 name="o_img_with_max_suggested_width"
-                 class="d-flex align-items-start justify-content-center h-100 oe_unmovable"
-                 t-options='{"widget": "image", "preview_image": "image_1024", "class": "oe_unmovable product_detail_img mh-100", "alt-field": "name", "zoom": product_image.can_image_1024_be_zoomed and "image_1920"}'
+            <div
+                t-field="product_image.image_1920"
+                name="o_img_with_max_suggested_width"
+                class="d-flex align-items-start justify-content-center w-100 oe_unmovable"
+                t-options="{
+                    'widget': 'image',
+                    'preview_image': 'image_1024',
+                    'class': 'oe_unmovable product_detail_img w-100',
+                    'alt-field': 'name',
+                    'zoom': product_image.can_image_1024_be_zoomed and 'image_1920',
+                }"
             />
         </div>
         <div
@@ -2971,7 +2983,7 @@
             t-options="{
                 'widget': 'image',
                 'preview_image': 'image_1024',
-                'class': 'oe_unmovable product_detail_img w-100',
+                'class': 'oe_unmovable product_detail_img w-100 mh-100',
                 'alt-field': 'name',
                 'zoom': product_image.can_image_1024_be_zoomed and 'image_1920',
             }"
@@ -2981,8 +2993,15 @@
     <!-- Product page images: Carousel -->
     <template id="website_sale.shop_product_carousel" name="Shop Product Carousel">
         <t t-set="product_carousel_block_name">Product Carousel</t>
-        <div id="o-carousel-product" class="carousel slide position-sticky mb-3 overflow-hidden" data-bs-ride="true" t-att-data-name="product_carousel_block_name">
-            <div class="o_carousel_product_outer carousel-outer position-relative flex-grow-1 overflow-hidden">
+        <div
+            id="o-carousel-product"
+            t-attf-class="#{len(product_images) > 1 and 'o_carousel_not_single'} carousel slide position-sticky mb-3 overflow-hidden"
+            data-bs-ride="true"
+            t-att-data-name="product_carousel_block_name"
+        >
+            <div
+                class="o_carousel_product_outer carousel-outer position-relative d-flex align-items-center w-100 overflow-hidden"
+            >
                 <span t-if="len(product_images) > 1"
                       t-attf-class="o_ribbon #{ribbon._get_position_class()} z-1"
                       t-attf-style="#{text_color and ('color: %s; ' % text_color)}#{bg_color and 'background-color:' + bg_color}"
@@ -3008,6 +3027,50 @@
         </div>
     </template>
 
+    <template
+        id="products_carousel_4x3"
+        name="carousel_img_ratio_4x3"
+        inherit_id="website_sale.shop_product_carousel"
+        active="False"
+    >
+        <xpath expr="//div[hasclass('o_carousel_product_outer')]" position="attributes">
+            <attribute name="class" add="o_wsale_carousel_ratio_4x3" separator=" "/>
+        </xpath>
+    </template>
+
+    <template
+        id="products_carousel_4x5"
+        name="carousel_img_ratio_4x5"
+        inherit_id="website_sale.shop_product_carousel"
+        active="False"
+    >
+        <xpath expr="//div[hasclass('o_carousel_product_outer')]" position="attributes">
+            <attribute name="class" add="o_wsale_carousel_ratio_4x5" separator=" "/>
+        </xpath>
+    </template>
+
+    <template
+        id="products_carousel_16x9"
+        name="carousel_img_ratio_16x9"
+        inherit_id="website_sale.shop_product_carousel"
+        active="False"
+    >
+        <xpath expr="//div[hasclass('o_carousel_product_outer')]" position="attributes">
+            <attribute name="class" add="o_wsale_carousel_ratio_16x9" separator=" "/>
+        </xpath>
+    </template>
+
+    <template
+        id="products_carousel_21x9"
+        name="carousel_img_ratio_21x9"
+        inherit_id="website_sale.shop_product_carousel"
+        active="False"
+    >
+        <xpath expr="//div[hasclass('o_carousel_product_outer')]" position="attributes">
+            <attribute name="class" add="o_wsale_carousel_ratio_21x9" separator=" "/>
+        </xpath>
+    </template>
+
     <template id="carousel_product_indicators_bottom" inherit_id="website_sale.shop_product_carousel" name="Carousel Product Indicators Bottom">
         <xpath expr="//div[hasclass('o_carousel_product_outer')]" position="after">
             <t t-call="website_sale.carousel_product_indicators">
@@ -3023,19 +3086,36 @@
             </t>
         </xpath>
         <xpath expr="//div[@id='o-carousel-product']" position="attributes">
-            <attribute name="class" add="o_carousel_product_left_indicators d-flex" separator=" "/>
+            <attribute name="t-attf-class" add="o_carousel_product_left_indicators d-flex" separator=" "/>
         </xpath>
     </template>
 
     <template id="carousel_product_indicators" name="Carousel Product">
-        <div t-ignore="True" t-attf-class="o_carousel_product_indicators {{indicators_div_class}}">
-            <ol t-if="len(product_images) > 1" t-attf-class="carousel-indicators {{indicators_list_class}} position-static pt-2 pt-lg-0 mx-auto my-0 text-start">
-                <li t-foreach="product_images" t-as="product_image"
+        <div
+            t-if="len(product_images) > 1"
+            t-ignore="True"
+            t-attf-class="o_carousel_product_indicators {{indicators_div_class}}"
+        >
+            <ol
+                t-att-class="'carousel-indicators '
+                    + (indicators_list_class or '')
+                    + ('justify-content-center ' if website.product_page_image_width == '100_pc' else '')
+                    + ' position-static pt-2 pt-lg-0 mx-auto my-0'"
+            >
+                <li
+                    t-foreach="product_images" t-as="product_image"
                     t-attf-class="align-top position-relative {{'active' if product_image_first else ''}}"
                     data-bs-target="#o-carousel-product"
-                    t-att-data-bs-slide-to="str(product_image_index)">
-                    <div t-field="product_image.image_128" t-options='{"widget": "image", "qweb_img_responsive": False, "class": "o_image_64_cover", "alt-field": "name"}'/>
-                    <i t-if="product_image._name == 'product.image' and product_image.embed_code" class="fa fa-2x fa-play-circle o_product_video_thumb bg-black-50 text-center"/>
+                    t-att-data-bs-slide-to="str(product_image_index)"
+                >
+                    <div
+                        t-field="product_image.image_128"
+                        t-options="{'widget': 'image', 'qweb_img_responsive': False, 'class': 'o_image_64_cover', 'alt-field': 'name'}"
+                    />
+                    <i
+                        t-if="product_image._name == 'product.image' and product_image.embed_code"
+                        class="fa fa-2x fa-play-circle o_product_video_thumb bg-black-50 text-center"
+                    />
                 </li>
             </ol>
         </div>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2964,7 +2964,18 @@
                  t-options='{"widget": "image", "preview_image": "image_1024", "class": "oe_unmovable product_detail_img mh-100", "alt-field": "name", "zoom": product_image.can_image_1024_be_zoomed and "image_1920"}'
             />
         </div>
-        <div t-else="" t-field="product_image.image_1920" t-att-class="image_classes + ' oe_unmovable'" t-options='{"widget": "image", "preview_image": "image_1024", "class": "oe_unmovable product_detail_img mh-100", "alt-field": "name", "zoom": product_image.can_image_1024_be_zoomed and "image_1920"}'/>
+        <div
+            t-else=""
+            t-field="product_image.image_1920"
+            t-att-class="image_classes + ' oe_unmovable'"
+            t-options="{
+                'widget': 'image',
+                'preview_image': 'image_1024',
+                'class': 'oe_unmovable product_detail_img w-100',
+                'alt-field': 'name',
+                'zoom': product_image.can_image_1024_be_zoomed and 'image_1920',
+            }"
+        />
     </template>
 
     <!-- Product page images: Carousel -->
@@ -3032,7 +3043,13 @@
 
     <!-- Product page images: Grid -->
     <template id="website_sale.shop_product_grid" name="Shop Product Grid">
-        <div id="o-grid-product" class="o_wsale_product_page_grid mb-3" data-name="Product Grid" t-att-data-image_spacing="website.product_page_image_spacing" t-att-data-grid_columns="website.product_page_grid_columns">
+        <div
+            id="o-grid-product"
+            class="mb-3"
+            data-name="Product Grid"
+            t-att-data-image_spacing="website.product_page_image_spacing"
+            t-att-data-grid_columns="website.product_page_grid_columns"
+        >
             <div class="container position-relative overflow-hidden">
                 <span t-attf-class="o_ribbon #{ribbon._get_position_class()}"
                       t-attf-style="#{text_color and ('color: %s; ' % text_color)}#{bg_color and 'background-color:' + bg_color}"
@@ -3040,17 +3057,37 @@
                 />
                 <!-- One row for every two images -->
                 <t t-set="image_classes" t-value="'w-100'"/>
-                <t t-set="col_classes" t-value="website._get_product_page_grid_image_classes()"/>
-                <t t-foreach="range(ceil(len(product_images) / website.product_page_grid_columns))" t-as="row_idx">
-                    <div class="row m-0">
-                        <t t-foreach="range(row_idx * website.product_page_grid_columns, (row_idx + 1) * website.product_page_grid_columns)" t-as="image_idx">
-                            <t t-set="product_image" t-value="image_idx &lt; len(product_images) and product_images[image_idx] or False"/>
-                            <div t-if="product_image" t-att-class="col_classes">
-                                <t t-call="website_sale.shop_product_image"/>
-                            </div>
-                        </t>
-                    </div>
-                </t>
+                <div class="row">
+                    <t t-foreach="website.product_page_grid_columns" t-as="col_idx">
+                        <t t-set="col_feed_counter" t-value="0"/>
+
+                        <div
+                            t-if="col_idx_index &lt; len(product_images)"
+                            class="col o_wsale_product_page_grid_column d-flex flex-column px-0"
+                        >
+                            <t t-foreach="len(product_images)" t-as="image_idx">
+                                <t
+                                    t-set="product_image"
+                                    t-value="image_idx &lt; len(product_images) and product_images[image_idx] or False"
+                                />
+                                <t
+                                    t-set="image_classes"
+                                    t-value="website._get_product_page_grid_image_spacing_classes()"
+                                />
+                                <t
+                                    t-if="product_image and col_idx == col_feed_counter"
+                                    t-call="website_sale.shop_product_image"
+                                />
+                                <t t-if="col_feed_counter == (website.product_page_grid_columns - 1)">
+                                    <t t-set="col_feed_counter" t-value="0"/>
+                                </t>
+                                <t t-else="">
+                                    <t t-set="col_feed_counter" t-value="col_feed_counter + 1"/>
+                                </t>
+                            </t>
+                        </div>
+                    </t>
+                </div>
             </div>
         </div>
     </template>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -3017,10 +3017,20 @@
                 </div>
                 <t t-if="len(product_images) > 1">
                     <a class="carousel-control-prev" href="#o-carousel-product" role="button" data-bs-slide="prev">
-                        <span class="oi oi-chevron-left fa-2x oe_unmovable" role="img" aria-label="Previous" title="Previous"/>
+                        <i
+                            class="oi oi-chevron-left oe_unmovable border bg-white text-900"
+                            role="img"
+                            aria-label="Previous"
+                            title="Previous"
+                        />
                     </a>
                     <a class="carousel-control-next" href="#o-carousel-product" role="button" data-bs-slide="next">
-                        <span class="oi oi-chevron-right fa-2x oe_unmovable" role="img" aria-label="Next" title="Next"/>
+                        <i
+                            class="oi oi-chevron-right oe_unmovable border bg-white text-900"
+                            role="img"
+                            aria-label="Next"
+                            title="Next"
+                        />
                     </a>
                 </t>
             </div>


### PR DESCRIPTION
**DEV This PR still requires a functional change on the Image Ratio editor option to properly set the active option when the associated template is active** *at the moment it still displays "Default (1x1)" while the other template is active. (the class on the `<main>` is refreshed on reload and the we_editor looses context).*

This PR aims to review the single image, carousel and grid layout on the product page.

**Grid**
Previously the images were displayed in multiple columns while keeping there original ratio creating ugly gaps in the grid.

They feeds each column with image filling them in order and filling the column width with letting the height scale accordingly.

If the amount of image < amount of col set, it will show only a column if there is an image to put inside.

Limitation is when the user uploads a tall image with a small width which uneven the columns. 
But it comes down to user choice, assumption made that the images uploaded by the user should share more or less the same ratio in the grid.

Using a margin instead of a padding allows the hover effect in edition to better fit the image element. 
Note: This is still visually weird due to the overflow-hidden above, this is necessary for the ribbons and will be removed if the ribbons are reworked.

**Carousel** 
We add the possibility for the user to choose an aspect ratio to be used in the carousel, this allows better control on the height of the content to better fit the user needs.

Furthermore, we now remove the irrelevant options that was shown in the editor while the user is editing a page that contains a single image. This was misleading as changing a carousel inner option would impact the other pages while not providing any visual feedback on the current page the user is editing.

Additionally it adapts the carousel arrows the better fit the reviewed design and follow the button border radius set by the user. 

**Single image**
When using a single image, this image should fill the entire column width on the product page. This commit lets the image width fills it's container while letting the height adapt accordingly.

Relying on the width fixes the issue with the media_preview since it now scales evenly letting the play button always in the middle of its container.

task-3986938
part of task-3986921

| Before | After |
| -- | -- | 
|![image](https://github.com/user-attachments/assets/641ba75c-0c7f-48e3-82a8-102858263862) | ![image](https://github.com/user-attachments/assets/9ec61e13-ccb3-4d04-acc3-eaf33ce14c07)| 
| Grid 3 col but 1 image v | Grid 3 col but 1 image v |
| ![image](https://github.com/user-attachments/assets/b5f5308b-e4b7-4a6e-8c84-32e1e863bb81) | ![image](https://github.com/user-attachments/assets/5274da94-4eaf-4f09-900e-170b2e9efbec)| 
| ![image](https://github.com/user-attachments/assets/49ec0522-e27d-4cb4-940a-7357288b6148) | ![image](https://github.com/user-attachments/assets/ecf18633-0108-4962-bab1-54a33daefd56) | 
| Carousel portrait image before v | Carousel portrait image with new option v |
|![image](https://github.com/user-attachments/assets/14d20592-41e7-4c82-8b5c-0c0cfd9844cc) | ![image](https://github.com/user-attachments/assets/2d1585ec-81d2-4096-a577-7ac5525b71c3) | 
| ![image](https://github.com/user-attachments/assets/ec566465-a52d-423a-b25b-1f7affdab081) | ![image](https://github.com/user-attachments/assets/92f168ec-219d-4f69-b5fd-160df2fafd17) |



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
