### PR TITLE
[IMP] hr: keep hr.employee and res.partner linked

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -359,9 +359,20 @@ class HrEmployeePrivate(models.Model):
         if self.resource_calendar_id and not self.tz:
             self.tz = self.resource_calendar_id.tz
 
+    def _remove_work_contact_id(self, user, employee_company):
+        """ Remove work_contact_id for previous employee if the user is assigned to a new employee """
+        employee_company = employee_company or self.company_id.id
+        # For employees with a user_id, the constraint (user can't be linked to multiple employees) is triggered
+        old_partner_employee_ids = user.partner_id.employee_ids.filtered(lambda e:
+            not e.user_id
+            and e.company_id.id == employee_company
+            and e != self
+        )
+        old_partner_employee_ids.work_contact_id = None
+
     def _sync_user(self, user, employee_has_image=False):
         vals = dict(
-            work_contact_id=user.partner_id.id,
+            work_contact_id=user.partner_id.id if user else self.work_contact_id.id,
             user_id=user.id,
         )
         if not employee_has_image:
@@ -390,6 +401,7 @@ class HrEmployeePrivate(models.Model):
                 user = self.env['res.users'].browse(vals['user_id'])
                 vals.update(self._sync_user(user, bool(vals.get('image_1920'))))
                 vals['name'] = vals.get('name', user.name)
+                self._remove_work_contact_id(user, vals.get('company_id'))
         employees = super().create(vals_list)
         # Sudo in case HR officer doesn't have the Contact Creation group
         employees.filtered(lambda e: not e.work_contact_id).sudo()._create_work_contacts()
@@ -434,10 +446,11 @@ class HrEmployeePrivate(models.Model):
             self.message_unsubscribe(self.work_contact_id.ids)
             if vals['work_contact_id']:
                 self._message_subscribe([vals['work_contact_id']])
-        if 'user_id' in vals:
+        if vals.get('user_id'):
             # Update the profile pictures with user, except if provided
-            vals.update(self._sync_user(self.env['res.users'].browse(vals['user_id']),
-                                        (bool(all(emp.image_1920 for emp in self)))))
+            user = self.env['res.users'].browse(vals['user_id'])
+            vals.update(self._sync_user(user, (bool(all(emp.image_1920 for emp in self)))))
+            self._remove_work_contact_id(user, vals.get('company_id'))
         if 'work_permit_expiration_date' in vals:
             vals['work_permit_scheduled_activity'] = False
         res = super(HrEmployeePrivate, self).write(vals)

--- a/addons/hr/tests/test_hr_employee.py
+++ b/addons/hr/tests/test_hr_employee.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import psycopg2
+
 from odoo.tests import Form, users
 from odoo.addons.hr.tests.common import TestHrCommon
+from odoo.tools import mute_logger
 
 
 class TestHrEmployee(TestHrCommon):
@@ -207,7 +210,7 @@ class TestHrEmployee(TestHrCommon):
     def test_employee_update_work_contact_id(self):
         """
             Check that the `work_contact_id` information is no longer
-            updated when an employee's `user_id` is removed.
+            updated when an employee's `user_id` is added to another employee.
         """
         user = self.env['res.users'].create({
             'name': 'Test',
@@ -231,6 +234,8 @@ class TestHrEmployee(TestHrCommon):
         employee_B.work_email = 'new_email@example.com'
         self.assertEqual(employee_A.work_email, 'employee_A@example.com')
         self.assertEqual(employee_B.work_email, 'new_email@example.com')
+        self.assertFalse(employee_A.work_contact_id)
+        self.assertEqual(employee_B.work_contact_id, user.partner_id)
 
     @users('admin')
     def test_change_user_on_employee(self):
@@ -264,6 +269,87 @@ class TestHrEmployee(TestHrCommon):
         # change user back -> check that there is no company error
         with Form(test_employee) as employee_form:
             employee_form.user_id = test_user
+
+    def test_change_user_on_employee_keep_partner(self):
+        """
+            Check that removing user from employee keeps the link in
+            work_contact_id until the user is assigned to another employee.
+        """
+        user = self.env['res.users'].create({
+            'name': 'Test User',
+            'login': 'test_user',
+        })
+        employee = self.env['hr.employee'].create({
+            'name': 'Test User - employee',
+            'user_id': user.id,
+        })
+        # remove user
+        employee.user_id = None
+        self.assertEqual(employee.work_contact_id, user.partner_id)
+        self.assertFalse(employee.user_id)
+        # create new employee from user
+        user.action_create_employee()
+        self.assertTrue(len(user.employee_ids) == 1, "Test user should have exactly one employee associated with it")
+        # previous employee shouldn't have a work_contact_id anymore, as the partner is reassigned
+        self.assertFalse(employee.work_contact_id)
+        # the new employee should be associated to both the user and its partner
+        new_employee = user.employee_ids
+        self.assertEqual(new_employee.work_contact_id, user.partner_id)
+        self.assertEqual(new_employee.user_id, user)
+
+    def test_change_user_on_employee_multi_company(self):
+        """
+            Removing user from employee keeps the link in work_contact_id in the correct company until the user
+            is assigned to another employee, and does not affect employees in other companies. When the unique
+            constraint of one employee per user in one company is triggered, the work_contact_id for the
+            existing employee is nor removed, and employees in other companies are not affected.
+        """
+        company_A = self.env['res.company'].create({'name': 'company_A'})
+        company_B = self.env['res.company'].create({'name': 'company_B'})
+        user = self.env['res.users'].create({
+            'name': 'Test User',
+            'login': 'test_user',
+        })
+        partner = user.partner_id
+        employee_A = self.env['hr.employee'].create({
+            'name': 'employee_A',
+            'user_id': user.id,
+            'company_id': company_A.id,
+        })
+        employee_B = self.env['hr.employee'].create({
+            'name': 'employee_B',
+            'user_id': user.id,
+            'company_id': company_B.id
+        })
+        # Creating an employee in one company does not remove the link with employee in the other company
+        self.assertEqual(user.with_company(company_A).employee_id, employee_A)
+        self.assertEqual(user.with_company(company_B).employee_id, employee_B)
+        # Partner is linked to both employees
+        partner.with_company(company_A).with_company(company_B)._compute_employees_count()
+        self.assertEqual(partner.employees_count, 2)
+        # Remove user from employee in one company does not affect link user-employee in the other company
+        employee_A.user_id = None
+        self.assertEqual(user.with_company(company_A).employee_id.ids, [])
+        self.assertEqual(user.with_company(company_B).employee_id, employee_B)
+        # Partner still linked to both employees
+        partner.with_company(company_A).with_company(company_B)._compute_employees_count()
+        self.assertEqual(partner.employees_count, 2)
+        # Creating a new employee for a user in company A does not affect link user-employee in the other company
+        new_employee_A = self.env['hr.employee'].create({
+            'name': 'new_employee_A',
+            'user_id': user.id,
+            'company_id': company_A.id,
+        })
+        # User cannot be assigned to more than one employee in the same company. work_contact_id should not be removed.
+        with mute_logger('odoo.sql_db'), self.assertRaises(psycopg2.errors.UniqueViolation), self.cr.savepoint():
+            self.env['hr.employee'].create({
+                'name': 'new_employee_B',
+                'user_id': user.id,
+                'company_id': company_B.id,
+            })
+        self.assertEqual(user.with_company(company_A).employee_id, new_employee_A)
+        self.assertEqual(user.with_company(company_B).employee_id, employee_B)
+        self.assertEqual(partner.employee_ids, employee_B + new_employee_A)
 
     def test_avatar(self):
         # Check simple employee has a generated image (initials)


### PR DESCRIPTION
Issue:
Currently, if the related user is removed from an employee, the link with the res.partner is also removed. This makes it impossible to post expense reports, as a partner is required to do so.

To reproduce:
1. Create a new user.
2. Click ‘Create Employee’ in the user view
3. Go to the employee through the smart button
4. In the tab HR Settings, remove the related user
5. Create an expense report and try to post it (Expenses => New => Create Report => Submit to Manager => Approve => Post Journal Entries)
6. An error message about missing vendor (res.partner) appears

Cause:
The field work_contact_id keeps the link between hr.employee and res.partner, and is updated in the function _sync_user. Since work_contact_id=user.partner_id.id, when the user is removed from the hr.employee, work_contact_id is also removed.

Fix:
The link between hr.employee and res.partner should be kept until the user is assigned to another employee. In this case, the partner associated to the user should also be associated with the second employee, and no longer to the first employee.

To do so, _sync_user assigns _origin.user_partner_id to work_contact_id if no user is passed (in case the user is removed). A helper function is called when creating or writing an employee, to unlink the partner and the previous employee in case the user is assigned to another employee.

task-4049996


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
