### PR TITLE
[FIX] mail: improve activity state search method

### DIFF
--- a/addons/hr_contract/tests/test_hr_contract_history_groupby.py
+++ b/addons/hr_contract/tests/test_hr_contract_history_groupby.py
@@ -15,14 +15,12 @@ class TestHrContractHistoryGroupby(TransactionCase):
             LEFT JOIN (
                     SELECT res_id,
                         CASE
-                            WHEN min(EXTRACT(day from (mail_activity.date_deadline - DATE_TRUNC('day', %s AT TIME ZONE COALESCE(res_partner.tz, %s))))) > 0 THEN 'planned'
-                            WHEN min(EXTRACT(day from (mail_activity.date_deadline - DATE_TRUNC('day', %s AT TIME ZONE COALESCE(res_partner.tz, %s))))) < 0 THEN 'overdue'
-                            WHEN min(EXTRACT(day from (mail_activity.date_deadline - DATE_TRUNC('day', %s AT TIME ZONE COALESCE(res_partner.tz, %s))))) = 0 THEN 'today'
+                            WHEN min(EXTRACT(day from (mail_activity.date_deadline - DATE_TRUNC('day', %s AT TIME ZONE COALESCE(mail_activity.user_tz, %s))))) > 0 THEN 'planned'
+                            WHEN min(EXTRACT(day from (mail_activity.date_deadline - DATE_TRUNC('day', %s AT TIME ZONE COALESCE(mail_activity.user_tz, %s))))) < 0 THEN 'overdue'
+                            WHEN min(EXTRACT(day from (mail_activity.date_deadline - DATE_TRUNC('day', %s AT TIME ZONE COALESCE(mail_activity.user_tz, %s))))) = 0 THEN 'today'
                             ELSE null
                         END AS activity_state
                         FROM mail_activity
-                        JOIN res_users ON (res_users.id = mail_activity.user_id)
-                        JOIN res_partner ON (res_partner.id = res_users.partner_id)
                         WHERE res_model = %s AND mail_activity.active = TRUE
                         GROUP BY res_id
                     ) AS "hr_contract__last_activity_state"

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -93,6 +93,7 @@ class MailActivity(models.Model):
         'res.users', 'Assigned to',
         default=lambda self: self.env.user,
         index=True, required=True, ondelete='cascade')
+    user_tz = fields.Selection(string='Timezone', related="user_id.tz", store=True)
     request_partner_id = fields.Many2one('res.partner', string='Requesting Partner')
     state = fields.Selection([
         ('overdue', 'Overdue'),

--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -163,40 +163,33 @@ class MailActivityMixin(models.AbstractModel):
         search_states_int = {integer_state_value.get(s or False) for s in search_states}
 
         self.env['mail.activity'].flush_model(['active', 'date_deadline', 'res_model', 'user_id'])
-        query = """
-          SELECT res_id
-            FROM (
-                SELECT res_id,
-                       -- Global activity state
-                       MIN(
-                            -- Compute the state of each individual activities
-                            -- -1: overdue
-                            --  0: today
-                            --  1: planned
-                           SIGN(EXTRACT(day from (
-                                mail_activity.date_deadline - DATE_TRUNC('day', %(today_utc)s AT TIME ZONE res_partner.tz)
-                           )))
-                        )::INT AS activity_state
-                  FROM mail_activity
-             LEFT JOIN res_users
-                    ON res_users.id = mail_activity.user_id
-             LEFT JOIN res_partner
-                    ON res_partner.id = res_users.partner_id
-                 WHERE mail_activity.res_model = %(res_model_table)s AND mail_activity.active = true 
-              GROUP BY res_id
-            ) AS res_record
-          WHERE %(search_states_int)s @> ARRAY[activity_state]
-        """
-
-        self._cr.execute(
-            query,
-            {
-                'today_utc': pytz.utc.localize(datetime.utcnow()),
-                'res_model_table': self._name,
-                'search_states_int': list(search_states_int)
-            },
+        query = SQL(
+            """(
+            SELECT res_id
+                FROM (
+                    SELECT res_id,
+                        -- Global activity state
+                        MIN(
+                                -- Compute the state of each individual activities
+                                -- -1: overdue
+                                --  0: today
+                                --  1: planned
+                            SIGN(EXTRACT(day from (
+                                    mail_activity.date_deadline - DATE_TRUNC('day', %(today_utc)s AT TIME ZONE COALESCE(mail_activity.user_tz, 'utc'))
+                            )))
+                            )::INT AS activity_state
+                    FROM mail_activity
+                    WHERE mail_activity.res_model = %(res_model_table)s AND mail_activity.active = true
+                GROUP BY res_id
+                ) AS res_record
+            WHERE %(search_states_int)s @> ARRAY[activity_state]
+            )""",
+            today_utc=pytz.utc.localize(datetime.utcnow()),
+            res_model_table=self._name,
+            search_states_int=list(search_states_int)
         )
-        return [('id', 'not in' if reverse_search else 'in', [r[0] for r in self._cr.fetchall()])]
+
+        return [('id', 'not in' if reverse_search else 'in', query)]
 
     @api.depends('activity_ids.date_deadline')
     def _compute_activity_date_deadline(self):
@@ -274,14 +267,12 @@ class MailActivityMixin(models.AbstractModel):
             """
             (SELECT res_id,
                 CASE
-                    WHEN min(EXTRACT(day from (mail_activity.date_deadline - DATE_TRUNC('day', %(today_utc)s AT TIME ZONE COALESCE(res_partner.tz, %(tz)s))))) > 0 THEN 'planned'
-                    WHEN min(EXTRACT(day from (mail_activity.date_deadline - DATE_TRUNC('day', %(today_utc)s AT TIME ZONE COALESCE(res_partner.tz, %(tz)s))))) < 0 THEN 'overdue'
-                    WHEN min(EXTRACT(day from (mail_activity.date_deadline - DATE_TRUNC('day', %(today_utc)s AT TIME ZONE COALESCE(res_partner.tz, %(tz)s))))) = 0 THEN 'today'
+                    WHEN min(EXTRACT(day from (mail_activity.date_deadline - DATE_TRUNC('day', %(today_utc)s AT TIME ZONE COALESCE(mail_activity.user_tz, %(tz)s))))) > 0 THEN 'planned'
+                    WHEN min(EXTRACT(day from (mail_activity.date_deadline - DATE_TRUNC('day', %(today_utc)s AT TIME ZONE COALESCE(mail_activity.user_tz, %(tz)s))))) < 0 THEN 'overdue'
+                    WHEN min(EXTRACT(day from (mail_activity.date_deadline - DATE_TRUNC('day', %(today_utc)s AT TIME ZONE COALESCE(mail_activity.user_tz, %(tz)s))))) = 0 THEN 'today'
                     ELSE null
                 END AS activity_state
             FROM mail_activity
-            JOIN res_users ON (res_users.id = mail_activity.user_id)
-            JOIN res_partner ON (res_partner.id = res_users.partner_id)
             WHERE res_model = %(res_model)s AND mail_activity.active = true
             GROUP BY res_id)
             """,

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -965,47 +965,48 @@ class TestORM(TestActivityCommon):
         # Don't mistake fields date and date_deadline:
         # * date is just a random value
         # * date_deadline defines activity_state
-        self.env['mail.test.activity'].create({
-            'date': '2021-05-02',
-            'name': "Yesterday, all my troubles seemed so far away",
-        }).activity_schedule(
-            'test_mail.mail_act_test_todo',
-            summary="Make another test super asap (yesterday)",
-            date_deadline=fields.Date.context_today(MailTestActivityCtx) - timedelta(days=7),
-        )
-        self.env['mail.test.activity'].create({
-            'date': '2021-05-09',
-            'name': "Things we said today",
-        }).activity_schedule(
-            'test_mail.mail_act_test_todo',
-            summary="Make another test asap",
-            date_deadline=fields.Date.context_today(MailTestActivityCtx),
-        )
-        self.env['mail.test.activity'].create({
-            'date': '2021-05-16',
-            'name': "Tomorrow Never Knows",
-        }).activity_schedule(
-            'test_mail.mail_act_test_todo',
-            summary="Make a test tomorrow",
-            date_deadline=fields.Date.context_today(MailTestActivityCtx) + timedelta(days=7),
-        )
+        with freeze_time("2024-09-24 10:00:00"):
+            self.env['mail.test.activity'].create({
+                'date': '2021-05-02',
+                'name': "Yesterday, all my troubles seemed so far away",
+            }).activity_schedule(
+                'test_mail.mail_act_test_todo',
+                summary="Make another test super asap (yesterday)",
+                date_deadline=fields.Date.context_today(MailTestActivityCtx) - timedelta(days=7),
+            )
+            self.env['mail.test.activity'].create({
+                'date': '2021-05-09',
+                'name': "Things we said today",
+            }).activity_schedule(
+                'test_mail.mail_act_test_todo',
+                summary="Make another test asap",
+                date_deadline=fields.Date.context_today(MailTestActivityCtx),
+            )
+            self.env['mail.test.activity'].create({
+                'date': '2021-05-16',
+                'name': "Tomorrow Never Knows",
+            }).activity_schedule(
+                'test_mail.mail_act_test_todo',
+                summary="Make a test tomorrow",
+                date_deadline=fields.Date.context_today(MailTestActivityCtx) + timedelta(days=7),
+            )
 
-        domain = [('date', "!=", False)]
-        groupby = "date:week"
-        progress_bar = {
-            'field': 'activity_state',
-            'colors': {
-                "overdue": 'danger',
-                "today": 'warning',
-                "planned": 'success',
+            domain = [('date', "!=", False)]
+            groupby = "date:week"
+            progress_bar = {
+                'field': 'activity_state',
+                'colors': {
+                    "overdue": 'danger',
+                    "today": 'warning',
+                    "planned": 'success',
+                }
             }
-        }
 
-        # call read_group to compute group names
-        groups = MailTestActivityCtx.read_group(domain, fields=['date'], groupby=[groupby])
-        progressbars = MailTestActivityCtx.read_progress_bar(domain, group_by=groupby, progress_bar=progress_bar)
-        self.assertEqual(len(groups), 3)
-        self.assertEqual(len(progressbars), 3)
+            # call read_group to compute group names
+            groups = MailTestActivityCtx.read_group(domain, fields=['date'], groupby=[groupby])
+            progressbars = MailTestActivityCtx.read_progress_bar(domain, group_by=groupby, progress_bar=progress_bar)
+            self.assertEqual(len(groups), 3)
+            self.assertEqual(len(progressbars), 3)
 
         # format the read_progress_bar result to get a dictionary under this
         # format: {activity_state: group_name}; the original format


### PR DESCRIPTION
The method _search_activity_state is trigger each time someone click on the progress bar of lead kanban view and at many other occasion.

This search can take up to 2 seconds + a seconds query id in a very long list of ids that take also 2 seconds to run.

This PR improve the perf of this search by removing join with huge table (res_users and res_partner) by storing the tz on the activity itself.

The tz is only compute when the user is set and not when the user change its timezone. It seems acceptable to keep the timezone of the user at the moment of creation of the activity.

The second improvement remove the additional query by directly injecting the domain in the query.

With both improvement the _search_activity_state spend 600ms instead of 4000ms for the same search.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
