### PR TITLE
[IMP] website: add new `s_image_text_overlap` snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -43,6 +43,7 @@
         'views/snippets/s_image_text.xml',
         'views/snippets/s_mockup_image.xml',
         'views/snippets/s_instagram_page.xml',
+        'views/snippets/s_image_text_overlap.xml',
         'views/snippets/s_banner.xml',
         'views/snippets/s_snippet_group.xml',
         'views/snippets/s_text_block.xml',

--- a/addons/website/views/snippets/s_image_text_overlap.xml
+++ b/addons/website/views/snippets/s_image_text_overlap.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_image_text_overlap" name="Image - Text Overlap">
+    <section class="s_image_text_overlap pt64 pb64">
+        <div class="container">
+            <div class="row o_grid_mode" data-row-count="9">
+                <div class="o_grid_item o_grid_item_image order-lg-0 g-col-lg-7 g-height-9 col-lg-7" style="grid-area: 1 / 1 / 10 / 8; --grid-item-padding-y: 0; z-index: 1; order: 2;">
+                    <img src="/web/image/website.s_picture_default_image" class="img img-fluid mx-auto rounded" alt=""/>
+                </div>
+                <div class="o_grid_item order-lg-0 g-col-lg-6 g-height-7 col-lg-6 o_cc o_cc5 rounded" style="grid-area: 2 / 7 / 9 / 13; --grid-item-padding-y: 56px; --grid-item-padding-x: 40px; z-index: 2; order: 1;">
+                    <h2 class="h3-fs">Services we offer</h2>
+                    <p>Write one or two paragraphs describing your product or services. To be successful your content needs to be useful to your readers.</p>
+                    <p>Start with the customer – find out what they want and give it to them.</p>
+                    <p><a href="#" class="btn btn-secondary">Learn more</a></p>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -118,6 +118,9 @@
                 <t t-snippet="website.s_image_text_box" string="Image Text Box" group="content">
                     <keywords>content, picture, photo, illustration, media, visual, article, story, combination, engage, call to action, cta, box, showcase</keywords>
                 </t>
+                <t t-snippet="website.s_image_text_overlap" string="Image - Text Overlap" group="content">
+                    <keywords>content, picture, photo, illustration, media, visual, article, story, combination, trendy, pattern, design</keywords>
+                </t>
                 <t t-snippet="website.s_call_to_action" string="Call to Action" group="content">
                     <keywords>CTA</keywords>
                 </t>


### PR DESCRIPTION
This commit introduces the new `s_image_text_overlap` content snippet.

task-4094368

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
