### PR TITLE
[REF] web_tour: sanitize tour utils

### DIFF
--- a/addons/hr_expense/static/src/js/tours/hr_expense.js
+++ b/addons/hr_expense/static/src/js/tours/hr_expense.js
@@ -68,9 +68,13 @@ registry.category("web_tour.tours").add('hr_expense_tour' , {
     isActive: ["mobile"],
     trigger: ".o_hr_expense_form_view_view",
 },
-...stepUtils.goBackBreadcrumbsMobile(
-    _t("Use the breadcrumbs to go back to the list of expenses."),
-),
+{
+    isActive: ["mobile"],
+    trigger: ".o_back_button",
+    content:  _t("Use the breadcrumbs to go back to the list of expenses."),
+    tooltipPosition: "bottom",
+    run: "click",
+},
 {
     trigger: ".o_hr_expense_form_view_view",
 }, {

--- a/addons/web_tour/static/src/tour_service/tour_utils.js
+++ b/addons/web_tour/static/src/tour_service/tour_utils.js
@@ -54,16 +54,6 @@ export const stepUtils = {
         return step;
     },
 
-    editionEnterpriseModifier(step) {
-        step.edition = "enterprise";
-        return step;
-    },
-
-    mobileModifier(step) {
-        step.isActive = ["mobile"];
-        return step;
-    },
-
     showAppsMenuItem() {
         return {
             isActive: ["auto", "community"],
@@ -91,9 +81,13 @@ export const stepUtils = {
         ];
     },
 
-    autoExpandMoreButtons() {
+    autoExpandMoreButtons(isActiveMobile = false) {
+        const isActive = ["auto"];
+        if (isActiveMobile) {
+            isActive.push("mobile");
+        }
         return {
-            isActive: ["auto"],
+            isActive,
             content: `autoExpandMoreButtons`,
             trigger: ".o-form-buttonbox",
             run() {
@@ -103,18 +97,6 @@ export const stepUtils = {
                 }
             },
         };
-    },
-
-    goBackBreadcrumbsMobile(description) {
-        return [
-            {
-                isActive: ["mobile"],
-                trigger: ".o_back_button",
-                content: description,
-                tooltipPosition: "bottom",
-                run: "click",
-            },
-        ];
     },
 
     goToAppSteps(dataMenuXmlid, description) {

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -1056,7 +1056,7 @@ stepUtils.autoExpandMoreButtons(),
     isActive: ["mobile"],
     trigger: '.o_navbar_breadcrumbs .o_breadcrumb:contains("S0")',
 },
-stepUtils.mobileModifier(stepUtils.autoExpandMoreButtons()),
+stepUtils.autoExpandMoreButtons(true),
 {
     isActive: ["desktop"],
     trigger: '.oe_stat_button:has(div[name=tasks_count])',
@@ -1122,9 +1122,13 @@ stepUtils.mobileModifier(stepUtils.autoExpandMoreButtons()),
     isActive: ["mobile"],
     trigger: ".o_breadcrumb .active:contains('the_flow.service')",
 },
-...stepUtils.goBackBreadcrumbsMobile(
-        _t('Back to the sale order')
-    ),
+{
+    isActive: ["mobile"],
+    trigger: ".o_back_button",
+    content: _t('Back to the sale order'),
+    tooltipPosition: "bottom",
+    run: "click",
+},
 {
     isActive: ["desktop"],
     trigger: 'div:not(.o_form_editable)', // Waiting save


### PR DESCRIPTION
In this commit, we remove the editionEnterpriseModifier function because it is no longer used in the codebase.
goBackBreadcrumbsMobile is used 2 times. Therefore, we also remove it from the utilities file, obviously adapting the places where it was used.
mobileModifier is used only once. Therefore, we modify the autoExpandMoreButtons function to add a "mobile" option and we can then remove the mobileModifier.

task~3974087
