### PR TITLE
[DRAFT][IMP] stock: return for exchange not to linked with return

### DIFF
--- a/addons/purchase_stock/wizard/__init__.py
+++ b/addons/purchase_stock/wizard/__init__.py
@@ -3,3 +3,4 @@
 
 from . import stock_replenishment_info
 from . import product_replenish
+from . import stock_picking_return

--- a/addons/purchase_stock/wizard/stock_picking_return.py
+++ b/addons/purchase_stock/wizard/stock_picking_return.py
@@ -1,0 +1,10 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class ReturnPicking(models.TransientModel):
+    _inherit = 'stock.return.picking'
+
+    def _exchange_move_location(self):
+        return self.picking_id.purchase_id.picking_ids[0].location_id.id

--- a/addons/sale_stock/wizard/__init__.py
+++ b/addons/sale_stock/wizard/__init__.py
@@ -3,3 +3,4 @@
 
 from . import stock_rules_report
 from . import sale_order_cancel
+from . import stock_picking_return

--- a/addons/sale_stock/wizard/stock_picking_return.py
+++ b/addons/sale_stock/wizard/stock_picking_return.py
@@ -1,0 +1,10 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class ReturnPicking(models.TransientModel):
+    _inherit = 'stock.return.picking'
+
+    def _exchange_move_location(self):
+        return self.picking_id.sale_id.picking_ids[0].location_id.id


### PR DESCRIPTION
In this PR
==============
In stock when operation is confirmed then applying for return order by 'return for exchange', the created delivery will not be linked to the return transfer.

task_id : 4011287
