### PR TITLE
[IMP] website: introduce `s_cta_badge` snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -101,6 +101,7 @@
         'views/snippets/s_button.xml',
         'views/snippets/s_image.xml',
         'views/snippets/s_video.xml',
+        'views/snippets/s_cta_badge.xml',
         'views/new_page_template_templates.xml',
         'views/website_views.xml',
         'views/website_pages_views.xml',

--- a/addons/website/static/src/img/snippets_thumbs/s_cta_badge.svg
+++ b/addons/website/static/src/img/snippets_thumbs/s_cta_badge.svg
@@ -1,0 +1,16 @@
+<svg width="82" height="60" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g clip-path="url(#a)">
+    <path d="M56.887 24H25.405a6.559 6.559 0 0 0 0 13.118h31.482a6.559 6.559 0 0 0 0-13.118Z" fill="url(#b)"/>
+    <path d="M58.25 29.25v1.5H34.188v-1.5H58.25ZM60.22 41.566c.15.145.183.312.1.5-.081.194-.224.29-.427.29h-2.771l1.458 3.454a.47.47 0 0 1-.247.61l-1.284.544a.47.47 0 0 1-.61-.247l-1.385-3.28-2.263 2.264a.447.447 0 0 1-.5.102c-.194-.082-.291-.225-.291-.428v-10.91c0-.204.097-.347.29-.43a.45.45 0 0 1 .5.103l7.43 7.428Z" fill="#fff"/>
+    <path d="M25.5 34a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z" fill="#fff" fill-opacity=".95"/>
+  </g>
+  <defs>
+    <linearGradient id="b" x1="18.846" y1="29.991" x2="60.203" y2="42.153" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#00A09D"/>
+      <stop offset="1" stop-color="#00C0D9"/>
+    </linearGradient>
+    <clipPath id="a">
+      <path fill="#fff" d="M0 0h82v60H0z"/>
+    </clipPath>
+  </defs>
+</svg>

--- a/addons/website/views/snippets/s_cta_badge.xml
+++ b/addons/website/views/snippets/s_cta_badge.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template name="CTA Badge" id="s_cta_badge">
+    <span class="s_cta_badge d-inline-block my-3 border rounded py-2 px-3 o_cc o_cc1 o_animable" data-name="CTA Badge" style="border-radius: 32px !important;">
+        <i class="fa fa-1x fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;What do you want to promote&amp;nbsp;? &#160;&#160;&#160;&#160;<a href="#">See more <i class="fa fa-long-arrow-right" role="img"/></a>
+    </span>
+</template>
+
+<template id="s_cta_badge_options" inherit_id="website.snippet_options">
+    <xpath expr="." position="inside">
+        <!-- Border and Shadow -->
+        <div data-js="Box" data-selector=".s_cta_badge">
+            <t t-call="website.snippet_options_border_widgets"/>
+            <t t-call="website.snippet_options_shadow_widgets"/>
+        </div>
+    </xpath>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -206,6 +206,9 @@
                     <keywords>evolution, growth</keywords>
                 </t>
                 <t t-snippet="website.s_badge" string="Badge" t-thumbnail="/website/static/src/img/snippets_thumbs/s_badge.svg"/>
+                <t t-snippet="website.s_cta_badge" string="CTA Badge" t-thumbnail="/website/static/src/img/snippets_thumbs/s_cta_badge.svg">
+                    <keywords>cta, button, btn, action, engagement, link, appeal, trigger, promotion, promote</keywords>
+                </t>
                 <t t-snippet="website.s_blockquote" string="Blockquote" t-thumbnail="/website/static/src/img/snippets_thumbs/s_blockquote.svg">
                     <keywords>cite</keywords>
                 </t>
@@ -690,7 +693,7 @@
     </div>
 
     <!-- Background -->
-    <t t-set="only_bg_color_selector" t-value="'section .row > div, .s_text_highlight, .s_mega_menu_thumbnails_footer, .s_hr'"/>
+    <t t-set="only_bg_color_selector" t-value="'section .row > div, .s_text_highlight, .s_mega_menu_thumbnails_footer, .s_hr, .s_cta_badge'"/>
     <t t-set="only_bg_color_exclude" t-value="'.s_col_no_bgcolor, .s_col_no_bgcolor.row > div, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .s_image_gallery .row > div, .s_text_cover .row > .o_not_editable, [data-snippet] :not(.oe_structure) > .s_hr'"/>
 
     <t t-set="base_only_bg_image_selector" t-value="'.s_tabs .oe_structure > *, footer .oe_structure > *'"/>
@@ -770,7 +773,7 @@
     <t t-set="so_content_addition_selector" t-translation="off">
         blockquote, .s_card:not(.s_timeline_card), .s_alert, .o_facebook_page, .s_share, .s_social_media, .s_rating,
         .s_hr, .s_google_map, .s_map, .s_countdown, .s_chart, .s_text_highlight, .s_progress_bar, .s_badge,
-        .s_embed_code, .s_donation, .s_add_to_cart, .s_online_appointment, .o_snippet_drop_in_only, .s_image
+        .s_embed_code, .s_donation, .s_add_to_cart, .s_online_appointment, .o_snippet_drop_in_only, .s_image, .s_cta_badge
     </t>
 
     <div id="so_content_addition"


### PR DESCRIPTION
This PR introduces a new inner snippet named `s_cta_badge`. Inspired by the `s_badge`, the `s_cta_badge` aims to provide an other way to display a call to action on a website.

- [x] The demo text is meaningful
- [x] Text adapts to colors presets and is readable
- [x] The template is mobile-friendly
- [x] The snippet only includes necessary options
- [x] Behaves consistently with the rest (images can be replaced, etc..)

| Snippet in use |
|--------|
| <img alt="image" src="https://github.com/user-attachments/assets/c63bc70b-09aa-4c1f-8ffd-db943213c754"> | 

task-3856844
Part of task-4077427

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
