### PR TITLE
[FIX] point_of_sale:  Fix validation error issue for same journal_id

### DIFF
--- a/addons/point_of_sale/models/pos_payment_method.py
+++ b/addons/point_of_sale/models/pos_payment_method.py
@@ -96,4 +96,7 @@ class PosPaymentMethod(models.Model):
 
     def copy(self, default=None):
         default = dict(default or {}, config_ids=[(5, 0, 0)])
+        if self.journal_id and self.journal_id.type == 'cash':
+            if ('journal_id' in default and default['journal_id'] == self.journal_id.id) or ('journal_id' not in default):
+                default.update({'journal_id': False})
         return super().copy(default)


### PR DESCRIPTION
 **Description of the issue/feature this PR addresses:**

  steps to reproduce error:-
        1.create db with 'point_of_sale' module
        2.duplicate the record of pos_payement_method with journal type cash
        3. install 'pos_restaurant' module this traceback will raise the **OR** start pos session validation error will come
       

```
Traceback (most recent call last):
  File "/home/odoo/odoo/odoo/17.0/odoo/http.py", line 1764, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/home/odoo/odoo/odoo/17.0/odoo/service/model.py", line 133, in retrying
    result = func()
  File "/home/odoo/odoo/odoo/17.0/odoo/http.py", line 1791, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/home/odoo/odoo/odoo/17.0/odoo/http.py", line 1995, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/home/odoo/odoo/odoo/17.0/odoo/addons/base/models/ir_http.py", line 222, in _dispatch
    result = endpoint(**request.params)
  File "/home/odoo/odoo/odoo/17.0/odoo/http.py", line 741, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/home/odoo/odoo/odoo/17.0/addons/web/controllers/dataset.py", line 28, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "/home/odoo/odoo/odoo/17.0/addons/web/controllers/dataset.py", line 20, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/home/odoo/odoo/odoo/17.0/odoo/api.py", line 468, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/home/odoo/odoo/odoo/17.0/odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "<decorator-gen-77>", line 2, in button_immediate_install
  File "/home/odoo/odoo/odoo/17.0/odoo/addons/base/models/ir_module.py", line 75, in check_and_log
    return method(self, *args, **kwargs)
  File "/home/odoo/odoo/odoo/17.0/odoo/addons/base/models/ir_module.py", line 466, in button_immediate_install
    return self._button_immediate_function(self.env.registry[self._name].button_install)
  File "/home/odoo/odoo/odoo/17.0/odoo/addons/base/models/ir_module.py", line 590, in _button_immediate_function
    registry = modules.registry.Registry.new(self._cr.dbname, update_module=True)
  File "<decorator-gen-16>", line 2, in new
  File "/home/odoo/odoo/odoo/17.0/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "/home/odoo/odoo/odoo/17.0/odoo/modules/registry.py", line 113, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/odoo/odoo/odoo/17.0/odoo/modules/loading.py", line 480, in load_modules
    processed_modules += load_marked_modules(env, graph,
  File "/home/odoo/odoo/odoo/17.0/odoo/modules/loading.py", line 364, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/home/odoo/odoo/odoo/17.0/odoo/modules/loading.py", line 227, in load_module_graph
    load_data(env, idref, mode, kind='data', package=package)
  File "/home/odoo/odoo/odoo/17.0/odoo/modules/loading.py", line 71, in load_data
    tools.convert_file(env, package.name, filename, idref, mode, noupdate, kind)
  File "/home/odoo/odoo/odoo/17.0/odoo/tools/convert.py", line 627, in convert_file
    convert_xml_import(env, module, fp, idref, mode, noupdate)
  File "/home/odoo/odoo/odoo/17.0/odoo/tools/convert.py", line 693, in convert_xml_import
    obj.parse(doc.getroot())
  File "/home/odoo/odoo/odoo/17.0/odoo/tools/convert.py", line 613, in parse
    self._tag_root(de)
  File "/home/odoo/odoo/odoo/17.0/odoo/tools/convert.py", line 556, in _tag_root
    f(rec)
  File "/home/odoo/odoo/odoo/17.0/odoo/tools/convert.py", line 567, in _tag_root
    raise ParseError(msg) from None  # Restart with "--log-handler odoo.tools.convert:DEBUG" for complete traceback
odoo.tools.convert.ParseError: while parsing /home/odoo/odoo/odoo/17.0/addons/pos_restaurant/data/pos_restaurant_data.xml:4
You cannot use the same journal on multiples cash payment methods.

View error context:
'-no context-'
```

- Here is the reason why  above mentioned traceback is raised:
-> [here](https://github.com/odoo/odoo/blob/b64a507697381fd7bb205f4a2b2217322d31811a/addons/pos_restaurant/data/pos_restaurant_data.xml#L4) new record of pos.config is creating which trigger the check of pos.config model due to that traceback is raised due to this [validation](https://github.com/odoo/odoo/blob/c72b25969715ab8331acd45d7fea8bfc2d9ab541/addons/point_of_sale/models/pos_config.py#L354)
 
- **Current behavior before PR:**
if we create ``new`` record of pos.payment.method journal_id  field domain not let create another record of journal with type cash if its already present
but if we  ``duplicate`` record we can do which is not corrrect as per this [validation](https://github.com/odoo/odoo/blob/c72b25969715ab8331acd45d7fea8bfc2d9ab541/addons/point_of_sale/models/pos_config.py#L354)

- **Desired behavior after PR is merged:**

  for resolving this not let duplicate journal_id with type cash. After, this patch user will not able select journal_id with type cash   due to [domain](https://github.com/odoo/odoo/blob/b64a507697381fd7bb205f4a2b2217322d31811a/addons/point_of_sale/models/pos_payment_method.py#L29) on journal_id  and  records never will create. From ui .



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
