### PR TITLE
[IMP] l10n_it_edi: improve installation speed for db will lots of entries

### DIFF
--- a/addons/l10n_it_edi/models/account_invoice.py
+++ b/addons/l10n_it_edi/models/account_invoice.py
@@ -39,7 +39,7 @@ class AccountMove(models.Model):
                         could not be delivered to the addressee') # ok we must do nothing
     ], default='to_send', copy=False, string="FatturaPA Send State")
 
-    l10n_it_stamp_duty = fields.Float(default=0, string="Dati Bollo", readonly=True, states={'draft': [('readonly', False)]})
+    l10n_it_stamp_duty = fields.Float(string="Dati Bollo", readonly=True, states={'draft': [('readonly', False)]})
 
     l10n_it_ddt_id = fields.Many2one('l10n_it.ddt', string='DDT', readonly=True, states={'draft': [('readonly', False)]}, copy=False)
 

--- a/addons/l10n_it_edi/models/res_company.py
+++ b/addons/l10n_it_edi/models/res_company.py
@@ -44,7 +44,7 @@ class ResCompany(models.Model):
 
 
     # Economic and Administrative Index
-    l10n_it_has_eco_index = fields.Boolean(default=False,
+    l10n_it_has_eco_index = fields.Boolean(
         help="The seller/provider is a company listed on the register of companies and as\
         such must also indicate the registration data on all documents (art. 2250, Italian\
         Civil Code)")
@@ -53,7 +53,7 @@ class ResCompany(models.Model):
     l10n_it_eco_index_number = fields.Char(string="Number in register of companies", size=20,
         help="This field must contain the number under which the\
         seller/provider is listed on the register of companies.")
-    l10n_it_eco_index_share_capital = fields.Float(default=0.0, string="Share capital actually paid up",
+    l10n_it_eco_index_share_capital = fields.Float(string="Share capital actually paid up",
         help="Mandatory if the seller/provider is a company with share\
         capital (SpA, SApA, Srl), this field must contain the amount\
         of share capital actually paid up as resulting from the last\
@@ -72,7 +72,7 @@ class ResCompany(models.Model):
 
 
     # Tax representative
-    l10n_it_has_tax_representative = fields.Boolean(default=False,
+    l10n_it_has_tax_representative = fields.Boolean(
         help="The seller/provider is a non-resident subject which\
         carries out transactions in Italy with relevance for VAT\
         purposes and which takes avail of a tax representative in\


### PR DESCRIPTION
Avoid setting default value of zero for Integer/Float fields or False for Boolean fields (those are already the fields default)

This avoid triggering write on the related models (on multi-companies database with millions on journal entries this speedup the installation of modules from ~8-9 minutes to ~15 seconds)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
