### PR TITLE
[FIX] mail: include whatsapp in webpush notifications

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -487,8 +487,8 @@ class Channel(models.Model):
         message_type = msg_vals.get('message_type', 'comment') if msg_vals else message.message_type
         pids = msg_vals.get('partner_ids', []) if msg_vals else message.partner_ids.ids
 
-        # notify only user input (comment or incoming / outgoing emails)
-        if message_type not in ('comment', 'email', 'email_outgoing'):
+        # notify only user input (comment, whatsapp messages or incoming / outgoing emails)
+        if message_type not in ('comment', 'email', 'email_outgoing', 'whatsapp_message'):
             return []
 
         recipients_data = []

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4358,7 +4358,7 @@ class MailThread(models.AbstractModel):
         author_id = [msg_vals.get('author_id')] if 'author_id' in msg_vals else msg_sudo.author_id.ids
         # never send to author and to people outside Odoo (email), except comments
         pids = set()
-        if msg_type == 'comment':
+        if msg_type in {'comment', 'whatsapp_message'}:
             pids = set(notif_pids) - set(author_id)
         elif msg_type in ('notification', 'user_notification', 'email'):
             pids = (set(notif_pids) - set(author_id) - set(no_inbox_pids))


### PR DESCRIPTION
[FIX] mail: include whatsapp in webpush notifications

There are couple of components in the notification
architecture. For the sake of illustration
let's simplify it with the following: Sender -> Queuer -> Receiver
Queuer is an FMC backend, so we should only be concerned about the
other two. Receiver which is just a frontend service worker that will
generate notifications as soon as he receives an event. The issue
(before this commit) was in the Sender part, which was skipping
whatsapp type message generation.

[Reproduce]
- Configure Whatsapp account, include user A in "Notify users"
- Allow notifications in your browser (chat icon/ OdooBot suggestion)
- Send a whatsapp message to the configured whatsapp number
- BUG: Push notification is not showing up

opw-3720699
