### PR TITLE
[FIX] account_edi_ubl_cii: XRechnung should fills the ActualDeliveryDate

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_xrechnung.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_xrechnung.py
@@ -20,6 +20,13 @@ class AccountEdiXmlUBLDE(models.AbstractModel):
             'credit_note': 'de.xrechnung:ubl-creditnote:2.2.0',
         }
 
+    def _get_delivery_vals_list(self, invoice):
+        # EXTENDS account.edi.xml.ubl_21
+        vals_list = super()._get_delivery_vals_list(invoice)
+        for vals in vals_list:
+            vals['actual_delivery_date'] = invoice.delivery_date or invoice.invoice_date
+        return vals_list
+
     def _export_invoice_vals(self, invoice):
         # EXTENDS account.edi.xml.ubl_bis3
         vals = super()._export_invoice_vals(invoice)

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_public_admin_1.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_public_admin_1.xml
@@ -77,7 +77,6 @@
     </cac:Party>
   </cac:AccountingCustomerParty>
   <cac:Delivery>
-    <cbc:ActualDeliveryDate>2017-01-01</cbc:ActualDeliveryDate>
     <cac:DeliveryLocation>
       <cac:Address>
         <cbc:StreetName>Rue des Bourlottes 9</cbc:StreetName>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_public_admin_2.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_public_admin_2.xml
@@ -77,7 +77,6 @@
     </cac:Party>
   </cac:AccountingCustomerParty>
   <cac:Delivery>
-    <cbc:ActualDeliveryDate>2017-01-01</cbc:ActualDeliveryDate>
     <cac:DeliveryLocation>
       <cac:Address>
         <cbc:StreetName>Chaussée de Namur 40</cbc:StreetName>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/xrechnung_ubl_out_invoice.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/xrechnung_ubl_out_invoice.xml
@@ -79,6 +79,7 @@
     </cac:Party>
   </cac:AccountingCustomerParty>
   <cac:Delivery>
+    <cac:ActualDeliveryDate>2017-01-01</cac:ActualDeliveryDate>
     <cac:DeliveryLocation>
       <cac:Address>
         <cbc:StreetName>Europa-Park-Straße 2</cbc:StreetName>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/xrechnung_ubl_out_refund.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/xrechnung_ubl_out_refund.xml
@@ -78,6 +78,7 @@
     </cac:Party>
   </cac:AccountingCustomerParty>
   <cac:Delivery>
+    <cac:ActualDeliveryDate>2017-01-01</cac:ActualDeliveryDate>
     <cac:DeliveryLocation>
       <cac:Address>
         <cbc:StreetName>Europa-Park-Straße 2</cbc:StreetName>


### PR DESCRIPTION
Error received by a DE customer when sending an invoice to a DE company: "Your XRechnung does not contain a billing period or a delivery or service date (mandatory information according to § 14 UStG). The information must be entered in the fields BT-72 for a delivery date or BT-73 and BT-74 for a period."

This node seems optional in Bis 3.0.

opw-4087527