### PR TITLE
[FIX] fleet: prevent adding character in vehicle  model year

### DIFF
--- a/addons/fleet/views/fleet_vehicle_model_views.xml
+++ b/addons/fleet/views/fleet_vehicle_model_views.xml
@@ -38,7 +38,7 @@
                                     <field name="seats"/>
                                     <field name="doors"/>
                                     <field name="color"/>
-                                    <field name="model_year" widget="char"/>
+                                    <field name="model_year"/>
                                     <field name="trailer_hook"/>
                                 </group>
                                 <group id="vehicle_information" string="Vehicle Information" invisible="vehicle_type != 'bike'">


### PR DESCRIPTION
Currently an error occurs when a user adds a character in the `Model Year` of fleet vehicles.

Stack Trace:
```
ValueError: invalid literal for int() with base 10: '2016/2017'
  File "odoo/http.py", line 2373, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1903, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1966, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1933, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2177, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 223, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 754, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 35, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 459, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/web/models/models.py", line 73, in web_save
    self = self.create(vals)
  File "<decorator-gen-41>", line 2, in create
  File "odoo/api.py", line 421, in _model_create_multi
    return create(self, [arg])
  File "addons/mail/models/mail_thread.py", line 268, in create
    threads = super(MailThread, self).create(vals_list)
  File "<decorator-gen-0>", line 2, in create
  File "odoo/api.py", line 422, in _model_create_multi
    return create(self, arg)
  File "odoo/models.py", line 4768, in create
    records = self._create(data_list)
  File "odoo/models.py", line 4935, in _create
    colval = field.convert_to_column(stored[fname], self, stored)
  File "odoo/fields.py", line 1491, in convert_to_column
    return int(value or 0)
```

With the recently code change with https://github.com/odoo/odoo/commit/d69cb61b6c69a4110bc1af30323d5c8b8398129b, a 'char' widget was added in the field 'model_year' so it allows entering a character instead of an of an integer.

This commit removes the 'char' widget from the mode l'model_year' so the user will allow entering only numbers.



sentry-5667064353

