### PR TITLE
[IMP] mail: message actions in mobile (bottom context menu) 

### DIFF
--- a/addons/im_livechat/static/src/embed/common/message_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/message_model_patch.js
@@ -2,10 +2,25 @@ import { Message } from "@mail/core/common/message_model";
 import { Record } from "@mail/core/common/record";
 
 import { patch } from "@web/core/utils/patch";
+import { SESSION_STATE } from "./livechat_service";
 
 patch(Message.prototype, {
     setup() {
         super.setup();
         this.chatbotStep = Record.one("ChatbotStep", { inverse: "message" });
+    },
+    canAddReaction(thread) {
+        return (
+            super.canAddReaction(thread) &&
+            (thread?.channel_type !== "livechat" ||
+                this.store.env.services["im_livechat.livechat"].state === SESSION_STATE.PERSISTED)
+        );
+    },
+    canReplyTo(thread) {
+        return (
+            super.canReplyTo(thread) &&
+            (thread?.channel_type !== "livechat" ||
+                this.store.env.services["im_livechat.chatbot"].inputEnabled)
+        );
     },
 });

--- a/addons/im_livechat/static/src/embed/common/message_patch.js
+++ b/addons/im_livechat/static/src/embed/common/message_patch.js
@@ -2,7 +2,6 @@ import { Message } from "@mail/core/common/message";
 
 import { patch } from "@web/core/utils/patch";
 import { url } from "@web/core/utils/urls";
-import { SESSION_STATE } from "./livechat_service";
 
 Message.props.push("isTypingMessage?");
 
@@ -13,23 +12,7 @@ patch(Message.prototype, {
     },
 
     get quickActionCount() {
-        return this.props.thread?.channel_type === "livechat" ? 2 : super.quickActionCount;
-    },
-
-    get canAddReaction() {
-        return (
-            super.canAddReaction &&
-            (this.props.thread?.channel_type !== "livechat" ||
-                this.env.services["im_livechat.livechat"].state === SESSION_STATE.PERSISTED)
-        );
-    },
-
-    get canReplyTo() {
-        return (
-            super.canReplyTo &&
-            (this.props.thread?.channel_type !== "livechat" ||
-                this.env.services["im_livechat.chatbot"].inputEnabled)
-        );
+        return this.props.thread?.channel_type === "livechat" ? 3 : super.quickActionCount;
     },
 
     /**

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -46,7 +46,6 @@ const EDIT_CLICK_TYPE = {
  * @property {string} [className]
  * @property {function} [onDiscardCallback]
  * @property {function} [onPostCallback]
- * @property {Component} [messageComponent]
  * @property {number} [autofocus]
  * @property {import("@web/core/utils/hooks").Ref} [dropzoneRef]
  * @extends {Component<Props, Env>}
@@ -75,7 +74,6 @@ export class Composer extends Component {
         "placeholder?",
         "dropzoneRef?",
         "messageEdition?",
-        "messageComponent?",
         "className?",
         "sidebar?",
         "type?",
@@ -652,7 +650,6 @@ export class Composer extends Component {
         } else {
             this.env.services.dialog.add(MessageConfirmDialog, {
                 message: composer.message,
-                messageComponent: this.props.messageComponent,
                 onConfirm: () => this.message.remove(),
                 prompt: _t("Are you sure you want to delete this message?"),
             });

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -26,6 +26,11 @@ $o-discuss-talkingColor: lighten($success, 5%);
     }
 }
 
+.o-discuss-mobileContextMenu {
+    top: auto !important;
+    border-top: $border-width solid $border-color !important;
+}
+
 .o-discuss-separator {
     opacity: $hr-opacity / 2;
 }

--- a/addons/mail/static/src/core/common/date_section.js
+++ b/addons/mail/static/src/core/common/date_section.js
@@ -1,4 +1,5 @@
 import { Component } from "@odoo/owl";
+import { isMobileOS } from "@web/core/browser/feature_detection";
 
 /**
  * @typedef {Object} Props
@@ -8,4 +9,8 @@ import { Component } from "@odoo/owl";
 export class DateSection extends Component {
     static template = "mail.DateSection";
     static props = ["date", "className?"];
+
+    get isMobileOS() {
+        return isMobileOS();
+    }
 }

--- a/addons/mail/static/src/core/common/date_section.xml
+++ b/addons/mail/static/src/core/common/date_section.xml
@@ -4,7 +4,7 @@
 <t t-name="mail.DateSection">
     <div class="o-mail-DateSection d-flex align-items-center w-100 fw-bold z-1" t-attf-class="{{ props.className }}">
         <hr class="o-discuss-separator flex-grow-1"/>
-        <span class="px-2 smaller text-muted"><t t-esc="props.date"/></span>
+        <span class="px-2 smaller text-muted" t-att-class="{ 'user-select-none': isMobileOS }"><t t-esc="props.date"/></span>
         <hr class="o-discuss-separator flex-grow-1"/>
     </div>
 </t>

--- a/addons/mail/static/src/core/common/discuss_component_registry.js
+++ b/addons/mail/static/src/core/common/discuss_component_registry.js
@@ -1,0 +1,3 @@
+import { registry } from "@web/core/registry";
+
+export const discussComponentRegistry = registry.category("discuss.component");

--- a/addons/mail/static/src/core/common/emoji_picker_mobile.js
+++ b/addons/mail/static/src/core/common/emoji_picker_mobile.js
@@ -1,0 +1,13 @@
+import { Component, xml } from "@odoo/owl";
+import { Dialog } from "@web/core/dialog/dialog";
+import { EMOJI_PICKER_PROPS, EmojiPicker } from "@web/core/emoji_picker/emoji_picker";
+
+export class EmojiPickerMobile extends Component {
+    static components = { Dialog, EmojiPicker };
+    static props = EMOJI_PICKER_PROPS;
+    static template = xml`
+        <Dialog size="'lg'" header="false" footer="false" contentClass="'o-discuss-mobileContextMenu d-flex position-absolute bottom-0 rounded-0 h-50 bg-100'">
+            <EmojiPicker t-props="props"/>
+        </Dialog>
+    `;
+}

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -9,6 +9,17 @@
     &.o-highlighted {
         transform: translateY(-#{map-get($spacers, 3)});
     }
+    &.o-longTouching {
+        background-color: rgba($o-action, .075);
+        outline: 1px solid rgba($o-action, .1);
+        outline-offset: -1px;
+    }
+
+    &.o-actionMenuMobileOpen {
+        background-color: rgba($o-action, .1);
+        outline: 1px solid rgba($o-action, .15);
+        outline-offset: -1px;
+    }
 }
 
 .o-mail-Message-date {
@@ -82,7 +93,6 @@
     }
 }
 
-
 .o-mail-ChatWindow .o-mail-Message.o-selfAuthored {
     flex-direction: row-reverse;
 
@@ -111,6 +121,10 @@
 
 .o-mail-Message-moreMenu {
     z-index: $o-mail-NavigableList-zIndex;
+}
+
+.o-mail-Message-openActionMobile:active {
+    opacity: 75% !important;
 }
 
 .o-mail-Message-pendingProgress {

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -2,14 +2,16 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.Message">
-        <ActionSwiper onRightSwipe="hasTouch() and isInInbox ? { action: () => this.message.setDone(), bgColor: 'bg-success', icon: 'fa-check-circle' } : undefined">
-            <div class="o-mail-Message position-relative"
+        <ActionSwiper onRightSwipe="hasTouch() and props.thread?.eq(store.inbox) ? { action: () => this.message.setDone(), bgColor: 'bg-success', icon: 'fa-check-circle' } : undefined">
+            <div class="o-mail-Message position-relative rounded-0"
                 t-att-class="attClass"
                 role="group"
                 t-att-aria-label="messageTypeText"
                 t-on-click="onClick"
                 t-on-mouseenter="onMouseenter"
                 t-on-mouseleave="onMouseleave"
+                t-on-touchstart.capture="onTouchstart"
+                t-on-touchend.capture="onTouchend"
                 t-ref="root"
                 t-if="message.exists()"
             >
@@ -56,11 +58,7 @@
                         <div
                             class="position-relative d-flex"
                             t-att-class="{
-                                   'justify-content-end': isAlignedRight,
-                                   'ps-4': env.inChatWindow and isAlignedRight and !state.isEditing,
-                                   'ps-2': env.inChatWindow and isAlignedRight and state.isEditing,
-                                   'pe-4': env.inChatWindow and !isAlignedRight and !state.isEditing and !env.messageCard,
-                                   'pe-2': env.inChatWindow and !isAlignedRight and composerViewInEditing,
+                                   'flex-row-reverse': isAlignedRight,
                                    }"
                         >
                             <div class="o-mail-Message-content o-min-width-0" t-att-class="{ 'w-100': state.isEditing, 'opacity-50': message.isPending, 'pt-1': message.is_note }">
@@ -84,7 +82,7 @@
                                                             'align-self-start rounded-end-3 rounded-bottom-3': !state.isEditing and !message.is_note,
                                                             'o-mail-Message-editable flex-grow-1': state.isEditing,
                                                             }" t-ref="body">
-                                                    <Composer t-if="state.isEditing" autofocus="true" composer="message.composer" messageComponent="constructor" onDiscardCallback.bind="exitEditMode" onPostCallback.bind="exitEditMode" mode="env.inChatter ? 'extended' : 'compact'" sidebar="false"/>
+                                                    <Composer t-if="state.isEditing" autofocus="true" composer="message.composer" onDiscardCallback.bind="exitEditMode" onPostCallback.bind="exitEditMode" mode="env.inChatter ? 'extended' : 'compact'" sidebar="false"/>
                                                     <t t-else="">
                                                         <em t-if="message.subject and !message.isSubjectSimilarToThreadName and !message.isSubjectDefault" class="mb-1 me-2">Subject: <t t-out="props.messageSearch?.highlight(message.subject) ?? message.subject"/></em>
                                                         <div t-if="message.message_type and message.message_type.includes('email')" t-ref="shadowBody"/>
@@ -119,7 +117,7 @@
                                     unlinkAttachment.bind="onClickAttachmentUnlink"
                                     imagesHeight="message.attachments.length === 1 ? 300 : 75"
                                     messageSearch="props.messageSearch"/>
-                                <LinkPreviewList t-if="message.linkPreviews.length > 0 and store.hasLinkPreviewFeature and !message.linkPreviewSquash" linkPreviews="message.linkPreviews" deletable="deletable"/>
+                                <LinkPreviewList t-if="message.linkPreviews.length > 0 and store.hasLinkPreviewFeature and !message.linkPreviewSquash" linkPreviews="message.linkPreviews" deletable="props.message.editable"/>
                             </div>
                             <t t-if="!message.is_note and !message.isPending and (!message.hasTextContent or env.inChatWindow)" t-call="mail.Message.actions"/>
                         </div>
@@ -133,57 +131,64 @@
 <t t-name="mail.Message.actions">
     <div t-if="props.hasActions and message.hasActions and !state.isEditing" class="o-mail-Message-actions d-print-none"
         t-att-class="{
-            'start-0 ms-3': isAlignedRight,
-            'end-0 me-3': (env.inChatWindow or ui.isSmall) and !isAlignedRight,
-            'position-absolute top-0 mt-n3': env.inChatWindow or ui.isSmall,
-            'ms-2': !env.inChatWindow and !ui.isSmall,
-            'mt-1': !env.inChatWindow and !ui.isSmall and !message.is_note,
+            'start-0': isAlignedRight,
+            'mx-1': !isMobileOS,
+            'mt-1': !message.is_note,
             'my-n2': message.is_note,
-            'invisible': !isActive,
+            'invisible': !isActive and !isMobileOS,
             'o-expanded': optionsDropdown.isOpen
         }"
     >
-        <t t-set="isReverse" t-value="env.inChatWindow and isAlignedRight"/>
-        <div class="d-flex rounded-1 overflow-hidden" t-att-class="{
-                'flex-row-reverse': isReverse,
-                'bg-view shadow-sm': env.inChatWindow,
-            }"
-        >
-            <t t-foreach="messageActions.actions.slice(0, quickActionCount)" t-as="action" t-key="action.id">
-                <t t-set="isStart" t-value="(!isReverse and action.isFirst) or (isReverse and action.isLast)"/>
-                <t t-set="isEnd" t-value="(!isReverse and action.isLast) or (isReverse and action.isFirst)"/>
-                <t t-if="action.callComponent" t-component="action.callComponent" t-props="action.props" classNames="{
-                    'rounded-start-1': isStart,
-                    'rounded-end-1': isEnd,
-                }"/>
-                <button t-else="" class="btn px-1 py-0 rounded-0" t-att-title="action.title" t-att-name="action.id" t-on-click.stop="action.onClick" t-att-class="{
-                    'rounded-start-1': isStart,
-                    'rounded-end-1': isEnd,
-                }">
-                    <i class="fa fa-lg" t-att-class="action.icon"/>
-                </button>
-            </t>
-            <div t-if="messageActions.actions.length gt quickActionCount" class="d-flex rounded-0">
-                <Dropdown state="optionsDropdown" position="props.message.threadAsNewest  ? 'top-start' : 'bottom-start'" menuClass="'d-flex flex-column py-0 o-mail-Message-moreMenu'" >
-                    <button class="btn px-1 py-0 rounded-0" t-att-title="expandText" t-att-class="{
-                        'bg-200': optionsDropdown.isOpen,
-                        'rounded-start-1': isReverse,
-                        'rounded-end-1': !isReverse,
+        <t t-if="isMobileOS and !mobileExpanded" t-call="mail.Message.expandAction"/>
+        <t t-else="">
+            <t t-set="isReverse" t-value="env.inChatWindow and isAlignedRight"/>
+            <div class="d-flex rounded-1 overflow-hidden" t-att-class="{ 'flex-row-reverse': isReverse }">
+                <t t-set="quickActions" t-value="messageActions.actions.slice(0, messageActions.actions.length gt quickActionCount ? quickActionCount - 1 : quickActionCount)"/>
+                <t t-foreach="quickActions" t-as="action" t-key="action.id">
+                    <t t-set="isStart" t-value="(!isReverse and action.isFirst) or (isReverse and action.isLast)"/>
+                    <t t-set="isEnd" t-value="(!isReverse and action.isLast) or (isReverse and action.isFirst)"/>
+                    <t t-if="action.callComponent" t-component="action.callComponent" t-props="action.props" classNames="{
+                        'rounded-start-1': isStart,
+                        'rounded-end-1': isEnd,
+                    }"/>
+                    <button t-else="" class="btn px-1 py-0 rounded-0" t-att-title="action.title" t-att-name="action.id" t-on-click.stop="action.onClick" t-att-class="{
+                        'rounded-start-1': isStart,
+                        'rounded-end-1': isEnd,
                     }">
-                        <i class="fa fa-lg fa-ellipsis-h" t-att-class="{ 'order-1': props.isInChatWindow }" tabindex="1"/>
+                        <i class="fa fa-lg" t-att-class="action.icon"/>
                     </button>
-                    <t t-set-slot="content">
-                        <t t-foreach="messageActions.actions.slice(quickActionCount)" t-as="action" t-key="action.id">
-                            <DropdownItem class="'px-2 d-flex align-items-center rounded-0'" onSelected="action.onClick" attrs="{ title: action.title}">
-                                <i class="fa fa-lg fa-fw pe-2" t-att-class="action.icon"/>
-                                <t t-esc="action.title"/>
-                            </DropdownItem>
+                </t>
+                <div t-if="messageActions.actions.length gt quickActionCount" class="d-flex rounded-0">
+                    <Dropdown state="optionsDropdown" position="props.message.threadAsNewest  ? 'top-start' : 'bottom-start'" menuClass="'d-flex flex-column py-0 o-mail-Message-moreMenu'" >
+                        <t t-call="mail.Message.expandAction"/>
+                        <t t-set-slot="content">
+                            <t t-foreach="messageActions.actions.slice(quickActionCount - 1)" t-as="action" t-key="action.id">
+                                <DropdownItem class="'px-2 d-flex align-items-center rounded-0'" onSelected="action.onClick" attrs="{ title: action.title}">
+                                    <i class="fa fa-lg fa-fw pe-2" t-att-class="action.icon"/>
+                                    <t t-esc="action.title"/>
+                                </DropdownItem>
+                            </t>
                         </t>
-                    </t>
-                </Dropdown>
+                    </Dropdown>
+                </div>
             </div>
-        </div>
+        </t>
     </div>
+</t>
+
+
+<t t-name="mail.Message.expandAction">
+    <button class="btn rounded-0" t-att-title="expandText" t-on-click="openMobileActions" t-att-class="{
+        'o-mail-Message-openActionMobile opacity-25 p-2 mt-n2 rounded-circle user-select-none': isMobileOS and !mobileExpanded,
+        'me-n2': isMobileOS and !mobileExpanded and isAlignedRight,
+        'ms-n2': isMobileOS and !mobileExpanded and !isAlignedRight,
+        'px-2 py-0': !isMobileOS,
+        'bg-200': optionsDropdown.isOpen,
+        'rounded-start-1': !isMobileOS and isReverse,
+        'rounded-end-1': !isMobileOS and !isReverse,
+    }">
+        <i class="fa fa-lg fa-ellipsis-v" t-att-class="{ 'order-1': props.isInChatWindow, 'fa-fw': isMobileOS }" tabindex="1"/>
+    </button>
 </t>
 
 <t t-name="mail.Message.notification">

--- a/addons/mail/static/src/core/common/message_action_menu_mobile.js
+++ b/addons/mail/static/src/core/common/message_action_menu_mobile.js
@@ -1,0 +1,55 @@
+import { Component, onMounted, onWillUnmount, useState } from "@odoo/owl";
+import { Dialog } from "@web/core/dialog/dialog";
+import { useMessageActions } from "./message_actions";
+import { useChildRef, useService } from "@web/core/utils/hooks";
+
+export class MessageActionMenuMobile extends Component {
+    static components = { Dialog };
+    static props = [
+        "message",
+        "close?",
+        "thread?",
+        "isFirstMessage?",
+        "messageToReplyTo?",
+        "openReactionMenu?",
+        "state",
+    ];
+    static template = "mail.MessageActionMenuMobile";
+
+    setup() {
+        super.setup();
+        this.store = useState(useService("mail.store"));
+        this.modalRef = useChildRef();
+        this.messageActions = useMessageActions();
+        this.onClickModal = this.onClickModal.bind(this);
+        onMounted(() => {
+            this.modalRef.el.addEventListener("click", this.onClickModal);
+        });
+        onWillUnmount(() => {
+            this.modalRef.el.removeEventListener("click", this.onClickModal);
+        });
+    }
+
+    onClickModal() {
+        this.props.close?.();
+    }
+
+    get message() {
+        return this.props.message;
+    }
+
+    get state() {
+        return this.props.state;
+    }
+
+    async onClickAction(action) {
+        const success = await action.onClick();
+        if (action.mobileCloseAfterClick && (success || success === undefined)) {
+            this.props.close?.();
+        }
+    }
+
+    openReactionMenu() {
+        return this.props.openReactionMenu?.();
+    }
+}

--- a/addons/mail/static/src/core/common/message_action_menu_mobile.scss
+++ b/addons/mail/static/src/core/common/message_action_menu_mobile.scss
@@ -1,0 +1,10 @@
+.o-mail-MessageActionMenuMobile button {
+
+    border-color: $border-color;
+
+    &:active {
+        // FIXME: active style is when button clicked but also when scrolling.
+        // The later should not show active style.
+        border: none !important;
+    }
+}

--- a/addons/mail/static/src/core/common/message_action_menu_mobile.xml
+++ b/addons/mail/static/src/core/common/message_action_menu_mobile.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="mail.MessageActionMenuMobile">
+        <Dialog size="'lg'" header="false" footer="false" contentClass="'o-discuss-mobileContextMenu d-flex position-absolute bottom-0 rounded-0 h-50 bg-100'" modalRef="modalRef" withBodyPadding="false">
+            <div class="btn-group d-flex flex-column rounded-3 gap-1 p-3" t-on-click.stop="">
+                <t t-foreach="messageActions.actions.slice(quickActionCount)" t-as="action" t-key="action.id">
+                    <button class="btn px-3 py-3 d-flex align-items-center rounded-0 btn-group-item gap-3 user-select-none bg-200" t-att-class="{ 'rounded-top-3': action_first, 'rounded-bottom-3': action_last }" t-on-click="() => this.onClickAction(action)">
+                        <i class="fa fa-lg fa-fw fs-2" t-att-class="action.icon"/>
+                        <span class="fs-4" t-esc="action.title"/>
+                    </button>
+                </t>
+            </div>
+        </Dialog>
+    </t>
+</templates>

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -1,38 +1,103 @@
-import { useComponent, useState } from "@odoo/owl";
+import { Component, toRaw, useComponent, useState, xml } from "@odoo/owl";
 
 import { _t } from "@web/core/l10n/translation";
 import { download } from "@web/core/network/download";
 import { registry } from "@web/core/registry";
 import { MessageReactionButton } from "./message_reaction_button";
+import { useService } from "@web/core/utils/hooks";
+import { discussComponentRegistry } from "./discuss_component_registry";
+import { Deferred } from "@web/core/utils/concurrency";
+import { EMOJI_PICKER_PROPS, EmojiPicker } from "@web/core/emoji_picker/emoji_picker";
+import { Dialog } from "@web/core/dialog/dialog";
+import { onExternalClick } from "@mail/utils/common/hooks";
+import { convertBrToLineBreak } from "@mail/utils/common/format";
 
 const { DateTime } = luxon;
 
 export const messageActionsRegistry = registry.category("mail.message/actions");
 
+class EmojiPickerMobile extends Component {
+    static components = { Dialog, EmojiPicker };
+    static props = [...EMOJI_PICKER_PROPS, "onClose?"];
+    static template = xml`
+        <Dialog size="'lg'" header="false" footer="false" contentClass="'o-discuss-mobileContextMenu d-flex position-absolute bottom-0 rounded-0 h-50 bg-100'">
+            <div t-ref="root">
+                <EmojiPicker t-props="emojiPickerProps"/>
+            </div>
+        </Dialog>
+    `;
+
+    get emojiPickerProps() {
+        return {
+            ...this.props,
+            onSelect: (...args) => {
+                this.props.onSelect(...args);
+                this.props.close?.();
+            },
+        };
+    }
+
+    setup() {
+        super.setup();
+        onExternalClick("root", () => this.props.close?.());
+    }
+}
+
 messageActionsRegistry
     .add("reaction", {
         callComponent: MessageReactionButton,
-        props: (component) => ({ message: component.props.message }),
-        condition: (component) => component.canAddReaction,
+        props: (component) => ({
+            message: component.props.message,
+            action: messageActionsRegistry.get("reaction"),
+        }),
+        condition: (component) => component.props.message.canAddReaction(component.props.thread),
+        icon: "oi oi-smile-add",
+        title: _t("Add a Reaction"),
+        onClick: async (component) => {
+            const def = new Deferred();
+            component.dialog.add(
+                EmojiPickerMobile,
+                {
+                    onSelect: (emoji) => {
+                        const reaction = component.props.message.reactions.find(
+                            ({ content, personas }) =>
+                                content === emoji &&
+                                personas.find((persona) => persona.eq(component.store.self))
+                        );
+                        if (!reaction) {
+                            component.props.message.react(emoji);
+                        }
+                        def.resolve(true);
+                    },
+                },
+                { context: component, onClose: () => def.resolve(false) }
+            );
+            return def;
+        },
         sequence: 10,
     })
     .add("reply-to", {
-        condition: (component) => component.canReplyTo,
+        condition: (component) => component.props.message.canReplyTo(component.props.thread),
         icon: "fa-reply",
         title: _t("Reply"),
-        onClick: (component) => component.onClickReplyTo(),
-        sequence: (component) => (component.isInInbox ? 55 : 20),
+        onClick: (component) => {
+            const message = toRaw(component.props.message);
+            const thread = toRaw(component.props.thread);
+            component.props.messageToReplyTo.toggle(thread, message);
+        },
+        sequence: (component) => (component.props.thread?.eq(component.store.inbox) ? 55 : 20),
     })
     .add("toggle-star", {
-        condition: (component) => component.canToggleStar,
+        condition: (component) => component.props.message.canToggleStar,
         icon: (component) =>
             component.props.message.starred ? "fa-star o-mail-Message-starred" : "fa-star-o",
         title: _t("Mark as Todo"),
         onClick: (component) => component.props.message.toggleStar(),
         sequence: 30,
+        mobileCloseAfterClick: false,
     })
     .add("mark-as-read", {
-        condition: (component) => component.isInInbox,
+        condition: (component) => component.props.thread?.eq(component.store.inbox),
         icon: "fa-check",
         title: _t("Mark as Read"),
         onClick: (component) => component.props.message.setDone(),
@@ -47,7 +112,7 @@ messageActionsRegistry
         dropdown: true,
     })
     .add("unfollow", {
-        condition: (component) => component.showUnfollow,
+        condition: (component) => component.props.message.canUnfollow(component.props.thread),
         icon: "fa-user-times",
         title: _t("Unfollow"),
         onClick: (component) => component.props.message.unfollow(),
@@ -59,21 +124,54 @@ messageActionsRegistry
             component.store.self.type === "partner",
         icon: "fa-eye-slash",
         title: _t("Mark as Unread"),
-        onClick: (component) => component.onClickMarkAsUnread(),
+        onClick: (component) => component.props.message.onClickMarkAsUnread(component.props.thread),
         sequence: 70,
     })
     .add("edit", {
-        condition: (component) => component.editable,
+        condition: (component) => component.props.message.editable,
         icon: "fa-pencil",
         title: _t("Edit"),
-        onClick: (component) => component.enterEditMode(),
+        onClick: (component) => {
+            const message = toRaw(component.props.message);
+            const text = convertBrToLineBreak(message.body);
+            message.composer = {
+                mentionedPartners: message.recipients,
+                text,
+                selection: {
+                    start: text.length,
+                    end: text.length,
+                    direction: "none",
+                },
+            };
+            component.state.isEditing = true;
+        },
         sequence: 80,
     })
     .add("delete", {
-        condition: (component) => component.deletable,
+        condition: (component) => component.props.message.editable,
         icon: "fa-trash",
         title: _t("Delete"),
-        onClick: (component) => component.onClickDelete(),
+        onClick: async (component) => {
+            const message = toRaw(component.message);
+            const def = new Deferred();
+            component.dialog.add(
+                discussComponentRegistry.get("MessageConfirmDialog"),
+                {
+                    message,
+                    prompt: _t("Are you sure you want to delete this message?"),
+                    onConfirm: () => {
+                        def.resolve(true);
+                        message.remove();
+                    },
+                },
+                { context: component, onClose: () => def.resolve(false) }
+            );
+            return def;
+        },
+        setup: () => {
+            const component = useComponent();
+            component.dialog = useService("dialog");
+        },
         sequence: 90,
     })
     .add("download_files", {
@@ -91,7 +189,7 @@ messageActionsRegistry
         sequence: 55,
     })
     .add("toggle-translation", {
-        condition: (component) => component.translatable,
+        condition: (component) => component.props.message.isTranslatable(component.props.thread),
         icon: (component) =>
             `fa-language ${component.state.showTranslation ? "o-mail-Message-translated" : ""}`,
         title: (component) => (component.state.showTranslation ? _t("Revert") : _t("Translate")),
@@ -112,6 +210,7 @@ function transformAction(component, id, action) {
     return {
         component: action.component,
         id,
+        mobileCloseAfterClick: action.mobileCloseAfterClick ?? true,
         /** Condition to display this action. */
         get condition() {
             return action.condition(component);
@@ -137,7 +236,7 @@ function transformAction(component, id, action) {
          * to the previous one.
          * */
         onClick() {
-            action.onClick?.(component);
+            return action.onClick?.(component);
         },
         /** Determines the order of this action (smaller first). */
         get sequence() {
@@ -145,6 +244,8 @@ function transformAction(component, id, action) {
                 ? action.sequence(component)
                 : action.sequence;
         },
+        /** Component setup to execute when this action is registered. */
+        setup: action.setup,
     };
 }
 
@@ -153,6 +254,11 @@ export function useMessageActions() {
     const transformedActions = messageActionsRegistry
         .getEntries()
         .map(([id, action]) => transformAction(component, id, action));
+    for (const action of transformedActions) {
+        if (action.setup) {
+            action.setup(action);
+        }
+    }
     const state = useState({
         get actions() {
             const actions = transformedActions

--- a/addons/mail/static/src/core/common/message_confirm_dialog.js
+++ b/addons/mail/static/src/core/common/message_confirm_dialog.js
@@ -2,6 +2,7 @@ import { Component } from "@odoo/owl";
 
 import { Dialog } from "@web/core/dialog/dialog";
 import { _t } from "@web/core/l10n/translation";
+import { discussComponentRegistry } from "./discuss_component_registry";
 
 export class MessageConfirmDialog extends Component {
     static components = { Dialog };
@@ -10,7 +11,6 @@ export class MessageConfirmDialog extends Component {
         "confirmColor?",
         "confirmText?",
         "message",
-        "messageComponent",
         "prompt",
         "size?",
         "title?",
@@ -24,8 +24,14 @@ export class MessageConfirmDialog extends Component {
     };
     static template = "mail.MessageConfirmDialog";
 
+    get messageComponent() {
+        return discussComponentRegistry.get("Message");
+    }
+
     onClickConfirm() {
         this.props.onConfirm();
         this.props.close();
     }
 }
+
+discussComponentRegistry.add("MessageConfirmDialog", MessageConfirmDialog);

--- a/addons/mail/static/src/core/common/message_confirm_dialog.xml
+++ b/addons/mail/static/src/core/common/message_confirm_dialog.xml
@@ -5,7 +5,7 @@
     <Dialog size="props.size" title="props.title">
         <p class="mx-3 mb-3" t-esc="props.prompt"/>
         <blockquote class="mx-3 mb-3 fst-normal" style="pointer-events:none;">
-            <t t-component="props.messageComponent" message="props.message" hasActions="false"/>
+            <t t-component="messageComponent" message="props.message" hasActions="false"/>
         </blockquote>
         <t t-set-slot="footer">
             <button class="btn me-2" t-att-class="props.confirmColor" t-on-click="onClickConfirm" t-out="props.confirmText"/>

--- a/addons/mail/static/src/core/common/message_reaction_button.js
+++ b/addons/mail/static/src/core/common/message_reaction_button.js
@@ -9,7 +9,7 @@ import { useService } from "@web/core/utils/hooks";
  */
 export class MessageReactionButton extends Component {
     static template = "mail.MessageReactionButton";
-    static props = ["message", "classNames?"];
+    static props = ["message", "classNames?", "action"];
 
     setup() {
         super.setup();

--- a/addons/mail/static/src/core/common/message_reaction_button.xml
+++ b/addons/mail/static/src/core/common/message_reaction_button.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.MessageReactionButton">
-        <button class="btn px-1 py-0 lh-1 rounded-0" t-att-class="props.classNames" tabindex="1" title="Add a Reaction" aria-label="Add a Reaction" t-ref="emoji-picker"><i class="oi fa-lg oi-smile-add"/></button>
+        <button class="btn px-1 py-0 lh-1 rounded-0" t-att-class="props.classNames" tabindex="1" t-att-title="props.action.title" aria-label="props.action.title" t-ref="emoji-picker"><i class="fa-lg" t-att-class="props.action.icon"/></button>
     </t>
 
 </templates>

--- a/addons/mail/static/src/discuss/message_pin/common/message_actions.js
+++ b/addons/mail/static/src/discuss/message_pin/common/message_actions.js
@@ -6,7 +6,7 @@ messageActionsRegistry.add("pin", {
         component.store.self.type === "partner" &&
         component.props.thread?.model === "discuss.channel",
     icon: "fa-thumb-tack",
-    title: (component) => component.props.message.pinned_at ? _t("Unpin") : _t("Pin"),
+    title: (component) => (component.props.message.pinned_at ? _t("Unpin") : _t("Pin")),
     onClick: (component) => component.props.message.pin(),
     sequence: 65,
 });

--- a/addons/mail/static/src/discuss/message_pin/common/message_model_patch.js
+++ b/addons/mail/static/src/discuss/message_pin/common/message_model_patch.js
@@ -3,7 +3,7 @@ import { Message } from "@mail/core/common/message_model";
 import { Record } from "@mail/core/common/record";
 import { _t } from "@web/core/l10n/translation";
 import { MessageConfirmDialog } from "@mail/core/common/message_confirm_dialog";
-import { Message as MessageComponent } from "@mail/core/common/message";
+import { Deferred } from "@web/core/utils/concurrency";
 
 patch(Message.prototype, {
     setup() {
@@ -13,12 +13,14 @@ patch(Message.prototype, {
     },
     pin() {
         if (this.pinned_at) {
-            this.unpin();
-        } else {
-            this.store.env.services.dialog.add(MessageConfirmDialog, {
+            return this.unpin();
+        }
+        const def = new Deferred();
+        this.store.env.services.dialog.add(
+            MessageConfirmDialog,
+            {
                 confirmText: _t("Yeah, pin it!"),
                 message: this,
-                messageComponent: MessageComponent,
                 prompt: _t(
                     "You sure want this message pinned to %(conversation)s forever and ever?",
                     {
@@ -28,6 +30,7 @@ patch(Message.prototype, {
                 size: "md",
                 title: _t("Pin It"),
                 onConfirm: () => {
+                    def.resolve(true);
                     this.store.env.services.orm.call(
                         "discuss.channel",
                         "set_message_pin",
@@ -35,28 +38,36 @@ patch(Message.prototype, {
                         { message_id: this.id, pinned: true }
                     );
                 },
-            });
-        }
+            },
+            { onClose: () => def.resolve(false) }
+        );
+        return def;
     },
     unpin() {
-        this.store.env.services.dialog.add(MessageConfirmDialog, {
-            confirmColor: "btn-danger",
-            confirmText: _t("Yes, remove it please"),
-            message: this,
-            messageComponent: MessageComponent,
-            prompt: _t(
-                "Well, nothing lasts forever, but are you sure you want to unpin this message?"
-            ),
-            size: "md",
-            title: _t("Unpin Message"),
-            onConfirm: () => {
-                this.store.env.services.orm.call(
-                    "discuss.channel",
-                    "set_message_pin",
-                    [this.thread.id],
-                    { message_id: this.id, pinned: false }
-                );
+        const def = new Deferred();
+        this.store.env.services.dialog.add(
+            MessageConfirmDialog,
+            {
+                confirmColor: "btn-danger",
+                confirmText: _t("Yes, remove it please"),
+                message: this,
+                prompt: _t(
+                    "Well, nothing lasts forever, but are you sure you want to unpin this message?"
+                ),
+                size: "md",
+                title: _t("Unpin Message"),
+                onConfirm: () => {
+                    def.resolve(true);
+                    this.store.env.services.orm.call(
+                        "discuss.channel",
+                        "set_message_pin",
+                        [this.thread.id],
+                        { message_id: this.id, pinned: false }
+                    );
+                },
             },
-        });
+            { onClose: () => def.resolve(false) }
+        );
+        return def;
     },
 });

--- a/addons/mail/static/tests/crosstab/crosstab.test.js
+++ b/addons/mail/static/tests/crosstab/crosstab.test.js
@@ -188,7 +188,6 @@ test("Message delete notification", async () => {
     });
     await start();
     await openDiscuss();
-    await click("[title='Expand']");
     await click("[title='Mark as Todo']");
     await contains("button", { text: "Inbox", contains: [".badge", { text: "1" }] });
     await contains("button", { text: "Starred", contains: [".badge", { text: "1" }] });

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -691,13 +691,7 @@ test("rendering of inbox message", async () => {
     await contains("[title='Add a Reaction']");
     await contains("[title='Mark as Todo']");
     await contains("[title='Mark as Read']");
-    await click("[title='Expand']");
-    await contains(".o-mail-Message-actions i", { count: 4 });
-    await contains(".o-mail-Message-moreMenu i", { count: 1 });
     await contains("[title='Reply']");
-    await contains("[title='Mark as Todo']");
-    await contains("[title='Mark as Read']");
-    await contains("[title='Expand']");
 });
 
 test("Unfollow message", async function () {
@@ -728,39 +722,36 @@ test("Unfollow message", async function () {
     await start();
     await openDiscuss();
     await contains(".o-mail-Message", { count: 3 });
-    await click(":nth-child(1 of .o-mail-Message) button[title='Expand']");
-    await contains(":nth-child(1 of .o-mail-Message)", {
+    await click(".o-mail-Message:eq(0) [title='Expand']");
+    await contains(".o-mail-Message:eq(0)", {
         contains: [[".o-mail-Message-header small", { text: "on Thread followed" }]],
     });
     await contains(".o-mail-Message-moreMenu", { count: 1 });
-    await contains("span[title='Unfollow']", { count: 1 });
-    await click(":nth-child(2 of .o-mail-Message) button[title='Expand']");
-    await contains(":nth-child(2 of .o-mail-Message)", {
+    await contains("[title='Unfollow']", { count: 1 });
+    await click(".o-mail-Message:eq(1) [title='Expand']");
+    await contains(".o-mail-Message:eq(1)", {
         contains: [[".o-mail-Message-header small", { text: "on Thread followed" }]],
     });
     await contains(".o-mail-Message-moreMenu", { count: 1 });
-    await contains("span[title='Unfollow']", { count: 1 });
-    await click(":nth-child(3 of .o-mail-Message) button[title='Expand']");
-    await contains(":nth-child(3 of .o-mail-Message)", {
+    await contains("[title='Unfollow']", { count: 1 });
+    await contains(".o-mail-Message:eq(2) [title='Expand']", { count: 0 });
+    await contains(".o-mail-Message:eq(2)", {
         contains: [[".o-mail-Message-header small", { text: "on Thread not followed" }]],
     });
-    await contains(".o-mail-Message-moreMenu", { count: 1 });
-    await contains("span[title='Unfollow']", { count: 0 });
-    await click(":nth-child(1 of .o-mail-Message) button[title='Expand']");
-    await click("span[title='Unfollow']");
+    await contains(".o-mail-Message:eq(2) [title='Unfollow']", { count: 0 });
+    await click(".o-mail-Message:eq(0) [title='Expand']");
+    await click("[title='Unfollow']");
     await contains(".o-mail-Message", { count: 2 }); // Unfollowing message 0 marks it as read -> Message removed
-    await click(":nth-child(1 of .o-mail-Message) button[title='Expand']");
-    await contains(":nth-child(1 of .o-mail-Message)", {
+    await contains(".o-mail-Message:eq(0)", {
         contains: [[".o-mail-Message-header small", { text: "on Thread followed" }]],
     });
-    await contains(".o-mail-Message-moreMenu", { count: 1 });
-    await contains("span[title='Unfollow']", { count: 0 });
-    await click(":nth-child(2 of .o-mail-Message) button[title='Expand']");
-    await contains(":nth-child(2 of .o-mail-Message)", {
+    await contains(".o-mail-Message:eq(0) [title='Expand']", { count: 0 });
+    await contains(".o-mail-Message:eq(0) [title='Unfollow']", { count: 0 });
+    await contains(".o-mail-Message:eq(1)", {
         contains: [[".o-mail-Message-header small", { text: "on Thread not followed" }]],
     });
-    await contains(".o-mail-Message-moreMenu", { count: 1 });
-    await contains("span[title='Unfollow']", { count: 0 });
+    await contains(".o-mail-Message:eq(1) [title='Expand']", { count: 0 });
+    await contains(".o-mail-Message:eq(1) [title='Unfollow']", { count: 0 });
 });
 
 test('messages marked as read move to "History" mailbox', async () => {

--- a/addons/mail/static/tests/discuss_app/inbox.test.js
+++ b/addons/mail/static/tests/discuss_app/inbox.test.js
@@ -38,10 +38,8 @@ test("reply: discard on reply button toggle", async () => {
     await start();
     await openDiscuss();
     await contains(".o-mail-Message");
-    await click("[title='Expand']");
     await click("[title='Reply']");
     await contains(".o-mail-Composer");
-    await click("[title='Expand']");
     await click("[title='Reply']");
     await contains(".o-mail-Composer", { count: 0 });
 });
@@ -67,8 +65,7 @@ test("reply: discard on pressing escape [REQUIRE FOCUS]", async () => {
     await start();
     await openDiscuss();
     await contains(".o-mail-Message");
-    await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message-moreMenu [title='Reply']");
+    await click("[title='Reply']");
     await contains(".o-mail-Composer");
     // Escape on emoji picker does not stop replying
     await click(".o-mail-Composer button[aria-label='Emojis']");
@@ -111,7 +108,6 @@ test('"reply to" composer should log note if message replied to is a note', asyn
     await start();
     await openDiscuss();
     await contains(".o-mail-Message");
-    await click("[title='Expand']");
     await click("[title='Reply']");
     await contains(".o-mail-Composer [placeholder='Log an internal note…']");
     await insertText(".o-mail-Composer-input", "Test");
@@ -144,7 +140,6 @@ test('"reply to" composer should send message if message replied to is not a not
     await start();
     await openDiscuss();
     await contains(".o-mail-Message");
-    await click("[title='Expand']");
     await click("[title='Reply']");
     await contains(".o-mail-Composer [placeholder='Send a message to followers…']");
     await insertText(".o-mail-Composer-input", "Test");
@@ -522,7 +517,6 @@ test("reply: stop replying button click", async () => {
     await start();
     await openDiscuss();
     await contains(".o-mail-Message");
-    await click("[title='Expand']");
     await click("[title='Reply']");
     await contains(".o-mail-Composer");
     await contains("i[title='Stop replying']");

--- a/addons/mail/static/tests/translation/translation.test.js
+++ b/addons/mail/static/tests/translation/translation.test.js
@@ -30,23 +30,18 @@ test("Toggle display of original/translated version of chatter message", async (
     });
     await start();
     await openFormView("res.partner", partnerId);
-    await click("button[title='Expand']");
-    await contains("span[title='Translate']");
-    await contains("span[title='Revert']", { count: 0 });
+    await contains("[title='Translate']");
+    await contains("[title='Revert']", { count: 0 });
     // Click acts as a toogle affecting its appearence and the actual message content displayed.
-    await click("span[title='Translate']");
-    await click("button[title='Expand']");
+    await click("[title='Translate']");
     await contains(".o-mail-Message-body", {
         text: "To bad weather, good face.(Translated from: Spanish)",
     });
-    await contains("span[title='Translate']", { count: 0 });
-    await contains("span[title='Revert']");
-    await click("span[title='Revert']");
-    await click("button[title='Expand']");
-    await contains(".o-mail-Message", {
-        text: "Al mal tiempo, buena cara.",
-    });
-    await click("span[title='Translate']");
+    await contains("[title='Translate']", { count: 0 });
+    await contains("[title='Revert']");
+    await click("[title='Revert']");
+    await contains(".o-mail-Message", { text: "Al mal tiempo, buena cara." });
+    await click("[title='Translate']");
     // The translation button should not trigger more than one external request for a single message.
     await assertSteps(["Request"]);
 });

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.js
@@ -127,9 +127,10 @@ export async function loadEmoji() {
 }
 
 export const EMOJI_PER_ROW = 9;
+export const EMOJI_PICKER_PROPS = ["close?", "onClose?", "onSelect", "state?", "storeScroll?"];
 
 export class EmojiPicker extends Component {
-    static props = ["close?", "onClose?", "onSelect", "state?", "storeScroll?"];
+    static props = EMOJI_PICKER_PROPS;
     static template = "web.EmojiPicker";
 
     categories = null;


### PR DESCRIPTION
Before this commit, message actions in mobile sucks.
This comes from them being designed with a pointer in mind, thus requiring hover / click + show dropdown menu to choose a message action.

This commit improves mobile UI/UX of message action as follow:
In mobile, messages quick action is replaced by persistent "..." button. Click on button shows a action menu in a dialog that takes the bottom of screen. This menu can also be accessed with long touch press on message.

Task-4102385

https://github.com/odoo/enterprise/pull/68046


https://github.com/user-attachments/assets/904243ca-3b2e-496a-9f31-5fda3dbfd97f

