### PR TITLE
[FIX] hr_holidays : Delete time-off timesheets when archiving employee

### DIFF
--- a/addons/hr_holidays/wizard/hr_departure_wizard.py
+++ b/addons/hr_holidays/wizard/hr_departure_wizard.py
@@ -20,7 +20,7 @@ class HrDepartureWizard(models.TransientModel):
             future_leaves = self.env['hr.leave'].search([('employee_id', '=', self.employee_id.id), 
                                                          ('date_to', '>', self.departure_date),
                                                          ('state', '!=', 'refuse')])
-            future_leaves.write({'state': 'refuse'})
+            future_leaves.action_refuse()
 
         if self.archive_allocation:
             employee_allocations = self.env['hr.leave.allocation'].search([('employee_id', '=', self.employee_id.id)])

--- a/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
+++ b/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
@@ -3,6 +3,7 @@
 
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
+from freezegun import freeze_time
 
 from odoo import fields, SUPERUSER_ID
 
@@ -122,3 +123,24 @@ class TestTimesheetHolidays(TestCommonTimesheet):
         })
         holiday.with_user(SUPERUSER_ID).action_validate()
         self.assertEqual(len(holiday.timesheet_ids), 0, 'Number of generated timesheets should be zero since the leave type does not generate timesheet')
+
+    @freeze_time('2018-02-01 08:00:00')
+    def test_timesheet_when_archiving_employee(self):
+        number_of_days = (self.leave_end_datetime - self.leave_start_datetime).days
+        holiday = self.Requests.with_user(self.user_employee).create({
+            'name': 'Leave 1',
+            'employee_id': self.empl_employee.id,
+            'holiday_status_id': self.hr_leave_type_with_ts.id,
+            'date_from': self.leave_start_datetime,
+            'date_to': self.leave_end_datetime,
+            'number_of_days': number_of_days,
+        })
+        holiday.with_user(SUPERUSER_ID).action_validate()
+
+        wizard = self.env['hr.departure.wizard'].create({
+            'employee_id': self.empl_employee.id,
+            'departure_date': datetime(2018, 2, 1, 12),
+            'archive_allocation': False,
+        })
+        wizard.action_register_departure()
+        self.assertEqual(len(holiday.timesheet_ids), 0, 'Timesheets related to the archived employee should have been deleted')


### PR DESCRIPTION
### Steps to reproduce:
	- Install Timesheet and Time-off modules
	- Let the time-off validation creates a timesheet
	- Create a time off for an employee and validate it
	- Archive this employee

### Current behavior before PR:
After archiving an employee you will still have the timesheets related to his upcoming leaves even when you are closing all of his activities.
This is happening because when archiving an employee we are just updating the state of his hr.leave to refuse without unlinking the timesheets https://github.com/odoo/odoo/blob/15.0/addons/hr_holidays/wizard/hr_departure_wizard.py#L23

### Desired behavior after PR is merged:
While archiving an employee we are calling the 'action_refuse' method where it will update the state of the employee's leaves and also will unlink the timesheet related to those leaves.

opw-4070684