### PR TITLE
[FIX] payment: retry post processing for Integrity Errors

### DIFF
--- a/addons/payment/controllers/post_processing.py
+++ b/addons/payment/controllers/post_processing.py
@@ -52,7 +52,9 @@ class PaymentPostProcessing(http.Controller):
         if monitored_tx.state == 'done' and not monitored_tx.is_post_processed:
             try:
                 monitored_tx._finalize_post_processing()
-            except psycopg2.OperationalError:  # The database cursor could not be committed.
+            except (
+                psycopg2.OperationalError, psycopg2.IntegrityError
+            ):  # The database cursor could not be committed.
                 request.env.cr.rollback()  # Rollback and try later.
                 raise Exception('retry')
             except Exception as e:


### PR DESCRIPTION
In some rare cases, the payment status poll can enter the post-processing of a given transaction and conflict with the post-processing triggered by a webhook notification, for the same transaction.

If the transaction is linked to a sale.order, both transactions will try to add the partner as follower during the post-processing, leading to a violation of the unique constraint ensuring that two mail.followers rows won't target the same record and partner.

psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "mail_followers_mail_followers_res_partner_res_model_id_uniq"
DETAIL: Key (res_model, res_id, partner_id)=(sale.order, 20205, 94178) already exists.

This commit makes sure that this kind of psycopg exceptions are caught and retried so that this kind of error is not shown to the user and the polling is successfully triggered a second time.

opw-4000159

