### PR TITLE
[FIX] web: keep frame in sign box on wrong aspect ratio

### DIFF
--- a/addons/web/static/src/core/signature/name_and_signature.xml
+++ b/addons/web/static/src/core/signature/name_and_signature.xml
@@ -90,9 +90,10 @@
                     </div>
                 </div>
 
-                <div class="o_signature_stroke position-absolute"/>
-
-                <div t-if="state.showSignatureArea" t-ref="signature" t-att-style="signatureStyle" class="o_web_sign_signature p-0 bg-transparent position-relative"/>
+                <div class="o_web_sign_signature_container position-relative">
+                    <div class="o_signature_stroke position-absolute"/>
+                    <div t-if="state.showSignatureArea" t-ref="signature" t-att-style="signatureStyle" class="o_web_sign_signature p-0 bg-transparent position-relative"/>
+                </div>
 
                 <div t-if="loadIsInvalid" t-attf-class="o_web_sign_load_invalid card-footer d-none">
                     <div class="alert alert-danger mb-0" role="alert">


### PR DESCRIPTION
Steps to reproduce:
- Install Sign
- Open Sign, add a document and put a signature box
- Make the sign box have a weird aspect ratio (very short and super wide for example)

Issues:
When you sign with the frame, the frame will be partially hidden making the hash invisible.

Solution:
Put the container back just like in the 16.0, that way we don't have the weird CSS behavior that we had previously.

opw-4042289