### PR TITLE
[FIX] hr_homeworking_calendar: Adjust UI for small display

### DIFF
--- a/addons/hr_homeworking_calendar/static/src/calendar/common/calendar_common_renderer.scss
+++ b/addons/hr_homeworking_calendar/static/src/calendar/common/calendar_common_renderer.scss
@@ -33,6 +33,9 @@
 
 @include media-breakpoint-down(md) {
 
+    .location_xs_hide {
+        display: none !important;
+    }
 
     .fc-timeGridWeek-view .o_homework_multi {
         --o-homework-icon-size: 1rem;

--- a/addons/hr_homeworking_calendar/static/src/calendar/common/calendar_common_renderer.xml
+++ b/addons/hr_homeworking_calendar/static/src/calendar/common/calendar_common_renderer.xml
@@ -47,8 +47,8 @@
         </div>
         <div t-else="" class="w-100 d-flex align-items-center opacity-0 opacity-100-hover wl_action" data-create="1">
             <button t-if="!workLocationSetForCurrentUser" class="o_worklocation_text bg-info bg-opacity-25 border-0 rounded-pill px-lg-2 py-0 text-nowrap">
-                <i class="fa fa-map-marker me-lg-1" aria-hidden="true"></i>
-                <span class="d-lg-inline fw-bold">Set Location</span>
+                <i class="fa fa-map-marker me-1" aria-hidden="true"></i>
+                <span class="d-lg-inline fw-bold">Set<span class="location_xs_hide"> Location</span></span>
             </button>
             <button t-if="showLine" class="o_worklocation_line d-lg-block w-100 bg-info bg-opacity-25 border-0 p-0"/>
         </div>


### PR DESCRIPTION
Previously, the "(icon) set location" button on the calendar(in month view) overlapped onto two days when viewing on a smaller device. This fix replaces the text with "(icon) set" to better fit within the day cell on a smaller device.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
