### PR TITLE
[FIX] web_editor: restore single quote escaping in _compute_image_src

### DIFF
--- a/addons/web_editor/models/ir_attachment.py
+++ b/addons/web_editor/models/ir_attachment.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from werkzeug.urls import url_quote
+from urllib.parse import quote
 
 from odoo import api, models, fields, tools
 
@@ -46,7 +46,7 @@ class IrAttachment(models.Model):
                     # Local URL
                     attachment.image_src = attachment.url
                 else:
-                    name = url_quote(attachment.name)
+                    name = quote(attachment.name)
                     attachment.image_src = '/web/image/%s-redirect/%s' % (attachment.id, name)
             else:
                 # Adding unique in URLs for cache-control
@@ -57,7 +57,7 @@ class IrAttachment(models.Model):
                     separator = '&' if '?' in attachment.url else '?'
                     attachment.image_src = '%s%sunique=%s' % (attachment.url, separator, unique)
                 else:
-                    name = url_quote(attachment.name)
+                    name = quote(attachment.name)
                     attachment.image_src = '/web/image/%s-%s/%s' % (attachment.id, unique, name)
 
     @api.depends('datas')


### PR DESCRIPTION
Since [1], Werkzeug 3.0.1 is used depending on the python version.
Unlike its previous versions, Werkzeug 3.0.1's `url_quote` does not
escape the single quote character to `%27` anymore.

This causes an issue for cover images that use the computed `image_src`
in a `background-image` CSS property using `url(...)` or `url('...')`.

This commit restores the former behavior of `_compute_image_src` to
avoid issues when its output is used in inadequately quoted CSS
properties.

Steps to reproduce:
- Use python_version >= '3.12' so that Werkzeug is 3.0.1.
- Create a new blog post.
- Set a cover image.
- Save.

=> Image is not displayed anymore because URL contains `'`.

[1]: https://github.com/odoo/odoo/commit/4a019ae9de64b260fe6b18d21f4624902b3bb880

task-4099056