### PR TITLE
[FIX] pos_restaurant: link table banner undefined table

### DIFF
--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
@@ -181,7 +181,7 @@ export class FloorScreen extends Component {
                         time: Date.now(),
                     };
                     this.alert.add(
-                        `Link Table ${table.name} with ${this.state.potentialLink.parent.name}`
+                        `Link Table ${table.table_number} with ${this.state.potentialLink.parent.table_number}`
                     );
                     return;
                 }


### PR DESCRIPTION
Before this commit:
===================
The link table number appears as "undefined" when a user tries to link two tables by dragging one table to another in the banner.

After this commit:
====================
The link table number now displays correctly.

task - 4087313
