### PR TITLE
[FIX] html_editor: preserve selection on setTag

### DIFF
--- a/addons/html_editor/static/tests/tags.test.js
+++ b/addons/html_editor/static/tests/tags.test.js
@@ -435,7 +435,7 @@ describe("to blockquote", () => {
         expect(getContent(el)).toBe("<p>abcd</p>");
 
         setTag("h1")(editor);
-        expect(getContent(el)).toBe("<h1>ab[]cd</h1>");
+        expect(getContent(el)).toBe("<h1>abcd</h1>");
     });
 
     test("setTag should work when we move the selection outside of the editor", async () => {
@@ -445,7 +445,7 @@ describe("to blockquote", () => {
         expect(getContent(el)).toBe("<p>abcd</p>");
 
         setTag("h1")(editor);
-        expect(getContent(el)).toBe("<h1>ab[]cd</h1>");
+        expect(getContent(el)).toBe("<h1>abcd</h1>");
     });
 
     test("triple click with setTag should only switch the tag on the selected line", async () => {
@@ -486,5 +486,13 @@ describe("to blockquote", () => {
 
         press("enter");
         expect(getContent(el)).toBe("<blockquote>ab[]cd</blockquote>");
+    });
+
+    test("setTag should work after control+a", async () => {
+        const { el, editor } = await setupEditor("<p>[]abcd</p>");
+        press("control+a");
+        expect(getContent(el)).toBe("[<p>abcd</p>]");
+        setTag("h1")(editor);
+        expect(getContent(el)).toBe("[<h1>abcd</h1>]");
     });
 });


### PR DESCRIPTION
Steps to reproduce:

1. On an empty document, type some text in the first paragraph.
2. Control + A to select all the text.
3. Select "Header 1" on the dropdown menu under the font button (first button).

A traceback is raised due to trying to set the selection to null.

This commit ensures that the selection is preserved correctly in the `setTag` method.

Details:
Previously, the logic for preserving the selection could result in passing null as argument to setSelection. In the case reported above, `startContainerChild` stored a reference to the paragraph that was replaced by the h1 (thus, removed). Since it was disconnected when `startContainerChild.parentNode` was evaluated, `null` was assignated to `startContainer` right before passing it as argument to `setSeletion`.
