### PR TITLE
[IMP] project: show all tasks in the 'Tasks Analysis' Report

### DIFF
--- a/addons/project/report/project_report.py
+++ b/addons/project/report/project_report.py
@@ -51,7 +51,6 @@ class ReportProjectTaskUser(models.Model):
     partner_id = fields.Many2one('res.partner', string='Customer', readonly=True)
     stage_id = fields.Many2one('project.task.type', string='Stage', readonly=True)
     task_id = fields.Many2one('project.task', string='Tasks', readonly=True)
-    active = fields.Boolean(readonly=True)
     tag_ids = fields.Many2many('project.tags', relation='project_tags_project_task_rel',
         column1='project_task_id', column2='project_tags_id',
         string='Tags', readonly=True)
@@ -71,7 +70,6 @@ class ReportProjectTaskUser(models.Model):
                 (select 1) AS nbr,
                 t.id as id,
                 t.id as task_id,
-                t.active,
                 t.create_date,
                 t.date_assign,
                 t.date_end,
@@ -103,7 +101,6 @@ class ReportProjectTaskUser(models.Model):
     def _group_by(self):
         return """
                 t.id,
-                t.active,
                 t.create_date,
                 t.date_assign,
                 t.date_end,

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -303,9 +303,6 @@
             <filter name="last_stage_update" position="after">
                 <filter string="Deadline" name="deadline" context="{'group_by': 'date_deadline'}"/>
             </filter>
-            <xpath expr="//search/filter[@name='inactive']" position='attributes'>
-                <attribute name='invisible'>1</attribute>
-            </xpath>
         </field>
     </record>
 

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -32,8 +32,6 @@
                     </filter>
                     <separator/>
                     <filter string="Show Sub-tasks" name="show_subtasks" context="{'show_subtasks': True}" invisible="'my_tasks' in context"/>
-                    <separator/>
-                    <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
                     <group expand="0" string="Group By">
                         <filter string="Stage" name="stage" context="{'group_by': 'stage_id'}"/>
                         <filter string="Milestone" name="milestone" context="{'group_by': 'milestone_id'}" groups="project.group_project_milestone"/>
@@ -114,11 +112,11 @@
                 <filter name="my_tasks" position="before">
                     <field string="Properties" name="task_properties"/>
                 </filter>
-                <filter name="inactive" position="before">
+                <filter name="show_subtasks" position="after">
+                    <separator/>
                     <filter string="Unread Messages" name="message_needaction" domain="[('message_needaction', '=', True)]" groups="mail.group_mail_notification_type_inbox"/>
                     <separator/>
-                </filter>
-                <filter name="inactive" position="after">
+                    <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
                     <separator invisible="1"/>
                     <filter invisible="1" string="Late Activities" name="activities_overdue"
                         domain="[('my_activity_date_deadline', '&lt;', context_today().strftime('%Y-%m-%d'))]"


### PR DESCRIPTION
- Currently, only active projects and their related tasks are displayed in the project task
  analysis report. In this commit, we have included all projects and tasks so that customers 
  can easily view them.

Technical Note:  
   - If the active field exists in the model, _where_calc filters the records to show only the
  active ones. Therefore, we have to remove the active field from this model.
  - To prevent unnecessary hiding we are removing the inactive filter from the
  base and moving it to the project search views where it is required.

task-4037091