### PR TITLE
[FIX] web_editor: text added back after validating a command

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -2231,7 +2231,7 @@ export class OdooEditor extends EventTarget {
             // Do not apply commands out of the editable area.
             return false;
         }
-        if (!sel.isCollapsed && BACKSPACE_FIRST_COMMANDS.includes(method)) {
+        if (!sel.isCollapsed && (BACKSPACE_FIRST_COMMANDS.includes(method) || this.powerbox.isOpen)) {
             let range = getDeepRange(this.editable, {sel, splitText: true, select: true, correctTripleClick: true});
             if (range &&
                 range.startContainer === range.endContainer &&

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/powerbox.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/powerbox.test.js
@@ -1,6 +1,6 @@
 import { setSelection } from '../../src/OdooEditor.js';
 import { Powerbox } from '../../src/powerbox/Powerbox.js';
-import { BasicEditor, _isMobile, insertText, testEditor, triggerEvent } from '../utils.js';
+import { BasicEditor, _isMobile, insertText, nextTick, testEditor, triggerEvent } from '../utils.js';
 
 const getCurrentCommandNames = powerbox => {
     return [...powerbox.el.querySelectorAll('.oe-powerbox-commandName')].map(c => c.innerText);
@@ -62,6 +62,22 @@ describe('Powerbox', () => {
                     await triggerEvent(editor.editable, 'keydown', { key: 'Enter' });
                 },
                 contentAfter: '<h1>ab[]</h1>',
+            });
+        });
+        it('should not reinsert the selected text after command validation', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>[]<br></p>',
+                stepFunction: async editor => {
+                    await insertText(editor, 'abc');
+                    const p = editor.editable.querySelector('p');
+                    setSelection(p.firstChild, 0, p.lastChild, 1);
+                    await nextTick();
+                    await insertText(editor, '/');
+                    window.chai.expect(editor.powerbox.isOpen).to.be.true;
+                    await insertText(editor, 'h1');
+                    await triggerEvent(editor.editable, "keydown", { key: "Enter" });
+                },
+                contentAfter: '<h1>[]<br></h1>',
             });
         });
         it('should close the powerbox if keyup event is called on other block', async () => {


### PR DESCRIPTION
**Steps to reproduce:**

- Go to the `Todo` app.
- Open a task.
- Write any text.
- Select the text.
- Type `/command`
- Hit Enter.

**Description of the issue/feature this PR addresses:**

The command is correctly added, but the issue is that the selected text is also re-added after the command is applied.

**Desired behavior after PR is merged:**

Selected text from before the `/command` will be removed and commands will still be executed. The process now involves clearing the content first and then launching the command.

task-3487792