### PR TITLE
[FIX] stock_landed_costs: active currencies in tests

### DIFF
--- a/addons/stock_landed_costs/tests/test_stockvaluationlayer.py
+++ b/addons/stock_landed_costs/tests/test_stockvaluationlayer.py
@@ -586,6 +586,8 @@ class TestStockValuationLCFIFOVB(TestStockValuationLCCommon):
     def test_create_landed_cost_from_bill_multi_currencies(self):
         # create a vendor bill in EUR where base currency in USD
         company = self.env.user.company_id
+        currency_grp = self.env.ref('base.group_multi_currency')
+        self.env.user.write({'groups_id': [(4, currency_grp.id)]})
         usd_currency = self.env.ref('base.USD')
         eur_currency = self.env.ref('base.EUR')
         eur_currency.active = True  # EUR might not be active


### PR DESCRIPTION
The test of commit 34a42ddadab15 assumes the multi currency as well as Euro where activated. It's true only in case Enterprise modules are part of the installation.

This commit makes sure it's activated in all cases.

runbot error

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
