### PR TITLE
[IMP] mail: send `activities` in the request list

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4551,7 +4551,10 @@ class MailThread(models.AbstractModel):
                 res["hasWriteAccess"] = True
         except AccessError:
             pass
-        if isinstance(self.env[self._name], self.env.registry["mail.activity.mixin"]):
+        if (
+            request_list and "activities" in request_list
+            and isinstance(self.env[self._name], self.env.registry["mail.activity.mixin"])
+        ):
             res["activities"] = Store.many(self.with_context(active_test=True).activity_ids)
         if request_list and "attachments" in request_list:
             res["attachments"] = Store.many(self._get_mail_thread_data_attachments())

--- a/addons/mail/static/src/chatter/web/chatter_patch.js
+++ b/addons/mail/static/src/chatter/web/chatter_patch.js
@@ -184,7 +184,13 @@ patch(Chatter.prototype, {
     },
 
     get requestList() {
-        return [...super.requestList, "followers", "attachments", "suggestedRecipients"];
+        return [
+            ...super.requestList,
+            "activities",
+            "followers",
+            "attachments",
+            "suggestedRecipients",
+        ];
     },
 
     /**

--- a/addons/mail/static/tests/chatter/web/chatter.test.js
+++ b/addons/mail/static/tests/chatter/web/chatter.test.js
@@ -53,7 +53,7 @@ test("simple chatter on a record", async () => {
     await contains(".o-mail-Chatter-topbar");
     await contains(".o-mail-Thread");
     await assertSteps([
-        `/mail/thread/data - {"request_list":["followers","attachments","suggestedRecipients"],"thread_id":${partnerId},"thread_model":"res.partner"}`,
+        `/mail/thread/data - {"request_list":["activities","followers","attachments","suggestedRecipients"],"thread_id":${partnerId},"thread_model":"res.partner"}`,
         `/mail/thread/messages - {"thread_id":${partnerId},"thread_model":"res.partner","limit":30}`,
     ]);
 });

--- a/addons/mail/static/tests/legacy/helpers/mock_server/controllers/discuss.js
+++ b/addons/mail/static/tests/legacy/helpers/mock_server/controllers/discuss.js
@@ -586,7 +586,10 @@ patch(MockServer.prototype, {
             return res;
         }
         res["canPostOnReadonly"] = thread_model === "discuss.channel"; // model that have attr _mail_post_access='read'
-        if (this.pyEnv.mockServer.models[thread_model].has_activities) {
+        if (
+            request_list.includes("activities") &&
+            this.pyEnv.mockServer.models[thread_model].has_activities
+        ) {
             const activities = this.pyEnv["mail.activity"].search_read([
                 ["id", "in", thread.activity_ids || []],
             ]);


### PR DESCRIPTION
Even if a thread is a `mail.activity.mixin`, we should only include activities data in `_to_store` when explicitly requested by the user. This will prevent unnecessary data transfer, especially in cases where the chatter (like a portal chatter) doesn't utilize activity data.

Part of task-2828744
