### PR TITLE
[FIX] website: neutralize slash in record name when converting cover

### DIFF
--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -978,7 +978,7 @@ export class WysiwygAdapterComponent extends Wysiwyg {
             }
             const modelName = await this.websiteService.getUserModelName(resModel);
             const recordNameEl = imageEl.closest("body").querySelector(`[data-oe-model="${resModel}"][data-oe-id="${resID}"][data-oe-field="name"]`);
-            const recordName = recordNameEl ? `'${recordNameEl.textContent}'` : resID;
+            const recordName = recordNameEl ? `'${recordNameEl.textContent.replaceAll("/", "")}'` : resID;
             const attachment = await this.rpc(
                 '/web_editor/attachment/add_data',
                 {


### PR DESCRIPTION
Since [1] cover images are implicitly converted to webp. An issue was fixed in [2] because the converted image attachments were not public.

This commit fixes another issue: if the cover's record name contains a slash inside its name, the name of the attachment also contains that slash. `_compute_image_src` then puts that slash inside `image_src` which is used to reference the converted image from the website page. But the route does not support delivering such paths.

Steps to reproduce:
- Create a new blog post.
- Name it "A/B Testing".
- Upload a JPG image as cover.
- Save.

=> The image was not displayed anymore.

[1]: https://github.com/odoo/odoo/commit/068dcc27e417d52b51d274c44497f4388fed780a
[2]: https://github.com/odoo/odoo/commit/715eb84a35d27fdbb378fd9937d7439f8619f99c

opw-4042913
opw-4047244
opw-4086947
