### PR TITLE
[IMP] website: introduce `s_boxed_numbers` snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -100,6 +100,7 @@
         'views/snippets/s_quotes_carousel_minimal.xml',
         'views/snippets/s_numbers.xml',
         'views/snippets/s_contact_info.xml',
+        'views/snippets/s_numbers_boxed.xml',
         'views/snippets/s_cta_box.xml',
         'views/snippets/s_masonry_block.xml',
         'views/snippets/s_sidegrid.xml',

--- a/addons/website/views/snippets/s_numbers_boxed.xml
+++ b/addons/website/views/snippets/s_numbers_boxed.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_numbers_boxed" name="Numbers boxed">
+    <section class="s_numbers_boxed pt80 pb80 o_colored_level o_cc o_cc5">
+        <div class="container">
+            <div class="row o_grid_mode" data-row-count="8" style="column-gap: 40px;">
+                <div class="o_grid_item g-height-2 g-col-lg-12 col-12 col-lg-12" style="grid-area: 1 / 1 / 3 / 13; z-index: 1; text-align: center;">
+                    <h2 style="text-align: center;">Insights, stats, and metrics</h2>
+                    <p style="text-align: center;">This section allows to highlight key statistics.</p>
+                </div>
+                <div class="o_grid_item g-height-5 g-col-lg-4 col-12 col-lg-4 border rounded o_cc o_cc3 order-lg-0" style="grid-area: 4 / 1 / 9 / 5; --grid-item-padding-y: 64px; text-align: center; border-radius: 9.6px !important; z-index: 2; order: 1;">
+                    <h3 class="display-3-fs"><font style="background-image: linear-gradient(135deg, var(--o-color-4) 15%, var(--o-color-5) 100%);" class="text-gradient">30+</font></h3>
+                    <p><strong>Useful options</strong></p>
+                </div>
+                <div class="o_grid_item g-height-5 g-col-lg-4 col-6 col-lg-4 border rounded o_cc o_cc3" style="grid-area: 4 / 5 / 9 / 9; --grid-item-padding-y: 64px; text-align: center; border-radius: 9.6px !important; z-index: 3;">
+                    <h3 class="display-3-fs"><font style="background-image: linear-gradient(45deg, var(--o-color-4) 15%, var(--o-color-5) 100%);" class="text-gradient">45%</font></h3>
+                    <p><strong>More leads</strong></p>
+                </div>
+                <div class="o_grid_item g-height-5 g-col-lg-4 col-6 col-lg-4 border rounded o_cc o_cc3" style="grid-area: 4 / 9 / 9 / 13; --grid-item-padding-y: 64px; text-align: center; border-radius: 9.6px !important; z-index: 4;">
+                    <h3 class="display-3-fs"><font style="background-image: linear-gradient(45deg, var(--o-color-4) 15%, var(--o-color-5) 100%);" class="text-gradient">8+</font></h3>
+                    <p><strong>Amazing pages</strong></p>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -177,6 +177,9 @@
                 <t t-snippet="website.s_numbers" string="Numbers" group="content">
                     <keywords>statistics, stats, KPI, metrics, dashboard, analytics, highlights, figures, skills, achievements, benchmarks, milestones, indicators, data, measurements, reports, trends, results, analytics, summaries, summary</keywords>
                 </t>
+                <t t-snippet="website.s_numbers_boxed" string="Numbers boxed" group="content">
+                    <keywords>statistics, stats, KPI, metrics, dashboard, analytics, highlights, figures, performance, achievements, benchmarks, milestones, indicators, data, measurements, reports, trends, results, analytics, summaries, summary</keywords>
+                </t>
                 <t t-snippet="website.s_numbers_list" string="Numbers list" group="content">
                     <keywords>statistics, stats, KPI, metrics, dashboard, analytics, highlights, figures, skills, achievements, benchmarks, milestones, indicators, data, measurements, reports, trends, results, analytics, cta, call to action, button</keywords>
                 </t>


### PR DESCRIPTION
This PR introduces the new `s_boxed_numbers` snippet.

- requires https://github.com/odoo/design-themes/pull/979

<img width="1711" alt="image" src="https://github.com/user-attachments/assets/3d50054a-5091-4e8c-8418-945f31d64f36">

---------

### Checklist
- [x] Meaningful demo-text
- [x] Adapts to color combinations -> Readable text
- [x] Mobile friendly
- [x] Has no `<h1>` tags (except for "Intro" snippets)
- [x] Has one `<h1>` tag ("Intro" snippets only)
- [x] Images are optimized
- [x] Images can be replaced by the website wizard (with fairly apparent exceptions)
- [x] No ineffective options. Eg "click -> nothing happens"
- [x] Edition is limited when not necessary
- [x] Behaves consistently with the rest of the snippets (images can be replaced, etc..)

task-4094382
Part of task-4077427

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr