### PR TITLE
[FIX] survey: fallback so that there is always next_page_or_question

### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -318,6 +318,9 @@ class Survey(http.Controller):
                     next_page_or_question = survey_sudo._get_next_page_or_question(
                         answer_sudo,
                         answer_sudo.last_displayed_page_id.id if answer_sudo.last_displayed_page_id else 0)
+                    # fallback to skipped page so that there is a next_page_or_question otherwise this should be a submit
+                    if not next_page_or_question:
+                        next_page_or_question = answer_sudo._get_next_skipped_page_or_question()
 
                 if next_page_or_question:
                     if answer_sudo.survey_first_submitted:


### PR DESCRIPTION
If you were to refresh on a skipped question, the next_page_or_question would not be populated therefore causing any reference to this fail. There should not be a case where there is no next_page_or_question in _prepare_survey_data as the _get_next_page_or_question is only expecting an empty question in survey_submit.

Adding a fallback to look for the next skipped question or page for when the next_skipped_page in the post parameter is lost in the http request through refreshing will allow this to work as expected.

opw-4088129

