### PR TITLE
[FIX] web_editor: missing protocol in video selector

### DIFF
--- a/addons/web_editor/static/src/components/media_dialog/video_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/video_selector.js
@@ -104,7 +104,7 @@ export class VideoSelector extends Component {
             if (this.props.media) {
                 const src = this.props.media.dataset.oeExpression || this.props.media.dataset.src || (this.props.media.tagName === 'IFRAME' && this.props.media.getAttribute('src')) || '';
                 if (src) {
-                    this.state.urlInput = src;
+                    this.state.urlInput = "https:" + src;
                     await this.updateVideo();
 
                     this.state.options = this.state.options.map((option) => {

--- a/addons/website/static/tests/tours/media_iframe_video.js
+++ b/addons/website/static/tests/tours/media_iframe_video.js
@@ -49,6 +49,25 @@ registerWebsitePreviewTour("website_media_iframe_video", {
             run: "click",
         },
         {
+            content: "Click on replace media",
+            trigger: "[data-replace-media='true']",
+            run: "click",
+        },
+        {
+            content: "Check that video url has protocol",
+            trigger: "#o_video_text",
+            run() {
+                if (!this.anchor.value.startsWith("https")) {
+                    console.error("Video Url is missing protocol");
+                }
+            },
+        },
+        {
+            content: "Close the dialog",
+            trigger: "button.btn-close",
+            run: "click",
+        },
+        {
             content: "Ensure that the parent of media_iframe_video is not an 'a' tag.",
             trigger: ":iframe .media_iframe_video",
             run: function () {


### PR DESCRIPTION
 Steps to Reproduce:
 1.Go to Website --> Drag and drop an Image snippet(here Image - text).
 2.Double click on the image --> Add any platform url in the video
 tab.
 3.Once the video is shown click add it will add the video to snippet.
 4.Again open video selector dialog the video url protocol is missing.

Issue Reason:
This issue is caused as url is checked against the regexes for particular platform and if url is valid then a formatted url is sent which doesn't contain protocol part.

Solution:
Changed the formatted url by adding `https:` part at the start of formatted url.

This PR solves the issue of missing url protocol in video selector once video is added.

task-4091138

