### PR TITLE
[FIX] l10n_in_pos: hsn doesn't displayed on reciept

### DIFF
--- a/addons/l10n_in_pos/static/src/overrides/models/order.js
+++ b/addons/l10n_in_pos/static/src/overrides/models/order.js
@@ -39,6 +39,7 @@ patch(Order.prototype, {
                 l10n_in_hsn_code: hsnCode,
                 price_unit: line.get_unit_price(),
                 quantity: line.get_quantity(),
+                discount: line.get_discount(),
                 uom: null,
                 taxes_data: this.pos.mapTaxValues(taxes),
             });


### PR DESCRIPTION
Steps to reproduce :
--------------------------
- Install pos and  l10n_in
- Go to products
- Create a product with HSN code and set tax
- Open a session
- Add that product to cart
- Order and pay the bill

Issue :
-------
Opened reciept doesn't contain tax information on the HSN summary section

Cause :
---------
Trying to fetch data which wasn't sent from arguments causing the related computations NaN and 0.

Fix :
-----
Passed the argument correctly.

task: 4095698