### PR TITLE
[FIX] stock_picking_batch: validate a wave with zero qty picking

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -207,7 +207,7 @@ class StockPickingBatch(models.Model):
         self._check_company()
         # Empty 'assigned' or 'waiting for another operation' pickings will be removed from the batch when it is validated.
         pickings = self.mapped('picking_ids').filtered(lambda picking: picking.state not in ('cancel', 'done'))
-        empty_waiting_pickings = self.mapped('picking_ids').filtered(lambda p: (p.state == 'waiting' and has_no_quantity(p)) or (p.state == 'assigned' and is_empty(p)))
+        empty_waiting_pickings = self.mapped('picking_ids').filtered(lambda p: (p.state in ('waiting', 'confirmed') and has_no_quantity(p)) or (p.state == 'assigned' and is_empty(p)))
         pickings = pickings - empty_waiting_pickings
 
         empty_pickings = set()

--- a/addons/stock_picking_batch/tests/test_wave_picking.py
+++ b/addons/stock_picking_batch/tests/test_wave_picking.py
@@ -602,3 +602,47 @@ class TestBatchPicking(TransactionCase):
         # check that the original picking was not added to a wave transfer
         self.assertFalse(picking.batch_id.filtered(lambda b: b.is_wave))
         self.assertEqual(picking.move_ids, move_1)
+
+    def test_validate_wave_with_zero_qty_picking(self):
+        """
+            Check that we can validate a wave transfer containing a picking without quantity.
+            In that case, the picking remains unchanged and is removed from the wave
+        """
+        (self.productA | self.productB).tracking = 'none'
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 10.0)
+        self.env['stock.quant']._update_available_quantity(self.productB, self.stock_location, 10.0)
+        picking_1, picking_2 = self.env['stock.picking'].create([
+            {'picking_type_id': self.picking_type_out},
+            {'picking_type_id': self.picking_type_out},
+        ])
+        self.env['stock.move'].create([
+            {
+            'name': self.productA.name,
+            'product_id': self.productA.id,
+            'product_uom_qty': 2,
+            'product_uom': self.productA.uom_id.id,
+            'picking_id': picking_1.id,
+            'location_id': picking_1.location_id.id,
+            'location_dest_id': picking_1.location_dest_id.id,
+            },
+            {
+            'name': self.productB.name,
+            'product_id': self.productB.id,
+            'product_uom_qty': 3,
+            'product_uom': self.productB.uom_id.id,
+            'picking_id': picking_2.id,
+            'location_id': picking_2.location_id.id,
+            'location_dest_id': picking_2.location_dest_id.id,
+            },
+        ])
+        (picking_1 | picking_2).action_confirm()
+        wave = self.env['stock.picking.batch'].create({
+            'name': 'Wave transfer',
+            'picking_ids': [Command.link(picking_1.id), Command.link(picking_2.id)],
+        })
+        self.assertEqual((picking_1 | picking_2).mapped('state'), ['assigned', 'assigned'])
+        picking_1.move_ids.quantity = 0.0
+        wave.action_done()
+        self.assertEqual(wave.state, 'done')
+        self.assertRecordValues(picking_1.move_ids, [{'state': 'confirmed', 'quantity': 0.0, 'picked': False}])
+        self.assertRecordValues(picking_2.move_ids, [{'state': 'done', 'quantity': 3.0, 'picked': True}])


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Create a storable product "A1" and "A2".
- Update their available quantity to 5.
- Create a picking with 5 units of "A1" and another picking with 5 units of "A2".
- Confirm both pickings.
- Create a new wave transfer and add both pickings.
- Update the quantity of "A1" to 0 units.
- Try to validate the wave.

**Problem:**
A user error is triggered: "You cannot validate a transfer if no quantities are reserved. To force the transfer, encode quantities."

**Solution:**
When the quantity of "A1" is updated to 0, the state of the picking becomes "confirmed" instead of "assigned" and as all the moves in this picking have a 0 quantity, we can exclude it from the wave and allow the wave validation.

opw-4016209
