### PR TITLE
[FIX] web: fix spacing in kanban quick create view

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_record_quick_create.scss
+++ b/addons/web/static/src/views/kanban/kanban_record_quick_create.scss
@@ -1,0 +1,17 @@
+.o_form_view.o_xxs_form_view.o_kanban_quick_create_form {
+    .o_inner_group {
+        row-gap: map-get($spacers, 2);
+    }
+
+    .o_wrap_field {
+        .o_cell {
+            .o_field_widget {
+                margin-bottom: $o-form-spacing-unit * 2;
+
+                > .o_field_widget {
+                    margin-bottom: 0;
+                }
+            }
+        }
+    }
+}

--- a/addons/web/static/src/views/kanban/kanban_record_quick_create.xml
+++ b/addons/web/static/src/views/kanban/kanban_record_quick_create.xml
@@ -11,7 +11,7 @@
             t-att-class="{ o_disabled: state.disabled, 'w-100 mx-0': props.listIsGrouped }"
             t-ref="root"
         >
-            <t t-component="props.Renderer" class="'o_form_view o_xxs_form_view p-0'" record="model.root" Compiler="props.Compiler" archInfo="props.archInfo"/>
+            <t t-component="props.Renderer" class="'o_form_view o_xxs_form_view o_kanban_quick_create_form p-0'" record="model.root" Compiler="props.Compiler" archInfo="props.archInfo"/>
             <div class="d-flex flex-wrap justify-content-end gap-1">
                 <button class="btn btn-primary o_kanban_add me-1" t-on-click="() => this.validate('add')">
                     Add


### PR DESCRIPTION
This commit's purpose is to fix the display of quick create card in the kanban view. Due to this commit : https://github.com/odoo/odoo/commit/206f3d4856a3da8c12088b49df6a01675a0c3c62 a lot of space were missing. This fix set the spacing back.

task - 4038168
version saas-17.4-master

