### PR TITLE
[IMP] base: logout all devices

### DIFF
--- a/odoo/addons/base/views/res_users_identitycheck_views.xml
+++ b/odoo/addons/base/views/res_users_identitycheck_views.xml
@@ -24,24 +24,5 @@
             </field>
         </record>
 
-        <record id="res_users_identitycheck_view_form_revokedevices" model="ir.ui.view">
-            <field name="name">Revoke All Devices</field>
-            <field name="model">res.users.identitycheck</field>
-            <field name="priority">40</field>
-            <field name="arch" type="xml">
-                <form string="Log out from all devices">
-                    <div>
-                        You are about to log out from all devices that currently have access to your account.<br/><br/>
-                        <strong>Type in your password to confirm :</strong>
-                        <field class="oe_inline o_field_highlight" name="password" password="True" required="True"/>
-                    </div>
-                    <footer>
-                        <button string="Log out from all devices" name="revoke_all_devices" type="object" class="btn-primary" data-hotkey="q"/>
-                        <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="z" />
-                    </footer>
-                </form>
-            </field>
-        </record>
-
     </data>
 </odoo>


### PR DESCRIPTION
Whenever a user tried to log out from all devices, they had to enter
their current password. This is a problem because if you override the
behavior of _check_credentials to restrict the passwords, you may be
locked out of logging out all your other devices. Such as is the case
with password length requirements.

It also does not remove the res.devices that are added to your account.
A user expects these all to be removed, except for their current one,
upon pressing the button.

Another problem is that the button to log out from all devices is under
"Other Devices", yet you still log out from all devices because you
change your password.

Plus, since we don't use @check_identity, the user will have to confirm
their identity again even if they just did so. It wasn't a standard
security check view.

This commit solves all these issues by utilising the new res.device
model.
