### PR TITLE
[FIX] Accounting: fix translation of "on" invoice pdf

### DIFF
--- a/addons/account/i18n/ar.po
+++ b/addons/account/i18n/ar.po
@@ -17431,6 +17431,13 @@ msgid "of tax"
 msgstr "من الضريبة"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "في"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/az.po
+++ b/addons/account/i18n/az.po
@@ -14918,6 +14918,13 @@ msgid "of tax"
 msgstr "verginin"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "da/də"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 msgid "on"

--- a/addons/account/i18n/bg.po
+++ b/addons/account/i18n/bg.po
@@ -16889,6 +16889,13 @@ msgid "of tax"
 msgstr ""
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "на"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/ca.po
+++ b/addons/account/i18n/ca.po
@@ -17780,6 +17780,13 @@ msgid "of tax"
 msgstr "de l'impost"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "en"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/cs.po
+++ b/addons/account/i18n/cs.po
@@ -17603,6 +17603,13 @@ msgid "of tax"
 msgstr "z daně"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "na"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/da.po
+++ b/addons/account/i18n/da.po
@@ -17428,6 +17428,13 @@ msgid "of tax"
 msgstr "af moms"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "på"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/de.po
+++ b/addons/account/i18n/de.po
@@ -17837,6 +17837,13 @@ msgid "of tax"
 msgstr "der Steuer"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "auf"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/es.po
+++ b/addons/account/i18n/es.po
@@ -17788,6 +17788,13 @@ msgid "of tax"
 msgstr "de impuesto"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "el"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/es_419.po
+++ b/addons/account/i18n/es_419.po
@@ -17781,6 +17781,13 @@ msgid "of tax"
 msgstr "de impuesto"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "el"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/et.po
+++ b/addons/account/i18n/et.po
@@ -17266,6 +17266,13 @@ msgid "of tax"
 msgstr "maksust"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr ","
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/fa.po
+++ b/addons/account/i18n/fa.po
@@ -17588,6 +17588,13 @@ msgid "of tax"
 msgstr "از مالیات"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "در"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/fi.po
+++ b/addons/account/i18n/fi.po
@@ -17653,6 +17653,13 @@ msgid "of tax"
 msgstr "veroa"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "päiväyksellä"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/fr.po
+++ b/addons/account/i18n/fr.po
@@ -17824,6 +17824,13 @@ msgid "of tax"
 msgstr "de la taxe"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "sur"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/he.po
+++ b/addons/account/i18n/he.po
@@ -16964,6 +16964,13 @@ msgid "of tax"
 msgstr "מהמס"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "ב"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/hr.po
+++ b/addons/account/i18n/hr.po
@@ -14910,6 +14910,13 @@ msgid "of tax"
 msgstr ""
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "na"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 msgid "on"

--- a/addons/account/i18n/hu.po
+++ b/addons/account/i18n/hu.po
@@ -16812,6 +16812,13 @@ msgid "of tax"
 msgstr ""
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "ezen a rekordon:"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/id.po
+++ b/addons/account/i18n/id.po
@@ -17688,6 +17688,13 @@ msgid "of tax"
 msgstr "of tax"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "pada"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/it.po
+++ b/addons/account/i18n/it.po
@@ -17788,6 +17788,13 @@ msgid "of tax"
 msgstr "dell'imposta"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "su"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/ko.po
+++ b/addons/account/i18n/ko.po
@@ -17068,6 +17068,13 @@ msgid "of tax"
 msgstr "세금"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "예시일:"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/lt.po
+++ b/addons/account/i18n/lt.po
@@ -16914,6 +16914,13 @@ msgid "of tax"
 msgstr ""
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "nuo"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/mn.po
+++ b/addons/account/i18n/mn.po
@@ -14939,6 +14939,13 @@ msgid "of tax"
 msgstr "татварын"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "дээр"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 msgid "on"

--- a/addons/account/i18n/nb.po
+++ b/addons/account/i18n/nb.po
@@ -16715,6 +16715,13 @@ msgid "of tax"
 msgstr ""
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "på"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/nl.po
+++ b/addons/account/i18n/nl.po
@@ -17755,6 +17755,13 @@ msgid "of tax"
 msgstr "van BTW"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "op"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/pl.po
+++ b/addons/account/i18n/pl.po
@@ -17537,6 +17537,13 @@ msgid "of tax"
 msgstr "podatku"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "na"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/pt.po
+++ b/addons/account/i18n/pt.po
@@ -17451,6 +17451,13 @@ msgid "of tax"
 msgstr ""
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "de"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/pt_BR.po
+++ b/addons/account/i18n/pt_BR.po
@@ -17750,6 +17750,13 @@ msgid "of tax"
 msgstr "de imposto"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "em"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/ro.po
+++ b/addons/account/i18n/ro.po
@@ -17657,6 +17657,13 @@ msgid "of tax"
 msgstr "de taxă"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "pe"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/ru.po
+++ b/addons/account/i18n/ru.po
@@ -17744,6 +17744,13 @@ msgid "of tax"
 msgstr "налог"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "вкл"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/sk.po
+++ b/addons/account/i18n/sk.po
@@ -17095,6 +17095,13 @@ msgid "of tax"
 msgstr "dane"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "na"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/sl.po
+++ b/addons/account/i18n/sl.po
@@ -16739,6 +16739,13 @@ msgid "of tax"
 msgstr ""
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "na"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/sr.po
+++ b/addons/account/i18n/sr.po
@@ -17609,6 +17609,13 @@ msgid "of tax"
 msgstr "of tax"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "uključen"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/sv.po
+++ b/addons/account/i18n/sv.po
@@ -17676,6 +17676,13 @@ msgid "of tax"
 msgstr "av skatt"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "på"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/th.po
+++ b/addons/account/i18n/th.po
@@ -17466,6 +17466,13 @@ msgid "of tax"
 msgstr "ของยอดภาษี"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "เมื่อ"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/tr.po
+++ b/addons/account/i18n/tr.po
@@ -17582,6 +17582,13 @@ msgid "of tax"
 msgstr "vergisi"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "açık"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/uk.po
+++ b/addons/account/i18n/uk.po
@@ -17688,6 +17688,13 @@ msgid "of tax"
 msgstr "податку"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "на"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/vi.po
+++ b/addons/account/i18n/vi.po
@@ -17658,6 +17658,13 @@ msgid "of tax"
 msgstr "thuế"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "trên"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/zh_CN.po
+++ b/addons/account/i18n/zh_CN.po
@@ -16957,6 +16957,13 @@ msgid "of tax"
 msgstr "税项"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "在"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/i18n/zh_TW.po
+++ b/addons/account/i18n/zh_TW.po
@@ -16938,6 +16938,13 @@ msgid "of tax"
 msgstr "稅金"
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_tax.py:0
+#, python-format
+msgid "on"
+msgstr "於"
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.document_tax_totals_company_currency_template
 #: model_terms:ir.ui.view,arch_db:account.tax_groups_totals
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1527,6 +1527,7 @@ class AccountTax(models.Model):
 
             subtotal_title = tax_group.preceding_subtotal or _("Untaxed Amount")
             sequence = tax_group.sequence
+            tax_group_name_suffix = _("on")
 
             subtotal_order[subtotal_title] = min(subtotal_order.get(subtotal_title, float('inf')), sequence)
             groups_by_subtotal[subtotal_title].append({
@@ -1538,6 +1539,7 @@ class AccountTax(models.Model):
                 'formatted_tax_group_amount': formatLang(self.env, tax_group_vals['tax_amount'], currency_obj=currency),
                 'formatted_tax_group_base_amount': formatLang(self.env, tax_group_vals['base_amount'], currency_obj=currency),
                 'hide_base_amount': tax_group_vals['hide_base_amount'],
+                'tax_group_name_suffix': tax_group_name_suffix,
             })
             if is_company_currency_requested:
                 groups_by_subtotal[subtotal_title][-1]['tax_group_amount_company_currency'] = tax_group_vals['tax_amount_company_currency']

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -360,7 +360,7 @@
                     <t t-else="">
                         <td>
                             <span t-out="amount_by_group['tax_group_name']">Tax 15%</span>
-                            <span> on </span>
+                            <span t-out="amount_by_group['tax_group_name_suffix']">on</span>
                             <span class="text-nowrap" t-out="amount_by_group['formatted_tax_group_base_amount']">27.00</span>
                         </td>
                         <td class="text-end o_price_total">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
There is a text "on" which is not getting translation in some languages and that's because for that record we do most of the translations on the python side. so it was missing appropriate config in `<lang>.po` file

Current behavior before PR:
When you install German or French (and some other languages), when you create and invoice pdf with that language there is a "on" text which is not getting translated.

Desired behavior after PR is merged:
When you install German or French (and some other languages), when you create and invoice pdf with that language everything is translated as expected.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
