### PR TITLE
[FIX] base: allow merged contacts to retain product link access in emails

### DIFF
--- a/odoo/addons/base/wizard/base_partner_merge.py
+++ b/odoo/addons/base/wizard/base_partner_merge.py
@@ -318,6 +318,8 @@ class MergePartnerAutomatic(models.TransientModel):
         self._update_reference_fields(src_partners, dst_partner)
         self._update_values(src_partners, dst_partner)
 
+        self.env.add_to_compute(dst_partner._fields['partner_share'], dst_partner)
+
         self._log_merge_operation(src_partners, dst_partner)
 
         # delete source partner, since they are merged


### PR DESCRIPTION
Problem:
While merging two partners in the contact app using the _update_foreign_keys method, the foreign keys are merged using SQL instead of ORM. The issue is that the partner_share field is computed based on the user_ids field and is stored. If we update using SQL, it will not trigger the _compute_partner_share method, which will set the latest value.

Other problems might arise for fields that are computed based on foreign keys updated using SQL during a merge.

Steps to reproduce:

In a new database, create a basic contact (individual, with name and email).
Merge this contact with another contact who has document access (e.g., Marc Demo).
Go to any product page.
Add a log note and tag the new contact.
The contact will receive an email without the "View product" button.

opw-3864317

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
