### PR TITLE
[IMP] iap, sms: improve sms registration

### DIFF
--- a/addons/base_setup/models/res_config_settings.py
+++ b/addons/base_setup/models/res_config_settings.py
@@ -28,6 +28,7 @@ class ResConfigSettings(models.TransientModel):
     module_account_inter_company_rules = fields.Boolean("Manage Inter Company")
     module_voip = fields.Boolean("VoIP")
     module_web_unsplash = fields.Boolean("Unsplash Image Library")
+    module_sms = fields.Boolean("SMS")
     module_partner_autocomplete = fields.Boolean("Partner Autocomplete")
     module_base_geolocalize = fields.Boolean("GeoLocalize")
     module_google_recaptcha = fields.Boolean("reCAPTCHA")

--- a/addons/base_setup/views/res_config_settings_views.xml
+++ b/addons/base_setup/views/res_config_settings_views.xml
@@ -103,7 +103,9 @@
 
                         <div id="contacts_settings">
                             <block title="Contacts" name="contacts_setting_container">
-                                <setting id="sms" string="Send SMS" documentation="/applications/marketing/sms_marketing/pricing/pricing_and_faq.html" help="Send texts to your contacts" />
+                                <setting id="sms" string="Send SMS" documentation="/applications/marketing/sms_marketing/pricing/pricing_and_faq.html" help="Send texts to your contacts">
+                                    <field name="module_sms"/>
+                                </setting>
                                 <setting help="Automatically enrich your contact base with company data" title="When populating your address book, Odoo provides a list of matching companies. When selecting one item, the company data and logo are auto-filled." id="partner_autocomplete">
                                     <field name="module_partner_autocomplete"/>
                                 </setting>

--- a/addons/iap/__manifest__.py
+++ b/addons/iap/__manifest__.py
@@ -14,6 +14,7 @@ to support In-App purchases inside Odoo. """,
         'base_setup'
     ],
     'data': [
+        'data/services.xml',
         'security/ir.model.access.csv',
         'security/ir_rule.xml',
         'views/iap_views.xml',

--- a/addons/iap/data/services.xml
+++ b/addons/iap/data/services.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <!-- The reveal service is defined in the iap module, as a lot of different modules depend on it. -->
+        <record id="iap_service_reveal" model="iap.service">
+            <field name="name">Lead Generation</field>
+            <field name="technical_name">reveal</field>
+            <field name="description">Get quality leads and opportunities: convert your website visitors into leads, generate leads based on a set of criteria and enrich the company data of your opportunities.</field>
+            <field name="unit_name">Credits</field>
+            <field name="integer_balance">True</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/iap/models/__init__.py
+++ b/addons/iap/models/__init__.py
@@ -1,5 +1,5 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import iap_account
 from . import iap_enrich_api
+from . import iap_service

--- a/addons/iap/models/iap_account.py
+++ b/addons/iap/models/iap_account.py
@@ -1,14 +1,15 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
+import secrets
 import threading
 import uuid
 import werkzeug.urls
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
 from odoo.addons.iap.tools import iap_tools
-from odoo.exceptions import AccessError
+from odoo.exceptions import AccessError, UserError
+from odoo.tools import get_lang
 
 _logger = logging.getLogger(__name__)
 
@@ -17,103 +18,122 @@ DEFAULT_ENDPOINT = 'https://iap.odoo.com'
 
 class IapAccount(models.Model):
     _name = 'iap.account'
-    _rec_name = 'service_name'
     _description = 'IAP Account'
 
     name = fields.Char()
-    service_name = fields.Char(readonly=True)
+    service_id = fields.Many2one('iap.service', required=True)
+    service_name = fields.Char(related='service_id.technical_name')
+    service_locked = fields.Boolean(default=False)  # If True, the service can't be edited anymore
+    description = fields.Char(related='service_id.description')
     account_token = fields.Char(
         default=lambda s: uuid.uuid4().hex,
         help="Account token is your authentication key for this service. Do not share it.",
         size=43)
     company_ids = fields.Many2many('res.company')
-    account_info_id = fields.Many2one(
-        'iap.account.info', compute='_compute_info', inverse='_inverse_info', search='_search_info')
-    account_info_ids = fields.One2many(
-        'iap.account.info', 'account_id',
-        string="Accounts from IAP")
-    balance = fields.Char(compute='_compute_balance')
-    description = fields.Char(related='account_info_id.description')
-    warn_me = fields.Boolean(
-        related='account_info_id.warn_me',
-        help="We will send you an email when your balance gets below that threshold",
-        readonly=False)
-    warning_threshold = fields.Float(related='account_info_id.warning_threshold', readonly=False)
-    warning_email = fields.Char(related='account_info_id.warning_email', readonly=False)
-    show_token = fields.Boolean()
 
-    @api.model
-    def get_view(self, view_id=None, view_type='form', **kwargs):
-        res = super().get_view(view_id, view_type, **kwargs)
-        if view_type == 'tree':
-            self.env['iap.account'].get_services()
-        return res
+    # Dynamic fields, which are received from iap server and set when loading the view
+    balance = fields.Char(readonly=True)
+    warning_threshold = fields.Float("Email Alert Threshold")
+    warning_user_ids = fields.Many2many('res.users', string="Email Alert Recipients")
+    state = fields.Selection([('banned', 'Banned'), ('registered', "Registered"), ('unregistered', "Unregistered")], readonly=True)
 
-    @api.depends('account_info_ids')
-    def _compute_info(self):
+    @api.constrains('warning_threshold', 'warning_user_ids')
+    def validate_warning_alerts(self):
         for account in self:
-            if account.account_info_ids:
-                account.account_info_id = account.account_info_ids[-1]
+            if account.warning_threshold < 0:
+                raise UserError(_("Please set a positive email alert threshold."))
+            users_with_no_email = [user.name for user in self.warning_user_ids if not user.email]
+            if users_with_no_email:
+                raise UserError(_(
+                    "One of the email alert recipients doesn't have an email address set. Users: %s",
+                    ",".join(users_with_no_email),
+                ))
 
-    @api.depends('account_info_id')
-    def _compute_balance(self):
-        for account in self:
-            account.balance = f'{account.account_info_id.balance} {account.account_info_id.unit_name}' if account.account_info_id else "0 Credits"
+    def web_read(self, *args, **kwargs):
+        if not self.env.context.get('disable_iap_fetch'):
+            self._get_account_information_from_iap()
+        return super().web_read(*args, **kwargs)
 
-    def _inverse_info(self):
-        for account in self:
-            if account.account_info_ids:
-                # delete previous reference
-                account_info = account.env['iap.account.info'].browse(account.account_info_ids[0].id)
-                account_info.account_id = False
-            # set new reference
-            account.account_info_id.account_id = account
-
-    def _search_info(self, operator, value):
-        return []
+    def web_save(self, *args, **kwargs):
+        return super(IapAccount, self.with_context(disable_iap_fetch=True)).web_save(*args, **kwargs)
 
     def write(self, values):
-        res = super(IapAccount, self).write(values)
-        iap_edits = ['warn_me', 'warning_threshold', 'warning_email']
-        if any(edited_attribute in values for edited_attribute in iap_edits):
-            try:
-                route = '/iap/update-warning-odoo'
-                endpoint = iap_tools.iap_get_endpoint(self.env)
-                url = endpoint + route
+        res = super().write(values)
+        if (
+            not self.env.context.get('disable_iap_update')
+            and any(warning_attribute in values for warning_attribute in ('warning_threshold', 'warning_user_ids'))
+        ):
+            route = '/iap/1/update-warning-email-alerts'
+            endpoint = iap_tools.iap_get_endpoint(self.env)
+            url = werkzeug.urls.url_join(endpoint, route)
+            for account in self:
                 data = {
-                    'account_token': self.mapped('account_token')[0],
-                    'dbuuid': self.env['ir.config_parameter'].sudo().get_param('database.uuid'),
-                    'warn_me': values.get('warn_me'),
-                    'warning_threshold': values.get('warning_threshold'),
-                    'warning_email': values.get('warning_email'),
+                    'account_token': account.account_token,
+                    'warning_threshold': account.warning_threshold,
+                    'warning_emails': [{
+                        'email': user.email,
+                        'lang_code': user.lang or get_lang(self.env).code,
+                    } for user in account.warning_user_ids],
                 }
-                iap_tools.iap_jsonrpc(url=url, params=data)
-            except AccessError as e:
-                _logger.warning('Save service error : %s', str(e))
+                try:
+                    iap_tools.iap_jsonrpc(url=url, params=data)
+                except AccessError as e:
+                    _logger.warning("Update of the warning email configuration has failed: %s", str(e))
         return res
 
-    def get_services(self):
+    @staticmethod
+    def is_running_test_suite():
+        return hasattr(threading.current_thread(), 'testing') and threading.current_thread().testing
+
+    def _get_account_information_from_iap(self):
+        # During testing, we don't want to call the iap server
+        if self.is_running_test_suite():
+            return
+        route = '/iap/1/get-accounts-information'
+        endpoint = iap_tools.iap_get_endpoint(self.env)
+        url = werkzeug.urls.url_join(endpoint, route)
+        params = {
+            'iap_accounts': [{
+                'token': account.account_token,
+                'service': account.service_id.technical_name,
+            } for account in self if account.service_id],
+            'dbuuid': self.env['ir.config_parameter'].sudo().get_param('database.uuid'),
+        }
         try:
-            route = '/iap/services-token'
-            endpoint = iap_tools.iap_get_endpoint(self.env)
-            url = endpoint + route
-            account_tokens = self.env['iap.account'].sudo().search([]).mapped('account_token')
-            params = {
-                'dbuuid': self.env['ir.config_parameter'].sudo().get_param('database.uuid'),
-                'iap_accounts': account_tokens,
-            }
-            services = iap_tools.iap_jsonrpc(url=url, params=params)
-            for service in services:
-                account_id = self.env['iap.account'].sudo().search(
-                    [('account_token', '=', service['account_token'])]).ids[0]
-                service['account_id'] = account_id
-                self.env['iap.account.info'].create(service)
+            accounts_information = iap_tools.iap_jsonrpc(url=url, params=params)
         except AccessError as e:
-            _logger.warning('Get services error : %s', str(e))
+            _logger.warning("Fetch of the IAP accounts information has failed: %s", str(e))
+            return
+
+        for token, information in accounts_information.items():
+            account_id = self.filtered(lambda acc: secrets.compare_digest(acc.account_token, token))
+
+            # Default rounding of 4 decimal places to avoid large decimals
+            balance_amount = round(information['balance'], None if account_id.service_id.integer_balance else 4)
+            balance = f"{balance_amount} {account_id.service_id.unit_name}"
+
+            information.pop('link_to_service_page', None)
+            account_info = {
+                'balance': balance,
+                'warning_threshold': information['warning_threshold'],
+                'state': information['registered'],
+                'service_locked': True,  # The account exist on IAP, prevent the edition of the service
+            }
+
+            if account_id.service_name == 'sms':
+                account_info.update({
+                    'sender_name': information.get('sender_name')
+                })
+
+            account_id.with_context(disable_iap_update=True, tracking_disable=True).write(account_info)
 
     @api.model_create_multi
     def create(self, vals_list):
         accounts = super().create(vals_list)
+        for account in accounts:
+            if not account.name:
+                account.name = account.service_id.name
+
         if self.env['ir.config_parameter'].sudo().get_param('database.is_neutralized'):
             # Disable new accounts on a neutralized database
             for account in accounts:
@@ -142,9 +162,12 @@ class IapAccount(models.Model):
                 IapAccount.search(domain + [('account_token', '=', False)]).sudo().unlink()
                 accounts = accounts - accounts_without_token
         if not accounts:
-            if hasattr(threading.current_thread(), 'testing') and threading.current_thread().testing:
+            service = self.env['iap.service'].search([('technical_name', '=', service_name)], limit=1)
+            if not service:
+                raise UserError("No service exists with the provided technical name")
+            if self.is_running_test_suite():
                 # During testing, we don't want to commit the creation of a new IAP account to the database
-                return self.create({'service_name': service_name})
+                return self.sudo().create({'service_id': service.id})
 
             with self.pool.cursor() as cr:
                 # Since the account did not exist yet, we will encounter a NoCreditError,
@@ -158,7 +181,7 @@ class IapAccount(models.Model):
                 if not account:
                     if not force_create:
                         return account
-                    account = IapAccount.create({'service_name': service_name})
+                    account = IapAccount.create({'service_id': service.id})
                 # fetch 'account_token' into cache with this cursor,
                 # as self's cursor cannot see this account
                 account_token = account.account_token
@@ -171,13 +194,17 @@ class IapAccount(models.Model):
         return accounts[0]
 
     @api.model
+    def get_account_id(self, service_name):
+        return self.get(service_name).id
+
+    @api.model
     def get_credits_url(self, service_name, base_url='', credit=0, trial=False, account_token=False):
         """ Called notably by ajax crash manager, buy more widget, partner_autocomplete, sanilmail. """
         dbuuid = self.env['ir.config_parameter'].sudo().get_param('database.uuid')
         if not base_url:
             endpoint = iap_tools.iap_get_endpoint(self.env)
             route = '/iap/1/credit'
-            base_url = endpoint + route
+            base_url = werkzeug.urls.url_join(endpoint, route)
         if not account_token:
             account_token = self.get(service_name).account_token
         d = {
@@ -191,18 +218,13 @@ class IapAccount(models.Model):
         return '%s?%s' % (base_url, werkzeug.urls.url_encode(d))
 
     def action_buy_credits(self):
-        for account in self:
-            return {
-                'type': 'ir.actions.act_url',
-                'url': self.env['iap.account'].get_credits_url(
-                    account_token=account.account_token,
-                    service_name=account.service_name,
-                ),
-            }
-
-    def action_toggle_show_token(self):
-        for account in self:
-            account.show_token = not account.show_token
+        return {
+            'type': 'ir.actions.act_url',
+            'url': self.env['iap.account'].get_credits_url(
+                account_token=self.account_token,
+                service_name=self.service_name,
+            ),
+        }
 
     @api.model
     def get_config_account_url(self):
@@ -215,7 +237,7 @@ class IapAccount(models.Model):
             url = f"/odoo/action-iap.iap_account_action/{account.id}?menu_id={menu.id}"
         else:
             url = f"/odoo/action-iap.iap_account_action?menu_id={menu.id}"
-        return  url
+        return url
 
     @api.model
     def get_credits(self, service_name):
@@ -225,7 +247,7 @@ class IapAccount(models.Model):
         if account:
             route = '/iap/1/balance'
             endpoint = iap_tools.iap_get_endpoint(self.env)
-            url = endpoint + route
+            url = werkzeug.urls.url_join(endpoint, route)
             params = {
                 'dbuuid': self.env['ir.config_parameter'].sudo().get_param('database.uuid'),
                 'account_token': account.account_token,
@@ -238,20 +260,3 @@ class IapAccount(models.Model):
                 credit = -1
 
         return credit
-
-
-class IAPAccountInfo(models.TransientModel):
-    _name = 'iap.account.info'
-    _description = 'IAP Account Info'
-    _transient_max_hours = 1
-
-    account_id = fields.Many2one('iap.account', string='IAP Account')
-    account_token = fields.Char()
-    balance = fields.Float(string='Balance', digits=(16, 4), default=0)
-    account_uuid_hashed = fields.Char(string='Account UUID')
-    service_name = fields.Char(string='Related Service')
-    description = fields.Char()
-    warn_me = fields.Boolean('Warn me', default=False)
-    warning_threshold = fields.Float('Threshold')
-    warning_email = fields.Char()
-    unit_name = fields.Char(default='Credits')

--- a/addons/iap/models/iap_service.py
+++ b/addons/iap/models/iap_service.py
@@ -1,0 +1,18 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class IapService(models.Model):
+    _name = 'iap.service'
+    _description = 'IAP Service'
+
+    name = fields.Char(required=True)
+    technical_name = fields.Char(readonly=True, required=True)
+    description = fields.Char(required=True, translate=True)
+    unit_name = fields.Char(required=True, translate=True)
+    integer_balance = fields.Boolean(required=True)
+
+    _sql_constraints = [
+        ('unique_technical_name', 'UNIQUE(technical_name)', 'Only one service can exist with a specific technical_name')
+    ]

--- a/addons/iap/security/ir.model.access.csv
+++ b/addons/iap/security/ir.model.access.csv
@@ -1,4 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_client_iap_account_manager,iap.account.manager,model_iap_account,base.group_system,1,1,1,1
 access_client_iap_account_user,iap.account.user,model_iap_account,base.group_user,1,0,1,0
-access_iap_account_info,access_iap_account_info,iap.model_iap_account_info,base.group_user,1,1,1,1
+access_iap_service_manager,iap.service.manager,model_iap_service,base.group_system,1,1,1,1
+access_iap_service_user,iap.service.user,model_iap_service,base.group_user,1,0,0,0

--- a/addons/iap/static/src/action_buttons_widget/action_buttons_widget.js
+++ b/addons/iap/static/src/action_buttons_widget/action_buttons_widget.js
@@ -22,11 +22,13 @@ class IAPActionButtonsWidget extends Component {
         this.action.doAction("iap.iap_account_action");
     }
 
-    async onBuyLinkClicked() {
-        const url = await this.orm.silent.call("iap.account", "get_credits_url", [this.props.serviceName]);
+    async onManageServiceLinkClicked() {
+        const account_id = await this.orm.silent.call("iap.account", "get_account_id", [this.props.serviceName]);
         this.action.doAction({
-            type: "ir.actions.act_url",
-            url: url,
+            type: "ir.actions.act_window",
+            res_model: "iap.account",
+            res_id: account_id,
+            views: [[false, "form"]],
         });
     }
 }

--- a/addons/iap/static/src/action_buttons_widget/action_buttons_widget.xml
+++ b/addons/iap/static/src/action_buttons_widget/action_buttons_widget.xml
@@ -4,7 +4,7 @@
     <t t-name="iap.ActionButtonsWidget">
         <div class="row">
             <div class="col-sm">
-                <button t-on-click="onBuyLinkClicked" class="btn btn-link buy_credits px-0 o-hidden-ios text-nowrap"><i class="oi oi-arrow-right"/> Buy credits</button><br/>
+                <button t-on-click="onManageServiceLinkClicked" class="btn btn-link px-0 o-hidden-ios text-nowrap"><i class="oi oi-arrow-right"/> Manage Service &amp; Buy Credits</button><br/>
                 <button t-if="props.showServiceButtons" t-on-click="onViewServicesClicked" class="btn btn-link px-0 o-hidden-ios text-nowrap"><i class="oi oi-arrow-right"/> View My Services</button>
             </div>
         </div>

--- a/addons/iap/tests/test_iap.py
+++ b/addons/iap/tests/test_iap.py
@@ -6,5 +6,13 @@ from odoo.tests.common import TransactionCase
 
 class TestIAP(TransactionCase):
     def test_get_account(self):
-        account = self.env["iap.account"].get("random_service_name")
+        service_name = 'random_service_name'
+        self.env['iap.service'].create({
+            'name': service_name,
+            'description': 'test service',
+            'unit_name': 'credit',
+            'integer_balance': True,
+            'technical_name': service_name,
+        })
+        account = self.env['iap.account'].get(service_name)
         self.assertTrue(account.account_token, "Must be able to read the field")

--- a/addons/iap/tools/iap_tools.py
+++ b/addons/iap/tools/iap_tools.py
@@ -124,7 +124,7 @@ def iap_jsonrpc(url, method='call', params=None, timeout=15):
         req = requests.post(url, json=payload, timeout=timeout)
         req.raise_for_status()
         response = req.json()
-        _logger.info("iap jsonrpc %s answered in %s seconds", url, req.elapsed.total_seconds())
+        _logger.info("iap jsonrpc %s responded in %.3f seconds", url, req.elapsed.total_seconds())
         if 'error' in response:
             name = response['error']['data'].get('name').rpartition('.')[-1]
             message = response['error']['data'].get('message')
@@ -142,7 +142,7 @@ def iap_jsonrpc(url, method='call', params=None, timeout=15):
         return response.get('result')
     except (ValueError, requests.exceptions.ConnectionError, requests.exceptions.MissingSchema, requests.exceptions.Timeout, requests.exceptions.HTTPError) as e:
         raise exceptions.AccessError(
-            _('The url that this service requested returned an error. Please contact the author of the app. The url it tried to contact was %s', url)
+            _("An error occurred while reaching %s. Please contact Odoo support if this error persists.", url)
         )
 
 #----------------------------------------------------------

--- a/addons/iap/views/iap_views.xml
+++ b/addons/iap/views/iap_views.xml
@@ -11,42 +11,27 @@
                     <group name="account" string="Account Information">
                         <group>
                             <field name="name" />
-                            <field name="service_name" />
+                            <field name="service_id" readonly="service_locked" options="{'no_open': True, 'no_create': True}"/>
                             <field name="description" />
                             <field name="company_ids" widget="many2many_tags"
                                 domain="[('id', 'in', allowed_company_ids)]" />
-                            <field name="show_token" invisible="1" />
-                            <label for="account_token" />
-                            <div class="o_row">
-                                <field name="account_token" password="False"
-                                    invisible="not show_token"/>
-                                <field name="account_token" password="True"
-                                    invisible="show_token"/>
-                                <button name="action_toggle_show_token" icon="fa-eye"
-                                    type="object"
-                                    class="oe_stat_button"
-                                    invisible="show_token"
-                                    title="Show Token"/>
-                                <button name="action_toggle_show_token" icon="fa-eye-slash"
-                                    type="object"
-                                    class="oe_stat_button"
-                                    invisible="not show_token"
-                                    title="Hide Token"/>
-                            </div>
-                            <field name="warn_me" />
-                            <field name="warning_threshold"
-                                invisible="not warn_me"/>
-                            <field name="warning_email"
-                                invisible="not warn_me"/>
+                            <field name="account_token" groups="base.group_no_one"/>
                         </group>
-                        <group class="d-flex flex-column">
-                            <group class="d-flex">
-                                <button name="action_buy_credits" type="object" string="Buy Credit"
-                                    class="oe_highlight"/>
-                            </group>
-                            <group>
-                                <field name="balance" class="oe-inline"/>
-                            </group>
+                        <group name="external">
+                            <label for="balance" class="oe_inline"/>
+                            <div>
+                                <field name="balance" class="oe_inline"/>
+                                <button type="object"
+                                    name="action_buy_credits" class="btn-link py-0">
+                                    <i class="oi oi-arrow-right"/>
+                                    Buy Credit
+                                </button>
+                            </div>
+                            <field name="warning_threshold"/>
+                            <field name="warning_user_ids"
+                                   invisible="warning_threshold == 0"
+                                   required="warning_threshold > 0"
+                                   widget="many2many_tags" />
                         </group>
                     </group>
                 </sheet>
@@ -59,9 +44,9 @@
         <field name="arch" type="xml">
             <tree string="IAP Accounts">
                 <field name="name" />
-                <field name="service_name" />
+                <field name="service_id" />
                 <field name="company_ids" widget="many2many_tags" />
-                <field name="account_token" readonly="1" password="True" />
+                <field name="account_token" groups="base.group_no_one"/>
                 <field name="balance" />
                 <field name="warning_threshold" optional="hidden" />
                 <field name="description" optional="hidden" />

--- a/addons/iap_mail/__manifest__.py
+++ b/addons/iap_mail/__manifest__.py
@@ -16,6 +16,7 @@
     'auto_install': True,
     'data': [
         'data/mail_templates.xml',
+        'views/iap_views.xml',
     ],
     'assets': {
         'web.assets_backend': [

--- a/addons/iap_mail/models/iap_account.py
+++ b/addons/iap_mail/models/iap_account.py
@@ -1,10 +1,16 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, models
+from odoo import api, fields, models
 
 
 class IapAccount(models.Model):
-    _inherit = 'iap.account'
+    _name = 'iap.account'
+    _inherit = ['iap.account', 'mail.thread']
+
+    # Add tracking to the base fields
+    company_ids = fields.Many2many('res.company', tracking=True)
+    warning_threshold = fields.Float("Email Alert Threshold", tracking=True)
+    warning_user_ids = fields.Many2many('res.users', string="Email Alert Recipients", tracking=True)
 
     @api.model
     def _send_success_notification(self, message, title=None):

--- a/addons/iap_mail/views/iap_views.xml
+++ b/addons/iap_mail/views/iap_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data>
+        <record id="iap_account_view_form" model="ir.ui.view">
+            <field name="name">iap.account.view.form</field>
+            <field name="model">iap.account</field>
+            <field name="inherit_id" ref="iap.iap_account_view_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//sheet" position="after">
+                    <chatter/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/l10n_in_edi/__manifest__.py
+++ b/addons/l10n_in_edi/__manifest__.py
@@ -24,6 +24,7 @@ For the creation of API username and password please ref this document: <https:/
     """,
     "data": [
         "data/account_edi_data.xml",
+        "data/iap_service_data.xml",
         "views/res_config_settings_views.xml",
         "views/edi_pdf_report.xml",
         "views/account_move_views.xml",

--- a/addons/l10n_in_edi/data/iap_service_data.xml
+++ b/addons/l10n_in_edi/data/iap_service_data.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="iap_service_l10n_in_edi" model="iap.service">
+            <field name="name">Indian EDI</field>
+            <field name="technical_name">l10n_in_edi</field>
+            <field name="description">Send electronic document to Indian government</field>
+            <field name="unit_name">Credits</field>
+            <field name="integer_balance">True</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/partner_autocomplete/__manifest__.py
+++ b/addons/partner_autocomplete/__manifest__.py
@@ -19,6 +19,7 @@ Auto-complete partner companies' data
         'views/res_company_views.xml',
         'views/res_config_settings_views.xml',
         'data/cron.xml',
+        'data/iap_service_data.xml',
     ],
     'auto_install': True,
     'assets': {

--- a/addons/partner_autocomplete/data/iap_service_data.xml
+++ b/addons/partner_autocomplete/data/iap_service_data.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="iap_service_partner_autocomplete" model="iap.service">
+            <field name="name">Partner Autocomplete</field>
+            <field name="technical_name">partner_autocomplete</field>
+            <field name="description">Automatically enrich your contact base with corporate data.</field>
+            <field name="unit_name">Enrichments</field>
+            <field name="integer_balance">True</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/sms/__manifest__.py
+++ b/addons/sms/__manifest__.py
@@ -19,7 +19,11 @@ The service is provided by the In App Purchase Odoo platform.
         'phone_validation'
     ],
     'data': [
+        'data/iap_service_data.xml',
         'data/ir_cron_data.xml',
+        'wizard/sms_account_code_views.xml',
+        'wizard/sms_account_phone_views.xml',
+        'wizard/sms_account_sender_views.xml',
         'wizard/sms_composer_views.xml',
         'wizard/sms_template_preview_views.xml',
         'wizard/sms_resend_views.xml',
@@ -28,6 +32,7 @@ The service is provided by the In App Purchase Odoo platform.
         'views/mail_notification_views.xml',
         'views/res_config_settings_views.xml',
         'views/res_partner_views.xml',
+        'views/iap_account_views.xml',
         'views/sms_sms_views.xml',
         'views/sms_template_views.xml',
         'security/ir.model.access.csv',

--- a/addons/sms/data/iap_service_data.xml
+++ b/addons/sms/data/iap_service_data.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="iap_service_sms" model="iap.service">
+            <field name="name">SMS</field>
+            <field name="technical_name">sms</field>
+            <field name="description">Send SMS Text Messages to your contacts directly from your database.</field>
+            <field name="unit_name">Credits</field>
+            <field name="integer_balance">False</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/sms/models/__init__.py
+++ b/addons/sms/models/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import iap_account
 from . import ir_actions_server
 from . import ir_model
 from . import mail_followers

--- a/addons/sms/models/iap_account.py
+++ b/addons/sms/models/iap_account.py
@@ -1,0 +1,29 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, _
+
+
+class IapAccount(models.Model):
+    _inherit = 'iap.account'
+
+    sender_name = fields.Char(help="This is the name that will be displayed as the sender of the SMS.", readonly=True)
+
+    def action_open_registration_wizard(self):
+        return {
+            'type': 'ir.actions.act_window',
+            'target': 'new',
+            'name': _('Register Account'),
+            'view_mode': 'form',
+            'res_model': 'sms.account.phone',
+            'context': {'default_account_id': self.id},
+        }
+
+    def action_open_sender_name_wizard(self):
+        return {
+            'type': 'ir.actions.act_window',
+            'target': 'new',
+            'name': _('Choose your sender name'),
+            'view_mode': 'form',
+            'res_model': 'sms.account.sender',
+            'context': {'default_account_id': self.id},
+        }

--- a/addons/sms/security/ir.model.access.csv
+++ b/addons/sms/security/ir.model.access.csv
@@ -11,3 +11,6 @@ access_sms_resend_recipient,access.sms.resend.recipient,model_sms_resend_recipie
 access_sms_resend,access.sms.resend,model_sms_resend,base.group_user,1,1,1,0
 access_sms_template_preview,access.sms.template.preview,model_sms_template_preview,base.group_user,1,1,1,0
 access_sms_template_reset,access.sms.template.reset,model_sms_template_reset,mail.group_mail_template_editor,1,1,1,1
+access_sms_account_registration_phone_number_wizard_system,access.sms.account.phone.system,model_sms_account_phone,base.group_system,1,1,1,1
+access_sms_account_verification_code_wizard_system,access.sms.account.code.system,model_sms_account_code,base.group_system,1,1,1,1
+access_sms_account_sender_name_wizard_system,access.sms.account.sender.system,model_sms_account_sender,base.group_system,1,1,1,1

--- a/addons/sms/views/iap_account_views.xml
+++ b/addons/sms/views/iap_account_views.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data>
+        <record id="iap_account_view_form" model="ir.ui.view">
+            <field name="name">iap.account.view.form</field>
+            <field name="model">iap.account</field>
+            <field name="inherit_id" ref="iap.iap_account_view_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//group[@name='account']" position="before">
+                    <div role="status" class="alert alert-danger mb-0" invisible="service_name != 'sms' or (state != 'unregistered' and state)">
+                        <i class="fa fa-warning"/> You cannot send SMS while your account is not registered.
+                        <button type="object"
+                            name="action_open_registration_wizard" class="btn-link p-0">
+                            <i class="oi oi-arrow-right"/>
+                            Register
+                        </button>
+                    </div>
+                    <div role="status" class="alert alert-danger mb-0" invisible="service_name != 'sms' or (state != 'banned')">
+                        <i class="fa fa-warning"/> An error occurred with your account. Please contact the support for more information...
+                    </div>
+                </xpath>
+                <xpath expr="//button[@name='action_buy_credits']" position="attributes">
+                    <attribute name="invisible">service_name == 'sms' and not state</attribute>
+                </xpath>
+                <xpath expr="//group[@name='external']/*[1]" position="before">
+                    <label for="sender_name" class="oe_inline" invisible="service_name != 'sms' or not (state == 'registered' and state)"/>
+                    <div invisible="service_name != 'sms'  or not (state == 'registered' and state)">
+                        <field name="sender_name" class="oe_inline" invisible="not sender_name"/>
+                        <button type="object" invisible="sender_name"
+                            name="action_open_sender_name_wizard" class="btn-link p-0">
+                            <i class="oi oi-arrow-right"/>
+                            Set Sender Name
+                        </button>
+                    </div>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/sms/wizard/__init__.py
+++ b/addons/sms/wizard/__init__.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 
+from . import sms_account_code
+from . import sms_account_phone
+from . import sms_account_sender
 from . import sms_composer
 from . import sms_resend
 from . import sms_template_preview

--- a/addons/sms/wizard/sms_account_code.py
+++ b/addons/sms/wizard/sms_account_code.py
@@ -1,0 +1,36 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, _
+from odoo.addons.sms.tools.sms_api import ERROR_MESSAGES, SmsApi
+from odoo.exceptions import ValidationError
+
+
+class SMSAccountCode(models.TransientModel):
+    _name = 'sms.account.code'
+    _description = 'SMS Account Verification Code Wizard'
+
+    account_id = fields.Many2one('iap.account', required=True)
+    verification_code = fields.Char(required=True)
+
+    def action_register(self):
+        status = SmsApi(self.env, self.account_id)._verify_account(self.verification_code)['state']
+        if status != 'success':
+            raise ValidationError(ERROR_MESSAGES.get(status, ERROR_MESSAGES['unknown_error']))
+
+        self.account_id.state = "registered"
+        self.env['iap.account']._send_success_notification(
+            message=_("Your SMS account has been successfully registered."),
+        )
+
+        sender_name_wizard = self.env['sms.account.sender'].create({
+            'account_id': self.account_id.id,
+        })
+
+        return {
+            'type': 'ir.actions.act_window',
+            'target': 'new',
+            'name': _('Choose your sender name'),
+            'view_mode': 'form',
+            'res_model': 'sms.account.sender',
+            'res_id': sender_name_wizard.id,
+        }

--- a/addons/sms/wizard/sms_account_code_views.xml
+++ b/addons/sms/wizard/sms_account_code_views.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="sms_account_code_view_form" model="ir.ui.view">
+        <field name="name">sms.account.code.view.form</field>
+        <field name="model">sms.account.code</field>
+        <field name="arch" type="xml">
+            <form string="Register your SMS account">
+                <sheet>
+                    <group>
+                        <field name="verification_code" required="1"/>
+                    </group>
+                    <footer>
+                        <button string="Register" name="action_register" type="object" class="btn btn-primary"/>
+                        <button string="Cancel" class="btn-secondary" special="cancel"/>
+                    </footer>
+                </sheet>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/addons/sms/wizard/sms_account_phone.py
+++ b/addons/sms/wizard/sms_account_phone.py
@@ -1,0 +1,27 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, _
+from odoo.addons.sms.tools.sms_api import ERROR_MESSAGES, SmsApi
+from odoo.exceptions import ValidationError
+
+
+class SMSAccountPhone(models.TransientModel):
+    _name = 'sms.account.phone'
+    _description = 'SMS Account Registration Phone Number Wizard'
+
+    account_id = fields.Many2one('iap.account', required=True)
+    phone_number = fields.Char(required=True)
+
+    def action_send_verification_code(self):
+        status = SmsApi(self.env, self.account_id)._send_verification_sms(self.phone_number)['state']
+        if status != 'success':
+            raise ValidationError(ERROR_MESSAGES.get(status, ERROR_MESSAGES['unknown_error']))
+
+        return {
+            'type': 'ir.actions.act_window',
+            'target': 'new',
+            'name': _('Register Account'),
+            'view_mode': 'form',
+            'res_model': 'sms.account.code',
+            'context': {'default_account_id': self.account_id.id},
+        }

--- a/addons/sms/wizard/sms_account_phone_views.xml
+++ b/addons/sms/wizard/sms_account_phone_views.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="sms_account_phone_view_form" model="ir.ui.view">
+        <field name="name">sms.account.phone.view.form</field>
+        <field name="model">sms.account.phone</field>
+        <field name="arch" type="xml">
+            <form string="Register your SMS account">
+                <sheet>
+                    <h5>Enter a phone number to get an SMS with a verification code.</h5>
+                    <group>
+                        <field name="phone_number" placeholder="+1 555-555-555"/>
+                    </group>
+                    <footer>
+                        <button string="Send verification code" name="action_send_verification_code" type="object" class="btn btn-primary"/>
+                        <button string="Cancel" class="btn-secondary" special="cancel"/>
+                    </footer>
+                </sheet>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/addons/sms/wizard/sms_account_sender.py
+++ b/addons/sms/wizard/sms_account_sender.py
@@ -1,0 +1,25 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import re
+from odoo import api, fields, models
+from odoo.addons.sms.tools.sms_api import ERROR_MESSAGES, SmsApi
+from odoo.exceptions import ValidationError
+
+
+class SMSAccountSender(models.TransientModel):
+    _name = 'sms.account.sender'
+    _description = 'SMS Account Sender Name Wizard'
+
+    account_id = fields.Many2one('iap.account', required=True)
+    sender_name = fields.Char()
+
+    @api.constrains("sender_name")
+    def _check_sender_name(self):
+        for record in self:
+            if not re.match(r"[a-zA-Z0-9\- ]{3,11}", record.sender_name):
+                raise ValidationError("Your sender name must be between 3 and 11 characters long and only contain alphanumeric characters.")
+
+    def action_set_sender_name(self):
+        status = SmsApi(self.env, self.account_id)._set_sender_name(self.sender_name)['state']
+        if status != 'success':
+            raise ValidationError(ERROR_MESSAGES.get(status, ERROR_MESSAGES['unknown_error']))

--- a/addons/sms/wizard/sms_account_sender_views.xml
+++ b/addons/sms/wizard/sms_account_sender_views.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="sms_account_sender_view_form" model="ir.ui.view">
+        <field name="name">sms.account.sender.view.form</field>
+        <field name="model">sms.account.sender</field>
+        <field name="arch" type="xml">
+            <form string="Choose your sender name">
+                <sheet>
+                    <p>
+                        Your sender name must be between 3 and 11 characters long and only contain alphanumeric characters.
+                        It must fit your company name, and you aren't allowed to modify it once you registered one, choose it carefully.
+                    </p>
+                    <p>
+                        Note that this is not required, if you don't set a sender name, your SMS will be sent from a short code.
+                    </p>
+                    <group>
+                        <field name="sender_name" required="1"/>
+                    </group>
+                    <footer>
+                        <button string="Set sender name" name="action_set_sender_name" type="object" class="btn btn-primary"/>
+                        <button string="Skip for now" class="btn-secondary" special="cancel"/>
+                    </footer>
+                </sheet>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/addons/snailmail/__manifest__.py
+++ b/addons/snailmail/__manifest__.py
@@ -12,6 +12,7 @@ Allows users to send documents by post
         'mail'
     ],
     'data': [
+        'data/iap_service_data.xml',
         'data/snailmail_data.xml',
         'views/report_assets.xml',
         'views/snailmail_views.xml',

--- a/addons/snailmail/data/iap_service_data.xml
+++ b/addons/snailmail/data/iap_service_data.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="iap_service_snailmail" model="iap.service">
+            <field name="name">Snail Mail</field>
+            <field name="technical_name">snailmail</field>
+            <field name="description">Send your customer invoices and follow-up reports by post, worldwide.</field>
+            <field name="unit_name">Stamps</field>
+            <field name="integer_balance">True</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1295,7 +1295,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
     def test_message_to_store_single(self):
         message = self.messages_all[0].with_env(self.env)
 
-        with self.assertQueryCount(employee=24):
+        with self.assertQueryCount(employee=27):
             res = Store(message, for_current_user=True).get_result()
 
         self.assertEqual(len(res["mail.message"]), 1)

--- a/addons/test_mail_sms/tests/test_sms_performance.py
+++ b/addons/test_mail_sms/tests/test_sms_performance.py
@@ -36,7 +36,7 @@ class TestSMSPerformance(BaseMailPerformance, sms_common.SMSCase):
     def test_message_sms_record_1_partner(self):
         record = self.test_record.with_user(self.env.user)
         pids = self.customer.ids
-        with self.subTest("QueryCount"), self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=24):  # tms: 24
+        with self.subTest("QueryCount"), self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=27):  # tms: 27
             messages = record._message_sms(
                 body='Performance Test',
                 partner_ids=pids,
@@ -51,7 +51,7 @@ class TestSMSPerformance(BaseMailPerformance, sms_common.SMSCase):
     def test_message_sms_record_10_partners(self):
         record = self.test_record.with_user(self.env.user)
         pids = self.partners.ids
-        with self.subTest("QueryCount"), self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=24):  # tms: 24
+        with self.subTest("QueryCount"), self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=27):  # tms: 27
             messages = record._message_sms(
                 body='Performance Test',
                 partner_ids=pids,
@@ -65,7 +65,7 @@ class TestSMSPerformance(BaseMailPerformance, sms_common.SMSCase):
     @warmup
     def test_message_sms_record_default(self):
         record = self.test_record.with_user(self.env.user)
-        with self.subTest("QueryCount"), self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=25):  # tms: 25
+        with self.subTest("QueryCount"), self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=28):  # tms: 28
             messages = record._message_sms(
                 body='Performance Test',
             )


### PR DESCRIPTION
Refactor the iap_account and iap_service models, which allows for a better registration flow for sms accounts. Where the user can verify their phone number, set a sender name and warning emails on their own db without needing to go to the iap website.

task-3741280

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
