### PR TITLE
[REF] mail, im_livechat, *: rename LivechatChannel and add to Store

### DIFF
--- a/addons/im_livechat/__manifest__.py
+++ b/addons/im_livechat/__manifest__.py
@@ -149,6 +149,10 @@ Help your customers with this chat, and analyse their feedback.
             'web/static/tests/_framework/**/*',
             'im_livechat/static/tests/embed/**/*',
         ],
+        "mail.assets_public": [
+            "im_livechat/static/src/core/common/**/*",
+            "im_livechat/static/src/core/public_web/**/*",
+        ],
     },
     'license': 'LGPL-3',
 }

--- a/addons/im_livechat/controllers/webclient.py
+++ b/addons/im_livechat/controllers/webclient.py
@@ -19,15 +19,6 @@ class WebClient(WebclientController):
     def _process_request_for_internal_user(self, store, **kwargs):
         super()._process_request_for_internal_user(store, **kwargs)
         if kwargs.get("livechat_channels"):
-            livechat_channels = (
-                request.env["im_livechat.channel"]
-                .search([])
-                .mapped(
-                    lambda c: {
-                        "id": c.id,
-                        "name": c.name,
-                        "hasSelfAsMember": request.env.user in c.user_ids,
-                    }
-                )
+            store.add(
+                request.env["im_livechat.channel"].search([]), fields=["hasSelfAsMember", "name"]
             )
-            store.add("LivechatChannel", livechat_channels)

--- a/addons/im_livechat/controllers/webclient.py
+++ b/addons/im_livechat/controllers/webclient.py
@@ -20,5 +20,5 @@ class WebClient(WebclientController):
         super()._process_request_for_internal_user(store, **kwargs)
         if kwargs.get("livechat_channels"):
             store.add(
-                request.env["im_livechat.channel"].search([]), fields=["hasSelfAsMember", "name"]
+                request.env["im_livechat.channel"].search([]), fields=["are_you_inside", "name"]
             )

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -72,8 +72,10 @@ class DiscussChannel(models.Model):
                 channel_info["operator"] = Store.one(
                     channel.livechat_operator_id, fields=["user_livechat_username", "write_date"]
                 )
-            if channel.channel_type == "livechat" and channel.livechat_channel_id and self.env.user._is_internal():
-                channel_info['livechatChannel'] = {"id": channel.livechat_channel_id.id, "name": channel.livechat_channel_id.name}
+            if channel.channel_type == "livechat" and self.env.user._is_internal():
+                channel_info["livechatChannel"] = Store.one(
+                    channel.livechat_channel_id, fields=["name"]
+                )
             store.add(channel, channel_info)
 
     @api.autovacuum

--- a/addons/im_livechat/static/src/core/common/livechat_channel_model.js
+++ b/addons/im_livechat/static/src/core/common/livechat_channel_model.js
@@ -4,7 +4,8 @@ export class LivechatChannel extends Record {
     static _name = "im_livechat.channel";
     static id = "id";
 
-    hasSelfAsMember = false;
+    /** @type {boolean} */
+    are_you_inside;
     /** @type {number} */
     id;
     /** @type {string} */

--- a/addons/im_livechat/static/src/core/common/livechat_channel_model.js
+++ b/addons/im_livechat/static/src/core/common/livechat_channel_model.js
@@ -1,0 +1,13 @@
+import { Record } from "@mail/core/common/record";
+
+export class LivechatChannel extends Record {
+    static _name = "im_livechat.channel";
+    static id = "id";
+
+    hasSelfAsMember = false;
+    /** @type {number} */
+    id;
+    /** @type {string} */
+    name;
+}
+LivechatChannel.register();

--- a/addons/im_livechat/static/src/core/public_web/discuss_app_category_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/discuss_app_category_model_patch.js
@@ -6,7 +6,7 @@ import { compareDatetime } from "@mail/utils/common/misc";
 patch(DiscussAppCategory.prototype, {
     setup() {
         super.setup(...arguments);
-        this.livechatChannel = Record.one("LivechatChannel", {
+        this.livechatChannel = Record.one("im_livechat.channel", {
             inverse: "appCategory",
             onDelete() {
                 this.delete();

--- a/addons/im_livechat/static/src/core/public_web/livechat_channel_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/livechat_channel_model_patch.js
@@ -1,0 +1,23 @@
+import { LivechatChannel } from "@im_livechat/core/common/livechat_channel_model";
+import { Record } from "@mail/core/common/record";
+
+import { patch } from "@web/core/utils/patch";
+
+const livechatChannelPatch = {
+    setup() {
+        super.setup(...arguments);
+        this.appCategory = Record.one("DiscussAppCategory", {
+            compute() {
+                return {
+                    extraClass: "o-mail-DiscussSidebarCategory-livechat",
+                    hideWhenEmpty: !this.hasSelfAsMember,
+                    id: `im_livechat.category_${this.id}`,
+                    name: this.name,
+                    sequence: 22,
+                };
+            },
+            inverse: "livechatChannel",
+        });
+    },
+};
+patch(LivechatChannel.prototype, livechatChannelPatch);

--- a/addons/im_livechat/static/src/core/public_web/livechat_channel_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/livechat_channel_model_patch.js
@@ -10,7 +10,7 @@ const livechatChannelPatch = {
             compute() {
                 return {
                     extraClass: "o-mail-DiscussSidebarCategory-livechat",
-                    hideWhenEmpty: !this.hasSelfAsMember,
+                    hideWhenEmpty: !this.are_you_inside,
                     id: `im_livechat.category_${this.id}`,
                     name: this.name,
                     sequence: 22,

--- a/addons/im_livechat/static/src/core/web/discuss_sidebar_categories_patch.xml
+++ b/addons/im_livechat/static/src/core/web/discuss_sidebar_categories_patch.xml
@@ -2,12 +2,12 @@
 <templates xml:space="preserve">
     <t t-name="im_livechat.DiscussSidebarCategory" t-inherit="mail.DiscussSidebarCategory" t-inherit-mode="extension">
         <xpath expr="//*[@t-ref='actions']/div[hasclass('btn-group')]" position="inside">
-            <button t-if="store.has_access_livechat and category.livechatChannel and category.open" class="btn btn-light" t-on-click="() => category.livechatChannel.hasSelfAsMember ? category.livechatChannel.leave({ notify: false }) : category.livechatChannel.join({ notify: false })">
+            <button t-if="store.has_access_livechat and category.livechatChannel and category.open" class="btn btn-light" t-on-click="() => category.livechatChannel.are_you_inside ? category.livechatChannel.leave({ notify: false }) : category.livechatChannel.join({ notify: false })">
                 <i t-att-class="{
-                       'fa fa-sign-out text-danger': category.livechatChannel.hasSelfAsMember,
-                       'fa fa-sign-in text-success': !category.livechatChannel.hasSelfAsMember
+                       'fa fa-sign-out text-danger': category.livechatChannel.are_you_inside,
+                       'fa fa-sign-in text-success': !category.livechatChannel.are_you_inside
                    }"
-                   t-att-title="category.livechatChannel.hasSelfAsMember ? category.livechatChannel.leaveTitle : category.livechatChannel.joinTitle"
+                   t-att-title="category.livechatChannel.are_you_inside ? category.livechatChannel.leaveTitle : category.livechatChannel.joinTitle"
                    role="img"
                 />
             </button>

--- a/addons/im_livechat/static/src/core/web/livechat_channel_command_provider.js
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_command_provider.js
@@ -23,12 +23,12 @@ registry.category("command_provider").add("im_livechat.channel_join_leave", {
         }
         await store.livechatChannels.fetch();
         const activeChannels = new Set(
-            Object.values(store.LivechatChannel.records)
+            Object.values(store["im_livechat.channel"].records)
                 .filter((c) => c.threads.length > 0)
                 .map((c) => c.id)
         );
         // Show live chat channels with ongoing conversations first
-        return Object.values(store.LivechatChannel.records)
+        return Object.values(store["im_livechat.channel"].records)
             .sort((c) => (activeChannels.has(c.id) ? -1 : 1))
             .map((c) => ({
                 action: c.hasSelfAsMember ? c.leave.bind(c) : c.join.bind(c),

--- a/addons/im_livechat/static/src/core/web/livechat_channel_command_provider.js
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_command_provider.js
@@ -31,11 +31,11 @@ registry.category("command_provider").add("im_livechat.channel_join_leave", {
         return Object.values(store["im_livechat.channel"].records)
             .sort((c) => (activeChannels.has(c.id) ? -1 : 1))
             .map((c) => ({
-                action: c.hasSelfAsMember ? c.leave.bind(c) : c.join.bind(c),
+                action: c.are_you_inside ? c.leave.bind(c) : c.join.bind(c),
                 Component: LivechatChannelCommand,
-                name: c.hasSelfAsMember ? c.leaveTitle : c.joinTitle,
+                name: c.are_you_inside ? c.leaveTitle : c.joinTitle,
                 props: {
-                    iconClass: c.hasSelfAsMember
+                    iconClass: c.are_you_inside
                         ? "fa fa-sign-out text-danger"
                         : "fa fa-sign-in text-success",
                 },

--- a/addons/im_livechat/static/src/core/web/livechat_channel_model_patch.js
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_model_patch.js
@@ -15,7 +15,7 @@ const livechatChannelPatch = {
         this.threads = Record.many("Thread", { inverse: "livechatChannel" });
     },
     async join({ notify = true } = {}) {
-        this.hasSelfAsMember = true;
+        this.are_you_inside = true;
         if (notify) {
             this.store.env.services.notification.add(_t("You joined %s.", this.name), {
                 type: "info",
@@ -29,7 +29,7 @@ const livechatChannelPatch = {
         return sprintf(_t("Join %s"), this.name);
     },
     async leave({ notify = true } = {}) {
-        this.hasSelfAsMember = false;
+        this.are_you_inside = false;
         if (notify) {
             this.store.env.services.notification.add(_t("You left %s.", this.name), {
                 type: "info",

--- a/addons/im_livechat/static/src/core/web/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/web/thread_model_patch.js
@@ -11,7 +11,7 @@ patch(Thread.prototype, {
                 return this.channel_type === "livechat" ? this.store.discuss : null;
             },
         });
-        this.livechatChannel = Record.one("LivechatChannel");
+        this.livechatChannel = Record.one("im_livechat.channel", { inverse: "threads" });
     },
     _computeDiscussAppCategory() {
         if (this.channel_type !== "livechat") {

--- a/addons/im_livechat/static/tests/mock_server/livechat_mock_server.js
+++ b/addons/im_livechat/static/tests/mock_server/livechat_mock_server.js
@@ -168,14 +168,9 @@ patch(mailDataHelpers, {
         const store = await super.processRequest(...arguments);
         const { livechat_channels } = await parseRequestParams(request);
         if (livechat_channels) {
-            const LivechatChannel = this.env["im_livechat.channel"];
             store.add(
-                "LivechatChannel",
-                LivechatChannel.search_read([]).map((channel) => ({
-                    id: channel.id,
-                    name: channel.name,
-                    hasSelfAsMember: channel.user_ids.includes(this.env.user.id),
-                }))
+                this.env["im_livechat.channel"].search([]),
+                makeKwArgs({ fields: ["hasSelfAsMember", "name"] })
             );
         }
         return store;

--- a/addons/im_livechat/static/tests/mock_server/livechat_mock_server.js
+++ b/addons/im_livechat/static/tests/mock_server/livechat_mock_server.js
@@ -170,7 +170,7 @@ patch(mailDataHelpers, {
         if (livechat_channels) {
             store.add(
                 this.env["im_livechat.channel"].search([]),
-                makeKwArgs({ fields: ["hasSelfAsMember", "name"] })
+                makeKwArgs({ fields: ["are_you_inside", "name"] })
             );
         }
         return store;

--- a/addons/im_livechat/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/discuss_channel.js
@@ -11,8 +11,6 @@ export class DiscussChannel extends mailModels.DiscussChannel {
      * @type {typeof mailModels.DiscussChannel["prototype"]["_to_store"]}
      */
     _to_store(ids, store) {
-        /** @type {import("mock_models").LivechatChannel} */
-        const LivechatChannel = this.env["im_livechat.channel"];
         /** @type {import("mock_models").ResPartner} */
         const ResPartner = this.env["res.partner"];
 
@@ -33,14 +31,10 @@ export class DiscussChannel extends mailModels.DiscussChannel {
                 } else {
                     channelInfo.operator = false;
                 }
-                if (channel.livechat_channel_id) {
-                    channelInfo.livechatChannel = LivechatChannel.search_read([
-                        ["id", "=", channel.livechat_channel_id],
-                    ]).map((c) => ({
-                        id: c.id,
-                        name: c.name,
-                    }))[0];
-                }
+                channelInfo.livechatChannel = mailDataHelpers.Store.one(
+                    this.env["im_livechat.channel"].browse(channel.livechat_channel_id),
+                    makeKwArgs({ fields: ["name"] })
+                );
             }
             store.add(this.browse(channel.id), channelInfo);
         }

--- a/addons/im_livechat/static/tests/mock_server/mock_models/im_livechat_channel.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/im_livechat_channel.js
@@ -17,7 +17,7 @@ export class LivechatChannel extends models.ServerModel {
             "mail.record/insert",
             new mailDataHelpers.Store(
                 this.browse(id),
-                makeKwArgs({ fields: ["hasSelfAsMember", "name"] })
+                makeKwArgs({ fields: ["are_you_inside", "name"] })
             ).get_result()
         );
     }
@@ -31,7 +31,7 @@ export class LivechatChannel extends models.ServerModel {
             "mail.record/insert",
             new mailDataHelpers.Store(
                 this.browse(id),
-                makeKwArgs({ fields: ["hasSelfAsMember", "name"] })
+                makeKwArgs({ fields: ["are_you_inside", "name"] })
             ).get_result()
         );
     }
@@ -102,11 +102,11 @@ export class LivechatChannel extends models.ServerModel {
         for (const livechatChannel of this.browse(ids)) {
             const [res] = this.read(
                 [livechatChannel.id],
-                fields.filter((field) => field !== "hasSelfAsMember"),
+                fields.filter((field) => field !== "are_you_inside"),
                 false
             );
-            if (fields.includes("hasSelfAsMember")) {
-                res.hasSelfAsMember = livechatChannel.user_ids.includes(this.env.user.id);
+            if (fields.includes("are_you_inside")) {
+                res.are_you_inside = livechatChannel.user_ids.includes(this.env.user.id);
             }
             store.add(this.browse(livechatChannel.id), res);
         }

--- a/addons/mail/static/src/model/record.js
+++ b/addons/mail/static/src/model/record.js
@@ -43,12 +43,15 @@ export class Record {
         const Model = toRaw(this);
         return this.records[Model.localId(data)];
     }
+    static getName() {
+        return this._name || this.name;
+    }
     static register(localRegistry) {
         if (localRegistry) {
             // Record-specific tests use local registry as to not affect other tests
-            localRegistry.add(this.name, this);
+            localRegistry.add(this.getName(), this);
         } else {
-            modelRegistry.add(this.name, this);
+            modelRegistry.add(this.getName(), this);
         }
     }
     static localId(data) {
@@ -59,7 +62,7 @@ export class Record {
         } else {
             idStr = data; // non-object data => single id
         }
-        return `${Model.name},${idStr}`;
+        return `${Model.getName()},${idStr}`;
     }
     static _localId(expr, data, { brackets = false } = {}) {
         const Model = toRaw(this);
@@ -196,7 +199,7 @@ export class Record {
             Object.assign(record._, { localId: Model.localId(ids) });
             Object.assign(recordProxy, { ...ids });
             Model.records[record.localId] = recordProxy;
-            if (record.Model.name === "Store") {
+            if (record.Model.getName() === "Store") {
                 Object.assign(record, {
                     env: Model._rawStore.env,
                     recordByLocalId: Model._rawStore.recordByLocalId,

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -342,6 +342,9 @@ class TestDiscussFullPerformance(HttpCase):
             "discuss.channel.rtc.session": [
                 self._expected_result_for_rtc_session(self.channel_channel_group_1, self.users[2]),
             ],
+            "im_livechat.channel": [
+                self._expected_result_for_livechat_channel(),
+            ],
             "mail.guest": [
                 self._expected_result_for_persona(guest=True),
             ],
@@ -703,7 +706,7 @@ class TestDiscussFullPerformance(HttpCase):
                 "is_editable": False,
                 "is_pinned": True,
                 "last_interest_dt": last_interest_dt,
-                "livechatChannel": {"id": self.im_livechat_channel.id, "name": "support"},
+                "livechatChannel": {"id": self.im_livechat_channel.id},
                 "message_needaction_counter": 0,
                 "message_needaction_counter_bus_id": bus_last_id,
                 "name": "test1 Ernest Employee",
@@ -738,7 +741,7 @@ class TestDiscussFullPerformance(HttpCase):
                 "is_editable": False,
                 "is_pinned": True,
                 "last_interest_dt": last_interest_dt,
-                "livechatChannel": {"id": self.im_livechat_channel.id, "name": "support"},
+                "livechatChannel": {"id": self.im_livechat_channel.id},
                 "message_needaction_counter": 0,
                 "message_needaction_counter_bus_id": bus_last_id,
                 "name": "anon 2 Ernest Employee",
@@ -1017,6 +1020,9 @@ class TestDiscussFullPerformance(HttpCase):
                 "thread": {"id": channel.id, "model": "discuss.channel"},
             }
         return {}
+
+    def _expected_result_for_livechat_channel(self):
+        return {"id": self.im_livechat_channel.id, "name": "support"}
 
     def _expected_result_for_message(self, channel):
         last_message = channel._get_last_messages()


### PR DESCRIPTION
\* = test_discuss_full

Allow JS model to define python names directly to avoid converting names, rename `im_livechat.channel`, and add it to Store.

Also fix bundles related to this model to fix issues that were hidden due to using record insert rather than store insert.

Part of task-3605717