### PR TITLE
[FIX] website: avoid height stretch in o_scroll_button

### DIFF
--- a/addons/website/static/src/snippets/s_text_cover/000.scss
+++ b/addons/website/static/src/snippets/s_text_cover/000.scss
@@ -1,7 +1,7 @@
 .s_text_cover {
     // Needed to be able to stretch the inner container so that
     // the snippet works with the 50% and 100% height
-    > * {
+    > *:not(.o_scroll_button) {
         &, > .row {
             min-height: inherit;
         }


### PR DESCRIPTION
Since version 17.0, there is an issue with the Text Cover snippet where the scroll button becomes deformed and takes up the entire height of the snippet when the scroll down button is toggled and the snippet is set to 100% height.

The problem occurs because the `.s_text_cover` CSS rule `.s_text_cover > *` applies `min-height: inherit;` to all direct children, including the scroll button.

To resolve this, the CSS rule has been updated to exclude the scroll button from inheriting the minimum height by adding a `:not(.o_scroll_button)` selector.

task-4091232