### PR TITLE
[FIX] mail, *: edit from header if having the rights

### DIFF
--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -319,6 +319,11 @@ export async function start(options) {
 export async function startServer() {
     const { env } = await makeMockServer();
     pyEnv = env;
+    pyEnv["res.users"].write([serverState.userId], {
+        groups_id: pyEnv["res.groups"]
+            .search_read([["id", "=", serverState.groupId]])
+            .map(({ id }) => id),
+    });
     return env;
 }
 

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -918,7 +918,7 @@ async function processRequest(request) {
         const domain = [
             "|",
             ["create_uid", "=", this.env.user.id],
-            ["group_ids", "in", this.env.user.groups_id.map((group) => group.id)],
+            ["group_ids", "in", this.env.user.groups_id],
         ];
         store.add(
             "CannedResponse",

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -249,14 +249,14 @@ export class DiscussChannel extends models.ServerModel {
             defaultDisplayMode: channel.default_display_mode,
             group_based_subscription: channel.group_ids.length > 0,
             is_editable: (() => {
-                switch (channel.channel_type) {
-                    case "channel":
-                        return channel.create_uid === this.env.uid;
-                    case "group":
-                        return Boolean(memberOfCurrentUser);
-                    default:
-                        return false;
+                if (channel.channel_type === "channel") {
+                    // Match the ACL rules
+                    return (
+                        !channel.group_public_id ||
+                        this.env.user.groups_id.includes(channel.group_public_id)
+                    );
                 }
+                return Boolean(memberOfCurrentUser);
             })(),
             memberCount: DiscussChannelMember.search_count([["channel_id", "=", channel.id]]),
             model: "discuss.channel",

--- a/addons/mail/views/discuss_channel_views.xml
+++ b/addons/mail/views/discuss_channel_views.xml
@@ -53,18 +53,18 @@
                         <div class="oe_button_box" name="button_box"/>
                         <field name="avatar_128" invisible="1"/>
                         <field name="is_editable" invisible="1"/>
-                        <field name="image_128" widget="image" class="oe_avatar" options="{'size': [90, 90], 'preview_image':'avatar_128'}" readonly="is_editable != 'True'"/>
+                        <field name="image_128" widget="image" class="oe_avatar" options="{'size': [90, 90], 'preview_image':'avatar_128'}" readonly="not is_editable"/>
                         <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                         <div class="oe_title">
                             <label for="name" string="Group Name"/>
                             <h1>
-                                #<field name="name" class="oe_inline" default_focus="1" placeholder="e.g. support" readonly="0"/>
+                                #<field name="name" class="oe_inline" default_focus="1" placeholder="e.g. support" readonly="not is_editable"/>
                             </h1>
                         </div>
                         <group class="o_label_nowrap">
                             <field name="active" invisible="1"/>
                             <field name="channel_type" groups="base.group_no_one"/>
-                            <field name="description" placeholder="Topics discussed in this group..."/>
+                            <field name="description" placeholder="Topics discussed in this group..." readonly="not is_editable"/>
                         </group>
                         <group class="o_label_nowrap" groups="base.group_no_one">
                             <field name="sfu_channel_uuid"/>
@@ -74,10 +74,10 @@
                             <page string="Privacy" name="privacy">
                                 <group class="o_label_nowrap">
                                     <field name="group_public_id"
-                                        invisible="channel_type != 'channel'"/>
+                                        invisible="channel_type != 'channel'" readonly="not is_editable"/>
                                     <field name="group_ids" widget="many2many_tags"
                                         invisible="channel_type != 'channel'"
-                                        string="Auto Subscribe Groups"/>
+                                        string="Auto Subscribe Groups" readonly="not is_editable"/>
                                 </group>
                             </page>
                             <page string="Members" name="members">

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -21,10 +21,13 @@ class TestDiscussFullPerformance(HttpCase):
     #     4: settings
     #     1: has_access_livechat
     _query_count_init_store = 17
-    _query_count = 50 + 1  # +1 is necessary to fix nondeterministic issue on runbot
+    # Queries for _query_count:
+    #     3: _compute_is_editable
+    _query_count = 53 + 1  # +1 is necessary to fix nondeterministic issue on runbot
     # Queries for _query_count_discuss_channels:
     #     1: bus last id
-    _query_count_discuss_channels = 70
+    #     3: _compute_is_editable
+    _query_count_discuss_channels = 73
 
     def setUp(self):
         super().setUp()
@@ -382,7 +385,7 @@ class TestDiscussFullPerformance(HttpCase):
                 "description": "General announcements for all employees.",
                 "group_based_subscription": True,
                 "invitedMembers": [["ADD", []]],
-                "is_editable": False,
+                "is_editable": True,
                 "is_pinned": True,
                 "last_interest_dt": False,
                 "message_needaction_counter": 0,
@@ -577,7 +580,7 @@ class TestDiscussFullPerformance(HttpCase):
                 "description": False,
                 "group_based_subscription": False,
                 "invitedMembers": [["ADD", []]],
-                "is_editable": False,
+                "is_editable": True,
                 "is_pinned": True,
                 "last_interest_dt": False,
                 "message_needaction_counter": 0,
@@ -607,7 +610,7 @@ class TestDiscussFullPerformance(HttpCase):
                 "description": False,
                 "group_based_subscription": False,
                 "invitedMembers": [["ADD", []]],
-                "is_editable": False,
+                "is_editable": True,
                 "is_pinned": True,
                 "last_interest_dt": False,
                 "message_needaction_counter": 0,
@@ -637,7 +640,7 @@ class TestDiscussFullPerformance(HttpCase):
                 "description": False,
                 "group_based_subscription": False,
                 "invitedMembers": [["ADD", []]],
-                "is_editable": False,
+                "is_editable": True,
                 "is_pinned": True,
                 "last_interest_dt": False,
                 "message_needaction_counter": 0,
@@ -667,7 +670,7 @@ class TestDiscussFullPerformance(HttpCase):
                 "description": False,
                 "group_based_subscription": False,
                 "invitedMembers": [["ADD", []]],
-                "is_editable": False,
+                "is_editable": True,
                 "is_pinned": True,
                 "last_interest_dt": False,
                 "message_needaction_counter": 0,
@@ -701,7 +704,7 @@ class TestDiscussFullPerformance(HttpCase):
                 "description": False,
                 "group_based_subscription": False,
                 "invitedMembers": [["ADD", []]],
-                "is_editable": False,
+                "is_editable": True,
                 "is_pinned": True,
                 "last_interest_dt": last_interest_dt,
                 "livechatChannel": {"id": self.im_livechat_channel.id, "name": "support"},
@@ -740,7 +743,7 @@ class TestDiscussFullPerformance(HttpCase):
                 "description": False,
                 "group_based_subscription": False,
                 "invitedMembers": [["ADD", []]],
-                "is_editable": False,
+                "is_editable": True,
                 "is_pinned": True,
                 "last_interest_dt": last_interest_dt,
                 "livechatChannel": {"id": self.im_livechat_channel.id, "name": "support"},


### PR DESCRIPTION
Edit channel name (or description) might be prevented on the header in
discuss, even though it's possible from the form view (config page).

If the ACL permits, it should be possible to edit from header too.

task-4100348
https://github.com/odoo/enterprise/pull/68140

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
