### PR TITLE
[REF] web_tour: replace _legacyIsVisible by hoot isVisible

### DIFF
--- a/addons/crm/static/tests/tours/crm_email_and_phone_propagation.js
+++ b/addons/crm/static/tests/tours/crm_email_and_phone_propagation.js
@@ -18,7 +18,7 @@
             trigger: ".o_form_editable .o_field_widget[name=email_from] input",
         },
         {
-            trigger: '.o_form_button_save',
+            trigger: ".o_form_button_save:not(:visible)",
             content: 'Save the lead',
             run: 'click',
         },

--- a/addons/crm/static/tests/tours/crm_rainbowman.js
+++ b/addons/crm/static/tests/tours/crm_rainbowman.js
@@ -101,7 +101,10 @@ registry.category("web_tour.tours").add("crm_rainbowman", {
             content: "click button mark won",
             run: "click",
         },
-        ...stepUtils.saveForm(),
+        {
+            content: "wait for save completion",
+            trigger: ".o_form_readonly, .o_form_saved",
+        },
         {
             trigger: ".o_reward_rainbow",
         },

--- a/addons/hr_skills/static/tests/tours/skills_tour.js
+++ b/addons/hr_skills/static/tests/tours/skills_tour.js
@@ -1,165 +1,173 @@
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
-registry.category("web_tour.tours").add('hr_skills_tour', {
-    url: '/odoo',
+registry.category("web_tour.tours").add("hr_skills_tour", {
+    url: "/odoo",
     steps: () => [
-    stepUtils.showAppsMenuItem(),
-    {
-        content: "Open Employees app",
-        trigger: ".o_app[data-menu-xmlid='hr.menu_hr_root']",
-        run: "click",
-    },
-    {
-        content: "Create a new employee",
-        trigger: ".o-kanban-button-new",
-        run: "click",
-    },
-    {
-        content: "Pick a name",
-        trigger: ".o_field_widget[name='name'] input",
-        run: "edit Jony McHallyFace",
-    },
-    {
-        content: "Save",
-        trigger: ".o_form_button_save",
-        run: "click",
-    },
-    {
-        content: "Add a new Resume experience",
-        trigger: ".o_field_resume_one2many tr.o_resume_group_header button.btn-secondary",
-        run: "click",
-    },
-    {
-        content: "Enter some company name",
-        trigger: ".modal:contains(new resume line) .modal-body .o_field_widget[name='name'] input",
-        run: "edit Mamie Rock",
-    },
-    {
-        content: "Set start date",
-        trigger: ".modal:contains(new resume line) .o_field_widget[name='date_start'] input",
-        run: "edit 12/05/2017",
-    },
-    {
-        content: "Give some description",
-        trigger: ".modal:contains(new resume line) .o_field_html[name='description'] p",
-        run: "editor Sang some songs and played some music",
-    },
-    {
-        content: "Save it",
-        trigger: ".modal:contains(new resume line) .o_form_button_save:contains(save)",
-        run: "click",
-    },
-    {
-        trigger: "body:not(:has(.modal:contains(new resume line)))",
-    },
-    {
-        content: "Edit newly created experience",
-        trigger: ".o_resume_line_title:contains(Mamie Rock)",
-        run: "click",
-    },
-    {
-        content: "Change type",
-        trigger: ".modal:contains(new resume line) .o_field_widget[name='line_type_id'] input",
-        run: "edit Experience",
-    },
-    {
-        content: "Choose experience",
-        trigger: '.ui-autocomplete .ui-menu-item a:contains("Experience")',
-        run: "click",
-    },
-    {
-        content: "Save experience change",
-        trigger: ".modal:contains(new resume line) .o_form_button_save:contains(save)",
-        run: "click",
-    },
-    {
-        trigger: "body:not(:has(.modal:contains(new resume line)))",
-    },
-    {
-        content: "Add a new Skill",
-        trigger: ".o_field_skills_one2many button:contains('Pick a skill from the list')",
-        run: "click",
-    },
-    {
-        content: "Select Music",
-        trigger: ".modal:contains(select skills) .o_field_widget[name='skill_type_id'] label:contains('Best Music')",
-        run: "click",
-    },
-    {
-        content: "Select a song",
-        trigger: ".modal:contains(select skills) .o_field_widget[name='skill_id'] input",
-        run: "edit Fortun",
-    },
-    {
-        content: "Choose the song",
-        trigger: '.ui-autocomplete .ui-menu-item a:contains("Fortunate Son")',
-        run: "click",
-    },
-    {
-        content: "Select a level",
-        trigger: ".modal:contains(select skills) .o_field_widget[name='skill_level_id'] input",
-        run: "edit Level",
-    },
-    {
-        content: "Choose the level",
-        trigger: '.ui-autocomplete .ui-menu-item a:contains("Level 2")',
-        run: "click",
-    },
-    {
-        content: "Save new skill",
-        trigger: ".modal:contains(select skills) .o_form_button_save:contains(save & close)",
-        run: "click",
-    },
-    {
-        content: "Wait the new skill is completely saved. Ensure also the modal is closed before open a new one.",
-        trigger: "body:not(:has(.modal))",
-    },
-    {
-        content: "Check if item is added",
-        trigger: ".o_data_row td.o_data_cell:contains('Fortunate Son')",
-    },
-    {
-        content: "Add a new Skill",
-        trigger: ".o_field_skills_one2many button:contains('ADD')",
-        run: "click",
-    },
-    {
-        content: "Music should be already selected",
-        trigger: ".modal:contains(select skills) .o_field_widget[name=skill_id] input:value(Fortunate Son)",
-    },
-    {
-        content: "Select a song",
-        trigger: ".modal:contains(select skills) .o_field_widget[name='skill_id'] input",
-        run: "edit Mary",
-    },
-    {
-        content: "Choose the song",
-        trigger: '.ui-autocomplete .ui-menu-item a:contains("Oh Mary")',
-        run: "click",
-    },
-    {
-        content: "Select a level",
-        trigger: ".modal:contains(select skills) .o_field_widget[name='skill_level_id'] input",
-        run: "edit Level 7",
-    },
-    {
-        content: "Choose the level",
-        trigger: '.ui-autocomplete .ui-menu-item a:contains("Level 7")',
-        run: "click",
-    },
-    {
-        content: "Save new skill",
-        trigger: ".modal:contains(select skills) .o_form_button_save:contains(save & close)",
-        run: "click",
-    },
-    {
-        content: "Wait the new skill is completely saved",
-        trigger: "body:not(:has(.modal))",
-    },
-    {
-        content: "Check if item is added",
-        trigger: ".o_data_row td.o_data_cell:contains('Oh Mary')",
-    },
-    ...stepUtils.saveForm(),
-]});
+        stepUtils.showAppsMenuItem(),
+        {
+            content: "Open Employees app",
+            trigger: ".o_app[data-menu-xmlid='hr.menu_hr_root']",
+            run: "click",
+        },
+        {
+            content: "Create a new employee",
+            trigger: ".o-kanban-button-new",
+            run: "click",
+        },
+        {
+            content: "Pick a name",
+            trigger: ".o_field_widget[name='name'] input",
+            run: "edit Jony McHallyFace",
+        },
+        {
+            content: "Save",
+            trigger: ".o_form_button_save",
+            run: "click",
+        },
+        {
+            content: "Add a new Resume experience",
+            trigger: ".o_field_resume_one2many tr.o_resume_group_header button.btn-secondary",
+            run: "click",
+        },
+        {
+            content: "Enter some company name",
+            trigger:
+                ".modal:contains(new resume line) .modal-body .o_field_widget[name='name'] input",
+            run: "edit Mamie Rock",
+        },
+        {
+            content: "Set start date",
+            trigger: ".modal:contains(new resume line) .o_field_widget[name='date_start'] input",
+            run: "edit 12/05/2017",
+        },
+        {
+            content: "Give some description",
+            trigger: ".modal:contains(new resume line) .o_field_html[name='description'] p",
+            run: "editor Sang some songs and played some music",
+        },
+        {
+            content: "Save it",
+            trigger: ".modal:contains(new resume line) .o_form_button_save:contains(save)",
+            run: "click",
+        },
+        {
+            trigger: "body:not(:has(.modal:contains(new resume line)))",
+        },
+        {
+            content: "Edit newly created experience",
+            trigger: ".o_resume_line_title:contains(Mamie Rock)",
+            run: "click",
+        },
+        {
+            content: "Change type",
+            trigger: ".modal:contains(new resume line) .o_field_widget[name='line_type_id'] input",
+            run: "edit Experience",
+        },
+        {
+            content: "Choose experience",
+            trigger: '.ui-autocomplete .ui-menu-item a:contains("Experience")',
+            run: "click",
+        },
+        {
+            content: "Save experience change",
+            trigger: ".modal:contains(new resume line) .o_form_button_save:contains(save)",
+            run: "click",
+        },
+        {
+            trigger: "body:not(:has(.modal:contains(new resume line)))",
+        },
+        {
+            content: "Add a new Skill",
+            trigger: ".o_field_skills_one2many button:contains('Pick a skill from the list')",
+            run: "click",
+        },
+        {
+            content: "Select Music",
+            trigger:
+                ".modal:contains(select skills) .o_field_widget[name='skill_type_id'] label:contains('Best Music')",
+            run: "click",
+        },
+        {
+            content: "Select a song",
+            trigger: ".modal:contains(select skills) .o_field_widget[name='skill_id'] input",
+            run: "edit Fortun",
+        },
+        {
+            content: "Choose the song",
+            trigger: '.ui-autocomplete .ui-menu-item a:contains("Fortunate Son")',
+            run: "click",
+        },
+        {
+            content: "Select a level",
+            trigger: ".modal:contains(select skills) .o_field_widget[name='skill_level_id'] input",
+            run: "edit Level",
+        },
+        {
+            content: "Choose the level",
+            trigger: '.ui-autocomplete .ui-menu-item a:contains("Level 2")',
+            run: "click",
+        },
+        {
+            content: "Save new skill",
+            trigger: ".modal:contains(select skills) .o_form_button_save:contains(save & close)",
+            run: "click",
+        },
+        {
+            content:
+                "Wait the new skill is completely saved. Ensure also the modal is closed before open a new one.",
+            trigger: "body:not(:has(.modal))",
+        },
+        {
+            content: "Check if item is added",
+            trigger: ".o_data_row td.o_data_cell:contains('Fortunate Son')",
+        },
+        {
+            content: "Add a new Skill",
+            trigger: ".o_field_skills_one2many button:contains('ADD')",
+            run: "click",
+        },
+        {
+            content: "Music should be already selected",
+            trigger:
+                ".modal:contains(select skills) .o_field_widget[name=skill_id] input:value(Fortunate Son)",
+        },
+        {
+            content: "Select a song",
+            trigger: ".modal:contains(select skills) .o_field_widget[name='skill_id'] input",
+            run: "edit Mary",
+        },
+        {
+            content: "Choose the song",
+            trigger: '.ui-autocomplete .ui-menu-item a:contains("Oh Mary")',
+            run: "click",
+        },
+        {
+            content: "Select a level",
+            trigger: ".modal:contains(select skills) .o_field_widget[name='skill_level_id'] input",
+            run: "edit Level 7",
+        },
+        {
+            content: "Choose the level",
+            trigger: '.ui-autocomplete .ui-menu-item a:contains("Level 7")',
+            run: "click",
+        },
+        {
+            content: "Save new skill",
+            trigger: ".modal:contains(select skills) .o_form_button_save:contains(save & close)",
+            run: "click",
+        },
+        {
+            content: "Wait the new skill is completely saved",
+            trigger: "body:not(:has(.modal))",
+        },
+        {
+            content: "Check if item is added",
+            trigger: ".o_data_row td.o_data_cell:contains('Oh Mary')",
+        },
+        {
+            content: "wait for save completion",
+            trigger: ".o_form_readonly, .o_form_saved",
+        },
+    ],
+});

--- a/addons/im_livechat/tests/test_chatbot_form_ui.py
+++ b/addons/im_livechat/tests/test_chatbot_form_ui.py
@@ -15,7 +15,7 @@ class TestLivechatChatbotFormUI(HttpCaseWithUserDemo):
             '/odoo',
             'im_livechat_chatbot_steps_sequence_tour',
             login='admin',
-            step_delay=1000
+            step_delay=200,
         )
 
         chatbot_script = self.env['chatbot.script'].search([('title', '=', 'Test Chatbot Sequence')])
@@ -39,7 +39,7 @@ class TestLivechatChatbotFormUI(HttpCaseWithUserDemo):
             '/odoo',
             'im_livechat_chatbot_steps_sequence_with_move_tour',
             login='admin',
-            step_delay=1000
+            step_delay=200,
         )
 
         chatbot_script = self.env['chatbot.script'].search([('title', '=', 'Test Chatbot Sequence')])

--- a/addons/mail/static/tests/tours/mail_message_load_order_tour.js
+++ b/addons/mail/static/tests/tours/mail_message_load_order_tour.js
@@ -19,7 +19,8 @@ registry.category("web_tour.tours").add("mail_message_load_order_tour", {
             run: "click",
         },
         {
-            trigger: ".o-mail-MessageCard-jump",
+            content: "Click on invisible jump (should hover card to be visible)",
+            trigger: ".o-mail-MessageCard-jump:not(:visible)",
             run: "click",
         },
         {

--- a/addons/mass_mailing/static/tests/tours/mailing_editor_theme.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_editor_theme.js
@@ -145,6 +145,6 @@ registry.category("web_tour.tours").add('mailing_editor_theme', {
             content: "Make sure the floating toolbar is visible",
             trigger: '#toolbar.oe-floating[style*="visible"]',
         },
-        ...stepUtils.discardForm(),
-    ]
+        //Nothing to discard => no waiting changes.
+    ],
 });

--- a/addons/mrp/static/tests/tours/mrp_sm_sml_synchronization.js
+++ b/addons/mrp/static/tests/tours/mrp_sm_sml_synchronization.js
@@ -1,5 +1,4 @@
 import { registry } from "@web/core/registry";
-import { stepUtils } from '@web_tour/tour_service/tour_utils';
 
 registry.category("web_tour.tours").add('test_manufacturing_and_byproduct_sm_to_sml_synchronization', {
     steps: () => [
@@ -156,6 +155,10 @@ registry.category("web_tour.tours").add('test_manufacturing_and_byproduct_sm_to_
             trigger: ".modal .modal-footer .o_form_button_save",
             run: "click",
         },
-        ...stepUtils.saveForm(),
+        {
+            isActive: ["auto"],
+            content: "wait for save completion",
+            trigger: ".o_form_readonly, .o_form_saved",
+        },
     ]
 });

--- a/addons/project/static/tests/tours/project_update_tour_tests.js
+++ b/addons/project/static/tests/tours/project_update_tour_tests.js
@@ -80,8 +80,8 @@ registry.category("web_tour.tours").add('project_update_tour', {
     trigger: '.o_kanban_quick_create .o_kanban_add',
     run: "click",
 }, {
-    trigger: '.o_kanban_group:nth-child(2) .o_kanban_header .o_kanban_config .dropdown-toggle',
-    run: "click",
+    trigger: ".o_kanban_group:nth-child(2) .o_kanban_header",
+    run: "hover && click .o_kanban_group:nth-child(2) .o_kanban_header .dropdown-toggle",
 }, {
     trigger: ".dropdown-item.o_column_edit",
     run: "click",

--- a/addons/project_todo/static/tests/tours/project_todo_main_functions.js
+++ b/addons/project_todo/static/tests/tours/project_todo_main_functions.js
@@ -72,7 +72,8 @@ registry.category("web_tour.tours").add('project_todo_main_functions', {
     trigger: ".o_project_task_kanban_view",
 },
 {
-    trigger: ".o_dropdown_kanban .btn.o-no-caret",
+    content: "Click on invisible caret. Should hover on card to be visible",
+    trigger: ".o_dropdown_kanban .btn.o-no-caret:not(:visible)",
     run: "click",
 }, {
     trigger: "a:contains('Set Cover Image')",

--- a/addons/purchase_product_matrix/static/tests/tours/purchase_product_matrix_tour.js
+++ b/addons/purchase_product_matrix/static/tests/tours/purchase_product_matrix_tour.js
@@ -51,7 +51,7 @@ registry.category("web_tour.tours").add('purchase_matrix_tour', {
 },
 // Open the matrix through the pencil button next to the product in line edit mode.
 {
-    trigger: ".o_form_status_indicator_buttons.invisible", // wait for save to be finished
+    trigger: ".o_form_status_indicator_buttons:not(:visible)", // wait for save to be finished
 },
 {
     trigger: '.o_field_pol_product_many2one',
@@ -80,7 +80,7 @@ registry.category("web_tour.tours").add('purchase_matrix_tour', {
 },
 // Ensures the matrix is opened with the values, when adding the same product.
 {
-    trigger: '.o_form_status_indicator_buttons.invisible',
+    trigger: ".o_form_status_indicator_buttons:not(:visible)",
 },
 {
     trigger: 'a:contains("Add a product")',

--- a/addons/test_base_automation/static/tests/tour/base_automation_tour.js
+++ b/addons/test_base_automation/static/tests/tour/base_automation_tour.js
@@ -479,9 +479,6 @@ registry.category("web_tour.tours").add("test_form_view_resequence_actions", {
         {
             trigger: "body:not(:has(.modal-content))",
         },
-        {
-            trigger: ".o_form_button_cancel",
-        },
     ],
 });
 

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_advanced_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_advanced_ui.js
@@ -12,7 +12,7 @@ registry.category("web_tour.tours").add('sale_product_configurator_advanced_tour
         ...tourUtils.createNewSalesOrder(),
         ...tourUtils.selectCustomer("Tajine Saucisse"),
         {
-            trigger: ".o_field_widget[name=partner_shipping_id] .o_external_button", // Wait for onchange_partner_id
+            trigger: ".o_field_widget[name=partner_shipping_id] .o_external_button:not(:visible)", // Wait for onchange_partner_id
         },
         ...tourUtils.addProduct("Customizable Desk (TEST)"),
         ...configuratorTourUtils.selectAndSetCustomAttribute("Customizable Desk", "Legs", "Custom", "Custom 1"),

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_edition_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_edition_ui.js
@@ -37,7 +37,8 @@ registry.category("web_tour.tours").add('sale_product_configurator_edition_tour'
             run: "edit nice custom value && click .modal-body",
         },
         {
-            trigger: 'tr:has(div[name="o_sale_product_configurator_name"]:contains("Customizable Desk")) label[style="background-color:#000000"] input',
+            trigger:
+                'tr:has(div[name="o_sale_product_configurator_name"]:contains("Customizable Desk")) label[style="background-color:#000000"] input:not(:visible)',
             run: "click",
         },
         {

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_ui.js
@@ -25,14 +25,14 @@ registry.category("web_tour.tours").add('sale_product_configurator_tour', {
             trigger: '.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) td[name="price"] span:contains("800.40")',
         },
         {
-            trigger: 'label[style="background-color:#000000"] input',
+            trigger: 'label[style="background-color:#000000"] input:not(:visible)',
             run: "click",
         },
         {
             trigger: '.btn-primary:disabled:contains("Confirm")',
         },
         {
-            trigger: 'label[style="background-color:#FFFFFF"] input',
+            trigger: 'label[style="background-color:#FFFFFF"] input:not(:visible)',
             run: "click",
         },
         {

--- a/addons/test_sale_product_configurators/static/tests/tours/product_matrix_tour.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_matrix_tour.js
@@ -108,7 +108,7 @@ registry.category("web_tour.tours").add('sale_matrix_tour', {
         },
         // Open the matrix through the pencil button next to the product in line edit mode.
         {
-            trigger: ".o_form_status_indicator_buttons.invisible", // wait for save to be finished
+            trigger: ".o_form_status_indicator_buttons.invisible:not(:visible)", // wait for save to be finished
         },
         tourUtils.editLineMatching("Matrix (PAV11, PAV22, PAV31)", "PA4: PAV41"),
         tourUtils.editConfiguration(),
@@ -134,7 +134,7 @@ registry.category("web_tour.tours").add('sale_matrix_tour', {
         },
         // Ensures the matrix is opened with the values, when adding the same product.
         {
-            trigger: ".o_form_status_indicator_buttons.invisible",
+            trigger: ".o_form_status_indicator_buttons.invisible:not(:visible)",
         },
         ...tourUtils.addProduct("Matrix"),
         {

--- a/addons/web/static/src/core/utils/ui.js
+++ b/addons/web/static/src/core/utils/ui.js
@@ -56,42 +56,6 @@ export function isVisible(el) {
 }
 
 /**
- * This function only exists because some tours currently rely on the fact that
- * we can click on elements with a non null width *xor* height (not both). However,
- * if one of these is 0, the element is not visible. We thus keep this function
- * to ease the transition to the more robust "isVisible" helper, which requires
- * both a non null width *and* height.
- *
- * @deprecated use isVisible instead
- * @param {Element} el
- * @returns {boolean}
- */
-export function _legacyIsVisible(el) {
-    if (el === document || el === window) {
-        return true;
-    }
-    if (!el) {
-        return false;
-    }
-    let _isVisible = false;
-    if ("offsetWidth" in el && "offsetHeight" in el) {
-        _isVisible = el.offsetWidth > 0 || el.offsetHeight > 0;
-    } else if ("getBoundingClientRect" in el) {
-        // for example, svgelements
-        const rect = el.getBoundingClientRect();
-        _isVisible = rect.width > 0 || rect.height > 0;
-    }
-    if (!_isVisible && getComputedStyle(el).display === "contents") {
-        for (const child of el.children) {
-            if (isVisible(child)) {
-                return true;
-            }
-        }
-    }
-    return _isVisible;
-}
-
-/**
  * @param {DOMRect} rect
  * @param {Position} pos
  * @returns {number}

--- a/addons/web_tour/static/src/tour_service/tour_step_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_step_automatic.js
@@ -1,4 +1,3 @@
-import { _legacyIsVisible } from "@web/core/utils/ui";
 import { tourState } from "./tour_state";
 import * as hoot from "@odoo/hoot-dom";
 import { callWithUnloadCheck } from "./tour_utils";
@@ -79,15 +78,13 @@ export class TourStepAutomatic extends TourStep {
             this.skipped = true;
             return true;
         }
-        let nodes;
         try {
-            nodes = hoot.queryAll(this.trigger);
+            //if pseudo-selector :visible is not present in trigger, visible is true
+            const visible = !this.trigger.includes(":visible");
+            this.element = hoot.queryFirst(this.trigger, { visible });
         } catch (error) {
             this.error = `HOOT: ${error.message}`;
         }
-        this.element = this.trigger.includes(":visible")
-            ? nodes.at(0)
-            : nodes.find(_legacyIsVisible);
         return !this.isUIBlocked && this.elementIsEnabled && this.elementIsInModal
             ? this.element
             : false;

--- a/addons/website/static/tests/tours/rte.js
+++ b/addons/website/static/tests/tours/rte.js
@@ -65,8 +65,8 @@ registerWebsitePreviewTour('rte_translator', {
     run: "click",
 }, {
     content: "click on Use this template",
-    trigger: ".o_page_template .o_button_area",
-    run: "click",
+    trigger: ".modal .o_page_template:first",
+    run: "hover && click .modal .o_page_template button.btn-primary",
 }, {
     content: "insert file name",
     trigger: ".modal:not(.o_inactive_modal):contains(new page) .modal-body input[type=text]",
@@ -97,8 +97,8 @@ registerWebsitePreviewTour('rte_translator', {
     run: "click",
 }, {
     content: "click on Use this template",
-    trigger: ".o_page_template .o_button_area",
-    run: "click",
+    trigger: ".modal .o_page_template:first",
+    run: "hover && click .modal .o_page_template button.btn-primary",
 }, {
     content: "insert page name",
     trigger: '.modal .modal-dialog .modal-body input[type="text"]',

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -940,6 +940,8 @@ registerWebsitePreviewTour("website_form_editable_content", {
         run: "drag_and_drop :iframe section.s_website_form",
     },
     {
+        // TODO we should ensure that as soon as the snippet 
+        // is visible, it is editable to avoid this step
         trigger: ":iframe section.s_website_form .col-lg-4[contenteditable=true]",
     },
     {
@@ -957,8 +959,10 @@ registerWebsitePreviewTour("website_form_editable_content", {
         content: "Check that the new text value was correctly set",
         trigger: ":iframe section.s_website_form h5:contains(/^ABC$/)",
     },
-    {   content: "Remove the dropped column",
-        trigger: ":iframe .oe_overlay.oe_active .oe_snippet_remove",
+    {
+        content: "Remove the dropped column",
+        // TODO: remove :not(:visible) and use hover && click.
+        trigger: ":iframe .oe_overlay.oe_active .oe_snippet_remove:not(:visible)",
         run: "click",
     },
     ...clickOnSave(),

--- a/addons/website_event_booth_exhibitor/static/tests/tours/website_event_booth_exhibitor.js
+++ b/addons/website_event_booth_exhibitor/static/tests/tours/website_event_booth_exhibitor.js
@@ -21,7 +21,7 @@
         run: "click",
     }, {
         content: 'Choose Booth',
-        trigger: '.o_wbooth_booths div:contains("OpenWood Demonstrator 2") input',
+        trigger: ".o_wbooth_booths div:contains(OpenWood Demonstrator 2) input:not(:visible)",
         run: "click",
     }, {
         content: "Validate attendees details",

--- a/addons/website_event_booth_sale/static/tests/tours/helpers/WebsiteEventBoothSaleTourMethods.js
+++ b/addons/website_event_booth_sale/static/tests/tours/helpers/WebsiteEventBoothSaleTourMethods.js
@@ -19,7 +19,7 @@
             },
             {
                 content: 'Select the booth',
-                trigger: '.o_wbooth_booths input[name="event_booth_ids"]',
+                trigger: ".o_wbooth_booths input[name=event_booth_ids]:not(:visible)",
                 run: function () {
                     document.querySelector('.o_wbooth_booths input[name="event_booth_ids"]:nth-child(1)').click();
                 },

--- a/addons/website_event_booth_sale/static/tests/tours/website_event_booth.js
+++ b/addons/website_event_booth_sale/static/tests/tours/website_event_booth.js
@@ -15,7 +15,7 @@ registry.category("web_tour.tours").add('website_event_booth_tour', {
     run: "click",
 }, {
     content: 'Select the first two booths',
-    trigger: '.o_wbooth_booths input[name="event_booth_ids"]',
+    trigger: ".o_wbooth_booths input[name=event_booth_ids]:not(:visible)",
     run() {
         document.querySelectorAll('.o_wbooth_booths input[name="event_booth_ids"]')[0].click();
         document.querySelectorAll('.o_wbooth_booths input[name="event_booth_ids"]')[1].click();

--- a/addons/website_event_booth_sale/static/tests/tours/website_event_booth_sale_pricelists.js
+++ b/addons/website_event_booth_sale/static/tests/tours/website_event_booth_sale_pricelists.js
@@ -18,7 +18,7 @@ registry.category("web_tour.tours").add('event_booth_sale_pricelists_different_c
     },
     {
         content: 'Select the booth',
-        trigger: '.o_wbooth_booths input[name="event_booth_ids"]:nth-child(1)',
+        trigger: ".o_wbooth_booths input[name=event_booth_ids]:nth-child(1):not(:visible)",
         run: "click",
     },
     {

--- a/addons/website_livechat/static/tests/tours/website_livechat_common.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_common.js
@@ -107,7 +107,7 @@ export const close = [
     },
     {
         content: "Check that the button is not displayed anymore",
-        trigger: ".o-livechat-root:shadow .o-mail-ChatHub",
+        trigger: ".o-livechat-root:shadow .o-mail-ChatHub:not(:visible)",
         run() {
             if (this.anchor.querySelectorAll(".o-livechat-livechatButton").length) {
                 console.error(`There should have no .o-livechat-livechatButton...`);

--- a/addons/website_sale/static/tests/tours/website_sale_category_page_and_products_snippet.js
+++ b/addons/website_sale/static/tests/tours/website_sale_category_page_and_products_snippet.js
@@ -17,13 +17,13 @@ registerWebsitePreviewTour('category_page_and_products_snippet_edition', {
     },
     {
         content: "Click on the s_dynamic_snippet_products snippet.",
-        trigger: ':iframe .o_snippet_preview_wrap[data-snippet-id="s_dynamic_snippet_products"]',
+        trigger: ":iframe .o_snippet_preview_wrap[data-snippet-id=s_dynamic_snippet_products]:not(:visible)",
         run: "click",
     },
-
     {
         content: "Click on the product snippet to show its options",
-        trigger: ':iframe #category_header .s_dynamic_snippet_products',
+        trigger: ":iframe section[data-snippet=s_dynamic_snippet_products]",
+        timeout: 30000, //load product snippet take long time due to load unknow img.
         run: "click",
     },
     {

--- a/addons/website_sale/static/tests/tours/website_sale_google_analytics.js
+++ b/addons/website_sale/static/tests/tours/website_sale_google_analytics.js
@@ -41,7 +41,8 @@ registry.category("web_tour.tours").add('google_analytics_view_item', {
     },
     {
         content: 'select another variant',
-        trigger: 'ul.js_add_cart_variants ul.list-inline li:has(label.active) + li:has(label) input',
+        trigger:
+            "ul.js_add_cart_variants ul.list-inline li:has(label.active) + li:has(label) input:not(:visible)",
         run: "click",
     },
     {

--- a/addons/website_sale/static/tests/tours/website_sale_shop_zoom.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_zoom.js
@@ -29,7 +29,7 @@ registry.category("web_tour.tours").add('shop_zoom', {
     },
     {
         content: "change variant",
-        trigger: 'input[data-attribute_name="Beautiful Color"][data-value_name="' + nameGreen + '"]',
+        trigger: `input[data-attribute_name='Beautiful Color'][data-value_name='${nameGreen}']:not(:visible)`,
         run: 'click',
     },
     {

--- a/addons/website_sale_comparison/static/tests/tours/website_sale_comparison.js
+++ b/addons/website_sale_comparison/static/tests/tours/website_sale_comparison.js
@@ -68,7 +68,7 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
     },
     {
         content: "select 2nd variant(Black Color)",
-        trigger: '.variant_attribute[data-attribute_name="Color"] input[data-value_name="Black"]',
+        trigger: ".variant_attribute[data-attribute_name=Color] input[data-value_name=Black]:not(:visible)",
         run: function (actions) {
           document.querySelector('img[class*="product_detail_img"]').setAttribute('data-image-to-change', 1);
           actions.click();

--- a/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist.js
+++ b/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist.js
@@ -196,7 +196,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
             trigger: '.my_wish_quantity:contains(1)',
         },
         {
-            trigger: '.oe_product_cart:contains("Bottle") .o_add_wishlist.disabled',
+            trigger: '.oe_product_cart:contains("Bottle") .o_add_wishlist.disabled:not(:visible)',
         },
         {
             content: "Click on product",
@@ -205,7 +205,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
         },
         {
             content: "Select Bottle with second variant from /product",
-            trigger: '.js_variant_change[data-value_name="blue"]',
+            trigger: "input.js_variant_change[data-value_name=blue]:not(:visible)",
             run: "click",
         },
         {
@@ -218,7 +218,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
         },
         {
             content: "Select Bottle with third variant from /product",
-            trigger: '.js_variant_change[data-value_name="black"]',
+            trigger: "input.js_variant_change[data-value_name=black]:not(:visible)",
             run: "click",
         },
         {
@@ -290,7 +290,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
         },
         {
             content: "Check there is wishlist button on product from /shop",
-            trigger: '.oe_product_cart:contains("Bottle") .o_add_wishlist',
+            trigger: ".oe_product_cart:contains(Bottle) .o_add_wishlist:not(:visible)",
         },
         {
             content: "Click on product",
@@ -299,7 +299,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
         },
         {
             content: "Select Bottle with first variant (red) from /product",
-            trigger: '.js_variant_change[data-value_name="red"]',
+            trigger: "input.js_variant_change[data-value_name=red]:not(:visible)",
             run: "click",
         },
         {
@@ -308,7 +308,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
         },
         {
             content: "Select Bottle with second variant (blue) from /product",
-            trigger: '.js_variant_change[data-value_name="blue"]',
+            trigger: "input.js_variant_change[data-value_name=blue]:not(:visible)",
             run: "click",
         },
         {

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -418,6 +418,11 @@ stepUtils.autoExpandMoreButtons(),
     run: "click",
 },
 {
+    isActive: ["mobile"],
+    trigger: ".o_field_widget[name=partner_id] .o_external_button:not(:visible)",
+},
+{
+    isActive: ["desktop"],
     trigger: ".o_field_widget[name=partner_id] .o_external_button",
 },
 {


### PR DESCRIPTION
In this commit, we replace the use of _legacyIsVisible by the visible option of hoot which refers to isVisible function of hoot-dom.js. This change implies changes in a few tours.
For information, _legacyIsVisible accepts elements with a width of 0 or a length of 0 (which is a bit absurd) while isVisible does not, which implies the changes where we just add :not(:visible) to the trigger. The other main modifications implies tours where you have to hover the trigger to then see the element you want to click on.

task~3974087

https://github.com/odoo/enterprise/pull/68080
