### PR TITLE
[FIX] website_sale: hide unpublished products from portal

### DIFF
--- a/addons/website_sale/models/website_snippet_filter.py
+++ b/addons/website_sale/models/website_snippet_filter.py
@@ -71,7 +71,7 @@ class WebsiteSnippetFilter(models.Model):
         search_domain = context.get('search_domain')
         limit = context.get('limit')
         domain = expression.AND([
-            [('website_published', '=', True)] if self.env.user._is_public() else [],
+            [('website_published', '=', True)] if self.env.user._is_public() or self.env.user._is_portal() else [],
             website.website_domain(),
             [('company_id', 'in', [False, website.company_id.id])],
             search_domain or [],


### PR DESCRIPTION
Steps to reproduce:
- Create 2 products and publish 1
- Website > Edit > Add a "Products" block
- Configure it to filter for recently sold products

- Configuration > Payment Providers > Enable Demo
- Configuration > Shipping methods > New
- Set delivery product to your unpublished product
- Publish the shipping method

- From Shop buy your published product
- Cart > Checkout > Use your shipping method
- Validate then return to your products block

The delivery products appears in recently sold, even as a portal user despite never being published and not being directly available to buy.

Having unpublished products on the portal should not be possible when logged in as a portal user, much less a delivery product which is insubstantial to the user.

opw-4075261

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
