### PR TITLE
[FIX] pos_restaurant: go to linked table

### DIFF
--- a/addons/pos_restaurant/static/src/app/models/restaurant_table.js
+++ b/addons/pos_restaurant/static/src/app/models/restaurant_table.js
@@ -16,6 +16,9 @@ export class RestaurantTable extends Base {
     isParent(t) {
         return t.parent_id && (t.parent_id.id === this.id || this.isParent(t.parent_id));
     }
+    getParent() {
+        return this.parent_id?.getParent() || this;
+    }
     getParentSide() {
         if (!this.parent_id) {
             return;

--- a/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
@@ -66,6 +66,19 @@ patch(Navbar.prototype, {
     get showTableIcon() {
         return this.getTable()?.name && this.pos.showBackButton();
     },
+    getTableName() {
+        const table = this.getTable();
+        const child_tables = this.pos.models["restaurant.table"].filter((t) => {
+            if (t.floor_id.id === table.floor_id.id) {
+                return table.isParent(t);
+            }
+        });
+        let name = table.name;
+        for (const child_table of child_tables) {
+            name += ` & ${child_table.name}`;
+        }
+        return name;
+    },
     onSwitchButtonClick() {
         const mode = this.pos.floorPlanStyle === "kanban" ? "default" : "kanban";
         localStorage.setItem("floorPlanStyle", mode);

--- a/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.xml
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.xml
@@ -14,7 +14,7 @@
         <xpath expr="//div[hasclass('pos-rightheader')]" position="before">
             <div t-if="pos.config.module_pos_restaurant" class="ms-1 d-flex overflow-hidden position-relative">
                 <span t-if="showTableIcon"
-                    t-esc="getTable().name"
+                    t-esc="getTableName()"
                     t-attf-style="background-color: {{getTable().color}};border-radius: 0.25rem;"
                     class="table-name text-white fw-bolder px-3 my-2 me-1 py-1 d-flex align-items-center" 
                     t-on-click="() => this.switchTable()"/>

--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -287,6 +287,9 @@ patch(PosStore.prototype, {
     async setTableFromUi(table, orderUuid = null) {
         try {
             this.tableSyncing = true;
+            if (table.parent_id) {
+                table = table.getParent();
+            }
             await this.setTable(table, orderUuid);
         } catch (e) {
             if (!(e instanceof ConnectionLostError)) {

--- a/addons/pos_restaurant/static/tests/tours/floor_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/floor_screen_tour.js
@@ -148,6 +148,10 @@ registry.category("web_tour.tours").add("FloorScreenTour", {
 
             // Check the linking of tables
             FloorScreen.clickFloor("Main Floor"),
+            FloorScreen.clickTable("4"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            ProductScreen.back(),
+            FloorScreen.isShown(),
             FloorScreen.linkTables("5", "4"),
             FloorScreen.isChildTable("5"),
             Utils.refresh(),
@@ -155,8 +159,13 @@ registry.category("web_tour.tours").add("FloorScreenTour", {
 
             // Check that tables are unlinked automatically when the order is done
             FloorScreen.clickTable("5"),
-            ProductScreen.tableNameShown("4"),
-            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            ProductScreen.tableNameShown("4 & 5"),
+            ProductScreen.selectedOrderlineHas("Coca-Cola", "1.0"),
+            ProductScreen.back(),
+            FloorScreen.isShown(),
+            FloorScreen.goTo("5"),
+            ProductScreen.tableNameShown("4 & 5"),
+            ProductScreen.selectedOrderlineHas("Coca-Cola", "1.0"),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Cash"),
             PaymentScreen.clickValidate(),

--- a/addons/pos_restaurant/static/tests/tours/utils/floor_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/floor_screen_util.js
@@ -1,4 +1,6 @@
 import { queryOne } from "@odoo/hoot-dom";
+import * as NumberPopup from "@point_of_sale/../tests/tours/utils/number_popup_util";
+import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 
 export function table({ name, withClass = "", withoutClass, run = () => {}, numOfSeats }) {
     let trigger = `.floor-map .table${withClass}`;
@@ -51,6 +53,17 @@ export function clickSaveEditButton() {
             trigger: '.edit-buttons button:contains("Save")',
             run: "click",
         },
+    ];
+}
+export function goTo(name) {
+    return [
+        {
+            content: `click on Go To button`,
+            trigger: `.pos-topheader .btn:contains("Go to...")`,
+            run: "click",
+        },
+        ...NumberPopup.enterValue(name),
+        Dialog.confirm(),
     ];
 }
 export function selectedFloorIs(name) {


### PR DESCRIPTION
Using the table switcher feature on linked table would lead the user to the table selected instead of the parent of it. This is now changed.

This commit also changes the name of the table selected displayed on the navbar. Before we were only showing the name of the parent table, it now displays the name of the table selected and the child tables.

task-id: 4087019

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
