### PR TITLE
[DRAFT][FIX] account: avoid posting duplicate inv pdf

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5202,8 +5202,9 @@ class AccountMove(models.Model):
 
     def _get_mail_thread_data_attachments(self):
         res = super()._get_mail_thread_data_attachments()
+        wizard_attachments = self.env['account.move.send']._get_invoice_extra_attachments(self)    # res field included
         # else, attachments with 'res_field' get excluded
-        return res | self.env['account.move.send']._get_invoice_extra_attachments(self)
+        return wizard_attachments if wizard_attachments else res
 
     # -------------------------------------------------------------------------
     # TOOLING


### PR DESCRIPTION
When the user would send & print the invoice, two pdf reports would be posted in the chatter attachments.

Steps to reproduce:
- required modules: account, studio
1. Go to account > Toggle studio > Reports > Invoices
2. Enable Reload from attachment > Save > Close
3. Go to Customers > Invoices > new > fill the form > confirm
4. Click on Send & Print > Send & Print again
5. Notice how 2 attachments are presents in the chatter "Invoices" and "INV_YEAR_ID.pdf"

Cause:
in account module _get_mail_thread_data_attachments would use the union operator '|' to do the instruction "return value_1 if present or else value_2" but this operator is being overriden by odoo's framework leading to a combination of 2 records into a recordset.

Solution:
Retrieve both attachment (from super() and from wizard). choose wizard over super() as explain in the comment:
> "else, attachments with 'res_field' get excluded"
(res_field are not defined in the attachment from super())

opw-4063056

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
