### PR TITLE
[FIX] calendar: Fix error when duplicating multiple events

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -519,7 +519,7 @@ class Meeting(models.Model):
     def create(self, vals_list):
         # Prevent sending update notification when _inverse_dates is called
         self = self.with_context(is_calendar_event_new=True)
-        defaults = self.default_get(['activity_ids', 'res_model_id', 'res_id', 'user_id', 'res_model', 'partner_ids'])
+        defaults = self.env['calendar.event'].default_get(['activity_ids', 'res_model_id', 'res_id', 'user_id', 'res_model', 'partner_ids'])
 
         vals_list = [  # Else bug with quick_create when we are filter on an other user
             dict(vals, user_id=defaults.get('user_id', self.env.user.id)) if not 'user_id' in vals else vals


### PR DESCRIPTION
Versions:
-------------
 saas-17.2

Steps to Reproduce:
----------------------------
1. Go to the Calendar app.
2. Switch to list view.
3. Select multiple events.
4. Attempt to duplicate the selected events.

Issue:
--------
An error occurs when trying to duplicate multiple events.

Cause:
----------
After a recent update, the `copy` method now processes records in batches, calling the `create` method with multiple records at once. Previously, this was done one by one. This change causes issues because the `default_get` method, used during creation, now encounters multiple records in `self`, leading to a singleton error.

Solution:
------------
Instead of using `self.default_get()` with multiple records, we now use `self.env['calendar.event'].default_get()`. This ensures that the default values are set correctly without causing the singleton error.

Task-4098739
