### PR TITLE
[FIX] web_editor, *: don't allow removing link on form submit buttons

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -5091,11 +5091,21 @@ registry.ReplaceMedia = SnippetOptionWidget.extend({
      * @override
      */
     async _computeWidgetVisibility(widgetName, params) {
+        // TODO: in master, refactor parent class check with Link
+        const parentClassList = this.$target[0].parentNode.classList;
+        const isParentLinkButton =
+            parentClassList.contains("s_website_form_send") ||
+            parentClassList.contains("o_submit");
+
         if (widgetName === 'media_link_opt') {
             if (this.$target[0].matches('img')) {
                 return isImageSupportedForStyle(this.$target[0]);
             }
-            return !this.$target[0].classList.contains('media_iframe_video');
+            return (
+                !this.$target[0].classList.contains("media_iframe_video") && !isParentLinkButton
+            );
+        } else if (["media_url_opt", "media_link_target_blank_opt"].includes(widgetName)) {
+            return !isParentLinkButton;
         }
         return this._super(...arguments);
     },

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
@@ -50,7 +50,20 @@ const LinkPopoverWidget = Widget.extend({
         this.$previewFaviconImg = this.$('.o_we_preview_favicon img');
         this.$previewFaviconFa = this.$('.o_we_preview_favicon .fa');
         this.$copyLink = this.$('.o_we_copy_link');
+        this.$removeLink = this.$(".o_we_remove_link");
         this.$fullUrl = this.$('.o_we_full_url');
+
+        // Don't allow removing the link on submit buttons
+        // TODO: in master, refactor fallback class check with Link
+        const linkTools = this.options.wysiwyg.linkTools;
+        if (
+            linkTools
+                ? linkTools.isButton
+                : this.target.classList.contains("s_website_form_send") ||
+                  this.target.classList.contains("o_submit")
+        ) {
+            this.$removeLink.toggleClass("d-none", true);
+        }
 
         // Use the right ClipboardJS with respect to the prototype of this.el
         // since, starting with Firefox 109, a widget element prototype that is

--- a/addons/web_editor/static/src/xml/image_link_tools.xml
+++ b/addons/web_editor/static/src/xml/image_link_tools.xml
@@ -17,6 +17,7 @@
         data-request-focus="true"/>
     <t t-set="new_window_checkbox_label">⌙ Open in new window</t>
     <we-checkbox t-att-string="new_window_checkbox_label"
+                 data-name="media_link_target_blank_opt"
         data-dependencies="media_url_opt"
         data-set-new-window="true" data-no-preview="true"/>
 </t>

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -1119,5 +1119,82 @@ odoo.define('website.tour.form_editor', function (require) {
         },
     ]);
 
+    tour.register(
+        "website_form_link_popover",
+        {
+            test: true,
+        },
+        [
+            {
+                content: "Enter edit mode",
+                trigger: "a[data-action=edit]",
+            },
+            {
+                content: "Check that we are in edit mode",
+                trigger: "#oe_snippets.o_loaded",
+                run: () => null,
+            },
+            {
+                content: "Drop the form snippet",
+                trigger: "#oe_snippets .oe_snippet:has(.s_website_form) .oe_snippet_thumbnail",
+                run: "drag_and_drop #wrap",
+            },
+            {
+                content: "Click on 'Submit'",
+                trigger: "a.s_website_form_send",
+            },
+            {
+                content: "Cannot remove submit button link",
+                trigger: ".popover",
+                run() {
+                    const removeLinkAction = this.$anchor[0].querySelector(".o_we_remove_link");
+                    if (!removeLinkAction.classList.contains("d-none")) {
+                        throw new Error("Submit button link should not be removable.");
+                    }
+                },
+            },
+            {
+                content: "Click on insert media",
+                trigger: "#media-insert",
+            },
+            {
+                content: "Click on Pictogram tab",
+                trigger: "#editor-media-icon-tab",
+            },
+            {
+                content: "Click on envelope icon",
+                trigger: '[data-id="fa-envelope-o"]',
+            },
+            {
+                content: "Click on submit button image",
+                trigger: "a.s_website_form_send .fa",
+            },
+            {
+                content: "Cannot remove submit button link via media",
+                trigger: ".snippet-option-ReplaceMedia",
+                run() {
+                    const toggleImageOption = this.$anchor[0].querySelector(
+                        '[data-name="media_link_opt"]'
+                    );
+                    if (!toggleImageOption.classList.contains("d-none")) {
+                        throw new Error("Submit button link should not be removable via media.");
+                    }
+                },
+            },
+            {
+                content: "Cannot modify link via media",
+                trigger: ".snippet-option-ReplaceMedia",
+                run() {
+                    const toggleImageOption = this.$anchor[0].querySelector(
+                        '[data-name="media_url_opt"]'
+                    );
+                    if (!toggleImageOption.classList.contains("d-none")) {
+                        throw new Error("Submit button link should not be modifiable via media.");
+                    }
+                },
+            },
+        ]
+    );
+
     return {};
 });

--- a/addons/website/tests/test_website_form_editor.py
+++ b/addons/website/tests/test_website_form_editor.py
@@ -64,6 +64,9 @@ class TestWebsiteFormEditor(HttpCaseWithUserPortal):
         self.assertIn('Test1&#34;&#39;', mail.body_html, 'The single quotes and double quotes characters should be visible on the received mail')
         self.assertIn('Test2`\\', mail.body_html, 'The backtick and backslash characters should be visible on the received mail')
 
+    def test_website_form_link_popover(self):
+        self.start_tour('/', 'website_form_link_popover', login='admin')
+
 
 @tagged('post_install', '-at_install')
 class TestWebsiteForm(TransactionCase):

--- a/addons/website_mass_mailing/static/tests/tours/newsletter_block.js
+++ b/addons/website_mass_mailing/static/tests/tours/newsletter_block.js
@@ -34,12 +34,32 @@ tour.register('newsletter_block_edition', {
         trigger: '.s_newsletter_block .js_subscribe_btn',
     },
     {
+        content: "Cannot remove Subscribe button link",
+        trigger: ".popover",
+        run() {
+            const removeLinkAction = this.$anchor[0].querySelector(".o_we_remove_link");
+            if (!removeLinkAction.classList.contains("d-none")) {
+                throw new Error("Subscribe button link should not be removable.");
+            }
+        },
+    },
+    {
         content: 'Toggle the option to display the Thanks button',
         trigger: 'we-button[data-toggle-thanks-button] we-checkbox',
     },
     {
         content: 'Click on the Thanks button',
         trigger: '.s_newsletter_block .js_subscribed_btn',
+    },
+    {
+        content: "Cannot remove Thanks button link",
+        trigger: ".popover",
+        run() {
+            const removeLinkAction = this.$anchor[0].querySelector(".o_we_remove_link");
+            if (!removeLinkAction.classList.contains("d-none")) {
+                throw new Error("Thanks button link should not be removable.");
+            }
+        },
     },
     {
         content: 'Click on the link style button',


### PR DESCRIPTION
*: website, website_mass_mailing

In forms, it is possible to remove the submit button's link. This leads
to irreversible loss of the form's submit button.

It is especially problematic in newsletter subscribe snippets, where
removing the submit link will raise an error.

Steps to reproduce:
- Go in the website editor in edit mode
- Add a form snippet (or a newsletter subscribe form or popup)
- Click on the submit button
- One of:
  - In the popover, click on the remove link icon (broken chain)
  - Use the insert media with any media (i.e. icon) and remove the link
    via the media's options

Old behavior: you can remove or edit the link of submit buttons
New behavior: the options to do so don't appear, therefore you cannot

This commit hides `media_link_opt`, `media_url_opt` and newly named
`media_link_target_blank_opt` options if the link is a form submit
button.

Naming `media_link_target_blank_opt` is ok in stable. If the option
appears anyway, it doesn't have any visual effect or bad consequence.

opw-4039766