### PR TITLE
[IMP] web: Support {min,max}Precision props in the date field

### DIFF
--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -29,6 +29,8 @@ import { standardFieldProps } from "../standard_field_props";
  *  warnFuture?: boolean;
  *  showSeconds?: boolean;
  *  showTime?: boolean;
+ *  minPrecision?: string;
+ *  maxPrecision?: string;
  * }} DateTimeFieldProps
  *
  * @typedef {import("@web/core/datetime/datetime_picker").DateTimePickerProps} DateTimePickerProps
@@ -49,6 +51,16 @@ export class DateTimeField extends Component {
         warnFuture: { type: Boolean, optional: true },
         showSeconds: { type: Boolean, optional: true },
         showTime: { type: Boolean, optional: true },
+        minPrecision: {
+            type: String,
+            optional: true,
+            validate: (props) => ["days", "months", "years", "decades"].includes(props),
+        },
+        maxPrecision: {
+            type: String,
+            optional: true,
+            validate: (props) => ["days", "months", "years", "decades"].includes(props),
+        },
     };
     static defaultProps = {
         showSeconds: true,
@@ -104,6 +116,12 @@ export class DateTimeField extends Component {
                 pickerProps.rounding = this.props.rounding;
             } else if (!this.props.showSeconds) {
                 pickerProps.rounding = 0;
+            }
+            if (this.props.maxPrecision) {
+                pickerProps.maxPrecision = this.props.maxPrecision;
+            }
+            if (this.props.minPrecision) {
+                pickerProps.minPrecision = this.props.minPrecision;
             }
             return pickerProps;
         };
@@ -292,6 +310,34 @@ export const dateField = {
             type: "boolean",
             help: _t(`Displays a warning icon if the input dates are in the future.`),
         },
+        {
+            label: _t("Minimal precision"),
+            name: "min_precision",
+            type: "selection",
+            help: _t(
+                `Choose which minimal precision (days, months, ...) you want in the datetime picker.`
+            ),
+            choices: [
+                { label: _t("Days"), value: "days" },
+                { label: _t("Months"), value: "months" },
+                { label: _t("Years"), value: "years" },
+                { label: _t("Decades"), value: "decades" },
+            ],
+        },
+        {
+            label: _t("Maximal precision"),
+            name: "max_precision",
+            type: "selection",
+            help: _t(
+                `Choose which maximal precision (days, months, ...) you want in the datetime picker.`
+            ),
+            choices: [
+                { label: _t("Days"), value: "days" },
+                { label: _t("Months"), value: "months" },
+                { label: _t("Years"), value: "years" },
+                { label: _t("Decades"), value: "decades" },
+            ],
+        },
     ],
     supportedTypes: ["date"],
     extractProps: ({ attrs, options }, dynamicInfo) => ({
@@ -304,6 +350,8 @@ export const dateField = {
         rounding: options.rounding && parseInt(options.rounding, 10),
         startDateField: options[START_DATE_FIELD_OPTION],
         warnFuture: exprToBoolean(options.warn_future),
+        minPrecision: options.min_precision,
+        maxPrecision: options.max_precision,
     }),
     fieldDependencies: ({ type, attrs, options }) => {
         const deps = [];

--- a/addons/web/static/tests/views/fields/date_field.test.js
+++ b/addons/web/static/tests/views/fields/date_field.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { edit, press, queryAll, queryOne, scroll } from "@odoo/hoot-dom";
+import { click, edit, press, queryAll, queryOne, scroll, queryAllTexts } from "@odoo/hoot-dom";
 import { animationFrame, mockDate, mockTimeZone } from "@odoo/hoot-mock";
 import {
     assertDateTimePicker,
@@ -429,4 +429,76 @@ test("allow to use compute dates (+5d for instance)", async () => {
     expect(".o_field_date input").toHaveValue("02/20/2021");
     await fieldInput("date").edit("+5d");
     expect(".o_field_date input").toHaveValue("02/20/2021");
+});
+
+test("date field with min_precision option", async () => {
+    await mountView({
+        type: "form",
+        resModel: "res.partner",
+        resId: 1,
+        // Do not let the date field get the focus in the first place
+        arch: `
+                <form>
+                    <group>
+                        <field name="date" options="{'min_precision': 'months'}" />
+                    </group>
+                </form>`,
+    });
+
+    click(".o_field_date input");
+    await animationFrame();
+    expect(".o_date_item_cell").toHaveCount(12);
+    expect(queryAllTexts(".o_date_item_cell")).toEqual([
+        "Jan",
+        "Feb",
+        "Mar",
+        "Apr",
+        "May",
+        "Jun",
+        "Jul",
+        "Aug",
+        "Sep",
+        "Oct",
+        "Nov",
+        "Dec",
+    ]);
+    expect(".o_date_item_cell.o_selected").toHaveText("Feb");
+
+    click(getPickerCell("Jan"));
+    await animationFrame();
+    // The picker should be closed
+    expect(".o_date_item_cell").toHaveCount(0);
+    expect(".o_field_widget[name='date'] input").toHaveValue("01/01/2017");
+});
+
+test("date field with max_precision option", async () => {
+    await mountView({
+        type: "form",
+        resModel: "res.partner",
+        resId: 1,
+        // Do not let the date field get the focus in the first place
+        arch: `
+                <form>
+                    <group>
+                        <field name="date" options="{'max_precision': 'months'}" />
+                    </group>
+                </form>`,
+    });
+
+    click(".o_field_date input");
+    await animationFrame();
+    // Try to zoomOut twice to be in the year selector
+    await zoomOut();
+    // Currently in the month selector
+    expect(".o_datetime_picker_header").toHaveText("2017");
+    await zoomOut();
+    // Stay in the month selector according to the max precision value
+    expect(".o_datetime_picker_header").toHaveText("2017");
+    expect(".o_date_item_cell.o_selected").toHaveText("Feb");
+
+    click(getPickerCell("Jan"));
+    await animationFrame();
+    click(getPickerCell("12"));
+    await animationFrame();
+    expect(".o_field_widget[name='date'] input").toHaveValue("01/12/2017");
 });


### PR DESCRIPTION
The aim of this commit is supporting the minPrecision and maxPrecision props from the datetime picker component in the date field.
The idea is allowing developers to pass these props via the field options in the view.

Task where it's necessary: 4070179


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
