### PR TITLE
[FIX] account: romanian translation

### DIFF
--- a/addons/account/i18n/ro.po
+++ b/addons/account/i18n/ro.po
@@ -1010,7 +1010,7 @@ msgid ""
 "<span invisible=\"state != 'draft' or name != '/' or posted_before or "
 "quick_edit_mode\">Draft</span>"
 msgstr ""
-"<span invisible=\"state != 'draft' or name != '/' or posted_before sau "
+"<span invisible=\"state != 'draft' or name != '/' or posted_before or "
 "quick_edit_mode\">Ciornă</span>"
 
 #. module: account


### PR DESCRIPTION
The problem is that the python logical operator "or" was translated

Steps to reproduce:

- add Romanian language

- create an invoice

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
