### PR TITLE
[FIX] stock_landed_costs: Fix creating landed cost from invoice without date

### DIFF
--- a/addons/stock_landed_costs/models/account_move.py
+++ b/addons/stock_landed_costs/models/account_move.py
@@ -31,7 +31,7 @@ class AccountMove(models.Model):
                 'product_id': l.product_id.id,
                 'name': l.product_id.name,
                 'account_id': l.product_id.product_tmpl_id.get_product_accounts()['stock_input'].id,
-                'price_unit': l.currency_id._convert(l.price_subtotal, l.company_currency_id, l.company_id, self.invoice_date),
+                'price_unit': l.currency_id._convert(l.price_subtotal, l.company_currency_id, l.company_id, self.invoice_date or fields.Date.context_today(l)),
                 'split_method': l.product_id.split_method_landed_cost or 'equal',
             }) for l in landed_costs_lines],
         })


### PR DESCRIPTION
This Fix addresses an issue where a traceback error occurs if the invoice date is not set when creating a landed cost.

To reproduce the issue:
1. Create a service product and set it as a landed cost product.
2. Create and validate a customer invoice for this product.
3. Reset the invoice to draft status.
4. Clear the date on the invoice.
5. Click on the "Create Landed Cost" button.

Error: A traceback occurs due to a failed assertion statement: "convert amount from unknown date".

This fix ensures that the date is always populated when creating a new landed cost record. If the invoice date is not set, the current date will be used.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
