### PR TITLE
[REF] html_editor: use the same api as the powerbox for the toolbar

### DIFF
--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -29,7 +29,7 @@ export class DomPlugin extends Plugin {
     static dependencies = ["selection", "split", "delete"];
     static shared = ["domInsert", "copyAttributes"];
     static resources = () => ({
-        powerboxCommands: {
+        powerboxItems: {
             name: _t("Separator"),
             description: _t("Insert a horizontal rule separator"),
             category: "structure",

--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -41,63 +41,60 @@ export class FormatPlugin extends Plugin {
             { hotkey: "control+u", command: "FORMAT_UNDERLINE" },
             { hotkey: "control+5", command: "FORMAT_STRIKETHROUGH" },
         ],
-        toolbarGroup: [
+        toolbarCategory: [
+            { id: "decoration", sequence: 20 },
+            { id: "remove_format", sequence: 26 },
+        ],
+        toolbarItems: [
             {
-                id: "decoration",
-                sequence: 20,
-                buttons: [
-                    {
-                        id: "bold",
-                        action(dispatch) {
-                            dispatch("FORMAT_BOLD");
-                        },
-                        icon: "fa-bold",
-                        name: "Toggle bold",
-                        isFormatApplied: isFormatted(p, "bold"),
-                    },
-                    {
-                        id: "italic",
-                        action(dispatch) {
-                            dispatch("FORMAT_ITALIC");
-                        },
-                        icon: "fa-italic",
-                        name: "Toggle italic",
-                        isFormatApplied: isFormatted(p, "italic"),
-                    },
-                    {
-                        id: "underline",
-                        action(dispatch) {
-                            dispatch("FORMAT_UNDERLINE");
-                        },
-                        icon: "fa-underline",
-                        name: "Toggle underline",
-                        isFormatApplied: isFormatted(p, "underline"),
-                    },
-                    {
-                        id: "strikethrough",
-                        action(dispatch) {
-                            dispatch("FORMAT_STRIKETHROUGH");
-                        },
-                        icon: "fa-strikethrough",
-                        name: "Toggle strikethrough",
-                        isFormatApplied: isFormatted(p, "strikeThrough"),
-                    },
-                ],
+                id: "bold",
+                category: "decoration",
+                action(dispatch) {
+                    dispatch("FORMAT_BOLD");
+                },
+                icon: "fa-bold",
+                name: "Toggle bold",
+                isFormatApplied: isFormatted(p, "bold"),
+            },
+            {
+                id: "italic",
+                category: "decoration",
+                action(dispatch) {
+                    dispatch("FORMAT_ITALIC");
+                },
+                icon: "fa-italic",
+                name: "Toggle italic",
+                isFormatApplied: isFormatted(p, "italic"),
+            },
+            {
+                id: "underline",
+                category: "decoration",
+                action(dispatch) {
+                    dispatch("FORMAT_UNDERLINE");
+                },
+                icon: "fa-underline",
+                name: "Toggle underline",
+                isFormatApplied: isFormatted(p, "underline"),
+            },
+            {
+                id: "strikethrough",
+                category: "decoration",
+                action(dispatch) {
+                    dispatch("FORMAT_STRIKETHROUGH");
+                },
+                icon: "fa-strikethrough",
+                name: "Toggle strikethrough",
+                isFormatApplied: isFormatted(p, "strikeThrough"),
             },
             {
                 id: "remove_format",
-                sequence: 26,
-                buttons: [
-                    {
-                        id: "remove_format",
-                        action(dispatch) {
-                            dispatch("FORMAT_REMOVE_FORMAT");
-                        },
-                        icon: "fa-eraser",
-                        name: "Remove Format",
-                        hasFormat: hasFormat(p),
-                    },
-                ],
+                category: "remove_format",
+                action(dispatch) {
+                    dispatch("FORMAT_REMOVE_FORMAT");
+                },
+                icon: "fa-eraser",
+                name: "Remove Format",
+                hasFormat: hasFormat(p),
             },
         ],
         arrows_should_skip: (ev, char, lastSkipped) => char === "\u200b",

--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -195,19 +195,18 @@ export class HtmlField extends Component {
             dynamicPlaceholderResModel:
                 this.props.record.data[this.props.dynamicPlaceholderModelReferenceField || "model"],
             resources: {
-                toolbarGroup: [
+                toolbarCategory: {
+                    id: "codeview",
+                    sequence: 100,
+                },
+                toolbarItems: [
                     {
                         id: "codeview",
-                        sequence: 100,
-                        buttons: [
-                            {
-                                id: "codeview",
-                                icon: "fa-code",
-                                action: () => {
-                                    this.toggleCodeView();
-                                },
-                            },
-                        ],
+                        category: "codeview",
+                        icon: "fa-code",
+                        action: () => {
+                            this.toggleCodeView();
+                        },
                     },
                 ],
             },

--- a/addons/html_editor/static/src/main/banner_plugin.js
+++ b/addons/html_editor/static/src/main/banner_plugin.js
@@ -12,7 +12,7 @@ export class BannerPlugin extends Plugin {
     /** @type { (p: BannerPlugin) => Record<string, any> } */
     static resources = (p) => ({
         powerboxCategory: { id: "banner", name: _t("Banner"), sequence: 20 },
-        powerboxCommands: [
+        powerboxItems: [
             {
                 category: "banner",
                 name: _t("Banner Info"),

--- a/addons/html_editor/static/src/main/chatgpt/chatgpt_plugin.js
+++ b/addons/html_editor/static/src/main/chatgpt/chatgpt_plugin.js
@@ -10,35 +10,33 @@ export class ChatGPTPlugin extends Plugin {
     static name = "chatgpt";
     static dependencies = ["selection", "history", "dom", "sanitize"];
     static resources = (p) => ({
-        toolbarGroup: [
+        toolbarCategory: [
             {
                 id: "ai",
                 sequence: 50,
-                buttons: [
-                    {
-                        id: "chatgpt",
-                        action(dispatch) {
-                            dispatch("OPEN_CHATGPT_DIALOG");
-                        },
-                        icon: "fa-magic",
-                        name: "chatgpt",
-                        label: _t("Generate or transform content with AI."),
-                    },
-                ],
+            },
+            { id: "translate", sequence: 110 },
+        ],
+        toolbarItems: [
+            {
+                id: "chatgpt",
+                category: "ai",
+                action(dispatch) {
+                    dispatch("OPEN_CHATGPT_DIALOG");
+                },
+                icon: "fa-magic",
+                name: "chatgpt",
+                label: _t("Generate or transform content with AI."),
             },
             {
                 id: "translate",
-                sequence: 110,
-                buttons: [
-                    {
-                        id: "translate",
-                        Component: LanguageSelector,
-                    },
-                ],
+                category: "translate",
+                Component: LanguageSelector,
             },
         ],
+
         powerboxCategory: { id: "ai", name: _t("AI Tools"), sequence: 70 },
-        powerboxCommands: {
+        powerboxItems: {
             name: _t("ChatGPT"),
             description: _t("Generate or transform content with AI."),
             category: "ai",

--- a/addons/html_editor/static/src/main/column_plugin.js
+++ b/addons/html_editor/static/src/main/column_plugin.js
@@ -33,7 +33,7 @@ export class ColumnPlugin extends Plugin {
     static dependencies = ["selection"];
     static resources = () => ({
         isUnremovable: isUnremovableColumn,
-        powerboxCommands: [
+        powerboxItems: [
             {
                 name: _t("2 columns"),
                 description: _t("Convert into 2 columns"),

--- a/addons/html_editor/static/src/main/emoji_plugin.js
+++ b/addons/html_editor/static/src/main/emoji_plugin.js
@@ -20,7 +20,7 @@ export class EmojiPlugin extends Plugin {
     static shared = ["showEmojiPicker"];
     /** @type { (p: EmojiPlugin) => Record<string, any> } */
     static resources = (p) => ({
-        powerboxCommands: [
+        powerboxItems: [
             {
                 category: "widget",
                 name: _t("Emoji"),

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -20,30 +20,34 @@ export class ColorPlugin extends Plugin {
     static shared = ["colorElement"];
     /** @type { (p: ColorPlugin) => Record<string, any> } */
     static resources = (p) => ({
-        toolbarGroup: {
+        toolbarCategory: {
             id: "color",
             sequence: 25,
-            buttons: [
-                {
-                    id: "forecolor",
-                    Component: ColorSelector,
-                    props: {
-                        type: "foreground",
-                        getUsedCustomColors: () => p.getUsedCustomColors("color"),
-                        getSelectedColors: () => p.selectedColors,
-                    },
-                },
-                {
-                    id: "backcolor",
-                    Component: ColorSelector,
-                    props: {
-                        type: "background",
-                        getUsedCustomColors: () => p.getUsedCustomColors("background"),
-                        getSelectedColors: () => p.selectedColors,
-                    },
-                },
-            ],
         },
+        toolbarItems: [
+            {
+                id: "forecolor",
+                category: "color",
+                Component: ColorSelector,
+                props: {
+                    type: "foreground",
+                    getUsedCustomColors: () => p.getUsedCustomColors("color"),
+                    getSelectedColors: () => p.selectedColors,
+                },
+            },
+            {
+                id: "backcolor",
+                category: "color",
+
+                Component: ColorSelector,
+                props: {
+                    type: "background",
+                    getUsedCustomColors: () => p.getUsedCustomColors("background"),
+                    getSelectedColors: () => p.selectedColors,
+                },
+            },
+        ],
+
         onSelectionChange: p.updateSelectedColor.bind(p),
         removeFormat: p.removeAllColor.bind(p),
     });

--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -104,40 +104,37 @@ export class FontPlugin extends Plugin {
         ],
         handle_delete_backward: { callback: p.handleDeleteBackward.bind(p), sequence: 20 },
         handle_delete_backward_word: { callback: p.handleDeleteBackward.bind(p), sequence: 20 },
-        toolbarGroup: [
+        toolbarCategory: [
             {
                 id: "font",
                 sequence: 10,
-                buttons: [
-                    {
-                        id: "font",
-                        Component: FontSelector,
-                        props: {
-                            getItems: () => fontItems,
-                            command: "SET_TAG",
-                        },
-                    },
-                ],
+            },
+            { id: "font-size", sequence: 29 },
+        ],
+        toolbarItems: [
+            {
+                id: "font",
+                category: "font",
+                Component: FontSelector,
+                props: {
+                    getItems: () => fontItems,
+                    command: "SET_TAG",
+                },
             },
             {
                 id: "font-size",
-                sequence: 29,
-                buttons: [
-                    {
-                        id: "font-size",
-                        Component: FontSelector,
-                        props: {
-                            getItems: () => p.fontSizeItems,
-                            isFontSize: true,
-                            command: "FORMAT_FONT_SIZE_CLASSNAME",
-                            document: p.document,
-                        },
-                    },
-                ],
+                category: "font-size",
+                Component: FontSelector,
+                props: {
+                    getItems: () => p.fontSizeItems,
+                    isFontSize: true,
+                    command: "FORMAT_FONT_SIZE_CLASSNAME",
+                    document: p.document,
+                },
             },
         ],
         powerboxCategory: { id: "format", name: _t("Format"), sequence: 30 },
-        powerboxCommands: [
+        powerboxItems: [
             {
                 name: _t("Heading 1"),
                 description: _t("Big section heading"),

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -60,34 +60,38 @@ export class LinkPlugin extends Plugin {
     static shared = ["createLink", "insertLink", "getPathAsUrlCommand"];
     /** @type { (p: LinkPlugin) => Record<string, any> } */
     static resources = (p) => ({
-        toolbarGroup: {
+        toolbarCategory: {
             id: "link",
             sequence: 40,
-            buttons: [
-                {
-                    id: "link",
-                    action(dispatch) {
-                        dispatch("CREATE_LINK_ON_SELECTION");
-                    },
-                    icon: "fa-link",
-                    name: "link",
-                    label: _t("Link"),
-                    isFormatApplied: isLinkActive,
-                },
-                {
-                    id: "unlink",
-                    action(dispatch) {
-                        dispatch("REMOVE_LINK_FROM_SELECTION");
-                    },
-                    icon: "fa-unlink",
-                    name: "unlink",
-                    label: _t("Remove Link"),
-                    isAvailable: isSelectionHasLink,
-                },
-            ],
         },
+        toolbarItems: [
+            {
+                id: "link",
+                category: "link",
+                action(dispatch) {
+                    dispatch("CREATE_LINK_ON_SELECTION");
+                },
+                icon: "fa-link",
+                name: "link",
+                label: _t("Link"),
+                isFormatApplied: isLinkActive,
+            },
+            {
+                id: "unlink",
+                category: "link",
+
+                action(dispatch) {
+                    dispatch("REMOVE_LINK_FROM_SELECTION");
+                },
+                icon: "fa-unlink",
+                name: "unlink",
+                label: _t("Remove Link"),
+                isAvailable: isSelectionHasLink,
+            },
+        ],
+
         powerboxCategory: { id: "navigation", name: _t("Navigation"), sequence: 50 },
-        powerboxCommands: [
+        powerboxItems: [
             {
                 name: _t("Link"),
                 description: _t("Add a link"),

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -44,40 +44,43 @@ export class ListPlugin extends Plugin {
         handle_tab: { callback: p.handleTab.bind(p), sequence: 10 },
         handle_shift_tab: { callback: p.handleShiftTab.bind(p), sequence: 10 },
         split_element_block: { callback: p.handleSplitBlock.bind(p) },
-        toolbarGroup: {
+        toolbarCategory: {
             id: "list",
             sequence: 30,
-            buttons: [
-                {
-                    id: "bulleted_list",
-                    action(dispatch) {
-                        dispatch("TOGGLE_LIST", { mode: "UL" });
-                    },
-                    icon: "fa-list-ul",
-                    name: "Bulleted list",
-                    isFormatApplied: isListActive("UL"),
-                },
-                {
-                    id: "numbered_list",
-                    action(dispatch) {
-                        dispatch("TOGGLE_LIST", { mode: "OL" });
-                    },
-                    icon: "fa-list-ol",
-                    name: "Numbered list",
-                    isFormatApplied: isListActive("OL"),
-                },
-                {
-                    id: "checklist",
-                    action(dispatch) {
-                        dispatch("TOGGLE_LIST", { mode: "CL" });
-                    },
-                    icon: "fa-check-square-o",
-                    name: "Checklist",
-                    isFormatApplied: isListActive("CL"),
-                },
-            ],
         },
-        powerboxCommands: [
+        toolbarItems: [
+            {
+                id: "bulleted_list",
+                category: "list",
+                action(dispatch) {
+                    dispatch("TOGGLE_LIST", { mode: "UL" });
+                },
+                icon: "fa-list-ul",
+                name: "Bulleted list",
+                isFormatApplied: isListActive("UL"),
+            },
+            {
+                id: "numbered_list",
+                category: "list",
+                action(dispatch) {
+                    dispatch("TOGGLE_LIST", { mode: "OL" });
+                },
+                icon: "fa-list-ol",
+                name: "Numbered list",
+                isFormatApplied: isListActive("OL"),
+            },
+            {
+                id: "checklist",
+                category: "list",
+                action(dispatch) {
+                    dispatch("TOGGLE_LIST", { mode: "CL" });
+                },
+                icon: "fa-check-square-o",
+                name: "Checklist",
+                isFormatApplied: isListActive("CL"),
+            },
+        ],
+        powerboxItems: [
             {
                 name: _t("Bulleted list"),
                 description: _t("Create a simple bulleted list"),

--- a/addons/html_editor/static/src/main/media/icon_plugin.js
+++ b/addons/html_editor/static/src/main/media/icon_plugin.js
@@ -15,89 +15,89 @@ export class IconPlugin extends Plugin {
                     },
                 },
             ],
-            toolbarGroup: [
+            toolbarCategory: [
                 {
                     id: "icon_color",
                     sequence: 1,
                     namespace: "icon",
-                    buttons: [
-                        {
-                            id: "icon_forecolor",
-                            inherit: "forecolor",
-                        },
-                        {
-                            id: "icon_backcolor",
-                            inherit: "backcolor",
-                        },
-                    ],
                 },
                 {
                     id: "icon_size",
                     sequence: 1,
                     namespace: "icon",
-                    buttons: [
-                        {
-                            id: "icon_size_1",
-                            action(dispatch) {
-                                dispatch("RESIZE_ICON", "1");
-                            },
-                            text: "1x",
-                            name: _t("Icon size 1x"),
-                            isFormatApplied: () => p.hasIconSize("1"),
-                        },
-                        {
-                            id: "icon_size_2",
-                            action(dispatch) {
-                                dispatch("RESIZE_ICON", "2");
-                            },
-                            text: "2x",
-                            name: _t("Icon size 2x"),
-                            isFormatApplied: () => p.hasIconSize("2"),
-                        },
-                        {
-                            id: "icon_size_3",
-                            action(dispatch) {
-                                dispatch("RESIZE_ICON", "3");
-                            },
-                            text: "3x",
-                            name: _t("Icon size 3x"),
-                            isFormatApplied: () => p.hasIconSize("3"),
-                        },
-                        {
-                            id: "icon_size_4",
-                            action(dispatch) {
-                                dispatch("RESIZE_ICON", "4");
-                            },
-                            text: "4x",
-                            name: _t("Icon size 4x"),
-                            isFormatApplied: () => p.hasIconSize("4"),
-                        },
-                        {
-                            id: "icon_size_5",
-                            action(dispatch) {
-                                dispatch("RESIZE_ICON", "5");
-                            },
-                            text: "5x",
-                            name: _t("Icon size 5x"),
-                            isFormatApplied: () => p.hasIconSize("5"),
-                        },
-                    ],
+                },
+                { id: "icon_spin", sequence: 3, namespace: "icon" },
+            ],
+            toolbarItems: [
+                {
+                    id: "icon_forecolor",
+                    category: "icon_color",
+                    inherit: "forecolor",
+                },
+                {
+                    id: "icon_backcolor",
+                    category: "icon_color",
+                    inherit: "backcolor",
+                },
+                {
+                    id: "icon_size_1",
+                    category: "icon_size",
+                    action(dispatch) {
+                        dispatch("RESIZE_ICON", "1");
+                    },
+                    text: "1x",
+                    name: _t("Icon size 1x"),
+                    isFormatApplied: () => p.hasIconSize("1"),
+                },
+                {
+                    id: "icon_size_2",
+                    category: "icon_size",
+                    action(dispatch) {
+                        dispatch("RESIZE_ICON", "2");
+                    },
+                    text: "2x",
+                    name: _t("Icon size 2x"),
+                    isFormatApplied: () => p.hasIconSize("2"),
+                },
+                {
+                    id: "icon_size_3",
+                    category: "icon_size",
+                    action(dispatch) {
+                        dispatch("RESIZE_ICON", "3");
+                    },
+                    text: "3x",
+                    name: _t("Icon size 3x"),
+                    isFormatApplied: () => p.hasIconSize("3"),
+                },
+                {
+                    id: "icon_size_4",
+                    category: "icon_size",
+                    action(dispatch) {
+                        dispatch("RESIZE_ICON", "4");
+                    },
+                    text: "4x",
+                    name: _t("Icon size 4x"),
+                    isFormatApplied: () => p.hasIconSize("4"),
+                },
+                {
+                    id: "icon_size_5",
+                    category: "icon_size",
+                    action(dispatch) {
+                        dispatch("RESIZE_ICON", "5");
+                    },
+                    text: "5x",
+                    name: _t("Icon size 5x"),
+                    isFormatApplied: () => p.hasIconSize("5"),
                 },
                 {
                     id: "icon_spin",
-                    sequence: 3,
-                    namespace: "icon",
-                    buttons: [
-                        {
-                            id: "icon_spin",
-                            action(dispatch) {
-                                dispatch("TOGGLE_SPIN_ICON");
-                            },
-                            icon: "fa-play",
-                            name: _t("Toggle icon spin"),
-                            isFormatApplied: () => p.hasSpinIcon(),
-                        },
-                    ],
+                    category: "icon_spin",
+                    action(dispatch) {
+                        dispatch("TOGGLE_SPIN_ICON");
+                    },
+                    icon: "fa-play",
+                    name: _t("Toggle icon spin"),
+                    isFormatApplied: () => p.hasSpinIcon(),
                 },
             ],
             colorApply: p.applyIconColor.bind(p),

--- a/addons/html_editor/static/src/main/media/image_crop_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_crop_plugin.js
@@ -10,21 +10,20 @@ export class ImageCropPlugin extends Plugin {
     /** @type { (p: ImageCropPlugin) => Record<string, any> } */
     static resources(p) {
         return {
-            toolbarGroup: [
+            toolbarCategory: {
+                id: "image_crop",
+                namespace: "image",
+                sequence: 27,
+            },
+            toolbarItems: [
                 {
                     id: "image_crop",
-                    namespace: "image",
-                    sequence: 27,
-                    buttons: [
-                        {
-                            id: "image_crop",
-                            name: _t("Crop image"),
-                            icon: "fa-crop",
-                            action(dispatch) {
-                                dispatch("CROP_IMAGE");
-                            },
-                        },
-                    ],
+                    category: "image_crop",
+                    name: _t("Crop image"),
+                    icon: "fa-crop",
+                    action(dispatch) {
+                        dispatch("CROP_IMAGE");
+                    },
                 },
             ],
         };

--- a/addons/html_editor/static/src/main/media/image_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_plugin.js
@@ -25,165 +25,146 @@ export class ImagePlugin extends Plugin {
                     },
                 },
             ],
-            toolbarGroup: [
+            toolbarCategory: [
                 {
                     id: "image_preview",
                     sequence: 23,
                     namespace: "image",
-                    buttons: [
-                        {
-                            id: "image_preview",
-                            action(dispatch) {
-                                dispatch("PREVIEW_IMAGE");
-                            },
-                            icon: "fa-search-plus",
-                            name: _t("Preview image"),
-                        },
-                    ],
                 },
-                {
-                    id: "image_description",
-                    sequence: 24,
-                    namespace: "image",
-                    buttons: [
-                        {
-                            id: "image_description",
-                            Component: ImageDescription,
-                            props: {
-                                getDescription: () => p.getImageAttribute("alt"),
-                                getTooltip: () => p.getImageAttribute("title"),
-                            },
-                        },
-                    ],
-                },
-                {
-                    id: "image_shape",
-                    sequence: 25,
-                    namespace: "image",
-                    buttons: [
-                        {
-                            id: "shape_rounded",
-                            action(dispatch) {
-                                dispatch("SHAPE_ROUNDED");
-                            },
-                            name: _t("Shape: Rounded"),
-                            icon: "fa-square",
-                            isFormatApplied: hasShape(p, "rounded"),
-                        },
-                        {
-                            id: "shape_circle",
-                            action(dispatch) {
-                                dispatch("SHAPE_CIRCLE");
-                            },
-                            name: _t("Shape: Circle"),
-                            icon: "fa-circle-o",
-                            isFormatApplied: hasShape(p, "rounded-circle"),
-                        },
-                        {
-                            id: "shape_shadow",
-                            action(dispatch) {
-                                dispatch("SHAPE_SHADOW");
-                            },
-                            name: _t("Shape: Shadow"),
-                            icon: "fa-sun-o",
-                            isFormatApplied: hasShape(p, "shadow"),
-                        },
-                        {
-                            id: "shape_thumbnail",
-                            action(dispatch) {
-                                dispatch("SHAPE_THUMBNAIL");
-                            },
-                            name: _t("Shape: Thumbnail"),
-                            icon: "fa-picture-o",
-                            isFormatApplied: hasShape(p, "img-thumbnail"),
-                        },
-                    ],
-                },
-                {
-                    id: "image_padding",
-                    sequence: 26,
-                    namespace: "image",
-                    buttons: [
-                        {
-                            id: "image_padding",
-                            name: _t("Image padding"),
-                            Component: ImagePadding,
-                        },
-                    ],
-                },
+                { id: "image_description", sequence: 24, namespace: "image" },
+                { id: "image_shape", sequence: 25, namespace: "image" },
+                { id: "image_padding", sequence: 26, namespace: "image" },
                 {
                     id: "image_size",
                     sequence: 26,
                     namespace: "image",
-                    buttons: [
-                        {
-                            id: "resize_default",
-                            action(dispatch) {
-                                dispatch("RESIZE_IMAGE", "");
-                            },
-                            name: _t("Resize Default"),
-                            text: _t("Default"),
-                            isFormatApplied: () => p.hasImageSize(""),
-                        },
-                        {
-                            id: "resize_100",
-                            action(dispatch) {
-                                dispatch("RESIZE_IMAGE", "100%");
-                            },
-                            name: _t("Resize Full"),
-                            text: "100%",
-                            isFormatApplied: () => p.hasImageSize("100%"),
-                        },
-                        {
-                            id: "resize_50",
-                            action(dispatch) {
-                                dispatch("RESIZE_IMAGE", "50%");
-                            },
-                            name: _t("Resize Half"),
-                            text: "50%",
-                            isFormatApplied: () => p.hasImageSize("50%"),
-                        },
-                        {
-                            id: "resize_25",
-                            action(dispatch) {
-                                dispatch("RESIZE_IMAGE", "25%");
-                            },
-                            name: _t("Resize Quarter"),
-                            text: "25%",
-                            isFormatApplied: () => p.hasImageSize("25%"),
-                        },
-                    ],
+                },
+                { id: "image_transform", sequence: 26, namespace: "image" },
+                { id: "image_delete", sequence: 30, namespace: "image" },
+            ],
+            toolbarItems: [
+                {
+                    id: "image_preview",
+                    category: "image_preview",
+                    action(dispatch) {
+                        dispatch("PREVIEW_IMAGE");
+                    },
+                    icon: "fa-search-plus",
+                    name: _t("Preview image"),
+                },
+                {
+                    id: "image_description",
+                    category: "image_description",
+                    Component: ImageDescription,
+                    props: {
+                        getDescription: () => p.getImageAttribute("alt"),
+                        getTooltip: () => p.getImageAttribute("title"),
+                    },
+                },
+                {
+                    id: "shape_rounded",
+                    category: "image_shape",
+                    action(dispatch) {
+                        dispatch("SHAPE_ROUNDED");
+                    },
+                    name: _t("Shape: Rounded"),
+                    icon: "fa-square",
+                    isFormatApplied: hasShape(p, "rounded"),
+                },
+                {
+                    id: "shape_circle",
+                    category: "image_shape",
+                    action(dispatch) {
+                        dispatch("SHAPE_CIRCLE");
+                    },
+                    name: _t("Shape: Circle"),
+                    icon: "fa-circle-o",
+                    isFormatApplied: hasShape(p, "rounded-circle"),
+                },
+                {
+                    id: "shape_shadow",
+                    category: "image_shape",
+                    action(dispatch) {
+                        dispatch("SHAPE_SHADOW");
+                    },
+                    name: _t("Shape: Shadow"),
+                    icon: "fa-sun-o",
+                    isFormatApplied: hasShape(p, "shadow"),
+                },
+                {
+                    id: "shape_thumbnail",
+                    category: "image_shape",
+                    action(dispatch) {
+                        dispatch("SHAPE_THUMBNAIL");
+                    },
+                    name: _t("Shape: Thumbnail"),
+                    icon: "fa-picture-o",
+                    isFormatApplied: hasShape(p, "img-thumbnail"),
+                },
+                {
+                    id: "image_padding",
+                    category: "image_padding",
+                    name: _t("Image padding"),
+                    Component: ImagePadding,
+                },
+                {
+                    id: "resize_default",
+                    category: "image_size",
+                    action(dispatch) {
+                        dispatch("RESIZE_IMAGE", "");
+                    },
+                    name: _t("Resize Default"),
+                    text: _t("Default"),
+                    isFormatApplied: () => p.hasImageSize(""),
+                },
+                {
+                    id: "resize_100",
+                    category: "image_size",
+                    action(dispatch) {
+                        dispatch("RESIZE_IMAGE", "100%");
+                    },
+                    name: _t("Resize Full"),
+                    text: "100%",
+                    isFormatApplied: () => p.hasImageSize("100%"),
+                },
+                {
+                    id: "resize_50",
+                    category: "image_size",
+                    action(dispatch) {
+                        dispatch("RESIZE_IMAGE", "50%");
+                    },
+                    name: _t("Resize Half"),
+                    text: "50%",
+                    isFormatApplied: () => p.hasImageSize("50%"),
+                },
+                {
+                    id: "resize_25",
+                    category: "image_size",
+                    action(dispatch) {
+                        dispatch("RESIZE_IMAGE", "25%");
+                    },
+                    name: _t("Resize Quarter"),
+                    text: "25%",
+                    isFormatApplied: () => p.hasImageSize("25%"),
                 },
                 {
                     id: "image_transform",
-                    sequence: 26,
-                    namespace: "image",
-                    buttons: [
-                        {
-                            id: "image_transform",
-                            action(dispatch) {
-                                dispatch("TRANSFORM_IMAGE");
-                            },
-                            name: _t("Transform the picture (click twice to reset transformation)"),
-                            icon: "fa-object-ungroup",
-                            isFormatApplied: () => p.currentImageTransformation.imageEl,
-                        },
-                    ],
+                    category: "image_transform",
+                    action(dispatch) {
+                        dispatch("TRANSFORM_IMAGE");
+                    },
+                    name: _t("Transform the picture (click twice to reset transformation)"),
+                    icon: "fa-object-ungroup",
+                    isFormatApplied: () => p.currentImageTransformation.imageEl,
                 },
                 {
                     id: "image_delete",
-                    sequence: 30,
-                    namespace: "image",
-                    buttons: [
-                        {
-                            id: "image_delete",
-                            action(dispatch) {
-                                dispatch("DELETE_IMAGE");
-                            },
-                            name: _t("Remove (DELETE)"),
-                            icon: "fa-trash text-danger",
-                        },
-                    ],
+                    category: "image_delete",
+                    action(dispatch) {
+                        dispatch("DELETE_IMAGE");
+                    },
+                    name: _t("Remove (DELETE)"),
+                    icon: "fa-trash text-danger",
                 },
             ],
         };

--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -18,9 +18,9 @@ export class MediaPlugin extends Plugin {
     static shared = ["savePendingImages"];
     /** @type { (p: MediaPlugin) => Record<string, any> } */
     static resources = (p) => {
-        const powerboxCommands = [];
+        const powerboxItems = [];
         if (!p.config.disableImage) {
-            powerboxCommands.push({
+            powerboxItems.push({
                 name: _t("Image"),
                 description: _t("Insert an image"),
                 category: "media",
@@ -31,7 +31,7 @@ export class MediaPlugin extends Plugin {
             });
         }
         if (!p.config.disableVideo) {
-            powerboxCommands.push({
+            powerboxItems.push({
                 name: _t("Video"),
                 description: _t("Insert a video"),
                 category: "media",
@@ -48,22 +48,19 @@ export class MediaPlugin extends Plugin {
         }
         const resources = {
             powerboxCategory: { id: "media", name: _t("Media"), sequence: 40 },
-            powerboxCommands,
-            toolbarGroup: {
-                id: "replace_image",
-                sequence: 29,
-                namespace: "image",
-                buttons: [
-                    {
-                        id: "replace_image",
-                        action(dispatch) {
-                            dispatch("REPLACE_IMAGE");
-                        },
-                        name: "Replace media",
-                        text: "Replace",
+            powerboxItems,
+            toolbarCategory: { id: "replace_image", sequence: 29, namespace: "image" },
+            toolbarItems: [
+                {
+                    id: "replace_image",
+                    category: "replace_image",
+                    action(dispatch) {
+                        dispatch("REPLACE_IMAGE");
                     },
-                ],
-            },
+                    name: "Replace media",
+                    text: "Replace",
+                },
+            ],
         };
         return resources;
     };

--- a/addons/html_editor/static/src/main/powerbox/search_powerbox_plugin.js
+++ b/addons/html_editor/static/src/main/powerbox/search_powerbox_plugin.js
@@ -23,7 +23,7 @@ export class SearchPowerboxPlugin extends Plugin {
             categoryIds.add(category.id);
         }
         this.categories = this.resources.powerboxCategory.sort((a, b) => a.sequence - b.sequence);
-        this.commands = this.resources.powerboxCommands.map((command) => ({
+        this.commands = this.resources.powerboxItems.map((command) => ({
             ...command,
             categoryName: this.categories.find((category) => category.id === command.category).name,
         }));

--- a/addons/html_editor/static/src/main/signature_plugin.js
+++ b/addons/html_editor/static/src/main/signature_plugin.js
@@ -9,7 +9,7 @@ export class SignaturePlugin extends Plugin {
     /** @type { (p: SignaturePlugin) => Record<string, any> } */
     static resources = (p) => ({
         powerboxCategory: { id: "basic_block", name: _t("Basic Bloc"), sequence: 100 },
-        powerboxCommands: [
+        powerboxItems: [
             {
                 category: "basic_block",
                 name: _t("Signature"),

--- a/addons/html_editor/static/src/main/star_plugin.js
+++ b/addons/html_editor/static/src/main/star_plugin.js
@@ -10,7 +10,7 @@ export class StarPlugin extends Plugin {
     static name = "star";
     static dependencies = ["dom"];
     static resources = (p) => ({
-        powerboxCommands: [
+        powerboxItems: [
             {
                 name: _t("3 Stars"),
                 description: _t("Insert a rating over 3 stars"),

--- a/addons/html_editor/static/src/main/table/table_ui_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_ui_plugin.js
@@ -14,7 +14,7 @@ export class TableUIPlugin extends Plugin {
     static dependencies = ["overlay", "table"];
     /** @type { (p: TableUIPlugin) => Record<string, any> } */
     static resources = (p) => ({
-        powerboxCommands: [
+        powerboxItems: [
             {
                 name: _t("Table"),
                 description: _t("Insert a table"),

--- a/addons/html_editor/static/src/main/text_direction_plugin.js
+++ b/addons/html_editor/static/src/main/text_direction_plugin.js
@@ -8,7 +8,7 @@ export class TextDirectionPlugin extends Plugin {
     static dependencies = ["selection", "split", "format"];
     /** @type { (p: TextDirectionPlugin) => Record<string, any> } */
     static resources = (p) => ({
-        powerboxCommands: [
+        powerboxItems: [
             {
                 name: _t("Switch direction"),
                 description: _t("Switch the text's direction"),

--- a/addons/html_editor/static/src/others/dynamic_placeholder/dynamic_placeholder.js
+++ b/addons/html_editor/static/src/others/dynamic_placeholder/dynamic_placeholder.js
@@ -22,7 +22,7 @@ export class DynamicPlaceholderPlugin extends Plugin {
     /** @type { (p: DynamicPlaceholderPlugin) => Record<string, any> } */
     static resources = (p) => ({
         powerboxCategory: { id: "marketing_tools", name: _t("Marketing Tools"), sequence: 60 },
-        powerboxCommands: {
+        powerboxItems: {
             name: _t("Dynamic Placeholder"),
             description: _t("Insert personalized content"),
             category: "marketing_tools",

--- a/addons/html_editor/static/tests/powerbox.test.js
+++ b/addons/html_editor/static/tests/powerbox.test.js
@@ -113,7 +113,7 @@ describe("search", () => {
             static name = "test";
             static resources = () => ({
                 powerboxCategory: { id: "test", name: "Test" },
-                powerboxCommands: [
+                powerboxItems: [
                     {
                         name: "Test1",
                         description: "Test1",
@@ -393,7 +393,7 @@ class NoOpPlugin extends Plugin {
     static name = "no_op";
     static resources = () => ({
         powerboxCategory: { id: "no_op", name: "No-op" },
-        powerboxCommands: [
+        powerboxItems: [
             {
                 name: "No-op",
                 description: "No-op",

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -312,18 +312,13 @@ test("toolbar correctly show namespace button group and stop showing when namesp
                         },
                     },
                 ],
-                toolbarGroup: [
+                toolbarCategory: { id: "test_group", sequence: 24, namespace: "aNamespace" },
+                toolbarItems: [
                     {
-                        id: "test_group",
-                        sequence: 24,
-                        namespace: "aNamespace",
-                        buttons: [
-                            {
-                                id: "test_btn",
-                                name: "Test Button",
-                                icon: "fa-square",
-                            },
-                        ],
+                        id: "test_btn",
+                        category: "test_group",
+                        name: "Test Button",
+                        icon: "fa-square",
                     },
                 ],
             };
@@ -344,21 +339,19 @@ test("toolbar correctly process inheritance buttons chain", async () => {
         static name = "TestPlugin";
         static resources(p) {
             return {
-                toolbarGroup: [
+                toolbarCategory: { id: "test_group" },
+                toolbarItems: [
                     {
-                        id: "test_group",
-                        buttons: [
-                            {
-                                id: "test_btn",
-                                name: "Test Button",
-                                icon: "fa-square",
-                            },
-                            {
-                                id: "test_btn2",
-                                inherit: "test_btn",
-                                name: "Test Button 2",
-                            },
-                        ],
+                        id: "test_btn",
+                        category: "test_group",
+                        name: "Test Button",
+                        icon: "fa-square",
+                    },
+                    {
+                        id: "test_btn2",
+                        category: "test_group",
+                        inherit: "test_btn",
+                        name: "Test Button 2",
                     },
                 ],
             };
@@ -383,22 +376,17 @@ test("toolbar does not evaluate isFormatApplied when namespace does not match", 
         static name = "TestPlugin";
         static resources(p) {
             return {
-                toolbarGroup: [
+                toolbarCategory: { id: "test_group", sequence: 24, namespace: "image" },
+                toolbarItems: [
                     {
-                        id: "test_group",
-                        sequence: 24,
-                        namespace: "image",
-                        buttons: [
-                            {
-                                id: "test_btn",
-                                action(dispatch) {
-                                    dispatch("test_cmd");
-                                },
-                                name: "Test Button",
-                                icon: "fa-square",
-                                isFormatApplied: () => expect.step("image format evaluated"),
-                            },
-                        ],
+                        id: "test_btn",
+                        category: "test_group",
+                        action(dispatch) {
+                            dispatch("test_cmd");
+                        },
+                        name: "Test Button",
+                        icon: "fa-square",
+                        isFormatApplied: () => expect.step("image format evaluated"),
                     },
                 ],
             };
@@ -427,20 +415,16 @@ test("plugins can create buttons with text in toolbar", async () => {
         static name = "TestPlugin";
         static resources(p) {
             return {
-                toolbarGroup: [
+                toolbarCategory: { id: "test_group", sequence: 24 },
+                toolbarItems: [
                     {
-                        id: "test_group",
-                        sequence: 24,
-                        buttons: [
-                            {
-                                id: "test_btn",
-                                action(dispatch) {
-                                    dispatch("test_cmd");
-                                },
-                                name: "Test Button",
-                                text: "Text button",
-                            },
-                        ],
+                        id: "test_btn",
+                        category: "test_group",
+                        action(dispatch) {
+                            dispatch("test_cmd");
+                        },
+                        name: "Test Button",
+                        text: "Text button",
                     },
                 ],
             };

--- a/addons/project/static/src/project_sharing/editor/project_sharing_media_plugin.js
+++ b/addons/project/static/src/project_sharing/editor/project_sharing_media_plugin.js
@@ -5,7 +5,8 @@ import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
 export class ProjectSharingMediaPlugin extends MediaPlugin {
     static resources = (p) => {
         const resources = MediaPlugin.resources(p);
-        delete resources.toolbarGroup;
+        delete resources.toolbarCategory;
+        delete resources.toolbarItems;
         return resources;
     };
     async createAttachment({ el, imageData, resId }) {

--- a/addons/web_editor/static/src/js/backend/html_field.js
+++ b/addons/web_editor/static/src/js/backend/html_field.js
@@ -186,7 +186,7 @@ export class HtmlField extends Component {
             dynamicPlaceholderOptions = {
                 // Add the powerbox option to open the Dynamic Placeholder
                 // generator.
-                powerboxCommands: [
+                powerboxItems: [
                     {
                         category: _t('Marketing Tools'),
                         name: _t('Dynamic Placeholder'),

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -2648,8 +2648,8 @@ export class Wysiwyg extends Component {
         if (editorOptions.powerboxCategories) {
             categories.push(...editorOptions.powerboxCategories);
         }
-        if (editorOptions.powerboxCommands) {
-            commands.push(...editorOptions.powerboxCommands);
+        if (editorOptions.powerboxItems) {
+            commands.push(...editorOptions.powerboxItems);
         }
         return {commands, categories};
     }

--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -482,7 +482,7 @@ export class WysiwygAdapterComponent extends Wysiwyg {
             document: this.websiteService.pageDocument,
             sideAttach: true,
             isWebsite: true, // If set to true, it will trigger isolated behaviours in website patches. (.include)
-            powerboxCommands: powerboxItems[0],
+            powerboxItems: powerboxItems[0],
             powerboxCategories: powerboxItems[1],
             bindLinkTool: true,
             showEmptyElementHint: false,


### PR DESCRIPTION
The purpose of this commit is to modify the api used to define toolbar elements so that it is like the powerbox api.

We're therefore going to replace toolbarGroup by toolbarCategory/toolbarCommands. These are the equivalents of powerboxCategory and powerboxCommands.

Thanks to this new API, a plugin can add a command to an existing category.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
