### PR TITLE
[IMP] website: introduce `s_discovery` snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -95,6 +95,7 @@
         'views/snippets/s_image_title.xml',
         'views/snippets/s_key_images.xml',
         'views/snippets/s_kickoff.xml',
+        'views/snippets/s_discovery.xml',
         'views/snippets/s_text_highlight.xml',
         'views/snippets/s_progress_bar.xml',
         'views/snippets/s_blockquote.xml',

--- a/addons/website/views/snippets/s_discovery.xml
+++ b/addons/website/views/snippets/s_discovery.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_discovery" name="Discovery">
+    <section class="s_discovery pt136 pb136" style="text-align: center;">
+        <div class="container">
+            <span class="s_cta_badge o_cc o_cc1 d-inline-block my-3 border rounded py-2 px-3 o_animable" data-snippet="s_cta_badge" data-name="CTA Badge" style="border-radius: 32px !important;">
+                <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;What do you want to promote&amp;nbsp;? &#160;&#160;&#160;&#160;<a href="#">See more <i class="fa fa-long-arrow-right" role="img"/></a>
+            </span>
+            <h1 class="display-2" style="text-align: center;">Discover our solutions</h1>
+            <p class="lead" style="text-align: center;">Write one or two paragraphs describing your product, services or a specific feature.<br/> To be successful your content needs to be useful to your readers.<br/><br/></p>
+            <p style="text-align: center;">
+                <a t-att-href="cta_btn_href" class="btn btn-primary"><t t-out="cta_btn_text">Our store</t></a>
+                <a t-att-href="cta_btn_href" class="btn btn-secondary"><t t-out="cta_btn_text">Contact us</t></a>
+            </p>
+        </div>
+    </section>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -75,6 +75,9 @@
                 <t t-snippet="website.s_sidegrid" string="Side grid" group="intro">
                     <keywords>grid, gallery, pictures, photos, media, text, content, album, showcase, visuals, portfolio, mosaic, collage, arrangement, collection, visual-grid, split, alignment</keywords>
                 </t>
+                <t t-snippet="website.s_discovery" string="Discovery" group="intro">
+                    <keywords>hero, jumbotron, headline, header, intro, home, content, introduction, overview, spotlight, presentation, welcome, context, description, primary, highlight, lead, discover</keywords>
+                </t>
 
                 <!-- Columns group -->
                 <t t-snippet="website.s_three_columns" string="Columns" group="columns">


### PR DESCRIPTION
This PR introduces the new `s_discovery` snippet.

| Snippet in use |
|--------|
| <img width="865" alt="image" src="https://github.com/user-attachments/assets/9a86f82e-42cc-4f6e-ba76-494df714522a"> | 
---------

### Checklist
- [x] Meaningful demo-text
- [x] Adapts to color combinations -> Readable text
- [x] Mobile friendly
- [x] Has no `<h1>` tags (except for "Intro" snippets)
- [x] Has one `<h1>` tag ("Intro" snippets only)
- [x] Images are optimized
- [x] Images can be replaced by the website wizard (with fairly apparent exceptions)
- [x] No ineffective options. Eg "click -> nothing happens"
- [x] Edition is limited when not necessary
- [x] Behaves consistently with the rest of the snippets (images can be replaced, etc..)

task-4077581
Part of task-4077427

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr