### PR TITLE
[FIX] point_of_sale: NaN appeard untaxted amount in receipt

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -30,7 +30,7 @@
                     <span>
                         <span t-esc="tax.name"/>
                         on
-                        <span t-esc="props.formatCurrency(tax.base)"/>
+                        <span t-esc="props.formatCurrency(tax.base_amount)"/>
                     </span>
                     <span t-esc="props.formatCurrency(tax.amount)" class="ms-auto"/>
                 </div>


### PR DESCRIPTION
Steps:
===
Install a point_of_sale module.
Open POS & Add some taxable products in the cart.
Complete payment and see the receipt.

Issue:
===
NaN appears instead of amount.

Cause:
===
Instead of fetching base_amount, it's fetching base.

FIX:
===
Fetch correct base_amount.

task-4086039
