### PR TITLE
[FIX] mail: jump to present hide for unstar-all and mark-all read

### DIFF
--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -57,7 +57,7 @@
             </div>
         </t>
     </div>
-    <t t-if="!env.inChatter" t-call="mail.Thread.jumpPresent"/>
+    <t t-if="!env.inChatter and !props.thread.isEmpty" t-call="mail.Thread.jumpPresent"/>
 </t>
 
 <t t-name="mail.Thread.jumpPresent">


### PR DESCRIPTION
**Current behavior before PR:**

if we click on `Unstar all` or `Mark all read` button from discuss it shows jump to present banner which it shouldn't.

**Desired behavior after PR is merged:**

now on clicking as above mentioned it does not show jump to present banner anymore.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
