### PR TITLE
[FIX] stock: don't rollback transaction if scheduler succeeeded

### DIFF
--- a/addons/stock/wizard/stock_scheduler_compute.py
+++ b/addons/stock/wizard/stock_scheduler_compute.py
@@ -37,7 +37,6 @@ class StockSchedulerCompute(models.TransientModel):
                 self.env['procurement.group'].with_context(allowed_company_ids=cids).run_scheduler(
                     use_new_cursor=self._cr.dbname,
                     company_id=company.id)
-            self._cr.rollback()
         return {}
 
     def procure_calculation(self):


### PR DESCRIPTION
Currently, when the stock scheduler is run, a new cursor is created and the result is rolled back even if all tasks succeeded. Even though tasks themselves are not rolled back because they are run using new other cursors, rolling it back is not correct and it makes harder to test the scheduler feature.

The rollback was introduced in [1], presumably by mistake.

This commit makes the transaction to be rolled back only when the current transaction actually failed.

[1]: https://github.com/odoo/odoo/commit/1a1a10b7

This is the same as #175621, but targeting 15.0 instead of 17.0.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
