### PR TITLE
[FIX] website_sale: avoid wrapping  product categories

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -806,9 +806,9 @@
                                     t-attf-style="background-image:url('data:image/png;base64,
                                         #{c.image_128}')"
                                     class="o_image_40_cover oe_img_bg o_bg_img_center
-                                        rounded-3 me-3"
+                                        flex-shrink-0 rounded-3 me-3"
                                     t-att-alt="c.name "/>
-                                <span t-field="c.name"/>
+                                <span class="text-nowrap" t-field="c.name"/>
                             </div>
                         </a>
                     </li>


### PR DESCRIPTION
Part of website_sale product / shop redesign (task-3986921).

Previously if the category name was too long the text was wrapping, increasing the height of the container and shrinking the image.

This commit applies a text-nowrap and a flex-shrink to avoid this behavior.

| Before | After |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/b424e6bb-17f6-427f-94a3-d4cca6b54bac) | ![image](https://github.com/user-attachments/assets/77cae26a-f25e-4e64-be33-5ef0b7bc4cf9) | 

task-3987172

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
