### PR TITLE
[FIX] mail: chat bubble of DM chat props validation

### DIFF
--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -14,7 +14,7 @@
         <button class="o-mail-ChatBubble" t-att-name="props.chatWindow.displayName" t-att-class="{ 'o-bouncing': state.bouncing, 'position-fixed': env.embedLivechat, 'position-relative': !env.embedLivechat, 'o-active': preview.isOpen }" t-att-style="env.embedLivechat ? `top: ${ position.top }; left: ${ position.left };` : ''" t-on-click="() => props.chatWindow.open()" t-on-animationend="() => state.bouncing = false" t-ref="root">
             <div t-if="thread?.importantCounter > 0" class="o-mail-ChatBubble-counter position-absolute badge rounded-pill fw-bold o-discuss-badge shadow" t-out="thread?.importantCounter"/>
             <button t-if="state.showClose and !env.embedLivechat" class="o-mail-ChatBubble-close position-absolute shadow rounded-circle fw-bold bg-view" title="Close Chat Window" t-on-click.stop="() => this.props.chatWindow.close()"><i class="oi oi-close"/></button>
-            <ImStatus t-if="thread?.correspondent?.persona?.im_status and thread?.correspondent?.persona?.im_status != 'offline'" className="'o-mail-ChatBubble-status position-absolute o-mail-brighter'" member="thread.correspondent" thread="thread"/>
+            <ImStatus t-if="thread?.correspondent?.persona?.im_status and thread?.correspondent?.persona?.im_status != 'offline'" className="'o-mail-ChatBubble-status position-absolute o-mail-brighter'" member="thread.correspondent"/>
             <button class="o-mail-ChatHub-bubbleBtn btn">
                 <img class="o-mail-ChatBubble-avatar rounded-circle" t-att-class="{ 'o-big': env.embedLivechat }" t-att-src="thread?.avatarUrl" alt="Thread image" draggable="false"/>
             </button>

--- a/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
+++ b/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
@@ -386,3 +386,20 @@ test("Compacted chat hub shows badge with amount of hidden chats with important 
     await contains(".o-mail-ChatBubble i.fa.fa-commenting");
     await contains(".o-mail-ChatBubble .o-discuss-badge", { text: "9" });
 });
+
+test("Show IM status", async () => {
+    const pyEnv = await startServer();
+    const demoId = pyEnv["res.partner"].create({ name: "Demo User", im_status: "online" });
+    pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({
+                fold_state: "folded",
+                partner_id: serverState.partnerId,
+            }),
+            Command.create({ partner_id: demoId }),
+        ],
+        channel_type: "chat",
+    });
+    await start();
+    await contains(".o-mail-ChatBubble .fa-circle.text-success[aria-label='User is online']");
+});


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/175287

PR above changed `ImStatus` component to support passing a `member`, so that we no longer need to pass `thread`.

However, one occurrence was still passing `thread`, even though it was properly passing `member`. This is not a problem in non-debug mode, but in debug mode this crashes because `ImStatus` component does not expect a prop `thread`.
