### PR TITLE
[IMP] website: introduce `s_numbers_framed` snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -104,6 +104,7 @@
         'views/snippets/s_contact_info.xml',
         'views/snippets/s_numbers_boxed.xml',
         'views/snippets/s_cta_box.xml',
+        'views/snippets/s_numbers_framed.xml',
         'views/snippets/s_masonry_block.xml',
         'views/snippets/s_sidegrid.xml',
         'views/snippets/s_media_list.xml',

--- a/addons/website/views/snippets/s_numbers_framed.xml
+++ b/addons/website/views/snippets/s_numbers_framed.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_numbers_framed" name="Numbers framed">
+    <section class="s_numbers_framed o_colored_level pt80 pb80" data-oe-shape-data="{'shape':'web_editor/Blobs/12','flip':[], 'showOnMobile':true}">
+        <div class="o_we_shape o_shape_show_mobile o_web_editor_Blobs_12 o_we_animated"/>
+        <div class="o_container_small">
+            <h2 style="text-align: center;">Insights, stats, and metrics</h2>
+            <p class="lead" style="text-align: center;">This section allows to highlight key statistics.</p>
+            <div class="row">
+                <div class="col-12 col-lg-4 o_cc o_cc2 pt48 pb48">
+                    <h3 class="display-1" style="text-align: center;">12k</h3>
+                    <p class="fw-bold" style="text-align: center;">Useful options</p>
+                </div>
+                <div class="col-12 col-lg-4 o_cc o_cc2 pt48 pb48">
+                    <h3 class="display-1" style="text-align: center;">45%</h3>
+                    <p class="fw-bold" style="text-align: center;">More leads</p>
+                </div>
+                <div class="col-12 col-lg-4 o_cc o_cc2 pt48 pb48">
+                    <h3 class="display-1" style="text-align: center;">8+</h3>
+                    <p class="fw-bold" style="text-align: center;">Amazing pages</p>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -183,6 +183,9 @@
                 <t t-snippet="website.s_numbers_boxed" string="Numbers boxed" group="content">
                     <keywords>statistics, stats, KPI, metrics, dashboard, analytics, highlights, figures, performance, achievements, benchmarks, milestones, indicators, data, measurements, reports, trends, results, analytics, summaries, summary</keywords>
                 </t>
+                <t t-snippet="website.s_numbers_framed" string="Numbers framed" group="content">
+                    <keywords>statistics, stats, KPI, metrics, dashboard, analytics, highlights, figures, performance, achievements, benchmarks, milestones, indicators, data, measurements, reports, trends, results</keywords>
+                </t>
                 <t t-snippet="website.s_numbers_list" string="Numbers list" group="content">
                     <keywords>statistics, stats, KPI, metrics, dashboard, analytics, highlights, figures, skills, achievements, benchmarks, milestones, indicators, data, measurements, reports, trends, results, analytics, cta, call to action, button</keywords>
                 </t>


### PR DESCRIPTION
This PR introduces the new `s_framed_numbers` snippet.

![image](https://github.com/user-attachments/assets/6da3955c-c1db-421b-af93-319139374d2a)

- requires https://github.com/odoo/design-themes/pull/1000

---------

### Checklist
- [x] Meaningful demo-text
- [x] Adapts to color combinations -> Readable text
- [x] Mobile friendly
- [x] Has no `<h1>` tags (except for "Intro" snippets)
- [x] Has one `<h1>` tag ("Intro" snippets only)
- [x] Images are optimized
- [x] Images can be replaced by the website wizard (with fairly apparent exceptions)
- [x] No ineffective options. Eg "click -> nothing happens"
- [x] Edition is limited when not necessary
- [x] Behaves consistently with the rest of the snippets (images can be replaced, etc..)

task-4094384
Part of task-4077427

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr