### PR TITLE
[IMP] mail: make space for call in chatwindow

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call.js
+++ b/addons/mail/static/src/discuss/call/common/call.js
@@ -72,10 +72,10 @@ export class Call extends Component {
     }
 
     get minimized() {
-        if (this.state.isFullscreen || this.props.compact || this.props.thread.activeRtcSession) {
+        if (this.state.isFullscreen || this.props.thread.activeRtcSession) {
             return false;
         }
-        if (!this.isActiveCall || this.props.thread.videoCount === 0) {
+        if (!this.isActiveCall || this.props.thread.videoCount === 0 || this.props.compact) {
             return true;
         }
         return false;

--- a/addons/mail/static/src/discuss/call/common/call.scss
+++ b/addons/mail/static/src/discuss/call/common/call.scss
@@ -10,6 +10,10 @@
     &.o-minimized {
         height: 20%; // ensures that the view returns to the right height when resized
         min-height: #{"max(20%, 130px)"};
+        &.o-compact {
+            height: 10%;
+            min-height: #{"max(10%, 100px)"};
+        }
     }
 }
 

--- a/addons/mail/static/src/discuss/call/common/call.xml
+++ b/addons/mail/static/src/discuss/call/common/call.xml
@@ -3,7 +3,7 @@
 
     <t t-name="discuss.Call">
         <PttAdBanner/>
-        <div class="o-discuss-Call user-select-none d-flex" t-att-class="{'o-fullscreen fixed-top vw-100 vh-100': state.isFullscreen, 'o-minimized': minimized, 'position-relative': !state.isFullscreen }">
+        <div class="o-discuss-Call user-select-none d-flex" t-att-class="{'o-fullscreen fixed-top vw-100 vh-100': state.isFullscreen, 'o-compact': props.compact,'o-minimized': minimized, 'position-relative': !state.isFullscreen }">
             <div class="o-discuss-Call-main d-flex flex-grow-1 flex-column align-items-center justify-content-center position-relative overflow-auto" t-on-mouseleave="onMouseleaveMain">
                 <div
                     class="o-discuss-Call-mainCards d-flex align-items-center overflow-hidden h-100 w-100 flex-wrap justify-content-center"
@@ -12,7 +12,14 @@
                     t-on-mousemove="onMousemoveMain"
                     t-ref="grid"
                 >
-                    <CallParticipantCard t-foreach="visibleMainCards" t-as="cardData" t-key="cardData.key"
+                    <CallParticipantCard t-foreach="visibleMainCards.slice(0,6)" t-as="cardData" t-key="cardData.key"
+                        cardData="cardData"
+                        className="'o-discuss-Call-mainCardStyle'"
+                        minimized="minimized"
+                        thread="props.thread"
+                    />
+                    <span t-if="env.inChatWindow and visibleMainCards.length > 6" class="fa fa-ellipsis-h ps-1 pe-1"/>
+                    <CallParticipantCard t-if="!env.inChatWindow" t-foreach="visibleMainCards.slice(6)" t-as="cardData" t-key="cardData.key"
                         cardData="cardData"
                         className="'o-discuss-Call-mainCardStyle'"
                         minimized="minimized"

--- a/addons/mail/static/src/discuss/call/common/call_action_list.xml
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.xml
@@ -9,7 +9,7 @@
                         <t t-call="discuss.CallActionList.actionButton" />
                     </t>
                     <Dropdown position="'top-end'" menuClass="'d-flex flex-column py-0'">
-                        <button t-att-class="`btn d-flex m-1 border-0 rounded-circle shadow-none opacity-100 opacity-75-hover ${ isSmall ? 'p-2' : 'p-3' }`" t-att-title="MORE">
+                        <button t-att-class="`btn smaller d-flex m-1 border-0 rounded-circle shadow-none opacity-100 opacity-75-hover ${ isSmall ? 'p-2' : 'p-3' }`" t-att-title="MORE">
                             <div class="fa-stack">
                                 <i class="fa fa-ellipsis-v fa-stack-1x" t-att-class="{ 'fa-lg': !isSmall }"/>
                             </div>
@@ -25,7 +25,7 @@
                         </t>
                     </Dropdown>
                 </t>
-                <button t-if="props.thread.rtcInvitingSession and !isOfActiveCall" class="btn btn-danger d-flex m-1 border-0 rounded-circle shadow-none"
+                <button t-if="props.thread.rtcInvitingSession and !isOfActiveCall" class="btn smaller btn-danger d-flex m-1 border-0 rounded-circle shadow-none"
                     t-att-class="{ 'p-2': isSmall, 'p-3': !isSmall }"
                     aria-label="Reject"
                     title="Reject"
@@ -37,7 +37,7 @@
                 </button>
                 <t t-if="props.thread.eq(rtc.state.channel)" t-set="callText">Disconnect</t>
                 <t t-else="" t-set="callText">Join Call</t>
-                <button class="btn d-flex m-1 border-0 rounded-circle shadow-none"
+                <button class="btn smaller d-flex m-1 border-0 rounded-circle shadow-none"
                     t-att-aria-label="callText"
                     t-att-class="{ 'btn-danger': isOfActiveCall, 'p-2': isSmall, 'p-3': !isSmall, 'btn-success': !isOfActiveCall }"
                     t-att-disabled="rtc.state.hasPendingRequest"
@@ -60,7 +60,7 @@
     </t>
 
     <t t-name="discuss.CallActionList.actionButton">
-        <button class="btn d-flex m-1 border-0 rounded-circle shadow-none opacity-100 opacity-75-hover"
+        <button class="btn smaller d-flex m-1 border-0 rounded-circle shadow-none opacity-100 opacity-75-hover"
             t-att-class="{ 'p-2': isSmall, 'p-3': !isSmall }"
             t-att-aria-label="action.name"
             t-att-title="action.name"


### PR DESCRIPTION
Currently, the call in chatwindow is too big and takes too much space, making it hard to use the chatwindow for chatting. This commit reduces the size of the call in chatwindow.

1. The call participant card is now smaller and only displays the avatar by default.
2. When there is more than six participants, hide the rest in chatwindow and display an ellipsis.
3. Reduce the size of the call action button.

before:
![3885352209](https://github.com/user-attachments/assets/a9773f60-8fb5-40b5-a1a2-f0c071504b25)

after:
![2898089824](https://github.com/user-attachments/assets/ac4fb08b-8315-4c63-b29e-c2a23b105377)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
