### PR TITLE
[FIX] account: fix traceback when the user removes the journal in payment

### DIFF
--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -656,7 +656,7 @@ class AccountPaymentRegister(models.TransientModel):
     @api.depends('partner_id', 'amount', 'payment_date', 'payment_type', 'line_ids')
     def _compute_duplicate_moves(self):
         for wizard in self:
-            if wizard.can_edit_wizard:
+            if wizard.can_edit_wizard and wizard.journal_id:
                 wizard.duplicate_move_ids = self._fetch_duplicate_reference()
             else:
                 wizard.duplicate_move_ids = self.env['account.move']


### PR DESCRIPTION
Currently, a traceback occurs when the user removes the `journal` while registering a payment.

To reproduce this issue:

1) Install `accounting`
2) create an invoice with a line and confirm it
3) Click on `payment Register` and remove the `journal`

Error:- 
```
ValueError: Expected singleton: account.journal()
```

This is because when the user removes the journal a compute method triggers,
through which another method `_fetch_duplicate_reference` calls.

In this method, `journal_id` is referenced to call another method in which ensure one is used. 
This leads to the traceback

https://github.com/odoo/odoo/blob/79aef2ed06f813197651f83272d4508200a8ce72/addons/account/wizard/account_payment_register.py#L675-L677

After applying this commit, it will resolve this issue by doing an extra check of j`ournal_id`, 
which makes the code more robust.

sentry-5675331371

