### PR TITLE
[FIX] pos_daily_sales_report: sales report show wrong closing difference

### DIFF
--- a/addons/pos_daily_sales_reports/models/pos_daily_sales_reports.py
+++ b/addons/pos_daily_sales_reports/models/pos_daily_sales_reports.py
@@ -131,7 +131,7 @@ class ReportSaleDetails(models.AbstractModel):
                         for account_payment in account_payments:
                             if payment['id'] == account_payment.pos_payment_method_id.id:
                                 payment['final_count'] = payment['total']
-                                payment['money_counted'] = account_payment.amount
+                                payment['money_counted'] = account_payment.amount_signed
                                 payment['money_difference'] = payment['money_counted'] - payment['final_count']
                                 payment['cash_moves'] = []
                                 if payment['money_difference'] > 0:


### PR DESCRIPTION
before this commit, the pos sales details report shows wrong closing difference 
value in the below scenario

* open a session
* place an order, with negative qty lets say product A with 1 qty and price 150 and now add product B 
with qty as -1 with price 250
* now the order total is -100
* complete the order with non cash payment method, let say bank
* close the session
* print the sales report from point of sale ->reporting -> session report, select the session and print
* downloaded report will show cash difference which is not existing

![Screenshot from 2024-08-04 11-27-40](https://github.com/user-attachments/assets/a05584ef-0a03-404d-9887-8e0c6af45e95)



after this commit, the report will show correct data


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
