### PR TITLE
[FIX] web: compare correctly URL query string

### DIFF
--- a/addons/web/static/src/core/browser/router.js
+++ b/addons/web/static/src/core/browser/router.js
@@ -1,6 +1,6 @@
 import { EventBus } from "@odoo/owl";
 import { omit, pick } from "../utils/objects";
-import { objectToUrlEncodedString } from "../utils/urls";
+import { compareUrls, objectToUrlEncodedString } from "../utils/urls";
 import { browser } from "./browser";
 import { slidingWindow } from "@web/core/utils/arrays";
 import { isNumeric } from "@web/core/utils/strings";
@@ -311,7 +311,7 @@ function makeDebouncedPush(mode) {
         // Calculates new route based on aggregated search and options
         const nextState = computeNextState(pushArgs.state, pushArgs.replace);
         const url = browser.location.origin + router.stateToUrl(nextState);
-        if (url + browser.location.hash !== browser.location.href) {
+        if (!compareUrls(url + browser.location.hash, browser.location.href)) {
             // If the route changed: pushes or replaces browser state
             if (mode === "push") {
                 // Because doPush is delayed, the history entry will have the wrong name.

--- a/addons/web/static/src/core/utils/urls.js
+++ b/addons/web/static/src/core/utils/urls.js
@@ -1,5 +1,6 @@
 import { session } from "@web/session";
 import { browser } from "../browser/browser";
+import { shallowEqual } from "@web/core/utils/objects";
 const { DateTime } = luxon;
 
 export class RedirectionError extends Error {}
@@ -132,4 +133,25 @@ export function redirect(url) {
         throw new RedirectionError("Can't redirect to another origin");
     }
     browser.location.assign(_url.href);
+}
+
+/**
+ * This function compares two URLs. It doesn't care about the order of the search parameters.
+ *
+ * @param {string} _url1
+ * @param {string} _url2
+ * @returns {boolean} true if the urls are identical, false otherwise
+ */
+export function compareUrls(_url1, _url2) {
+    const url1 = new URL(_url1);
+    const url2 = new URL(_url2);
+    return (
+        url1.origin === url2.origin &&
+        url1.pathname === url2.pathname &&
+        shallowEqual(
+            Object.fromEntries(url1.searchParams),
+            Object.fromEntries(url2.searchParams)
+        ) &&
+        url1.hash === url2.hash
+    );
 }

--- a/addons/web/static/tests/core/router.test.js
+++ b/addons/web/static/tests/core/router.test.js
@@ -1377,7 +1377,7 @@ describe("pushState", () => {
     test("can lock keys", async () => {
         createRouter();
 
-        router.addLockedKey(["k1"]);
+        router.addLockedKey("k1");
 
         router.replaceState({ k1: 2 });
         await tick();
@@ -1399,7 +1399,7 @@ describe("pushState", () => {
     test("can re-lock keys in same final call", async () => {
         createRouter();
 
-        router.addLockedKey(["k1"]);
+        router.addLockedKey("k1");
 
         router.pushState({ k1: 2 });
         await tick();
@@ -1542,6 +1542,27 @@ describe("pushState", () => {
         await tick();
         expect(router.current).toEqual({ k1: 2, k2: 3 });
         expect(browser.location.href).toBe("https://www.hoot.test/odoo?k2=3");
+    });
+    test("different order of keys shouldn't push a new state", async () => {
+        redirect("/odoo?k1=2");
+        createRouter({
+            onPushState: () => expect.step("pushState"),
+        });
+
+        router.addLockedKey("z");
+        router.addLockedKey("a");
+
+        router.pushState({ z: 1, a: 2 });
+        await tick();
+        expect.verifySteps(["pushState"]);
+        expect(router.current).toEqual({ a: 2, z: 1, k1: 2 });
+        expect(browser.location.href).toBe("https://www.hoot.test/odoo?k1=2&z=1&a=2");
+
+        router.pushState({ k1: 2 }, { replace: true });
+        await tick();
+        expect.verifySteps([]);
+        expect(router.current).toEqual({ a: 2, z: 1, k1: 2 });
+        expect(browser.location.href).toBe("https://www.hoot.test/odoo?k1=2&z=1&a=2");
     });
 });
 


### PR DESCRIPTION
When on the main menu, `/odoo?cids=1`, if you activate the debug assets,
the router will push a new key (debug) into the query string :
`/odoo?cids=1&debug=assets`. To fully activate the debug, a reload will
be done. After the reload, the action service will push the new loaded
state (the menu), taking into account the locked keys (in this case:
`cid` and `debug`), which will inverse the order of the query string :
`/odoo?debug=assets&cids=1`.

This occurs because, the order of the keys on the query string will
depend on: the push order; if the keys are locked keys or not; and of
the kind of push state (replacement or simple push state). The issue
with this almost "random" order of the keys, is that the router could
push the same URL (with keys in different order) multiple times into the
browser history.

Before this commit, to compare the actual URL with the new one, we just
compare the two strings, and if the order of the query strings are not
the same the URLs are considered as different.

This commit, will avoid this issue by deep comparing the query string as
objects, so when just a difference of order exists in the query string,
they will be considered as the same URL.

opw-3557575
