### PR TITLE
[FIX] purchase: update price and description in POL when changing vendor

### DIFF
--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -318,7 +318,7 @@ class PurchaseOrderLine(models.Model):
             return {'warning': warning}
         return {}
 
-    @api.depends('product_qty', 'product_uom', 'company_id')
+    @api.depends('product_qty', 'product_uom', 'company_id', 'order_id.partner_id')
     def _compute_price_unit_and_date_planned_and_name(self):
         for line in self:
             if not line.product_id or line.invoice_lines or not line.company_id:


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1”:
    - internal reference : “J1”
    - purchase tab:
        - Azure interior: price: $5, Vendor Product Code: Vendor 1
        - Deco addict: price $10, Vendor Product Code: Vendor 2

- Create a purchase order:
    - Vendor: Azure interior
    - Product: P1

Result: the price and the description is updated to [Vendor 1] P1 and $5

- Update the vendor to Deco Addict

Problem:
The price and description are not updated to $10 and [Vendor 2] P1
because the `onchange_product_id` is not triggered and We can't add it
to the depends since the vendor field is not present in POL

opw-[3953442](https://www.odoo.com/web#id=3953442&view_type=form&model=project.task)