### PR TITLE
[FIX] stock: change picking type reservation method on large DB

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -550,6 +550,8 @@ Please change the quantity done or the rounding precision of your unit of measur
                 move.reservation_date = fields.Date.to_date(move.date) - timedelta(days=days)
             else:
                 move.reservation_date = False
+        self.filtered('id').flush_recordset()
+        self.filtered('id').invalidate_recordset()
 
     @api.depends('has_tracking', 'picking_type_id.use_create_lots', 'picking_type_id.use_existing_lots', 'state', 'origin_returned_move_id', 'product_id.detailed_type', 'picking_code')
     def _compute_show_info(self):


### PR DESCRIPTION
### Issue:

Changing the reservation method of a picking type on a large DB might result in a memory error invalidating the requested change.

### Cause of the issue:

The dependency `picking_type_id.reservation_method` was introduced on the `_compute_reservation_date` method of stock moves by commit c4023d7. This dependency is important to update the reservation_date of all moves whose picking type reservation type changed to date. Because of this new dependency, if one change the `reservation_method` of a picking type say manufacturing, it will fetch and "recompute" the `reservation_date` of all stock.moves whose picking type is manufacting. The ORM will handle these records 1000 by 1000 but if you have a million  records of that picking type (which is the case of the customer) all of these records will be added to the cache during the `_fetch_query`. This will lead to a Memory error since the cache is not cleared after a certain amount of computed records during the `_compute_reservation_date`.

opw-4019589
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
