### PR TITLE
[FIX] configurator tour crash in onboarding

### DIFF
--- a/addons/web_tour/static/tests/tour_service.test.js
+++ b/addons/web_tour/static/tests/tour_service.test.js
@@ -139,7 +139,7 @@ test("Step Tour validity", async () => {
         null,
         4
     )}\nInvalid object: 'run' is not a string or function`;
-    getService("tour_service").startTour("tour1");
+    await getService("tour_service").startTour("tour1");
     expect.verifySteps([waited_error1, waited_error2, waited_error3]);
 });
 
@@ -182,7 +182,7 @@ test("points to next step", async () => {
     }
 
     await mountWithCleanup(Root);
-    getService("tour_service").startTour("tour1", { mode: "manual" });
+    await getService("tour_service").startTour("tour1", { mode: "manual" });
     await animationFrame();
     await advanceTime(100);
     expect(".o_tour_pointer").toHaveCount(1);
@@ -220,7 +220,7 @@ test("next step with new anchor at same position", async () => {
     }
 
     await mountWithCleanup(Root);
-    getService("tour_service").startTour("tour1", { mode: "manual" });
+    await getService("tour_service").startTour("tour1", { mode: "manual" });
     await animationFrame();
     await advanceTime(100);
     expect(".o_tour_pointer").toHaveCount(1);
@@ -282,8 +282,7 @@ test("a failing tour logs the step that failed in run", async () => {
             },
         ],
     });
-    getService("tour_service").startTour("tour2", { mode: "auto" });
-    await advanceTime(750);
+    await getService("tour_service").startTour("tour2", { mode: "auto" });
     await advanceTime(750);
     expect.verifySteps(["log: Tour tour2 on step: '.button0'"]);
     await advanceTime(750);
@@ -335,8 +334,7 @@ test("a failing tour with disabled element", async () => {
             },
         ],
     });
-    getService("tour_service").startTour("tour3", { mode: "auto" });
-    await advanceTime(750);
+    await getService("tour_service").startTour("tour3", { mode: "auto" });
     await advanceTime(750);
     expect.verifySteps(["log: Tour tour3 on step: '.button0'"]);
     await advanceTime(750);
@@ -426,8 +424,7 @@ test("a failing tour logs the step that failed", async () => {
             },
         ],
     });
-    getService("tour_service").startTour("tour1", { mode: "auto" });
-    await advanceTime(750);
+    await getService("tour_service").startTour("tour1", { mode: "auto" });
     await advanceTime(750);
     expect.verifySteps(["log: Tour tour1 on step: 'content (trigger: .button0)'"]);
     await advanceTime(750);
@@ -488,7 +485,7 @@ test("check tour with inactive steps", async () => {
             },
         ],
     });
-    getService("tour_service").startTour("pipu_tour", { mode: "auto" });
+    await getService("tour_service").startTour("pipu_tour", { mode: "auto" });
     await advanceTime(750);
     await advanceTime(750);
     await advanceTime(750);
@@ -526,7 +523,7 @@ test("pointer is added on top of overlay's stack", async () => {
 
     await mountWithCleanup(Root);
 
-    getService("tour_service").startTour("tour1", { mode: "manual" });
+    await getService("tour_service").startTour("tour1", { mode: "manual" });
     getService("dialog").add(DummyDialog, {});
     await advanceTime(100);
     expect(`.o-overlay-item`).toHaveCount(2);
@@ -621,7 +618,7 @@ test("hovering to the anchor element should show the content", async () => {
     }
 
     await mountWithCleanup(Root);
-    getService("tour_service").startTour("la_vuelta", { mode: "manual" });
+    await getService("tour_service").startTour("la_vuelta", { mode: "manual" });
     await animationFrame();
     await advanceTime(750);
     expect(".o_tour_pointer").toHaveCount(1);
@@ -665,8 +662,8 @@ test("should show only 1 pointer at a time", async () => {
     }
 
     await mountWithCleanup(Root);
-    getService("tour_service").startTour("paris_roubaix", { mode: "manual" });
-    getService("tour_service").startTour("milan_sanremo", { mode: "manual" });
+    await getService("tour_service").startTour("paris_roubaix", { mode: "manual" });
+    await getService("tour_service").startTour("milan_sanremo", { mode: "manual" });
     await animationFrame();
     await advanceTime(100);
     expect(".o_tour_pointer").toHaveCount(1);
@@ -702,7 +699,7 @@ test("perform edit on next step", async () => {
     }
 
     await mountWithCleanup(Root);
-    getService("tour_service").startTour("giro_d_italia", { mode: "manual" });
+    await getService("tour_service").startTour("giro_d_italia", { mode: "manual" });
     await animationFrame();
     await advanceTime(100);
     expect(".o_tour_pointer").toHaveCount(1);
@@ -748,7 +745,7 @@ test("scrolling to next step should update the pointer's height", async (assert)
     }
 
     await mountWithCleanup(Root);
-    getService("tour_service").startTour("tour_de_france", { mode: "manual" });
+    await getService("tour_service").startTour("tour_de_france", { mode: "manual" });
     await animationFrame();
     await advanceTime(100); // awaits the macro engine
     const pointer = queryFirst(".o_tour_pointer");
@@ -818,7 +815,7 @@ test("scroller pointer to reach next step", async () => {
     }
 
     await mountWithCleanup(Root);
-    getService("tour_service").startTour("tour_des_flandres", { mode: "manual" });
+    await getService("tour_service").startTour("tour_des_flandres", { mode: "manual" });
     await animationFrame();
     await advanceTime(100); // awaits the macro engine
 
@@ -917,7 +914,7 @@ test("manual tour with inactive steps", async () => {
         `;
     }
     await mountWithCleanup(Root);
-    getService("tour_service").startTour("tour_de_wallonie", { mode: "manual" });
+    await getService("tour_service").startTour("tour_de_wallonie", { mode: "manual" });
     await animationFrame();
     await advanceTime(100);
     expect(".o_tour_pointer").toHaveCount(1);

--- a/addons/web_tour_recorder/static/src/tour_recorder/tour_recorder_dialog.js
+++ b/addons/web_tour_recorder/static/src/tour_recorder/tour_recorder_dialog.js
@@ -77,7 +77,8 @@ patch(ToursDialog.prototype, {
         downloadFile(
             JSON.stringify({
                 ...tour,
-                wait_for: undefined,
+                wait_for: undefined, // TODO: remove in master
+                waitFor: undefined,
                 steps: tour.steps.map((s) => {
                     return {
                         ...s,

--- a/addons/web_tour_recorder/static/src/tour_recorder/tour_recorder_service.js
+++ b/addons/web_tour_recorder/static/src/tour_recorder/tour_recorder_service.js
@@ -90,7 +90,7 @@ export const tourRecorderService = {
         /**
          * @param {string} customTourName
          */
-        function startCustomTour(customTourName, options) {
+        async function startCustomTour(customTourName, options) {
             const customTours = getCustomTours();
             const customTour = customTours.find((t) => t.name === customTourName);
             if (!registry.category("web_tour.tours").contains(customTour.name)) {
@@ -103,7 +103,7 @@ export const tourRecorderService = {
                     JSON.stringify(customTour)
                 );
             }
-            tour_service.startTour(customTour.name, options);
+            return tour_service.startTour(customTour.name, options);
         }
 
         return {

--- a/addons/website/static/src/js/tours/configurator_tour.js
+++ b/addons/website/static/src/js/tours/configurator_tour.js
@@ -4,14 +4,14 @@ import wTourUtils from "@website/js/tours/tour_utils";
 import { _t } from "@web/core/l10n/translation";
 
 wTourUtils.registerThemeHomepageTour('configurator_tour', () => {
-
+    const iframeDocument = document.querySelector(".o_iframe").contentDocument;
     let titleSelector = "#wrap > section:first-child";
-    let title = document.querySelector(titleSelector).querySelector("h1, h2");
+    let title = iframeDocument.querySelector(titleSelector).querySelector("h1, h2");
     if (!(title instanceof Node)) {
         titleSelector = titleSelector.replace("section:first-child", "section:nth-child(2)");
-        title = document.querySelector(titleSelector).querySelector("h1, h2");
+        title = iframeDocument.querySelector(titleSelector).querySelector("h1, h2");
     }
-    const isTitleTextImage = document
+    const isTitleTextImage = iframeDocument
         .querySelector(titleSelector)
         .classList.contains("s_text_image");
     titleSelector = titleSelector.concat(` ${title.matches('h1') ? 'h1' : 'h2'}`);
@@ -28,7 +28,7 @@ wTourUtils.registerThemeHomepageTour('configurator_tour', () => {
     }
 
     const shapeStep = [];
-    if (document.querySelector(shapeSelector)) {
+    if (iframeDocument.querySelector(shapeSelector)) {
         if (!$(backgroundSelector).is($(shapeSelector))) {
             shapeStep.push(...wTourUtils.clickOnSnippet(shapeSelector));
         }

--- a/addons/website/static/src/js/tours/configurator_tour.js
+++ b/addons/website/static/src/js/tours/configurator_tour.js
@@ -5,14 +5,16 @@ import { _t } from "@web/core/l10n/translation";
 
 wTourUtils.registerThemeHomepageTour('configurator_tour', () => {
 
-    let titleSelector = '#wrap > section:first-child';
-    let title = $(titleSelector).find('h1, h2').first();
-    if (!title.length) {
-        titleSelector = titleSelector.replace('section:first-child', 'section:nth-child(2)');
-        title = $(titleSelector).find('h1, h2').first();
+    let titleSelector = "#wrap > section:first-child";
+    let title = document.querySelector(titleSelector).querySelector("h1, h2");
+    if (!(title instanceof Node)) {
+        titleSelector = titleSelector.replace("section:first-child", "section:nth-child(2)");
+        title = document.querySelector(titleSelector).querySelector("h1, h2");
     }
-    let isTitleTextImage = $(titleSelector).hasClass('s_text_image');
-    titleSelector = titleSelector.concat(` ${title.is('h1') ? 'h1' : 'h2'}`);
+    const isTitleTextImage = document
+        .querySelector(titleSelector)
+        .classList.contains("s_text_image");
+    titleSelector = titleSelector.concat(` ${title.matches('h1') ? 'h1' : 'h2'}`);
 
     const shapeSelector = '#wrap > section[data-oe-shape-data]';
     const backgroundSelector = '#wrap > section:nth-child(2)';
@@ -26,7 +28,7 @@ wTourUtils.registerThemeHomepageTour('configurator_tour', () => {
     }
 
     const shapeStep = [];
-    if ($(shapeSelector).first().length) {
+    if (document.querySelector(shapeSelector)) {
         if (!$(backgroundSelector).is($(shapeSelector))) {
             shapeStep.push(...wTourUtils.clickOnSnippet(shapeSelector));
         }

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -3,6 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
+import { waitFor } from "@odoo/hoot-dom";
 import { markup } from "@odoo/owl";
 
 function addMedia(position = "right") {
@@ -430,9 +431,10 @@ function registerThemeHomepageTour(name, steps) {
         throw new Error(`tour.steps has to be a function that returns TourStep[]`);
     }
     return registerWebsitePreviewTour(name, {
-        url: '/',
-        sequence: 50,
-        saveAs: "homepage",
+            url: "/",
+            sequence: 50,
+            saveAs: "homepage",
+            waitFor: () => waitFor('.o_iframe[is-ready="true"]', { timeout: 5000 }),
         },
         () => [
             ...clickOnEditAndWaitEditMode(),

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -434,6 +434,7 @@ function registerThemeHomepageTour(name, steps) {
             url: "/",
             sequence: 50,
             saveAs: "homepage",
+            test: true, // disable manual mode for theme homepage tours - FIXME
             waitFor: () => waitFor('.o_iframe[is-ready="true"]', { timeout: 5000 }),
         },
         () => [


### PR DESCRIPTION
In master, we should get rid of the `wait_for` tour option that doesn't serve any purpose anymore. Starting a tour is done by calling the `startTour` method of the `tour_service` (exported via `odoo.startTour`).

The tour service is already responsible for waiting for the DOM to be loaded (owl's `whenReady` method). This PR adds the new responsibility of waiting for `waitFor` dependencies when starting or resuming a tour.

For this purpose, the `startTour` and the `resumeTour` method are now asynchronous. This is stable-compatible because waiting for dependencies (await) is done after sideeffects to the tour service and tour registry.

In python, it makes no sense to manually wait for a test to be "ready" anymore. However, we still want to wait for the tour service to be ready, so we should introduce a new `odoo.isTourServiceReady` variable to replace the `ready` code.

-----

[REV] website: avoid error on configurator tour

This reverts the temporary fix by bso [1].

[1]: 2ec3afd842c7cc84a309c56f80e561724de155f8

task-4100223

-----

[FIX] web_tour, website, *: fix configurator tour crash in onboarding
    
*: web_tour_recorder

This commit fixes the JQuery replacement of the configurator tour [1].

It adds a `waitFor` option to tours that gets awaited before starting or
resuming tours. The goal of `waitFor` is to replace `wait_for` in master
which doesn't have any desired effect anymore.

This commit fixes the `homepage` tour registered with
`registerThemeHomepageTour` by waiting for the iframe to be loaded and
ready.

[1]: odoo@cfaf6d3#diff-3ec0693f8de5ef84844fffbe674e6c13c279b79170c167f0ff2979f6bcd19358L8-L31

task-4100223

Co-authored-by: Benoit Socias <bso@odoo.com>

-----

[FIX] website: disable broken theme hompage tours manual mode

When theme homepage tours are launched in manual mode
(post-configurator), many of them cannot be completed because of failing
checks at some steps.

This commit temporarily disables the manual mode of these tests until a
better solution is developed with task-4100300.

task-4100223