### PR TITLE
[FIX] project : share project from SO smart button

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -645,6 +645,8 @@ class Project(models.Model):
         local_context = self.env.context | {
             'default_template_id': template.id if template else False,
             'default_email_layout_xmlid': 'mail.mail_notification_light',
+            'active_model': 'project.project',
+            'active_id': self.id,
         }
         action = self.env["ir.actions.actions"]._for_xml_id("project.project_share_wizard_action")
         if self.env.context.get('default_access_mode'):


### PR DESCRIPTION
### Steps to reproduce:
	- Install Sale and Project modules
	- Create a service product that creates project
	- Create a quotation with the created service product and confirm it
	- Click on the project smart button
	- Try sharing the project

### Current behavior before PR:
An error gets triggered when trying to share a project from SO. This happens because the share link that is shown in the share project wizard is not the correct one /mail/view?model=sale.order&res_id=318&access_token=" it will have the sale.order data because of the action_stack the context will have the active_model as sale.order and active_id as SO id which will lead to generation of the wrong link.

### Desired behavior after PR is merged:
While opening the share project wizard we will add the project's data to the context to replace the sale.order data so we can have the link generated correctly /mail/view?model=project.project&res_id=178&access_token=

opw-4087926