### PR TITLE
[FIX] l10n_fi: adjusting tax report

### DIFF
--- a/addons/l10n_fi/data/account_tax_report_line.xml
+++ b/addons/l10n_fi/data/account_tax_report_line.xml
@@ -11,9 +11,9 @@
         <field name="report_id" ref="vat_report"/>
     </record>
     <record id="tax_report_sales_25_5" model="account.tax.report.line">
-        <field name="name">25.5 %:n vero</field>
+        <field name="name">25.5 %:n vero (+ 24 %:n vero)</field>
         <field name="code">sale_25_5</field>
-        <field name="tag_name">fi_320</field>
+        <field name="tag_name">fi_320 + fi_301</field>
         <field name="sequence">10</field>
         <field name="report_id" ref="vat_report"/>
         <field name="parent_id" ref="tax_report_sales_title"/>
@@ -85,7 +85,8 @@
     </record>
     <record id="tax_report_tax_payable" model="account.tax.report.line">
         <field name="name">Maksettava vero / Palautukseen oikeuttava vero (-)</field>
-        <field name="formula">sale_25_5 + sale_24 + sale_14 + sale_10 + goods_eu + service_eu + goods_no_eu + construct - deductible</field>
+        <!-- "sale_25_5" refers to both 24% and 25.5% taxes. Will only be 25.5 on 01/01/2025.-->
+        <field name="formula">sale_25_5 + sale_14 + sale_10 + goods_eu + service_eu + goods_no_eu + construct - deductible</field>
         <field name="sequence">110</field>
         <field name="report_id" ref="vat_report"/>
     </record>


### PR DESCRIPTION
Description of the issue this commit addresses:

A new tax has been added and will be used as from the first of september 2024. With this new tax, the tax report has been modified to include it by adding a new line but what's actually required as from the first september is to include the new tax to the existing 24% tax line in the report.

---

Desired behavior after this commit is merged:

The 25.5% tax line in the report includes both 24.0 and 25.5 rates and is named after the 25.5 one but still says that the 24.0 rate taxes are included in it. This will be changed to totally exclude the 24.0 rate once it will not be used anymore probably on the first of january 2025.

---

Documentation:
Change of default VAT rate: https://www.vero.fi/en/businesses-and-corporations/taxes-and-charges/vat/rates-of-vat/new-vat-rate-from-1-september-2024--instructions-for-vat-reporting/
Line about both taxes being in the same line of the report: https://www.vero.fi/en/businesses-and-corporations/taxes-and-charges/vat/rates-of-vat/new-vat-rate-from-1-september-2024--instructions-for-vat-reporting/#:~:text=All%20sales%20with%20both%20the%2024%25%20and%20the%2025.5%25%20rates%20must%20be%20entered%20into%20the%20same%20space%20on%20the%20form

---

task-4101930

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
