### PR TITLE
[IMP] l10n_in: Set PAN field to readonly when parent contact exists

### DIFF
--- a/addons/l10n_in/views/res_partner_views.xml
+++ b/addons/l10n_in/views/res_partner_views.xml
@@ -14,7 +14,7 @@
                 <field name="l10n_in_gst_treatment" invisible="'IN' not in fiscal_country_codes" readonly="parent_id"/>
             </xpath>
             <xpath expr="//field[@name='vat']" position="after">
-                <field name="l10n_in_pan" placeholder="e.g. ABCTY1234D" invisible="'IN' not in fiscal_country_codes" />
+                <field name="l10n_in_pan" placeholder="e.g. ABCTY1234D" invisible="'IN' not in fiscal_country_codes" readonly="parent_id"/>
             </xpath>
             <xpath expr="//sheet" position="before">
                 <field name="display_pan_warning" invisible="1"/>


### PR DESCRIPTION
- Updated the PAN field to be readonly in cases where a parent contact is present.
- This ensures consistency and prevents accidental modification of inherited PAN information.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
