### PR TITLE
[IMP] mass_mailing: remove checklist command

### DIFF
--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -118,6 +118,7 @@
         'web_editor.backend_assets_wysiwyg': [
             'mass_mailing/static/src/js/mass_mailing_wysiwyg.js',
             'mass_mailing/static/src/scss/mass_mailing.wysiwyg.scss',
+            'mass_mailing/static/src/js/Powerbox.js',
         ],
         'web.assets_backend': [
             'mass_mailing/static/src/scss/mailing_filter_widget.scss',

--- a/addons/mass_mailing/static/src/js/Powerbox.js
+++ b/addons/mass_mailing/static/src/js/Powerbox.js
@@ -1,0 +1,14 @@
+/** @odoo-module **/
+
+import { Powerbox } from "@web_editor/js/editor/odoo-editor/src/powerbox/Powerbox";
+import { patch } from "@web/core/utils/patch";
+
+patch(Powerbox.prototype, {
+    /**
+     * @override
+     */
+    setup() {
+        super.setup(...arguments);
+        this.commands = this.commands.filter(command => command.name !== 'Checklist');
+    }
+});

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/powerbox/Powerbox.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/powerbox/Powerbox.js
@@ -68,8 +68,11 @@ export class Powerbox {
                 [document, 'mousedown', this._boundClose],
             );
         }
-
+        this.setup();
     }
+
+    setup() {}
+
     destroy() {
         if (this.isOpen) {
             this.close();


### PR DESCRIPTION
This task removes the checklist command for mass_mailing since users cannot interact with checklists in emails. A patch is introduced to override and filter out the checklist command in the Powerbox.

Task-4089816