### PR TITLE
[FIX] product: traceback when changing product types

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -469,6 +469,7 @@ class ProductTemplate(models.Model):
                 raise UserError(_("Combo products can't have attributes"))
             self.taxes_id = False
             self.supplier_taxes_id = False
+        return {}
 
     def _get_related_fields_variant_template(self):
         """ Return a list of fields present on template and variants models and that are related"""


### PR DESCRIPTION
Steps to reproduce:
-go to any product's form view
-change the product type

Issue:
traceback occured when trying to change product type.

Cause:
not returning anything in _onchange_type method.

Fix:
return empty dictionary in _onchange_type method.

opw-4096074

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
