### PR TITLE
[FIX] point_of_sale: fix ListContainer position

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/list_container/list_container.js
+++ b/addons/point_of_sale/static/src/app/generic_components/list_container/list_container.js
@@ -67,7 +67,7 @@ export class ListContainer extends Component {
         // but in this case we want it to be right on top of it;
         // in order to do this we set the height of our div to 0 for the
         // duration that the popover is shown.
-        // this.container.el.style.height = 0;
+        this.container.el.style.height = 0;
         this.popover.open(this.container.el, {
             items: this.props.items,
             slots: this.props.slots,


### PR DESCRIPTION
When the list of items is too long to be entirely displayed, the `ListContainer` component renders a button that will open a popover with all the elements of the list. This popover is supposed to cover the items that were originally shown ( so as not to show some items twice ) but now it is rendered below the original items.

In this commit we fix this by making sure the the popover is rendered in the correct place.


before:
![before-list-container](https://github.com/user-attachments/assets/3cc68c9c-3e11-4751-b34c-103cd4631db4)
after:
![image](https://github.com/user-attachments/assets/e9262b70-9bc3-4128-a6a4-77e4e34982a4)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
