### PR TITLE
[IMP] website: introduce `s_big_number` snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -100,6 +100,7 @@
         'views/snippets/s_discovery.xml',
         'views/snippets/s_striped.xml',
         'views/snippets/s_intro_pill.xml',
+        'views/snippets/s_big_number.xml',
         'views/snippets/s_text_highlight.xml',
         'views/snippets/s_pricelist_cafe.xml',
         'views/snippets/s_progress_bar.xml',

--- a/addons/website/views/snippets/s_big_number.xml
+++ b/addons/website/views/snippets/s_big_number.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_big_number" name="Big number">
+    <section class="s_big_number o_half_screen_height o_cc o_cc5 pt104 pb104" data-oe-shape-data="{'shape':'web_editor/Rainy/09_001','flip':[],'showOnMobile':false}">
+        <div class="o_we_shape o_web_editor_Rainy_09_001"/>
+        <div class="container">
+            <div class="row s_nb_column_fixed">
+                <h2 style="text-align: center;">
+                    <div style="font-size: 10.75rem;">
+                        <font class="text-gradient" style="background-image: linear-gradient(0deg, rgb(222, 222, 222) 25%, rgb(29, 32, 48) 80%);">
+                            87%
+                        </font>
+                    </div>
+                </h2>
+                <div style="font-size: 2.25rem; text-align: center;">customer satisfaction</div>
+            </div>
+        </div>
+    </section>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/s_discovery.xml
+++ b/addons/website/views/snippets/s_discovery.xml
@@ -2,8 +2,8 @@
 <odoo>
 
 <template id="s_discovery" name="Discovery">
-    <section class="s_discovery pt136 pb136" style="text-align: center;">
-        <div class="container">
+    <section class="s_discovery pt136 pb136">
+        <div class="container" style="text-align: center;">
             <span class="s_cta_badge o_cc o_cc1 d-inline-block my-3 border rounded py-2 px-3 o_animable" data-snippet="s_cta_badge" data-name="CTA Badge" style="border-radius: 32px !important;">
                 <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;What do you want to promote&amp;nbsp;? &#160;&#160;&#160;&#160;<a href="#">See more <i class="fa fa-long-arrow-right" role="img"/></a>
             </span>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -159,6 +159,9 @@
                 <t t-snippet="website.s_numbers_grid" string="Numbers Grid" group="content">
                     <keywords>statistics, stats, KPI, metrics, dashboard, analytics, highlights, figures, performance, achievements, benchmarks, milestones, indicators, data, measurements, reports, trends, results</keywords>
                 </t>
+                <t t-snippet="website.s_big_number" string="Big number" group="content">
+                    <keywords>statistics, stats, KPI, metrics, dashboard, analytics, highlights, figures, performance, achievements, benchmarks, milestones, indicators, data, measurements, reports, trends, results, analytics, summaries, summary, large-figures, prominent, standout</keywords>
+                </t>
                 <t t-snippet="website.s_features" string="Features" group="content">
                     <keywords>promotion, characteristic, quality</keywords>
                 </t>


### PR DESCRIPTION
This PR introduces the new `s_big_number` snippet.

It also fixes an issue within `s_discovery` about a text alignment style
being applied on the section directly, which can't be reproduced within
the editor and then mislead the user with the wrong `text-align` icon
being activated.


- requires : https://github.com/odoo/design-themes/pull/894

| Snippet in use |
|--------|
| <img width="1474" alt="image" src="https://github.com/user-attachments/assets/a8da23dc-fb7f-46a3-8db7-b20ef17a3352"> | 

task-4094391
Part of task-4077427

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr