### PR TITLE
[FIX] pos_sale: show product name in downpayments

### DIFF
--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -52,7 +52,7 @@ class SaleOrderLine(models.Model):
             sale_line.qty_invoiced += sum([self._convert_qty(sale_line, pos_line.qty, 'p2s') for pos_line in sale_line.pos_order_line_ids], 0)
 
     def _get_sale_order_fields(self):
-        return ["product_id", "display_name", "price_unit", "product_uom_qty", "tax_id", "qty_delivered", "qty_invoiced", "discount", "qty_to_invoice", "price_total", "is_downpayment"]
+        return ["product_id", "display_name", "name", "price_unit", "product_uom_qty", "tax_id", "qty_delivered", "qty_invoiced", "discount", "qty_to_invoice", "price_total", "is_downpayment"]
 
     def read_converted(self):
         field_names = self._get_sale_order_fields()

--- a/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js
+++ b/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js
@@ -381,7 +381,7 @@ export class SaleOrderManagementScreen extends Component {
         Object.keys(grouped).forEach((key) => {
             const group = grouped[key];
             const tab = group.map((line) => ({
-                product_name: line.product_id[1],
+                product_name: line.name,
                 product_uom_qty: line.product_uom_qty,
                 price_unit: line.price_unit,
                 total: line.price_total,

--- a/addons/pos_sale/static/tests/helpers/ReceiptScreenTourMethods.js
+++ b/addons/pos_sale/static/tests/helpers/ReceiptScreenTourMethods.js
@@ -8,3 +8,12 @@ export function checkCustomerNotes(note) {
         }
     ];
 }
+export function checkDownpaymentProducts(product) {
+    return [
+        {
+            content: `check down-payment details`,
+            trigger: `.orderline:contains('Down Payment') .info-list:contains(${product})`,
+            run: () => {},
+        }
+    ];
+}

--- a/addons/pos_sale/static/tests/tours/PosSaleTour.js
+++ b/addons/pos_sale/static/tests/tours/PosSaleTour.js
@@ -87,6 +87,7 @@ registry.category("web_tour.tours").add("PosRefundDownpayment", {
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Cash"),
             PaymentScreen.clickValidate(),
+            ReceiptScreen.checkDownpaymentProducts('1xproduct_a'),
             ReceiptScreen.clickNextOrder(),
             ProductScreen.clickRefund(),
             // Filter should be automatically 'Paid'.


### PR DESCRIPTION
Currently, when making downpayment the name on the product concerned by the downpayment are not reflected on the receipt.

Steps to reproduce:
-------------------
* Go to the **Sale** App
* Make a quotation with multiple products -> Save
* Go to the **Point of Sale** App
* Make a downpayment for the quotation just created
* Pay and validate
> Observation: We see multiple '1x ' lines on the receipt, under the downpayment
line but the product names are not shown

Why the fix:
------------
https://github.com/odoo/odoo/blob/9e934b83ed200317947ee7575deb443e721290e8/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js#L384 `line.product_id` is now only a number thus `line.product_id[1]` is undefined. We could use `line.display_name` as it is already currently loaded but there is too much information on the display name. It has the following format: `Sale Order nbr - Name of the product - Customer of the SO`

opw-4043149