### PR TITLE
[FIX] {website_}event{_sale}: email and registration flow improvements

### DIFF
--- a/addons/event/data/mail_template_data.xml
+++ b/addons/event/data/mail_template_data.xml
@@ -282,7 +282,7 @@
                         </div>
                     </t>
                     <t t-if="not object.company_id.uses_default_logo">
-                        <img t-att-src="'/logo.png?company=%s' % object.company_id.id" style="padding: 0px; margin: 0px; height: auto; width: 80px;" t-att-alt="'%s' % object.company_id.name"/>
+                        <img t-att-src="'/logo.png?company=%s' % object.company_id.id" style="padding: 0px; margin: 0px; margin-right: 10px; height: auto; width: 80px;" t-att-alt="'%s' % object.company_id.name"/>
                     </t>
                 </td></tr>
                 <tr><td colspan="2" style="text-align:center;">
@@ -512,8 +512,10 @@
 <t t-set="date_begin" t-value="format_datetime(object.event_id.date_begin, tz='UTC', dt_format=&quot;yyyyMMdd'T'HHmmss'Z'&quot;)"/>
 <t t-set="date_end" t-value="format_datetime(object.event_id.date_end, tz='UTC', dt_format=&quot;yyyyMMdd'T'HHmmss'Z'&quot;)"/>
 <t t-set="is_online" t-value="'is_published' in object.event_id and object.event_id.is_published"/>
+<t t-set="is_sale" t-value="'sale_order_id' in object and object.sale_order_id"/>
 <t t-set="event_organizer" t-value="object.event_id.organizer_id"/>
 <t t-set="event_address" t-value="object.event_id.address_id"/>
+<t t-set="registration_ids" t-value="object.ids if not is_sale else object._get_event_registration_ids_from_order()"/>
 <table border="0" cellpadding="0" cellspacing="0"  width="590" style="padding: 16px; background-color: white; color: #454748; border-collapse:separate;">
 <tbody>
     <!-- HEADER -->
@@ -523,15 +525,20 @@
                 <tr><td valign="middle">
                     <span style="font-size: 10px;">Your registration</span><br/>
                     <span style="font-size: 20px; font-weight: bold;" t-out="object.name or 'Guest'"/>
-                </td><td valign="middle" align="right">
-                    <t t-if="is_online">
-                        <a t-attf-href="{{ object.event_id.website_url }}"
-                            style="padding: 8px 12px; font-size: 12px; color: #FFFFFF; text-decoration: none !important; font-weight: 400; background-color: #875A7B; border: 0px solid #875A7B; border-radius:3px">
-                            View Event
+                    <div style="margin-bottom: 5px;margin-top: 18px;">
+                        <a t-attf-href="/event/{{ object.event_id.id }}/my_tickets?registration_ids={{ registration_ids }}&amp;tickets_hash={{ object.event_id._get_tickets_access_hash(registration_ids) }}&amp;responsive_html=1"
+                            target="_blank" style="padding: 8px 12px; font-size: 12px; color: #FFFFFF; text-decoration: none !important; font-weight: 400; background-color: #875A7B; border: 0px solid #875A7B; border-radius:3px">
+                            View Tickets
                         </a>
+                    </div>
+                </td><td valign="middle" align="right">
+                    <t t-if="object.barcode">
+                        <div style="margin-bottom: 5px;">
+                            <img t-attf-src="/report/barcode/QR/{{object.barcode}}?&amp;width=100&amp;height=100&amp;quiet=0" width="100" height="100" alt="QR Code"/>
+                        </div>
                     </t>
-                    <t t-elif="not object.company_id.uses_default_logo">
-                        <img t-att-src="'/logo.png?company=%s' % object.company_id.id" style="padding: 0px; margin: 0px; height: auto; width: 80px;" t-att-alt="'%s' % object.company_id.name"/>
+                    <t t-if="not object.company_id.uses_default_logo">
+                        <img t-att-src="'/logo.png?company=%s' % object.company_id.id" style="padding: 0px; margin: 0px; margin-right: 10px; height: auto; width: 80px;" t-att-alt="'%s' % object.company_id.name"/>
                     </t>
                 </td></tr>
                 <tr><td colspan="2" style="text-align:center;">

--- a/addons/event/report/event_event_templates.xml
+++ b/addons/event/report/event_event_templates.xml
@@ -177,17 +177,17 @@
                                     <div class="d-flex">
                                         <i class="fa fa-calendar fa-2x fa-fw me-2 mt-1"/>
                                         <div t-if="event.is_one_day">
-                                            <span t-field="event.date_begin"
+                                            <span t-field="event.date_begin" class="text-nowrap"
                                                 t-options='{"widget": "datetime", "date_only": True, "tz_name": event.date_tz}'/><br/>
-                                            <span class="me-1">from</span><span t-field="event.date_begin"
+                                            <span class="me-1">from</span><span t-field="event.date_begin" class="text-nowrap"
                                                 t-options='{"widget": "datetime", "time_only": True, "hide_seconds": True, "tz_name": event.date_tz, "format": "short"}'/>
-                                            <span class="me-1">to</span><span t-field="event.date_end"
+                                            <span class="me-1">to</span><span t-field="event.date_end" class="text-nowrap"
                                                 t-options='{"widget": "datetime", "time_only": True, "hide_seconds": True, "tz_name": event.date_tz, "format": "short"}'/>
                                         </div>
                                         <div t-else="">
-                                            <span t-field="event.date_begin"
+                                            <span t-field="event.date_begin" class="text-nowrap"
                                                 t-options='{"widget": "datetime", "tz_name": event.date_tz, "format": "short"}'/><br/>
-                                            <span class="me-1">to</span><span t-field="event.date_end"
+                                            <span class="me-1">to</span><span t-field="event.date_end" class="text-nowrap"
                                                 t-options='{"widget": "datetime", "tz_name": event.date_tz, "format": "short"}'/>
                                         </div>
                                     </div>

--- a/addons/website_event_sale/controllers/sale.py
+++ b/addons/website_event_sale/controllers/sale.py
@@ -17,4 +17,9 @@ class WebsiteEventSale(WebsiteSale):
             aggregates=['id:recordset'],
         )
         values['attendee_ids_per_event'] = dict(attendee_per_event_read_group)
+        values['urls_per_event'] = {
+            event.id: event._get_event_resource_urls()
+            for event in values['events']
+        }
+
         return values

--- a/addons/website_event_sale/views/website_sale_templates.xml
+++ b/addons/website_event_sale/views/website_sale_templates.xml
@@ -82,11 +82,11 @@
                                 <h5>Don't miss out!</h5>
                                 <small>Add this event to your calendar</small>
                                 <div id="add_to_calendar" class="o_event_add_to_calendar_btns d-flex flex-wrap gap-3 mt-2">
-                                    <a role="button" class="o_outlook_calendar btn btn-block bg-white" t-att-href="iCal_url">
+                                    <a role="button" class="o_outlook_calendar btn btn-block bg-white" t-att-href="urls_per_event.get(event.id, {}).get('iCal_url', '')">
                                         <img src="/event/static/src/img/outlook-calendar.svg" alt="Outlook" loading="lazy"/>
                                         Add to iCal/Outlook
                                     </a>
-                                    <a role="button" class="o_google_calendar btn btn-block bg-white" t-att-href="google_url">
+                                    <a role="button" class="o_google_calendar btn btn-block bg-white" t-att-href="urls_per_event.get(event.id, {}).get('google_url', '')">
                                         <img src="/event/static/src/img/google-calendar.svg" alt="Google Agenda" loading="lazy"/>
                                         Add to Google Agenda
                                     </a>


### PR DESCRIPTION

1. [FIX] event: prevent line-break in datetimes in pdf ticket
    
Reintroduced in the commit b864c9455f72f95dc1355b7bef902e1d9a2d70a5,
datetimes in the pdf full page ticket had sometimes a strange
line break inside their string.

For instance "5.00 [LINEBREAK] PM".

The cause was not identified as the issue did not happen locally
and only in the pdf version of the ticket (not in the html
responsive one). However, forcing no line break on those fields
worked as expected. (The class was added on every of them to be
safe as testing all locale is not possible)

Task-4088465
worked as expected. (The class was added on every of them to be
safe as testing all locale is not possible)

2. [FIX] website_event_sale: make add to calendar buttons work
    
Reworked in commit fe3a54027ac299389c1b3b799c5a01e7c0b12c15,
The buttons allowing the user to add the event to
outlook or google calendar on the shop confirmation page used
an url that was not defined on that page. So they did not do
anything when clicked.

Add in _prepare_shop_payment_confirmation_values missing values
for each event on the page.

3. [IMP] event: align confirmation and reminder templates (and logo)
    
- In order to display the important information in the reminders,
the button 'View Events' is replaced with 'View Tickets' using
similar logic as the one in the confirmation. The display is also
aligned
- The qr code is displayed in the top right of the body.

Also, as the qr code is 100px with a white band around it, and
logo was 80px, I added a 10 px margin right on the logo to make
their centers aligned. Both in confirmation and reminder templates.

Existing upgrade script in 17.4 will upgrade the mail templates even
if they are under noupdate=1.

Task-4088465
