### PR TITLE
[FIX] point_of_sale: enable web printing when ePoS printing fails

### DIFF
--- a/addons/point_of_sale/static/src/app/printer/pos_printer_service.js
+++ b/addons/point_of_sale/static/src/app/printer/pos_printer_service.js
@@ -40,10 +40,10 @@ export class PosPrinterService extends PrinterService {
         try {
             return await super.printHtml(...arguments);
         } catch (error) {
-            return this.printHtmlAlternative(error);
+            return this.printHtmlAlternative(error, ...arguments);
         }
     }
-    async printHtmlAlternative(error) {
+    async printHtmlAlternative(error, ...args) {
         const { confirmed } = await this.popup.add(ConfirmPopup, {
             title: error.title || _t("Printing error"),
             body: error.body + _t("Do you want to print using the web printer? "),
@@ -54,7 +54,7 @@ export class PosPrinterService extends PrinterService {
         // We want to call the _printWeb when the popup is fully gone
         // from the screen which happens after the next animation frame.
         await new Promise(requestAnimationFrame);
-        return this.printWeb(...arguments);
+        return this.printWeb(...args);
     }
 }
 


### PR DESCRIPTION
Before this commit, if there was an issue with printing via an ePoS printer, the system did not allow for printing the receipt through the web as a fallback. This was due to the erroneous passing of the error object instead of the receipt content.

opw-4088596

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
