### PR TITLE
[FIX] calendar: fix traceback when clearing meeting

### DIFF
--- a/addons/calendar/static/src/views/calendar_form/calendar_form_controller.js
+++ b/addons/calendar/static/src/views/calendar_form/calendar_form_controller.js
@@ -23,7 +23,7 @@ export class CalendarFormController extends FormController {
     async beforeExecuteActionButton(clickParams) {
         const action = clickParams.name;
         if (action == "clear_videocall_location" || action === "set_discuss_videocall_location") {
-            let newVal = false;
+            let newVal = "";
             let videoCallSource = "custom";
             let changes = {};
             if (action === "set_discuss_videocall_location") {


### PR DESCRIPTION
**Versions:** 17.0

**Steps to reproduce:**
1. Enable debug mode.
2. Go to the calendar.
3. Create an event using the quick create form.
4. Click on the Odoo meeting link.
5. Try to clear the meeting.

**Issue:**  
A traceback occurs when attempting to clear a meeting in debug mode.

**Cause:**  
The 'CopyButton' component expects the content to be a string but receives `false`.

**Solution:**  
In the form controller, set `videocall_location` to an empty string instead of `false` in `beforeExecuteActionButton`.

Task-4091314