### PR TITLE
[FIX] sale: allow saleman without billing access to create invoice

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1221,7 +1221,7 @@ class SaleOrder(models.Model):
         """
         self.ensure_one()
 
-        txs_to_be_linked = self.transaction_ids.filtered(
+        txs_to_be_linked = self.transaction_ids.sudo().filtered(
             lambda tx: (
                 tx.state in ('pending', 'authorized')
                 or tx.state == 'done' and not (tx.payment_id and tx.payment_id.is_reconciled)


### PR DESCRIPTION
To reproduce (on runbot):
- Enable "Wire Transfer" payment provider
- Remove any "Accounting" rights on "demo" user
- As "demo" user, create a SO for Joel Willis
- As "portal" user, sign and pay with Wire Trransfer
- Then as "demo" user, confirm manually the SO and create the invoice

=> It raises an AccessError that user don't have the rights to read
  `payment.transaction`

Following odoo/odoo@2b1e2abda3df we should still allow sale user without billing access to create invoices from SO.

This commit adds a missing sudo from odoo/odoo@d9de20aca3d0

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
