### PR TITLE
[FIX] account: disable prediction when creating from attachment

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -904,12 +904,14 @@ class AccountJournal(models.Model):
                 'move_type': move_type,
             })
 
-            invoice._extend_with_attachments(attachment, new=True)
+            invoice.with_context(
+                disable_onchange_name_predictive=True,
+            )._extend_with_attachments(attachment, new=True)
 
             all_invoices |= invoice
 
             invoice.with_context(
-                account_predictive_bills_disable_prediction=True,
+                disable_onchange_name_predictive=True,
                 no_new_invoice=True,
             ).message_post(attachment_ids=attachment.ids)
 


### PR DESCRIPTION
Data in the attachment should come first and we should not try to predict anything when creating from an attachment. Currently, the prediction overrides taxes set in an attachment.
See further details in odoo/enterprise#65102

no task



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
