### PR TITLE
[FIX] point_of_sale,*: priority product loading

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -8,7 +8,6 @@ import secrets
 
 from odoo import api, fields, models, _, Command
 from odoo.http import request
-from odoo.osv.expression import OR, AND
 from odoo.exceptions import AccessError, ValidationError, UserError
 from odoo.tools import convert, SQL
 
@@ -691,8 +690,6 @@ class PosConfig(models.Model):
         ]
         if self.limit_categories and self.iface_available_categ_ids:
             domain.append(('pos_categ_ids', 'in', self._get_available_categories().ids))
-        if self.iface_tipproduct:
-            domain = OR([domain, [('id', '=', self.tip_product_id.id)]])
         return domain
 
     def _link_same_non_cash_payment_methods(self, source_config):
@@ -756,6 +753,7 @@ class PosConfig(models.Model):
             self.get_limited_product_count(),
         )
         product_ids = [r[0] for r in self.env.execute_query(sql)]
+        product_ids.extend(self._get_special_products().ids)
         products = self.env['product.product'].browse(product_ids)
         product_combo = products.filtered(lambda p: p['type'] == 'combo')
         product_in_combo = product_combo.combo_ids.combo_item_ids.product_id

--- a/addons/pos_discount/models/pos_config.py
+++ b/addons/pos_discount/models/pos_config.py
@@ -3,7 +3,6 @@
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
-from odoo.osv.expression import OR
 
 
 class PosConfig(models.Model):
@@ -37,7 +36,3 @@ class PosConfig(models.Model):
         res = super()._get_special_products()
         default_discount_product = self.env.ref('pos_discount.product_product_consumable', raise_if_not_found=False) or self.env['product.product']
         return res | self.env['pos.config'].search([]).mapped('discount_product_id') | default_discount_product
-
-    def _get_available_product_domain(self):
-        domain = super()._get_available_product_domain()
-        return OR([domain, [('id', '=', self.discount_product_id.id)]])

--- a/addons/pos_sale/models/pos_config.py
+++ b/addons/pos_sale/models/pos_config.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models, api
-from odoo.osv.expression import OR
 
 
 class PosConfig(models.Model):
@@ -18,10 +17,6 @@ class PosConfig(models.Model):
     def _get_special_products(self):
         res = super()._get_special_products()
         return res | self.env['pos.config'].search([]).mapped('down_payment_product_id')
-
-    def _get_available_product_domain(self):
-        domain = super()._get_available_product_domain()
-        return OR([domain, [('id', '=', self.down_payment_product_id.id)]])
 
     @api.model
     def _ensure_downpayment_product(self):


### PR DESCRIPTION
*: pos_discount, pos_sale

Steps to reproduce :
---------------------------
- Install point_of_sale
- Enable some special functionalities (ex. tip, discount etc)
- Open session with lots of products. (More than loading limit 20,000)

Issue :
--------
Sometimes the special products required to smoothly run all functionalities
enabled are not loaded.

Cause :
-----------
We have set a limit of 20,000 and if the special product is not in those
products it won't be loaded.

Fix :
-----
Now we ensured that all special products must be loaded without the
interference of the products  loading limit and no need to apply domain on
those 20,000 products so removed _get_available_product_domain() function.

Related PR: https://github.com/odoo/enterprise/pull/69347
task: 4072726