### PR TITLE
[IMP] pos_*: introducing refund with razorpay payment terminal

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -612,7 +612,7 @@ export class PosOrder extends Base {
             newPaymentLine.setAmount(totalAmountDue);
 
             if (
-                payment_method.payment_terminal ||
+                (payment_method.payment_terminal && !this._isRefundOrder()) ||
                 payment_method.payment_method_type === "qr_code"
             ) {
                 newPaymentLine.setPaymentStatus("pending");
@@ -822,6 +822,15 @@ export class PosOrder extends Base {
 
     isPaid() {
         return this.getDue() <= 0;
+    }
+
+    isRefundInProcess() {
+        return (
+            this._isRefundOrder() &&
+            this.payment_ids.some(
+                (pl) => pl.payment_method_id.use_payment_terminal && pl.payment_status !== "done"
+            )
+        );
     }
 
     isPaidWithCash() {

--- a/addons/point_of_sale/static/src/app/models/pos_payment.js
+++ b/addons/point_of_sale/static/src/app/models/pos_payment.js
@@ -78,6 +78,10 @@ export class PosPayment extends Base {
         }
         return isPaymentSuccessful;
     }
+
+    updateRefundPaymentLine(refundedPaymentLine) {
+        this.transaction_id = refundedPaymentLine.transaction_id;
+    }
 }
 
 registry.category("pos_available_models").add(PosPayment.pythonModel, PosPayment);

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.js
@@ -17,6 +17,7 @@ export class PaymentScreenPaymentLines extends Component {
         sendPaymentRequest: Function,
         sendPaymentReverse: Function,
         updateSelectedPaymentline: Function,
+        isRefundOrder: Boolean,
     };
 
     setup() {

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.xml
@@ -56,7 +56,7 @@
                                     <div class="electronic_status">
                                         Waiting for card
                                     </div>
-                                    <div class="button send_payment_cancel" title="Cancel Payment Request" t-on-click="() => this.props.sendPaymentCancel(line)">
+                                    <div t-if="!this.props.isRefundOrder" class="button send_payment_cancel" title="Cancel Payment Request" t-on-click="() => this.props.sendPaymentCancel(line)">
                                         Cancel
                                     </div>
                                 </t>
@@ -78,7 +78,12 @@
                                 </t>
                                 <t t-elif="line.payment_status == 'done'">
                                     <div class="electronic_status">
-                                        Payment Successful
+                                        <t t-if="!this.props.isRefundOrder">
+                                            Payment Successful
+                                        </t>
+                                        <t t-else="">
+                                            Refund Successful
+                                        </t>
                                     </div>
                                     <t t-if="line.can_be_reversed">
                                         <div class="button send_payment_reversal" title="Reverse Payment" t-on-click="() => this.props.sendPaymentReverse(line)">
@@ -95,6 +100,13 @@
                                     </div>
                                     <div></div>
                                 </t>
+                            </div>
+                        </t>
+                        <t t-if="this.props.isRefundOrder and line.payment_method_id.use_payment_terminal and !line.payment_status">
+                            <div class="button send_refund_request highlight text-bg-primary p-4 text-center"
+                                title="Send Refund Request"
+                                t-on-click="() => this.props.sendPaymentRequest(line)">
+                                Refund
                             </div>
                         </t>
                     </t>

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
@@ -16,7 +16,8 @@
                         sendPaymentCancel.bind="sendPaymentCancel"
                         sendPaymentRequest.bind="sendPaymentRequest"
                         selectLine.bind="selectPaymentLine"
-                        updateSelectedPaymentline.bind="updateSelectedPaymentline" />
+                        updateSelectedPaymentline.bind="updateSelectedPaymentline"
+                        isRefundOrder="isRefundOrder" />
                 </div>
                 <t t-call="point_of_sale.PaymentScreenButtons" />
                 <div t-attf-class="d-flex switchpane gap-2 mt-2">
@@ -49,7 +50,8 @@
                                 sendPaymentCancel.bind="sendPaymentCancel"
                                 sendPaymentRequest.bind="sendPaymentRequest"
                                 selectLine.bind="selectPaymentLine"
-                                updateSelectedPaymentline.bind="updateSelectedPaymentline" />
+                                updateSelectedPaymentline.bind="updateSelectedPaymentline"
+                                isRefundOrder="isRefundOrder" />
                         </div>
                     </div>
                 </div>
@@ -69,14 +71,14 @@
     <t t-name="point_of_sale.PaymentScreenValidate">
         <t t-if="ui.isSmall">
             <button class="btn-switchpane validation-button btn btn-primary btn-lg flex-fill py-3 lh-lg"
-                t-att-class="{ secondary: !(currentOrder.isPaid() and currentOrder._isValidEmptyOrder()) }"
+                t-att-class="{ secondary: !(currentOrder.isPaid() and currentOrder._isValidEmptyOrder()) and !currentOrder.isRefundInProcess() }"
                 t-on-click="() => this.validateOrder()">
                 <span>Validate</span>
             </button>
         </t>
         <t t-else="">
             <button class="button next validation btn btn-primary btn-lg w-50 py-3 lh-lg"
-                t-attf-class="{{currentOrder.isPaid() and currentOrder._isValidEmptyOrder() ? 'highlight' : 'disabled'}}"
+                t-attf-class="{{currentOrder.isPaid() and currentOrder._isValidEmptyOrder() and !currentOrder.isRefundInProcess() ? 'highlight' : 'disabled'}}"
                 t-on-click="() => this.validateOrder()">
                 <span class="next_text">Validate</span>
             </button>

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.xml
@@ -9,7 +9,10 @@
                         <div class="o_payment_successful d-flex flex-column w-100 w-xxl-75 p-3 pt-xxl-5 mx-auto">
                             <div class="d-flex flex-column align-items-center p-1 p-lg-3 border border-success rounded-3 bg-success-subtle text-success fs-3">
                                 <i t-if="!ui.isSmall" class="fa fa-fw fa-2x fa-check-circle"/>
-                                <span class="fs-3 fw-bolder">Payment Successful</span>
+                                <span class="fs-3 fw-bolder">
+                                    <t t-if="pos.getOrder()._isRefundOrder()">Refund Initiated</t>
+                                    <t t-else="">Payment Successful</t>
+                                </span>
                                 <div class="fs-4 fw-bold d-flex justify-content-center align-items-center gap-2">
                                     <span t-esc="orderAmountPlusTip" />
                                     <span t-if="this.currentOrder.nb_print === 0" class="edit-order-payment badge bg-success text-white rounded cursor-pointer pt-1" t-on-click="() => this.pos.orderDetails(this.pos.getOrder())">Edit payment</span>

--- a/addons/pos_razorpay/models/pos_payment.py
+++ b/addons/pos_razorpay/models/pos_payment.py
@@ -5,3 +5,4 @@ class PosPayment(models.Model):
     _inherit = "pos.payment"
 
     razorpay_reverse_ref_no = fields.Char('Razorpay Reverse Reference No.')
+    razorpay_p2p_request_id = fields.Char('Razorpay p2pRequestId', help='Required to fetch payment status during the refund order process')

--- a/addons/pos_razorpay/models/pos_payment_method.py
+++ b/addons/pos_razorpay/models/pos_payment_method.py
@@ -16,6 +16,40 @@ class PosPaymentMethod(models.Model):
     def _get_payment_terminal_selection(self):
         return super()._get_payment_terminal_selection() + [('razorpay', 'Razorpay')]
 
+    def razorpay_make_refund_request(self, data):
+        razorpay = RazorpayPosRequest(self)
+        request_body = razorpay._razorpay_get_request_parameters()
+        if data.get('refund_type') == 'refund':
+            request_body.update({
+                'amount': data.get('amount'),
+                'originalTransactionId': data.get('transaction_id'),
+                'externalRefNumber': data.get('externalRefNumber')
+            })
+        else:
+            request_body.update({
+                'txnId': data.get('transaction_id'),
+            })
+        endpoint = 'unified/refund' if data.get('refund_type') == 'refund' else 'void'
+        response = razorpay._call_razorpay(endpoint=endpoint, payload=request_body)
+        if response.get('success') and not response.get('errorCode'):
+            return {
+                'status': response.get('status'),
+                'authCode': response.get('authCode'),
+                'cardLastFourDigit': response.get('cardLastFourDigit'),
+                'externalRefNumber': response.get('externalRefNumber'),
+                'reverseReferenceNumber': response.get('reverseReferenceNumber'),
+                'txnId': response.get('txnId'),
+                'paymentMode': response.get('paymentMode'),
+                'paymentCardType': response.get('paymentCardType'),
+                'paymentCardBrand': response.get('paymentCardBrand'),
+                'nameOnCard': response.get('nameOnCard'),
+                'acquirerCode': response.get('acquirerCode'),
+                'postingDate': response.get('postingDate'),
+            }
+        default_error_msg = _('The Razorpay POS refund request has encountered an unexpected error code.')
+        error = response.get('errorMessage') or default_error_msg
+        return {'error': str(error)}
+
     def razorpay_make_payment_request(self, data):
         razorpay = RazorpayPosRequest(self)
         body = razorpay._razorpay_get_payment_request_body(payment_mode=True)
@@ -35,7 +69,7 @@ class PosPaymentMethod(models.Model):
 
     def razorpay_fetch_payment_status(self, data):
         razorpay = RazorpayPosRequest(self)
-        body = razorpay._razorpay_get_payment_status_request_body()
+        body = razorpay._razorpay_get_request_parameters()
         body.update({'origP2pRequestId': data.get('p2pRequestId')})
         response = razorpay._call_razorpay(endpoint='status', payload=body)
         if response.get('success') and not response.get('errorCode'):
@@ -55,6 +89,8 @@ class PosPaymentMethod(models.Model):
                     'nameOnCard': response.get('nameOnCard'),
                     'acquirerCode': response.get('acquirerCode'),
                     'createdTime': response.get('createdTime'),
+                    'p2pRequestId': response.get('p2pRequestId'),
+                    'settlementStatus': response.get('settlementStatus'),
                 }
             elif payment_status == 'FAILED' or payment_messageCode == 'P2P_DEVICE_CANCELED':
                 return {'error': str(response.get('message', _('Razorpay POS transaction failed'))),

--- a/addons/pos_razorpay/models/razorpay_pos_request.py
+++ b/addons/pos_razorpay/models/razorpay_pos_request.py
@@ -16,7 +16,11 @@ class RazorpayPosRequest:
         self.payment_method = payment_method
         self.session = requests.Session()
 
-    def _razorpay_get_endpoint(self):
+    def _razorpay_get_endpoint(self, endpoint):
+        if endpoint in ['unified/refund', 'void']:
+            if self.razorpay_test_mode:
+                return 'https://demo.ezetap.com/api/2.0/payment/'
+            return 'https://www.ezetap.com/api/2.0/payment/'
         if self.razorpay_test_mode:
             return 'https://demo.ezetap.com/api/3.0/p2padapter/'
         return 'https://www.ezetap.com/api/3.0/p2padapter/'
@@ -29,10 +33,9 @@ class RazorpayPosRequest:
         :return The JSON-formatted content of the response.
         :rtype: dict
         """
-        endpoint = f'{self._razorpay_get_endpoint()}{endpoint}'
-        request_timeout = self.payment_method.env['ir.config_parameter'].sudo().get_param('pos_razorpay.timeout', REQUEST_TIMEOUT)
+        url = f'{self._razorpay_get_endpoint(endpoint)}{endpoint}'
         try:
-            response = self.session.post(endpoint, json=payload, timeout=request_timeout)
+            response = self.session.post(url, json=payload, timeout=REQUEST_TIMEOUT)
             response.raise_for_status()
             res_json = response.json()
         except requests.exceptions.RequestException as error:
@@ -51,10 +54,10 @@ class RazorpayPosRequest:
         }
         if payment_mode:
             request_parameters.update({'mode': self.razorpay_allowed_payment_modes.upper()})
-        request_parameters.update(self._razorpay_get_payment_status_request_body())
+        request_parameters.update(self._razorpay_get_request_parameters())
         return request_parameters
 
-    def _razorpay_get_payment_status_request_body(self):
+    def _razorpay_get_request_parameters(self):
         return {
             'username': self.razorpay_username,
             'appKey': self.razorpay_api_key,

--- a/addons/pos_razorpay/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/pos_razorpay/static/src/app/screens/payment_screen/payment_screen.js
@@ -1,6 +1,7 @@
 import { PaymentScreen } from "@point_of_sale/app/screens/payment_screen/payment_screen";
 import { patch } from "@web/core/utils/patch";
 import { onMounted } from "@odoo/owl";
+import { _t } from "@web/core/l10n/translation";
 
 patch(PaymentScreen.prototype, {
     setup() {
@@ -22,5 +23,36 @@ patch(PaymentScreen.prototype, {
                 }
             }
         });
+    },
+    async addNewPaymentLine(paymentMethod) {
+        if (paymentMethod.use_payment_terminal === "razorpay" && this.isRefundOrder) {
+            const refundedOrder = this.currentOrder.lines[0]?.refunded_orderline_id?.order_id;
+            const razorpayPaymentlines = refundedOrder.payment_ids.filter(
+                (pi) => pi.payment_method_id.use_payment_terminal === "razorpay"
+            );
+            const current_due = this.currentOrder.getDue();
+            if (
+                razorpayPaymentlines.length !== 1 ||
+                Math.abs(current_due) < razorpayPaymentlines[0].amount ||
+                current_due === 0
+            ) {
+                this.pos.notification.add(
+                    _t(
+                        "Adding a new Razorpay payment line is not allowed under the current conditions."
+                    ),
+                    { type: "warning", sticky: false }
+                );
+                return false;
+            }
+            const res = await super.addNewPaymentLine(paymentMethod);
+            const newPaymentLine = this.paymentLines.at(-1);
+            if (res) {
+                newPaymentLine.setAmount(-razorpayPaymentlines[0].amount);
+                newPaymentLine.updateRefundPaymentLine(razorpayPaymentlines[0]);
+            }
+            return res;
+        } else {
+            return await super.addNewPaymentLine(paymentMethod);
+        }
     },
 });

--- a/addons/pos_razorpay/static/src/app/services/pos_store.js
+++ b/addons/pos_razorpay/static/src/app/services/pos_store.js
@@ -1,0 +1,53 @@
+import { patch } from "@web/core/utils/patch";
+import { PosStore } from "@point_of_sale/app/services/pos_store";
+
+patch(PosStore.prototype, {
+    async pay() {
+        const currentOrder = this.getOrder();
+        const refundedOrder = currentOrder?.lines[0]?.refunded_orderline_id?.order_id;
+        const razorpayPaymentlines = refundedOrder?.payment_ids.filter(
+            (pi) => pi.payment_method_id.use_payment_terminal === "razorpay"
+        );
+        const reazorpayPaymentMethod = currentOrder.config_id.payment_method_ids.find(
+            (pm) => pm.use_payment_terminal === "razorpay"
+        );
+        await super.pay();
+        if (reazorpayPaymentMethod && refundedOrder && razorpayPaymentlines?.length === 1) {
+            const paymentIds = refundedOrder.payment_ids || [];
+            // Add all the available payment lines in the refunded order if the current order amount is the same as the refunded order
+            if (Math.abs(currentOrder.getTotalDue()) === refundedOrder.amount_total) {
+                paymentIds.forEach((pi) => {
+                    if (pi.payment_method_id) {
+                        const paymentLine = currentOrder.addPaymentline(pi.payment_method_id);
+                        paymentLine.setAmount(-pi.amount);
+                        paymentLine.updateRefundPaymentLine(pi);
+                    }
+                });
+            } else {
+                // Add available payment lines of refunded order based on conditions.
+                const getTotalDue = currentOrder.getTotalDue();
+                if (getTotalDue < 0 && Math.abs(getTotalDue) > razorpayPaymentlines[0].amount) {
+                    const paymentLine = currentOrder.addPaymentline(
+                        razorpayPaymentlines[0].payment_method_id
+                    );
+                    paymentLine.setAmount(-razorpayPaymentlines[0].amount);
+                    paymentLine.updateRefundPaymentLine(razorpayPaymentlines[0]);
+                }
+                if (currentOrder.getDue() < 0) {
+                    paymentIds.forEach((pi) => {
+                        const current_due = currentOrder.getDue();
+                        if (
+                            current_due < 0 &&
+                            pi.payment_method_id &&
+                            !pi.payment_method_id.use_payment_terminal
+                        ) {
+                            currentOrder
+                                .addPaymentline(pi.payment_method_id)
+                                .setAmount(current_due);
+                        }
+                    });
+                }
+            }
+        }
+    },
+});

--- a/addons/pos_razorpay/static/src/app/utls/payment/payment_razorpay.js
+++ b/addons/pos_razorpay/static/src/app/utls/payment/payment_razorpay.js
@@ -1,6 +1,6 @@
 import { _t } from "@web/core/l10n/translation";
 import { PaymentInterface } from "@point_of_sale/app/utils/payment/payment_interface";
-import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { AlertDialog, ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { serializeDateTime } from "@web/core/l10n/dates";
 import { register_payment_method } from "@point_of_sale/app/services/pos_store";
 
@@ -86,11 +86,51 @@ export class PaymentRazorpay extends PaymentInterface {
         });
     }
 
-    _processRazorpay(cid) {
+    _razorpayHandleRefundResponse(response) {
+        const paymentLine = this.pendingRazorpayline();
+        if (response?.error) {
+            paymentLine.setPaymentStatus("retry");
+            this._showError(response.error);
+            this._removePaymentHandler(["referenceId"]);
+            return false;
+        }
+        const resultCode = response?.status;
+        if (
+            resultCode === "REFUNDED" &&
+            response?.externalRefNumber !== localStorage.getItem("referenceId")
+        ) {
+            return this._razorpayHandleRefundResponse({
+                error: _t("Reference number mismatched"),
+            });
+        } else if (resultCode === "REFUNDED" || resultCode === "VOIDED") {
+            this._updatePaymentLine(paymentLine, response);
+            paymentLine.payment_date = this._getPaymentDate(response?.postingDate - 19800000);
+            paymentLine.setPaymentStatus("done");
+            this._removePaymentHandler(["referenceId"]);
+        }
+        return Promise.resolve(true);
+    }
+
+    _updatePaymentLine(paymentLine, response) {
+        paymentLine.update({
+            payment_method_authcode: response?.authCode,
+            card_no: response?.cardLastFourDigit || "",
+            payment_method_issuer_bank: response?.acquirerCode,
+            payment_method_payment_mode: response?.paymentMode,
+            card_type: response?.paymentCardType,
+            card_brand: response?.paymentCardBrand || "",
+            cardholder_name: response?.nameOnCard.replace("/", ""),
+            razorpay_reverse_ref_no: response?.reverseReferenceNumber,
+            transaction_id: response?.txnId,
+            payment_ref_no: response?.externalRefNumber,
+        });
+    }
+
+    async _processRazorpay(cid) {
         const order = this.pos.getOrder();
         const line = order.getSelectedPaymentline();
 
-        if (line.amount < 0) {
+        if (line.amount < 0 && !order._isRefundOrder()) {
             this._showError(_t("Cannot process transactions with negative amount."));
             return Promise.resolve();
         }
@@ -101,13 +141,59 @@ export class PaymentRazorpay extends PaymentInterface {
             "referenceId",
             referencePrefix + "/" + orderId + "/" + crypto.randomUUID().replaceAll("-", "")
         );
-        const data = {
-            amount: line.amount,
-            referenceId: localStorage.getItem("referenceId"),
-        };
-        return this._callRazorpay(data, "razorpay_make_payment_request").then((data) =>
-            this._razorpayHandleResponse(data)
-        );
+        if (order._isRefundOrder()) {
+            line.setPaymentStatus("waitingCard");
+            const data = {
+                amount: Math.abs(line.amount),
+                externalRefNumber: localStorage.getItem("referenceId"),
+                transaction_id: line?.transaction_id,
+            };
+            const response = await this._checkPaymentStatus(line);
+            if (response?.settlementStatus === "SETTLED") {
+                data.refund_type = "refund";
+            } else {
+                const refundedOrder = order.lines[0].refunded_orderline_id.order_id;
+                const refundedPaymentLine = refundedOrder.payment_ids.find(
+                    (pi) => pi.transaction_id === line.transaction_id
+                );
+                if (Math.abs(line.amount) < refundedPaymentLine.amount) {
+                    try {
+                        const userConfirmed = await this._confirmVoidPayment();
+                        if (!userConfirmed) {
+                            return false;
+                        }
+                    } catch (error) {
+                        console.error(error);
+                        return false;
+                    }
+                }
+                data.refund_type = "void";
+            }
+            response?.settlementStatus === "SETTLED"
+                ? (data.refund_type = "refund")
+                : (data.refund_type = "void");
+            return this._callRazorpay(data, "razorpay_make_refund_request").then((data) =>
+                this._razorpayHandleRefundResponse(data)
+            );
+        } else {
+            const data = {
+                amount: line.amount,
+                referenceId: localStorage.getItem("referenceId"),
+            };
+            return this._callRazorpay(data, "razorpay_make_payment_request").then((data) =>
+                this._razorpayHandleResponse(data)
+            );
+        }
+    }
+
+    /**
+     * This method verifies the card payment before processing.
+     * If the payment is settled, we will proceed with the refund; otherwise, we will void it.
+     */
+    async _checkPaymentStatus(line) {
+        const data = { p2pRequestId: line?.razorpay_p2p_request_id };
+        const response = await this._callRazorpay(data, "razorpay_fetch_payment_status");
+        return response;
     }
 
     /**
@@ -157,16 +243,8 @@ export class PaymentRazorpay extends PaymentInterface {
             ) {
                 return this._razorpayHandleResponse({ error: _t("Reference number mismatched") });
             } else if (resultCode === "AUTHORIZED") {
-                paymentLine.payment_method_authcode = response?.authCode;
-                paymentLine.card_no = response?.cardLastFourDigit || "";
-                paymentLine.payment_method_issuer_bank = response?.acquirerCode;
-                paymentLine.payment_method_payment_mode = response?.paymentMode;
-                paymentLine.card_type = response?.paymentCardType;
-                paymentLine.card_brand = response?.paymentCardBrand || "";
-                paymentLine.cardholder_name = response?.nameOnCard;
-                paymentLine.payment_ref_no = response?.externalRefNumber;
-                paymentLine.razorpay_reverse_ref_no = response?.reverseReferenceNumber;
-                paymentLine.transaction_id = response?.txnId;
+                this._updatePaymentLine(paymentLine, response);
+                paymentLine.razorpay_p2p_request_id = response?.p2pRequestId;
                 // `createdTime` is provided in milliseconds in local GMT+5.5 timezone.
                 // Thus, we need to subtract 19800000 to get the correct time in milliseconds.
                 paymentLine.payment_date = this._getPaymentDate(response?.createdTime - 19800000);
@@ -208,6 +286,22 @@ export class PaymentRazorpay extends PaymentInterface {
         this.env.services.dialog.add(AlertDialog, {
             title: title || _t("Razorpay Error"),
             body: error_msg,
+        });
+    }
+
+    async _confirmVoidPayment() {
+        return new Promise((resolve, reject) => {
+            this.env.services.dialog.add(ConfirmationDialog, {
+                title: _t("Void Payment Confirmation"),
+                body: _t(
+                    "Your transaction isn't settled yet, and the refund is less than the amount paid.\n" +
+                        "The full amount will be cancelled, do you want to proceed?"
+                ),
+                confirmLabel: _t("Void Transaction"),
+                cancelLabel: _t("Cancel"),
+                confirm: () => resolve(true),
+                cancel: () => reject(false),
+            });
         });
     }
 }

--- a/addons/pos_razorpay/static/src/overrides/models/pos_payment.js
+++ b/addons/pos_razorpay/static/src/overrides/models/pos_payment.js
@@ -1,0 +1,10 @@
+import { PosPayment } from "@point_of_sale/app/models/pos_payment";
+import { patch } from "@web/core/utils/patch";
+
+patch(PosPayment.prototype, {
+    //@override
+    updateRefundPaymentLine(refundedPaymentLine) {
+        super.updateRefundPaymentLine(refundedPaymentLine);
+        this.razorpay_p2p_request_id = refundedPaymentLine?.razorpay_p2p_request_id;
+    },
+});


### PR DESCRIPTION
pos_*: point_of_sale, pos_razorpay

Before this commit:
=========
- There is no refund option with the Razorpay payment terminal. Users need to refund orders paid with the Razorpay payment method using cash or another.
- We were taking request timeout from the config parameter the Razorpay API request.

After this commit:
==========
- Users will have the option to refund Razorpay terminal-based paid orders using
  Razorpay.
- A refund button will be provided on the terminal refund payment line. Clicking
  on this button will initiate the terminal refund process, and the order will
  be validated after the successful refund process.
- We will use static request timeout for the Razorpay API request.

task-4061153