### PR TITLE
[FIX] web: line break after phone marker in contact widget

### DIFF
--- a/addons/web/static/src/webclient/actions/reports/report.scss
+++ b/addons/web/static/src/webclient/actions/reports/report.scss
@@ -266,5 +266,6 @@ li.oe-nested {
 .o_portal_address {
     span[itemprop="telephone"] {
         white-space: nowrap;
+        display: inline-block;
     }
 }


### PR DESCRIPTION
Currently there might be a line break after the phone marker in the contact widget.
It depends on the document layout and the length of the phone number.

After this commit the line break does not happen anymore.

(In commit cbcda0b222b17312b9e42e23801a330f0030033f line breaks inside phone numbers were removed.)

To reproduce:
1. Ensure Purchase app is installed
2. Settings -> Configure Document Layout
   - layout: boxed
   - font: Oswald
   - paper format: A4
3. Edit some partner to have a long phone number (E.g. via Purchase -> Orders (menu) -> Vendors) e.g. use: (870)-931-0505 12 12 12 12
4. Create a request for quotation / purchase order and select the partner from 3 as Vendor
5. Confirm the purchase order
6. Print the purchase order
7. There is a line break after the phone marker in the vendor address

opw-3783870
opw-3970768


PR the mentioned commit belongs to: https://github.com/odoo/odoo/pull/166336