### PR TITLE
[FIX] core: repr() of OdooTestResult was not working

### DIFF
--- a/odoo/tests/result.py
+++ b/odoo/tests/result.py
@@ -169,8 +169,7 @@ class OdooTestResult(object):
         return length
 
     def __repr__(self):
-        return ("<%s.%s run=%i errors=%i failures=%i>" %
-                (self.__class__.__module__, self.__class__.__qualname__, self.testsRun, len(self.errors_count), len(self.failures_count)))
+        return f"<{self.__class__.__module__}.{self.__class__.__qualname__} run={self.testsRun} errors={self.errors_count} failures={self.failures_count}>"
 
     def __str__(self):
         return f'{self.failures_count} failed, {self.errors_count} error(s) of {self.testsRun} tests'


### PR DESCRIPTION
The counters are ints and `len` was called on them.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
