### PR TITLE
[IMP] pos_sale: ui state button content alignment

### DIFF
--- a/addons/pos_sale/views/pos_order_views.xml
+++ b/addons/pos_sale/views/pos_order_views.xml
@@ -13,8 +13,8 @@
                         icon="fa-shopping-basket"
                         invisible="sale_order_count == 0" groups="sales_team.group_sale_salesman">
                         <div class="o_field_widget o_stat_info">
-                            <span class="o_stat_value">
-                                <field name="sale_order_count" widget="statinfo" nolabel="1" class="mr4" /> Transfered<br/>
+                            <span class="o_stat_value d-flex">
+                                <field name="sale_order_count" widget="statinfo" nolabel="1" class="mr4" /> Transferred<br/>
                                 from Sale
                             </span>
                         </div>

--- a/addons/pos_sale/views/sale_order_views.xml
+++ b/addons/pos_sale/views/sale_order_views.xml
@@ -13,8 +13,8 @@
                         icon="fa-shopping-basket"
                         invisible="pos_order_count == 0" groups="point_of_sale.group_pos_user">
                         <div class="o_field_widget o_stat_info">
-                            <span class="o_stat_value">
-                                <field name="pos_order_count" widget="statinfo" nolabel="1" class="mr4" /> Transfered<br/>
+                            <span class="o_stat_value d-flex">
+                                <field name="pos_order_count" widget="statinfo" nolabel="1" class="mr4" /> Transferred<br/>
                                 to POS
                             </span>
                         </div>


### PR DESCRIPTION
Before this commit:
===================
The content was overloading in the smart button "Transferred from sale". Icon and text were not aligned

![image](https://github.com/user-attachments/assets/a1da5cec-7330-44d0-8a0a-322dcee0e9ff)


After this commit:
====================
Content is now aligned with the smart button. The icon and text are aligned now."Transfered" is changed to "Transferred"

![image](https://github.com/user-attachments/assets/5a0f42b0-afc4-44b5-a7af-dd96c1a93f3c)




task - 4080915
