### PR TITLE
[IMP] website: add new `s_numbers_grid` snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -78,6 +78,7 @@
         'views/snippets/s_chart.xml',
         'views/snippets/s_parallax.xml',
         'views/snippets/s_quotes_carousel.xml',
+        'views/snippets/s_numbers_grid.xml',
         'views/snippets/s_numbers.xml',
         'views/snippets/s_cta_box.xml',
         'views/snippets/s_masonry_block.xml',

--- a/addons/website/views/snippets/s_numbers_grid.xml
+++ b/addons/website/views/snippets/s_numbers_grid.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template name="Numbers Grid" id="s_numbers_grid">
+    <section class="s_numbers_grid o_cc o_cc2 pt56 pb56">
+        <div class="container">
+            <div class="row o_grid_mode" data-row-count="6" style="gap: 8px;">
+                <div class="o_grid_item g-col-md-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 1 / 1 / 4 / 4; z-index: 1; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
+                    <p>Revenue Growth</p>
+                    <span class="display-5">54%</span>
+                </div>
+                <div class="o_grid_item g-col-md-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 1 / 4 / 4 / 7;; z-index: 2; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
+                    <p>Projects deployed</p>
+                    <span class="display-5">+225</span>
+                </div>
+                <div class="o_grid_item g-col-md-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 1 / 7 / 4 / 10; z-index: 3; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
+                    <p>Expected revenue</p>
+                    <span class="display-5">$50M</span>
+                </div>
+                <div class="o_grid_item g-col-md-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 1 / 10 / 4 / 13; z-index: 4; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
+                    <p>Online Members</p>
+                    <span class="display-5">235,403</span>
+                </div>
+                <div class="o_grid_item g-col-md-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 4 / 1 / 7 / 4; z-index: 5; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
+                    <p>Customer Retention</p>
+                    <span class="display-5">85%</span>
+                </div>
+                <div class="o_grid_item g-col-md-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 4 / 4 / 7 / 7; z-index: 6; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
+                    <p>Inventory turnover</p>
+                    <span class="display-5">4x</span>
+                </div>
+                <div class="o_grid_item g-col-md-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 4 / 7 / 7 / 10; z-index: 7; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
+                    <p>Website visitors</p>
+                    <span class="display-5">100,000</span>
+                </div>
+                <div class="o_grid_item g-col-md-3 g-height-3 col-lg-3 col-6 o_cc o_cc1 pt16 pb40 border rounded" data-name="Number Cell" style="grid-area: 4 / 10 / 7 / 13; z-index: 8; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
+                    <p>Transactions</p>
+                    <span class="display-5">45,958</span>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -147,6 +147,9 @@
                 <t t-snippet="website.s_numbers_list" string="Numbers list" group="content">
                     <keywords>statistics, stats, KPI, metrics, dashboard, analytics, highlights, figures, performance, achievements, benchmarks, milestones, indicators, data, measurements, reports, trends, results, analytics, cta, call to action, button</keywords>
                 </t>
+                <t t-snippet="website.s_numbers_grid" string="Numbers Grid" group="content">
+                    <keywords>statistics, stats, KPI, metrics, dashboard, analytics, highlights, figures, performance, achievements, benchmarks, milestones, indicators, data, measurements, reports, trends, results</keywords>
+                </t>
                 <t t-snippet="website.s_features" string="Features" group="content">
                     <keywords>promotion, characteristic, quality</keywords>
                 </t>


### PR DESCRIPTION
This commit introduces the new `s_numbers_grid` content snippet.

Part of task-4077427
task-4094390

requires: https://github.com/odoo/design-themes/pull/855

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
