### PR TITLE
[FIX] mail: access right issues on read-only documents

### DIFF
--- a/addons/mail/static/src/chatter/web/chatter.xml
+++ b/addons/mail/static/src/chatter/web/chatter.xml
@@ -10,18 +10,18 @@
                     'btn-secondary': state.composerType === 'note',
                     'active': state.composerType === 'message',
                     'my-2': !props.compactHeight
-                }" t-att-disabled="!state.thread.hasWriteAccess and !(state.thread.hasReadAccess and state.thread.canPostOnReadonly) and props.threadId" data-hotkey="m" t-on-click="() => this.toggleComposer('message')">
+                }" t-att-disabled="isReadonly" data-hotkey="m" t-on-click="() => this.toggleComposer('message')">
                     Send message
                 </button>
                 <button class="o-mail-Chatter-logNote btn text-nowrap me-1" t-att-class="{
                     'btn-primary active': state.composerType === 'note',
                     'btn-secondary': state.composerType !== 'note',
                     'my-2': !props.compactHeight
-                }" data-hotkey="shift+m" t-on-click="() => this.toggleComposer('note')">
+                }" t-att-disabled="isReadonly" data-hotkey="shift+m" t-on-click="() => this.toggleComposer('note')">
                     Log note
                 </button>
                 <div class="flex-grow-1 d-flex">
-                    <button t-if="props.has_activities" class="o-mail-Chatter-activity btn btn-secondary text-nowrap" t-att-class="{ 'my-2': !props.compactHeight }" data-hotkey="shift+a" t-on-click="scheduleActivity">
+                    <button t-if="props.has_activities" class="o-mail-Chatter-activity btn btn-secondary text-nowrap" t-att-class="{ 'my-2': !props.compactHeight }" t-att-disabled="isReadonly" data-hotkey="shift+a" t-on-click="scheduleActivity">
                         <span>Activities</span>
                     </button>
                     <span class="o-mail-Chatter-topbarGrow flex-grow-1 pe-2"/>
@@ -31,7 +31,7 @@
                     <button t-if="props.hasAttachmentPreview and state.thread.attachmentsInWebClientView.length" class="btn btn-link text-action" t-on-click="popoutAttachment">
                         <i class="fa fa-window-restore" aria-hidden="Pop out Attachments" title="Pop out Attachments"/>
                     </button>
-                    <FileUploader t-if="attachments.length === 0" fileUploadClass="'o-mail-Chatter-fileUploader'" multiUpload="true" onUploaded.bind="onUploaded" onClick="(ev) => this.onClickAttachFile(ev)">
+                    <FileUploader t-if="attachments.length === 0 and state.thread.hasWriteAccess" fileUploadClass="'o-mail-Chatter-fileUploader'" multiUpload="true" onUploaded.bind="onUploaded" onClick="(ev) => this.onClickAttachFile(ev)">
                         <t t-set-slot="toggler">
                             <t t-call="mail.Chatter.attachFiles"/>
                         </t>
@@ -151,7 +151,7 @@
 </t>
 
 <t t-name="mail.Chatter.attachFiles">
-    <button class="o-mail-Chatter-attachFiles btn btn-link text-action px-1 d-flex align-items-center" aria-label="Attach files" t-att-class="{ 'my-2': !props.compactHeight }" t-on-click="onClickAddAttachments" t-att-disabled="state.isSearchOpen">
+    <button class="o-mail-Chatter-attachFiles btn btn-link text-action px-1 d-flex align-items-center" aria-label="Attach files" t-att-class="{ 'my-2': !props.compactHeight }" t-on-click="onClickAddAttachments" t-att-disabled="state.isSearchOpen or (!state.thread.hasWriteAccess and attachments.length === 0)">
         <i class="fa fa-paperclip fa-lg me-1"/>
         <sup t-if="attachments.length > 0" t-esc="attachments.length"/>
         <i t-if="!state.thread.areAttachmentsLoaded and state.thread.isLoadingAttachments and state.showAttachmentLoading" class="fa fa-circle-o-notch fa-spin" aria-label="Attachment counter loading..."/>

--- a/addons/mail/static/src/chatter/web_portal/chatter.js
+++ b/addons/mail/static/src/chatter/web_portal/chatter.js
@@ -64,6 +64,10 @@ export class Chatter extends Component {
         return [];
     }
 
+    get isReadonly() {
+        return this.state.thread?.isReadonly(false) && this.props.threadId;
+    }
+
     changeThread(threadModel, threadId) {
         this.state.thread = this.store.Thread.insert({ model: threadModel, id: threadId });
         if (threadId === false) {

--- a/addons/mail/static/src/chatter/web_portal/composer_patch.js
+++ b/addons/mail/static/src/chatter/web_portal/composer_patch.js
@@ -5,7 +5,9 @@ import { patch } from "@web/core/utils/patch";
 patch(Composer.prototype, {
     get placeholder() {
         if (this.thread && this.thread.model !== "discuss.channel" && !this.props.placeholder) {
-            if (this.props.type === "message") {
+            if (this.thread.isReadonly()) {
+                return _t("You don't have the rights to post on this Document...");
+            } else if (this.props.type === "message") {
                 return _t("Send a message to followers…");
             } else {
                 return _t("Log an internal note…");

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -49,6 +49,7 @@
                             t-model="props.composer.text"
                             t-att-placeholder="placeholder"
                             t-att-readOnly="!state.active"
+                            t-att-disabled="thread?.isReadonly()"
                         />
                         <!--
                              This is an invisible textarea used to compute the composer
@@ -63,6 +64,7 @@
                         />
                     </div>
                     <div class="o-mail-Composer-actions d-flex bg-view rounded"
+                        t-if="!thread?.isReadonly()"
                         t-att-class="{
                             'ms-1': compact and ui.isSmall,
                             'mx-1': compact and !ui.isSmall,

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -290,7 +290,11 @@ export class Message extends Component {
     }
 
     get canReplyTo() {
-        return this.props.messageToReplyTo && this.message.message_type !== "user_notification";
+        return (
+            this.props.messageToReplyTo &&
+            this.message.message_type !== "user_notification" &&
+            !this.message.thread?.isReadonly()
+        );
     }
 
     get canToggleStar() {

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -822,6 +822,32 @@ export async function mail_thread_data(request) {
     ).get_result();
 }
 
+registerRoute("/mail/thread/data/access_rights", mail_thread_data_access_rights);
+/** @type {RouteCallback} */
+export async function mail_thread_data_access_rights(request) {
+    const { thread_data } = await parseRequestParams(request);
+    const store = new mailDataHelpers.Store();
+    for (const model in thread_data) {
+        const ThreadModel = this.env[model];
+        for (const threadId of thread_data[model]) {
+            const thread = ThreadModel.browse(threadId);
+            if (!thread.length) {
+                continue;
+            }
+            store.add(
+                thread,
+                {
+                    hasWriteAccess: true, // mimic user with write access by default
+                    hasReadAccess: true,
+                    canPostOnReadonly: thread._mail_post_access === "read",
+                },
+                makeKwArgs({ as_thread: true })
+            );
+        }
+    }
+    return store.get_result();
+}
+
 registerRoute("/mail/thread/messages", mail_thread_messages);
 /** @type {RouteCallback} */
 async function mail_thread_messages(request) {


### PR DESCRIPTION
**Current behavior before PR:**

Access Right Error raises on a read-only document when a user tries to post a message, update followers in the followers menu or upload an attachment.

**Desired behavior after PR is merged:**

Disabled messaging buttons which would cause an Access Right Error for such cases.

Related Ent PR: https://github.com/odoo/enterprise/pull/68073

**Task**-[3062266](https://www.odoo.com/odoo/project.task/3062266)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
