### PR TITLE
[REV] web: increasing z-index of overlay-item

### DIFF
--- a/addons/web/static/src/core/overlay/overlay_container.scss
+++ b/addons/web/static/src/core/overlay/overlay_container.scss
@@ -1,4 +1,4 @@
 .o-overlay-item {
     position: fixed;
-    z-index: $zindex-modal + 5;
+    z-index: $zindex-modal;
 }


### PR DESCRIPTION
This reverts commit 09b9d181d593906b92e53c412ab9a2069df81064 because this commit introduced a regression in html field when the record is editable in Form view dialog, the user can no longer access to the editor commands because the dropdown showing the commands is displayed behind the dialog.

opw-4100147
