### PR TITLE
[IMP] point_of_sale: remove resume order button in receipt screen

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -83,16 +83,6 @@ export class ReceiptScreen extends Component {
         const { name, props } = this.nextScreen;
         this.pos.showScreen(name, props);
     }
-    resumeOrder() {
-        this.currentOrder.uiState.screen_data.value = "";
-        this.currentOrder.uiState.locked = true;
-        this.pos.selectNextOrder();
-        const { name, props } = this.ticketScreen;
-        this.pos.showScreen(name, props);
-    }
-    isResumeVisible() {
-        return this.pos.get_open_orders().length > 0;
-    }
     async _sendReceiptToCustomer({ action }) {
         const order = this.currentOrder;
         if (typeof order.id !== "number") {

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.xml
@@ -46,9 +46,6 @@
                             <button class="button next validation btn btn-primary btn-lg w-100 py-4 lh-lg" t-att-class="{ highlight: !locked }" t-if="!splittedOrder" t-on-click="orderDone" name="done">
                                 New Order
                             </button>
-                            <button t-if="isResumeVisible()" class="button next validation btn btn-secondary btn-lg w-100 py-4 lh-lg" t-att-class="{ highlight: !locked }" t-on-click="resumeOrder" name="resume">
-                                Resume Order
-                            </button>
                         </div>
                     </div>
                     <div class="pos-receipt-container d-flex flex-grow-1 flex-lg-grow-0 w-100 w-lg-50 user-select-none justify-content-center bg-200 text-center overflow-hidden">
@@ -60,9 +57,6 @@
                 <div  id="action_btn_mobile" t-if="ui.isSmall" class="switchpane d-flex gap-2 p-2">
                     <div class="btn-switchpane validation-button btn btn-primary btn-lg py-3 flex-fill lh-lg" t-att-class="{ highlight: !locked }" t-if="!splittedOrder" t-on-click="orderDone" name="done">
                                 New Order
-                    </div>
-                    <div t-if="isResumeVisible() and !splittedOrder" class="btn-switchpane validation-button btn btn-secondary btn-lg flex-fill py-3 lh-lg" t-att-class="{ highlight: !locked }" t-on-click="resumeOrder" name="resume">
-                                Resume Order
                     </div>
                 </div>
             </div>

--- a/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.xml
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.xml
@@ -22,7 +22,7 @@
                         <span t-if="!ui.isSmall">Plan</span>
                         <img t-else="" src="/pos_restaurant/static/img/plan.svg" class="navbar-icon" alt="Floor Plan"/>
                     </button>
-                    <button class="table-free-order-label btn btn-lg lh-lg" t-att-class="{'btn-primary': screen === 'ProductScreen' or pos.orderToTransferUuid}" t-on-click="() => this.onClickTableTab()">
+                    <button class="table-free-order-label btn btn-lg lh-lg" t-att-class="{'btn-primary': screen !== 'FloorScreen' or pos.orderToTransferUuid}" t-on-click="() => this.onClickTableTab()">
                         <span t-if="getOrderToDisplay()" t-esc="getOrderToDisplay().getName().slice(0, 7)"/>
                         <span t-elif="!ui.isSmall">Table</span>
                         <img t-else="" src="/pos_restaurant/static/img/table.svg" class="navbar-icon" alt="Table Selector"/>

--- a/addons/pos_restaurant/static/src/overrides/components/receipt_screen/receipt_screen.js
+++ b/addons/pos_restaurant/static/src/overrides/components/receipt_screen/receipt_screen.js
@@ -27,7 +27,11 @@ patch(ReceiptScreen.prototype, {
         this.pos.showScreen("ProductScreen");
     },
     isContinueSplitting() {
-        if (this.pos.config.module_pos_restaurant && this.pos.selectedTable) {
+        if (
+            this.pos.config.module_pos_restaurant &&
+            !this.pos.selectedTable &&
+            !this.currentOrder.originalSplittedOrder
+        ) {
             const originalOrderUuid = this.currentOrder.uiState.splittedOrderUuid;
 
             if (!originalOrderUuid) {
@@ -40,12 +44,6 @@ patch(ReceiptScreen.prototype, {
         } else {
             return false;
         }
-    },
-    isResumeVisible() {
-        if (this.isContinueSplitting()) {
-            return false;
-        }
-        return super.isResumeVisible(...arguments);
     },
     //@override
     get nextScreen() {

--- a/addons/pos_restaurant/static/src/overrides/components/receipt_screen/receipt_screen.xml
+++ b/addons/pos_restaurant/static/src/overrides/components/receipt_screen/receipt_screen.xml
@@ -12,5 +12,11 @@
                 Continue
             </div>
         </xpath>
+        <xpath expr="//div[@id='action_btn_desktop']/button[hasclass('validation')]" position="attributes">
+            <attribute name="t-if">!isContinueSplitting()</attribute>
+        </xpath>
+        <xpath expr="//div[@id='action_btn_mobile']/div[hasclass('validation-button')]" position="attributes">
+            <attribute name="t-if">!isContinueSplitting()</attribute>
+        </xpath>
     </t>
 </templates>

--- a/addons/pos_restaurant/static/tests/tours/split_bill_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/split_bill_screen_tour.js
@@ -112,11 +112,9 @@ registry.category("web_tour.tours").add("SplitBillScreenTour3", {
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickValidate(),
-            ReceiptScreen.clickNextOrder(),
+            ReceiptScreen.clickContinueOrder(),
 
             // Check if there is still water in the order
-            FloorScreen.isShown(),
-            FloorScreen.clickTable("2"),
 
             ProductScreen.selectedOrderlineHas("Water", "1.0"),
             ProductScreen.clickPayButton(true),
@@ -171,11 +169,9 @@ registry.category("web_tour.tours").add("SplitBillScreenTour4ProductCombo", {
             ProductScreen.clickPayButton(),
             ...PaymentScreen.clickPaymentMethod("Bank"),
             ...PaymentScreen.clickValidate(),
-            ...ReceiptScreen.clickNextOrder(),
+            ...ReceiptScreen.clickContinueOrder(),
 
-            // Check if there is still water in the order
-            ...FloorScreen.isShown(),
-            FloorScreen.clickTable("2"),
+            // Check if there is still Minute Maid in the order
             // now we check that all the lines that remained in the order are correct
             ...ProductScreen.selectedOrderlineHas("Minute Maid", "1.0"),
             ...ProductScreen.clickOrderline("Office Combo"),


### PR DESCRIPTION
In this commit:
===============
The `Resume Order` button has been removed from the receipt screen. Since we have a 'Continue' button for split orders, users can navigate directly to the remaining order on the product screen.
If the order is paid, the system will display the 'New Order' button on the receipt screen.
Thus, the `Resume Order` button is redundant and has been removed.

task- 4070215


