### PR TITLE
[FIX] pos_preparation_display: prevent splited order display

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -1087,6 +1087,13 @@ export class PosOrder extends Base {
             change: this.get_change() && formatCurrency(this.get_change()),
         };
     }
+    get originalSplittedOrder() {
+        const splittedOrderUuid = this.uiState.splittedOrderUuid;
+        if (splittedOrderUuid) {
+            return this.models["pos.order"].find((o) => o.uuid === splittedOrderUuid);
+        }
+        return null;
+    }
 }
 
 registry.category("pos_available_models").add(PosOrder.pythonModel, PosOrder);

--- a/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
+++ b/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
@@ -57,7 +57,6 @@ export class SplitBillScreen extends Component {
     async createSplittedOrder() {
         const curOrderUuid = this.currentOrder.uuid;
         const originalOrder = this.pos.models["pos.order"].find((o) => o.uuid === curOrderUuid);
-        this.pos.selectedTable = null;
         const newOrder = this.pos.add_new_order();
         newOrder.note = `${newOrder.tracking_number} Split from ${originalOrder.table_id.name}`;
         newOrder.uiState.splittedOrderUuid = curOrderUuid;
@@ -66,11 +65,12 @@ export class SplitBillScreen extends Component {
         const lineToDel = [];
         for (const line of originalOrder.lines) {
             if (this.qtyTracker[line.uuid]) {
-                this.pos.models["pos.order.line"].create(
+                const newLine = this.pos.models["pos.order.line"].create(
                     {
                         ...line.serialize(),
                         qty: this.qtyTracker[line.uuid],
                         order_id: newOrder.id,
+                        skip_change: true,
                     },
                     false,
                     true


### PR DESCRIPTION
Prior to this commit, splitting an order would create a new order, causing it to appear again on the preparation display. This could lead to the kitchen preparing the same order twice. The sequence of events was as follows:

1. The order is placed.
2. The kitchen receives and prepares the order.
3. The waiter delivers the order to the table.
4. The client receives the bill and requests a split.

At the point of splitting, a new order is created. This duplicate order should not be sent to the kitchen as it represents a meal that has already been prepared and consumed. This commit resolves this issue by preventing display of duplicate orders to the kitchen during order splitting.

Enterprise PR: https://github.com/odoo/enterprise/pull/68039

opw-4089558

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
