### PR TITLE
[IMP] point_of_sale,pos_restaurant: order note for entire order

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -309,7 +309,8 @@ class PosOrder(models.Model):
     picking_type_id = fields.Many2one('stock.picking.type', related='session_id.config_id.picking_type_id', string="Operation Type", readonly=False)
     procurement_group_id = fields.Many2one('procurement.group', 'Procurement Group', copy=False)
 
-    note = fields.Text(string='Internal Notes')
+    floating_order_name = fields.Char(string='Order Name')
+    general_note = fields.Text(string='General Note')
     nb_print = fields.Integer(string='Number of Print', readonly=True, copy=False, default=0)
     pos_reference = fields.Char(string='Receipt Number', readonly=True, copy=False, index=True)
     sale_journal = fields.Many2one('account.journal', related='session_id.config_id.journal_id', string='Sales Journal', store=True, readonly=True, ondelete='restrict')
@@ -773,8 +774,8 @@ class PosOrder(models.Model):
         if self.refunded_order_id.account_move:
             vals['ref'] = _('Reversal of: %s', self.refunded_order_id.account_move.name)
             vals['reversed_entry_id'] = self.refunded_order_id.account_move.id
-        if self.note:
-            vals.update({'narration': self.note})
+        if self.floating_order_name:
+            vals.update({'narration': self.floating_order_name})
         return vals
 
     def _prepare_aml_values_list_per_nature(self):
@@ -1320,7 +1321,7 @@ class PosOrderLine(models.Model):
     refunded_orderline_id = fields.Many2one('pos.order.line', 'Refunded Order Line', help='If this orderline is a refund, then the refunded orderline is specified in this field.')
     refunded_qty = fields.Float('Refunded Quantity', compute='_compute_refund_qty', help='Number of items refunded in this orderline.')
     uuid = fields.Char(string='Uuid', readonly=True, copy=False)
-    note = fields.Char('Internal Note')
+    note = fields.Char('Product Note')
 
     combo_parent_id = fields.Many2one('pos.order.line', string='Combo Parent') # FIXME rename to parent_line_id
     combo_line_ids = fields.One2many('pos.order.line', 'combo_parent_id', string='Combo Lines') # FIXME rename to child_line_ids

--- a/addons/point_of_sale/static/src/app/generic_components/order_widget/order_widget.js
+++ b/addons/point_of_sale/static/src/app/generic_components/order_widget/order_widget.js
@@ -12,6 +12,8 @@ export class OrderWidget extends Component {
         tax: { type: String, optional: true },
         style: { type: String, optional: true },
         class: { type: String, optional: true },
+        generalNote: { type: String, optional: true },
+        screenName: { type: String, optional: true },
     };
     static defaultProps = {
         style: "",

--- a/addons/point_of_sale/static/src/app/generic_components/order_widget/order_widget.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/order_widget/order_widget.xml
@@ -8,6 +8,12 @@
                         <t t-if="props.slots?.default" t-slot="default" line="line"/>
                         <Orderline t-else="" line="line" />
                     </t>
+                    <div class="mt-1 bg-opacity-75" t-attf-class="{{ props.screenName == 'ReceiptScreen' ? 'p-0' : 'p-2 border-bottom border-top border-opacity-75'}}" t-if="props.generalNote">
+                        <b class="fw-bolder">General Note</b>
+                        <t t-foreach="props.generalNote.split('\n')" t-as="subNote" t-key="subNote_index">
+                            <br/>• <t t-esc="subNote"/>
+                        </t>
+                    </div>
                 </div>
                 <div t-if="props.total or props.tax" class="order-summary d-flex flex-column gap-1 px-3 py-2 border-top fw-bolder lh-sm">
                     <div t-if="props.tax" class="tax-info subentry d-flex justify-content-between w-100 fs-6 text-muted ">

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -116,8 +116,11 @@ export class ControlButtons extends Component {
             },
         });
     }
-    get internalNoteLabel() {
-        return _t("Internal Note");
+    internalNoteLabel(order) {
+        if (order) {
+            return _t("General Note");
+        }
+        return this.pos.config.module_pos_restaurant ? _t("Kitchen Note") : _t("Internal Note");
     }
 
     get buttonClass() {

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -5,7 +5,7 @@
         <SelectPartnerButton partner="partner" t-if="!props.showRemainingButtons"/>
         <t t-if="!props.showRemainingButtons || (ui.isSmall and props.showRemainingButtons)">
             <OrderlineNoteButton
-                label="internalNoteLabel"
+                label="internalNoteLabel()"
                 getter="(orderline) => orderline.getNote()"
                 class="buttonClass"
                 setter="(orderline, note) => orderline.setNote(note)" />
@@ -16,6 +16,7 @@
         <!-- All these buttons will only be displayed in a dialog -->
         <t t-if="props.showRemainingButtons">
             <div class="control-buttons control-buttons-modal d-grid gap-2 mt-2">
+                <OrderlineNoteButton class="buttonClass" label="internalNoteLabel(this.pos.get_order())"/>
                 <OrderlineNoteButton class="buttonClass" icon="'fa fa-sticky-note'"/>
                 <button class="o_pricelist_button btn btn-secondary btn-lg py-5" t-on-click="() => this.clickPricelist()">
                     <i class="fa fa-th-list me-2" role="img" aria-label="Price list" title="Price list" />

--- a/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.xml
@@ -3,7 +3,8 @@
     <t t-name="point_of_sale.OrderSummary">
       <OrderWidget lines="currentOrder.getSortedOrderlines()" t-slot-scope="scope" class="'bg-light'"
           total="env.utils.formatCurrency(currentOrder.get_total_with_tax())"
-          tax="!env.utils.floatIsZero(currentOrder.get_total_tax()) and env.utils.formatCurrency(currentOrder.get_total_tax()) or ''">
+          tax="!env.utils.floatIsZero(currentOrder.get_total_tax()) and env.utils.formatCurrency(currentOrder.get_total_tax()) or ''"
+          generalNote="currentOrder.general_note or ''">
           <t t-set="line" t-value="scope.line" />
           <Orderline line="line.getDisplayData()"
               t-on-click="(event) => this.clickLine(event, line)"

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -4,7 +4,7 @@
         <div class="pos-receipt p-2">
             <t t-set="showTaxGroupLabels" t-value="doesAnyOrderlineHaveTaxLabel()"/>
             <ReceiptHeader data="props.data.headerData" />
-            <OrderWidget lines="props.data.orderlines" t-slot-scope="scope">
+            <OrderWidget lines="props.data.orderlines" t-slot-scope="scope" generalNote="props.data.generalNote or ''" screenName="props.data.screenName">
                 <t t-set="line" t-value="scope.line"/>
                 <Orderline basic_receipt="props.basic_receipt" line="omit(scope.line, 'customerNote')" class="{ 'px-0': true }" showTaxGroupLabels="showTaxGroupLabels">
                     <li t-if="line.customerNote" class="customer-note w-100 p-2 my-1 rounded text-break">

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -126,7 +126,8 @@
                         </div>
                         <OrderWidget lines="_selectedSyncedOrder.lines" t-slot-scope="scope"
                             total="env.utils.formatCurrency(_selectedSyncedOrder.get_total_with_tax())"
-                            tax="!env.utils.floatIsZero(_selectedSyncedOrder.get_total_tax()) and env.utils.formatCurrency(_selectedSyncedOrder.get_total_tax()) or ''">
+                            tax="!env.utils.floatIsZero(_selectedSyncedOrder.get_total_tax()) and env.utils.formatCurrency(_selectedSyncedOrder.get_total_tax()) or ''"
+                            generalNote="_selectedSyncedOrder?.general_note or ''">
                             <t t-set="line" t-value="scope.line" />
                             <Orderline line="line.getDisplayData()"
                                 class="{'selected': line.id === getSelectedOrderlineId()}"

--- a/addons/point_of_sale/static/src/customer_display/customer_display.xml
+++ b/addons/point_of_sale/static/src/customer_display/customer_display.xml
@@ -10,9 +10,9 @@
                 <div class="position-absolute bottom-0 mb-4 d-none d-lg-flex align-items-center ps-3 pe-2 py-1 rounded-3 text-bg-dark small">Powered by <OdooLogo style="'width: 3rem;'" monochrome="true"/></div>
             </div>
             <div class="o_customer_display_main d-flex flex-column flex-grow-1 overflow-auto">
-                <OrderWidget t-if="!order.finalized" lines="order.lines" t-slot-scope="scope" class="'gap-0 p-0 pb-3 bg-view'" style="'scroll-snap-type: y mandatory;'">
+                <OrderWidget t-if="!order.finalized" lines="order.lines" t-slot-scope="scope" class="'gap-0 p-0 mx-2 pb-3 bg-view'" style="'scroll-snap-type: y mandatory;'" generalNote="order.generalNote or ''">
                     <Orderline line="scope.line" class="{
-                            'o_customer_display_orderline mx-2 bg-white fs-3 rounded-0': true,
+                            'o_customer_display_orderline bg-white fs-3 rounded-0': true,
                         }"
                     />
                     <t t-set-slot="emptyCart">

--- a/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
@@ -205,13 +205,13 @@ export function clickInternalNoteButton() {
         },
         {
             isActive: ["mobile"],
-            trigger: controlButtonTrigger("Internal Note"),
+            trigger: controlButtonTrigger("Kitchen Note"),
             run: "click",
         },
         {
             isActive: ["desktop"],
             content: "click Internal Note button",
-            trigger: controlButtonTrigger("Internal Note"),
+            trigger: controlButtonTrigger("Kitchen Note"),
             run: "click",
         },
     ];

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -182,6 +182,7 @@
                                 <field name="country_code" invisible="1"/>
                                 <field name="company_id" groups="base.group_multi_company"/>
                                 <field name="pricelist_id" groups="product.group_product_pricelist" readonly="state != 'draft'"/>
+                                <field name="floating_order_name" invisible="not floating_order_name"/>
                             </group>
                             <group string="Contact Info">
                                 <group class="w-75">
@@ -198,8 +199,8 @@
                             </group>
                         </group>
                     </page>
-                    <page string="Notes" name="notes">
-                        <field name="note"/>
+                    <page string="General Notes" name="notes">
+                        <field name="general_note" readonly="1"/>
                     </page>
                 </notebook>
             </sheet>

--- a/addons/pos_restaurant/models/pos_session.py
+++ b/addons/pos_restaurant/models/pos_session.py
@@ -18,9 +18,12 @@ class PosSession(models.Model):
     def _set_last_order_preparation_change(self, order_ids):
         for order_id in order_ids:
             order = self.env['pos.order'].browse(order_id)
-            last_order_preparation_change = {}
+            last_order_preparation_change = {
+                'lines': {},
+                'generalNote': '',
+            }
             for orderline in order['lines']:
-                last_order_preparation_change[orderline.uuid + " - "] = {
+                last_order_preparation_change['lines'][orderline.uuid + " - "] = {
                     "uuid": orderline.uuid,
                     "name": orderline.full_product_name,
                     "note": "",

--- a/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.js
+++ b/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.js
@@ -58,18 +58,18 @@ patch(ControlButtons.prototype, {
         this.currentOrder.takeaway = isTakeAway;
         this.currentOrder.update({ fiscal_position_id: isTakeAway ? takeawayFp : defaultFp });
     },
-    editOrderNote(order) {
+    editFloatingOrderName(order) {
         this.dialog.add(TextInputPopup, {
-            title: _t("Edit order note"),
+            title: _t("Edit Order Name"),
             placeholder: _t("18:45 John 4P"),
-            startingValue: order.note || "",
+            startingValue: order.floating_order_name || "",
             getPayload: async (newName) => {
                 if (typeof order.id == "number") {
                     this.pos.data.write("pos.order", [order.id], {
-                        note: newName,
+                        floating_order_name: newName,
                     });
                 } else {
-                    order.note = newName;
+                    order.floating_order_name = newName;
                 }
             },
         });

--- a/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.xml
+++ b/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.xml
@@ -26,8 +26,8 @@
                 <button class="btn btn-secondary btn-lg py-5" t-on-click="clickTransferOrder">
                     <i class="oi oi-arrow-right me-1" />Transfer / Merge
                 </button>
-                <button class="btn btn-secondary btn-lg py-5" t-on-click="() => this.editOrderNote(this.pos.get_order())">
-                    <i class="fa fa-pencil-square-o me-1" />Edit Order Note
+                <button t-if="!pos.get_order()?.table_id" class="btn btn-secondary btn-lg py-5" t-on-click="() => this.editFloatingOrderName(this.pos.get_order())">
+                    <i class="fa fa-pencil-square-o me-1" />Edit Order Name
                 </button>
             </t>
         </xpath>

--- a/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
+++ b/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
@@ -57,8 +57,9 @@ export class SplitBillScreen extends Component {
         const originalOrder = this.pos.models["pos.order"].find((o) => o.uuid === curOrderUuid);
         this.pos.selectedTable = null;
         const newOrder = this.pos.createNewOrder();
-        const originalOrderName = originalOrder.getOrderName();
-        newOrder.note = `${newOrder.tracking_number} Split from ${originalOrderName}`;
+        const originalOrderName = originalOrder.getFloatingOrderName();
+        newOrder.floating_order_name = `${newOrder.tracking_number} Split from ${originalOrderName}`;
+        newOrder.general_note = originalOrder.general_note || "";
         newOrder.uiState.splittedOrderUuid = curOrderUuid;
         newOrder.originalSplittedOrder = originalOrder;
 

--- a/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.xml
+++ b/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.xml
@@ -15,7 +15,7 @@
 
                 <div class="main d-flex flex-column flex-lg-row flex-grow-1 gap-2 p-2 overflow-hidden">
                     <div class="flex-grow-1 w-100 w-lg-50 me-0 me-lg-2 rounded-3 bg-view overflow-auto">
-                        <OrderWidget lines="orderlines" t-slot-scope="scope">
+                        <OrderWidget lines="orderlines" t-slot-scope="scope" generalNote="currentOrder.general_note or ''">
                             <t t-set="line" t-value="scope.line" />
                             <Orderline line="getLineData(line)"
                                 t-on-click="() => this.onClickLine(line)"

--- a/addons/pos_restaurant/static/src/overrides/components/product_screen/actionpad_widget/actionpad_widget.js
+++ b/addons/pos_restaurant/static/src/overrides/components/product_screen/actionpad_widget/actionpad_widget.js
@@ -18,8 +18,12 @@ patch(ActionpadWidget.prototype, {
         return this.pos.get_order();
     },
     get hasChangesToPrint() {
-        const hasChange = this.pos.getOrderChanges();
-        return hasChange.count;
+        let hasChange = this.pos.getOrderChanges();
+        hasChange =
+            hasChange.generalNote == ""
+                ? true // for the case when removed all general note
+                : hasChange.count || hasChange.generalNote;
+        return hasChange;
     },
     get swapButtonClasses() {
         return {

--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -3,6 +3,7 @@ import { PosStore } from "@point_of_sale/app/store/pos_store";
 import { PaymentScreen } from "@point_of_sale/app/screens/payment_screen/payment_screen";
 import { FloorScreen } from "@pos_restaurant/app/floor_screen/floor_screen";
 import { ConnectionLostError } from "@web/core/network/rpc";
+import { _t } from "@web/core/l10n/translation";
 
 const NON_IDLE_EVENTS = [
     "mousemove",
@@ -57,9 +58,10 @@ patch(PosStore.prototype, {
         await this.data.read("pos.order", [...orderToLoad]);
     },
     get categoryCount() {
-        const orderChange = this.getOrderChanges().orderlines;
+        const orderChanges = this.getOrderChanges();
+        const linesChanges = orderChanges.orderlines;
 
-        const categories = Object.values(orderChange).reduce((acc, curr) => {
+        const categories = Object.values(linesChanges).reduce((acc, curr) => {
             const categories =
                 this.models["product.product"].get(curr.product_id)?.pos_categ_ids || [];
 
@@ -76,7 +78,11 @@ patch(PosStore.prototype, {
 
             return acc;
         }, {});
-        return Object.values(categories);
+
+        return [
+            ...Object.values(categories),
+            ...("generalNote" in orderChanges ? [{ count: 1, name: _t("General Note") }] : []),
+        ];
     },
     createNewOrder() {
         const order = super.createNewOrder(...arguments);


### PR DESCRIPTION
In this commit
--------------------
- Introduced new field order_note to show note for entire order.
- Renamed Internal note to Product note to clarify that it is for particular line (on that line's product).
- Created entire functionality to add order note display it in screens like Customer Display, Order screen, Ticket screen,
Splitbill screen.

task: 4081356

Related PR
---------------
Enterprise PR: https://github.com/odoo/enterprise/pull/67871
Upgrade PR: https://github.com/odoo/upgrade/pull/6341