### PR TITLE
[FIX] payment_paypal: don't prompt users for their delivery address

### DIFF
--- a/addons/payment_paypal/models/payment_transaction.py
+++ b/addons/payment_paypal/models/payment_transaction.py
@@ -52,6 +52,7 @@ class PaymentTransaction(models.Model):
             'item_number': self.reference,
             'last_name': partner_last_name,
             'lc': self.partner_lang,
+            'no_shipping': '1',  # Do not prompt for a delivery address.
             'notify_url': notify_url,
             'return_url': urls.url_join(base_url, PaypalController._return_url),
             'state': self.partner_state_id.name,

--- a/addons/payment_paypal/tests/test_paypal.py
+++ b/addons/payment_paypal/tests/test_paypal.py
@@ -28,6 +28,7 @@ class PaypalForm(PaypalCommon):
             'item_number': self.reference,
             'last_name': 'Buyer',
             'lc': 'en_US',
+            'no_shipping': '1',
             'notify_url': self._build_url(PaypalController._notify_url),
             'return': return_url,
             'rm': '2',

--- a/addons/payment_paypal/views/payment_paypal_templates.xml
+++ b/addons/payment_paypal/views/payment_paypal_templates.xml
@@ -20,6 +20,7 @@
             <input type="hidden" name="item_number" t-att-value="item_number"/>
             <input type="hidden" name="last_name" t-att-value="last_name"/>
             <input type="hidden" name="lc" t-att-value="lc"/>
+            <input type="hidden" name="no_shipping" t-att-value="no_shipping"/>
             <input t-if="notify_url"
                    type="hidden" name="notify_url" t-att-value="notify_url"/>
             <input type="hidden" name="return" t-att-value="return_url"/>


### PR DESCRIPTION
Before this commit, customers could change their delivery address from PayPal's checkout page. It created confusion because the change did not update the selected delivery address in Odoo, if any.

This commit adds the `no_shipping='1'` parameter to the API request to prevent PayPal from prompting users for a delivery address.

opw-4079193