### PR TITLE
[FIX] website: fix logo resizing and fixed header

### DIFF
--- a/addons/website/static/src/js/content/menu.js
+++ b/addons/website/static/src/js/content/menu.js
@@ -433,7 +433,7 @@ publicWidget.registry.FixedHeader = BaseAnimatedHeader.extend({
                 // to hidden. Without this, the dropdowns would be invisible.
                 // (e.g., "user menu" dropdown).
                 this.hiddenOnScrollEl.style.overflow = this.fixedHeader ? "hidden" : "";
-                this.hiddenOnScrollEl.style.height = `${elHeight}px`;
+                this.hiddenOnScrollEl.style.height = this.fixedHeader ? `${elHeight}px` : "";
                 let elPadding = parseInt(getComputedStyle(this.hiddenOnScrollEl).paddingBlock);
                 if (elHeight < elPadding * 2) {
                     const heightDifference = elPadding * 2 - elHeight;
@@ -442,6 +442,14 @@ publicWidget.registry.FixedHeader = BaseAnimatedHeader.extend({
                         .setProperty("padding-block", `${elPadding}px`, "important");
                 } else {
                     this.hiddenOnScrollEl.style.paddingBlock = "";
+                }
+                if (this.fixedHeader) {
+                    // The height of the "hiddenOnScrollEl" element changes, so
+                    // the height of the header also changes. Therefore, we need
+                    // to get the current height of the header and then to
+                    // update the top padding of the main element.
+                    headerHeight = this.el.getBoundingClientRect().height;
+                    this._updateMainPaddingTop();
                 }
             }
             if (!this.fixedHeader && this.dropdownClickedEl) {


### PR DESCRIPTION
Steps to reproduce:

- In website edit mode.
- Drop enough blocks into the page to have a vertical scrollbar.
- Click on the header.
- Select the "Vertical" template in the options of the header.
- Select the "Fixed" scroll effect in the options of the header.
- click on the logo in the header.
- Enter "80px" in the "Height" input in the options of the "Navbar Logo".
- Scroll the page to the bottom.
- Then, scroll the page to the top.
- Bug: the "Navbar Logo" overlaps the navbar links.

This bug occurred because the header size was calculated before the transition animation for the header height was completed.

opw-4078173