### PR TITLE
[FIX] sale_stock: compute sol reserved qty wizzard from all moves

### DIFF
--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -117,7 +117,7 @@ class SaleOrder(models.Model):
             # TODO: Log a note on each down document
             deadline_datetime = values.get('commitment_date')
             for order in self:
-                order.order_line.move_ids.date_deadline = deadline_datetime or order.expected_date
+                order.order_line.move_ids.filtered(lambda m: m.location_dest_usage == 'customer').date_deadline = deadline_datetime or order.expected_date
 
         res = super(SaleOrder, self).write(values)
         if values.get('order_line') and self.state == 'sale':

--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -65,7 +65,7 @@ class SaleOrderLine(models.Model):
         for line in self.filtered(lambda l: l.state == 'sale'):
             if not line.display_qty_widget:
                 continue
-            moves = line.move_ids.filtered(lambda m: m.product_id == line.product_id)
+            moves = line.move_ids.filtered(lambda m: m.product_id == line.product_id and m.state not in ('draft', 'done', 'cancel'))
             line.forecast_expected_date = max(
                 (
                     forecast_expected_date_per_move[move.id]

--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -22,6 +22,11 @@ class StockMove(models.Model):
         distinct_fields.append('sale_line_id')
         return distinct_fields
 
+    def _prepare_procurement_values(self):
+        res = super()._prepare_procurement_values()
+        res['sale_line_id'] = self.sale_line_id.id
+        return res
+
     def _get_related_invoices(self):
         """ Overridden from stock_account to return the customer invoices
         related to this stock move.
@@ -31,6 +36,12 @@ class StockMove(models.Model):
         rslt += invoices
         #rslt += invoices.mapped('reverse_entry_ids')
         return rslt
+
+    def _get_stock_move_values(self, product_id, product_qty, product_uom, location_id, name, origin, company_id, values):
+        move_values = super()._get_stock_move_values(product_id, product_qty, product_uom, location_id, name, origin, company_id, values)
+        if values.get('sale_line_id'):
+            move_values['sale_line_id'] = values['sale_line_id']
+        return move_values
 
     def _get_source_document(self):
         res = super()._get_source_document()

--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -1761,6 +1761,59 @@ class TestSaleStock(TestSaleCommon, ValuationReconciliationTestCommon):
         self.assertEqual(sale_order.order_line.qty_delivered, -1.0)
         self.assertEqual(sale_order.order_line.qty_to_invoice, -1.0)
 
+    def test_sol_reserved_qty_wizard_3_steps_delivery(self):
+        """
+        Check that the reserved qty wizard related to a sol is computed from
+        the pick move in 2+ step deliveries.
+        """
+        admin = self.env.ref('base.user_admin')
+        warehouse = self.env.ref('stock.warehouse0').with_user(admin)
+        warehouse.delivery_steps = 'pick_pack_ship'
+        product = self.product_a
+        product.type = 'product'
+        self.env['stock.quant']._update_available_quantity(product, warehouse.lot_stock_id, 10.0)
+        sale_order = self.env['sale.order'].with_user(admin).create({
+            'company_id': warehouse.company_id.id,
+            'warehouse_id': warehouse.id,
+            'partner_id': self.partner_a.id,
+            'order_line': [
+                Command.create({
+                'product_id': product.id,
+                'product_uom_qty': 7.0,
+                }),
+            ],
+        })
+        sale_order.action_confirm()
+        self.assertEqual(len(sale_order.picking_ids), 3)
+        pick = sale_order.picking_ids.filtered(lambda p: p.location_id == warehouse.lot_stock_id)
+        ship = sale_order.picking_ids.filtered(lambda p: p.location_dest_id == self.env.ref('stock.stock_location_customers'))
+        pack = sale_order.picking_ids - pick - ship
+        self.assertEqual(pick.move_line_ids.reserved_qty, 7.0)
+        self.assertEqual(sale_order.order_line.qty_available_today, 7.0)
+        self.assertEqual(sum(pack.move_line_ids.mapped('reserved_qty')), 0)
+        pick.move_ids.quantity_done = 7.0
+        pick.button_validate()
+        self.assertEqual(sum(pack.move_line_ids.mapped('reserved_qty')), 7.0)
+        self.assertEqual(sale_order.order_line.qty_available_today, 7.0)
+        pack.move_ids.quantity_done = 2.0
+        backorder_wizard_dict = pack.button_validate()
+        backorder_wizard = Form(self.env[backorder_wizard_dict['res_model']].with_user(admin).with_context(backorder_wizard_dict['context'])).save()
+        backorder_wizard.with_user(admin).process()
+        backorder = pack.backorder_ids
+        self.assertEqual(sum(backorder.move_line_ids.mapped('reserved_qty')), 5.0)
+        self.assertEqual(sum(ship.move_line_ids.mapped('reserved_qty')), 2.0)
+        self.assertEqual(sale_order.order_line.qty_available_today, 7.0)
+        self.assertEqual(sale_order.order_line.qty_delivered, 0.0)
+        backorder.move_ids.quantity_done = 5.0
+        backorder.button_validate()
+        self.assertEqual(sum(ship.move_line_ids.mapped('reserved_qty')), 7.0)
+        self.assertEqual(sale_order.order_line.qty_available_today, 7.0)
+        self.assertEqual(sale_order.order_line.qty_delivered, 0.0)
+        ship.move_ids.quantity_done = 7.0
+        ship.button_validate()
+        self.assertEqual(sale_order.order_line.qty_available_today, 0.0)
+        self.assertEqual(sale_order.order_line.qty_delivered, 7.0)
+
     def test_delivery_status(self):
         """
             Tests the delivery status of a sales order.

--- a/addons/stock_dropshipping/tests/test_dropship.py
+++ b/addons/stock_dropshipping/tests/test_dropship.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
+
 from odoo.tests import common, Form
 from odoo.tools import mute_logger
 
@@ -155,3 +157,29 @@ class TestDropship(common.TransactionCase):
         self.assertEqual(sale_order.picking_ids.state, 'done')
         self.assertEqual(sale_order.picking_ids.move_line_ids.lot_id.name, '123')
         self.assertEqual(sale_order.picking_ids.move_line_ids.lot_id.last_delivery_partner_id, self.customer)
+
+    def test_sol_reserved_qty_wizard_dropship(self):
+        """
+        Check that the reserved qty wizard related to a sol is computed from
+        the PO if the product is dropshipped.
+        """
+        product = self.dropship_product
+        product.route_ids = self.dropshipping_route
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'order_line': [Command.create({
+                'product_id': product.id,
+                'product_uom_qty': 3.0,
+            })]
+        })
+        sale_order.action_confirm()
+        self.assertEqual(sale_order.order_line.qty_available_today, 0.0)
+        purchase_order = self.env['purchase.order'].search([('partner_id', '=', self.supplier.id)])
+        purchase_order.button_confirm()
+        picking_dropship = sale_order.picking_ids.filtered(lambda p: p.picking_type_id)
+        self.assertTrue(picking_dropship)
+        self.assertEqual(sale_order.order_line.qty_available_today, 3.0)
+        self.assertRecordValues(sale_order.order_line, [{'qty_available_today': 3.0, 'qty_delivered': 0.0}])
+        picking_dropship.move_ids.quantity_done = 3.0
+        picking_dropship.button_validate()
+        self.assertEqual(sale_order.order_line.qty_delivered, 3.0)


### PR DESCRIPTION
Issue: the reserved quantity appearing on the SOL wizard is not well behaved with respect to 2+ steps deliveries.

### Steps to reproduce:

- Enable Multi-step routes in the settings
- Inventory > Configuration > Warehouse Management > Warehouses
- Enable delivery in 2 steps
- Create a storable product and put 1 unit in stock
- Create and confirm an SO for 1 unit
- Click on the chart icon next to the delivered qty

> the reserved qty is 0 + "No future availability" even though 1 unit is reserved from stock

### Cause of the issue:

The reserved qty displayed on the next to the delivered qty on the SOL is the `qty_available_today` computed field of the SOL model. This field is computed by summing the qties of the stock moves linked to the SOL: https://github.com/odoo/odoo/blob/c2996eadacdd774974ebfe52e00a732bb1cf4102/addons/sale_stock/models/sale_order_line.py#L68
https://github.com/odoo/odoo/blob/c2996eadacdd774974ebfe52e00a732bb1cf4102/addons/sale_stock/models/sale_order_line.py#L77-L81

However, when you are not delivering in 1 step, the only delivery move linkedto the SOL will be the move which destination is the customer location. To be more precise, confirming the SO in a delivery in two steps a stock move from the Output to the customer will be created and linked to the SOL. During the action confirm of this move a procurment will be run to generate a move from stock to the Output but the SOL will not be referenced anymore so that the SOL will not be linked to it.

Note:

The behavior is different in saas-17.2 where each of the delivering move is linked to the SOL so that the fix needs to be adapted in that version

opw-3981935
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
