### PR TITLE
[FIX] auth_passkey: logout from all devices

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1117,6 +1117,7 @@ class Users(models.Model):
 
     def action_revoke_all_devices(self):
         ctx = dict(self.env.context, dialog_size='medium')
+        ctx['default_auth_method'] = 'password'
         return {
             'name': _('Log out from all devices?'),
             'type': 'ir.actions.act_window',


### PR DESCRIPTION
When you have a passkey added to your account, you couldn't logout from all devices anymore. This happened because _check_identity's auth_method was set to webauthn instead of password.

This commit fixes that by setting the default_auth_method to password in this specific form. This fix is only needed for saas-17.4 since https://github.com/odoo/odoo/pull/175849 fixes the issue in master.