### PR TITLE
[FIX] website_sale: apply custom ribbon color

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.editor.js
+++ b/addons/website_sale/static/src/js/website_sale.editor.js
@@ -177,7 +177,7 @@ options.registry.WebsiteSaleProductsItem = options.Class.extend({
     async createRibbon(previewMode, widgetValue, params) {
         await this._setRibbon(false);
         this.$ribbon.text(_t('Badge Text'));
-        this.$ribbon.addClass('bg-primary o_ribbon_left');
+        this.$ribbon.addClass('o_ribbon_left');
         this.ribbonEditMode = true;
         await this._saveRibbon(true);
     },
@@ -376,8 +376,7 @@ options.registry.WebsiteSaleProductsItem = options.Class.extend({
         $ribbons.removeClass(htmlClasses);
 
         $ribbons.addClass(ribbon.html_class || '');
-        $ribbons.attr('style',
-            `background-color: ${ribbon.bg_color ? `${ribbon.bg_color} !important` : 'inherit'}`);
+        $ribbons.css('background-color', ribbon.bg_color || '');
         $ribbons.css('color', ribbon.text_color || '');
 
         if (!this.ribbons[ribbonId]) {


### PR DESCRIPTION
Issue
-----
Changing the color of the product's ribbon to a custome one in eCommerce has
no effect outside of the editor (after clicking "Save", the background color
of the ribbon returns to the default one).

Change
-----
Since the bg-primary class is now set on the ribbon HTML at creation.
https://github.com/odoo/odoo/blob/56fd8440707a0f3f2ba298f8bf016577ca08796b/addons/website_sale/static/src/js/website_sale.editor.js#L180
Remove the bg-primary class from the ribbon.

opw-4069818