### PR TITLE
[FIX] base: return action content for readable fields

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -229,11 +229,6 @@ class IrActions(models.Model):
         """
         self.ensure_one()
         readable_fields = self._get_readable_fields()
-        if (self.sudo().type == "ir.actions.act_window"):
-            result = self.sudo().read()[0]
-            embedded_actions = self.env["ir.embedded.actions"].browse(result["embedded_action_ids"]).read()
-            result.update({"embedded_action_ids": embedded_actions})
-            return result
         return {
             field: value
             for field, value in self.sudo().read()[0].items()
@@ -384,6 +379,18 @@ class IrActionsActWindow(models.Model):
             # this is used by frontend, with the document layout wizard before send and print
             "close_on_report_download",
         }
+
+    def _get_action_dict(self):
+        """ Override to return action content with detailed embedded actions data if available.
+
+            :return: A dict with updated action dictionary including embedded actions information.
+        """
+        result = super()._get_action_dict()
+        if embedded_action_ids := result["embedded_action_ids"]:
+            EmbeddedActions = self.env["ir.embedded.actions"]
+            embedded_fields = EmbeddedActions._get_readable_fields()
+            result["embedded_action_ids"] = EmbeddedActions.browse(embedded_action_ids).read(embedded_fields)
+        return result
 
 
 VIEW_TYPES = [


### PR DESCRIPTION
With the recently added embedded actions with commit https://github.com/odoo/odoo/commit/f983703dfa3c5102fa818523ae419a70cc4b5230, added below line  where it returns non related fields to actions, which may generate an error.
 https://github.com/odoo/odoo/blob/ebf6da8d24c72a391113310e66285ded1f5fc9b5/odoo/addons/base/models/ir_actions.py#L232-L236



___
Currently there are two scenarious where error occurs:
 1  In the `account_online_synchronization` module, a below exception was generated when cron `Account: Journal online sync` run.

2  While clicking send and print

Steps to produce:
-   Install l10n_hu_edi
-   switch to the new company
-   Create an invoice with a line
-   Confirm it and click send and print

___
ERROR:
```
TypeError: Object of type datetime is not JSON serializable
```

This exception was generated because   [code](https://github.com/odoo/enterprise/blob/b491d3fa529115229fcce58500f742a992a7f2e5/account_online_synchronization/models/account_online.py#L423 ) tries to store a dictionary of action with a datetime object in the json field `connection_state_details`, but when data is converted to cache at [4]-https://github.com/odoo/odoo/blob/ebf6da8d24c72a391113310e66285ded1f5fc9b5/odoo/fields.py#L3346
, it throws an exception because `json.dumps` does not support datetime objects.


This commit will resolve the issue by following:
1. Override the `_get_action_dict` in 'ir.actions.act_window'.
2. In overridden '_get_action_dict' it just adds readable embedded field data when `embedded_action_ids` is available.



sentry-5655598227

