### PR TITLE
[FIX] account: fix 'ref' field misalignment on 'entry' move

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -887,7 +887,7 @@
                                        invisible="move_type not in ('out_invoice', 'out_refund', 'out_receipt')"/>
                                 <label for="partner_id" string="Vendor" style="font-weight:bold;"
                                        invisible="move_type not in ('in_invoice', 'in_refund', 'in_receipt')"/>
-                                <div class="o_col">
+                                <div class="o_col" invisible="move_type not in ('out_invoice', 'out_refund', 'out_receipt', 'in_invoice', 'in_refund', 'in_receipt')">
                                     <field name="partner_id" widget="res_partner_many2one" nolabel="1"
                                            context="{
                                             'res_partner_search_mode': (context.get('default_move_type', 'entry') in ('out_invoice', 'out_refund', 'out_receipt') and 'customer') or (context.get('default_move_type', 'entry') in ('in_invoice', 'in_refund', 'in_receipt') and 'supplier') or False,


### PR DESCRIPTION
Following odoo/odoo@ce41d1db9753, we should apply the same `invisible` logic for the new `<div class="o_col">` as the inner field, otherwise that element will still be rendered (even if empty) and will induce a shift - producing misalignment between label and its field.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
