### PR TITLE
[FIX] website: prevent scrolling when keeping focus when hovering menus

### DIFF
--- a/addons/website/static/src/js/content/menu.js
+++ b/addons/website/static/src/js/content/menu.js
@@ -659,7 +659,7 @@ publicWidget.registry.hoverableDropdown = animations.Animation.extend({
         // Keep the focus on the previously focused element if any, otherwise do
         // not focus the dropdown on hover.
         if (focusedEl) {
-            focusedEl.focus();
+            focusedEl.focus({preventScroll: true});
         } else {
             const dropdownToggleEl = ev.currentTarget.querySelector(".dropdown-toggle");
             if (dropdownToggleEl) {


### PR DESCRIPTION
In order to be more accessible, commit [1] allowed the hoverable menus to have an outline when they are focused by using the Tab key. When hovering these menus with the mouse, the outline should not appear, unless it was already focused (with the Tab key). Also, when hovering, the focus should stay on the already focused element.

This last part causes some issues: indeed, the focus is kept by calling the `focus` function and the issue with it is that it scrolls to the element on which it is called. This made the screen scroll unexpectedly anytime we hovered a hoverable menu, to bring the focused element into view.

This commit fixes this issue by specifying that the screen should not scroll when focusing the element.

Steps to reproduce:
- In the menu editor, add some submenus.
- In edit mode, click on the header and set the "Sub Menus" option to "On Hover" and the "Scroll Effect" option to "Scroll".
- Go to the "/shop" page.
- In edit mode, add the cart button on the products and then save.
- Scroll down the page and add a product to the cart.
- Scroll up the page and hover the menu with a submenu. => The page scrolls down to the product we just added, since it was the focused element.

[1]: https://github.com/odoo/odoo/commit/0f7cbf2969b3c4b6c496e5b54814c4a9b3081af4

opw-4069610