### PR TITLE
[FIX] stock: allow picking type import

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -453,7 +453,7 @@ class Picking(models.Model):
         'Has Scrap Moves', compute='_has_scrap_move')
     picking_type_id = fields.Many2one(
         'stock.picking.type', 'Operation Type',
-        required=True, readonly=True, index=True,
+        required=True, index=True,
         default=_default_picking_type_id)
     picking_type_code = fields.Selection(
         related='picking_type_id.code',


### PR DESCRIPTION
Steps to reproduce:
- Enable storage locations
- Inventory > Internal Transfers
- Gear Icon > Import records
- Try to import a file containing picking type

Picking type cannot be imported because it is a readonly field, this is even more problematic since picking_type_id is a required field, thus preventing the import of any other data.

Previously, the field picking_type_id used to have a state attribute to make it editable when in draft, but this is no longer the case in 17.0. https://github.com/odoo/odoo/pull/104741

opw-4074746

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
