### PR TITLE
[FIX] mrp: update duration of a done workorder

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -516,6 +516,8 @@ class MrpWorkorder(models.Model):
 
     def _plan_workorder(self, replan=False):
         self.ensure_one()
+        if replan and not self.leave_id:
+            return
         # Plan workorder after its predecessors
         start_date = max(self.production_id.date_planned_start, datetime.now())
         for workorder in self.blocked_by_workorder_ids:


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1” with the following BoM:
    - Component: add any product
    - Operations:
        - OP1, duration: 60 min
        - OP2, duration: 60 min
        - OP3, duration: 60 min

- Create a MO to produce one unit of P1
- Confirm the MO
- Don’t plan the workorders and start only OP2
- End OP2
- Result: OP1 and OP3 are not planned (expected behavior)
- Try to update the duration of OP2

Problem:
A traceback is triggered:
```
File "/home/odoo/src/odoo/addons/mrp/models/mrp_production.py", line 1521, in _plan_workorders
'date_start': min([workorder.leave_id.date_from for workorder in workorders]),
TypeError: '<' not supported between instances of 'datetime.datetime' and 'bool'
```

When the workorder is started, the MO becomes `is_planned`, and when the duration is updated, the write method of the `mrp.production` model is called with the workorder in the values with the new duration. This condition will be True:

https://github.com/odoo/odoo/blob/66b7b2f138568fe87183fb284e8caf977bb8adc6/addons/mrp/models/mrp_production.py#L856-L857

And the MO should be replanned:

https://github.com/odoo/odoo/blob/66b7b2f138568fe87183fb284e8caf977bb8adc6/addons/mrp/models/mrp_production.py#L890-L891

Thus, all workorders that come after this workorder need to be replanned, including OP3, but only those that have already been planned, which is not the case for OP3 as it doesn't have a `date_start`. (first error)

https://github.com/odoo/odoo/blob/66b7b2f138568fe87183fb284e8caf977bb8adc6/addons/mrp/models/mrp_production.py#L1525-L1526

Since we then try to get the minimum `date_start` from all workorders that are not done or canceled, we end up using OP3 and OP1 as well, even though it has a `date_start` of False(OP1). When the `min` function compares an actual date (set in OP3) with False (in OP1), it will return False by default, leading to an attempt to set False as the `date_start` of the MO, which is a required field, hence an error is triggered.

opw-4068323
