### PR TITLE
[FIX] website_links: fix select2 creation

### DIFF
--- a/addons/website_links/static/src/js/website_links.js
+++ b/addons/website_links/static/src/js/website_links.js
@@ -133,7 +133,7 @@ var SelectBox = publicWidget.Widget.extend({
      * @param {String} name
      */
     _createObject: function (name) {
-        return this.orm.call("utm.mixin", "find_or_create_record", [[], this.obj, name]).then(record => {
+        return this.orm.call("utm.mixin", "find_or_create_record", [this.obj, name]).then(record => {
             this.$el.attr('value', record);
         });
     },


### PR DESCRIPTION
Purpose
=======
Fix the traceback appearing when trying to create a new record using the select2 on the tracking page "/r".

Specification
=============
The "find_or_create_record" method takes 3 arguments but 4 were given. The first given argument (an empty array) isn't needed to call the method.

related commit: 68dc5be8279bc8e9cb4614bb774637ddd78aba83

Task-4100264

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
