### PR TITLE
[FIX] pos_restaurant: only show floating orders

### DIFF
--- a/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
@@ -59,6 +59,10 @@ patch(Navbar.prototype, {
     showTabs() {
         return !this.pos.selectedTable;
     },
+    getFloatingOrders() {
+        const draftOrders = super.getFloatingOrders() || [];
+        return draftOrders.filter((o) => !o.table_id);
+    },
     get showTableIcon() {
         return typeof this.getTable()?.table_number === "number" && this.pos.showBackButton();
     },


### PR DESCRIPTION
After the commit f4d9d68407ed4c11dd42d2545f5f166cc92b7f09 the floating order mechanism from pos_restaurant was generalized to a "tabs" system in all the pos configs. In a retail pos, all draft orders are supposed to be shown in tabs, but in a pos_restaurant only draft orders w\o table should be shown in tabs ( i.e. floating orders ).

This was not taken into account in the previous commit.

The issue is fixed in this commit.

Task: 4095614




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
