### PR TITLE
[FIX] discuss: prevent calls to start in public welcome page

### DIFF
--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -176,6 +176,7 @@ For more specific needs, you may also assign custom-defined actions
             'web/static/tests/legacy/utils.js',
             'mail/static/tests/tours/discuss_channel_public_tour.js',
             'mail/static/tests/tours/discuss_channel_as_guest_tour.js',
+            'mail/static/tests/tours/discuss_channel_call_public_tour.js',
             'mail/static/tests/tours/discuss_sidebar_in_public_page_tour.js',
         ],
         # Unit test files

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -381,7 +381,7 @@ export class Store extends BaseStore {
             partners_to: [this.self.id],
         });
         this.ChatWindow.get(thread)?.update({ autofocus: 0 });
-        this.env.services["discuss.rtc"].toggleCall(thread, { video: true });
+        this.env.services["discuss.rtc"].toggleCall(thread, { camera: true });
         this.openInviteThread = thread;
     }
 

--- a/addons/mail/static/src/discuss/core/public/boot.js
+++ b/addons/mail/static/src/discuss/core/public/boot.js
@@ -17,5 +17,10 @@ import { makeEnv, startServices } from "@web/env";
     await startServices(env);
     env.services["mail.store"].insert(odoo.discuss_data);
     odoo.isReady = true;
-    await mount(MainComponentsContainer, document.body, { env, getTemplate, dev: env.debug });
+    const root = await mount(MainComponentsContainer, document.body, {
+        env,
+        getTemplate,
+        dev: env.debug,
+    });
+    odoo.__WOWL_DEBUG__ = { root };
 })();

--- a/addons/mail/static/src/discuss/core/public/discuss_client_action_patch.js
+++ b/addons/mail/static/src/discuss/core/public/discuss_client_action_patch.js
@@ -35,4 +35,7 @@ patch(DiscussClientAction.prototype, {
         this.publicState.welcome ||=
             this.store.discuss.thread?.defaultDisplayMode === "video_full_screen";
     },
+    closeWelcomePage() {
+        this.publicState.welcome = false;
+    },
 });

--- a/addons/mail/static/src/discuss/core/public/discuss_client_action_patch.xml
+++ b/addons/mail/static/src/discuss/core/public/discuss_client_action_patch.xml
@@ -6,7 +6,7 @@
             <attribute name="t-if">!publicState.welcome and store.discuss.hasRestoredThread </attribute>
         </xpath>
         <xpath expr="//Discuss" position="after">
-            <WelcomePage t-if="publicState.welcome" proceed="() => publicState.welcome = false"/>
+            <WelcomePage t-if="publicState.welcome" proceed.bind="closeWelcomePage"/>
         </xpath>
     </t>
 </templates>

--- a/addons/mail/static/tests/tours/discuss_channel_call_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_call_public_tour.js
@@ -1,0 +1,32 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("discuss_channel_call_public_tour.js", {
+    test: true,
+    steps: () => [
+        {
+            content: "The call does not start on the welcome page",
+            trigger: ".o-mail-WelcomePage",
+            async run() {
+                await new Promise((r) => setTimeout(r, 250));
+                const rtcService = odoo.__WOWL_DEBUG__.root.env.services["discuss.rtc"];
+                if (rtcService?.selfSession || rtcService?.state.hasPendingRequest) {
+                    console.error("The call should not have started.");
+                }
+            },
+        },
+        {
+            content: "Click join",
+            trigger: "button[title='Join Channel']",
+            run: "click",
+        },
+        {
+            content: "Check that the call has started",
+            trigger: ".o-discuss-Call",
+            run() {
+                if (!odoo.__WOWL_DEBUG__.root.env.services["discuss.rtc"]?.selfSession) {
+                    console.error("The call should have started.");
+                }
+            },
+        },
+    ],
+});

--- a/addons/mail/tests/discuss/test_discuss_channel_as_guest.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_as_guest.py
@@ -67,6 +67,10 @@ class TestMailPublicPage(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
         self.assertTrue(self.channel.message_ids[0].author_guest_id)
         self.start_tour(self.channel.invitation_url, self.tour, cookies={guest._cookie_name: guest._format_auth_cookie()})
 
+    def test_discuss_channel_public_page_call_public(self):
+        self.channel.default_display_mode = 'video_full_screen'
+        self.start_tour(self.channel.invitation_url, "discuss_channel_call_public_tour.js")
+
     def test_mail_group_public_page_as_guest(self):
         self.start_tour(self.group.invitation_url, "discuss_channel_as_guest_tour.js")
         guest = self.env['mail.guest'].search([('channel_ids', 'in', self.channel.id)], limit=1, order='id desc')


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/171016, calls would be started
even when the welcome page was present.

This commit fixes this issue.