### PR TITLE
[FIX] pos_loyalty: fix specific discount domain for loyalty program

### DIFF
--- a/addons/pos_loyalty/models/pos_session.py
+++ b/addons/pos_loyalty/models/pos_session.py
@@ -68,8 +68,7 @@ class PosSession(models.Model):
         if domain_str == "null":
             return domain_str
 
-        domain = ast.literal_eval(domain_str)
-
+        domain = json.loads(domain_str)
         for index, condition in enumerate(domain):
             if isinstance(condition, (list, tuple)) and len(condition) == 3:
                 field_name, operator, value = condition


### PR DESCRIPTION
Loyalty programs discount could be applied on specific products through a domain. When putting a domain with a True or False as a third operand (e.g. ('is_available_in_pos', '=', True)), the PoS was crashing at launch because the domain goes through a json.dumps that changes the Boolean to lower case and then through ast.literal_eval that doesn't accept lower case Boolean.

The change is to replace lower case Boolean to upper case Boolean in the domain before the ast.literal_eval.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
