### PR TITLE
[FIX] stock: change picking type reservation method on large DB

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -540,7 +540,7 @@ Please change the quantity done or the rounding precision of your unit of measur
                     move_line.quantity = 1
             move.write({'move_line_ids': move_lines_commands})
 
-    @api.depends('picking_type_id.reservation_method', 'picking_type_id', 'date', 'priority', 'state')
+    @api.depends('picking_type_id', 'date', 'priority', 'state')
     def _compute_reservation_date(self):
         for move in self:
             if move.picking_type_id.reservation_method == 'by_date' and move.state in ['draft', 'confirmed', 'waiting', 'partially_available']:

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -194,6 +194,22 @@ class PickingType(models.Model):
                         'prefix': vals['sequence_code'], 'padding': 5,
                         'company_id': picking_type.env.company.id,
                     })
+        if 'reservation_method' in vals:
+            if vals['reservation_method'] == 'by_date':
+                if picking_types := self.filtered(lambda p: p.reservation_method != 'by_date'):
+                    domain = [('picking_type_id', 'in', picking_types.ids), ('state', 'in', ('draft', 'confirmed', 'waiting', 'partially_available'))]
+                    group_by = ['picking_type_id']
+                    aggregates = ['id:recordset']
+                    for picking_type, moves in self.env['stock.move']._read_group(domain, group_by, aggregates):
+                        common_days = vals.get('reservation_days_before') or picking_type.reservation_days_before
+                        priority_days = vals.get('reservation_days_before_priority') or picking_type.reservation_days_before_priority
+                        for move in moves:
+                            move.reservation_date = fields.Date.to_date(move.date) - timedelta(days=priority_days if move.priority == '1' else common_days)
+            else:
+                if picking_types := self.filtered(lambda p: p.reservation_method == 'by_date'):
+                    moves = self.env['stock.move'].search([('picking_type_id', 'in', picking_types.ids), ('state', 'not in', ('assigned', 'done', 'cancel'))])
+                    moves.reservation_date = False
+
         return super(PickingType, self).write(vals)
 
     @api.depends('code')


### PR DESCRIPTION
### Issue:

Changing the reservation method of a picking type on a large DB might result in a memory error invalidating the requested change.

### Cause of the issue:

The dependency `picking_type_id.reservation_method` was introduced on the `_compute_reservation_date` method of stock moves by commit c4023d7. This dependency was introduced to remove the reservation date on all moves whose picking type reservation method is no more "date". Because of this new dependency, if one change the `reservation_method` of a picking type say manufacturing, it will fetch and "recompute" the `reservation_date` of all stock.moves whose picking type is manufacting. The ORM will handle these records 1000 by 1000 but if you happen to have a million records of that picking type (which is the case of the customer) all of these records will be added to the cache during the `_fetch_query`. This will lead to a Memory error since the cache is not cleared after a certain amount of computed records during the `_compute_reservation_date`.

opw-4019589
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
