### PR TITLE
[IMP] core: start odoo with non-installable invalid modules

### DIFF
--- a/odoo/modules/__init__.py
+++ b/odoo/modules/__init__.py
@@ -11,6 +11,7 @@ from . import module
 from .module import (
     adapt_version,
     check_manifest_dependencies,
+    check_version,
     get_module_path,
     get_module_resource,  # backward-compatibility
     get_modules,


### PR DESCRIPTION
When reading manifests, there is a ValueError when the version of the module is not compatible with the version of Odoo. Instead of blocking the startup of Odoo, let it start and mark the module as not installable.

Use case: when testing upgrades, you may want to start a Odoo even if you have some modules on your addons-path that are not compatible with the current version (you just skip them).

task-4040096

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
