### PR TITLE
[IMP] account,web: add shortcut key for form fields in invoice

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -971,13 +971,13 @@
                             <group id="header_right_group">
                                 <label for="invoice_date" string="Invoice Date" style="font-weight:bold;"
                                        invisible="move_type not in ('out_invoice', 'out_refund', 'out_receipt')"/>
-                                <field name="invoice_date" nolabel="1" options="{'warn_future': true}"
+                                <field name="invoice_date" nolabel="1" options="{'warn_future': true}" data-hotkey="d"
                                        invisible="move_type not in ('out_invoice', 'out_refund', 'out_receipt')"
                                        readonly="state != 'draft'" placeholder="Today"/>
 
                                 <label for="invoice_date" string="Bill Date" style="font-weight:bold;"
                                        invisible="move_type not in ('in_invoice', 'in_refund', 'in_receipt')"/>
-                                <field name="invoice_date" nolabel="1" options="{'warn_future': true}"
+                                <field name="invoice_date" nolabel="1" options="{'warn_future': true}" data-hotkey="d"
                                        invisible="move_type not in ('in_invoice', 'in_refund', 'in_receipt')"
                                        readonly="state != 'draft'"/>
 
@@ -1071,8 +1071,8 @@
                                        }" readonly="state != 'draft'">
                                     <tree editable="bottom" string="Journal Items" default_order="sequence, id">
                                         <control>
-                                            <create name="add_line_control" string="Add a line"/>
-                                            <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
+                                            <create name="add_line_control" string="Add a line" data-hotkey="a"/>
+                                            <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}" data-hotkey="shift+s"/>
                                             <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
                                             <button name="action_add_from_catalog" string="Catalog" type="object" class="btn-link" context="{'order_id': parent.id}"/>
                                         </control>

--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -49,6 +49,7 @@ export class DateTimeField extends Component {
         rounding: { type: Number, optional: true },
         startDateField: { type: String, optional: true },
         warnFuture: { type: Boolean, optional: true },
+        dataHotkey: { type: [String, Boolean], optional: true },
         showSeconds: { type: Boolean, optional: true },
         showTime: { type: Boolean, optional: true },
         minPrecision: {
@@ -355,6 +356,7 @@ export const dateField = {
         minDate: options.min_date,
         alwaysRange: exprToBoolean(options.always_range),
         placeholder: attrs.placeholder,
+        dataHotkey: attrs["data-hotkey"],
         required: dynamicInfo.required,
         rounding: options.rounding && parseInt(options.rounding, 10),
         startDateField: options[START_DATE_FIELD_OPTION],

--- a/addons/web/static/src/views/fields/datetime/datetime_field.xml
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.xml
@@ -23,6 +23,7 @@
                     t-att-id="showSeparator ? props.endDateField and props.id : props.id"
                     class="o_input cursor-pointer"
                     autocomplete="off"
+                    t-att-data-hotkey="props.dataHotkey"
                     t-att-placeholder="props.placeholder"
                     t-att-data-field="startDateField"
                     t-on-input="onInput"

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -37,6 +37,7 @@ import {
     onError,
     onMounted,
     onRendered,
+    onWillUnmount,
     status,
     useEffect,
     useExternalListener,
@@ -191,7 +192,14 @@ export class FormController extends Component {
         };
         this.model = useState(useModel(this.props.Model, this.modelParams, { beforeFirstLoad }));
 
+        const duplicateShortcutListener = (ev) => {
+            if (ev.ctrlKey && ev.key === 'i') {
+                this.duplicateRecord();
+            }
+        }
+
         onMounted(() => {
+            document.addEventListener("keydown", duplicateShortcutListener);
             effect(
                 (model) => {
                     if (status(this) === "mounted") {
@@ -201,6 +209,10 @@ export class FormController extends Component {
                 [this.model]
             );
         });
+
+        onWillUnmount(() => {
+            document.removeEventListener("keydown", duplicateShortcutListener);
+        })
 
         onError((error) => {
             const suggestedCompany = error.cause?.data?.context?.suggested_company;

--- a/addons/web/static/src/views/list/list_arch_parser.js
+++ b/addons/web/static/src/views/list/list_arch_parser.js
@@ -172,6 +172,7 @@ export class ListArchParser {
                             type: "create",
                             context: childNode.getAttribute("context"),
                             string: childNode.getAttribute("string"),
+                            dataHotkey: childNode.getAttribute("data-hotkey") || false,
                         });
                     }
                 }

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -124,6 +124,7 @@
                             t-if="create.type === 'create'"
                             href="#"
                             role="button"
+                            t-att-data-hotkey="create.dataHotkey"
                             t-att-class="create_index !== 0 ? 'ml16' : ''"
                             t-att-tabindex="props.list.editedRecord ? '-1' : '0'"
                             t-on-click.stop.prevent="() => this.add({ context: create.context })"


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When entering a vendor bill or customer invoice in accounting software using a keyboard, it can be frustrating to have to press the tab key multiple times to get to the Date and Product line fields after selecting the Contact. These fields are commonly used and important for quick data entry. To make the process more user-friendly and efficient, a shortcut key should be available to directly jump to these fields.

Desired behavior after PR is merged:
After this PR, shortcut keys are added to navigate to the `Invoice Date / Bill Date` (alt+d), `Add a Line button` (alt+a) and `Add a Section button` (alt+shift+s).

Task [link](https://www.odoo.com/odoo/project/967/tasks/4074347)  
task-4074347