### PR TITLE
[FIX] portal: fix typo in getting author avatar url

### DIFF
--- a/addons/portal/models/mail_message.py
+++ b/addons/portal/models/mail_message.py
@@ -97,7 +97,7 @@ class MailMessage(models.Model):
             if 'author_avatar_url' in properties_names:
                 if options and options.get("token"):
                     values['author_avatar_url'] = f'/mail/avatar/mail.message/{message.id}/author_avatar/50x50?access_token={options["token"]}'
-                elif options and options.get("_hash") and options.get("pid"):
+                elif options and options.get("hash") and options.get("pid"):
                     values['author_avatar_url'] = f'/mail/avatar/mail.message/{message.id}/author_avatar/50x50?_hash={options["hash"]}&pid={options["pid"]}'
                 else:
                     values['author_avatar_url'] = f'/web/image/mail.message/{message.id}/author_avatar/50x50'


### PR DESCRIPTION
Since #172475, there is a typo in checking security params to get the author avatar url.

Note:
The correct avatar url with hash and pid and the alternative are the same visually in the related use case of hash and pid in elearning module.


