### PR TITLE
[FIX] mail: no reply to on user notifications

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -290,7 +290,7 @@ export class Message extends Component {
     }
 
     get canReplyTo() {
-        return this.props.messageToReplyTo;
+        return this.props.messageToReplyTo && this.message.message_type !== "user_notification";
     }
 
     get canToggleStar() {

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -1587,6 +1587,26 @@ test("Can reply to chatter messages from history", async () => {
     await contains("button[title='Full composer']");
 });
 
+test("Can't reply to user notifications", async () => {
+    // User notifications are specific to a user
+    const pyEnv = await startServer();
+    const messageId = pyEnv["mail.message"].create({
+        body: "Dear Mitchell Admin, you have received a new rank",
+        message_type: "user_notification",
+        model: "res.partner",
+    });
+    pyEnv["mail.notification"].create({
+        mail_message_id: messageId,
+        notification_type: "inbox",
+        is_read: true,
+        res_partner_id: serverState.partnerId,
+    });
+    await start();
+    await openDiscuss("mail.box_history");
+    await contains(".o-mail-Message-actions");
+    await contains(".o-mail-Message-actions [title='Reply']", { count: 0 });
+});
+
 test("Mark as unread", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({


### PR DESCRIPTION
Before this commit:

It was possible to reply to a `user_notification` message. It doesn't make sense to reply to a `user_notification`. Moreover `user_notification`s doesn't necessarily have a related record. So, it is prone to errors.

After this commit:

No longer able to reply to  a `user_notification`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
