### PR TITLE
[FIX] mrp: shop floor component manual consumption

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -221,7 +221,7 @@ class MrpWorkorder(models.Model):
         for workorder in self:
             if workorder.qty_producing != 0 and workorder.production_id.qty_producing != workorder.qty_producing:
                 workorder.production_id.qty_producing = workorder.qty_producing
-                workorder.production_id._set_qty_producing()
+                workorder.production_id._set_qty_producing(False)
 
     # Both `date_start` and `date_finished` are related fields on `leave_id`. Let's say
     # we slide a workorder on a gantt view, a single call to write is made with both


### PR DESCRIPTION
With this Commit :
----------------------------------------------------------
- In the previous implementation, components marked for manual consumption were automatically consumed, like auto-consumed components, when starting production on a manufacturing order (MO). This occurred due to missing logic and conditions in the code that failed to differentiate between manual and automatic component consumption, and it only affected the shop floor operations.

- This update corrects the components' consumption process and enhances production tracking's reliability, ensuring that manual components are managed according to their intended usage.

Task id: 4096514

Enterprise PR: odoo/enterprise#77831