### PR TITLE
[FIX] packaging: add openpyxl dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -40,6 +40,7 @@ Depends:
  python3-lxml-html-clean | python3-lxml,
  python3-num2words,
  python3-ofxparse,
+ python3-openpyxl,
  python3-passlib,
  python3-polib,
  python3-psutil,

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,8 @@ MarkupSafe==2.1.5 ; python_version >= '3.12'  # (Noble) Mostly to have a wheel p
 num2words==0.5.10 ; python_version < '3.12'  # (Jammy / Bookworm)
 num2words==0.5.13 ; python_version >= '3.12' 
 ofxparse==0.21
+openpyxl==3.0.9 ; python_version < '3.12'
+openpyxl==3.1.2 ; python_version >= '3.12'
 passlib==1.7.4 # min version = 1.7.2 (Focal with security backports)
 Pillow==9.0.1 ; python_version <= '3.10'
 Pillow==9.4.0 ; python_version > '3.10' and python_version < '3.12'

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         'MarkupSafe',
         'num2words',
         'ofxparse',
+        'openpyxl',
         'passlib',
         'pillow',  # windows binary http://www.lfd.uci.edu/~gohlke/pythonlibs/
         'polib',

--- a/setup/package.dfdebian
+++ b/setup/package.dfdebian
@@ -36,6 +36,7 @@ RUN apt-get update -qq &&  \
         python3-libsass \
         python3-lxml \
         python3-ofxparse \
+        python3-openpyxl \
         python3-passlib \
         python3-polib \
         python3-psutil \

--- a/setup/package.dffedora
+++ b/setup/package.dffedora
@@ -35,6 +35,7 @@ RUN dnf update -d 0 -e 0 -y && \
         python3-mock \
         python3-num2words \
         python3-ofxparse.noarch \
+        python3-openpyxl \
         python3-passlib \
         python3-pillow \
         python3-polib \


### PR DESCRIPTION
As xlrd 2.0 removed support for xlsx and since #169482 the openpyxl lib is needed on Noble installations to import xlsx files.
