### PR TITLE
[FIX] sale_project: allow linking task based on invoice/shipping partner

### DIFF
--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -1,9 +1,7 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
 from collections import defaultdict
-from datetime import date
 
 from odoo import api, fields, models, _, _lt
 from odoo.exceptions import ValidationError, AccessError
@@ -829,16 +827,20 @@ class ProjectTask(models.Model):
             if not task.allow_billable:
                 task.sale_order_id = False
                 continue
-            sale_order_id = task.sale_order_id or self.env["sale.order"]
-            if task.sale_line_id:
-                sale_order_id = task.sale_line_id.sudo().order_id
-            elif task.project_id.sale_order_id:
-                sale_order_id = task.project_id.sale_order_id
-            if task.partner_id.commercial_partner_id != sale_order_id.partner_id.commercial_partner_id:
-                sale_order_id = False
-            if sale_order_id and not task.partner_id:
-                task.partner_id = sale_order_id.partner_id
-            task.sale_order_id = sale_order_id
+            sale_order = (
+                task.sale_line_id.order_id
+                or task.project_id.sale_order_id
+                or task.sale_order_id
+            )
+            so_partners = (
+                sale_order.partner_id
+                | sale_order.partner_invoice_id
+                | sale_order.partner_shipping_id
+            )
+            if task.partner_id.commercial_partner_id in so_partners.commercial_partner_id:
+                task.sale_order_id = sale_order
+            else:
+                task.sale_order_id = False
 
     @api.depends('allow_billable')
     def _compute_partner_id(self):

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -1,11 +1,11 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import Command
-from odoo.tests.common import new_test_user
+from odoo.exceptions import AccessError
+from odoo.tests import Form, new_test_user, tagged
+
 from .common import TestSaleProjectCommon
-from odoo.tests import Form
-from odoo.tests.common import tagged
+
 
 @tagged('post_install', '-at_install')
 class TestSaleProject(TestSaleProjectCommon):
@@ -774,3 +774,46 @@ class TestSaleProject(TestSaleProjectCommon):
         })
         action = sale_order_2.action_view_task()
         self.assertEqual(action["context"]["default_project_id"], self.project_global.id)
+
+    def test_task_compute_sale_order_id(self):
+        """
+        Check whether a task's sale_order_id is set iff its partner_id matches
+        the SO's partner_id, partner_invoice_id, or partner_shipping_id fields.
+        """
+        project_user = new_test_user(
+            self.env, groups='project.group_project_user',
+            login='Project user', name='Project user',
+        )
+        partners = [
+            self.partner,
+            self.partner_a,
+            self.partner_b,
+            self.env['res.partner'].create({'name': "unrelated partner"}),
+        ]
+        sale_order = self.env['sale.order'].with_context(tracking_disable=True).create({
+            'partner_id': partners[0].id,
+            'partner_invoice_id': partners[1].id,
+            'partner_shipping_id': partners[2].id,
+            'order_line': [Command.create({'product_id': self.product_order_service1.id})],
+        })
+        sale_order.action_confirm()
+
+        task0, task1, task2, task3 = self.env['project.task'].with_user(project_user).create([{
+            'name': f"Task {i}",
+            'sale_line_id': sale_order.order_line.id,
+            'project_id': self.project_global.id,
+            'partner_id': partner.id,
+        } for i, partner in enumerate(partners)])
+
+        self.assertEqual(task0.sale_order_id, sale_order, "Task matches SO's partner_id")
+        self.assertEqual(task1.sale_order_id, sale_order, "Task matches SO's partner_invoice_id")
+        self.assertEqual(task2.sale_order_id, sale_order, "Task matches SO's partner_shipping_id")
+        self.assertFalse(task3.sale_order_id, "Task partner doesn't match any of the SO partners")
+
+        with self.assertRaises(AccessError):
+            sale_order.with_user(project_user).partner_id
+        task3.with_user(project_user).write({
+            'partner_id': self.partner.id,
+            'sale_line_id': sale_order.order_line.id,
+        })
+        self.assertEqual(task3.sale_order_id, sale_order, "Task matches SO's partner_id")


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Have industry_fsm_sale from enterprise installed;
2. create a SO using a different `partner_id` for the shipping address;
3. add a product that uses timesheets without creating a task;
3. confirm the sale order;
4. in Field Service, create a new task;
5. set Customer to `partner_id` used for shipping address;
6. select the relevant Sales Order Item;
7. add a product in catalog.

Issue
-----
After adding a product to the field service task, a new SO is created instead of adding it to the existing SO (as would be the case if the task was created by the SOL).

Cause
-----
When computing a task's `sale_order_id`, it checks whether the task's `partner_id` matches that of the sale order. FSM tasks generally use the `partner_shipping_id` instead, so if this one is different, `sale_order_id` is set to `False`.

Solution
--------
Aside from  sale order's `partner_id`, also check its `partner_invoice_id` and `partner_shipping_id` when deciding whether the task should get linked to the SO.

Also changes one of the dependent fields of the compute method from `project_id` to `project_id.sale_order_id`, assuming that when a task's `sale_order_id` is derived from its project's, changing the project's SO should trigger a recompute for the task's as well.

opw-3901885