### PR TITLE
[FIX] stock: don't rollback scheduler if it succeeeded

### DIFF
--- a/addons/stock/wizard/stock_scheduler_compute.py
+++ b/addons/stock/wizard/stock_scheduler_compute.py
@@ -36,7 +36,6 @@ class StockSchedulerCompute(models.TransientModel):
                 self.env['procurement.group'].with_context(allowed_company_ids=cids).run_scheduler(
                     use_new_cursor=self._cr.dbname,
                     company_id=company.id)
-            self._cr.rollback()
         return {}
 
     def procure_calculation(self):


### PR DESCRIPTION
Currently, when the stock scheduler is run, a new cursor is created and
the result is rolled back even if all tasks succeeded. Even though tasks
themselves are not rolled back because they are run using new other
cursors, rolling it back is not correct and it makes harder to test the
scheduler feature.

The rollback was introduced in da6bd90e by mistake.

This commit makes the transaction to be rolled back only when the
current transaction actually failed.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
