### PR TITLE
[FIX] l10n_fi: wrong invoice label for new 25.5% tax

### DIFF
--- a/addons/l10n_fi/data/template/account.tax-fi.csv
+++ b/addons/l10n_fi/data/template/account.tax-fi.csv
@@ -1,5 +1,5 @@
 "id","name","description","invoice_label","amount","tax_group_id","type_tax_use","amount_type","active","price_include","include_base_amount","repartition_line_ids/repartition_type","repartition_line_ids/document_type","repartition_line_ids/account_id","repartition_line_ids/tag_ids","repartition_line_ids/factor_percent","description@fi","invoice_label@fi"
-"tax_dom_sales_goods_25_5","25.5%","","25%","25.5","tax_group_25_5","sale","percent","","","","base","invoice","","","","","25.5%"
+"tax_dom_sales_goods_25_5","25.5%","","25.5%","25.5","tax_group_25_5","sale","percent","","","","base","invoice","","","","","25.5%"
 "","","","","","","","","","","","tax","invoice","account_2930","+fi_320","","",""
 "","","","","","","","","","","","base","refund","","","","",""
 "","","","","","","","","","","","tax","refund","account_2930","-fi_320","","",""


### PR DESCRIPTION
Description of the issue this commit addresses:

Wrong invoice label for the tax 25.5 which shows 25%.

---

Desired behavior after this commit is merged:

The tax has the label 25.5% on invoices.

---

no task-feedback

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
