### PR TITLE
[FIX] point_of_sale: prevent error while choosing store with deleted POS category

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -919,17 +919,21 @@ class PosConfig(models.Model):
 
         convert.convert_file(self.env, 'point_of_sale', 'data/scenarios/furniture_data.xml', None, noupdate=True, mode='init', kind='data')
 
+    def get_categories(self, categories):
+        # filters out unavailable external id
+        return [self.env.ref(category).id for category in categories if self.env.ref(category, raise_if_not_found=False)]
+
     @api.model
     def load_onboarding_clothes_scenario(self):
         ref_name = 'point_of_sale.pos_config_clothes'
         if not self.env.ref(ref_name, raise_if_not_found=False):
             convert.convert_file(self.env, 'point_of_sale', 'data/scenarios/clothes_data.xml', None, noupdate=True, mode='init', kind='data')
 
-        clothes_categories = [
-            self.env.ref('point_of_sale.pos_category_upper').id,
-            self.env.ref('point_of_sale.pos_category_lower').id,
-            self.env.ref('point_of_sale.pos_category_others').id
-        ]
+        clothes_categories = self.get_categories([
+            'point_of_sale.pos_category_upper',
+            'point_of_sale.pos_category_lower',
+            'point_of_sale.pos_category_others'
+        ])
         journal, payment_methods_ids = self._create_journal_and_payment_methods()
         config = self.env['pos.config'].create([{
             'name': _('Clothes Shop'),
@@ -952,10 +956,10 @@ class PosConfig(models.Model):
             convert.convert_file(self.env, 'point_of_sale', 'data/scenarios/bakery_data.xml', None, mode='init', noupdate=True, kind='data')
 
         journal, payment_methods_ids = self._create_journal_and_payment_methods()
-        bakery_categories = [
-            self.env.ref('point_of_sale.pos_category_breads').id,
-            self.env.ref('point_of_sale.pos_category_pastries').id
-        ]
+        bakery_categories = self.get_categories([
+            'point_of_sale.pos_category_breads',
+            'point_of_sale.pos_category_pastries',
+        ])
         config = self.env['pos.config'].create({
             'name': _('Bakery Shop'),
             'company_id': self.env.company.id,
@@ -977,11 +981,11 @@ class PosConfig(models.Model):
             self._load_furniture_data()
 
         journal, payment_methods_ids = self._create_journal_and_payment_methods('point_of_sale.cash_payment_method_furniture')
-        furniture_categories = [
-            self.env.ref('point_of_sale.pos_category_miscellaneous').id,
-            self.env.ref('point_of_sale.pos_category_desks').id,
-            self.env.ref('point_of_sale.pos_category_chairs').id
-        ]
+        furniture_categories = self.get_categories([
+            'point_of_sale.pos_category_miscellaneous',
+            'point_of_sale.pos_category_desks',
+            'point_of_sale.pos_category_chairs'
+        ])
         config = self.env['pos.config'].create([{
             'name': _('Furniture Shop'),
             'company_id': self.env.company.id,

--- a/addons/pos_restaurant/models/pos_config.py
+++ b/addons/pos_restaurant/models/pos_config.py
@@ -123,10 +123,10 @@ class PosConfig(models.Model):
             self._load_bar_data()
 
         journal, payment_methods_ids = self._create_journal_and_payment_methods()
-        bar_categories = [
-            self.env.ref('pos_restaurant.pos_category_cocktails').id,
-            self.env.ref('pos_restaurant.pos_category_soft_drinks').id,
-        ]
+        bar_categories = self.get_categories([
+            'pos_restaurant.pos_category_cocktails',
+            'pos_restaurant.pos_category_soft_drinks',
+        ])
         config = self.env['pos.config'].create({
             'name': 'Bar',
             'company_id': self.env.company.id,
@@ -150,10 +150,10 @@ class PosConfig(models.Model):
             self._load_restaurant_data()
 
         journal, payment_methods_ids = self._create_journal_and_payment_methods()
-        restaurant_categories = [
-            self.env.ref('pos_restaurant.food').id,
-            self.env.ref('pos_restaurant.drinks').id,
-        ]
+        restaurant_categories = self.get_categories([
+            'pos_restaurant.food',
+            'pos_restaurant.drinks',
+        ])
         config = self.env['pos.config'].create({
             'name': _('Restaurant'),
             'company_id': self.env.company.id,


### PR DESCRIPTION
Currently, an error occurs when trying to load onboarding clothes.

Step to produce:

- Install the 'point_of_sale' module.
-  Go to the point of Sale / Configuration / Products / Pos Product Categories, and Delete the record name 'Upper body'.
- Go to 'Dashboard' to archive all sessions, Click on the 'Clothes' scenario card.

Stack Trace:

```
KeyError: ('ir.model.data', <function IrModelData._xmlid_lookup at 0x7fe08b6ffd80>, 'point_of_sale.pos_category_upper')
  File "odoo/tools/cache.py", line 103, in lookup
    r = d[key]
  File "decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
  File "odoo/tools/func.py", line 84, in locked
    return func(inst, *args, **kwargs)
  File "odoo/tools/lru.py", line 34, in __getitem__
    a = self.d[obj]
ValueError: External ID not found in the system: point_of_sale.pos_category_upper
  File "odoo/http.py", line 2373, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1903, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1966, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1933, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2177, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 223, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 754, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 35, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 459, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/point_of_sale/models/pos_config.py", line 924, in load_onboarding_clothes_scenario
    self.env.ref('point_of_sale.pos_category_upper').id,
  File "odoo/api.py", line 584, in ref
    res_model, res_id = self['ir.model.data']._xmlid_to_res_model_res_id(
  File "odoo/addons/base/models/ir_model.py", line 2229, in _xmlid_to_res_model_res_id
    return self._xmlid_lookup(xmlid)
  File "decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
  File "odoo/tools/cache.py", line 110, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File "odoo/addons/base/models/ir_model.py", line 2222, in _xmlid_lookup
    raise ValueError('External ID not found in the system: %s' % xmlid)

```

An error occurs when the system tries to retrieve an external ID 'point_of_sale.pos_category_upper' at [1] when opening a 'Clothes' scenario card in POS, but it is not available.

link [1]: https://github.com/odoo/odoo/blob/475459d06dfb81031812fd0d1813d13eb865451f/addons/point_of_sale/models/pos_config.py#L923-L927

To handle this issue, add a method in the pos.config model that filters out unavailable external IDs.

Sentry-5667341424

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
