### PR TITLE
[IMP] website: add new `s_motto` snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -52,6 +52,7 @@
         'views/snippets/s_image_punchy.xml',
         'views/snippets/s_carousel.xml',
         'views/snippets/s_alert.xml',
+        'views/snippets/s_motto.xml',
         'views/snippets/s_card.xml',
         'views/snippets/s_share.xml',
         'views/snippets/s_social_media.xml',

--- a/addons/website/views/snippets/s_motto.xml
+++ b/addons/website/views/snippets/s_motto.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_motto" name="Motto">
+    <section class="s_motto pt160 pb160 o_cc o_cc1" data-oe-shape-data="{'shape':'web_editor/Floats/07', 'showOnMobile':false, 'animated': true}">
+        <div class="o_we_shape o_web_editor_Floats_07 o_we_animated"/>
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-8">
+                    <h1 class="display-4">Design is the intermediary between <strong>information</strong> and <strong>understanding</strong></h1>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -60,6 +60,9 @@
                 <t t-snippet="website.s_striped_center_top" string="Striped Center Top" group="intro">
                     <keywords>hero, jumbotron, headline, header, intro, home, content, picture, photo, illustration, media, visual, article, combination, trendy, pattern, design</keywords>
                 </t>
+                <t t-snippet="website.s_motto" string="Motto" group="intro">
+                    <keywords>cite, slogan, tagline, mantra, catchphrase, statements, sayings, comments, mission, citations, maxim, quotes, principle</keywords>
+                </t>
 
                 <!-- Columns group -->
                 <t t-snippet="website.s_three_columns" string="Columns" group="columns">


### PR DESCRIPTION
This commit introduces the new `s_motto` intro snippet.

Part of task-4077427
task-4077607

requires: https://github.com/odoo/design-themes/pull/851

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
