### PR TITLE
[FIX] web_editor: allow interacting with toolbar in list view

### DIFF
--- a/addons/web_editor/static/src/js/backend/list_editable_renderer.js
+++ b/addons/web_editor/static/src/js/backend/list_editable_renderer.js
@@ -1,0 +1,13 @@
+/** @odoo-module **/
+
+import ListRenderer from "web.ListRenderer";
+
+ListRenderer.include({
+    _onWindowClicked: function (event) {
+        // ignore clicks in the web_editor toolbar
+        if ($(event.target).closest(".oe-toolbar").length) {
+            return;
+        }
+        return this._super.apply(this, arguments);
+    },
+});

--- a/addons/web_editor/static/tests/field_html_tests.js
+++ b/addons/web_editor/static/tests/field_html_tests.js
@@ -4,6 +4,7 @@ odoo.define('web_editor.field_html_tests', function (require) {
 var ajax = require('web.ajax');
 var FormController = require('web.FormController');
 var FormView = require('web.FormView');
+const ListView = require('web.ListView');
 var testUtils = require('web.test_utils');
 var weTestUtils = require('web_editor.test_utils');
 var core = require('web.core');
@@ -1098,6 +1099,40 @@ QUnit.module('web_editor', {}, function () {
             assert.equal(form.$('.a').attr('contenteditable'), undefined);
 
             form.destroy();
+        });
+
+        QUnit.test("use the toolbar in a list view", async function (assert) {
+            const expectedValue = `<p>t<span style="font-size: 9px;">oto toto </span>toto</p><p>tata</p>`;
+            const list = await testUtils.createView({
+                View: ListView,
+                model: 'note.note',
+                data: this.data,
+                arch: `<tree editable="top">
+                    <field name="body" widget="html"/>
+                </tree>`,
+                mockRPC: function (route, args) {
+                    if (args.method === "write") {
+                        assert.step("write");
+                        assert.strictEqual(args.args[1].body, expectedValue, "should save the content");
+                    }
+                    return this._super.apply(this, arguments);
+                },
+            });
+            await testUtils.dom.click(".o_data_row:first [name=body]");
+            await legacyExtraNextTick();
+            await new Promise(resolve => setTimeout(resolve, 50));
+            const $field = $('.oe_form_field[name="body"]');
+            const pText = $field.find('.note-editable p').first().contents()[0];
+            Wysiwyg.setRange(pText, 1, pText, 10);
+            await testUtils.dom.click("#font-size button");
+            await testUtils.dom.click("#font-size a[data-arg1=9px]");
+            await testUtils.dom.click(".o_list_button_save");
+            assert.strictEqual(
+                $(".o_data_row:first [name=body] .o_readonly").html(),
+                expectedValue,
+            );
+            assert.verifySteps(["write"]);
+            list.destroy();
         });
 
 


### PR DESCRIPTION
Steps to reproduce
==================

- Go to Sales > Quotation
- Open any record
- Open studio
- Switch to the x2many list view
- Insert a new html field
- Exist studio
- Type some text in the html field
- Select a portion of it
- Click on the bold button

=> Nothing happens

Solution
========

Don't unselect the current row when clicking inside the editor toolbar

opw-4064662