### PR TITLE
[FIX] website: make video upload "sanitize friendly"

### DIFF
--- a/addons/test_website/static/tests/tours/website_field_sanitize.js
+++ b/addons/test_website/static/tests/tours/website_field_sanitize.js
@@ -1,0 +1,62 @@
+/** @odoo-module */
+
+import { registry } from "@web/core/registry";
+import wTourUtils from "@website/js/tours/tour_utils";
+
+// As admin, add a YouTube video iframe in a `sanitize_overridable` HTML field.
+registry.category("web_tour.tours").add("website_designer_iframe_video", {
+    test: true,
+    steps: () => [
+        {
+            content: "Open the media dialog to add a video",
+            trigger: "iframe .fa-heart",
+            run: "dblclick",
+        },
+        {
+            content: 'Go to the "Videos" tab in the media dialog',
+            trigger: ".o_select_media_dialog .o_notebook_headers .nav-item a:contains('Videos')",
+        },
+        {
+            content: "Add a YouTube video",
+            trigger: ".o_select_media_dialog #o_video_text",
+            run: "text //www.youtube.com/embed/G8b4UZIcTfg",
+        },
+        {
+            content: "Save and close the media dialog",
+            extra_trigger: ".modal .o_video_preview .media_iframe_video iframe[src*='G8b4UZIcTfg']",
+            trigger: ".modal-footer .btn-primary",
+        },
+        ...wTourUtils.clickOnSave(),
+        {
+            content: "Check that the video was correctly saved",
+            trigger: "iframe .media_iframe_video[data-oe-expression*='G8b4UZIcTfg']",
+            run: () => {},
+        },
+    ],
+});
+
+// Check that a restricted editor can edit the field content (even with
+// a video iframe).
+registry.category("web_tour.tours").add("website_restricted_editor_iframe_video", {
+    test: true,
+    steps: () => [
+        {
+            content: "Check that the video iframe was correctly restored after saving the changes",
+            trigger:
+                "iframe [data-oe-field]:not([data-oe-sanitize-prevent-edition]) .media_iframe_video[data-oe-expression*='G8b4UZIcTfg']",
+            run: () => {},
+        },
+        {
+            content: "As a restricted editor, edit the HTML field content",
+            trigger: "iframe .o_test_website_description",
+            run: "text I can still edit the HTML field",
+        },
+        ...wTourUtils.clickOnSave(),
+        {
+            content: "Check that the HTML content (with a video iframe) was correctly updated",
+            trigger:
+                "iframe .o_test_website_description:contains('I can still edit the HTML field')",
+            run: () => {},
+        },
+    ],
+});

--- a/addons/test_website/tests/__init__.py
+++ b/addons/test_website/tests/__init__.py
@@ -23,3 +23,4 @@ from . import test_snippet_background_video
 from . import test_systray
 from . import test_views_during_module_operation
 from . import test_website_controller_page
+from . import test_website_field_sanitize

--- a/addons/test_website/tests/test_website_field_sanitize.py
+++ b/addons/test_website/tests/test_website_field_sanitize.py
@@ -1,0 +1,41 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo
+import odoo.tests
+
+
+@odoo.tests.tagged('-at_install', 'post_install')
+class TestWebsiteFieldSanitize(odoo.tests.HttpCase):
+    def test_sanitize_video_iframe(self):
+        self.env['res.users'].create({
+            'name': 'Restricted Editor',
+            'login': 'restricted',
+            'password': 'restricted',
+            'groups_id': [(6, 0, [
+                self.ref('base.group_user'),
+                self.ref('website.group_website_restricted_editor'),
+                self.ref('test_website.group_test_website_admin'),
+            ])]
+        })
+        self.record = self.env['test.model'].create({
+            'name': 'Test Record',
+            'website_description': """
+                <div class="o_test_website_description">
+                    A simple sanitize friendly content.
+                    <i class="fa fa-heart"/>
+                </div>
+            """,
+        })
+
+        # Add a video to an HTML field (admin).
+        self.start_tour(
+            self.env['website'].get_client_action_url(f'/test_website/model_item/{self.record.id}', True),
+            'website_designer_iframe_video',
+            login='admin'
+        )
+        # Make sure a user can still edit the content (restricted editor).
+        self.start_tour(
+            self.env['website'].get_client_action_url(f'/test_website/model_item/{self.record.id}', True),
+            'website_restricted_editor_iframe_video',
+            login='restricted'
+        )

--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -166,6 +166,7 @@
             'website/static/src/js/content/auto_hide_menu.js',
             'website/static/src/js/content/redirect.js',
             'website/static/src/js/content/adapt_content.js',
+            'website/static/src/js/content/generate_video_iframe.js',
         ],
         'web.assets_frontend_lazy': [
             # Remove assets_frontend_minimal
@@ -173,6 +174,7 @@
             ('remove', 'website/static/src/js/content/auto_hide_menu.js'),
             ('remove', 'website/static/src/js/content/redirect.js'),
             ('remove', 'website/static/src/js/content/adapt_content.js'),
+            ('remove', 'website/static/src/js/content/generate_video_iframe.js'),
         ],
         'web._assets_primary_variables': [
             'website/static/src/scss/primary_variables.scss',

--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -1399,4 +1399,19 @@ export class WysiwygAdapterComponent extends Wysiwyg {
         }
         this._hideDropdowns();
     }
+    /**
+     * @override
+     */
+    async _onMediaDialogSave(params, element) {
+        await super._onMediaDialogSave(...arguments);
+        // This wasn't needed before activating the "iframe video" public widget
+        // in the edit mode. It should allow destroying newly added iframes and
+        // prevent saving them in the DOM.
+        if (element.classList.contains("media_iframe_video")) {
+            this._websiteRootEvent("widgets_start_request", {
+                editableMode: true,
+                $target: $(element),
+            });
+        }
+    }
 }

--- a/addons/website/static/src/js/content/generate_video_iframe.js
+++ b/addons/website/static/src/js/content/generate_video_iframe.js
@@ -1,0 +1,94 @@
+/** @odoo-module **/
+
+const SUPPORTED_DOMAINS = [
+    "youtu.be",
+    "youtube.com",
+    "youtube-nocookie.com",
+    "instagram.com",
+    "vine.co",
+    "player.vimeo.com",
+    "vimeo.com",
+    "dailymotion.com",
+    "player.youku.com",
+    "youku.com",
+];
+
+/**
+ * Escapes a string to HTML interpolation.
+ * Remark: this function is already available in the codebase (see:
+ * `web/.../core/utils/strings.js`), but we need to reimplement it
+ * here for non-lazy code.
+ *
+ * @param {String} str The string to escape.
+ * @returns {String}
+ */
+export function escape(str) {
+    if (!str) {
+        return "";
+    }
+    for (const [unescaped, escaped] of [
+        ["&", "&amp;"],
+        ["<", "&lt;"],
+        [">", "&gt;"],
+        ["'", "&#x27;"],
+        ['"', "&quot;"],
+        ["`", "&#x60;"],
+    ]) {
+        str = str.replaceAll(unescaped, escaped);
+    }
+    return str;
+}
+
+/**
+ * Builds a video iframe for a saved `src` and appends it to the DOM.
+ *
+ * @param {HTMLElement} parentEl The iframe container.
+ * @returns {HTMLIframeElement}
+ */
+export function generateVideoIframe(parentEl) {
+    // Bug fix / compatibility: empty the <div/> element as all information
+    // to rebuild the iframe should have been saved on the <div/> element
+    parentEl.replaceChildren();
+
+    // Add extra content for size / edition
+    const extraEditionEl = document.createElement("div");
+    extraEditionEl.className = "css_editable_mode_display";
+    const extraSizeEl = document.createElement("div");
+    extraSizeEl.className = "media_iframe_video_size";
+    parentEl.append(extraEditionEl, extraSizeEl);
+
+    // Rebuild the iframe. Depending on version / compatibility / instance,
+    // the src is saved in the 'data-src' attribute or the
+    // 'data-oe-expression' one (the latter is used as a workaround in 10.0
+    // system but should obviously be reviewed in master).
+    const src = escape(parentEl.dataset.oeExpression || parentEl.dataset.src);
+    // Validate the src to only accept supported domains we can trust
+    const m = src.match(/^(?:https?:)?\/\/([^/?#]+)/);
+    if (!m) {
+        // Unsupported protocol or wrong URL format, don't inject iframe
+        return;
+    }
+    const domain = m[1].replace(/^www\./, "");
+    if (!SUPPORTED_DOMAINS.includes(domain)) {
+        // Unsupported domain, don't inject iframe
+        return;
+    }
+    const iframeEl = document.createElement("iframe");
+    iframeEl.setAttribute("src", src);
+    iframeEl.setAttribute("frameborder", "0");
+    iframeEl.setAttribute("allowfullscreen", "allowfullscreen");
+    parentEl.appendChild(iframeEl);
+
+    return iframeEl;
+}
+
+/**
+ * Auto generate video iframes.
+ */
+document.addEventListener("DOMContentLoaded", () => {
+    for (const videoIframeEl of document.querySelectorAll(".media_iframe_video")) {
+        if (!videoIframeEl.querySelector(":scope > iframe")) {
+            generateVideoIframe(videoIframeEl);
+        }
+    }
+});


### PR DESCRIPTION
Steps to reproduce the current behaviour:

- Update the DEMO user to be a website "restricted editor" and sales
"admin" who cannot bypass HTML field sanitization.

- As ADMIN, add a YouTube video to a product page > Save.

- As DEMO, try to update the content on the product page > You cannot
(a dialog informs you that you cannot edit the content because an admin
edited it previously).

Explanation:

Starting from [1], an HTML field can be flagged as `sanitize_overridable`
which allowed users with the `base.group_sanitize_override` group to
skip the HTML field sanitize process.

If such users added some content that is not considered "sanitize
friendly" (e.g. YouTube iframe), a restricted user won't be allowed to
add content in the fields, since the sanitizer will remove the original
content from the DOM.

For this case, the code from [2] added an implementation to consider the
field as none editable and warn the user once he tries to update it.

Implementation:

The goal of this commit it to fix the current limitation for video
upload that currently prevents non admin users to edit a website record
once an admin adds a video on it...

The idea of the fix is the following:

- We already have a technical fallback when uploading a video to save
the iframe `src` to an attribute: `data-oe-expression`.
- The public widget is now destroying the video iframes so they are
never saved in the DOM.
- A non-lazy code will build the iframes immediately on page load.
- The public widget can always create the iframes if they are not
already created (for compatibility).

[1]: https://github.com/odoo/odoo/commit/cf844e34dd0ce4830eb99fd0fa5b6b9cb58c867c
[2]: https://github.com/odoo/odoo/commit/cb80c15d3db49ede3c93171abcaa9064b88822c6

task-3757205