### PR TITLE
[IMP] spreadsheet: allow to apply revisions in readonly mode

### DIFF
--- a/addons/spreadsheet/static/src/public_readonly_app/public_readonly.js
+++ b/addons/spreadsheet/static/src/public_readonly_app/public_readonly.js
@@ -61,9 +61,11 @@ export class PublicReadonlySpreadsheet extends Component {
 
     async createModel() {
         this.data = await this.http.get(this.props.dataUrl);
-        this.model = new Model(this.data, {
-            mode: this.props.mode === "dashboard" ? "dashboard" : "readonly",
-        });
+        this.model = new Model(
+            this.data,
+            { mode: this.props.mode === "dashboard" ? "dashboard" : "readonly" },
+            this.data.revisions || []
+        );
         if (this.env.debug) {
             // eslint-disable-next-line no-import-assign
             spreadsheet.__DEBUG__ = spreadsheet.__DEBUG__ || {};


### PR DESCRIPTION
Purpose
=======
Allow to apply revisions when viewing a spreadsheet with the public readonly view.

To avoid making a new HTTP call to download the revision, they can be directly included in the dictionary when we download the spreadsheet data.

Task-4014620