### PR TITLE
[FIX] stock: restrict read fields for forecast

### DIFF
--- a/addons/stock/report/stock_forecasted.py
+++ b/addons/stock/report/stock_forecasted.py
@@ -158,7 +158,7 @@ class StockForecasted(models.AbstractModel):
         if move_in:
             document_in = move_in._get_source_document()
             line.update({
-                'move_in' : move_in.read()[0] if read else move_in,
+                'move_in': move_in.read(fields=self._get_report_moves_fields())[0] if read else move_in,
                 'document_in' : {
                     '_name' : document_in._name,
                     'id' : document_in.id,
@@ -170,7 +170,7 @@ class StockForecasted(models.AbstractModel):
         if move_out:
             document_out = move_out._get_source_document()
             line.update({
-                'move_out' : move_out.read()[0] if read else move_out,
+                'move_out': move_out.read(fields=self._get_report_moves_fields())[0] if read else move_out,
                 'document_out' : {
                     '_name' : document_out._name,
                     'id' : document_out.id,
@@ -183,6 +183,9 @@ class StockForecasted(models.AbstractModel):
                     'picking_id': move_out.picking_id.read(fields=['id', 'priority'])[0],
                 })
         return line
+
+    def _get_report_moves_fields(self):
+        return ['id', 'date']
 
     def _get_report_lines(self, product_template_ids, product_ids, wh_location_ids, wh_stock_location, read=True):
 


### PR DESCRIPTION
Steps to reproduce:
- Have a user have no inventory rights and User rights for sales
- As that user, create a sale order that sells a storable product, which has at least one picking related to it in progress
- Click on the forecast icon then on 'View Forecast'

Issue:
An access error will be triggered, as the user doesn't have the rights to consult `stock.valuation.layer` records.

These records being useless for the forecast report itself, we can restrict instead what fields are read for the moves, to only fetch actually required fields.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
