### PR TITLE
[FIX] web_unsplash: fix the crash in DocumentSelector

### DIFF
--- a/addons/web_unsplash/static/src/media_dialog/media_dialog.xml
+++ b/addons/web_unsplash/static/src/media_dialog/media_dialog.xml
@@ -29,7 +29,7 @@
 
     <t t-inherit="html_editor.FileSelector" t-inherit-mode="extension">
         <xpath expr="//div[@name='load_more_attachments']" position="before">
-            <div t-if="unsplashState.unsplashError" class="d-flex mt-2 unsplash_error">
+            <div t-if="unsplashState?.unsplashError" class="d-flex mt-2 unsplash_error">
                 <UnsplashError
                     title="errorTitle"
                     subtitle="errorSubtitle"
@@ -48,7 +48,7 @@
 
     <t t-inherit="html_editor.FileSelector" t-inherit-mode="extension">
         <xpath expr="//FileSelectorControlPanel" position="attributes">
-            <attribute name="useUnsplash">unsplashState.useUnsplash</attribute>
+            <attribute name="useUnsplash">unsplashState?.useUnsplash</attribute>
         </xpath>
     </t>
 </templates>

--- a/addons/web_unsplash/static/tests/unsplash.test.js
+++ b/addons/web_unsplash/static/tests/unsplash.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { click, waitFor } from "@odoo/hoot-dom";
+import { click, waitFor, press } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { contains, makeMockEnv, onRpc } from "@web/../tests/web_test_helpers";
 import { setupEditor } from "@html_editor/../tests/_helpers/editor";
@@ -98,4 +98,27 @@ test("Unsplash error is displayed when there is no key", async () => {
     await fetchDef;
     await waitFor(".unsplash_error");
     expect(".unsplash_error").toHaveCount(1);
+});
+
+test("Document tab does not crash with FileSelector extension", async () => {
+    onRpc("/web/dataset/call_kw/ir.attachment/search_read", () => {
+        return [
+            {
+                id: 1,
+                name: "logo",
+                mimetype: "image/png",
+                image_src: "/web/static/img/logo2.png",
+                access_token: false,
+                public: true,
+            },
+        ];
+    });
+    const env = await makeMockEnv();
+    const { editor } = await setupEditor("<p>a[]</p>", { env });
+    insertText(editor, "/image");
+    await animationFrame();
+    press("enter");
+    await animationFrame();
+    click("li:nth-child(2) > a.nav-link");
+    expect(".o_existing_attachment_cell").toHaveCount(1);
 });


### PR DESCRIPTION
Steps to reproduce
------------------
- Go to the editor
- Type "/image"
- Go to the Document tab

Expected Behaviour
-----------------
The user should see the documents he can insert.

Current Behaviour
-----------------
crash

This commit fix an error made in the PR #172938.
The `FileSelector` component is inherited by `ImageSelector` and `DocumentSelector`.
`web_unsplash` does inherit the `FileSelector` template to add `UnsplashError` in the template. 
However `DocumentSelector` can't read `unsplashState` and then crash.

This commit fix it by making this state optional, if the extended component does have the state then use `UnsplashError` else ignore it.

