### PR TITLE
[FIX] l10n_it_edi_website_sale: fix crash when submitting address

### DIFF
--- a/addons/l10n_it_edi_website_sale/controllers/main.py
+++ b/addons/l10n_it_edi_website_sale/controllers/main.py
@@ -25,7 +25,7 @@ class L10nITWebsiteSale(WebsiteSale):
                 error_messages.append(e.name)
 
         pa_index = address_values.get('l10n_it_pa_index')
-        if pa_index and len(pa_index) < 6 or len(pa_index) > 7:
+        if pa_index and (len(pa_index) < 6 or len(pa_index) > 7):
             invalid_fields.add('l10n_it_pa_index')
             error_messages.append(_("Destination Code (SDI) must have between 6 and 7 characters"))
 


### PR DESCRIPTION
Fix wrong condition introduced by odoo/odoo@453cfab75850 to avoid crashing on /shop/address/submit:

```
Traceback (most recent call last):
  ...
  File "/data/build/odoo/addons/website_sale/controllers/main.py", line 1189, in shop_address_submit
    invalid_fields, missing_fields, error_messages = self._validate_address_values(
                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/addons/l10n_it_edi_website_sale/controllers/main.py", line 28, in _validate_address_values
    if pa_index and len(pa_index) < 6 or len(pa_index) > 7:
                                         ^^^^^^^^^^^^^
TypeError: object of type 'NoneType' has no len()
```

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
