### PR TITLE
[FIX] purchase_stock: fix supplier min qty on set as shipper

### DIFF
--- a/addons/purchase_stock/models/product.py
+++ b/addons/purchase_stock/models/product.py
@@ -130,8 +130,8 @@ class SupplierInfo(models.Model):
             orderpoint.route_id = self.env['stock.rule'].search([('action', '=', 'buy')], limit=1).route_id.id
         orderpoint.supplier_id = self
         supplier_min_qty = self.product_uom._compute_quantity(self.min_qty, orderpoint.product_id.uom_id)
-        if orderpoint.qty_to_order < supplier_min_qty:
-            orderpoint.qty_to_order = supplier_min_qty
+        if orderpoint.product_min_qty < supplier_min_qty:
+            orderpoint.product_min_qty = supplier_min_qty
         if self._context.get('replenish_id'):
             replenish = self.env['product.replenish'].browse(self._context.get('replenish_id'))
             replenish.supplier_id = self

--- a/doc/cla/individual/johnny-longneck.md
+++ b/doc/cla/individual/johnny-longneck.md
@@ -1,0 +1,11 @@
+Germany, 2024-07-29
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+John Herholz j.longneck@gmail.com https://github.com/johnny-longneck


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
[#175876](https://github.com/odoo/odoo/issues/175876)

Current behavior before PR:
On replenishment the set as shipper method sets the suppliers min qty in the orderpoint's qty to order
This is fatal, as it proposes a replenishment for a demand that is not there

Desired behavior after PR is merged:
set as shipper uses the suppliers min qty to populate the orderpoint's min qty field

EDIT: More Details:
The initial problem was, that you could not filter by supplier on new order points.
So it is necessary to click at least one time "Set supplier"
When the supplier that is chosen has a minimum quantity, this field will not be set to the orderpoints min qty.
Instead
It will directly set the quantity to order, ignoring stock forecast.

So when adding a new supplier to the system and having to set the supplier on all orderpoints,
**It will automatically create a quantity to order without checking forecast.**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
