### PR TITLE
[IMP] mail: reaction hovering effects

### DIFF
--- a/addons/mail/static/src/core/common/message_reaction_list.scss
+++ b/addons/mail/static/src/core/common/message_reaction_list.scss
@@ -1,3 +1,9 @@
+.o-mail-MessageReaction:not(.o-selfReacted) {
+    &:hover {
+        --border-color: #{$primary};
+    }
+}
+
 .o-mail-MessageReactionList-preview {
     font-family: "text-emoji", $font-family-base;
 


### PR DESCRIPTION
Adding a hovering effect on the reaction icons in the message reactions, to make it more intuitive for the user to understand that they can click on them to add their own reaction.

Current behavior before PR:
![Peek 2024-08-06 141-29](https://github.com/user-attachments/assets/a15ec2df-9620-4ce5-9f0e-593559468cc0)

Desired behavior after PR is merged:
![Peek 2024-08-06 14-29](https://github.com/user-attachments/assets/2a1ef3e3-a3f7-46a5-a359-0243eebc2cf5)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
