### PR TITLE
[IMP] website: introduce s_numbers_list snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -120,6 +120,7 @@
         'views/snippets/s_unveil.xml',
         'views/snippets/s_image_hexagonal.xml',
         'views/snippets/s_striped_center_top.xml',
+        'views/snippets/s_numbers_list.xml',
         'views/new_page_template_templates.xml',
         'views/website_views.xml',
         'views/website_pages_views.xml',

--- a/addons/website/views/snippets/s_numbers_list.xml
+++ b/addons/website/views/snippets/s_numbers_list.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_numbers_list" name="Numbers list">
+    <section class="s_numbers_list o_cc o_cc1 pt80 pb80">
+        <div class="container">
+            <div class="row s_nb_column_fixed">
+                <div class="col-lg-5 pb32">
+                    <h3>Key Metrics of Company's Achievements</h3>
+                    <p><br/>From revenue growth to customer retention and market expansion, our key metrics of company achievements underscore our strategic prowess and dedication to driving sustainable business success.</p>
+                </div>
+                <div class="col-lg-6 offset-lg-1 s_col_no_bgcolor" data-name="Numbers group">
+                    <div class="row">
+                        <div class="col-6 col-lg-6 pt16 pb16" data-name="Number">
+                            <span class="h2-fs">15%</span>
+                            <p>Revenue Growth</p>
+                            <div class="s_hr pt16 pb40">
+                                <hr class="w-100 mx-auto"/>
+                            </div>
+                        </div>
+                        <div class="col-6 col-lg-6 pt16 pb16" data-name="Number">
+                            <span class="h2-fs">$50M</span>
+                            <p>Expected revenue</p>
+                            <div class="s_hr pt16 pb40">
+                                <hr class="w-100 mx-auto"/>
+                            </div>
+                        </div>
+                        <div class="col-6 col-lg-6 pt16 pb16" data-name="Number">
+                            <span class="h2-fs">85%</span>
+                            <p>User Retention</p>
+                            <div class="s_hr pt16 pb40">
+                                <hr class="w-100 mx-auto"/>
+                            </div>
+                        </div>
+                        <div class="col-6 col-lg-6 pt16 pb16" data-name="Number">
+                            <span class="h2-fs">100,000</span>
+                            <p>Website visitors</p>
+                            <div class="s_hr pt16 pb40">
+                                <hr class="w-100 mx-auto"/>
+                            </div>
+                        </div>
+                        <div class="col-6 col-lg-6 pt16 pb16" data-name="Number">
+                            <span class="h2-fs">20+</span>
+                            <p>Projects deployed</p>
+                            <div class="s_hr pt16 pb40">
+                                <hr class="w-100 mx-auto"/>
+                            </div>
+                        </div>
+                        <div class="col-6 col-lg-6 pt16 pb16" data-name="Number">
+                            <span class="h2-fs">4x</span>
+                            <p>Inventory turnover</p>
+                            <div class="s_hr pt16 pb40">
+                                <hr class="w-100 mx-auto"/>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -119,6 +119,9 @@
                 <t t-snippet="website.s_numbers" string="Numbers" group="content">
                     <keywords>statistics, stats, KPI</keywords>
                 </t>
+                <t t-snippet="website.s_numbers_list" string="Numbers list" group="content">
+                    <keywords>statistics, stats, KPI, metrics, dashboard, analytics, highlights, figures, performance, achievements, benchmarks, milestones, indicators, data, measurements, reports, trends, results, analytics, cta, call to action, button</keywords>
+                </t>
                 <t t-snippet="website.s_features" string="Features" group="content">
                     <keywords>promotion, characteristic, quality</keywords>
                 </t>


### PR DESCRIPTION
This PR introduces the new `s_numbers_list` snippet.

| Snippet in use |
|--------|
| <img width="1727" alt="image" src="https://github.com/user-attachments/assets/bd351b46-9559-4508-a94a-39ac3e6e15d3">
 
---------

### Checklist
- [x] Meaningful demo-text
- [x] Adapts to color combinations -> Readable text
- [x] Mobile friendly
- [x] Has no `<h1>` tags (except for "Intro" snippets)
- [x] Has one `<h1>` tag ("Intro" snippets only)
- [x] Images are optimized
- [x] Images can be replaced by the website wizard (with fairly apparent exceptions)
- [x] No ineffective options. Eg "click -> nothing happens"
- [x] Edition is limited when not necessary
- [x] Behaves consistently with the rest of the snippets (images can be replaced, etc..)

task-4094388
Part of task-4077427

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr