### PR TITLE
[IMP] website: introduce `s_numbers_showcase` snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -76,6 +76,7 @@
         'views/snippets/s_timeline.xml',
         'views/snippets/s_process_steps.xml',
         'views/snippets/s_accordion.xml',
+        'views/snippets/s_numbers_showcase.xml',
         'views/snippets/s_text_highlight.xml',
         'views/snippets/s_progress_bar.xml',
         'views/snippets/s_blockquote.xml',

--- a/addons/website/static/src/snippets/s_numbers_showcase/000.scss
+++ b/addons/website/static/src/snippets/s_numbers_showcase/000.scss
@@ -1,0 +1,6 @@
+.s_numbers_showcase {
+    .o_grid_item {
+        display: flex;
+        flex-direction: column;
+    }
+}

--- a/addons/website/views/snippets/s_numbers_showcase.xml
+++ b/addons/website/views/snippets/s_numbers_showcase.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_numbers_showcase" name="Numbers Showcase">
+    <section class="s_numbers_showcase pt80 pb80 o_colored_level">
+        <div class="container">
+            <div class="row o_grid_mode" data-row-count="8" style="gap: 24px;">
+                <div class="o_grid_item g-height-8 g-col-lg-4 col-lg-4" style="--grid-item-padding-y: 16px; --grid-item-padding-x: 16px; grid-area: 1 / 1 / 9 / 5; z-index: 1;">
+                    <h2>Explore our<br/> key statistics</h2>
+                    <p><br/></p>
+                    <p class="lead">Analyzing the numbers behind our success: an in-depth look at the key metrics driving our company's achievements.</p>
+                    <p><a href="#" class="btn btn-primary" role="button">More details</a></p>
+                </div>
+                <div class="o_grid_item g-height-4 g-col-lg-4 col-lg-4 o_cc o_cc3" style="--grid-item-padding-y: 32px; --grid-item-padding-x: 32px; grid-area: 1 / 5 / 5 / 9; z-index: 2;">
+                    <h3 class="display-3">12k</h3>
+                    <p><br/></p>
+                    <h4>Useful options</h4>
+                    <p>Explore a vast array of practical and beneficial choices.</p>
+                </div>
+                <div class="o_grid_item g-height-4 g-col-lg-4 col-lg-4 o_cc o_cc5" style="--grid-item-padding-y: 32px; --grid-item-padding-x: 32px; grid-area: 1 / 9 / 5 / 13; z-index: 3;">
+                    <h3 class="display-3">45%</h3>
+                    <p><br/></p>
+                    <h4>More leads</h4>
+                    <p>Boost your pipeline with an increase in potential leads.</p>
+                </div>
+                <div class="o_grid_item g-height-4 g-col-lg-8 col-lg-8 o_cc o_cc4" style="--grid-item-padding-y: 32px; --grid-item-padding-x: 32px; grid-area: 5 / 5 / 9 / 13; z-index: 4;">
+                    <h3 class="display-3">8+</h3>
+                    <p><br/></p>
+                    <h4>Amazing pages</h4>
+                    <p>Discover outstanding and highly engaging web pages.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+<!-- Assets -->
+<record id="website.s_numbers_showcase_000_scss" model="ir.asset">
+    <field name="name">Numbers Showcase 000 SCSS</field>
+    <field name="bundle">web.assets_frontend</field>
+    <field name="path">website/static/src/snippets/s_numbers_showcase/000.scss</field>
+</record>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -95,6 +95,9 @@
                 <t t-snippet="website.s_tabs" string="Tabs" group="content"/>
                 <t t-snippet="website.s_timeline" string="Timeline" group="content"/>
                 <t t-snippet="website.s_process_steps" string="Steps" t-forbid-sanitize="true" group="content"/>
+                <t t-snippet="website.s_numbers_showcase" string="Numbers Showcase" group="content">
+                    <keywords>statistics, stats, KPI, metrics, dashboard, analytics, highlights, figures, performance, achievements, benchmarks, milestones, indicators, data, measurements, reports, trends, results, analytics, cta, call to action, button</keywords>
+                </t>
 
                 <!-- Images group -->
                 <t t-snippet="website.s_picture" string="Title - Image" group="images">


### PR DESCRIPTION
This commit adds the new `s_numbers_showcase` snippet.

task-4094383
Part of task-4077427

Requires:
- https://github.com/odoo/design-themes/pull/856


![Capture d’écran 2024-08-06 à 22 57 06](https://github.com/user-attachments/assets/e0d51c64-dcce-4fd6-abb4-3473538ea3b4)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
