### PR TITLE
[FIX] hr_attendance: prevent errors when employees manually do their attendance

### DIFF
--- a/addons/hr_attendance/controllers/main.py
+++ b/addons/hr_attendance/controllers/main.py
@@ -36,7 +36,7 @@ class HrAttendance(http.Controller):
             response = {
                 **HrAttendance._get_user_attendance_data(employee),
                 'employee_name': employee.name,
-                'employee_avatar': image_data_uri(employee.image_256),
+                'employee_avatar': employee.image_256 and image_data_uri(employee.image_256),
                 'total_overtime': float_round(employee.total_overtime, precision_digits=2),
                 'kiosk_delay': employee.company_id.attendance_kiosk_delay * 1000,
                 'attendance': {'check_in': employee.last_attendance_id.check_in,


### PR DESCRIPTION
Currently, an error occurs when employees manually do their attendance, and an employee's avatar is not available.

Step to produce:

- Install the 'hr_attendance' module.
- Go to the Employees open any employee and remove an image from it.
- Go to Attendances / Kiosk Mode and click 'Identify Manually', Open the employee who does not have an image.

Stack Trace:

```
TypeError: 'bool' object is not subscriptable
  File "odoo/http.py", line 2373, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1903, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1966, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1933, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2177, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 223, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 754, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/hr_attendance/controllers/main.py", line 137, in employee_attendance_data
    return self._get_employee_info_response(employee)
  File "addons/hr_attendance/controllers/main.py", line 39, in _get_employee_info_response
    'employee_avatar': image_data_uri(employee.image_256),
  File "odoo/tools/image.py", line 540, in image_data_uri
    FILETYPE_BASE64_MAGICWORD.get(base64_source[:1], 'png'),
```

An error occurs when the system tries to retrieve a data URL from an employee image but it is not available resulting False (bool) value passing instead of binary.

link [1]:https://github.com/odoo/odoo/blob/0a69d91ff2ccb90fc5ca94013a4fc7371017c876/addons/hr_attendance/controllers/main.py#L39

To handle this issue, Add a condition that, Only converts data URI from an employee's image if it is available.

Sentry-5681797884

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
