### PR TITLE
[DRAFT][FIX] project: redirect portal task documents

### DIFF
--- a/addons/project/views/project_portal_project_task_templates.xml
+++ b/addons/project/views/project_portal_project_task_templates.xml
@@ -71,7 +71,10 @@
                                     <t t-call="project.portal_my_tasks_priority_widget_template"/>
                                 </td>
                                 <td>
-                                    <a t-attf-href="/my/#{task_url}/#{task.id}?{{ keep_query() }}"><span t-att-title="task.name" t-field="task.name"/></a>
+                                    <!-- This div is necessary for documents_project/views/project_templates.xml -->
+                                    <div name="task_documents">
+                                        <a t-attf-href="/my/#{task_url}/#{task.id}?{{ keep_query() }}"><span t-att-title="task.name" t-field="task.name"/></a>
+                                    </div>
                                 </td>
                                 <td>
                                     <t t-set="assignees" t-value="task.sudo().user_ids"/>


### PR DESCRIPTION
Steps to reproduce:
- Create a project and a task
- Attach a file to the task
- Share the task with Joel Willis (portal user)
- DO NOT share the project with him
- Log in as Joel Willis (portal user)
- Click Tasks > '1 Document' button next to project name

This is necessary for the xpath in 852cb8eab813da9d8f3beee4bcfdf953d20a89b4 to function.

This redirects back to portal home menu. This happens because the button leads to projects/id/documents, which Joel Willis has not been granted access to.

The expectation would be a redirection to tasks/id/documents instead, as portal > projects handles this use case, and we curently do not have a way to share documents attached to a specific task through portal.

opw-4009258

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
