### PR TITLE
[FIX] website: ensure JQuery is loaded before using it in new page

### DIFF
--- a/addons/website/static/src/components/dialog/add_page_dialog.js
+++ b/addons/website/static/src/components/dialog/add_page_dialog.js
@@ -1,4 +1,5 @@
 import { isBrowserFirefox } from "@web/core/browser/feature_detection";
+import { ensureJQuery } from "@web/core/ensure_jquery";
 import { rpc } from "@web/core/network/rpc";
 import { Deferred } from "@web/core/utils/concurrency";
 import { renderToElement } from "@web/core/utils/render";
@@ -203,6 +204,7 @@ export class AddPageTemplatePreview extends Component {
                 imgEl.setAttribute("loading", "eager");
             }
             mainEl.appendChild(wrapEl);
+            await ensureJQuery();
             await wUtils.onceAllImagesLoaded($(wrapEl));
             // Restore image lazy loading.
             for (const imgEl of lazyLoadedImgEls) {


### PR DESCRIPTION
Since [1] JQuery is not available by default in backend assets. It is however still used to wait for images to be loaded while displaying new page templates.

This commit ensures JQuery is loaded before using it.

Steps to reproduce:
- Create a New Page.

=> An error popup was displayed after a few seconds.

[1]: https://github.com/odoo/odoo/commit/b8fc93ea97b8870459063214d5cf468a6a3c6efe

task-4100272
