### PR TITLE
[IMP] website: add new `s_image_text_box` snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -37,6 +37,7 @@
         'views/snippets/s_title.xml',
         'views/snippets/s_cover.xml',
         'views/snippets/s_text_cover.xml',
+        'views/snippets/s_image_text_box.xml',
         'views/snippets/s_text_image.xml',
         'views/snippets/s_image_text.xml',
         'views/snippets/s_mockup_image.xml',

--- a/addons/website/views/snippets/s_image_text_box.xml
+++ b/addons/website/views/snippets/s_image_text_box.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_text_box" name="Image Text Box">
+    <section class="s_image_text_box pt80 pb80">
+        <div class="container">
+            <div class="row o_grid_mode" data-row-count="10" style="column-gap: 24px;">
+                <div class="o_grid_item o_grid_item_image g-col-lg-6 g-height-10 col-lg-6" style="grid-area: 1 / 1 / 11 / 7; z-index: 1; --grid-item-padding-y: 0px; --grid-item-padding-x: 0px; order:2;">
+                    <img src="/web/image/website.s_text_cover_default_image" class="img img-fluid rounded order-lg-0" alt=""/>
+                </div>
+                <div class="o_grid_item o_cc o_cc2 g-col-lg-6 g-height-10 col-lg-6 rounded order-lg-0" style="grid-area: 1 / 7 / 11 / 13; z-index: 2; --grid-item-padding-y: 140px; --grid-item-padding-x: 48px; order:1;">
+                    <h3>Learn about our offerings</h3>
+                    <p>Write one or two paragraphs describing your product or services. To be successful your content needs to be useful to your readers.</p>
+                    <p>Start with the customer – find out what they want and give it to them.</p>
+                    <p class="mb-0"><a href="#" class="btn btn-primary">Learn more</a></p>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -82,6 +82,9 @@
                 <t t-snippet="website.s_image_hexagonal" string="Image Hexagonal" group="content">
                     <keywords>content, picture, photo, illustration, media, visual, article, story, combination, more, hexagon, geometric</keywords>
                 </t>
+                <t t-snippet="website.s_image_text_box" string="Image Text Box" group="content">
+                    <keywords>content, picture, photo, illustration, media, visual, article, story, combination, engage, call to action, cta, box, showcase</keywords>
+                </t>
                 <t t-snippet="website.s_call_to_action" string="Call to Action" group="content">
                     <keywords>CTA</keywords>
                 </t>


### PR DESCRIPTION
This commit introduces the new `s_image_text_box` content snippet.

Part of task-4077427
task-4094363

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
