### PR TITLE
[IMP] delivery: add button to show the confirmation message

### DIFF
--- a/addons/delivery/wizard/choose_delivery_carrier_views.xml
+++ b/addons/delivery/wizard/choose_delivery_carrier_views.xml
@@ -38,7 +38,21 @@
                 </div>
                 <footer>
                     <button name="button_confirm" invisible="not context.get('carrier_recompute')" type="object" string="Update" class="btn-primary" data-hotkey="q"/>
-                    <button name="button_confirm" invisible="context.get('carrier_recompute')" type="object" string="Add" class="btn-primary" data-hotkey="q"/>
+                    <button
+                        name="button_confirm"
+                        type="object"
+                        invisible="context.get('carrier_recompute') or not delivery_type in ('fixed', 'base_on_rule') and not display_price"
+                        string="Add"
+                        class="btn-primary"
+                        data-hotkey="q"/>
+                    <button
+                        name="button_confirm"
+                        type="object"
+                        invisible="context.get('carrier_recompute') or display_price or delivery_type in ('fixed', 'base_on_rule')"
+                        confirm="Are you sure you want the delivery to be free for this order? You might have forgotten to compute the rates."
+                        string="Add"
+                        class="btn-primary"
+                        data-hotkey="q"/>
                     <button string="Discard" special="cancel" data-hotkey="x" class="btn-secondary"/>
                 </footer>
             </form>


### PR DESCRIPTION
Before this commit:
- In some cases, when a user selects a shipping method (e.g., SendCloud, FedEx),
   the delivery price (display_price) defaults to zero.
-This can lead to confusion, as users might unintentionally confirm a delivery
option without properly computing rates.

After this commit:
- A confirmation message is added to ensure users are aware of the zero delivery
price.
-This allows users to verify rates before confirming.

Task: 4083628