### PR TITLE
[FIX] snailmail: multi-company selector error

### DIFF
--- a/addons/snailmail/static/src/scss/snailmail_external_layout_asset.scss
+++ b/addons/snailmail/static/src/scss/snailmail_external_layout_asset.scss
@@ -1,11 +1,11 @@
 /* Fix header height */
-div .header.o_company_1_layout > div[class$="_header"] {
+div .header > div[class$="_header"] {
     overflow: hidden !important;
     max-height: 150px;
 }
 
 /*Modifications for the Standard and Boxed document layouts */
-.article.o_report_layout_standard.o_company_1_layout, .article.o_report_layout_boxed.o_company_1_layout {
+.article.o_report_layout_standard, .article.o_report_layout_boxed {
     > .pt-5 {
         padding-top: 0 !important;
     }


### PR DESCRIPTION
It was reported that on some locales (eg) Japan the snailmail styling
was not properly applied.

This was due to the selector in snailmail styling which was incorrect for a multi-company setup. Targeting `.o_company_1_layout` will break the selector for any company which is not the first one.

task-4099258


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
