### PR TITLE
[FIX] web_editor: fix signature command in forum

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -2057,7 +2057,7 @@ const Wysiwyg = Widget.extend({
                     const res = await this._rpc({
                         model: 'res.users',
                         method: 'read',
-                        args: [this.getSession().uid, ['signature']],
+                        args: [this.getSession().user_id, ['signature']],
                     });
                     if (res && res[0] && res[0].signature) {
                         this.odooEditor.execCommand('insert', parseHTML(res[0].signature));


### PR DESCRIPTION
Issue:
Signature command doesn't work in 16.0 and raises an error in 17.0+

Steps to reproduce the issue:
- install website
- add forum in the website
- create a new post in the forum
- add signature
- (nothing happens in 16.0, error in 17.0)

Origin of the issue:
====================
The session in the forum post view doesn't have `uid`.

Solution:
========
Use `session.user_id` instead of `session.uid` which works in forum as well as in other apps.

opw-4066436