### PR TITLE
[FIX] *: add .translate to untranslated props

### DIFF
--- a/addons/html_editor/static/src/main/chatgpt/chatgpt_translate_dialog.xml
+++ b/addons/html_editor/static/src/main/chatgpt/chatgpt_translate_dialog.xml
@@ -1,7 +1,7 @@
 <templates id="template" xml:space="preserve">
 
 <t t-name="html_editor.ChatGPTTranslateDialog">
-    <Dialog size="'lg'" title="'Translate with AI'">
+    <Dialog size="'lg'" title.translate="Translate with AI">
         <div t-if="state.translationInProgress" class="d-flex">
             <img src="/web/static/img/spin.svg" alt="Loading..." class="me-2"
                 style="filter:invert(1); opacity: 0.5; width: 30px; height: 30px;" />

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_translate_dialog.xml
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/chatgpt_translate_dialog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="web_editor.ChatGPTTranslateDialog">
-        <Dialog size="'lg'" title="'Translate with AI'">
+        <Dialog size="'lg'" title.translate="Translate with AI">
             <div t-if="state.translationInProgress" class="d-flex">
                 <img src="/web/static/img/spin.svg" alt="Loading..." class="me-2"
                     style="filter:invert(1); opacity: 0.5; width: 30px; height: 30px;" />

--- a/addons/website/static/src/client_actions/website_dashboard/website_dashboard.xml
+++ b/addons/website/static/src/client_actions/website_dashboard/website_dashboard.xml
@@ -43,7 +43,7 @@
                 </div>
                 <div class="o_buttons text-center">
                     <h3>Easily track your visitor with Plausible</h3>
-                    <DocumentationLink path="'/applications/websites/website/reporting/plausible.html'" label="'Connect Plausible'"/>
+                    <DocumentationLink path="'/applications/websites/website/reporting/plausible.html'" label.translate="Connect Plausible"/>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
add .translate to untranslated props.
This commit fixes the props that pass strings to use `.translate`
introduced in: https://github.com/odoo/odoo/pull/174697

Enterprise: https://github.com/odoo/enterprise/pull/68048