### PR TITLE
[REF] web_tour: remove noPrepend from TourStep schema

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_service.js
+++ b/addons/web_tour/static/src/tour_service/tour_service.js
@@ -18,7 +18,6 @@ const StepSchema = {
     content: { type: [String, Object], optional: true }, //allow object(_t && markup)
     debugHelp: { type: String, optional: true },
     isActive: { type: Array, element: String, optional: true },
-    noPrepend: { type: Boolean, optional: true },
     run: { type: [String, Function], optional: true },
     timeout: { type: Number, optional: true },
     tooltipPosition: { type: String, optional: true },

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -431,7 +431,10 @@ function registerWebsitePreviewTour(name, options, steps) {
             } else {
                 tourSteps[0].timeout = 20000;
             }
-            return tourSteps;
+            return tourSteps.map((step) => {
+                delete step.noPrepend;
+                return step;
+            });
         },
     });
 }

--- a/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
+++ b/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
@@ -154,5 +154,9 @@ registry.category("web_tour.tours").add("snippets_all_drag_and_drop", {
         trigger: "body",
         run: () => unpatchWysiwygAdapter(),
     }
-]),
+            ])
+            .map((step) => {
+                delete step.noPrepend;
+                return step;
+            }),
 });


### PR DESCRIPTION
In this commit, we remove the noPrepend key from the TourStep class schema. This key is not used in the tour_service and therefore has no place in the TourStep schema.

task~3974087