### PR TITLE
[FIX] stock: update counted quantity widget on blur

### DIFF
--- a/addons/stock/__manifest__.py
+++ b/addons/stock/__manifest__.py
@@ -112,6 +112,7 @@
             'stock/static/tests/tours/*.js',
         ],
         'web.qunit_suite_tests': [
+            'stock/static/tests/counted_quantity_widget_tests.js',
             'stock/static/tests/inventory_report_list_tests.js',
             'stock/static/tests/popover_widget_tests.js',
             'stock/static/tests/stock_traceability_report_backend_tests.js',

--- a/addons/stock/static/src/widgets/counted_quantity_widget.js
+++ b/addons/stock/static/src/widgets/counted_quantity_widget.js
@@ -17,9 +17,11 @@ export class CountedQuantityWidgetField extends FloatField {
                 if (inputEl) {
                     inputEl.addEventListener("input", this.onInput.bind(this));
                     inputEl.addEventListener("keydown", this.onKeydown.bind(this));
+                    inputEl.addEventListener("blur", this.onBlur.bind(this));
                     return () => {
                         inputEl.removeEventListener("input", this.onInput.bind(this));
                         inputEl.removeEventListener("keydown", this.onKeydown.bind(this));
+                        inputEl.removeEventListener("blur", this.onBlur.bind(this));
                     };
                 }
             },
@@ -31,13 +33,24 @@ export class CountedQuantityWidgetField extends FloatField {
         return this.props.record.update({ inventory_quantity_set: true });
     }
 
+    updateValue(ev){
+        try {
+           const val = this.parse(ev.target.value);
+            this.props.record.update({ [this.props.name]: val });
+        } catch {} // ignore since it will be handled later
+    }
+
+    onBlur(ev) {
+         if (!this.props.record.data.inventory_quantity_set) {
+           return;
+        }
+        this.updateValue(ev);
+    }
+
     onKeydown(ev) {
         const hotkey = getActiveHotkey(ev);
         if (["enter", "tab", "shift+tab"].includes(hotkey)) {
-            try {
-                const val = this.parse(ev.target.value);
-                this.props.record.update({ [this.props.name]: val });
-            } catch {} // ignore since it will be handled later
+            this.updateValue(ev);
             this.onInput(ev);
         }
     }

--- a/addons/stock/static/tests/counted_quantity_widget_tests.js
+++ b/addons/stock/static/tests/counted_quantity_widget_tests.js
@@ -1,0 +1,101 @@
+/** @odoo-module **/
+
+import { click, editInput, getFixture } from "@web/../tests/helpers/utils";
+import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
+
+let serverData;
+let target;
+
+QUnit.module("CountedQuantityWidget", (hooks) => {
+    hooks.beforeEach(() => {
+        target = getFixture();
+        serverData = {
+            models: {
+                'stock.quant': {
+                    fields: {
+                        quantity: { string: "Quantity", type: "float" },
+                        inventory_quantity: { string: "Counted quantity", type: "float" },
+                        inventory_quantity_set: { string: "Inventory quantity set", type: "boolean" },
+                        inventory_diff_quantity: { string: "Difference", type: "float" },
+                    },
+                    records: [
+                        { id: 1, quantity: 50},
+                    ],
+                    onchanges: {
+                        inventory_quantity: (quant) => {
+                            quant.inventory_diff_quantity = quant.inventory_quantity - quant.quantity;
+                        },
+
+                    }
+                },
+            },
+        };
+
+        setupViewRegistries();
+    });
+
+    QUnit.test("Test changing the inventory quantity with the widget", async function (assert) {
+        await makeView({
+            type: "list",
+            serverData,
+            resModel: "stock.quant",
+            arch: `<tree editable="bottom">
+                        <field name="quantity"/>
+                        <field name="inventory_quantity" widget="counted_quantity_widget"/>
+                        <field name="inventory_quantity_set"/>
+                        <field name="inventory_diff_quantity"/>
+                   </tree>
+                `,
+        });
+
+        await click(target, "td.o_counted_quantity_widget_cell");
+        let input = document.activeElement;
+        await editInput(input, null, "23");
+        await click(target, "td[name=inventory_diff_quantity]");
+
+        assert.equal(
+            target.querySelector("td[name=inventory_diff_quantity] div input").value,
+            -27
+        );
+        assert.strictEqual(
+            target.querySelector("td[name=inventory_quantity_set] div input").value,
+            "on"
+        );
+
+        await click(target, "td.o_counted_quantity_widget_cell");
+        input = document.activeElement;
+        await editInput(input, null, "40.5");
+        await click(target, "td[name=inventory_diff_quantity]");
+
+        assert.equal(
+            target.querySelector("td[name=inventory_diff_quantity] div input").value,
+            -9.5
+        );
+
+    });
+
+    QUnit.test("Test setting the inventory quantity to its default value of 0", async function (assert) {
+        await makeView({
+            type: "list",
+            serverData,
+            resModel: "stock.quant",
+            arch: `<tree editable="bottom">
+                        <field name="quantity"/>
+                        <field name="inventory_quantity" widget="counted_quantity_widget"/>
+                        <field name="inventory_quantity_set"/>
+                        <field name="inventory_diff_quantity"/>
+                   </tree>
+                `,
+        });
+
+        await click(target, "td.o_counted_quantity_widget_cell");
+        let input = document.activeElement;
+        await editInput(input, null, "0");
+        await click(target, "td[name=inventory_diff_quantity]");
+
+        assert.equal(
+            target.querySelector("td[name=inventory_diff_quantity] div input").value,
+            -50
+        );
+    });
+});


### PR DESCRIPTION
Issue
-----
When setting a "Counted Quantity" of 0 in the inventory adjustment, the
difference would incorrectly stay as 0.

Steps
-----
1. Inventory > Operations > Physical Inventory.
2. Set the "Counted Quantity" of a line where it is not set to 0.
-> The difference stays at 0.

Cause
-----
The widget was previously relying on an onchange being triggered even if
the actual value wasn't changed in input fields.
This beahviour was modified by https://github.com/odoo/odoo/commit/dcba2a87b7ab15b357d57c410868f19e829a8db0.
https://github.com/odoo/odoo/blob/69de944b95a9790548b239f3bf05ba48eda2efef/addons/web/static/src/views/fields/input_field_hook.js#L74
Since then, changing the value from 0.00 to 0 won't trigger the onchange
and the difference won't be computed.

Change
-----
Update the record on blur, in the same way it is already done on keydown.

opw-4064858
opw-4063994