### PR TITLE
[IMP] core: _sql_constraints object and indexes

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -1408,13 +1408,10 @@ class AccountGroup(models.Model):
     code_prefix_end = fields.Char(compute='_compute_code_prefix_end', readonly=False, store=True, precompute=True)
     company_id = fields.Many2one('res.company', required=True, readonly=True, default=lambda self: self.env.company)
 
-    _sql_constraints = [
-        (
-            'check_length_prefix',
-            'CHECK(char_length(COALESCE(code_prefix_start, \'\')) = char_length(COALESCE(code_prefix_end, \'\')))',
-            'The length of the starting and the ending code prefix must be the same'
-        ),
-    ]
+    _check_length_prefix = models.Constraint(
+        "CHECK(char_length(COALESCE(code_prefix_start, '')) = char_length(COALESCE(code_prefix_end, '')))",
+        'The length of the starting and the ending code prefix must be the same',
+    )
 
     @api.depends('code_prefix_start')
     def _compute_code_prefix_end(self):

--- a/addons/account/models/account_account_tag.py
+++ b/addons/account/models/account_account_tag.py
@@ -14,7 +14,10 @@ class AccountAccountTag(models.Model):
     tax_negate = fields.Boolean(string="Negate Tax Balance", help="Check this box to negate the absolute value of the balance of the lines associated with this tag in tax report computation.")
     country_id = fields.Many2one(string="Country", comodel_name='res.country', help="Country for which this tag is available, when applied on taxes.")
 
-    _sql_constraints = [('name_uniq', "unique(name, applicability, country_id)", "A tag with the same name and applicability already exists in this country.")]
+    _name_uniq = models.Constraint(
+        'unique(name, applicability, country_id)',
+        'A tag with the same name and applicability already exists in this country.',
+    )
 
     @api.depends('applicability', 'country_id')
     @api.depends_context('company')

--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -25,9 +25,10 @@ class AccountJournalGroup(models.Model):
     excluded_journal_ids = fields.Many2many('account.journal', string="Excluded Journals")
     sequence = fields.Integer(default=10)
 
-    _sql_constraints = [
-        ('uniq_name', 'unique(company_id, name)', 'A Ledger group name must be unique per company.'),
-    ]
+    _uniq_name = models.Constraint(
+        'unique(company_id, name)',
+        'A Ledger group name must be unique per company.',
+    )
 
 
 class AccountJournal(models.Model):
@@ -223,9 +224,10 @@ class AccountJournal(models.Model):
     accounting_date = fields.Date(compute='_compute_accounting_date')
     display_alias_fields = fields.Boolean(compute='_compute_display_alias_fields')
 
-    _sql_constraints = [
-        ('code_company_uniq', 'unique (company_id, code)', 'Journal codes must be unique per company.'),
-    ]
+    _code_company_uniq = models.Constraint(
+        'unique (company_id, code)',
+        'Journal codes must be unique per company.',
+    )
 
     def _compute_display_alias_fields(self):
         self.display_alias_fields = self.env['mail.alias.domain'].search_count([], limit=1)

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -417,37 +417,22 @@ class AccountMoveLine(models.Model):
     # === Misc Information === #
     is_refund = fields.Boolean(compute='_compute_is_refund')
 
-    _sql_constraints = [
-        (
-            "check_credit_debit",
-            "CHECK(display_type IN ('line_section', 'line_note') OR credit * debit=0)",
-            "Wrong credit or debit value in accounting entry!"
-        ),
-        (
-            "check_amount_currency_balance_sign",
-            """CHECK(
-                display_type IN ('line_section', 'line_note')
-                OR (
-                    (balance <= 0 AND amount_currency <= 0)
-                    OR
-                    (balance >= 0 AND amount_currency >= 0)
-                )
-            )""",
-            "The amount expressed in the secondary currency must be positive when account is debited and negative when "
-            "account is credited. If the currency is the same as the one from the company, this amount must strictly "
-            "be equal to the balance."
-        ),
-        (
-            "check_accountable_required_fields",
-            "CHECK(display_type IN ('line_section', 'line_note') OR account_id IS NOT NULL)",
-            "Missing required account on accountable line."
-        ),
-        (
-            "check_non_accountable_fields_null",
-            "CHECK(display_type NOT IN ('line_section', 'line_note') OR (amount_currency = 0 AND debit = 0 AND credit = 0 AND account_id IS NULL))",
-            "Forbidden balance or account on non-accountable line"
-        ),
-    ]
+    _check_credit_debit = models.Constraint(
+        "CHECK(display_type IN ('line_section', 'line_note') OR credit * debit=0)",
+        'Wrong credit or debit value in accounting entry!',
+    )
+    _check_amount_currency_balance_sign = models.Constraint(
+        "CHECK(\n                display_type IN ('line_section', 'line_note')\n                OR (\n                    (balance <= 0 AND amount_currency <= 0)\n                    OR\n                    (balance >= 0 AND amount_currency >= 0)\n                )\n            )",
+        'The amount expressed in the secondary currency must be positive when account is debited and negative when account is credited. If the currency is the same as the one from the company, this amount must strictly be equal to the balance.',
+    )
+    _check_accountable_required_fields = models.Constraint(
+        "CHECK(display_type IN ('line_section', 'line_note') OR account_id IS NOT NULL)",
+        'Missing required account on accountable line.',
+    )
+    _check_non_accountable_fields_null = models.Constraint(
+        "CHECK(display_type NOT IN ('line_section', 'line_note') OR (amount_currency = 0 AND debit = 0 AND credit = 0 AND account_id IS NULL))",
+        'Forbidden balance or account on non-accountable line',
+    )
 
     @api.model
     def get_views(self, views, options=None):

--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -194,13 +194,10 @@ class AccountPayment(models.Model):
     duplicate_payment_ids = fields.Many2many(comodel_name='account.payment', compute='_compute_duplicate_payment_ids')
     attachment_ids = fields.One2many('ir.attachment', 'res_id', string='Attachments')
 
-    _sql_constraints = [
-        (
-            'check_amount_not_negative',
-            'CHECK(amount >= 0.0)',
-            "The payment amount cannot be negative.",
-        ),
-    ]
+    _check_amount_not_negative = models.Constraint(
+        'CHECK(amount >= 0.0)',
+        'The payment amount cannot be negative.',
+    )
 
     def init(self):
         super().init()

--- a/addons/account/models/account_payment_method.py
+++ b/addons/account/models/account_payment_method.py
@@ -12,9 +12,10 @@ class AccountPaymentMethod(models.Model):
     code = fields.Char(required=True)  # For internal identification
     payment_type = fields.Selection(selection=[('inbound', 'Inbound'), ('outbound', 'Outbound')], required=True)
 
-    _sql_constraints = [
-        ('name_code_unique', 'unique (code, payment_type)', 'The combination code/payment type already exists!'),
-    ]
+    _name_code_unique = models.Constraint(
+        'unique (code, payment_type)',
+        'The combination code/payment type already exists!',
+    )
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -175,7 +175,10 @@ class AccountReconcileModel(models.Model):
     _order = 'sequence, id'
     _check_company_auto = True
 
-    _sql_constraints = [('name_unique', 'unique(name, company_id)', 'A reconciliation model already bears this name.')]
+    _name_unique = models.Constraint(
+        'unique(name, company_id)',
+        'A reconciliation model already bears this name.',
+    )
 
     # Base fields.
     active = fields.Boolean(default=True)

--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -343,9 +343,10 @@ class AccountReportLine(models.Model):
     horizontal_split_side = fields.Selection(string="Horizontal Split Side", selection=[('left', "Left"), ('right', "Right")], compute='_compute_horizontal_split_side', readonly=False, store=True, recursive=True)
     tax_tags_formula = fields.Char(string="Tax Tags Formula Shortcut", help="Internal field to shorten expression_ids creation for the tax_tags engine", inverse='_inverse_aggregation_tax_formula', store=False)
 
-    _sql_constraints = [
-        ('code_uniq', 'unique (report_id, code)', "A report line with the same code already exists."),
-    ]
+    _code_uniq = models.Constraint(
+        'unique (report_id, code)',
+        'A report line with the same code already exists.',
+    )
 
     @api.depends('parent_id.hierarchy_level')
     def _compute_hierarchy_level(self):
@@ -569,18 +570,14 @@ class AccountReportExpression(models.Model):
              "(on a _carryover_*-labeled expression), in case it is different from the parent line."
     )
 
-    _sql_constraints = [
-        (
-            "domain_engine_subformula_required",
-            "CHECK(engine != 'domain' OR subformula IS NOT NULL)",
-            "Expressions using 'domain' engine should all have a subformula."
-        ),
-        (
-            "line_label_uniq",
-            "UNIQUE(report_line_id,label)",
-            "The expression label must be unique per report line."
-        ),
-    ]
+    _domain_engine_subformula_required = models.Constraint(
+        "CHECK(engine != 'domain' OR subformula IS NOT NULL)",
+        "Expressions using 'domain' engine should all have a subformula.",
+    )
+    _line_label_uniq = models.Constraint(
+        'UNIQUE(report_line_id,label)',
+        'The expression label must be unique per report line.',
+    )
 
     @api.constrains('carryover_target', 'label')
     def _check_carryover_target(self):

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -302,11 +302,10 @@ class AccountFiscalPositionTax(models.Model):
     tax_dest_id = fields.Many2one('account.tax', string='Tax to Apply', check_company=True)
     tax_dest_active = fields.Boolean(related="tax_dest_id.active")
 
-    _sql_constraints = [
-        ('tax_src_dest_uniq',
-         'unique (position_id,tax_src_id,tax_dest_id)',
-         'A tax fiscal position could be defined only one time on same taxes.')
-    ]
+    _tax_src_dest_uniq = models.Constraint(
+        'unique (position_id,tax_src_id,tax_dest_id)',
+        'A tax fiscal position could be defined only one time on same taxes.',
+    )
 
 
 class AccountFiscalPositionAccount(models.Model):
@@ -325,11 +324,10 @@ class AccountFiscalPositionAccount(models.Model):
         check_company=True, required=True,
         domain="[('deprecated', '=', False)]")
 
-    _sql_constraints = [
-        ('account_src_dest_uniq',
-         'unique (position_id,account_src_id,account_dest_id)',
-         'An account fiscal position could be defined only one time on same accounts.')
-    ]
+    _account_src_dest_uniq = models.Constraint(
+        'unique (position_id,account_src_id,account_dest_id)',
+        'An account fiscal position could be defined only one time on same accounts.',
+    )
 
 
 class ResPartner(models.Model):

--- a/addons/account_edi/models/account_edi_document.py
+++ b/addons/account_edi/models/account_edi_document.py
@@ -39,13 +39,10 @@ class AccountEdiDocument(models.Model):
     edi_format_name = fields.Char(string='Format Name', related='edi_format_id.name')
     edi_content = fields.Binary(compute='_compute_edi_content', compute_sudo=True)
 
-    _sql_constraints = [
-        (
-            'unique_edi_document_by_move_by_format',
-            'UNIQUE(edi_format_id, move_id)',
-            'Only one edi document by move by format',
-        ),
-    ]
+    _unique_edi_document_by_move_by_format = models.Constraint(
+        'UNIQUE(edi_format_id, move_id)',
+        'Only one edi document by move by format',
+    )
 
     @api.depends('move_id', 'error', 'state')
     def _compute_edi_content(self):

--- a/addons/account_edi/models/account_edi_format.py
+++ b/addons/account_edi/models/account_edi_format.py
@@ -24,9 +24,10 @@ class AccountEdiFormat(models.Model):
     name = fields.Char()
     code = fields.Char(required=True)
 
-    _sql_constraints = [
-        ('unique_code', 'unique (code)', 'This code already exists')
-    ]
+    _unique_code = models.Constraint(
+        'unique (code)',
+        'This code already exists',
+    )
 
     ####################################################
     # Low-level methods

--- a/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
+++ b/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
@@ -7,7 +7,6 @@ import requests
 
 from odoo import _, fields, models
 from odoo.exceptions import UserError
-from odoo.tools import index_exists
 from .account_edi_proxy_auth import OdooEdiProxyAuth
 
 _logger = logging.getLogger(__name__)
@@ -55,26 +54,15 @@ class Account_Edi_Proxy_ClientUser(models.Model):
         string='EDI operating mode',
     )
 
-    _sql_constraints = [
-        ('unique_id_client', 'unique(id_client)', 'This id_client is already used on another user.'),
-        ('unique_active_edi_identification', '', 'This edi identification is already assigned to an active user'),
-        ('unique_active_company_proxy', '', 'This company has an active user already created for this EDI type'),
-    ]
-
-    def _auto_init(self):
-        super()._auto_init()
-        if not index_exists(self.env.cr, 'account_edi_proxy_client_user_unique_active_edi_identification'):
-            self.env.cr.execute("""
-                CREATE UNIQUE INDEX account_edi_proxy_client_user_unique_active_edi_identification
-                                 ON account_edi_proxy_client_user(edi_identification, proxy_type, edi_mode)
-                              WHERE (active = True)
-            """)
-        if not index_exists(self.env.cr, 'account_edi_proxy_client_user_unique_active_company_proxy'):
-            self.env.cr.execute("""
-                CREATE UNIQUE INDEX account_edi_proxy_client_user_unique_active_company_proxy
-                                 ON account_edi_proxy_client_user(company_id, proxy_type, edi_mode)
-                              WHERE (active = True)
-            """)
+    _unique_id_client = models.Constraint('unique(id_client)', "This id_client is already used on another user.")
+    _unique_active_edi_identification = models.UniqueIndex(
+        '(edi_identification, proxy_type, edi_mode) WHERE (active = TRUE)',
+        "This edi identification is already assigned to an active user",
+    )
+    _unique_active_company_proxy = models.UniqueIndex(
+        '(company_id, proxy_type, edi_mode) WHERE (active = TRUE)',
+        "This company has an active user already created for this EDI type",
+    )
 
     def _get_proxy_urls(self):
         # To extend

--- a/addons/auth_oauth/models/res_users.py
+++ b/addons/auth_oauth/models/res_users.py
@@ -21,9 +21,10 @@ class ResUsers(models.Model):
     oauth_uid = fields.Char(string='OAuth User ID', help="Oauth Provider user_id", copy=False)
     oauth_access_token = fields.Char(string='OAuth Access Token', readonly=True, copy=False, prefetch=False)
 
-    _sql_constraints = [
-        ('uniq_users_oauth_provider_oauth_uid', 'unique(oauth_provider_id, oauth_uid)', 'OAuth UID must be unique per provider'),
-    ]
+    _uniq_users_oauth_provider_oauth_uid = models.Constraint(
+        'unique(oauth_provider_id, oauth_uid)',
+        'OAuth UID must be unique per provider',
+    )
 
     def _auth_oauth_rpc(self, endpoint, access_token):
         if self.env['ir.config_parameter'].sudo().get_param('auth_oauth.authorization_header'):

--- a/addons/auth_passkey/models/auth_passkey_key.py
+++ b/addons/auth_passkey/models/auth_passkey_key.py
@@ -26,9 +26,10 @@ class AuthPasskeyKey(models.Model):
     public_key = fields.Char(required=True, groups='base.group_system', compute='_compute_public_key', inverse='_inverse_public_key')
     sign_count = fields.Integer(default=0, groups='base.group_system')
 
-    _sql_constraints = [
-        ('unique_identifier', 'UNIQUE(credential_identifier)', 'The credential identifier should be unique.'),
-    ]
+    _unique_identifier = models.Constraint(
+        'UNIQUE(credential_identifier)',
+        'The credential identifier should be unique.',
+    )
 
     def init(self):
         super().init()

--- a/addons/calendar/models/calendar_event_type.py
+++ b/addons/calendar/models/calendar_event_type.py
@@ -16,6 +16,7 @@ class CalendarEventType(models.Model):
     name = fields.Char('Name', required=True)
     color = fields.Integer('Color', default=_default_color)
 
-    _sql_constraints = [
-        ('name_uniq', 'unique (name)', "Tag name already exists!"),
-    ]
+    _name_uniq = models.Constraint(
+        'unique (name)',
+        'Tag name already exists!',
+    )

--- a/addons/calendar/models/calendar_filter.py
+++ b/addons/calendar/models/calendar_filter.py
@@ -12,9 +12,10 @@ class CalendarFilters(models.Model):
     active = fields.Boolean('Active', default=True)
     partner_checked = fields.Boolean('Checked', default=True)  # used to know if the partner is checked in the filter of the calendar view for the user_id.
 
-    _sql_constraints = [
-        ('user_id_partner_id_unique', 'UNIQUE(user_id, partner_id)', 'A user cannot have the same contact twice.')
-    ]
+    _user_id_partner_id_unique = models.Constraint(
+        'UNIQUE(user_id, partner_id)',
+        'A user cannot have the same contact twice.',
+    )
 
     @api.model
     def unlink_from_partner_id(self, partner_id):

--- a/addons/calendar/models/calendar_recurrence.py
+++ b/addons/calendar/models/calendar_recurrence.py
@@ -121,15 +121,16 @@ class CalendarRecurrence(models.Model):
     until = fields.Date('Repeat Until')
     trigger_id = fields.Many2one('ir.cron.trigger')
 
-    _sql_constraints = [
-        ('month_day',
-         "CHECK (rrule_type != 'monthly' "
-                "OR month_by != 'day' "
-                "OR day >= 1 AND day <= 31 "
-                "OR weekday in %s AND byday in %s)"
-                % (tuple(wd[0] for wd in WEEKDAY_SELECTION), tuple(bd[0] for bd in BYDAY_SELECTION)),
-         "The day must be between 1 and 31"),
-    ]
+    _month_day = models.Constraint("""CHECK (
+        rrule_type != 'monthly'
+        OR month_by != 'day'
+        OR day >= 1 AND day <= 31
+        OR weekday IN %s AND byday IN %s)""" % (
+            tuple(wd[0] for wd in WEEKDAY_SELECTION),
+            tuple(bd[0] for bd in BYDAY_SELECTION),
+        ),
+        "The day must be between 1 and 31",
+    )
 
     def _get_daily_recurrence_name(self):
         if self.end_type == 'count':

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -240,9 +240,10 @@ class CrmLead(models.Model):
     medium_id = fields.Many2one(ondelete='set null')
     source_id = fields.Many2one(ondelete='set null')
 
-    _sql_constraints = [
-        ('check_probability', 'check(probability >= 0 and probability <= 100)', 'The probability of closing the deal should be between 0% and 100%!')
-    ]
+    _check_probability = models.Constraint(
+        'check(probability >= 0 and probability <= 100)',
+        'The probability of closing the deal should be between 0% and 100%!',
+    )
 
     @api.depends('company_id')
     def _compute_user_company_ids(self):

--- a/addons/crm/models/crm_recurring_plan.py
+++ b/addons/crm/models/crm_recurring_plan.py
@@ -13,6 +13,7 @@ class CrmRecurringPlan(models.Model):
     active = fields.Boolean('Active', default=True)
     sequence = fields.Integer('Sequence', default=10)
 
-    _sql_constraints = [
-        ('check_number_of_months', 'CHECK(number_of_months >= 0)', 'The number of month can\'t be negative.'),
-    ]
+    _check_number_of_months = models.Constraint(
+        'CHECK(number_of_months >= 0)',
+        "The number of month can't be negative.",
+    )

--- a/addons/crm_iap_mine/models/crm_iap_lead_industry.py
+++ b/addons/crm_iap_mine/models/crm_iap_lead_industry.py
@@ -14,6 +14,7 @@ class CrmIapLeadIndustry(models.Model):
     color = fields.Integer(string='Color Index')
     sequence = fields.Integer('Sequence')
 
-    _sql_constraints = [
-        ('name_uniq', 'unique (name)', 'Industry name already exists!'),
-    ]
+    _name_uniq = models.Constraint(
+        'unique (name)',
+        'Industry name already exists!',
+    )

--- a/addons/crm_iap_mine/models/crm_iap_lead_role.py
+++ b/addons/crm_iap_mine/models/crm_iap_lead_role.py
@@ -12,9 +12,10 @@ class CrmIapLeadRole(models.Model):
     reveal_id = fields.Char(required=True)
     color = fields.Integer(string='Color Index')
 
-    _sql_constraints = [
-        ('name_uniq', 'unique (name)', 'Role name already exists!'),
-    ]
+    _name_uniq = models.Constraint(
+        'unique (name)',
+        'Role name already exists!',
+    )
 
     def _compute_display_name(self):
         for role in self:

--- a/addons/crm_iap_mine/models/crm_iap_lead_seniority.py
+++ b/addons/crm_iap_mine/models/crm_iap_lead_seniority.py
@@ -11,9 +11,10 @@ class CrmIapLeadSeniority(models.Model):
     name = fields.Char(string='Name', required=True, translate=True)
     reveal_id = fields.Char(required=True)
 
-    _sql_constraints = [
-        ('name_uniq', 'unique (name)', 'Name already exists!'),
-    ]
+    _name_uniq = models.Constraint(
+        'unique (name)',
+        'Name already exists!',
+    )
 
     @api.depends('name')
     def _compute_display_name(self):

--- a/addons/data_recycle/models/data_recycle_model.py
+++ b/addons/data_recycle/models/data_recycle_model.py
@@ -69,9 +69,10 @@ class Data_RecycleModel(models.Model):
         ('months', 'Months')], string='Notify Frequency Period', default='weeks')
     last_notification = fields.Datetime(readonly=True)
 
-    _sql_constraints = [
-        ('check_notif_freq', 'CHECK(notify_frequency > 0)', 'The notification frequency should be greater than 0'),
-    ]
+    _check_notif_freq = models.Constraint(
+        'CHECK(notify_frequency > 0)',
+        'The notification frequency should be greater than 0',
+    )
 
     @api.constrains('recycle_action')
     def _check_recycle_action(self):

--- a/addons/delivery/models/delivery_carrier.py
+++ b/addons/delivery/models/delivery_carrier.py
@@ -104,10 +104,14 @@ class DeliveryCarrier(models.Model):
         'delivery.price.rule', 'carrier_id', 'Pricing Rules', copy=True
     )
 
-    _sql_constraints = [
-        ('margin_not_under_100_percent', 'CHECK (margin >= -1)', 'Margin cannot be lower than -100%'),
-        ('shipping_insurance_is_percentage', 'CHECK(shipping_insurance >= 0 AND shipping_insurance <= 100)', "The shipping insurance must be a percentage between 0 and 100."),
-    ]
+    _margin_not_under_100_percent = models.Constraint(
+        'CHECK (margin >= -1)',
+        'Margin cannot be lower than -100%',
+    )
+    _shipping_insurance_is_percentage = models.Constraint(
+        'CHECK(shipping_insurance >= 0 AND shipping_insurance <= 100)',
+        'The shipping insurance must be a percentage between 0 and 100.',
+    )
 
     @api.constrains('must_have_tag_ids', 'excluded_tag_ids')
     def _check_tags(self):

--- a/addons/delivery/models/delivery_zip_prefix.py
+++ b/addons/delivery/models/delivery_zip_prefix.py
@@ -23,6 +23,7 @@ class DeliveryZipPrefix(models.Model):
             vals['name'] = vals['name'].upper()
         return super().write(vals)
 
-    _sql_constraints = [
-        ('name_uniq', 'unique (name)', "Prefix already exists!"),
-    ]
+    _name_uniq = models.Constraint(
+        'unique (name)',
+        'Prefix already exists!',
+    )

--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -84,9 +84,10 @@ class EventRegistration(models.Model):
     registration_properties = fields.Properties(
         'Properties', definition='event_id.registration_properties_definition', copy=True)
 
-    _sql_constraints = [
-        ('barcode_event_uniq', 'unique(barcode)', "Barcode should be unique")
-    ]
+    _barcode_event_uniq = models.Constraint(
+        'unique(barcode)',
+        'Barcode should be unique',
+    )
 
     @api.constrains('state', 'event_id', 'event_ticket_id')
     def _check_seats_availability(self):

--- a/addons/event/models/event_registration_answer.py
+++ b/addons/event/models/event_registration_answer.py
@@ -19,9 +19,10 @@ class EventRegistrationAnswer(models.Model):
     value_answer_id = fields.Many2one('event.question.answer', string="Suggested answer")
     value_text_box = fields.Text('Text answer')
 
-    _sql_constraints = [
-        ('value_check', "CHECK(value_answer_id IS NOT NULL OR COALESCE(value_text_box, '') <> '')", "There must be a suggested value or a text value.")
-    ]
+    _value_check = models.Constraint(
+        "CHECK(value_answer_id IS NOT NULL OR COALESCE(value_text_box, '') <> '')",
+        'There must be a suggested value or a text value.',
+    )
 
     # for displaying selected answers by attendees in attendees list view
     @api.depends('value_answer_id', 'question_type', 'value_text_box')

--- a/addons/event_booth_sale/models/event_booth_registration.py
+++ b/addons/event_booth_sale/models/event_booth_registration.py
@@ -19,8 +19,10 @@ class EventBoothRegistration(models.Model):
     contact_email = fields.Char(string='Contact Email', compute='_compute_contact_email', readonly=False, store=True)
     contact_phone = fields.Char(string='Contact Phone', compute='_compute_contact_phone', readonly=False, store=True)
 
-    _sql_constraints = [('unique_registration', 'unique(sale_order_line_id, event_booth_id)',
-                         'There can be only one registration for a booth by sale order line')]
+    _unique_registration = models.Constraint(
+        'unique(sale_order_line_id, event_booth_id)',
+        'There can be only one registration for a booth by sale order line',
+    )
 
     @api.depends('partner_id')
     def _compute_contact_name(self):

--- a/addons/event_crm/models/event_lead_request.py
+++ b/addons/event_crm/models/event_lead_request.py
@@ -26,9 +26,10 @@ class EventLeadRequest(models.Model):
     processed_registration_id = fields.Integer("Processed Registration",
         help="The ID of the last processed event.registration, used to know where to resume.")
 
-    _sql_constraints = [
-        ('uniq_event', 'unique(event_id)', 'You can only have one generation request per event at a time.'),
-    ]
+    _uniq_event = models.Constraint(
+        'unique(event_id)',
+        'You can only have one generation request per event at a time.',
+    )
 
     @api.model
     def _cron_generate_leads(self, job_limit=100, registrations_batch_size=None):

--- a/addons/fleet/models/fleet_vehicle_model_category.py
+++ b/addons/fleet/models/fleet_vehicle_model_category.py
@@ -8,9 +8,10 @@ class FleetVehicleModelCategory(models.Model):
     _description = 'Category of the model'
     _order = 'sequence asc, id asc'
 
-    _sql_constraints = [
-        ('name_uniq', 'UNIQUE (name)', 'Category name must be unique')
-    ]
+    _name_uniq = models.Constraint(
+        'UNIQUE (name)',
+        'Category name must be unique',
+    )
 
     name = fields.Char(required=True)
     sequence = fields.Integer()

--- a/addons/fleet/models/fleet_vehicle_state.py
+++ b/addons/fleet/models/fleet_vehicle_state.py
@@ -11,4 +11,7 @@ class FleetVehicleState(models.Model):
     name = fields.Char(required=True, translate=True)
     sequence = fields.Integer()
 
-    _sql_constraints = [('fleet_state_name_unique', 'unique(name)', 'State name already exists')]
+    _fleet_state_name_unique = models.Constraint(
+        'unique(name)',
+        'State name already exists',
+    )

--- a/addons/fleet/models/fleet_vehicle_tag.py
+++ b/addons/fleet/models/fleet_vehicle_tag.py
@@ -10,4 +10,7 @@ class FleetVehicleTag(models.Model):
     name = fields.Char('Tag Name', required=True, translate=True)
     color = fields.Integer('Color')
 
-    _sql_constraints = [('name_uniq', 'unique (name)', "Tag name already exists!")]
+    _name_uniq = models.Constraint(
+        'unique (name)',
+        'Tag name already exists!',
+    )

--- a/addons/gamification/models/gamification_karma_rank.py
+++ b/addons/gamification/models/gamification_karma_rank.py
@@ -19,9 +19,10 @@ class GamificationKarmaRank(models.Model):
     user_ids = fields.One2many('res.users', 'rank_id', string='Users')
     rank_users_count = fields.Integer("# Users", compute="_compute_rank_users_count")
 
-    _sql_constraints = [
-        ('karma_min_check', "CHECK( karma_min > 0 )", 'The required karma has to be above 0.')
-    ]
+    _karma_min_check = models.Constraint(
+        'CHECK( karma_min > 0 )',
+        'The required karma has to be above 0.',
+    )
 
     @api.depends('user_ids')
     def _compute_rank_users_count(self):

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -180,10 +180,14 @@ class HrEmployee(models.Model):
     message_has_error_counter = fields.Integer(groups="hr.group_hr_user")
     message_attachment_count = fields.Integer(groups="hr.group_hr_user")
 
-    _sql_constraints = [
-        ('barcode_uniq', 'unique (barcode)', "The Badge ID must be unique, this one is already assigned to another employee."),
-        ('user_uniq', 'unique (user_id, company_id)', "A user cannot be linked to multiple employees in the same company.")
-    ]
+    _barcode_uniq = models.Constraint(
+        'unique (barcode)',
+        'The Badge ID must be unique, this one is already assigned to another employee.',
+    )
+    _user_uniq = models.Constraint(
+        'unique (user_id, company_id)',
+        'A user cannot be linked to multiple employees in the same company.',
+    )
 
     @api.model
     def check_field_access_rights(self, operation, field_names):

--- a/addons/hr/models/hr_employee_category.py
+++ b/addons/hr/models/hr_employee_category.py
@@ -17,6 +17,7 @@ class HrEmployeeCategory(models.Model):
     color = fields.Integer(string='Color Index', default=_get_default_color)
     employee_ids = fields.Many2many('hr.employee', 'employee_category_rel', 'category_id', 'employee_id', string='Employees')
 
-    _sql_constraints = [
-        ('name_uniq', 'unique (name)', "Tag name already exists!"),
-    ]
+    _name_uniq = models.Constraint(
+        'unique (name)',
+        'Tag name already exists!',
+    )

--- a/addons/hr/models/hr_job.py
+++ b/addons/hr/models/hr_job.py
@@ -26,10 +26,14 @@ class HrJob(models.Model):
     company_id = fields.Many2one('res.company', string='Company', default=lambda self: self.env.company)
     contract_type_id = fields.Many2one('hr.contract.type', string='Employment Type')
 
-    _sql_constraints = [
-        ('name_company_uniq', 'unique(name, company_id, department_id)', 'The name of the job position must be unique per department in company!'),
-        ('no_of_recruitment_positive', 'CHECK(no_of_recruitment >= 0)', 'The expected number of new employees must be positive.')
-    ]
+    _name_company_uniq = models.Constraint(
+        'unique(name, company_id, department_id)',
+        'The name of the job position must be unique per department in company!',
+    )
+    _no_of_recruitment_positive = models.Constraint(
+        'CHECK(no_of_recruitment >= 0)',
+        'The expected number of new employees must be positive.',
+    )
 
     @api.depends('no_of_recruitment', 'employee_ids.job_id', 'employee_ids.active')
     def _compute_employees(self):

--- a/addons/hr_expense/models/hr_expense_sheet.py
+++ b/addons/hr_expense/models/hr_expense_sheet.py
@@ -221,11 +221,10 @@ class HrExpenseSheet(models.Model):
     cannot_approve_reason = fields.Char(string='Cannot Approve Reason', compute='_compute_can_approve')
     is_editable = fields.Boolean(string="Expense Lines Are Editable By Current User", compute='_compute_is_editable')
 
-    _sql_constraints = [(
-        'journal_id_required_posted',
+    _journal_id_required_posted = models.Constraint(
         "CHECK((state IN ('post', 'done') AND journal_id IS NOT NULL) OR (state NOT IN ('post', 'done')))",
-        'The journal must be set on posted expense'
-    )]
+        'The journal must be set on posted expense',
+    )
 
     @api.depends('expense_line_ids.total_amount', 'expense_line_ids.tax_amount')
     def _compute_amount(self):

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -219,11 +219,18 @@ class HrLeave(models.Model):
     has_mandatory_day = fields.Boolean(compute='_compute_has_mandatory_day')
     leave_type_increases_duration = fields.Boolean(compute='_compute_leave_type_increases_duration')
 
-    _sql_constraints = [
-        ('date_check2', "CHECK ((date_from <= date_to))", "The start date must be before or equal to the end date."),
-        ('date_check3', "CHECK ((request_date_from <= request_date_to))", "The request start date must be before or equal to the request end date."),
-        ('duration_check', "CHECK ( number_of_days >= 0 )", "If you want to change the number of days you should use the 'period' mode"),
-    ]
+    _date_check2 = models.Constraint(
+        'CHECK ((date_from <= date_to))',
+        'The start date must be before or equal to the end date.',
+    )
+    _date_check3 = models.Constraint(
+        'CHECK ((request_date_from <= request_date_to))',
+        'The request start date must be before or equal to the request end date.',
+    )
+    _duration_check = models.Constraint(
+        'CHECK ( number_of_days >= 0 )',
+        "If you want to change the number of days you should use the 'period' mode",
+    )
 
     def _auto_init(self):
         res = super()._auto_init()

--- a/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
@@ -136,23 +136,22 @@ class HrLeaveAccrualLevel(models.Model):
         default='day', string="Accrual Validity Type", required=True,
         help="This field defines the unit of time after which the accrual ends.")
 
-    _sql_constraints = [
-        ('check_dates',
-         "CHECK( (frequency IN ('daily', 'hourly')) or"
-         "(week_day IS NOT NULL AND frequency = 'weekly') or "
-         "(first_day > 0 AND second_day > first_day AND first_day <= 31 AND second_day <= 31 AND frequency = 'bimonthly') or "
-         "(first_day > 0 AND first_day <= 31 AND frequency = 'monthly')or "
-         "(first_month_day > 0 AND first_month_day <= 31 AND second_month_day > 0 AND second_month_day <= 31 AND frequency = 'biyearly') or "
-         "(yearly_day > 0 AND yearly_day <= 31 AND frequency = 'yearly'))",
-         "The dates you've set up aren't correct. Please check them."),
-        ('start_count_check', "CHECK( start_count >= 0 )", "You can not start an accrual in the past."),
-        ('added_value_greater_than_zero', 'CHECK(added_value > 0)', "You must give a rate greater than 0 in accrual plan levels."),
-        (
-            'valid_yearly_cap_value',
-            'CHECK(cap_accrued_time_yearly IS NOT TRUE OR COALESCE(maximum_leave_yearly, 0) > 0)',
-            "You cannot have a cap on yearly accrued time without setting a maximum amount."
-        ),
-    ]
+    _check_dates = models.Constraint(
+        "CHECK( (frequency IN ('daily', 'hourly')) or(week_day IS NOT NULL AND frequency = 'weekly') or (first_day > 0 AND second_day > first_day AND first_day <= 31 AND second_day <= 31 AND frequency = 'bimonthly') or (first_day > 0 AND first_day <= 31 AND frequency = 'monthly')or (first_month_day > 0 AND first_month_day <= 31 AND second_month_day > 0 AND second_month_day <= 31 AND frequency = 'biyearly') or (yearly_day > 0 AND yearly_day <= 31 AND frequency = 'yearly'))",
+        "The dates you've set up aren't correct. Please check them.",
+    )
+    _start_count_check = models.Constraint(
+        'CHECK( start_count >= 0 )',
+        'You can not start an accrual in the past.',
+    )
+    _added_value_greater_than_zero = models.Constraint(
+        'CHECK(added_value > 0)',
+        'You must give a rate greater than 0 in accrual plan levels.',
+    )
+    _valid_yearly_cap_value = models.Constraint(
+        'CHECK(cap_accrued_time_yearly IS NOT TRUE OR COALESCE(maximum_leave_yearly, 0) > 0)',
+        'You cannot have a cap on yearly accrued time without setting a maximum amount.',
+    )
 
     @api.constrains('cap_accrued_time', 'maximum_leave')
     def _check_maximum_leave(self):

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -124,9 +124,10 @@ class HrLeaveAllocation(models.Model):
     leaves_taken = fields.Float(compute='_compute_leaves', string='Time off Taken')
     expiring_carryover_days = fields.Float("The number of carried over days that will expire on carried_over_days_expiration_date")
     carried_over_days_expiration_date = fields.Date("Carried over days expiration date")
-    _sql_constraints = [
-        ('duration_check', "CHECK( ( number_of_days > 0 AND allocation_type='regular') or (allocation_type != 'regular'))", "The duration must be greater than 0."),
-    ]
+    _duration_check = models.Constraint(
+        "CHECK( ( number_of_days > 0 AND allocation_type='regular') or (allocation_type != 'regular'))",
+        'The duration must be greater than 0.',
+    )
 
     @api.constrains('date_from', 'date_to')
     def _check_date_from_date_to(self):

--- a/addons/hr_holidays/models/hr_leave_mandatory_day.py
+++ b/addons/hr_holidays/models/hr_leave_mandatory_day.py
@@ -18,6 +18,7 @@ class HrLeaveMandatoryDay(models.Model):
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
     department_ids = fields.Many2many('hr.department', string="Departments")
 
-    _sql_constraints = [
-        ('date_from_after_day_to', 'CHECK(start_date <= end_date)', 'The start date must be anterior than the end date.')
-    ]
+    _date_from_after_day_to = models.Constraint(
+        'CHECK(start_date <= end_date)',
+        'The start date must be anterior than the end date.',
+    )

--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -107,11 +107,10 @@ class HrLeaveType(models.Model):
     max_allowed_negative = fields.Integer(string="Amount in Negative",
         help="Define the maximum level of negative days this kind of time off can reach. Value must be at least 1.")
 
-    _sql_constraints = [(
-        'check_negative',
+    _check_negative = models.Constraint(
         'CHECK(NOT allows_negative OR max_allowed_negative > 0)',
-        'The negative amount must be greater than 0. If you want to set 0, disable the negative cap instead.'
-    )]
+        'The negative amount must be greater than 0. If you want to set 0, disable the negative cap instead.',
+    )
 
     @api.model
     def _search_valid(self, operator, value):

--- a/addons/hr_homeworking/models/hr_homeworking.py
+++ b/addons/hr_homeworking/models/hr_homeworking.py
@@ -16,9 +16,10 @@ class HrEmployeeLocation(models.Model):
     date = fields.Date(string="Date")
     day_week_string = fields.Char(compute="_compute_day_week_string")
 
-    _sql_constraints = [
-        ('uniq_exceptional_per_day', 'unique(employee_id, date)', 'Only one default work location and one exceptional work location per day per employee.'),
-    ]
+    _uniq_exceptional_per_day = models.Constraint(
+        'unique(employee_id, date)',
+        'Only one default work location and one exceptional work location per day per employee.',
+    )
 
     @api.depends('date')
     def _compute_day_week_string(self):

--- a/addons/hr_recruitment/models/hr_applicant_category.py
+++ b/addons/hr_recruitment/models/hr_applicant_category.py
@@ -15,6 +15,7 @@ class HrApplicantCategory(models.Model):
     name = fields.Char("Tag Name", required=True)
     color = fields.Integer(string='Color Index', default=_get_default_color)
 
-    _sql_constraints = [
-        ('name_uniq', 'unique (name)', "Tag name already exists!"),
-    ]
+    _name_uniq = models.Constraint(
+        'unique (name)',
+        'Tag name already exists!',
+    )

--- a/addons/hr_recruitment/models/hr_job_platform.py
+++ b/addons/hr_recruitment/models/hr_job_platform.py
@@ -13,9 +13,10 @@ class HrJobPlatform(models.Model):
     regex = fields.Char(help="The regex facilitates to extract information from the subject or body "
                              "of the received email to autopopulate the Applicant's name field")
 
-    _sql_constraints = [
-        ('email_uniq', 'unique (email)', "The Email must be unique, this one already corresponds to another Job Platform."),
-    ]
+    _email_uniq = models.Constraint(
+        'unique (email)',
+        'The Email must be unique, this one already corresponds to another Job Platform.',
+    )
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/hr_recruitment/models/hr_recruitment_degree.py
+++ b/addons/hr_recruitment/models/hr_recruitment_degree.py
@@ -10,6 +10,7 @@ class HrRecruitmentDegree(models.Model):
     name = fields.Char("Degree Name", required=True, translate=True)
     sequence = fields.Integer("Sequence", default=1)
 
-    _sql_constraints = [
-        ('name_uniq', 'unique (name)', 'The name of the Degree of Recruitment must be unique!')
-    ]
+    _name_uniq = models.Constraint(
+        'unique (name)',
+        'The name of the Degree of Recruitment must be unique!',
+    )

--- a/addons/hr_recruitment_skills/models/hr_candidate_skill.py
+++ b/addons/hr_recruitment_skills/models/hr_candidate_skill.py
@@ -33,9 +33,10 @@ class HrCandidateSkill(models.Model):
     level_progress = fields.Integer(
         related='skill_level_id.level_progress')
 
-    _sql_constraints = [
-        ('_unique_skill', 'unique (candidate_id, skill_id)', "Two levels for the same skill is not allowed"),
-    ]
+    __unique_skill = models.Constraint(
+        'unique (candidate_id, skill_id)',
+        'Two levels for the same skill is not allowed',
+    )
 
     @api.constrains('skill_id', 'skill_type_id')
     def _check_skill_type(self):

--- a/addons/hr_skills/models/hr_employee_skill.py
+++ b/addons/hr_skills/models/hr_employee_skill.py
@@ -21,9 +21,10 @@ class HrEmployeeSkill(models.Model):
     level_progress = fields.Integer(related='skill_level_id.level_progress')
     color = fields.Integer(related="skill_type_id.color")
 
-    _sql_constraints = [
-        ('_unique_skill', 'unique (employee_id, skill_id)', "Two levels for the same skill is not allowed"),
-    ]
+    __unique_skill = models.Constraint(
+        'unique (employee_id, skill_id)',
+        'Two levels for the same skill is not allowed',
+    )
 
     @api.constrains('skill_id', 'skill_type_id')
     def _check_skill_type(self):

--- a/addons/hr_skills/models/hr_employee_skill_log.py
+++ b/addons/hr_skills/models/hr_employee_skill_log.py
@@ -17,6 +17,7 @@ class HrEmployeeSkillLog(models.Model):
     level_progress = fields.Integer(related='skill_level_id.level_progress', store=True, aggregator="avg")
     date = fields.Date(default=fields.Date.context_today)
 
-    _sql_constraints = [
-        ('_unique_skill_log', 'unique (employee_id, department_id, skill_id, date)', "Two levels for the same skill on the same day is not allowed"),
-    ]
+    __unique_skill_log = models.Constraint(
+        'unique (employee_id, department_id, skill_id, date)',
+        'Two levels for the same skill on the same day is not allowed',
+    )

--- a/addons/hr_skills/models/hr_resume_line.py
+++ b/addons/hr_skills/models/hr_resume_line.py
@@ -18,6 +18,7 @@ class HrResumeLine(models.Model):
     # Used to apply specific template on a line
     display_type = fields.Selection([('classic', 'Classic')], string="Display Type", default='classic')
 
-    _sql_constraints = [
-        ('date_check', "CHECK ((date_start <= date_end OR date_end IS NULL))", "The start date must be anterior to the end date."),
-    ]
+    _date_check = models.Constraint(
+        'CHECK ((date_start <= date_end OR date_end IS NULL))',
+        'The start date must be anterior to the end date.',
+    )

--- a/addons/hr_skills/models/hr_skill_level.py
+++ b/addons/hr_skills/models/hr_skill_level.py
@@ -13,9 +13,10 @@ class HrSkillLevel(models.Model):
     level_progress = fields.Integer(string="Progress", help="Progress from zero knowledge (0%) to fully mastered (100%).")
     default_level = fields.Boolean(help="If checked, this level will be the default one selected when choosing this skill.")
 
-    _sql_constraints = [
-        ('check_level_progress', 'CHECK(level_progress BETWEEN 0 AND 100)', "Progress should be a number between 0 and 100."),
-    ]
+    _check_level_progress = models.Constraint(
+        'CHECK(level_progress BETWEEN 0 AND 100)',
+        'Progress should be a number between 0 and 100.',
+    )
 
     @api.depends('level_progress')
     @api.depends_context('from_skill_level_dropdown')

--- a/addons/hr_work_entry/models/hr_work_entry.py
+++ b/addons/hr_work_entry/models/hr_work_entry.py
@@ -288,6 +288,7 @@ class HrUserWorkEntryEmployee(models.Model):
     employee_id = fields.Many2one('hr.employee', 'Employee', required=True)
     active = fields.Boolean('Active', default=True)
 
-    _sql_constraints = [
-        ('user_id_employee_id_unique', 'UNIQUE(user_id,employee_id)', 'You cannot have the same employee twice.')
-    ]
+    _user_id_employee_id_unique = models.Constraint(
+        'UNIQUE(user_id,employee_id)',
+        'You cannot have the same employee twice.',
+    )

--- a/addons/hr_work_entry/models/hr_work_entry.py
+++ b/addons/hr_work_entry/models/hr_work_entry.py
@@ -48,21 +48,24 @@ class HrWorkEntry(models.Model):
     # using special operator classes and it also supports partial WHERE clauses. Similarly to
     # CHECK constraints, it's backed by an index.
     # 1: https://www.postgresql.org/docs/9.6/sql-createtable.html#SQL-CREATETABLE-EXCLUDE
-    _sql_constraints = [
-        ('_work_entry_has_end', 'check (date_stop IS NOT NULL)', 'Work entry must end. Please define an end date or a duration.'),
-        ('_work_entry_start_before_end', 'check (date_stop > date_start)', 'Starting time should be before end time.'),
-        (
-            '_work_entries_no_validated_conflict',
-            """
-                EXCLUDE USING GIST (
-                    tsrange(date_start, date_stop, '()') WITH &&,
-                    int4range(employee_id, employee_id, '[]') WITH =
-                )
-                WHERE (state = 'validated' AND active = TRUE)
-            """,
-            'Validated work entries cannot overlap'
-        ),
-    ]
+    _work_entry_has_end = models.Constraint(
+        'CHECK (date_stop IS NOT NULL)',
+        'Work entry must end. Please define an end date or a duration.',
+    )
+    _work_entry_start_before_end = models.Constraint(
+        'CHECK (date_stop > date_start)',
+        'Starting time should be before end time.',
+    )
+    _work_entries_no_validated_conflict = models.Constraint(
+        """
+            EXCLUDE USING GIST (
+                tsrange(date_start, date_stop, '()') WITH &&,
+                int4range(employee_id, employee_id, '[]') WITH =
+            )
+            WHERE (state = 'validated' AND active = TRUE)
+        """,
+        'Validated work entries cannot overlap',
+    )
 
     def init(self):
         tools.create_index(self._cr, "hr_work_entry_date_start_date_stop_index", self._table, ["date_start", "date_stop"])

--- a/addons/iap/models/iap_service.py
+++ b/addons/iap/models/iap_service.py
@@ -12,6 +12,7 @@ class IapService(models.Model):
     unit_name = fields.Char(required=True, translate=True)
     integer_balance = fields.Boolean(required=True)
 
-    _sql_constraints = [
-        ('unique_technical_name', 'UNIQUE(technical_name)', 'Only one service can exist with a specific technical_name')
-    ]
+    _unique_technical_name = models.Constraint(
+        'UNIQUE(technical_name)',
+        'Only one service can exist with a specific technical_name',
+    )

--- a/addons/im_livechat/models/chatbot_message.py
+++ b/addons/im_livechat/models/chatbot_message.py
@@ -21,7 +21,7 @@ class ChatbotMessage(models.Model):
     user_script_answer_id = fields.Many2one('chatbot.script.answer', string="User's answer", ondelete="set null")
     user_raw_answer = fields.Html(string="User's raw answer")
 
-    _sql_constraints = [
-        ('_unique_mail_message_id', 'unique (mail_message_id)',
-         "A mail.message can only be linked to a single chatbot message"),
-    ]
+    __unique_mail_message_id = models.Constraint(
+        'unique (mail_message_id)',
+        'A mail.message can only be linked to a single chatbot message',
+    )

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -25,8 +25,10 @@ class DiscussChannel(models.Model):
     chatbot_message_ids = fields.One2many('chatbot.message', 'discuss_channel_id', string='Chatbot Messages')
     country_id = fields.Many2one('res.country', string="Country", help="Country of the visitor of the channel")
 
-    _sql_constraints = [('livechat_operator_id', "CHECK((channel_type = 'livechat' and livechat_operator_id is not null) or (channel_type != 'livechat'))",
-                         'Livechat Operator ID is required for a channel of type livechat.')]
+    _livechat_operator_id = models.Constraint(
+        "CHECK((channel_type = 'livechat' and livechat_operator_id is not null) or (channel_type != 'livechat'))",
+        'Livechat Operator ID is required for a channel of type livechat.',
+    )
 
     @api.depends('message_ids')
     def _compute_duration(self):

--- a/addons/l10n_ar/models/l10n_ar_afip_responsibility_type.py
+++ b/addons/l10n_ar/models/l10n_ar_afip_responsibility_type.py
@@ -13,5 +13,5 @@ class L10n_ArAfipResponsibilityType(models.Model):
     code = fields.Char(required=True, index=True)
     active = fields.Boolean(default=True)
 
-    _sql_constraints = [('name', 'unique(name)', 'Name must be unique!'),
-                        ('code', 'unique(code)', 'Code must be unique!')]
+    _name_uniq = models.Constraint('unique(name)', 'Name must be unique!')
+    _code_uniq = models.Constraint('unique(code)', 'Code must be unique!')

--- a/addons/l10n_br/models/l10n_br_zip_range.py
+++ b/addons/l10n_br/models/l10n_br_zip_range.py
@@ -12,10 +12,14 @@ class L10n_BrZipRange(models.Model):
     start = fields.Char(string="From", required=True)
     end = fields.Char(string="To", required=True)
 
-    _sql_constraints = [
-        ("uniq_start", "unique(start)", 'The "from" zip must be unique'),
-        ("uniq_end", 'unique("end")', 'The "to" zip must be unique.'),
-    ]
+    _uniq_start = models.Constraint(
+        'unique(start)',
+        'The "from" zip must be unique',
+    )
+    _uniq_end = models.Constraint(
+        'unique("end")',
+        'The "to" zip must be unique.',
+    )
 
     @api.constrains("start", "end")
     def _check_range(self):

--- a/addons/l10n_eg_edi_eta/models/eta_thumb_drive.py
+++ b/addons/l10n_eg_edi_eta/models/eta_thumb_drive.py
@@ -21,9 +21,10 @@ class L10n_Eg_EdiThumbDrive(models.Model):
     pin = fields.Char('ETA USB Pin', required=True)
     access_token = fields.Char(required=True)
 
-    _sql_constraints = [
-        ('user_drive_uniq', 'unique (user_id, company_id)', 'You can only have one thumb drive per user per company!'),
-    ]
+    _user_drive_uniq = models.Constraint(
+        'unique (user_id, company_id)',
+        'You can only have one thumb drive per user per company!',
+    )
 
     def action_sign_invoices(self, invoice_ids):
         self.ensure_one()

--- a/addons/l10n_in/models/port_code.py
+++ b/addons/l10n_in/models/port_code.py
@@ -13,6 +13,7 @@ class L10n_InPortCode(models.Model):
     name = fields.Char(string="Port", required=True)
     state_id = fields.Many2one('res.country.state', string="State")
 
-    _sql_constraints = [
-        ('code_uniq', 'unique (code)', 'The Port Code must be unique!')
-    ]
+    _code_uniq = models.Constraint(
+        'unique (code)',
+        'The Port Code must be unique!',
+    )

--- a/addons/l10n_in_withholding/models/l10n_in_section_alert.py
+++ b/addons/l10n_in_withholding/models/l10n_in_section_alert.py
@@ -23,10 +23,14 @@ class L10n_InSectionAlert(models.Model):
         ], string="Aggregate Period", default='fiscal_yearly')
     l10n_in_section_tax_ids = fields.One2many("account.tax", "l10n_in_section_id", string="Taxes")
 
-    _sql_constraints = [
-        ('per_transaction_limit', 'CHECK(per_transaction_limit >= 0)', 'Per transaction limit must be positive'),
-        ('aggregate_limit', 'CHECK(aggregate_limit >= 0)', 'Aggregate limit must be positive'),
-    ]
+    _per_transaction_limit = models.Constraint(
+        'CHECK(per_transaction_limit >= 0)',
+        'Per transaction limit must be positive',
+    )
+    _aggregate_limit = models.Constraint(
+        'CHECK(aggregate_limit >= 0)',
+        'Aggregate limit must be positive',
+    )
 
     @api.depends('tax_source_type')
     def _compute_display_name(self):

--- a/addons/l10n_it_edi/models/res_partner.py
+++ b/addons/l10n_it_edi/models/res_partner.py
@@ -22,15 +22,14 @@ class ResPartner(models.Model):
              "with receiving (and processing) the invoice.",
     )
 
-    _sql_constraints = [
-        ('l10n_it_codice_fiscale',
-            "CHECK(l10n_it_codice_fiscale IS NULL OR l10n_it_codice_fiscale = '' OR LENGTH(l10n_it_codice_fiscale) >= 11)",
-            "Codice fiscale must have between 11 and 16 characters."),
-
-        ('l10n_it_pa_index',
-            "CHECK(l10n_it_pa_index IS NULL OR l10n_it_pa_index = '' OR LENGTH(l10n_it_pa_index) >= 6)",
-            "Destination Code must have between 6 and 7 characters."),
-    ]
+    _l10n_it_codice_fiscale = models.Constraint(
+        "CHECK(l10n_it_codice_fiscale IS NULL OR l10n_it_codice_fiscale = '' OR LENGTH(l10n_it_codice_fiscale) >= 11)",
+        'Codice fiscale must have between 11 and 16 characters.',
+    )
+    _l10n_it_pa_index = models.Constraint(
+        "CHECK(l10n_it_pa_index IS NULL OR l10n_it_pa_index = '' OR LENGTH(l10n_it_pa_index) >= 6)",
+        'Destination Code must have between 6 and 7 characters.',
+    )
 
     def _l10n_it_edi_is_public_administration(self):
         """ Returns True if the destination of the FatturaPA belongs to the Public Administration. """

--- a/addons/l10n_it_edi_doi/models/declaration_of_intent.py
+++ b/addons/l10n_it_edi_doi/models/declaration_of_intent.py
@@ -133,14 +133,14 @@ class L10n_It_Edi_DoiDeclaration_Of_Intent(models.Model):
         readonly=True,
     )
 
-    _sql_constraints = [
-        ('protocol_number_unique',
-         'unique(protocol_number_part1, protocol_number_part2)',
-         "The Protocol Number of a Declaration of Intent must be unique! Please choose another one."),
-        ('threshold_positive',
-         'CHECK(threshold > 0)',
-         "The Threshold of a Declaration of Intent must be positive."),
-    ]
+    _protocol_number_unique = models.Constraint(
+        'unique(protocol_number_part1, protocol_number_part2)',
+        'The Protocol Number of a Declaration of Intent must be unique! Please choose another one.',
+    )
+    _threshold_positive = models.Constraint(
+        'CHECK(threshold > 0)',
+        'The Threshold of a Declaration of Intent must be positive.',
+    )
 
     @api.depends('protocol_number_part1', 'protocol_number_part2')
     def _compute_display_name(self):

--- a/addons/l10n_latam_invoice_document/models/account_move.py
+++ b/addons/l10n_latam_invoice_document/models/account_move.py
@@ -4,18 +4,25 @@ from collections import defaultdict
 
 from odoo import models, fields, api, _
 from odoo.exceptions import UserError, ValidationError
-from odoo.tools.sql import column_exists, create_column, drop_index, index_exists
+from odoo.tools.sql import column_exists, create_column
 
 
 class AccountMove(models.Model):
 
     _inherit = ["account.move"]
 
-    _sql_constraints = [(
-        'unique_name', "", "Another entry with the same name already exists.",
-    ), (
-        'unique_name_latam', "", "Another entry with the same name already exists.",
-    )]
+    _unique_name = models.UniqueIndex(
+        "(name, journal_id)"
+        " WHERE (state = 'posted' AND name != '/'"
+        " AND (l10n_latam_document_type_id IS NULL OR move_type NOT IN ('in_invoice', 'in_refund', 'in_receipt')))",
+        "Another entry with the same name already exists.",
+    )
+    _unique_name_latam = models.UniqueIndex(
+        "(name, commercial_partner_id, l10n_latam_document_type_id, company_id)"
+        " WHERE (state = 'posted' AND name != '/'"
+        " AND (l10n_latam_document_type_id IS NOT NULL AND move_type IN ('in_invoice', 'in_refund', 'in_receipt')))",
+        "Another entry with the same name already exists.",
+    )
 
     def _auto_init(self):
         # Skip the computation of the field `l10n_latam_document_type_id` at the module installation
@@ -47,19 +54,6 @@ class AccountMove(models.Model):
         # for a Chilian or Argentian company (`res.company`) before installing `l10n_cl` or `l10n_ar`.
         if not column_exists(self.env.cr, "account_move", "l10n_latam_document_type_id"):
             create_column(self.env.cr, "account_move", "l10n_latam_document_type_id", "int4")
-
-        if not index_exists(self.env.cr, "account_move_unique_name_latam"):
-            drop_index(self.env.cr, "account_move_unique_name", self._table)
-            self.env.cr.execute("""
-                CREATE UNIQUE INDEX account_move_unique_name
-                                 ON account_move(name, journal_id)
-                              WHERE (state = 'posted' AND name != '/'
-                                AND (l10n_latam_document_type_id IS NULL OR move_type NOT IN ('in_invoice', 'in_refund', 'in_receipt')));
-                CREATE UNIQUE INDEX account_move_unique_name_latam
-                                 ON account_move(name, commercial_partner_id, l10n_latam_document_type_id, company_id)
-                              WHERE (state = 'posted' AND name != '/'
-                                AND (l10n_latam_document_type_id IS NOT NULL AND move_type IN ('in_invoice', 'in_refund', 'in_receipt')));
-            """)
         return super()._auto_init()
 
     l10n_latam_available_document_type_ids = fields.Many2many('l10n_latam.document.type', compute='_compute_l10n_latam_available_document_types')

--- a/addons/l10n_pl/models/l10n_pl_tax_office.py
+++ b/addons/l10n_pl/models/l10n_pl_tax_office.py
@@ -9,9 +9,10 @@ class L10n_PlL10n_Pl_Tax_Office(models.Model):
     code = fields.Char('Code', required=True)
     name = fields.Char('Description', required=True)
 
-    _sql_constraints = [
-        ('code_company_uniq', 'unique (code)', 'The code of the tax office must be unique !')
-    ]
+    _code_company_uniq = models.Constraint(
+        'unique (code)',
+        'The code of the tax office must be unique !',
+    )
 
     @api.depends('name', 'code')
     def _compute_display_name(self):

--- a/addons/l10n_vn_edi_viettel/models/sinvoice.py
+++ b/addons/l10n_vn_edi_viettel/models/sinvoice.py
@@ -34,9 +34,10 @@ class L10n_Vn_Edi_ViettelSinvoiceTemplate(models.Model):
         inverse_name='invoice_template_id',
     )
 
-    _sql_constraints = [
-        ('name_uniq', 'unique (name)', 'The template code must be unique!')
-    ]
+    _name_uniq = models.Constraint(
+        'unique (name)',
+        'The template code must be unique!',
+    )
 
     @api.constrains('name', 'template_invoice_type')
     def _constrains_changes(self):
@@ -83,9 +84,10 @@ class L10n_Vn_Edi_ViettelSinvoiceSymbol(models.Model):
         required=True,
     )
 
-    _sql_constraints = [
-        ('name_template_uniq', 'unique (name, invoice_template_id)', 'The combination symbol/template must be unique!')
-    ]
+    _name_template_uniq = models.Constraint(
+        'unique (name, invoice_template_id)',
+        'The combination symbol/template must be unique!',
+    )
 
     @api.constrains('name', 'invoice_template_id')
     def _constrains_changes(self):

--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -296,9 +296,10 @@ class LinkTrackerCode(models.Model):
     code = fields.Char(string='Short URL Code', required=True, store=True)
     link_id = fields.Many2one('link.tracker', 'Link', required=True, ondelete='cascade')
 
-    _sql_constraints = [
-        ('code', 'unique( code )', 'Code must be unique.')
-    ]
+    _code = models.Constraint(
+        'unique( code )',
+        'Code must be unique.',
+    )
 
     @api.model
     def _get_random_code_strings(self, n=1):

--- a/addons/loyalty/models/loyalty_card.py
+++ b/addons/loyalty/models/loyalty_card.py
@@ -45,9 +45,10 @@ class LoyaltyCard(models.Model):
         readonly=True,
     )
 
-    _sql_constraints = [
-        ('card_code_unique', 'UNIQUE(code)', 'A coupon/loyalty card must have a unique code.')
-    ]
+    _card_code_unique = models.Constraint(
+        'UNIQUE(code)',
+        'A coupon/loyalty card must have a unique code.',
+    )
 
     @api.constrains('code')
     def _contrains_code(self):

--- a/addons/loyalty/models/loyalty_program.py
+++ b/addons/loyalty/models/loyalty_program.py
@@ -118,10 +118,10 @@ class LoyaltyProgram(models.Model):
         """
     )
 
-    _sql_constraints = [
-        ('check_max_usage', 'CHECK (limit_usage = False OR max_usage > 0)',
-            'Max usage must be strictly positive if a limit is used.'),
-    ]
+    _check_max_usage = models.Constraint(
+        'CHECK (limit_usage = False OR max_usage > 0)',
+        'Max usage must be strictly positive if a limit is used.',
+    )
 
     @api.constrains('currency_id', 'pricelist_ids')
     def _check_pricelist_currency(self):

--- a/addons/loyalty/models/loyalty_reward.py
+++ b/addons/loyalty/models/loyalty_reward.py
@@ -109,14 +109,18 @@ class LoyaltyReward(models.Model):
     point_name = fields.Char(related='program_id.portal_point_name', readonly=True)
     clear_wallet = fields.Boolean(default=False)
 
-    _sql_constraints = [
-        ('required_points_positive', 'CHECK (required_points > 0)',
-            'The required points for a reward must be strictly positive.'),
-        ('product_qty_positive', "CHECK (reward_type != 'product' OR reward_product_qty > 0)",
-            'The reward product quantity must be strictly positive.'),
-        ('discount_positive', "CHECK (reward_type != 'discount' OR discount > 0)",
-            'The discount must be strictly positive.'),
-    ]
+    _required_points_positive = models.Constraint(
+        'CHECK (required_points > 0)',
+        'The required points for a reward must be strictly positive.',
+    )
+    _product_qty_positive = models.Constraint(
+        "CHECK (reward_type != 'product' OR reward_product_qty > 0)",
+        'The reward product quantity must be strictly positive.',
+    )
+    _discount_positive = models.Constraint(
+        "CHECK (reward_type != 'discount' OR discount > 0)",
+        'The discount must be strictly positive.',
+    )
 
     @api.depends('reward_product_id.product_tmpl_id.uom_id', 'reward_product_tag_id')
     def _compute_reward_product_uom_id(self):

--- a/addons/loyalty/models/loyalty_rule.py
+++ b/addons/loyalty/models/loyalty_rule.py
@@ -74,9 +74,10 @@ class LoyaltyRule(models.Model):
     ], string="Application", compute='_compute_mode', store=True, readonly=False)
     code = fields.Char(string='Discount code', compute='_compute_code', store=True, readonly=False)
 
-    _sql_constraints = [
-        ('reward_point_amount_positive', 'CHECK (reward_point_amount > 0)', 'Rule points reward must be strictly positive.'),
-    ]
+    _reward_point_amount_positive = models.Constraint(
+        'CHECK (reward_point_amount > 0)',
+        'Rule points reward must be strictly positive.',
+    )
 
     @api.constrains('reward_point_split')
     def _constraint_trigger_multi(self):

--- a/addons/lunch/models/lunch_alert.py
+++ b/addons/lunch/models/lunch_alert.py
@@ -56,11 +56,10 @@ class LunchAlert(models.Model):
 
     location_ids = fields.Many2many('lunch.location', string='Location')
 
-    _sql_constraints = [
-        ('notification_time_range',
-            'CHECK(notification_time >= 0 and notification_time <= 12)',
-            'Notification time must be between 0 and 12')
-    ]
+    _notification_time_range = models.Constraint(
+        'CHECK(notification_time >= 0 and notification_time <= 12)',
+        'Notification time must be between 0 and 12',
+    )
 
     @api.depends('mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun')
     def _compute_available_today(self):

--- a/addons/lunch/models/lunch_supplier.py
+++ b/addons/lunch/models/lunch_supplier.py
@@ -112,11 +112,10 @@ class LunchSupplier(models.Model):
     show_order_button = fields.Boolean(compute='_compute_buttons')
     show_confirm_button = fields.Boolean(compute='_compute_buttons')
 
-    _sql_constraints = [
-        ('automatic_email_time_range',
-         'CHECK(automatic_email_time >= 0 AND automatic_email_time <= 12)',
-         'Automatic Email Sending Time should be between 0 and 12'),
-    ]
+    _automatic_email_time_range = models.Constraint(
+        'CHECK(automatic_email_time >= 0 AND automatic_email_time <= 12)',
+        'Automatic Email Sending Time should be between 0 and 12',
+    )
 
     @api.depends('phone')
     def _compute_display_name(self):

--- a/addons/mail/models/bus_presence.py
+++ b/addons/mail/models/bus_presence.py
@@ -11,9 +11,10 @@ class BusPresence(models.Model):
     def init(self):
         self.env.cr.execute("CREATE UNIQUE INDEX IF NOT EXISTS bus_presence_guest_unique ON %s (guest_id) WHERE guest_id IS NOT NULL" % self._table)
 
-    _sql_constraints = [
-        ("partner_or_guest_exists", "CHECK((user_id IS NOT NULL AND guest_id IS NULL) OR (user_id IS NULL AND guest_id IS NOT NULL))", "A bus presence must have a user or a guest."),
-    ]
+    _partner_or_guest_exists = models.Constraint(
+        'CHECK((user_id IS NOT NULL AND guest_id IS NULL) OR (user_id IS NULL AND guest_id IS NOT NULL))',
+        'A bus presence must have a user or a guest.',
+    )
 
     def _get_bus_target(self):
         return self.guest_id or super()._get_bus_target()

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -78,19 +78,26 @@ class DiscussChannel(models.Model):
     group_public_id = fields.Many2one('res.groups', string='Authorized Group', compute='_compute_group_public_id', readonly=False, store=True)
     invitation_url = fields.Char('Invitation URL', compute='_compute_invitation_url')
     allow_public_upload = fields.Boolean(default=False)
-    _sql_constraints = [
-        ('channel_type_not_null', 'CHECK(channel_type IS NOT NULL)', 'The channel type cannot be empty'),
-        ("from_message_id_unique", "UNIQUE(from_message_id)", "Messages can only be linked to one sub-channel"),
-        (
-            "sub_channel_no_group_public_id",
-            "CHECK(parent_channel_id IS NULL OR group_public_id IS NULL)",
-            "Group public id should not be set on sub-channels as access is based on parent channel",
-        ),
-        ('uuid_unique', 'UNIQUE(uuid)', 'The channel UUID must be unique'),
-        ('group_public_id_check',
-         "CHECK (channel_type = 'channel' OR group_public_id IS NULL)",
-         'Group authorization and group auto-subscription are only supported on channels.')
-    ]
+    _channel_type_not_null = models.Constraint(
+        'CHECK(channel_type IS NOT NULL)',
+        'The channel type cannot be empty',
+    )
+    _from_message_id_unique = models.Constraint(
+        'UNIQUE(from_message_id)',
+        'Messages can only be linked to one sub-channel',
+    )
+    _sub_channel_no_group_public_id = models.Constraint(
+        'CHECK(parent_channel_id IS NULL OR group_public_id IS NULL)',
+        'Group public id should not be set on sub-channels as access is based on parent channel',
+    )
+    _uuid_unique = models.Constraint(
+        'UNIQUE(uuid)',
+        'The channel UUID must be unique',
+    )
+    _group_public_id_check = models.Constraint(
+        "CHECK (channel_type = 'channel' OR group_public_id IS NULL)",
+        'Group authorization and group auto-subscription are only supported on channels.',
+    )
 
     # CONSTRAINTS
     @api.constrains("from_message_id")

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -169,9 +169,10 @@ class DiscussChannelMember(models.Model):
         self.env.cr.execute("CREATE UNIQUE INDEX IF NOT EXISTS discuss_channel_member_partner_unique ON %s (channel_id, partner_id) WHERE partner_id IS NOT NULL" % self._table)
         self.env.cr.execute("CREATE UNIQUE INDEX IF NOT EXISTS discuss_channel_member_guest_unique ON %s (channel_id, guest_id) WHERE guest_id IS NOT NULL" % self._table)
 
-    _sql_constraints = [
-        ("partner_or_guest_exists", "CHECK((partner_id IS NOT NULL AND guest_id IS NULL) OR (partner_id IS NULL AND guest_id IS NOT NULL))", "A channel member must be a partner or a guest."),
-    ]
+    _partner_or_guest_exists = models.Constraint(
+        'CHECK((partner_id IS NOT NULL AND guest_id IS NULL) OR (partner_id IS NULL AND guest_id IS NOT NULL))',
+        'A channel member must be a partner or a guest.',
+    )
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/mail/models/discuss/discuss_channel_rtc_session.py
+++ b/addons/mail/models/discuss/discuss_channel_rtc_session.py
@@ -30,10 +30,10 @@ class DiscussChannelRtcSession(models.Model):
     is_muted = fields.Boolean(string="Is microphone muted")
     is_deaf = fields.Boolean(string="Has disabled incoming sound")
 
-    _sql_constraints = [
-        ('channel_member_unique', 'UNIQUE(channel_member_id)',
-         'There can only be one rtc session per channel member')
-    ]
+    _channel_member_unique = models.Constraint(
+        'UNIQUE(channel_member_id)',
+        'There can only be one rtc session per channel member',
+    )
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/mail/models/discuss/discuss_gif_favorite.py
+++ b/addons/mail/models/discuss/discuss_gif_favorite.py
@@ -8,10 +8,7 @@ class DiscussGifFavorite(models.Model):
 
     tenor_gif_id = fields.Char("GIF id from Tenor", required=True)
 
-    _sql_constraints = [
-        (
-            "user_gif_favorite",
-            "unique(create_uid,tenor_gif_id)",
-            "User should not have duplicated favorite GIF",
-        ),
-    ]
+    _user_gif_favorite = models.Constraint(
+        'unique(create_uid,tenor_gif_id)',
+        'User should not have duplicated favorite GIF',
+    )

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -111,14 +111,10 @@ class MailActivity(models.Model):
     can_write = fields.Boolean(compute='_compute_can_write') # used to hide buttons if the current user has no access
     active = fields.Boolean(default=True)
 
-    _sql_constraints = [
-        # Required on a Many2one reference field is not sufficient as actually
-        # writing 0 is considered as a valid value, because this is an integer field.
-        # We therefore need a specific constraint check.
-        ('check_res_id_is_set',
-         'CHECK(res_id IS NOT NULL AND res_id !=0 )',
-         'Activities have to be linked to records with a not null res_id.')
-    ]
+    _check_res_id_is_set = models.Constraint(
+        'CHECK(res_id IS NOT NULL AND res_id !=0 )',
+        'Activities have to be linked to records with a not null res_id.',
+    )
 
     @api.onchange('previous_activity_type_id')
     def _compute_has_recommended_activities(self):

--- a/addons/mail/models/mail_alias.py
+++ b/addons/mail/models/mail_alias.py
@@ -93,14 +93,7 @@ class MailAlias(models.Model):
         ], compute='_compute_alias_status', store=True,
         help='Alias status assessed on the last message received.')
 
-    def init(self):
-        """Make sure there aren't multiple records for the same name and alias
-        domain. Not in _sql_constraint because COALESCE is not supported for
-        PostgreSQL constraint. """
-        self.env.cr.execute("""
-            CREATE UNIQUE INDEX IF NOT EXISTS mail_alias_name_domain_unique
-            ON mail_alias (alias_name, COALESCE(alias_domain_id, 0))
-        """)
+    _name_domain_unique = models.UniqueIndex('(alias_name, COALESCE(alias_domain_id, 0))')
 
     @api.constrains('alias_domain_id', 'alias_force_thread_id', 'alias_parent_model_id',
                     'alias_parent_thread_id', 'alias_model_id')

--- a/addons/mail/models/mail_alias_domain.py
+++ b/addons/mail/models/mail_alias_domain.py
@@ -39,18 +39,14 @@ class MailAliasDomain(models.Model):
              "'notifications@example.com' to override all outgoing emails.")
     default_from_email = fields.Char('Default From', compute='_compute_default_from_email')
 
-    _sql_constraints = [
-        (
-            'bounce_email_uniques',
-            'UNIQUE(bounce_alias, name)',
-            'Bounce emails should be unique'
-        ),
-        (
-            'catchall_email_uniques',
-            'UNIQUE(catchall_alias, name)',
-            'Catchall emails should be unique'
-        ),
-    ]
+    _bounce_email_uniques = models.Constraint(
+        'UNIQUE(bounce_alias, name)',
+        'Bounce emails should be unique',
+    )
+    _catchall_email_uniques = models.Constraint(
+        'UNIQUE(catchall_alias, name)',
+        'Catchall emails should be unique',
+    )
 
     @api.depends('bounce_alias', 'name')
     def _compute_bounce_email(self):

--- a/addons/mail/models/mail_blacklist.py
+++ b/addons/mail/models/mail_blacklist.py
@@ -15,9 +15,10 @@ class MailBlacklist(models.Model):
                         tracking=1)
     active = fields.Boolean(default=True, tracking=2)
 
-    _sql_constraints = [
-        ('unique_email', 'unique (email)', 'Email address already exists!')
-    ]
+    _unique_email = models.Constraint(
+        'unique (email)',
+        'Email address already exists!',
+    )
 
     @api.model_create_multi
     def create(self, values):

--- a/addons/mail/models/mail_followers.py
+++ b/addons/mail/models/mail_followers.py
@@ -66,9 +66,10 @@ class MailFollowers(models.Model):
         self._invalidate_documents()
         return super().unlink()
 
-    _sql_constraints = [
-        ('mail_followers_res_partner_res_model_id_uniq', 'unique(res_model,res_id,partner_id)', 'Error, a partner cannot follow twice the same object.'),
-    ]
+    _mail_followers_res_partner_res_model_id_uniq = models.Constraint(
+        'unique(res_model,res_id,partner_id)',
+        'Error, a partner cannot follow twice the same object.',
+    )
 
     # --------------------------------------------------
     # Private tools methods to fetch followers data

--- a/addons/mail/models/mail_message_reaction.py
+++ b/addons/mail/models/mail_message_reaction.py
@@ -19,9 +19,10 @@ class MailMessageReaction(models.Model):
         self.env.cr.execute("CREATE UNIQUE INDEX IF NOT EXISTS mail_message_reaction_partner_unique ON %s (message_id, content, partner_id) WHERE partner_id IS NOT NULL" % self._table)
         self.env.cr.execute("CREATE UNIQUE INDEX IF NOT EXISTS mail_message_reaction_guest_unique ON %s (message_id, content, guest_id) WHERE guest_id IS NOT NULL" % self._table)
 
-    _sql_constraints = [
-        ("partner_or_guest_exists", "CHECK((partner_id IS NOT NULL AND guest_id IS NULL) OR (partner_id IS NULL AND guest_id IS NOT NULL))", "A message reaction must be from a partner or from a guest."),
-    ]
+    _partner_or_guest_exists = models.Constraint(
+        'CHECK((partner_id IS NOT NULL AND guest_id IS NULL) OR (partner_id IS NULL AND guest_id IS NOT NULL))',
+        'A message reaction must be from a partner or from a guest.',
+    )
 
     def _to_store(self, store: Store):
         for (message_id, content), reactions in groupby(self, lambda r: (r.message_id, r.content)):

--- a/addons/mail/models/mail_notification.py
+++ b/addons/mail/models/mail_notification.py
@@ -49,12 +49,10 @@ class MailNotification(models.Model):
         ], string='Failure type')
     failure_reason = fields.Text('Failure reason', copy=False)
 
-    _sql_constraints = [
-        # email notification: partner is required
-        ('notification_partner_required',
-         "CHECK(notification_type NOT IN ('email', 'inbox') OR res_partner_id IS NOT NULL)",
-         'Customer is required for inbox / email notification'),
-    ]
+    _notification_partner_required = models.Constraint(
+        "CHECK(notification_type NOT IN ('email', 'inbox') OR res_partner_id IS NOT NULL)",
+        'Customer is required for inbox / email notification',
+    )
 
     # ------------------------------------------------------------
     # CRUD

--- a/addons/mail/models/mail_push_device.py
+++ b/addons/mail/models/mail_push_device.py
@@ -24,7 +24,10 @@ class MailPushDevice(models.Model):
                              "- auth: The auth value should be treated as a secret and not shared outside of Odoo"))
     expiration_time = fields.Datetime(string='Expiration Token Date')
 
-    _sql_constraints = [('endpoint_unique', 'unique(endpoint)', 'The endpoint must be unique !')]
+    _endpoint_unique = models.Constraint(
+        'unique(endpoint)',
+        'The endpoint must be unique !',
+    )
 
     @api.model
     def get_web_push_vapid_public_key(self):

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -25,11 +25,10 @@ class ResUsers(models.Model):
              "- Handle by Emails: notifications are sent to your email address\n"
              "- Handle in Odoo: notifications appear in your Odoo Inbox")
 
-    _sql_constraints = [(
-        "notification_type",
+    _notification_type = models.Constraint(
         "CHECK (notification_type = 'email' OR NOT share)",
-        "Only internal user can receive notifications in Odoo",
-    )]
+        'Only internal user can receive notifications in Odoo',
+    )
 
     @api.depends('share', 'groups_id')
     def _compute_notification_type(self):

--- a/addons/mail/models/res_users_settings_volumes.py
+++ b/addons/mail/models/res_users_settings_volumes.py
@@ -17,9 +17,10 @@ class ResUsersSettingsVolumes(models.Model):
         self.env.cr.execute("CREATE UNIQUE INDEX IF NOT EXISTS res_users_settings_volumes_partner_unique ON %s (user_setting_id, partner_id) WHERE partner_id IS NOT NULL" % self._table)
         self.env.cr.execute("CREATE UNIQUE INDEX IF NOT EXISTS res_users_settings_volumes_guest_unique ON %s (user_setting_id, guest_id) WHERE guest_id IS NOT NULL" % self._table)
 
-    _sql_constraints = [
-        ("partner_or_guest_exists", "CHECK((partner_id IS NOT NULL AND guest_id IS NULL) OR (partner_id IS NULL AND guest_id IS NOT NULL))", "A volume setting must have a partner or a guest."),
-    ]
+    _partner_or_guest_exists = models.Constraint(
+        'CHECK((partner_id IS NOT NULL AND guest_id IS NULL) OR (partner_id IS NULL AND guest_id IS NOT NULL))',
+        'A volume setting must have a partner or a guest.',
+    )
 
     @api.depends('user_setting_id', 'partner_id', 'guest_id')
     def _compute_display_name(self):

--- a/addons/mail_group/models/mail_group_member.py
+++ b/addons/mail_group/models/mail_group_member.py
@@ -21,11 +21,10 @@ class MailGroupMember(models.Model):
     mail_group_id = fields.Many2one('mail.group', string='Group', required=True, ondelete='cascade')
     partner_id = fields.Many2one('res.partner', 'Partner', ondelete='cascade')
 
-    _sql_constraints = [(
-        'unique_partner',
+    _unique_partner = models.Constraint(
         'UNIQUE(partner_id, mail_group_id)',
         'This partner is already subscribed to the group',
-    )]
+    )
 
     @api.depends('partner_id.email')
     def _compute_email(self):

--- a/addons/mail_group/models/mail_group_moderation.py
+++ b/addons/mail_group/models/mail_group_moderation.py
@@ -16,11 +16,10 @@ class MailGroupModeration(models.Model):
         string='Status', required=True, default='ban')
     mail_group_id = fields.Many2one('mail.group', string='Group', required=True, ondelete='cascade')
 
-    _sql_constraints = [(
-        'mail_group_email_uniq',
+    _mail_group_email_uniq = models.Constraint(
         'UNIQUE(mail_group_id, email)',
         'You can create only one rule for a given email address in a group.',
-    )]
+    )
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/mail_plugin/models/res_partner_iap.py
+++ b/addons/mail_plugin/models/res_partner_iap.py
@@ -23,4 +23,7 @@ class ResPartnerIap(models.Model):
     iap_search_domain = fields.Char('Search Domain / Email', help='Domain used to find the company')
     iap_enrich_info = fields.Text('IAP Enrich Info', help='IAP response stored as a JSON string', readonly=True)
 
-    _sql_constraints = [('unique_partner_id', 'UNIQUE(partner_id)', 'Only one partner IAP is allowed for one partner')]
+    _unique_partner_id = models.Constraint(
+        'UNIQUE(partner_id)',
+        'Only one partner IAP is allowed for one partner',
+    )

--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -157,9 +157,10 @@ class MaintenanceEquipment(models.Model):
     def _onchange_category_id(self):
         self.technician_user_id = self.category_id.technician_user_id
 
-    _sql_constraints = [
-        ('serial_no', 'unique(serial_no)', "Another asset already exists with this serial number!"),
-    ]
+    _serial_no = models.Constraint(
+        'unique(serial_no)',
+        'Another asset already exists with this serial number!',
+    )
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/marketing_card/models/card_campaign_tag.py
+++ b/addons/marketing_card/models/card_campaign_tag.py
@@ -12,4 +12,7 @@ class CardCampaignTag(models.Model):
     name = fields.Char(required=True)
     color = fields.Integer(default=_get_default_color)
 
-    _sql_constraints = [('name_uniq', "unique(name)", "Tags may not reuse existing names.")]
+    _name_uniq = models.Constraint(
+        'unique(name)',
+        'Tags may not reuse existing names.',
+    )

--- a/addons/marketing_card/models/card_card.py
+++ b/addons/marketing_card/models/card_card.py
@@ -18,10 +18,10 @@ class CardCard(models.Model):
         ('visited', 'Visited'),
     ])
 
-    _sql_constraints = [
-        ('campaign_record_unique', 'unique(campaign_id, res_id)',
-         'Each record should be unique for a campaign'),
-    ]
+    _campaign_record_unique = models.Constraint(
+        'unique(campaign_id, res_id)',
+        'Each record should be unique for a campaign',
+    )
 
     @api.depends('res_model', 'res_id')
     def _compute_display_name(self):

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -234,11 +234,10 @@ class MailingMailing(models.Model):
         'Warning Message', compute='_compute_warning_message',
         help='Warning message displayed in the mailing form view')
 
-    _sql_constraints = [(
-        'percentage_valid',
+    _percentage_valid = models.Constraint(
         'CHECK(ab_testing_pc >= 0 AND ab_testing_pc <= 100)',
-        'The A/B Testing Percentage needs to be between 0 and 100%'
-    )]
+        'The A/B Testing Percentage needs to be between 0 and 100%',
+    )
 
     @api.constrains('mailing_model_id', 'mailing_filter_id')
     def _check_mailing_filter_model(self):

--- a/addons/mass_mailing/models/mailing_subscription.py
+++ b/addons/mass_mailing/models/mailing_subscription.py
@@ -28,10 +28,10 @@ class MailingSubscription(models.Model):
     message_bounce = fields.Integer(related='contact_id.message_bounce', store=False, readonly=False)
     is_blacklisted = fields.Boolean(related='contact_id.is_blacklisted', store=False, readonly=False)
 
-    _sql_constraints = [
-        ('unique_contact_list', 'unique (contact_id, list_id)',
-         'A mailing contact cannot subscribe to the same mailing list multiple times.')
-    ]
+    _unique_contact_list = models.Constraint(
+        'unique (contact_id, list_id)',
+        'A mailing contact cannot subscribe to the same mailing list multiple times.',
+    )
 
     @api.depends('opt_out')
     def _compute_opt_out_datetime(self):

--- a/addons/mass_mailing/models/mailing_trace.py
+++ b/addons/mass_mailing/models/mailing_trace.py
@@ -112,14 +112,10 @@ class MailingTrace(models.Model):
     links_click_ids = fields.One2many('link.tracker.click', 'mailing_trace_id', string='Links click')
     links_click_datetime = fields.Datetime('Clicked On', help='Stores last click datetime in case of multi clicks.')
 
-    _sql_constraints = [
-        # Required on a Many2one reference field is not sufficient as actually
-        # writing 0 is considered as a valid value, because this is an integer field.
-        # We therefore need a specific constraint check.
-        ('check_res_id_is_set',
-         'CHECK(res_id IS NOT NULL AND res_id !=0 )',
-         'Traces have to be linked to records with a not null res_id.')
-    ]
+    _check_res_id_is_set = models.Constraint(
+        'CHECK(res_id IS NOT NULL AND res_id !=0 )',
+        'Traces have to be linked to records with a not null res_id.',
+    )
 
     @api.depends('trace_type', 'mass_mailing_id')
     def _compute_display_name(self):

--- a/addons/membership/models/product.py
+++ b/addons/membership/models/product.py
@@ -13,6 +13,7 @@ class ProductTemplate(models.Model):
     membership_date_to = fields.Date(string='Membership End Date',
         help='Date until which membership remains active.')
 
-    _sql_constraints = [
-        ('membership_date_greater', 'check(membership_date_to >= membership_date_from)', 'Error! Ending Date cannot be set before Beginning Date.')
-    ]
+    _membership_date_greater = models.Constraint(
+        'check(membership_date_to >= membership_date_from)',
+        'Error! Ending Date cannot be set before Beginning Date.',
+    )

--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -90,9 +90,10 @@ class MrpBom(models.Model):
         help="Create and confirm Manufacturing Orders this many days in advance, to have enough time to replenish components or manufacture semi-finished products.\n"
              "Note that security lead times will also be considered when appropriate.")
 
-    _sql_constraints = [
-        ('qty_positive', 'check (product_qty > 0)', 'The quantity to produce must be positive!'),
-    ]
+    _qty_positive = models.Constraint(
+        'check (product_qty > 0)',
+        'The quantity to produce must be positive!',
+    )
 
     @api.depends(
         'product_tmpl_id.attribute_line_ids.value_ids',
@@ -570,11 +571,10 @@ class MrpBomLine(models.Model):
         help="When activated, then the registration of consumption for that component is recorded manually exclusively.\n"
              "If not activated, and any of the components consumption is edited manually on the manufacturing order, Odoo assumes manual consumption also.")
 
-    _sql_constraints = [
-        ('bom_qty_zero', 'CHECK (product_qty>=0)', 'All product quantities must be greater or equal to 0.\n'
-            'Lines with 0 quantities can be used as optional lines. \n'
-            'You should install the mrp_byproduct module if you want to manage extra products on BoMs!'),
-    ]
+    _bom_qty_zero = models.Constraint(
+        'CHECK (product_qty>=0)',
+        'All product quantities must be greater or equal to 0.\nLines with 0 quantities can be used as optional lines. \nYou should install the mrp_byproduct module if you want to manage extra products on BoMs!',
+    )
 
     @api.depends('product_id', 'bom_id')
     def _compute_child_bom_id(self):

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -272,10 +272,14 @@ class MrpProduction(models.Model):
         search='_search_date_category', readonly=True
     )
 
-    _sql_constraints = [
-        ('name_uniq', 'unique(name, company_id)', 'Reference must be unique per Company!'),
-        ('qty_positive', 'check (product_qty > 0)', 'The quantity to produce must be positive!'),
-    ]
+    _name_uniq = models.Constraint(
+        'unique(name, company_id)',
+        'Reference must be unique per Company!',
+    )
+    _qty_positive = models.Constraint(
+        'check (product_qty > 0)',
+        'The quantity to produce must be positive!',
+    )
 
     @api.depends('procurement_group_id.stock_move_ids.created_production_id.procurement_group_id.mrp_production_ids',
                  'procurement_group_id.stock_move_ids.move_orig_ids.created_production_id.procurement_group_id.mrp_production_ids')

--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -78,9 +78,10 @@ class MrpUnbuild(models.Model):
         ('draft', 'Draft'),
         ('done', 'Done')], string='Status', default='draft')
 
-    _sql_constraints = [
-        ('qty_positive', 'check (product_qty > 0)', 'The quantity to unbuild must be positive!'),
-    ]
+    _qty_positive = models.Constraint(
+        'check (product_qty > 0)',
+        'The quantity to unbuild must be positive!',
+    )
 
     @api.depends('mo_id', 'product_id')
     def _compute_product_uom_id(self):

--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -410,10 +410,10 @@ class MrpWorkcenterTag(models.Model):
     name = fields.Char("Tag Name", required=True)
     color = fields.Integer("Color Index", default=_get_default_color)
 
-    _sql_constraints = [
-        ('tag_name_unique', 'unique(name)',
-         'The tag name must be unique.'),
-    ]
+    _tag_name_unique = models.Constraint(
+        'unique(name)',
+        'The tag name must be unique.',
+    )
 
 
 class MrpWorkcenterProductivityLossType(models.Model):
@@ -586,7 +586,11 @@ class MrpWorkcenterCapacity(models.Model):
     time_start = fields.Float('Setup Time (minutes)', default=_default_time_start, help="Time in minutes for the setup.")
     time_stop = fields.Float('Cleanup Time (minutes)', default=_default_time_stop, help="Time in minutes for the cleaning.")
 
-    _sql_constraints = [
-        ('positive_capacity', 'CHECK(capacity > 0)', 'Capacity should be a positive number.'),
-        ('unique_product', 'UNIQUE(workcenter_id, product_id)', 'Product capacity should be unique for each workcenter.'),
-    ]
+    _positive_capacity = models.Constraint(
+        'CHECK(capacity > 0)',
+        'Capacity should be a positive number.',
+    )
+    _unique_product = models.Constraint(
+        'UNIQUE(workcenter_id, product_id)',
+        'Product capacity should be unique for each workcenter.',
+    )

--- a/addons/mrp_account/wizard/mrp_wip_accounting.py
+++ b/addons/mrp_account/wizard/mrp_wip_accounting.py
@@ -17,10 +17,10 @@ class MrpAccountWipAccountingLine(models.TransientModel):
     currency_id = fields.Many2one('res.currency', "Currency", default=lambda self: self.env.company.currency_id)
     wip_accounting_id = fields.Many2one('mrp.account.wip.accounting', "WIP accounting wizard")
 
-    _sql_constraints = [
-        ('check_debit_credit', 'CHECK ( debit = 0 OR credit = 0 )',
-         'A single line cannot be both credit and debit.')
-    ]
+    _check_debit_credit = models.Constraint(
+        'CHECK ( debit = 0 OR credit = 0 )',
+        'A single line cannot be both credit and debit.',
+    )
 
     @api.depends('credit')
     def _compute_debit(self):

--- a/addons/onboarding/models/onboarding_onboarding.py
+++ b/addons/onboarding/models/onboarding_onboarding.py
@@ -36,9 +36,10 @@ class OnboardingOnboarding(models.Model):
         help='All Onboarding Progress Records (across companies).')
 
     sequence = fields.Integer(default=10)
-    _sql_constraints = [
-        ('route_name_uniq', 'UNIQUE (route_name)', 'Onboarding alias must be unique.'),
-    ]
+    _route_name_uniq = models.Constraint(
+        'UNIQUE (route_name)',
+        'Onboarding alias must be unique.',
+    )
 
     @api.depends('progress_ids', 'progress_ids.company_id', 'step_ids', 'step_ids.is_per_company')
     def _compute_is_per_company(self):

--- a/addons/onboarding/models/onboarding_progress_step.py
+++ b/addons/onboarding/models/onboarding_progress_step.py
@@ -17,13 +17,7 @@ class OnboardingProgressStep(models.Model):
 
     company_id = fields.Many2one('res.company', ondelete='cascade')
 
-    def init(self):
-        """Make sure there aren't multiple records for the same onboarding step and company."""
-        # not in _sql_constraint because COALESCE is not supported for PostgreSQL constraint
-        self.env.cr.execute("""
-            CREATE UNIQUE INDEX IF NOT EXISTS onboarding_progress_step_company_uniq
-            ON onboarding_progress_step (step_id, COALESCE(company_id, 0))
-        """)
+    _company_uniq = models.UniqueIndex('(step_id, COALESCE(company_id, 0))')
 
     def action_consolidate_just_done(self):
         was_just_done = self.filtered(lambda progress: progress.step_state == 'just_done')

--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -119,9 +119,10 @@ class PaymentTransaction(models.Model):
     partner_country_id = fields.Many2one(string="Country", comodel_name='res.country')
     partner_phone = fields.Char(string="Phone")
 
-    _sql_constraints = [
-        ('reference_uniq', 'unique(reference)', "Reference must be unique!"),
-    ]
+    _reference_uniq = models.Constraint(
+        'unique(reference)',
+        'Reference must be unique!',
+    )
 
     #=== COMPUTE METHODS ===#
 

--- a/addons/payment_custom/models/payment_provider.py
+++ b/addons/payment_custom/models/payment_provider.py
@@ -9,11 +9,10 @@ from odoo.addons.payment_custom import const
 class PaymentProvider(models.Model):
     _inherit = ['payment.provider']
 
-    _sql_constraints = [(
-        'custom_providers_setup',
+    _custom_providers_setup = models.Constraint(
         "CHECK(custom_mode IS NULL OR (code = 'custom' AND custom_mode IS NOT NULL))",
-        "Only custom providers should have a custom mode."
-    )]
+        'Only custom providers should have a custom mode.',
+    )
 
     code = fields.Selection(
         selection_add=[('custom', "Custom")], ondelete={'custom': 'set default'}

--- a/addons/phone_validation/models/phone_blacklist.py
+++ b/addons/phone_validation/models/phone_blacklist.py
@@ -14,9 +14,10 @@ class PhoneBlacklist(models.Model):
     number = fields.Char(string='Phone Number', required=True, tracking=True, help='Number should be E164 formatted')
     active = fields.Boolean(default=True, tracking=True)
 
-    _sql_constraints = [
-        ('unique_number', 'unique (number)', 'Number already exists')
-    ]
+    _unique_number = models.Constraint(
+        'unique (number)',
+        'Number already exists',
+    )
 
     @api.model_create_multi
     def create(self, values):

--- a/addons/point_of_sale/models/pos_note.py
+++ b/addons/point_of_sale/models/pos_note.py
@@ -10,7 +10,10 @@ class PosNote(models.Model):
     name = fields.Char(required=True)
     sequence = fields.Integer('Sequence', default=1)
 
-    _sql_constraints = [('name_unique', 'unique (name)', "A note with this name already exists")]
+    _name_unique = models.Constraint(
+        'unique (name)',
+        'A note with this name already exists',
+    )
 
     @api.model
     def _load_pos_data_domain(self, data):

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -92,7 +92,10 @@ class PosSession(models.Model):
     update_stock_at_closing = fields.Boolean('Stock should be updated at closing')
     bank_payment_ids = fields.One2many('account.payment', 'pos_session_id', 'Bank Payments', help='Account payments representing aggregated and bank split payments.')
 
-    _sql_constraints = [('uniq_name', 'unique(name)', "The name of this POS Session must be unique!")]
+    _uniq_name = models.Constraint(
+        'unique(name)',
+        'The name of this POS Session must be unique!',
+    )
 
     @api.model
     def _load_pos_data_relations(self, model, response):

--- a/addons/product/models/product_attribute.py
+++ b/addons/product/models/product_attribute.py
@@ -10,13 +10,10 @@ class ProductAttribute(models.Model):
     # `_sort_key_attribute_value` in `product.template`
     _order = 'sequence, id'
 
-    _sql_constraints = [
-        (
-            'check_multi_checkbox_no_variant',
-            "CHECK(display_type != 'multi' OR create_variant = 'no_variant')",
-            "Multi-checkbox display type is not compatible with the creation of variants"
-        ),
-    ]
+    _check_multi_checkbox_no_variant = models.Constraint(
+        "CHECK(display_type != 'multi' OR create_variant = 'no_variant')",
+        'Multi-checkbox display type is not compatible with the creation of variants',
+    )
 
     name = fields.Char(string="Attribute", required=True, translate=True)
     active = fields.Boolean(

--- a/addons/product/models/product_packaging.py
+++ b/addons/product/models/product_packaging.py
@@ -22,10 +22,14 @@ class ProductPackaging(models.Model):
     product_uom_id = fields.Many2one('uom.uom', related='product_id.uom_id', readonly=True)
     company_id = fields.Many2one('res.company', 'Company', index=True)
 
-    _sql_constraints = [
-        ('positive_qty', 'CHECK(qty > 0)', 'Contained Quantity should be positive.'),
-        ('barcode_uniq', 'unique(barcode)', 'A barcode can only be assigned to one packaging.'),
-    ]
+    _positive_qty = models.Constraint(
+        'CHECK(qty > 0)',
+        'Contained Quantity should be positive.',
+    )
+    _barcode_uniq = models.Constraint(
+        'unique(barcode)',
+        'A barcode can only be assigned to one packaging.',
+    )
 
     @api.constrains('barcode')
     def _check_barcode_uniqueness(self):

--- a/addons/product/models/product_tag.py
+++ b/addons/product/models/product_tag.py
@@ -36,9 +36,10 @@ class ProductTag(models.Model):
         compute='_compute_product_ids', search='_search_product_ids'
     )
 
-    _sql_constraints = [
-        ('name_uniq', 'unique (name)', "Tag name already exists!"),
-    ]
+    _name_uniq = models.Constraint(
+        'unique (name)',
+        'Tag name already exists!',
+    )
 
     @api.depends('product_template_ids', 'product_product_ids')
     def _compute_product_ids(self):

--- a/addons/product/models/product_template_attribute_value.py
+++ b/addons/product/models/product_template_attribute_value.py
@@ -61,11 +61,10 @@ class ProductTemplateAttributeValue(models.Model):
     color = fields.Integer(string="Color", default=_get_default_color)
     image = fields.Image(related='product_attribute_value_id.image')
 
-    _sql_constraints = [
-        ('attribute_value_unique',
-         'unique(attribute_line_id, product_attribute_value_id)',
-         "Each value should be defined only once per attribute per product."),
-    ]
+    _attribute_value_unique = models.Constraint(
+        'unique(attribute_line_id, product_attribute_value_id)',
+        'Each value should be defined only once per attribute per product.',
+    )
 
     @api.constrains('attribute_line_id', 'product_attribute_value_id')
     def _check_valid_values(self):

--- a/addons/project/models/project_collaborator.py
+++ b/addons/project/models/project_collaborator.py
@@ -11,9 +11,10 @@ class ProjectCollaborator(models.Model):
     partner_email = fields.Char(related='partner_id.email', export_string_translation=False)
     limited_access = fields.Boolean('Limited Access', default=False, export_string_translation=False)
 
-    _sql_constraints = [
-        ('unique_collaborator', 'UNIQUE(project_id, partner_id)', 'A collaborator cannot be selected more than once in the project sharing access. Please remove duplicate(s) and try again.'),
-    ]
+    _unique_collaborator = models.Constraint(
+        'UNIQUE(project_id, partner_id)',
+        'A collaborator cannot be selected more than once in the project sharing access. Please remove duplicate(s) and try again.',
+    )
 
     @api.depends('project_id', 'partner_id')
     def _compute_display_name(self):

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -188,9 +188,10 @@ class ProjectProject(models.Model):
     can_mark_milestone_as_done = fields.Boolean(compute='_compute_next_milestone_id', groups="project.group_project_milestone", export_string_translation=False)
     is_milestone_deadline_exceeded = fields.Boolean(compute='_compute_next_milestone_id', groups="project.group_project_milestone", export_string_translation=False)
 
-    _sql_constraints = [
-        ('project_date_greater', 'check(date >= date_start)', "The project's start date must be before its end date.")
-    ]
+    _project_date_greater = models.Constraint(
+        'check(date >= date_start)',
+        "The project's start date must be before its end date.",
+    )
 
     @api.onchange('company_id')
     def _onchange_company_id(self):

--- a/addons/project/models/project_tags.py
+++ b/addons/project/models/project_tags.py
@@ -22,9 +22,10 @@ class ProjectTags(models.Model):
     project_ids = fields.Many2many('project.project', 'project_project_project_tags_rel', string='Projects', export_string_translation=False)
     task_ids = fields.Many2many('project.task', string='Tasks', export_string_translation=False)
 
-    _sql_constraints = [
-        ('name_uniq', 'unique (name)', "A tag with the same name already exists."),
-    ]
+    _name_uniq = models.Constraint(
+        'unique (name)',
+        'A tag with the same name already exists.',
+    )
 
     def _get_project_tags_domain(self, domain, project_id):
         # TODO: Remove in master

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -298,10 +298,14 @@ class ProjectTask(models.Model):
     )
     link_preview_name = fields.Char(compute='_compute_link_preview_name', export_string_translation=False)
 
-    _sql_constraints = [
-        ('recurring_task_has_no_parent', 'CHECK (NOT (recurring_task IS TRUE AND parent_id IS NOT NULL))', "A subtask cannot be recurrent."),
-        ('private_task_has_no_parent', 'CHECK (NOT (project_id IS NULL AND parent_id IS NOT NULL))', "A private task cannot have a parent."),
-    ]
+    _recurring_task_has_no_parent = models.Constraint(
+        'CHECK (NOT (recurring_task IS TRUE AND parent_id IS NOT NULL))',
+        'A subtask cannot be recurrent.',
+    )
+    _private_task_has_no_parent = models.Constraint(
+        'CHECK (NOT (project_id IS NULL AND parent_id IS NOT NULL))',
+        'A private task cannot have a parent.',
+    )
 
     @api.constrains('company_id', 'partner_id')
     def _ensure_company_consistency_with_partner(self):

--- a/addons/project/models/project_task_stage_personal.py
+++ b/addons/project/models/project_task_stage_personal.py
@@ -13,6 +13,7 @@ class ProjectTaskStagePersonal(models.Model):
     user_id = fields.Many2one('res.users', required=True, ondelete='cascade', index=True, export_string_translation=False)
     stage_id = fields.Many2one('project.task.type', domain="[('user_id', '=', user_id)]", ondelete='set null', export_string_translation=False)
 
-    _sql_constraints = [
-        ('project_personal_stage_unique', 'UNIQUE (task_id, user_id)', 'A task can only have a single personal stage per user.'),
-    ]
+    _project_personal_stage_unique = models.Constraint(
+        'UNIQUE (task_id, user_id)',
+        'A task can only have a single personal stage per user.',
+    )

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -77,14 +77,14 @@ class PurchaseOrderLine(models.Model):
         ('line_note', "Note")], default=False, help="Technical field for UX purpose.")
     is_downpayment = fields.Boolean()
 
-    _sql_constraints = [
-        ('accountable_required_fields',
-            "CHECK(display_type IS NOT NULL OR is_downpayment OR (product_id IS NOT NULL AND product_uom IS NOT NULL AND date_planned IS NOT NULL))",
-            "Missing required fields on accountable purchase order line."),
-        ('non_accountable_null_fields',
-            "CHECK(display_type IS NULL OR (product_id IS NULL AND price_unit = 0 AND product_uom_qty = 0 AND product_uom IS NULL AND date_planned is NULL))",
-            "Forbidden values on non-accountable purchase order line"),
-    ]
+    _accountable_required_fields = models.Constraint(
+        'CHECK(display_type IS NOT NULL OR is_downpayment OR (product_id IS NOT NULL AND product_uom IS NOT NULL AND date_planned IS NOT NULL))',
+        'Missing required fields on accountable purchase order line.',
+    )
+    _non_accountable_null_fields = models.Constraint(
+        'CHECK(display_type IS NULL OR (product_id IS NULL AND price_unit = 0 AND product_uom_qty = 0 AND product_uom IS NULL AND date_planned is NULL))',
+        'Forbidden values on non-accountable purchase order line',
+    )
     product_template_attribute_value_ids = fields.Many2many(related='product_id.product_template_attribute_value_ids', readonly=True)
     product_no_variant_attribute_value_ids = fields.Many2many('product.template.attribute.value', string='Product attribute values that do not create variants', ondelete='restrict')
 

--- a/addons/rating/models/rating.py
+++ b/addons/rating/models/rating.py
@@ -52,9 +52,10 @@ class RatingRating(models.Model):
     access_token = fields.Char('Security Token', default=_default_access_token)
     consumed = fields.Boolean(string="Filled Rating")
 
-    _sql_constraints = [
-        ('rating_range', 'check(rating >= 0 and rating <= 5)', 'Rating should be between 0 and 5'),
-    ]
+    _rating_range = models.Constraint(
+        'check(rating >= 0 and rating <= 5)',
+        'Rating should be between 0 and 5',
+    )
 
     @api.depends('res_model', 'res_id')
     def _compute_res_name(self):

--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -736,6 +736,7 @@ class RepairTags(models.Model):
     name = fields.Char('Tag Name', required=True)
     color = fields.Integer(string='Color Index', default=_get_default_color)
 
-    _sql_constraints = [
-        ('name_uniq', 'unique (name)', "Tag name already exists!"),
-    ]
+    _name_uniq = models.Constraint(
+        'unique (name)',
+        'Tag name already exists!',
+    )

--- a/addons/resource/models/resource_resource.py
+++ b/addons/resource/models/resource_resource.py
@@ -50,9 +50,10 @@ class ResourceResource(models.Model):
         _tz_get, string='Timezone', required=True,
         default=lambda self: self._context.get('tz') or self.env.user.tz or 'UTC')
 
-    _sql_constraints = [
-        ('check_time_efficiency', 'CHECK(time_efficiency>0)', 'Time efficiency must be strictly positive'),
-    ]
+    _check_time_efficiency = models.Constraint(
+        'CHECK(time_efficiency>0)',
+        'Time efficiency must be strictly positive',
+    )
 
     @api.depends('user_id')
     def _compute_avatar_128(self):

--- a/addons/sale/models/product_product.py
+++ b/addons/sale/models/product_product.py
@@ -103,9 +103,10 @@ class ProductAttributeCustomValue(models.Model):
 
     sale_order_line_id = fields.Many2one('sale.order.line', string="Sales Order Line", ondelete='cascade')
 
-    _sql_constraints = [
-        ('sol_custom_value_unique', 'unique(custom_product_template_attribute_value_id, sale_order_line_id)', "Only one Custom Value is allowed per Attribute Value per Sales Order Line.")
-    ]
+    _sol_custom_value_unique = models.Constraint(
+        'unique(custom_product_template_attribute_value_id, sale_order_line_id)',
+        'Only one Custom Value is allowed per Attribute Value per Sales Order Line.',
+    )
 
 
 class ProductPackaging(models.Model):

--- a/addons/sale/models/res_company.py
+++ b/addons/sale/models/res_company.py
@@ -8,12 +8,10 @@ class ResCompany(models.Model):
     _inherit = ['res.company']
     _check_company_auto = True
 
-    _sql_constraints = [
-        ('check_quotation_validity_days',
-            'CHECK(quotation_validity_days >= 0)',
-            "You cannot set a negative number for the default quotation validity."
-            " Leave empty (or 0) to disable the automatic expiration of quotations."),
-    ]
+    _check_quotation_validity_days = models.Constraint(
+        'CHECK(quotation_validity_days >= 0)',
+        'You cannot set a negative number for the default quotation validity. Leave empty (or 0) to disable the automatic expiration of quotations.',
+    )
 
     portal_confirmation_sign = fields.Boolean(string="Online Signature", default=True)
     portal_confirmation_pay = fields.Boolean(string="Online Payment")

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -47,11 +47,10 @@ class SaleOrder(models.Model):
     _order = 'date_order desc, id desc'
     _check_company_auto = True
 
-    _sql_constraints = [
-        ('date_order_conditional_required',
-         "CHECK((state = 'sale' AND date_order IS NOT NULL) OR state != 'sale')",
-         "A confirmed sales order requires a confirmation date."),
-    ]
+    _date_order_conditional_required = models.Constraint(
+        "CHECK((state = 'sale' AND date_order IS NOT NULL) OR state != 'sale')",
+        'A confirmed sales order requires a confirmation date.',
+    )
 
     @property
     def _rec_names_search(self):

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -20,14 +20,14 @@ class SaleOrderLine(models.Model):
     _order = 'order_id, sequence, id'
     _check_company_auto = True
 
-    _sql_constraints = [
-        ('accountable_required_fields',
-            "CHECK(display_type IS NOT NULL OR is_downpayment OR (product_id IS NOT NULL AND product_uom IS NOT NULL))",
-            "Missing required fields on accountable sale order line."),
-        ('non_accountable_null_fields',
-            "CHECK(display_type IS NULL OR (product_id IS NULL AND price_unit = 0 AND product_uom_qty = 0 AND product_uom IS NULL AND customer_lead = 0))",
-            "Forbidden values on non-accountable sale order line"),
-    ]
+    _accountable_required_fields = models.Constraint(
+        'CHECK(display_type IS NOT NULL OR is_downpayment OR (product_id IS NOT NULL AND product_uom IS NOT NULL))',
+        'Missing required fields on accountable sale order line.',
+    )
+    _non_accountable_null_fields = models.Constraint(
+        'CHECK(display_type IS NULL OR (product_id IS NULL AND price_unit = 0 AND product_uom_qty = 0 AND product_uom IS NULL AND customer_lead = 0))',
+        'Forbidden values on non-accountable sale order line',
+    )
 
     # Fields are ordered according by tech & business logics
     # and computed fields are defined after their dependencies.

--- a/addons/sale_loyalty/models/sale_order_coupon_points.py
+++ b/addons/sale_loyalty/models/sale_order_coupon_points.py
@@ -10,7 +10,7 @@ class SaleOrderCouponPoints(models.Model):
     coupon_id = fields.Many2one(comodel_name='loyalty.card', required=True, ondelete='cascade')
     points = fields.Float(required=True)
 
-    _sql_constraints = [
-        ('order_coupon_unique', 'UNIQUE (order_id, coupon_id)',
-        'The coupon points entry already exists.')
-    ]
+    _order_coupon_unique = models.Constraint(
+        'UNIQUE (order_id, coupon_id)',
+        'The coupon points entry already exists.',
+    )

--- a/addons/sale_management/models/sale_order_template_line.py
+++ b/addons/sale_management/models/sale_order_template_line.py
@@ -8,15 +8,14 @@ class SaleOrderTemplateLine(models.Model):
     _description = "Quotation Template Line"
     _order = 'sale_order_template_id, sequence, id'
 
-    _sql_constraints = [
-        ('accountable_product_id_required',
-            "CHECK(display_type IS NOT NULL OR (product_id IS NOT NULL AND product_uom_id IS NOT NULL))",
-            "Missing required product and UoM on accountable sale quote line."),
-
-        ('non_accountable_fields_null',
-            "CHECK(display_type IS NULL OR (product_id IS NULL AND product_uom_qty = 0 AND product_uom_id IS NULL))",
-            "Forbidden product, quantity and UoM on non-accountable sale quote line"),
-    ]
+    _accountable_product_id_required = models.Constraint(
+        'CHECK(display_type IS NOT NULL OR (product_id IS NOT NULL AND product_uom_id IS NOT NULL))',
+        'Missing required product and UoM on accountable sale quote line.',
+    )
+    _non_accountable_fields_null = models.Constraint(
+        'CHECK(display_type IS NULL OR (product_id IS NULL AND product_uom_qty = 0 AND product_uom_id IS NULL))',
+        'Forbidden product, quantity and UoM on non-accountable sale quote line',
+    )
 
     sale_order_template_id = fields.Many2one(
         comodel_name='sale.order.template',

--- a/addons/sale_pdf_quote_builder/models/sale_pdf_form_field.py
+++ b/addons/sale_pdf_quote_builder/models/sale_pdf_form_field.py
@@ -40,11 +40,10 @@ class SalePdfFormField(models.Model):
         string="Quotation Documents", comodel_name='quotation.document'
     )
 
-    _sql_constraints = [(
-        'unique_name_per_doc_type',
+    _unique_name_per_doc_type = models.Constraint(
         'UNIQUE(name, document_type)',
-        "Form field name must be unique for a given document type."
-    )]
+        'Form field name must be unique for a given document type.',
+    )
 
     # === CONSTRAINT METHODS ===#
 

--- a/addons/sale_timesheet/models/project_sale_line_employee_map.py
+++ b/addons/sale_timesheet/models/project_sale_line_employee_map.py
@@ -38,9 +38,10 @@ class ProjectSaleLineEmployeeMap(models.Model):
     cost_currency_id = fields.Many2one('res.currency', string="Cost Currency", related='employee_id.currency_id', readonly=True, export_string_translation=False)
     is_cost_changed = fields.Boolean('Is Cost Manually Changed', compute='_compute_is_cost_changed', store=True, export_string_translation=False)
 
-    _sql_constraints = [
-        ('uniqueness_employee', 'UNIQUE(project_id,employee_id)', 'An employee cannot be selected more than once in the mapping. Please remove duplicate(s) and try again.'),
-    ]
+    _uniqueness_employee = models.Constraint(
+        'UNIQUE(project_id,employee_id)',
+        'An employee cannot be selected more than once in the mapping. Please remove duplicate(s) and try again.',
+    )
 
     @api.depends('employee_id', 'project_id.sale_line_employee_ids.employee_id')
     def _compute_existing_employee_ids(self):

--- a/addons/sales_team/models/crm_tag.py
+++ b/addons/sales_team/models/crm_tag.py
@@ -14,6 +14,7 @@ class CrmTag(models.Model):
     name = fields.Char('Tag Name', required=True, translate=True)
     color = fields.Integer('Color', default=_get_default_color)
 
-    _sql_constraints = [
-        ('name_uniq', 'unique (name)', "Tag name already exists!"),
-    ]
+    _name_uniq = models.Constraint(
+        'unique (name)',
+        'Tag name already exists!',
+    )

--- a/addons/sms/models/sms_sms.py
+++ b/addons/sms/models/sms_sms.py
@@ -70,9 +70,10 @@ class SmsSms(models.Model):
         help='Will automatically be deleted, while notifications will not be deleted in any case.'
     )
 
-    _sql_constraints = [
-        ('uuid_unique', 'unique(uuid)', 'UUID must be unique'),
-    ]
+    _uuid_unique = models.Constraint(
+        'unique(uuid)',
+        'UUID must be unique',
+    )
 
     @api.depends('uuid')
     def _compute_sms_tracker_id(self):

--- a/addons/sms/models/sms_tracker.py
+++ b/addons/sms/models/sms_tracker.py
@@ -30,9 +30,10 @@ class SmsTracker(models.Model):
     sms_uuid = fields.Char('SMS uuid', required=True)
     mail_notification_id = fields.Many2one('mail.notification', ondelete='cascade')
 
-    _sql_constraints = [
-        ('sms_uuid_unique', 'unique(sms_uuid)', 'A record for this UUID already exists'),
-    ]
+    _sms_uuid_unique = models.Constraint(
+        'unique(sms_uuid)',
+        'A record for this UUID already exists',
+    )
 
     def _action_update_from_provider_error(self, provider_error):
         """

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -96,8 +96,14 @@ class StockLocation(models.Model):
     forecast_weight = fields.Float('Forecasted Weight', compute="_compute_weight")
     is_empty = fields.Boolean('Is Empty', compute='_compute_is_empty', search='_search_is_empty')
 
-    _sql_constraints = [('barcode_company_uniq', 'unique (barcode,company_id)', 'The barcode for a location must be unique per company!'),
-                        ('inventory_freq_nonneg', 'check(cyclic_inventory_frequency >= 0)', 'The inventory frequency (days) for a location must be non-negative')]
+    _barcode_company_uniq = models.Constraint(
+        'unique (barcode,company_id)',
+        'The barcode for a location must be unique per company!',
+    )
+    _inventory_freq_nonneg = models.Constraint(
+        'check(cyclic_inventory_frequency >= 0)',
+        'The inventory frequency (days) for a location must be non-negative',
+    )
 
     @api.depends('outgoing_move_line_ids.quantity_product_uom', 'incoming_move_line_ids.quantity_product_uom',
                  'outgoing_move_line_ids.state', 'incoming_move_line_ids.state',

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -92,10 +92,14 @@ class StockWarehouseOrderpoint(models.Model):
 
     unwanted_replenish = fields.Boolean('Unwanted Replenish', compute="_compute_unwanted_replenish")
 
-    _sql_constraints = [
-        ('qty_multiple_check', 'CHECK( qty_multiple >= 0 )', 'Qty Multiple must be greater than or equal to zero.'),
-        ('product_location_check', 'unique (product_id, location_id, company_id)', 'A replenishment rule already exists for this product on this location.'),
-    ]
+    _qty_multiple_check = models.Constraint(
+        'CHECK( qty_multiple >= 0 )',
+        'Qty Multiple must be greater than or equal to zero.',
+    )
+    _product_location_check = models.Constraint(
+        'unique (product_id, location_id, company_id)',
+        'A replenishment rule already exists for this product on this location.',
+    )
 
     @api.depends('warehouse_id')
     def _compute_allowed_location_ids(self):

--- a/addons/stock/models/stock_package_type.py
+++ b/addons/stock/models/stock_package_type.py
@@ -26,13 +26,26 @@ class StockPackageType(models.Model):
     company_id = fields.Many2one('res.company', 'Company', index=True)
     storage_category_capacity_ids = fields.One2many('stock.storage.category.capacity', 'package_type_id', 'Storage Category Capacity', copy=True)
 
-    _sql_constraints = [
-        ('barcode_uniq', 'unique(barcode)', "A barcode can only be assigned to one package type!"),
-        ('positive_height', 'CHECK(height>=0.0)', 'Height must be positive'),
-        ('positive_width', 'CHECK(width>=0.0)', 'Width must be positive'),
-        ('positive_length', 'CHECK(packaging_length>=0.0)', 'Length must be positive'),
-        ('positive_max_weight', 'CHECK(max_weight>=0.0)', 'Max Weight must be positive'),
-    ]
+    _barcode_uniq = models.Constraint(
+        'unique(barcode)',
+        'A barcode can only be assigned to one package type!',
+    )
+    _positive_height = models.Constraint(
+        'CHECK(height>=0.0)',
+        'Height must be positive',
+    )
+    _positive_width = models.Constraint(
+        'CHECK(width>=0.0)',
+        'Width must be positive',
+    )
+    _positive_length = models.Constraint(
+        'CHECK(packaging_length>=0.0)',
+        'Length must be positive',
+    )
+    _positive_max_weight = models.Constraint(
+        'CHECK(max_weight>=0.0)',
+        'Max Weight must be positive',
+    )
 
     def _compute_length_uom_name(self):
         for package_type in self:

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -702,9 +702,10 @@ class StockPicking(models.Model):
         search='_search_date_category', readonly=True
     )
 
-    _sql_constraints = [
-        ('name_uniq', 'unique(name, company_id)', 'Reference must be unique per company!'),
-    ]
+    _name_uniq = models.Constraint(
+        'unique(name, company_id)',
+        'Reference must be unique per company!',
+    )
 
     def _compute_has_tracking(self):
         for picking in self:

--- a/addons/stock/models/stock_scrap.py
+++ b/addons/stock/models/stock_scrap.py
@@ -234,6 +234,7 @@ class StockScrapReasonTag(models.Model):
     sequence = fields.Integer(default=10)
     color = fields.Char(string="Color", default='#3C3C3C')
 
-    _sql_constraints = [
-        ('name_uniq', 'unique (name)', "Tag name already exists!"),
-    ]
+    _name_uniq = models.Constraint(
+        'unique (name)',
+        'Tag name already exists!',
+    )

--- a/addons/stock/models/stock_storage_category.py
+++ b/addons/stock/models/stock_storage_category.py
@@ -21,9 +21,10 @@ class StockStorageCategory(models.Model):
     company_id = fields.Many2one('res.company', 'Company')
     weight_uom_name = fields.Char(string='Weight unit', compute='_compute_weight_uom_name')
 
-    _sql_constraints = [
-        ('positive_max_weight', 'CHECK(max_weight >= 0)', 'Max weight should be a positive number.'),
-    ]
+    _positive_max_weight = models.Constraint(
+        'CHECK(max_weight >= 0)',
+        'Max weight should be a positive number.',
+    )
 
     @api.depends('capacity_ids')
     def _compute_storage_capacity_ids(self):
@@ -58,8 +59,15 @@ class StockStorageCategoryCapacity(models.Model):
     product_uom_id = fields.Many2one(related='product_id.uom_id')
     company_id = fields.Many2one('res.company', 'Company', related="storage_category_id.company_id")
 
-    _sql_constraints = [
-        ('positive_quantity', 'CHECK(quantity > 0)', 'Quantity should be a positive number.'),
-        ('unique_product', 'UNIQUE(product_id, storage_category_id)', 'Multiple capacity rules for one product.'),
-        ('unique_package_type', 'UNIQUE(package_type_id, storage_category_id)', 'Multiple capacity rules for one package type.'),
-    ]
+    _positive_quantity = models.Constraint(
+        'CHECK(quantity > 0)',
+        'Quantity should be a positive number.',
+    )
+    _unique_product = models.Constraint(
+        'UNIQUE(product_id, storage_category_id)',
+        'Multiple capacity rules for one product.',
+    )
+    _unique_package_type = models.Constraint(
+        'UNIQUE(package_type_id, storage_category_id)',
+        'Multiple capacity rules for one package type.',
+    )

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -90,10 +90,14 @@ class StockWarehouse(models.Model):
         help="Routes will be created for these resupply warehouses and you can select them on products and product categories", copy=False)
     sequence = fields.Integer(default=10,
         help="Gives the sequence of this line when displaying the warehouses.")
-    _sql_constraints = [
-        ('warehouse_name_uniq', 'unique(name, company_id)', 'The name of the warehouse must be unique per company!'),
-        ('warehouse_code_uniq', 'unique(code, company_id)', 'The short name of the warehouse must be unique per company!'),
-    ]
+    _warehouse_name_uniq = models.Constraint(
+        'unique(name, company_id)',
+        'The name of the warehouse must be unique per company!',
+    )
+    _warehouse_code_uniq = models.Constraint(
+        'unique(code, company_id)',
+        'The short name of the warehouse must be unique per company!',
+    )
 
     @api.onchange('company_id')
     def _onchange_company_id(self):

--- a/addons/survey/models/survey_question.py
+++ b/addons/survey/models/survey_question.py
@@ -177,23 +177,50 @@ class SurveyQuestion(models.Model):
         ]"""
     )
 
-    _sql_constraints = [
-        ('positive_len_min', 'CHECK (validation_length_min >= 0)', 'A length must be positive!'),
-        ('positive_len_max', 'CHECK (validation_length_max >= 0)', 'A length must be positive!'),
-        ('validation_length', 'CHECK (validation_length_min <= validation_length_max)', 'Max length cannot be smaller than min length!'),
-        ('validation_float', 'CHECK (validation_min_float_value <= validation_max_float_value)', 'Max value cannot be smaller than min value!'),
-        ('validation_date', 'CHECK (validation_min_date <= validation_max_date)', 'Max date cannot be smaller than min date!'),
-        ('validation_datetime', 'CHECK (validation_min_datetime <= validation_max_datetime)', 'Max datetime cannot be smaller than min datetime!'),
-        ('positive_answer_score', 'CHECK (answer_score >= 0)', 'An answer score for a non-multiple choice question cannot be negative!'),
-        ('scored_datetime_have_answers', "CHECK (is_scored_question != True OR question_type != 'datetime' OR answer_datetime is not null)",
-            'All "Is a scored question = True" and "Question Type: Datetime" questions need an answer'),
-        ('scored_date_have_answers', "CHECK (is_scored_question != True OR question_type != 'date' OR answer_date is not null)",
-            'All "Is a scored question = True" and "Question Type: Date" questions need an answer'),
-        ('scale', "CHECK (question_type != 'scale' OR (scale_min >= 0 AND scale_max <= 10 AND scale_min < scale_max))",
-            'The scale must be a growing non-empty range between 0 and 10 (inclusive)'),
-        ('is_time_limited_have_time_limit', "CHECK (is_time_limited != TRUE OR time_limit IS NOT NULL AND time_limit > 0)",
-            'All time-limited questions need a positive time limit'),
-    ]
+    _positive_len_min = models.Constraint(
+        'CHECK (validation_length_min >= 0)',
+        'A length must be positive!',
+    )
+    _positive_len_max = models.Constraint(
+        'CHECK (validation_length_max >= 0)',
+        'A length must be positive!',
+    )
+    _validation_length = models.Constraint(
+        'CHECK (validation_length_min <= validation_length_max)',
+        'Max length cannot be smaller than min length!',
+    )
+    _validation_float = models.Constraint(
+        'CHECK (validation_min_float_value <= validation_max_float_value)',
+        'Max value cannot be smaller than min value!',
+    )
+    _validation_date = models.Constraint(
+        'CHECK (validation_min_date <= validation_max_date)',
+        'Max date cannot be smaller than min date!',
+    )
+    _validation_datetime = models.Constraint(
+        'CHECK (validation_min_datetime <= validation_max_datetime)',
+        'Max datetime cannot be smaller than min datetime!',
+    )
+    _positive_answer_score = models.Constraint(
+        'CHECK (answer_score >= 0)',
+        'An answer score for a non-multiple choice question cannot be negative!',
+    )
+    _scored_datetime_have_answers = models.Constraint(
+        "CHECK (is_scored_question != True OR question_type != 'datetime' OR answer_datetime is not null)",
+        'All "Is a scored question = True" and "Question Type: Datetime" questions need an answer',
+    )
+    _scored_date_have_answers = models.Constraint(
+        "CHECK (is_scored_question != True OR question_type != 'date' OR answer_date is not null)",
+        'All "Is a scored question = True" and "Question Type: Date" questions need an answer',
+    )
+    _scale = models.Constraint(
+        "CHECK (question_type != 'scale' OR (scale_min >= 0 AND scale_max <= 10 AND scale_min < scale_max))",
+        'The scale must be a growing non-empty range between 0 and 10 (inclusive)',
+    )
+    _is_time_limited_have_time_limit = models.Constraint(
+        'CHECK (is_time_limited != TRUE OR time_limit IS NOT NULL AND time_limit > 0)',
+        'All time-limited questions need a positive time limit',
+    )
 
     # -------------------------------------------------------------------------
     # CONSTRAINT METHODS
@@ -813,10 +840,10 @@ class SurveyQuestionAnswer(models.Model):
     is_correct = fields.Boolean('Correct')
     answer_score = fields.Float('Score', help="A positive score indicates a correct choice; a negative or null score indicates a wrong answer")
 
-    _sql_constraints = [
-        ('value_not_empty', "CHECK (value IS NOT NULL OR value_image_filename IS NOT NULL)",
-         'Suggested answer value must not be empty (a text and/or an image must be provided).'),
-    ]
+    _value_not_empty = models.Constraint(
+        'CHECK (value IS NOT NULL OR value_image_filename IS NOT NULL)',
+        'Suggested answer value must not be empty (a text and/or an image must be provided).',
+    )
 
     @api.depends('value_label', 'question_id.question_type', 'question_id.title', 'matrix_question_id')
     def _compute_display_name(self):

--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -162,22 +162,38 @@ class SurveySurvey(models.Model):
     # conditional questions management
     has_conditional_questions = fields.Boolean("Contains conditional questions", compute="_compute_has_conditional_questions")
 
-    _sql_constraints = [
-        ('access_token_unique', 'unique(access_token)', 'Access token should be unique'),
-        ('session_code_unique', 'unique(session_code)', 'Session code should be unique'),
-        ('certification_check', "CHECK( scoring_type!='no_scoring' OR certification=False )",
-            'You can only create certifications for surveys that have a scoring mechanism.'),
-        ('scoring_success_min_check', "CHECK( scoring_success_min IS NULL OR (scoring_success_min>=0 AND scoring_success_min<=100) )",
-            'The percentage of success has to be defined between 0 and 100.'),
-        ('time_limit_check', "CHECK( (is_time_limited=False) OR (time_limit is not null AND time_limit > 0) )",
-            'The time limit needs to be a positive number if the survey is time limited.'),
-        ('attempts_limit_check', "CHECK( (is_attempts_limited=False) OR (attempts_limit is not null AND attempts_limit > 0) )",
-            'The attempts limit needs to be a positive number if the survey has a limited number of attempts.'),
-        ('badge_uniq', 'unique (certification_badge_id)', "The badge for each survey should be unique!"),
-        ('session_speed_rating_has_time_limit',
-         "CHECK (session_speed_rating != TRUE OR session_speed_rating_time_limit IS NOT NULL AND session_speed_rating_time_limit > 0)",
-         'A positive default time limit is required when the session rewards quick answers.'),
-    ]
+    _access_token_unique = models.Constraint(
+        'unique(access_token)',
+        'Access token should be unique',
+    )
+    _session_code_unique = models.Constraint(
+        'unique(session_code)',
+        'Session code should be unique',
+    )
+    _certification_check = models.Constraint(
+        "CHECK( scoring_type!='no_scoring' OR certification=False )",
+        'You can only create certifications for surveys that have a scoring mechanism.',
+    )
+    _scoring_success_min_check = models.Constraint(
+        'CHECK( scoring_success_min IS NULL OR (scoring_success_min>=0 AND scoring_success_min<=100) )',
+        'The percentage of success has to be defined between 0 and 100.',
+    )
+    _time_limit_check = models.Constraint(
+        'CHECK( (is_time_limited=False) OR (time_limit is not null AND time_limit > 0) )',
+        'The time limit needs to be a positive number if the survey is time limited.',
+    )
+    _attempts_limit_check = models.Constraint(
+        'CHECK( (is_attempts_limited=False) OR (attempts_limit is not null AND attempts_limit > 0) )',
+        'The attempts limit needs to be a positive number if the survey has a limited number of attempts.',
+    )
+    _badge_uniq = models.Constraint(
+        'unique (certification_badge_id)',
+        'The badge for each survey should be unique!',
+    )
+    _session_speed_rating_has_time_limit = models.Constraint(
+        'CHECK (session_speed_rating != TRUE OR session_speed_rating_time_limit IS NOT NULL AND session_speed_rating_time_limit > 0)',
+        'A positive default time limit is required when the session rewards quick answers.',
+    )
 
     @api.depends('background_image', 'access_token')
     def _compute_background_image_url(self):

--- a/addons/survey/models/survey_user_input.py
+++ b/addons/survey/models/survey_user_input.py
@@ -56,9 +56,10 @@ class SurveyUser_Input(models.Model):
     is_session_answer = fields.Boolean('Is in a Session', help="Is that user input part of a survey session or not.")
     question_time_limit_reached = fields.Boolean("Question Time Limit Reached", compute='_compute_question_time_limit_reached')
 
-    _sql_constraints = [
-        ('unique_token', 'UNIQUE (access_token)', 'An access token must be unique!'),
-    ]
+    _unique_token = models.Constraint(
+        'UNIQUE (access_token)',
+        'An access token must be unique!',
+    )
 
     @api.depends('user_input_line_ids.answer_score', 'user_input_line_ids.question_id', 'predefined_question_ids.answer_score')
     def _compute_scoring_values(self):

--- a/addons/test_import_export/models/models_export_impex.py
+++ b/addons/test_import_export/models/models_export_impex.py
@@ -155,10 +155,8 @@ class ExportUnique(models.Model):
     value2 = fields.Integer()
     value3 = fields.Integer()
 
-    _sql_constraints = [
-        ('value_unique', 'unique (value)', ""),
-        ('pair_unique', 'unique (value2, value3)', ""),
-    ]
+    _value_unique = models.Constraint('unique (value)')
+    _pair_unique = models.Constraint('unique (value2, value3)')
 
 
 class ExportInheritsParent(models.Model):

--- a/addons/test_import_export/models/models_export_impex.py
+++ b/addons/test_import_export/models/models_export_impex.py
@@ -156,8 +156,8 @@ class ExportUnique(models.Model):
     value3 = fields.Integer()
 
     _sql_constraints = [
-        ('value_unique', 'unique (value)', "The value must be unique"),
-        ('pair_unique', 'unique (value2, value3)', "The values must be unique"),
+        ('value_unique', 'unique (value)', ""),
+        ('pair_unique', 'unique (value2, value3)', ""),
     ]
 
 

--- a/addons/uom/models/uom_uom.py
+++ b/addons/uom/models/uom_uom.py
@@ -74,11 +74,18 @@ class UomUom(models.Model):
     ratio = fields.Float('Combined Ratio', compute='_compute_ratio', inverse='_set_ratio', store=False)
     color = fields.Integer('Color', compute='_compute_color')
 
-    _sql_constraints = [
-        ('factor_gt_zero', 'CHECK (factor!=0)', 'The conversion ratio for a unit of measure cannot be 0!'),
-        ('rounding_gt_zero', 'CHECK (rounding>0)', 'The rounding precision must be strictly positive.'),
-        ('factor_reference_is_one', "CHECK((uom_type = 'reference' AND factor = 1.0) OR (uom_type != 'reference'))", "The reference unit must have a conversion factor equal to 1.")
-    ]
+    _factor_gt_zero = models.Constraint(
+        'CHECK (factor!=0)',
+        'The conversion ratio for a unit of measure cannot be 0!',
+    )
+    _rounding_gt_zero = models.Constraint(
+        'CHECK (rounding>0)',
+        'The rounding precision must be strictly positive.',
+    )
+    _factor_reference_is_one = models.Constraint(
+        "CHECK((uom_type = 'reference' AND factor = 1.0) OR (uom_type != 'reference'))",
+        'The reference unit must have a conversion factor equal to 1.',
+    )
 
     def _check_category_reference_uniqueness(self):
         categ_res = self._read_group(

--- a/addons/utm/models/utm_campaign.py
+++ b/addons/utm/models/utm_campaign.py
@@ -27,9 +27,10 @@ class UtmCampaign(models.Model):
     is_auto_campaign = fields.Boolean(default=False, string="Automatically Generated Campaign", help="Allows us to filter relevant Campaigns")
     color = fields.Integer(string='Color Index')
 
-    _sql_constraints = [
-        ('unique_name', 'UNIQUE(name)', 'The name must be unique'),
-    ]
+    _unique_name = models.Constraint(
+        'UNIQUE(name)',
+        'The name must be unique',
+    )
 
     @api.depends('title')
     def _compute_name(self):

--- a/addons/utm/models/utm_medium.py
+++ b/addons/utm/models/utm_medium.py
@@ -13,9 +13,10 @@ class UtmMedium(models.Model):
     name = fields.Char(string='Medium Name', required=True, translate=False)
     active = fields.Boolean(default=True)
 
-    _sql_constraints = [
-        ('unique_name', 'UNIQUE(name)', 'The name must be unique'),
-    ]
+    _unique_name = models.Constraint(
+        'UNIQUE(name)',
+        'The name must be unique',
+    )
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/utm/models/utm_source.py
+++ b/addons/utm/models/utm_source.py
@@ -10,9 +10,10 @@ class UtmSource(models.Model):
 
     name = fields.Char(string='Source Name', required=True)
 
-    _sql_constraints = [
-        ('unique_name', 'UNIQUE(name)', 'The name must be unique'),
-    ]
+    _unique_name = models.Constraint(
+        'UNIQUE(name)',
+        'The name must be unique',
+    )
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/utm/models/utm_tag.py
+++ b/addons/utm/models/utm_tag.py
@@ -20,6 +20,7 @@ class UtmTag(models.Model):
         string='Color Index', default=lambda self: self._default_color(),
         help='Tag color. No color means no display in kanban to distinguish internal tags from public categorization tags.')
 
-    _sql_constraints = [
-        ('name_uniq', 'unique (name)', "Tag name already exists!"),
-    ]
+    _name_uniq = models.Constraint(
+        'unique (name)',
+        'Tag name already exists!',
+    )

--- a/addons/web_tour/models/tour.py
+++ b/addons/web_tour/models/tour.py
@@ -16,9 +16,10 @@ class Web_TourTour(models.Model):
     custom = fields.Boolean(string="Custom")
     user_consumed_ids = fields.Many2many("res.users")
 
-    _sql_constraints = [
-        ('uniq_name', 'unique(name)', "A tour already exists with this name . Tour's name must be unique!"),
-    ]
+    _uniq_name = models.Constraint(
+        'unique(name)',
+        "A tour already exists with this name . Tour's name must be unique!",
+    )
 
     @api.depends("name")
     def _compute_sharing_url(self):

--- a/addons/website/models/res_users.py
+++ b/addons/website/models/res_users.py
@@ -13,10 +13,10 @@ class ResUsers(models.Model):
 
     website_id = fields.Many2one('website', related='partner_id.website_id', store=True, related_sudo=False, readonly=False)
 
-    _sql_constraints = [
-        # Partial constraint, complemented by a python constraint (see below).
-        ('login_key', 'unique (login, website_id)', 'You can not have two users with the same login!'),
-    ]
+    _login_key = models.Constraint(
+        'unique (login, website_id)',
+        'You can not have two users with the same login!',
+    )
 
     @api.constrains('login', 'website_id')
     def _check_login(self):

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -200,9 +200,10 @@ class Website(models.Model):
         ('b2c', 'Free sign up'),
     ], string='Customer Account', default='b2b')
 
-    _sql_constraints = [
-        ('domain_unique', 'unique(domain)', 'Website Domain should be unique.'),
-    ]
+    _domain_unique = models.Constraint(
+        'unique(domain)',
+        'Website Domain should be unique.',
+    )
 
     @api.onchange('language_ids')
     def _onchange_language_ids(self):

--- a/addons/website/models/website_controller_page.py
+++ b/addons/website/models/website_controller_page.py
@@ -11,9 +11,10 @@ class WebsiteControllerPage(models.Model):
     ]
     _description = 'Model Page'
     _order = 'website_id, id DESC'
-    _sql_constraints = [
-        ('unique_name_slugified', 'UNIQUE(name_slugified)', 'url should be unique')
-    ]
+    _unique_name_slugified = models.Constraint(
+        'UNIQUE(name_slugified)',
+        'url should be unique',
+    )
 
     view_id = fields.Many2one('ir.ui.view', string='Listing view', required=True, ondelete="cascade")
     record_view_id = fields.Many2one('ir.ui.view', string='Record view', ondelete="cascade")

--- a/addons/website/models/website_visitor.py
+++ b/addons/website/models/website_visitor.py
@@ -75,9 +75,10 @@ class WebsiteVisitor(models.Model):
     time_since_last_action = fields.Char('Last action', compute="_compute_time_statistics", help='Time since last page view. E.g.: 2 minutes ago')
     is_connected = fields.Boolean('Is connected?', compute='_compute_time_statistics', help='A visitor is considered as connected if his last page view was within the last 5 minutes.')
 
-    _sql_constraints = [
-        ('access_token_unique', 'unique(access_token)', 'Access token should be unique.'),
-    ]
+    _access_token_unique = models.Constraint(
+        'unique(access_token)',
+        'Access token should be unique.',
+    )
 
     @api.depends('partner_id')
     def _compute_display_name(self):

--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -128,9 +128,10 @@ class BlogTagCategory(models.Model):
     name = fields.Char('Name', required=True, translate=True)
     tag_ids = fields.One2many('blog.tag', 'category_id', string='Tags')
 
-    _sql_constraints = [
-        ('name_uniq', 'unique (name)', "Tag category already exists!"),
-    ]
+    _name_uniq = models.Constraint(
+        'unique (name)',
+        'Tag category already exists!',
+    )
 
 
 class BlogTag(models.Model):
@@ -143,9 +144,10 @@ class BlogTag(models.Model):
     color = fields.Integer('Color')
     post_ids = fields.Many2many('blog.post', string='Posts')
 
-    _sql_constraints = [
-        ('name_uniq', 'unique (name)', "Tag name already exists!"),
-    ]
+    _name_uniq = models.Constraint(
+        'unique (name)',
+        'Tag name already exists!',
+    )
 
 
 class BlogPost(models.Model):

--- a/addons/website_crm_iap_reveal/models/crm_reveal_rule.py
+++ b/addons/website_crm_iap_reveal/models/crm_reveal_rule.py
@@ -62,9 +62,10 @@ class CrmRevealRule(models.Model):
 
     # This limits the number of extra contact.
     # Even if more than 5 extra contacts provided service will return only 5 contacts (see service module for more)
-    _sql_constraints = [
-        ('limit_extra_contacts', 'check(extra_contacts >= 1 and extra_contacts <= 5)', 'Maximum 5 contacts are allowed!'),
-    ]
+    _limit_extra_contacts = models.Constraint(
+        'check(extra_contacts >= 1 and extra_contacts <= 5)',
+        'Maximum 5 contacts are allowed!',
+    )
 
     def _compute_lead_count(self):
         leads = self.env['crm.lead']._read_group([

--- a/addons/website_event_track/models/event_track_tag.py
+++ b/addons/website_event_track/models/event_track_tag.py
@@ -21,6 +21,7 @@ class EventTrackTag(models.Model):
     sequence = fields.Integer('Sequence', default=10)
     category_id = fields.Many2one('event.track.tag.category', string="Category", ondelete="set null")
 
-    _sql_constraints = [
-        ('name_uniq', 'unique (name)', "Tag name already exists!"),
-    ]
+    _name_uniq = models.Constraint(
+        'unique (name)',
+        'Tag name already exists!',
+    )

--- a/addons/website_forum/models/forum_post_vote.py
+++ b/addons/website_forum/models/forum_post_vote.py
@@ -16,9 +16,10 @@ class ForumPostVote(models.Model):
     forum_id = fields.Many2one('forum.forum', string='Forum', related="post_id.forum_id", store=True, readonly=False)
     recipient_id = fields.Many2one('res.users', string='To', related="post_id.create_uid", store=True, readonly=False)
 
-    _sql_constraints = [
-        ('vote_uniq', 'unique (post_id, user_id)', "Vote already exists!"),
-    ]
+    _vote_uniq = models.Constraint(
+        'unique (post_id, user_id)',
+        'Vote already exists!',
+    )
 
     def _get_karma_value(self, old_vote, new_vote, up_karma, down_karma):
         """Return the karma to add / remove based on the old vote and on the new vote."""

--- a/addons/website_forum/models/forum_tag.py
+++ b/addons/website_forum/models/forum_tag.py
@@ -21,9 +21,10 @@ class ForumTag(models.Model):
         string='Posts', domain=[('state', '=', 'active')])
     posts_count = fields.Integer('Number of Posts', compute='_compute_posts_count', store=True)
     website_url = fields.Char("Link to questions with the tag", compute='_compute_website_url')
-    _sql_constraints = [
-        ('name_uniq', 'unique (name, forum_id)', "Tag name already exists!"),
-    ]
+    _name_uniq = models.Constraint(
+        'unique (name, forum_id)',
+        'Tag name already exists!',
+    )
 
     @api.depends("post_ids", "post_ids.tag_ids", "post_ids.state", "post_ids.active")
     def _compute_posts_count(self):

--- a/addons/website_sale_slides/models/slide_channel.py
+++ b/addons/website_sale_slides/models/slide_channel.py
@@ -23,9 +23,10 @@ class SlideChannel(models.Model):
         groups="sales_team.group_sale_salesman")
     currency_id = fields.Many2one(related='product_id.currency_id')
 
-    _sql_constraints = [
-        ('product_id_check', "CHECK( enroll!='payment' OR product_id IS NOT NULL )", "Product is required for on payment channels.")
-    ]
+    _product_id_check = models.Constraint(
+        "CHECK( enroll!='payment' OR product_id IS NOT NULL )",
+        'Product is required for on payment channels.',
+    )
 
     @api.depends('product_id')
     def _compute_product_sale_revenues(self):

--- a/addons/website_sale_wishlist/models/product_wishlist.py
+++ b/addons/website_sale_wishlist/models/product_wishlist.py
@@ -6,11 +6,10 @@ from odoo.http import request
 
 class ProductWishlist(models.Model):
     _description = 'Product Wishlist'
-    _sql_constraints = [
-        ("product_unique_partner_id",
-         "UNIQUE(product_id, partner_id)",
-         "Duplicated wishlisted product for this partner."),
-    ]
+    _product_unique_partner_id = models.Constraint(
+        'UNIQUE(product_id, partner_id)',
+        'Duplicated wishlisted product for this partner.',
+    )
 
     partner_id = fields.Many2one('res.partner', string='Owner')
     product_id = fields.Many2one('product.product', string='Product', required=True)

--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -46,16 +46,14 @@ class SlideChannelPartner(models.Model):
     invitation_link = fields.Char('Invitation Link', compute="_compute_invitation_link")
     last_invitation_date = fields.Datetime('Last Invitation Date')
 
-    _sql_constraints = [
-        ('channel_partner_uniq',
-         'unique(channel_id, partner_id)',
-         'A partner membership to a channel must be unique!'
-        ),
-        ('check_completion',
-         'check(completion >= 0 and completion <= 100)',
-         'The completion of a channel is a percentage and should be between 0% and 100.'
-        )
-    ]
+    _channel_partner_uniq = models.Constraint(
+        'unique(channel_id, partner_id)',
+        'A partner membership to a channel must be unique!',
+    )
+    _check_completion = models.Constraint(
+        'check(completion >= 0 and completion <= 100)',
+        'The completion of a channel is a percentage and should be between 0% and 100.',
+    )
 
     @api.depends('channel_id', 'partner_id')
     def _compute_invitation_link(self):
@@ -445,13 +443,10 @@ class SlideChannel(models.Model):
     prerequisite_user_has_completed = fields.Boolean(
         'Has Completed Prerequisite', compute='_compute_prerequisite_user_has_completed')
 
-    _sql_constraints = [
-        (
-            "check_enroll",
-            "CHECK(visibility != 'members' OR enroll = 'invite')",
-            "The Enroll Policy should be set to 'On Invitation' when visibility is set to 'Course Attendees'"
-        ),
-    ]
+    _check_enroll = models.Constraint(
+        "CHECK(visibility != 'members' OR enroll = 'invite')",
+        "The Enroll Policy should be set to 'On Invitation' when visibility is set to 'Course Attendees'",
+    )
 
     @api.depends('visibility')
     def _compute_enroll(self):

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -36,16 +36,14 @@ class SlideSlidePartner(models.Model):
     completed = fields.Boolean('Completed')
     quiz_attempts_count = fields.Integer('Quiz attempts count', default=0)
 
-    _sql_constraints = [
-        ('slide_partner_uniq',
-         'unique(slide_id, partner_id)',
-         'A partner membership to a slide must be unique!'
-        ),
-        ('check_vote',
-         'CHECK(vote IN (-1, 0, 1))',
-         'The vote must be 1, 0 or -1.'
-        ),
-    ]
+    _slide_partner_uniq = models.Constraint(
+        'unique(slide_id, partner_id)',
+        'A partner membership to a slide must be unique!',
+    )
+    _check_vote = models.Constraint(
+        'CHECK(vote IN (-1, 0, 1))',
+        'The vote must be 1, 0 or -1.',
+    )
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -82,9 +80,10 @@ class SlideTag(models.Model):
 
     name = fields.Char('Name', required=True, translate=True)
 
-    _sql_constraints = [
-        ('slide_tag_unique', 'UNIQUE(name)', 'A tag must be unique!'),
-    ]
+    _slide_tag_unique = models.Constraint(
+        'UNIQUE(name)',
+        'A tag must be unique!',
+    )
 
 
 class SlideSlide(models.Model):
@@ -236,9 +235,10 @@ class SlideSlide(models.Model):
     is_published = fields.Boolean(tracking=1)
     website_published = fields.Boolean(tracking=False)
 
-    _sql_constraints = [
-        ('exclusion_html_content_and_url', "CHECK(html_content IS NULL OR url IS NULL)", "A slide is either filled with a url or HTML content. Not both.")
-    ]
+    _exclusion_html_content_and_url = models.Constraint(
+        'CHECK(html_content IS NULL OR url IS NULL)',
+        'A slide is either filled with a url or HTML content. Not both.',
+    )
 
     @api.depends('slide_category', 'source_type', 'image_binary_content')
     def _compute_image_1920(self):

--- a/addons/website_slides/models/slide_slide_resource.py
+++ b/addons/website_slides/models/slide_slide_resource.py
@@ -21,10 +21,14 @@ class SlideSlideResource(models.Model):
     download_url = fields.Char('Download URL', compute='_compute_download_url')
     sequence = fields.Integer(string="Sequence")
 
-    _sql_constraints = [
-        ('check_url', "CHECK (resource_type != 'url' OR link IS NOT NULL)", 'A resource of type url must contain a link.'),
-        ('check_file_type', "CHECK (resource_type != 'file' OR link IS NULL)", 'A resource of type file cannot contain a link.'),
-    ]
+    _check_url = models.Constraint(
+        "CHECK (resource_type != 'url' OR link IS NOT NULL)",
+        'A resource of type url must contain a link.',
+    )
+    _check_file_type = models.Constraint(
+        "CHECK (resource_type != 'file' OR link IS NULL)",
+        'A resource of type file cannot contain a link.',
+    )
 
     @api.depends('resource_type')
     def _compute_reset_resources(self):

--- a/addons/website_slides_forum/models/slide_channel.py
+++ b/addons/website_slides_forum/models/slide_channel.py
@@ -10,9 +10,10 @@ class SlideChannel(models.Model):
     forum_id = fields.Many2one('forum.forum', 'Course Forum', copy=False)
     forum_total_posts = fields.Integer('Number of active forum posts', related="forum_id.total_posts")
 
-    _sql_constraints = [
-        ('forum_uniq', 'unique (forum_id)', "Only one course per forum!"),
-    ]
+    _forum_uniq = models.Constraint(
+        'unique (forum_id)',
+        'Only one course per forum!',
+    )
 
     def action_redirect_to_forum(self):
         self.ensure_one()

--- a/addons/website_slides_survey/models/slide_slide.py
+++ b/addons/website_slides_survey/models/slide_slide.py
@@ -59,10 +59,14 @@ class SlideSlide(models.Model):
     # small override of 'is_preview' to uncheck it automatically for slides of type 'certification'
     is_preview = fields.Boolean(compute='_compute_is_preview', readonly=False, store=True)
 
-    _sql_constraints = [
-        ('check_survey_id', "CHECK(slide_category != 'certification' OR survey_id IS NOT NULL)", "A slide of type 'certification' requires a certification."),
-        ('check_certification_preview', "CHECK(slide_category != 'certification' OR is_preview = False)", "A slide of type certification cannot be previewed."),
-    ]
+    _check_survey_id = models.Constraint(
+        "CHECK(slide_category != 'certification' OR survey_id IS NOT NULL)",
+        "A slide of type 'certification' requires a certification.",
+    )
+    _check_certification_preview = models.Constraint(
+        "CHECK(slide_category != 'certification' OR is_preview = False)",
+        'A slide of type certification cannot be previewed.',
+    )
 
     @api.depends('survey_id')
     def _compute_name(self):

--- a/odoo/addons/base/models/decimal_precision.py
+++ b/odoo/addons/base/models/decimal_precision.py
@@ -20,9 +20,10 @@ class DecimalPrecision(models.Model):
     name = fields.Char('Usage', required=True)
     digits = fields.Integer('Digits', required=True, default=2)
 
-    _sql_constraints = [
-        ('name_uniq', 'unique (name)', """Only one value can be defined for each given usage!"""),
-    ]
+    _name_uniq = models.Constraint(
+        'unique (name)',
+        "Only one value can be defined for each given usage!",
+    )
 
     @api.model
     @tools.ormcache('application')

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -410,17 +410,13 @@ class IrActionsAct_WindowView(models.Model):
     _order = 'sequence,id'
     _allow_sudo_commands = False
 
+    _unique_mode_per_action = models.UniqueIndex('(act_window_id, view_mode)')
+
     sequence = fields.Integer()
     view_id = fields.Many2one('ir.ui.view', string='View')
     view_mode = fields.Selection(VIEW_TYPES, string='View Type', required=True)
     act_window_id = fields.Many2one('ir.actions.act_window', string='Action', ondelete='cascade')
     multi = fields.Boolean(string='On Multiple Doc.', help="If set to true, the action will not be displayed on the right toolbar of a form view.")
-
-    def _auto_init(self):
-        res = super()._auto_init()
-        tools.create_unique_index(self._cr, 'act_window_view_unique_mode_per_action',
-                                  self._table, ['act_window_id', 'view_mode'])
-        return res
 
 
 class IrActionsAct_Window_Close(models.Model):

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -55,7 +55,10 @@ class IrActionsActions(models.Model):
     _order = 'name'
     _allow_sudo_commands = False
 
-    _sql_constraints = [('path_unique', 'unique(path)', "Path to show in the URL must be unique! Please choose another one.")]
+    _path_unique = models.Constraint(
+        'unique(path)',
+        "Path to show in the URL must be unique! Please choose another one.",
+    )
 
     name = fields.Char(string='Action Name', required=True, translate=True)
     type = fields.Char(string='Action Type', required=True)

--- a/odoo/addons/base/models/ir_config_parameter.py
+++ b/odoo/addons/base/models/ir_config_parameter.py
@@ -36,9 +36,10 @@ class IrConfig_Parameter(models.Model):
     key = fields.Char(required=True)
     value = fields.Text(required=True)
 
-    _sql_constraints = [
-        ('key_uniq', 'unique (key)', 'Key must be unique.')
-    ]
+    _key_uniq = models.Constraint(
+        'unique (key)',
+        "Key must be unique.",
+    )
 
     @mute_logger('odoo.addons.base.models.ir_config_parameter')
     def init(self, force=False):

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -83,13 +83,10 @@ class IrCron(models.Model):
     failure_count = fields.Integer(default=0, help="The number of consecutive failures of this job. It is automatically reset on success.")
     first_failure_date = fields.Datetime(string='First Failure Date', help="The first time the cron failed. It is automatically reset on success.")
 
-    _sql_constraints = [
-        (
-            'check_strictly_positive_interval',
-            'CHECK(interval_number > 0)',
-            'The interval number must be a strictly positive number.'
-        ),
-    ]
+    _check_strictly_positive_interval = models.Constraint(
+        'CHECK(interval_number > 0)',
+        "The interval number must be a strictly positive number.",
+    )
 
     @api.depends('ir_actions_server_id.name')
     def _compute_cron_name(self):

--- a/odoo/addons/base/models/ir_embedded_actions.py
+++ b/odoo/addons/base/models/ir_embedded_actions.py
@@ -27,22 +27,17 @@ class IrEmbeddedActions(models.Model):
     context = fields.Char(default="{}", help="Context dictionary as Python expression, empty by default (Default: {})")
     groups_ids = fields.Many2many('res.groups', help='Groups that can execute the embedded action. Leave empty to allow everybody.')
 
-    _sql_constraints = [
-        (
-            'check_only_one_action_defined',
-            """CHECK(
-                (action_id IS NOT NULL AND python_method IS NULL) OR
-                (action_id IS NULL AND python_method IS NOT NULL)
-            )""",
-            'Constraint to ensure that either an XML action or a python_method is defined, but not both.'
-        ), (
-            'check_python_method_requires_name',
-            """CHECK(
-                NOT (python_method IS NOT NULL AND name IS NULL)
-            )""",
-            'Constraint to ensure that if a python_method is defined, then the name must also be defined.'
-        )
-    ]
+    _check_only_one_action_defined = models.Constraint(
+        '''CHECK(
+            (action_id IS NOT NULL AND python_method IS NULL)
+            OR (action_id IS NULL AND python_method IS NOT NULL)
+        )''',
+        "Constraint to ensure that either an XML action or a python_method is defined, but not both.",
+    )
+    _check_python_method_requires_name = models.Constraint(
+        'CHECK(NOT (python_method IS NOT NULL AND name IS NULL))',
+        "Constraint to ensure that if a python_method is defined, then the name must also be defined.",
+    )
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -189,13 +189,10 @@ class IrMail_Server(models.Model):
                                                                   "is used. Default priority is 10 (smaller number = higher priority)")
     active = fields.Boolean(default=True)
 
-    _sql_constraints = [
-        (
-            'certificate_requires_tls',
-            "CHECK(smtp_encryption != 'none' OR smtp_authentication != 'certificate')",
-            "Certificate-based authentication requires a TLS transport"
-        ),
-    ]
+    _certificate_requires_tls = models.Constraint(
+        "CHECK(smtp_encryption != 'none' OR smtp_authentication != 'certificate')",
+        "Certificate-based authentication requires a TLS transport",
+    )
 
     @api.depends('smtp_authentication')
     def _compute_smtp_authentication_info(self):

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1789,17 +1789,16 @@ class IrModelConstraint(models.Model):
     _description = 'Model Constraint'
     _allow_sudo_commands = False
 
-    name = fields.Char(string='Constraint', required=True, index=True,
-                       help="PostgreSQL constraint or foreign key name.")
-    definition = fields.Char(help="PostgreSQL constraint definition")
+    name = fields.Char(
+        string='Constraint', required=True, index=True, readonly=True,
+        help="PostgreSQL constraint or foreign key name.")
+    definition = fields.Char(help="PostgreSQL constraint definition", readonly=True)
     message = fields.Char(help="Error message returned when the constraint is violated.", translate=True)
-    model = fields.Many2one('ir.model', required=True, ondelete="cascade", index=True)
-    module = fields.Many2one('ir.module.module', required=True, index=True, ondelete='cascade')
-    type = fields.Char(string='Constraint Type', required=True, size=1, index=True,
-                       help="Type of the constraint: `f` for a foreign key, "
-                            "`u` for other constraints.")
-    write_date = fields.Datetime()
-    create_date = fields.Datetime()
+    model = fields.Many2one('ir.model', required=True, ondelete="cascade", index=True, readonly=True)
+    module = fields.Many2one('ir.module.module', required=True, index=True, ondelete='cascade', readonly=True)
+    type = fields.Char(
+        string='Constraint Type', required=True, size=1, index=True, readonly=True,
+        help="Type of the constraint: `f` for a foreign key, `u` for other constraints.")
 
     _sql_constraints = [
         ('module_name_uniq', 'unique(name, module)',

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1911,7 +1911,7 @@ class IrModelConstraint(models.Model):
             message = cons.message
             if not isinstance(message, str) or not message:
                 message = None
-            typ = 'f' if isinstance(cons, models.Constraint) and cons._type == 'FK' else 'u'
+            typ = 'u'
             record = self._reflect_constraint(model, conname, typ, definition, module, message)
             xml_id = '%s.constraint_%s' % (module, conname)
             if record:

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -304,9 +304,10 @@ class IrModuleModule(models.Model):
     to_buy = fields.Boolean('Odoo Enterprise Module', default=False)
     has_iap = fields.Boolean(compute='_compute_has_iap')
 
-    _sql_constraints = [
-        ('name_uniq', 'UNIQUE (name)', 'The name of the module must be unique!'),
-    ]
+    _name_uniq = models.Constraint(
+        'UNIQUE (name)',
+        "The name of the module must be unique!",
+    )
 
     def _compute_has_iap(self):
         for module in self:

--- a/odoo/addons/base/models/ir_rule.py
+++ b/odoo/addons/base/models/ir_rule.py
@@ -27,11 +27,10 @@ class IrRule(models.Model):
     perm_create = fields.Boolean(string='Create', default=True)
     perm_unlink = fields.Boolean(string='Delete', default=True)
 
-    _sql_constraints = [
-        ('no_access_rights',
-         'CHECK (perm_read!=False or perm_write!=False or perm_create!=False or perm_unlink!=False)',
-         'Rule must have at least one checked access right!'),
-    ]
+    _no_access_rights = models.Constraint(
+        'CHECK (perm_read!=False or perm_write!=False or perm_create!=False or perm_unlink!=False)',
+        "Rule must have at least one checked access right!",
+    )
 
     @api.model
     def _eval_context(self):

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -432,15 +432,14 @@ actual arch.
         if self._has_cycle('inherit_id'):
             raise ValidationError(_('You cannot create recursive inherited views.'))
 
-    _sql_constraints = [
-        ('inheritance_mode',
-         "CHECK (mode != 'extension' OR inherit_id IS NOT NULL)",
-         "Invalid inheritance mode: if the mode is 'extension', the view must"
-         " extend an other view"),
-        ('qweb_required_key',
-         "CHECK (type != 'qweb' OR key IS NOT NULL)",
-         "Invalid key: QWeb view should have a key"),
-    ]
+    _inheritance_mode = models.Constraint(
+        "CHECK (mode != 'extension' OR inherit_id IS NOT NULL)",
+        "Invalid inheritance mode: if the mode is 'extension', the view must extend an other view",
+    )
+    _qweb_required_key = models.Constraint(
+        "CHECK (type != 'qweb' OR key IS NOT NULL)",
+        "Invalid key: QWeb view should have a key",
+    )
     _model_type_inherit_id = models.Index('(model, inherit_id)')
 
     def _compute_defaults(self, values):

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -73,11 +73,7 @@ class IrUiViewCustom(models.Model):
     user_id = fields.Many2one('res.users', string='User', index=True, required=True, ondelete='cascade')
     arch = fields.Text(string='View Architecture', required=True)
 
-    def _auto_init(self):
-        res = super()._auto_init()
-        tools.create_index(self._cr, 'ir_ui_view_custom_user_id_ref_id',
-                           self._table, ['user_id', 'ref_id'])
-        return res
+    _user_id_ref_id = models.Index('(user_id, ref_id)')
 
 
 def _hasclass(context, *cls):
@@ -445,12 +441,7 @@ actual arch.
          "CHECK (type != 'qweb' OR key IS NOT NULL)",
          "Invalid key: QWeb view should have a key"),
     ]
-
-    def _auto_init(self):
-        res = super()._auto_init()
-        tools.create_index(self._cr, 'ir_ui_view_model_type_inherit_id',
-                           self._table, ['model', 'inherit_id'])
-        return res
+    _model_type_inherit_id = models.Index('(model, inherit_id)')
 
     def _compute_defaults(self, values):
         if 'inherit_id' in values:

--- a/odoo/addons/base/models/res_bank.py
+++ b/odoo/addons/base/models/res_bank.py
@@ -84,11 +84,10 @@ class ResPartnerBank(models.Model):
     company_id = fields.Many2one('res.company', 'Company', related='partner_id.company_id', store=True, readonly=True)
     country_code = fields.Char(related='partner_id.country_code', string="Country Code")
 
-    _sql_constraints = [(
-        'unique_number',
+    _unique_number = models.Constraint(
         'unique(sanitized_acc_number, partner_id)',
-        'The combination Account Number/Partner must be unique.'
-    )]
+        "The combination Account Number/Partner must be unique.",
+    )
 
     @api.depends('acc_number')
     def _compute_sanitized_acc_number(self):

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -78,9 +78,10 @@ class ResCompany(models.Model):
     layout_background = fields.Selection([('Blank', 'Blank'), ('Demo logo', 'Demo logo'), ('Custom', 'Custom')], default="Blank", required=True)
     layout_background_image = fields.Binary("Background Image")
     uninstalled_l10n_module_ids = fields.Many2many('ir.module.module', compute='_compute_uninstalled_l10n_module_ids')
-    _sql_constraints = [
-        ('name_uniq', 'unique (name)', 'The company name must be unique!')
-    ]
+    _name_uniq = models.Constraint(
+        'unique (name)',
+        "The company name must be unique!",
+    )
 
     def init(self):
         for company in self.search([('paperformat_id', '=', False)]):

--- a/odoo/addons/base/models/res_country.py
+++ b/odoo/addons/base/models/res_country.py
@@ -75,12 +75,14 @@ class ResCountry(models.Model):
     state_required = fields.Boolean(default=False)
     zip_required = fields.Boolean(default=True)
 
-    _sql_constraints = [
-        ('name_uniq', 'unique (name)',
-            'The name of the country must be unique!'),
-        ('code_uniq', 'unique (code)',
-            'The code of the country must be unique!')
-    ]
+    _name_uniq = models.Constraint(
+        'unique (name)',
+        "The name of the country must be unique!",
+    )
+    _code_uniq = models.Constraint(
+        'unique (code)',
+        "The code of the country must be unique!",
+    )
 
     @api.model
     def name_search(self, name='', args=None, operator='ilike', limit=100):
@@ -166,9 +168,10 @@ class ResCountryState(models.Model):
                help='Administrative divisions of a country. E.g. Fed. State, Departement, Canton')
     code = fields.Char(string='State Code', help='The state code.', required=True)
 
-    _sql_constraints = [
-        ('name_code_uniq', 'unique(country_id, code)', 'The code of the state must be unique by country!')
-    ]
+    _name_code_uniq = models.Constraint(
+        'unique(country_id, code)',
+        "The code of the state must be unique by country!",
+    )
 
     @api.model
     def name_search(self, name='', args=None, operator='ilike', limit=100):

--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -47,10 +47,14 @@ class ResCurrency(models.Model):
     currency_subunit_label = fields.Char(string="Currency Subunit", translate=True)
     is_current_company_currency = fields.Boolean(compute='_compute_is_current_company_currency')
 
-    _sql_constraints = [
-        ('unique_name', 'unique (name)', 'The currency code must be unique!'),
-        ('rounding_gt_zero', 'CHECK (rounding>0)', 'The rounding factor must be greater than 0!')
-    ]
+    _unique_name = models.Constraint(
+        'unique (name)',
+        "The currency code must be unique!",
+    )
+    _rounding_gt_zero = models.Constraint(
+        'CHECK (rounding>0)',
+        "The rounding factor must be greater than 0!",
+    )
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -357,10 +361,14 @@ class ResCurrencyRate(models.Model):
     company_id = fields.Many2one('res.company', string='Company',
                                  default=lambda self: self.env.company.root_id)
 
-    _sql_constraints = [
-        ('unique_name_per_day', 'unique (name,currency_id,company_id)', 'Only one currency rate per day allowed!'),
-        ('currency_rate_check', 'CHECK (rate>0)', 'The currency rate must be strictly positive.'),
-    ]
+    _unique_name_per_day = models.Constraint(
+        'unique (name,currency_id,company_id)',
+        "Only one currency rate per day allowed!",
+    )
+    _currency_rate_check = models.Constraint(
+        'CHECK (rate>0)',
+        "The currency rate must be strictly positive.",
+    )
 
     def _sanitize_vals(self, vals):
         if 'inverse_company_rate' in vals and ('company_rate' in vals or 'rate' in vals):

--- a/odoo/addons/base/models/res_lang.py
+++ b/odoo/addons/base/models/res_lang.py
@@ -90,11 +90,18 @@ class ResLang(models.Model):
     flag_image = fields.Image("Image")
     flag_image_url = fields.Char(compute=_compute_field_flag_image_url)
 
-    _sql_constraints = [
-        ('name_uniq', 'unique(name)', 'The name of the language must be unique!'),
-        ('code_uniq', 'unique(code)', 'The code of the language must be unique!'),
-        ('url_code_uniq', 'unique(url_code)', 'The URL code of the language must be unique!'),
-    ]
+    _name_uniq = models.Constraint(
+        'unique(name)',
+        "The name of the language must be unique!",
+    )
+    _code_uniq = models.Constraint(
+        'unique(code)',
+        "The code of the language must be unique!",
+    )
+    _url_code_uniq = models.Constraint(
+        'unique(url_code)',
+        "The URL code of the language must be unique!",
+    )
 
     @api.constrains('active')
     def _check_active(self):

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -305,9 +305,10 @@ class ResPartner(models.Model):
     # hack to allow using plain browse record in qweb views, and used in ir.qweb.field.contact
     self: ResPartner = fields.Many2one(comodel_name='res.partner', compute='_compute_get_ids')
 
-    _sql_constraints = [
-        ('check_name', "CHECK( (type='contact' AND name IS NOT NULL) or (type!='contact') )", 'Contacts require a name'),
-    ]
+    _check_name = models.Constraint(
+        "CHECK( (type='contact' AND name IS NOT NULL) or (type!='contact') )",
+        "Contacts require a name",
+    )
 
     def _get_street_split(self):
         self.ensure_one()

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -194,10 +194,12 @@ class ResGroups(models.Model):
     api_key_duration = fields.Float(string='API Keys maximum duration days',
         help="Determines the maximum duration of an api key created by a user belonging to this group.")
 
-    _sql_constraints = [
-        ('name_uniq', 'unique (category_id, name)', 'The name of the group must be unique within an application!'),
-        ('check_api_key_duration', 'CHECK(api_key_duration >= 0)', 'The api key duration cannot be a negative value.'),
-    ]
+    _name_uniq = models.Constraint("UNIQUE (category_id, name)",
+        'The name of the group must be unique within an application!')
+    _check_api_key_duration = models.Constraint(
+        'CHECK(api_key_duration >= 0)',
+        'The api key duration cannot be a negative value.',
+    )
 
     @api.constrains('users')
     def _check_one_user_type(self):
@@ -409,9 +411,8 @@ class ResUsers(models.Model):
     groups_count = fields.Integer('# Groups', help='Number of groups that apply to the current user',
                                   compute='_compute_accesses_count', compute_sudo=True)
 
-    _sql_constraints = [
-        ('login_key', 'UNIQUE (login)', 'You can not have two users with the same login!')
-    ]
+    _login_key = models.Constraint("UNIQUE (login)",
+        'You can not have two users with the same login!')
 
     def init(self):
         cr = self.env.cr

--- a/odoo/addons/base/models/res_users_settings.py
+++ b/odoo/addons/base/models/res_users_settings.py
@@ -10,9 +10,10 @@ class ResUsersSettings(models.Model):
 
     user_id = fields.Many2one('res.users', string="User", required=True, readonly=True, ondelete='cascade')
 
-    _sql_constraints = [
-        ('unique_user_id', 'UNIQUE(user_id)', 'One user should only have one user settings.')
-    ]
+    _unique_user_id = models.Constraint(
+        'UNIQUE(user_id)',
+        "One user should only have one user settings.",
+    )
 
     @api.model
     def _get_fields_blacklist(self):

--- a/odoo/addons/base/security/ir.model.access.csv
+++ b/odoo/addons/base/security/ir.model.access.csv
@@ -8,7 +8,7 @@
 "access_ir_exports_group_system","ir_exports group_system","model_ir_exports","base.group_allow_export",1,1,1,1
 "access_ir_exports_line_group_system","ir_exports_line group_system","model_ir_exports_line","base.group_user",1,1,1,1
 "access_ir_model_group_erp_manager","ir_model group_erp_manager","model_ir_model","group_erp_manager",1,1,1,1
-"access_ir_model_constraint_group_erp_manager","ir_model_constraint group_erp_manager","model_ir_model_constraint","group_erp_manager",1,1,1,1
+"access_ir_model_constraint_group_erp_manager","ir_model_constraint group_erp_manager","model_ir_model_constraint","group_erp_manager",1,1,0,1
 "access_ir_model_relation_group_erp_manager","ir_model_relation group_erp_manager","model_ir_model_relation","group_erp_manager",1,1,1,1
 "access_ir_model_inherit","ir_model_inherit nobody","model_ir_model_inherit",,0,0,0,0
 "access_ir_model_access_group_erp_manager","ir_model_access_group_erp_manager","model_ir_model_access","group_erp_manager",1,1,1,1

--- a/odoo/addons/test_http/models.py
+++ b/odoo/addons/test_http/models.py
@@ -24,9 +24,10 @@ class Test_HttpStargate(models.Model):
     availability = fields.Float(default=0.99, aggregator="avg")
     last_use_date = fields.Date()
 
-    _sql_constraints = [
-        ('address_length', 'CHECK(LENGTH(address) = 6)', "Local addresses have 6 glyphs"),
-    ]
+    _address_length = models.Constraint(
+        'CHECK(LENGTH(address) = 6)',
+        "Local addresses have 6 glyphs",
+    )
 
     @api.depends('galaxy_id')
     def _compute_has_galaxy_crystal(self):

--- a/odoo/addons/test_inherit/models/test_models.py
+++ b/odoo/addons/test_inherit/models/test_models.py
@@ -85,7 +85,10 @@ class Test_Inherit_Parent(models.AbstractModel):  # noqa: F811
 
     foo = fields.Integer()
 
-    _sql_constraints = [('unique_foo', 'UNIQUE(foo)', 'foo must be unique')]
+    _unique_foo = models.Constraint(
+        'UNIQUE(foo)',
+        "foo must be unique",
+    )
 
     def stuff(self):
         return super().stuff() + 'P2'

--- a/odoo/addons/test_inherit/tests/test_inherit.py
+++ b/odoo/addons/test_inherit/tests/test_inherit.py
@@ -151,8 +151,8 @@ class TestInherit(common.TransactionCase):
         # check inferred model attributes
         self.assertEqual(parent._table, 'test_inherit_parent')
         self.assertEqual(child._table, 'test_inherit_child')
-        self.assertEqual(len(parent._sql_constraints), 1)
-        self.assertEqual(len(child._sql_constraints), 1)
+        self.assertEqual(len(parent._table_objects), 1)
+        self.assertEqual(len(child._table_objects), 1)
 
         # check properties memoized on model
         self.assertEqual(len(parent._constraint_methods), 1)

--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -35,9 +35,10 @@ class Test_New_ApiCategory(models.Model):
     discussions = fields.Many2many('test_new_api.discussion', 'test_new_api_discussion_category',
                                    'category', 'discussion')
 
-    _sql_constraints = [
-        ('positive_color', 'CHECK(color >= 0)', 'The color code must be positive!')
-    ]
+    _positive_color = models.Constraint(
+        'CHECK(color >= 0)',
+        "The color code must be positive!",
+    )
 
     @api.depends('name', 'parent.display_name')     # this definition is recursive
     def _compute_display_name(self):

--- a/odoo/addons/test_performance/models/models.py
+++ b/odoo/addons/test_performance/models/models.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models, fields, api, tools
+from odoo import api, fields, models
 
 
 class Test_PerformanceBase(models.Model):
@@ -52,9 +51,7 @@ class Test_PerformanceLine(models.Model):
     base_id = fields.Many2one('test_performance.base', required=True, ondelete='cascade')
     value = fields.Integer()
 
-    def init(self):
-        # line values should be unique per "base" - useful for testing corner cases with unique lines
-        tools.create_unique_index(self._cr, 'test_performance_line_uniq', self._table, ['base_id', 'value'])
+    _line_uniq = models.UniqueIndex('(base_id, value)', "base_id and value should be unique")
 
 
 class Test_PerformanceTag(models.Model):

--- a/odoo/addons/test_rpc/models.py
+++ b/odoo/addons/test_rpc/models.py
@@ -18,6 +18,7 @@ class Test_RpcModel_B(models.Model):
     name = fields.Char(required=True)
     value = fields.Integer()
 
-    _sql_constraints = [
-        ('qty_positive', 'check (value > 0)', 'The value must be positive'),
-    ]
+    _qty_positive = models.Constraint(
+        'check (value > 0)',
+        "The value must be positive",
+    )

--- a/odoo/addons/test_rpc/tests/test_error.py
+++ b/odoo/addons/test_rpc/tests/test_error.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from functools import partial
 from xmlrpc.client import Fault
 
@@ -26,13 +24,13 @@ class TestError(common.HttpCase):
 
         e = ctx.exception
         self.assertIn("The operation cannot be completed:", e.faultString)
-        self.assertIn("Create/update: a mandatory field is not set.", e.faultString)
+        self.assertIn("create/update: a mandatory field is not set", e.faultString)
         self.assertIn(
-            "Delete: another model requires the record being deleted. If possible, archive it instead.",
+            "delete: another model requires the record being deleted",
             e.faultString,
         )
-        self.assertIn("Model: Model B (test_rpc.model_b)", e.faultString)
-        self.assertIn("Field: Name (name)", e.faultString)
+        self.assertIn("Model: 'Model B' (test_rpc.model_b)", e.faultString)
+        self.assertIn("field 'Name' (name)", e.faultString)
 
     def test_02_delete(self):
         """ Delete: NOT NULL and ON DELETE RESTRICT constraints """
@@ -46,11 +44,11 @@ class TestError(common.HttpCase):
         e = ctx.exception
         self.assertIn("The operation cannot be completed:", e.faultString)
         self.assertIn(
-            "another model requires the record being deleted. If possible, archive it instead.",
+            "Another model requires the record being deleted, if possible, archive it instead",
             e.faultString,
         )
-        self.assertIn("Model: Model A (test_rpc.model_a)", e.faultString)
-        self.assertIn("Constraint: test_rpc_model_a_field_b1_fkey", e.faultString)
+        self.assertIn("Model: 'Model A' (test_rpc.model_a)", e.faultString)
+        self.assertIn("Foreign key: 'required field'", e.faultString)
 
         # Unlink b2 => ON DELETE RESTRICT constraint raises
         with self.assertRaises(Fault) as ctx, mute_logger("odoo.sql_db"):
@@ -59,11 +57,11 @@ class TestError(common.HttpCase):
         e = ctx.exception
         self.assertIn("The operation cannot be completed:", e.faultString)
         self.assertIn(
-            " another model requires the record being deleted. If possible, archive it instead.",
+            "Another model requires the record being deleted, if possible, archive it instead",
             e.faultString,
         )
-        self.assertIn("Model: Model A (test_rpc.model_a)", e.faultString)
-        self.assertIn("Constraint: test_rpc_model_a_field_b2_fkey", e.faultString)
+        self.assertIn("Model: 'Model A' (test_rpc.model_a)", e.faultString)
+        self.assertIn("Foreign key: 'restricted field'", e.faultString)
 
     def test_03_sql_constraint(self):
         with mute_logger("odoo.sql_db"):

--- a/odoo/addons/test_uninstall/models.py
+++ b/odoo/addons/test_uninstall/models.py
@@ -15,17 +15,28 @@ class Test_UninstallModel(models.Model):
     ref = fields.Many2one('res.users', string='User')
     rel = fields.Many2many('res.users', string='Users')
 
-    _sql_constraints = [
-        ('name_uniq', 'unique (name)', 'Each name must be unique.'),
-    ]
+    _name_uniq = models.Constraint(
+        'unique (name)',
+        "Each name must be unique.",
+    )
 
 
 class ResUsers(models.Model):
     _inherit = ['res.users']
 
-    _sql_constraints = [
-        ('test_uninstall_res_user_unique_constraint', 'unique (password)', 'Test uninstall unique constraint'),
-        ('test_uninstall_res_user_check_constraint', 'check (true)', 'Test uninstall check constraint'),
-        ('test_uninstall_res_user_exclude_constraint', 'exclude (password with =)', 'Test uninstall exclude constraint'),
-        ('test_uninstall_res_user_exclude_constraint_looooooooooooong_name', 'exclude (password with =)', 'Test uninstall exclude constraint'),
-    ]
+    _test_uninstall_res_user_unique_constraint = models.Constraint(
+        'unique (password)',
+        "Test uninstall unique constraint",
+    )
+    _test_uninstall_res_user_check_constraint = models.Constraint(
+        'check (true)',
+        "Test uninstall check constraint",
+    )
+    _test_uninstall_res_user_exclude_constraint = models.Constraint(
+        'exclude (password with =)',
+        "Test uninstall exclude constraint",
+    )
+    _test_uninstall_res_user_exclude_constraint_looooooooooooong_name = models.Constraint(
+        'exclude (password with =)',
+        "Test uninstall exclude constraint",
+    )

--- a/odoo/models/__init__.py
+++ b/odoo/models/__init__.py
@@ -2,7 +2,7 @@
 # Exports features of the ORM to developers.
 # This is a `__init__.py` file to avoid merge conflicts on `odoo/models.py`.
 
-# TODO we should only expose *Model objects here, maybe check_comp*
+# TODO we should only expose *Model objects, TableObjects, maybe check_comp*
 
 from odoo.orm.models import (
     LOG_ACCESS_COLUMNS,
@@ -21,6 +21,7 @@ from odoo.orm.models import (
     parse_read_group_spec,
     to_record_ids,
 )
+from odoo.orm.table_objects import Constraint
 from odoo.orm.utils import (
     READ_GROUP_TIME_GRANULARITY,
     check_method_name,

--- a/odoo/models/__init__.py
+++ b/odoo/models/__init__.py
@@ -21,7 +21,7 @@ from odoo.orm.models import (
     parse_read_group_spec,
     to_record_ids,
 )
-from odoo.orm.table_objects import Constraint
+from odoo.orm.table_objects import Constraint, Index, UniqueIndex
 from odoo.orm.utils import (
     READ_GROUP_TIME_GRANULARITY,
     check_method_name,

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -69,7 +69,6 @@ from .fields_misc import Id
 from .fields_temporal import Datetime
 from .fields_textual import Char
 
-from .table_objects import Constraint
 from .identifiers import NewId
 from .utils import OriginIds, expand_ids, check_pg_name, check_object_name, check_property_field_value_name, origin_ids, READ_GROUP_ALL_TIME_GRANULARITY, READ_GROUP_TIME_GRANULARITY, READ_GROUP_NUMBER_GRANULARITY
 from odoo.osv import expression
@@ -225,12 +224,6 @@ class MetaModel(api.Meta):
 
             if not attrs.get('_name'):
                 attrs['_name'] = class_name_to_model_name(name)
-
-        # copy _sql_constraints into _table_object_definitions
-        for cons in attrs.get('_sql_constraints', ()):
-            cons_name, definition, cons_message = cons
-            constraint = Constraint(definition, cons_message)
-            attrs['_' + cons_name] = constraint
 
         return super().__new__(meta, name, bases, attrs)
 
@@ -525,7 +518,6 @@ class BaseModel(metaclass=MetaModel):
     """
     _table = None                   #: SQL table name used by model if :attr:`_auto`
     _table_query = None             #: SQL expression of the table's content (optional)
-    _sql_constraints: list[tuple[str, str, str]] = ()   #: SQL constraints [(name, sql_def, message)]
     _table_objects: dict[str, TableObject] = frozendict()  #: SQL/Table objects
 
     _rec_name = None                #: field to use for labeling records, default: ``name``
@@ -636,9 +628,12 @@ class BaseModel(metaclass=MetaModel):
         the Python sense) from all classes that define the model, and possibly
         other registry classes.
         """
-        if getattr(cls, '_constraints', None):
+        if hasattr(cls, '_constraints'):
             _logger.warning("Model attribute '_constraints' is no longer supported, "
                             "please use @api.constrains on methods instead.")
+        if hasattr(cls, '_sql_constraints'):
+            _logger.warning("Model attribute '_sql_constraints' is no longer supported, "
+                            "please define model.Constraint on the model.")
 
         # all models except 'base' implicitly inherit from 'base'
         name = cls._name

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -37,13 +37,12 @@ import uuid
 import warnings
 from collections import defaultdict, deque
 from collections.abc import MutableMapping, Callable
-from contextlib import closing
 from inspect import getmembers
 from operator import attrgetter, itemgetter
 
 import babel
 import babel.dates
-import psycopg2
+import psycopg2.errors
 import psycopg2.extensions
 from psycopg2.extras import Json
 
@@ -70,6 +69,7 @@ from .fields_misc import Id
 from .fields_temporal import Datetime
 from .fields_textual import Char
 
+from .table_objects import Constraint
 from .identifiers import NewId
 from .utils import OriginIds, expand_ids, check_pg_name, check_object_name, check_property_field_value_name, origin_ids, READ_GROUP_ALL_TIME_GRANULARITY, READ_GROUP_TIME_GRANULARITY, READ_GROUP_NUMBER_GRANULARITY
 from odoo.osv import expression
@@ -77,6 +77,7 @@ from odoo.osv import expression
 import typing
 if typing.TYPE_CHECKING:
     from collections.abc import Reversible
+    from .table_objects import TableObject
     from .environments import Environment
     from .registry import Registry
     from .types import Self, ValuesType, IdType
@@ -205,6 +206,8 @@ class MetaModel(api.Meta):
         attrs.setdefault('__slots__', ())
         # this collects the fields defined on the class (via Field.__set_name__())
         attrs.setdefault('_field_definitions', [])
+        # this collects the table object definitions on the class (via TableObject.__set_name__())
+        attrs.setdefault('_table_object_definitions', [])
 
         if attrs.get('_register', True):
             # determine '_module'
@@ -222,6 +225,12 @@ class MetaModel(api.Meta):
 
             if not attrs.get('_name'):
                 attrs['_name'] = class_name_to_model_name(name)
+
+        # copy _sql_constraints into _table_object_definitions
+        for cons in attrs.get('_sql_constraints', ()):
+            cons_name, definition, cons_message = cons
+            constraint = Constraint(definition, cons_message)
+            attrs['_' + cons_name] = constraint
 
         return super().__new__(meta, name, bases, attrs)
 
@@ -516,7 +525,8 @@ class BaseModel(metaclass=MetaModel):
     """
     _table = None                   #: SQL table name used by model if :attr:`_auto`
     _table_query = None             #: SQL expression of the table's content (optional)
-    _sql_constraints: list[tuple[str, str, str]] = []   #: SQL constraints [(name, sql_def, message)]
+    _sql_constraints: list[tuple[str, str, str]] = ()   #: SQL constraints [(name, sql_def, message)]
+    _table_objects: dict[str, TableObject] = frozendict()  #: SQL/Table objects
 
     _rec_name = None                #: field to use for labeling records, default: ``name``
     _rec_names_search: list[str] | None = None    #: fields to consider in ``name_search``
@@ -630,10 +640,6 @@ class BaseModel(metaclass=MetaModel):
             _logger.warning("Model attribute '_constraints' is no longer supported, "
                             "please use @api.constrains on methods instead.")
 
-        # Keep links to non-inherited constraints in cls; this is useful for
-        # instance when exporting translations
-        cls._local_sql_constraints = cls.__dict__.get('_sql_constraints', [])
-
         # all models except 'base' implicitly inherit from 'base'
         name = cls._name
         parents = list(cls._inherit)
@@ -656,6 +662,7 @@ class BaseModel(metaclass=MetaModel):
                 '_inherit_children': OrderedSet(),      # names of children models
                 '_inherits_children': set(),            # names of children models
                 '_fields': {},                          # populated in _setup_base()
+                '_table_objects': frozendict(),         # populated in _setup_base()
             })
             check_parent = cls._build_model_check_parent
 
@@ -726,7 +733,6 @@ class BaseModel(metaclass=MetaModel):
         cls._log_access = cls._auto
         inherits = {}
         depends = {}
-        cls._sql_constraints = {}
 
         for base in reversed(cls.__base_classes):
             if is_definition_class(base):
@@ -741,11 +747,6 @@ class BaseModel(metaclass=MetaModel):
 
             for mname, fnames in base._depends.items():
                 depends.setdefault(mname, []).extend(fnames)
-
-            for cons in base._sql_constraints:
-                cls._sql_constraints[cons[0]] = cons
-
-        cls._sql_constraints = list(cls._sql_constraints.values())
 
         # avoid assigning an empty dict to save memory
         if inherits:
@@ -764,10 +765,6 @@ class BaseModel(metaclass=MetaModel):
 
     @classmethod
     def _init_constraints_onchanges(cls):
-        # store list of sql constraint qualified names
-        for (key, _, _) in cls._sql_constraints:
-            cls.pool._sql_constraints.add(cls._table + '_' + key)
-
         # reset properties memoized on cls
         cls._constraint_methods = BaseModel._constraint_methods
         cls._ondelete_methods = BaseModel._ondelete_methods
@@ -1253,7 +1250,12 @@ class BaseModel(metaclass=MetaModel):
                     messages.append(dict(info, type='warning', message=str(e)))
                 except psycopg2.Error as e:
                     info = rec_data['info']
-                    messages.append(dict(info, type='error', **PGERROR_TO_OE[e.pgcode](self, fg, info, e)))
+                    pg_error_info = {'message': self._sql_error_to_message(e)}
+                    if e.diag.table_name == self._table:
+                        e_fields = get_columns_from_sql_diagnostics(self.env.cr, e.diag, check_registry=True)
+                        if len(e_fields) == 1:
+                            pg_error_info['field'] = e_fields[0]
+                    messages.append(dict(info, type='error', **pg_error_info))
                     # Failed to write, log to messages, rollback savepoint (to
                     # avoid broken transaction) and keep going
                     errors += 1
@@ -3348,37 +3350,83 @@ class BaseModel(metaclass=MetaModel):
             _logger.error('parent_path field on model %r should be indexed! Add index=True to the field definition.', self._name)
 
     def _add_sql_constraints(self):
-        """ Modify this model's database table constraints so they match the one
-        in _sql_constraints.
-
+        """ Modify this model's database table objects so they match the one
+        in _table_objects.
         """
-        cr = self._cr
-        foreign_key_re = re.compile(r'\s*foreign\s+key\b.*', re.I)
+        for obj in self._table_objects.values():
+            obj.apply_to_database(self)
 
-        for (key, definition, _message) in self._sql_constraints:
-            conname = '%s_%s' % (self._table, key)
-            if len(conname) > 63:
-                hashed_conname = sql.make_identifier(conname)
-                current_definition = sql.constraint_definition(cr, self._table, hashed_conname)
-                if not current_definition:
-                    _logger.info("Constraint name %r has more than 63 characters, internal PG identifier is %r", conname, hashed_conname)
-                conname = hashed_conname
-            else:
-                current_definition = sql.constraint_definition(cr, self._table, conname)
-            if current_definition == definition:
-                continue
+    @api.model
+    def _sql_error_to_message(self, exc: psycopg2.Error) -> str:
+        """ Convert a database exception to a user error message depending on the model.
 
-            if current_definition:
-                # constraint exists but its definition may have changed
-                sql.drop_constraint(cr, self._table, conname)
+        Note that the cursor on self has to be in a valid state.
+        """
+        if (constraint_name := exc.diag.constraint_name) and (cons := self._table_objects.get(constraint_name)):
+            cons_rec = self.env['ir.model.constraint'].search_fetch([
+                ('name', '=', constraint_name),
+                ('model.model', '=', self._name),
+            ], ['message'], limit=1)
+            if message := cons_rec.message:
+                return message
+            # get the message from the object
+            if message := cons.get_error_message(self, exc.diag):
+                return message
+        return self._sql_error_to_message_generic(exc)
 
-            if not definition:
-                # virtual constraint (e.g. implemented by a custom index)
-                self.pool.post_init(sql.check_index_exist, cr, conname)
-            elif foreign_key_re.match(definition):
-                self.pool.post_init(sql.add_constraint, cr, self._table, conname, definition)
-            else:
-                self.pool.post_constraint(sql.add_constraint, cr, self._table, conname, definition)
+    @api.model
+    def _sql_error_to_message_generic(self, exc: psycopg2.Error) -> str:
+        """ Convert a database exception to a generic user error message. """
+        diag = exc.diag
+        unknown = self.env._('Unknown')
+        model_string = self.env['ir.model']._get(self._name).name or self._description
+        info = {
+            'model_display': f"'{model_string}' ({self._name})",
+            'table_name': diag.table_name,
+            'constraint_name': diag.constraint_name,
+        }
+        if self._table == diag.table_name:
+            columns = get_columns_from_sql_diagnostics(self.env.cr, diag, check_registry=True)
+        else:
+            columns = get_columns_from_sql_diagnostics(self.env.cr, diag)
+            info['model_display'] = unknown
+        if not columns:
+            info['field_display'] = unknown
+        elif len(columns) == 1 and (field := self._fields.get(columns[0])):
+            field_string = field._description_string(self.env)
+            info['field_display'] = f"'{field_string}' ({field.name})"
+        else:
+            info['field_display'] = f"'{format_list(self.env, columns)}'"
+
+        if isinstance(exc, psycopg2.errors.NotNullViolation):
+            return self.env._(
+                "Missing required value for the field %(field_display)s.\n"
+                "Model: %(model_display)s\n"
+                "- create/update: a mandatory field is not set\n"
+                "- delete: another model requires the record being deleted, you can archive it instead\n",
+                **info,
+            )
+
+        if isinstance(exc, psycopg2.errors.ForeignKeyViolation):
+            if len(columns) != 1:
+                info['field_display'] = info['constraint_name']
+            return self.env._(
+                "Another model requires the record being deleted, if possible, archive it instead.\n\n"
+                "Model: %(model_display)s\n"
+                "Foreign key: %(field_display)s\n",
+                **info,
+            )
+
+        if isinstance(exc, psycopg2.errors.UniqueViolation) and columns:
+            column_names = [self._fields[f].string if f in self._fields else f for f in columns]
+            info['field_display'] = f"'{', '.join(columns)}' ({format_list(self.env, column_names)})"
+            info['detail'] = diag.message_detail  # contains conflicting key and value
+            return self.env._("The value for %(field_display)s already exists.\n\nDetail: %(detail)s\n", **info)
+
+        # No good message can be created for psycopg2.errors.CheckViolation
+
+        # fallback
+        return tools.exception_to_unicode(exc)
 
     #
     # Update objects that use this one to update their _inherits fields
@@ -3539,6 +3587,15 @@ class BaseModel(metaclass=MetaModel):
             cls._active_name = 'active'
         elif 'x_active' in cls._fields:
             cls._active_name = 'x_active'
+
+        # 7. determine table objects
+        assert not cls._table_object_definitions, "cls is a registry model"
+        cls._table_objects = frozendict({
+            cons.full_name(self): cons
+            for klass in reversed(cls._model_classes)
+            if isinstance(klass, MetaModel)
+            for cons in klass._table_object_definitions
+        })
 
     @api.model
     def _setup_fields(self):
@@ -7367,80 +7424,25 @@ def itemgetter_tuple(items):
     return operator.itemgetter(*items)
 
 
-def convert_pgerror_not_null(model, fields, info, e):
-    env = model.env
-    if e.diag.table_name != model._table:
-        return {'message': env._("Missing required value for the field '%(name)s' on a linked model [%(linked_model)s]", name=e.diag.column_name, linked_model=e.diag.table_name)}
-
-    field_name = e.diag.column_name
-    field = fields[field_name]
-    message = env._("Missing required value for the field '%(name)s' (%(technical_name)s)", name=field['string'], technical_name=field_name)
-    return {
-        'message': message,
-        'field': field_name,
-    }
-
-
-def convert_pgerror_unique(model, fields, info, e):
-    # new cursor since we're probably in an error handler in a blown
-    # transaction which may not have been rollbacked/cleaned yet
-    with closing(model.env.registry.cursor()) as cr_tmp:
-        cr_tmp.execute(SQL("""
-            SELECT
-                conname AS "constraint name",
-                t.relname AS "table name",
-                ARRAY(
-                    SELECT attname FROM pg_attribute
-                    WHERE attrelid = conrelid
-                      AND attnum = ANY(conkey)
-                ) as "columns"
-            FROM pg_constraint
-            JOIN pg_class t ON t.oid = conrelid
-            WHERE conname = %s
-        """, e.diag.constraint_name))
-        constraint, table, ufields = cr_tmp.fetchone() or (None, None, None)
-    # if the unique constraint is on an expression or on an other table
-    if not ufields or model._table != table:
-        return {'message': tools.exception_to_unicode(e)}
-
-    # TODO: add stuff from e.diag.message_hint? provides details about the constraint & duplication values but may be localized...
-    if len(ufields) == 1:
-        field_name = ufields[0]
-        field = fields[field_name]
-        message = model.env._(
-            "The value for the field '%(field)s' already exists (this is probably '%(other_field)s' in the current model).",
-            field=field_name,
-            other_field=field['string'],
-        )
-        return {
-            'message': message,
-            'field': field_name,
-        }
-    field_strings = [fields[fname]['string'] for fname in ufields]
-    message = model.env._(
-        "The values for the fields '%(fields)s' already exist (they are probably '%(other_fields)s' in the current model).",
-        fields=format_list(model.env, ufields),
-        other_fields=format_list(model.env, field_strings),
-    )
-    return {
-        'message': message,
-        # no field, unclear which one we should pick and they could be in any order
-    }
-
-
-def convert_pgerror_constraint(model, fields, info, e):
-    sql_constraints = dict([(('%s_%s') % (e.diag.table_name, x[0]), x) for x in model._sql_constraints])
-    if e.diag.constraint_name in sql_constraints.keys():
-        return {'message': "'%s'" % sql_constraints[e.diag.constraint_name][2]}
-    return {'message': tools.exception_to_unicode(e)}
-
-
-PGERROR_TO_OE = defaultdict(
-    # shape of mapped converters
-    lambda: (lambda model, fvg, info, pgerror: {'message': tools.exception_to_unicode(pgerror)}),
-    {
-        '23502': convert_pgerror_not_null,
-        '23505': convert_pgerror_unique,
-        '23514': convert_pgerror_constraint,
-    },
-)
+def get_columns_from_sql_diagnostics(cr, diagnostics, *, check_registry=False) -> list[str]:
+    """Given the diagnostics of an error, return the affected column names by the constraint.
+    Return an empty list if we cannot determine the columns.
+    """
+    if column := diagnostics.column_name:
+        return [column]
+    if not check_registry:
+        return []
+    cr.execute(SQL("""
+        SELECT
+            ARRAY(
+                SELECT attname FROM pg_attribute
+                WHERE attrelid = conrelid
+                AND attnum = ANY(conkey)
+            ) as "columns"
+        FROM pg_constraint
+        JOIN pg_class t ON t.oid = conrelid
+        WHERE conname = %s
+            AND t.relname = %s
+    """, diagnostics.constraint_name, diagnostics.table_name))
+    [columns] = cr.fetchone() or ([])
+    return columns

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -4,7 +4,7 @@
 """
     Object Relational Mapping module:
      * Hierarchical structure
-     * Constraints consistency and validation
+     * Constraints consistency and validation, indexes
      * Object metadata depends on its status
      * Optimised processing by complex query (multiple actions at once)
      * Default field values

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -156,7 +156,6 @@ class Registry(Mapping):
 
     def init(self, db_name: str):
         self.models: dict[str, type[BaseModel]] = {}    # model name/model instance mapping
-        self._sql_constraints = set()
         self._init = True
         self._database_translated_fields = ()  # names of translated fields in database
         if config['test_enable'] or config['test_file']:

--- a/odoo/orm/table_objects.py
+++ b/odoo/orm/table_objects.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import re
+import typing
+
+from odoo.tools import sql
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import psycopg2.extensions
+
+    from .environments import Environment
+    from .models import BaseModel
+
+    ConstraintMessageType = (
+        str
+        | Callable[[Environment, psycopg2.extensions.Diagnostics | None], str]
+    )
+
+
+class TableObject:
+    """ Declares a SQL object related to the model.
+
+    The identifier of the SQL object will be "{model._table}_{name}".
+    """
+    name: str
+    message: ConstraintMessageType = ''
+    _module: str = ''
+
+    def __init__(self):
+        """Abstract SQL object"""
+        # to avoid confusion: name is unique inside the model, full_name is in the database
+        self.name = ''
+
+    def __set_name__(self, owner, name):
+        # database objects should be private member fo the class:
+        # first of all, you should not need to access them from any model
+        # and this avoid having them in the middle of the fields when listing members
+        assert name.startswith('_'), "Names of SQL objects in a model must start with '_'"
+        self.name = name[1:]
+        if getattr(owner, 'pool', None) is None:  # models.is_definition_class(owner)
+            # only for fields on definition classes, not registry classes
+            self._module = owner._module
+            owner._table_object_definitions.append(self)
+
+    @property
+    def definition(self) -> str:
+        raise NotImplementedError
+
+    def full_name(self, model: BaseModel) -> str:
+        assert self.name, f"The table object is not named ({self.definition})"
+        name = f"{model._table}_{self.name}"
+        return sql.make_identifier(name)
+
+    def get_error_message(self, model: BaseModel, diagnostics=None) -> str:
+        """Build an error message for the object/constraint.
+
+        :param model: Optional model on which the constraint is defined
+        :param diagnostics: Optional diagnostics from the raised exception
+        :return: Translated error for the user
+        """
+        message = self.message
+        if callable(message):
+            return message(model.env, diagnostics)
+        return message
+
+    def apply_to_database(self, model: BaseModel):
+        raise NotImplementedError
+
+    def __str__(self) -> str:
+        return f"({self.name!r}={self.definition!r}, {self.message!r})"
+
+
+class Constraint(TableObject):
+    """ SQL table constraint.
+
+    The definition of the constraint is used to `ADD CONSTRAINT` on the table.
+    """
+    _FOREIGN_KEY_RE = re.compile(r'\sforeign\s+key\b.*', re.IGNORECASE)
+
+    def __init__(
+        self,
+        definition: str,
+        message: ConstraintMessageType = '',
+    ) -> None:
+        """ SQL table containt.
+
+        The definition is the SQL that will be used to add the constraint.
+        If the constraint is violated, we will show the message to the user
+        or an empty string to get a default message.
+
+        Examples of constraint definitions:
+        - CHECK (x > 0)
+        - FOREIGN KEY (abc) REFERENCES some_table(id)
+        - UNIQUE (user_id)
+        """
+        super().__init__()
+        self._definition = definition
+        if message:
+            self.message = message
+        if self._FOREIGN_KEY_RE.match(definition):
+            self._type = 'FK'
+        elif not definition:
+            self._type = 'VIRTUAL'
+        else:
+            self._type = 'CONSTRAINT'
+
+    @property
+    def definition(self):
+        return self._definition
+
+    def apply_to_database(self, model: BaseModel):
+        cr = model.env.cr
+        conname = self.full_name(model)
+        definition = self.definition
+        current_definition = sql.constraint_definition(cr, model._table, conname)
+        if current_definition == definition:
+            return
+
+        if current_definition:
+            # constraint exists but its definition may have changed
+            sql.drop_constraint(cr, model._table, conname)
+
+        if self._type == 'VIRTUAL':
+            # virtual constraint (e.g. implemented by a custom index)
+            model.pool.post_init(sql.check_index_exist, cr, conname)
+        elif self._type == "FK":
+            model.pool.post_init(sql.add_constraint, cr, model._table, conname, definition)
+        else:
+            model.pool.post_constraint(sql.add_constraint, cr, model._table, conname, definition)

--- a/odoo/service/model.py
+++ b/odoo/service/model.py
@@ -13,8 +13,7 @@ from odoo.exceptions import UserError, ValidationError
 from odoo.http import request
 from odoo.models import check_method_name
 from odoo.modules.registry import Registry
-from odoo.tools import DotDict, lazy
-from odoo.tools.translate import translate_sql_constraint
+from odoo.tools import lazy
 
 from . import security
 
@@ -71,53 +70,6 @@ def execute(db, uid, obj, method, *args, **kw):
         return res
 
 
-def _as_validation_error(env, exc):
-    """ Return the IntegrityError encapsuled in a nice ValidationError """
-
-    unknown = env._('Unknown')
-    model = DotDict({'_name': 'unknown', '_description': unknown})
-    field = DotDict({'name': 'unknown', 'string': unknown})
-    for rclass in env.registry.values():
-        if exc.diag.table_name == rclass._table:
-            model = rclass
-            field = model._fields.get(exc.diag.column_name) or field
-            break
-
-    match exc:
-        case errors.NotNullViolation():
-            return ValidationError(env._(
-                "The operation cannot be completed:\n"
-                "- Create/update: a mandatory field is not set.\n"
-                "- Delete: another model requires the record being deleted."
-                " If possible, archive it instead.\n\n"
-                "Model: %(model_name)s (%(model_tech_name)s)\n"
-                "Field: %(field_name)s (%(field_tech_name)s)\n",
-                model_name=model._description,
-                model_tech_name=model._name,
-                field_name=field.string,
-                field_tech_name=field.name,
-            ))
-
-        case errors.ForeignKeyViolation():
-            return ValidationError(env._(
-                "The operation cannot be completed: another model requires "
-                "the record being deleted. If possible, archive it instead.\n\n"
-                "Model: %(model_name)s (%(model_tech_name)s)\n"
-                "Constraint: %(constraint)s\n",
-                model_name=model._description,
-                model_tech_name=model._name,
-                constraint=exc.diag.constraint_name,
-            ))
-
-    if exc.diag.constraint_name in env.registry._sql_constraints:
-        return ValidationError(env._(
-            "The operation cannot be completed: %s",
-            translate_sql_constraint(env.cr, exc.diag.constraint_name, env.context.get('lang', 'en_US'))
-        ))
-
-    return ValidationError(env._("The operation cannot be completed: %s", exc.args[0]))
-
-
 def retrying(func, env):
     """
     Call ``func`` until the function returns without serialisation
@@ -153,7 +105,13 @@ def retrying(func, env):
                         else:
                             raise RuntimeError(f"Cannot retry request on input file {filename!r} after serialization failure") from exc
                 if isinstance(exc, IntegrityError):
-                    raise _as_validation_error(env, exc) from exc
+                    model = env['base']
+                    for rclass in env.registry.values():
+                        if exc.diag.table_name == rclass._table:
+                            model = env[rclass._name]
+                            break
+                    message = env._("The operation cannot be completed: %s", model._sql_error_to_message(exc))
+                    raise ValidationError(message) from exc
                 if not isinstance(exc, PG_CONCURRENCY_EXCEPTIONS_TO_RETRY):
                     raise
                 if not tryleft:

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -435,13 +435,6 @@ html_translate.is_text = is_text
 
 xml_translate.term_adapter = xml_term_adapter
 
-def translate_sql_constraint(cr, key, lang):
-    cr.execute("""
-        SELECT COALESCE(c.message->>%s, c.message->>'en_US') as message
-        FROM ir_model_constraint c
-        WHERE name=%s and type='u'
-        """, (lang, key))
-    return cr.fetchone()[0]
 
 
 def get_translation(module: str, lang: str, source: str, args: tuple | dict) -> str:

--- a/odoo/upgrade_code/18.1-00-sql-constraint.py
+++ b/odoo/upgrade_code/18.1-00-sql-constraint.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import ast
+import json
+import logging
+import re
+import typing
+
+if typing.TYPE_CHECKING:
+    from odoo.cli.upgrade_code import FileManager
+
+
+def upgrade(file_manager: FileManager):
+    log = logging.getLogger(__name__)
+    sql_expression_re = re.compile(r"\b_sql_constraints\s*=\s*\[([^\]]+)]")
+    ind = ' ' * 4
+
+    def build_sql_object(match):
+        # get the tuple of expressions
+        try:
+            constraints = ast.literal_eval('[' + match.group(1) + ']')
+        except SyntaxError:
+            # skip if we cannot match
+            return match.group(0)
+        result = []
+        for name, definition, *messages in constraints:
+            message = messages[0] if messages else ''
+            constructor = 'Constraint'
+            if message:
+                # format on 2 lines
+                message_repr = json.dumps(message)  # so that the message is in double quotes
+                args = f"\n{ind * 2}{definition!r},\n{ind * 2}{message_repr},\n{ind}"
+            elif len(definition) > 60:
+                args = f"\n{ind * 2}{definition!r}"
+            else:
+                args = repr(definition)
+            result.append(f"_{name} = models.{constructor}({args})")
+        return f"\n{ind}".join(result)
+
+    for file in file_manager:
+        if file.path.suffix != '.py':
+            continue
+        content = file.content
+        content = sql_expression_re.sub(build_sql_object, content)
+        if sql_expression_re.search(content):
+            log.warning("Failed to replace in file %s", file.path)
+        file.content = content


### PR DESCRIPTION
Introducting models.TableConstraint and models.TableIndex that can be used inside `sql_constraints`...
Introducting models.Constraint, models.Index and UniqueIndex that can be used in models. We make the message extensible since you now have access to the diagnostics and can make it dynamic. The messages between the web interface and the imports are also aligned.

This way you can specify constraints and indexes easily:

    _some_check = models.Constraint("CHECK(a > 1)")
    _user_idx = models.Index("(active, user_id)")

The creation/synchronization of index differences is now handled by the ORM just as the constraints were.

odoo/enterprise#68589
odoo/documentation#11071
task-3390431

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
