### PR TITLE
[FIX] bus, mail: only send presences to interested users

### DIFF
--- a/addons/bus/controllers/websocket.py
+++ b/addons/bus/controllers/websocket.py
@@ -3,7 +3,6 @@
 import json
 
 from odoo.http import Controller, request, route, SessionExpiredException
-from odoo.addons.base.models.assetsbundle import AssetsBundle
 from ..models.bus import channel_with_db
 from ..websocket import WebsocketConnectionHandler
 
@@ -31,22 +30,16 @@ class WebsocketController(Controller):
 
     @route('/websocket/peek_notifications', type='json', auth='public', cors='*')
     def peek_notifications(self, channels, last, is_first_poll=False):
-        if not all(isinstance(c, str) for c in channels):
-            raise ValueError("bus.Bus only string channels are allowed.")
         if is_first_poll:
             # Used to detect when the current session is expired.
             request.session['is_websocket_session'] = True
         elif 'is_websocket_session' not in request.session:
             raise SessionExpiredException()
-        channels = list(set(
-            channel_with_db(request.db, c)
-            for c in request.env['ir.websocket']._build_bus_channel_list(channels)
-        ))
-        last_known_notification_id = request.env['bus.bus'].sudo().search([], limit=1, order='id desc').id or 0
-        if last > last_known_notification_id:
-            last = 0
-        notifications = request.env['bus.bus']._poll(channels, last)
-        return {'channels': channels, 'notifications': notifications}
+        subscribe_data = request.env["ir.websocket"]._prepare_subscribe_data(channels, last)
+        subscribe_data["missed_presences"]._send_presence()
+        channels_with_db = [channel_with_db(request.db, c) for c in subscribe_data["channels"]]
+        notifications = request.env["bus.bus"]._poll(channels_with_db, subscribe_data["last"])
+        return {"channels": channels_with_db, "notifications": notifications}
 
     @route('/websocket/update_bus_presence', type='json', auth='public', cors='*')
     def update_bus_presence(self, inactivity_period, im_status_ids_by_model):

--- a/addons/bus/models/bus_presence.py
+++ b/addons/bus/models/bus_presence.py
@@ -73,7 +73,7 @@ class BusPresence(models.Model):
 
     def _get_bus_target(self):
         self.ensure_one()
-        return self.env.ref("base.group_user")
+        return self.user_id.partner_id if self.user_id else None
 
     def _get_identity_field_name(self):
         self.ensure_one()
@@ -108,10 +108,12 @@ class BusPresence(models.Model):
         """
         notifications = []
         for presence in self:
-            if identity_data := presence._get_identity_data():
+            identity_data = presence._get_identity_data()
+            target = presence._get_bus_target()
+            if identity_data and target:
                 notifications.append(
                     (
-                        presence._get_bus_target(),
+                        (target, "presence"),
                         "bus.bus/im_status_updated",
                         {"im_status": im_status or presence.status, **identity_data},
                     )

--- a/addons/bus/models/ir_websocket.py
+++ b/addons/bus/models/ir_websocket.py
@@ -1,5 +1,9 @@
+from datetime import datetime, timedelta
+
 from odoo import models
 from odoo.http import request, SessionExpiredException
+from odoo.tools import OrderedSet
+from odoo.osv import expression
 from odoo.service import security
 from ..models.bus import dispatch
 from ..websocket import wsrequest
@@ -18,6 +22,41 @@ class IrWebsocket(models.AbstractModel):
             )]
         return im_status
 
+    def _get_missed_presences_identity_domains(self, presence_channels):
+        """
+        Return a list of domains that will be combined with `expression.OR` to
+        find presences related to `presence_channels`. This is used to find
+        missed presences when subscribing to presence channels.
+
+        :param typing.List[typing.Tuple[recordset, str]] presence_channels: The
+            presence channels the user subscribed to.
+        """
+        partners = self.env["res.partner"].browse(
+            [p.id for p, _ in presence_channels if isinstance(p, self.pool["res.partner"])]
+        )
+        # sudo: res.partner - can acess users of partner channels to find
+        # their presences as those channels were already verified during
+        # `_build_bus_channel_list`.
+        return [[("user_id", "in", partners.with_context(active_test=False).sudo().user_ids.ids)]]
+
+    def _build_presence_channel_list(self, presences):
+        """
+        Return the list of presences to subscribe to.
+
+        :param typing.List[typing.Tuple[str, int]] presences: The presence
+            list sent by the client where the first element is the model
+            name and the second is the record id.
+        """
+        channels = []
+        if self.env.user and self.env.user._is_internal():
+            channels.extend(
+                (partner, "presence")
+                for partner in self.env["res.partner"]
+                .with_context(active_test=False)
+                .search([("id", "in", [int(p[1]) for p in presences if p[0] == "res.partner"])])
+            )
+        return channels
+
     def _build_bus_channel_list(self, channels):
         """
             Return the list of channels to subscribe to. Override this
@@ -33,14 +72,56 @@ class IrWebsocket(models.AbstractModel):
             channels.append(self.env.user.partner_id)
         return channels
 
-    def _subscribe(self, data):
-        if not all(isinstance(c, str) for c in data['channels']):
+    def _prepare_subscribe_data(self, channels, last):
+        """
+        Parse the data sent by the client and return the list of channels,
+        missed presences and the last known notification id. This will be used
+        both by the websocket controller and the websocket request class when
+        the `subscribe` event is received.
+
+        :param typing.List[str] channels: List of channels to subscribe to sent
+            by the client.
+        :param int last: Last known notification sent by the client.
+
+        :return:
+            A dict containing the following keys:
+            - channels (set of str): The list of channels to subscribe to.
+            - last (int): The last known notification id.
+            - missed_presences (odoo.models.Recordset): The missed presences.
+
+        :raise ValueError: If the list of channels is not a list of strings.
+        """
+        if not all(isinstance(c, str) for c in channels):
             raise ValueError("bus.Bus only string channels are allowed.")
-        last_known_notification_id = self.env['bus.bus'].sudo().search([], limit=1, order='id desc').id or 0
-        if data['last'] > last_known_notification_id:
-            data['last'] = 0
-        channels = set(self._build_bus_channel_list(data['channels']))
-        dispatch.subscribe(channels, data['last'], self.env.registry.db_name, wsrequest.ws)
+        # sudo - bus.bus: reading non-sensitive last bus id.
+        last = 0 if last > self.env["bus.bus"].sudo()._bus_last_id() else last
+        str_presence_channels = {
+            c for c in channels if isinstance(c, str) and c.startswith("odoo-presence-")
+        }
+        presence_channels = self._build_presence_channel_list(
+            [tuple(c.replace("odoo-presence-", "").split("_")) for c in str_presence_channels]
+        )
+        # There is a gap between a subscription client side (which is debounced)
+        # and the actual subcription thus presences can be missed. Send a
+        # notification to avoid missing presences during a subscription.
+        domain = expression.AND(
+            [
+                [("last_poll", ">", datetime.now() - timedelta(seconds=2))],
+                expression.OR(self._get_missed_presences_identity_domains(presence_channels)),
+            ]
+        )
+        # sudo: bus.presence: can access presences linked to presence channels.
+        missed_presences = self.env["bus.presence"].sudo().search(domain)
+        all_channels = OrderedSet(presence_channels)
+        all_channels.update(
+            self._build_bus_channel_list([c for c in channels if c not in str_presence_channels])
+        )
+        return {"channels": all_channels, "last": last, "missed_presences": missed_presences}
+
+    def _subscribe(self, og_data):
+        data = self._prepare_subscribe_data(og_data["channels"], og_data["last"])
+        dispatch.subscribe(data["channels"], data["last"], self.env.registry.db_name, wsrequest.ws)
+        data["missed_presences"]._send_presence()
 
     def _update_bus_presence(self, inactivity_period, im_status_ids_by_model):
         if self.env.user and not self.env.user._is_public():

--- a/addons/bus/static/src/im_status_service.js
+++ b/addons/bus/static/src/im_status_service.js
@@ -40,10 +40,7 @@ export const imStatusService = {
                 becomeAwayTimeout = browser.setTimeout(() => updateBusPresence(), awayTime);
             }
         };
-
-        bus_service.addEventListener("connect", () => {
-            browser.setTimeout(updateBusPresence, FIRST_UPDATE_DELAY);
-        });
+        bus_service.addEventListener("connect", () => updateBusPresence(), { once: true });
         bus_service.subscribe("bus.bus/im_status_updated", async ({ partner_id, im_status }) => {
             if (session.is_public || !partner_id || partner_id !== user.partnerId) {
                 return;

--- a/addons/bus/static/src/workers/websocket_worker_utils.js
+++ b/addons/bus/static/src/workers/websocket_worker_utils.js
@@ -27,3 +27,18 @@ export function debounce(func, wait, immediate) {
         }
     };
 }
+
+/**
+ * Deferred is basically a resolvable/rejectable extension of Promise.
+ */
+export class Deferred extends Promise {
+    constructor() {
+        let resolve;
+        let reject;
+        const prom = new Promise((res, rej) => {
+            resolve = res;
+            reject = rej;
+        });
+        return Object.assign(prom, { resolve, reject });
+    }
+}

--- a/addons/bus/static/tests/legacy/helpers/mock_websocket.js
+++ b/addons/bus/static/tests/legacy/helpers/mock_websocket.js
@@ -64,6 +64,7 @@ class WorkerMock extends SharedWorkerMock {
 }
 
 let websocketWorker;
+QUnit.testDone(() => (websocketWorker = null));
 /**
  * @param {*} params Parameters used to patch the websocket worker.
  * @returns {WebsocketWorker} Instance of the worker which will run during the

--- a/addons/bus/tests/test_websocket_controller.py
+++ b/addons/bus/tests/test_websocket_controller.py
@@ -79,9 +79,30 @@ class TestWebsocketController(HttpCaseWithUserDemo):
         self.make_jsonrpc_request("/websocket/on_closed", {}, headers=headers)
         message = self.make_jsonrpc_request(
             "/websocket/peek_notifications",
-            {"channels": [], "last": 0, "is_first_poll": True},
+            {
+                "channels": [f"odoo-presence-res.partner_{self.partner_demo.id}"],
+                "last": 0,
+                "is_first_poll": True,
+            },
             headers=headers,
         )["notifications"][0]["message"]
         self.assertEqual(message["type"], "bus.bus/im_status_updated")
         self.assertEqual(message["payload"]["partner_id"], self.partner_demo.id)
         self.assertEqual(message["payload"]["im_status"], "offline")
+
+    def test_receive_missed_presences_on_peek_notifications(self):
+        session = self.authenticate("demo", "demo")
+        headers = {"Cookie": f"session_id={session.sid};"}
+        self.env["bus.presence"].create({"user_id": self.user_demo.id, "status": "online"})
+        message = self.make_jsonrpc_request(
+            "/websocket/peek_notifications",
+            {
+                "channels": [f"odoo-presence-res.partner_{self.partner_demo.id}"],
+                "last": self.env["bus.bus"]._bus_last_id(),
+                "is_first_poll": True,
+            },
+            headers=headers,
+        )["notifications"][0]["message"]
+        self.assertEqual(message["type"], "bus.bus/im_status_updated")
+        self.assertEqual(message["payload"]["partner_id"], self.partner_demo.id)
+        self.assertEqual(message["payload"]["im_status"], "online")

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -881,7 +881,7 @@ class WebsocketConnectionHandler:
     # Latest version of the websocket worker. This version should be incremented
     # every time `websocket_worker.js` is modified to force the browser to fetch
     # the new worker bundle.
-    _VERSION = "1.0.8"
+    _VERSION = "1.0.9"
 
     @classmethod
     def websocket_allowed(cls, request):

--- a/addons/im_livechat/static/tests/sidebar_patch.test.js
+++ b/addons/im_livechat/static/tests/sidebar_patch.test.js
@@ -1,4 +1,4 @@
-import { waitNotifications } from "@bus/../tests/bus_test_helpers";
+import { waitForChannels, waitNotifications } from "@bus/../tests/bus_test_helpers";
 import {
     click,
     contains,
@@ -382,6 +382,7 @@ test("unknown livechat can be displayed and interacted with", async () => {
     await contains(".o-mail-DiscussSidebarCategory-livechat", { count: 0 });
     await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
     await openDiscuss(channelId);
+    await waitForChannels([`discuss.channel_${channelId}`]);
     await contains(
         ".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel.o-active",
         { text: "Jane" }

--- a/addons/mail/models/bus_presence.py
+++ b/addons/mail/models/bus_presence.py
@@ -16,7 +16,7 @@ class BusPresence(models.Model):
     ]
 
     def _get_bus_target(self):
-        return "broadcast" if self.guest_id else super()._get_bus_target()
+        return self.guest_id or super()._get_bus_target()
 
     def _get_identity_field_name(self):
         return "guest_id" if self.guest_id else super()._get_identity_field_name()

--- a/addons/mail/models/discuss/ir_websocket.py
+++ b/addons/mail/models/discuss/ir_websocket.py
@@ -21,6 +21,47 @@ class IrWebsocket(models.AbstractModel):
             )]
         return im_status
 
+    def _get_missed_presences_identity_domains(self, presence_channels):
+        identity_domain = super()._get_missed_presences_identity_domains(presence_channels)
+        if guest_ids := [
+            g.id for g, _ in presence_channels if isinstance(g, self.pool["mail.guest"])
+        ]:
+            identity_domain.append([("guest_id", "in", guest_ids)])
+        return identity_domain
+
+    @add_guest_to_context
+    def _build_presence_channel_list(self, presences):
+        channels = super()._build_presence_channel_list(presences)
+        guest_ids = [int(p[1]) for p in presences if p[0] == "mail.guest"]
+        if self.env.user and self.env.user._is_internal():
+            channels.extend(
+                (guest, "presence")
+                for guest in self.env["mail.guest"].search([("id", "in", guest_ids)])
+            )
+            # Partners already handled in super call (bus)
+            return channels
+        self_discuss_channels = self.env["discuss.channel"]
+        if self.env.user and not self.env.user._is_public():
+            self_discuss_channels = self.env.user.partner_id.channel_ids
+        elif guest := self.env["mail.guest"]._get_guest_from_context():
+            # sudo - mail.guest: guest can access their own channels.
+            self_discuss_channels = guest.sudo().channel_ids
+        partner_domain = [
+            ("id", "in", [int(p[1]) for p in presences if p[0] == "res.partner"]),
+            ("channel_ids", "in", self_discuss_channels.ids),
+        ]
+        # sudo - res.partner: allow access when sharing a common channel.
+        channels.extend(
+            (partner, "presence")
+            for partner in self.env["res.partner"].sudo().search(partner_domain)
+        )
+        guest_domain = [("id", "in", guest_ids), ("channel_ids", "in", self_discuss_channels.ids)]
+        # sudo - mail.guest: allow access when sharing a common channel.
+        channels.extend(
+            (guest, "presence") for guest in self.env["mail.guest"].sudo().search(guest_domain)
+        )
+        return channels
+
     @add_guest_to_context
     def _build_bus_channel_list(self, channels):
         channels = list(channels)  # do not alter original list
@@ -65,5 +106,5 @@ class IrWebsocket(models.AbstractModel):
             return
         token = cookies.get(self.env["mail.guest"]._cookie_name, "")
         if guest := self.env["mail.guest"]._get_guest_from_token(token):
-            # sudo - bus.presence: guests can delete their presences
-            self.env["bus.presence"].sudo().search([("guest_id", "=", guest.id)]).unlink()
+            # sudo - bus.presence: guests can write their own presence
+            self.env["bus.presence"].sudo().search([("guest_id", "=", guest.id)]).status = "offline"

--- a/addons/mail/static/src/core/common/persona_model.js
+++ b/addons/mail/static/src/core/common/persona_model.js
@@ -37,9 +37,26 @@ export class Persona extends Record {
     storeAsTrackedImStatus = Record.one("Store", {
         /** @this {import("models").Persona} */
         compute() {
-            if (this.type === "partner" && this.im_status !== "im_partner" && !this.is_public) {
+            if (
+                this.type === "guest" ||
+                (this.type === "partner" && this.im_status !== "im_partner" && !this.is_public)
+            ) {
                 return this.store;
             }
+        },
+        onAdd() {
+            if (!this.store.env.services.bus_service.isActive) {
+                return;
+            }
+            const model = this.type === "partner" ? "res.partner" : "mail.guest";
+            this.store.env.services.bus_service.addChannel(`odoo-presence-${model}_${this.id}`);
+        },
+        onDelete() {
+            if (!this.store.env.services.bus_service.isActive) {
+                return;
+            }
+            const model = this.type === "partner" ? "res.partner" : "mail.guest";
+            this.store.env.services.bus_service.deleteChannel(`odoo-presence-${model}_${this.id}`);
         },
         eager: true,
         inverse: "imStatusTrackedPersonas",

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -96,13 +96,6 @@ export class Store extends BaseStore {
     hasMessageTranslationFeature;
     imStatusTrackedPersonas = Record.many("Persona", {
         inverse: "storeAsTrackedImStatus",
-        /** @this {import("models").Store} */
-        onUpdate() {
-            this.env.services["im_status"].registerToImStatus(
-                "res.partner",
-                this.imStatusTrackedPersonas.map((p) => p.id)
-            );
-        },
     });
     hasLinkPreviewFeature = true;
     // messaging menu

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -18,6 +18,15 @@ export class DiscussCoreCommon {
     }
 
     setup() {
+        this.busService.addEventListener(
+            "connect",
+            () =>
+                this.store.imStatusTrackedPersonas.forEach((p) => {
+                    const model = p.type === "partner" ? "res.partner" : "mail.guest";
+                    this.busService.addChannel(`odoo-presence-${model}_${p.id}`);
+                }),
+            { once: true }
+        );
         this.busService.subscribe("discuss.channel/joined", async (payload) => {
             const { channel, invited_by_user_id: invitedByUserId } = payload;
             const thread = this.store.Thread.insert(channel);

--- a/addons/mail/static/tests/discuss/core/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/discuss.test.js
@@ -42,14 +42,19 @@ test("bus subscription is refreshed when channel is joined", async () => {
     mockDate(
         `${later.year}-${later.month}-${later.day} ${later.hour}:${later.minute}:${later.second}`
     );
-    await start();
-    await assertSteps(["subscribe - []"]);
+    const env = await start();
+    const imStatusChannels = [];
+    for (const { type, id } of env.services["mail.store"].imStatusTrackedPersonas) {
+        const model = type === "partner" ? "res.partner" : "mail.guest";
+        imStatusChannels.unshift(`"odoo-presence-${model}_${id}"`);
+    }
+    await assertSteps([`subscribe - [${imStatusChannels.join(",")}]`]);
     await openDiscuss();
     await assertSteps([]);
     await click(".o-mail-DiscussSidebar [title='Add or join a channel']");
     await insertText(".o-discuss-ChannelSelector input", "new channel");
     await click(".o-discuss-ChannelSelector-suggestion");
-    await assertSteps(["subscribe - []"]);
+    await assertSteps([`subscribe - [${imStatusChannels.join(",")}]`]);
 });
 
 test("bus subscription is refreshed when channel is left", async () => {
@@ -66,10 +71,15 @@ test("bus subscription is refreshed when channel is left", async () => {
     mockDate(
         `${later.year}-${later.month}-${later.day} ${later.hour}:${later.minute}:${later.second}`
     );
-    await start();
-    await assertSteps(["subscribe - []"]);
+    const env = await start();
+    const imStatusChannels = [];
+    for (const { type, id } of env.services["mail.store"].imStatusTrackedPersonas) {
+        const model = type === "partner" ? "res.partner" : "mail.guest";
+        imStatusChannels.unshift(`"odoo-presence-${model}_${id}"`);
+    }
+    await assertSteps([`subscribe - [${imStatusChannels.join(",")}]`]);
     await openDiscuss();
     await assertSteps([]);
     await click("[title='Leave this channel']");
-    await assertSteps(["subscribe - []"]);
+    await assertSteps([`subscribe - [${imStatusChannels.join(",")}]`]);
 });

--- a/addons/mail/static/tests/discuss/core/web/sidebar.test.js
+++ b/addons/mail/static/tests/discuss/core/web/sidebar.test.js
@@ -1,4 +1,4 @@
-import { waitNotifications } from "@bus/../tests/bus_test_helpers";
+import { waitForChannels, waitNotifications } from "@bus/../tests/bus_test_helpers";
 import {
     click,
     contains,
@@ -71,6 +71,7 @@ test("unknown channel can be displayed and interacted with", async () => {
     await contains("button.o-active", { text: "Inbox" });
     await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
     await openDiscuss(channelId);
+    await waitForChannels([`discuss.channel_${channelId}`]);
     await contains(
         ".o-mail-DiscussSidebarCategory-channel + .o-mail-DiscussSidebarChannel.o-active",
         { text: "Not So Secret" }

--- a/addons/mail/tests/discuss/__init__.py
+++ b/addons/mail/tests/discuss/__init__.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_avatar_acl
+from . import test_bus_presence
 from . import test_discuss_channel
 from . import test_discuss_channel_access
 from . import test_discuss_channel_as_guest

--- a/addons/mail/tests/discuss/test_bus_presence.py
+++ b/addons/mail/tests/discuss/test_bus_presence.py
@@ -1,0 +1,92 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import json
+
+try:
+    import websocket as ws
+except ImportError:
+    ws = None
+
+from odoo.tests import tagged, new_test_user
+from odoo.addons.bus.tests.common import WebsocketCase
+from odoo.addons.mail.tests.common import MailCommon
+
+
+@tagged("post_install", "-at_install")
+class TestBusPresence(WebsocketCase, MailCommon):
+    def _receive_presence(self, sender, recipient):
+        self._reset_bus()
+        sent_from_user = isinstance(sender, self.env.registry["res.users"])
+        receive_to_user = isinstance(recipient, self.env.registry["res.users"])
+        if receive_to_user:
+            session = self.authenticate(recipient.login, recipient.login)
+            auth_cookie = f"session_id={session.sid};"
+        else:
+            self.authenticate(None, None)
+            auth_cookie = f"{recipient._cookie_name}={recipient._format_auth_cookie()};"
+        websocket = self.websocket_connect(cookie=auth_cookie, timeout=1)
+        sender_bus_target = sender.partner_id if sent_from_user else sender
+        self.subscribe(
+            websocket,
+            [f"odoo-presence-{sender_bus_target._name}_{sender_bus_target.id}"],
+            self.env["bus.bus"]._bus_last_id(),
+        )
+        self.env["bus.presence"].create(
+            {"user_id" if sent_from_user else "guest_id": sender.id, "status": "online"}
+        )
+        self.trigger_notification_dispatching([(sender_bus_target, "presence")])
+        notifications = json.loads(websocket.recv())
+        self.assertEqual(notifications[0]["message"]["type"], "bus.bus/im_status_updated")
+        self.assertEqual(notifications[0]["message"]["payload"]["im_status"], "online")
+        self.assertEqual(
+            notifications[0]["message"]["payload"]["partner_id" if sent_from_user else "guest_id"],
+            sender_bus_target.id,
+        )
+        self._close_websockets()
+
+    def test_receive_presences_as_guest(self):
+        guest = self.env["mail.guest"].create({"name": "Guest"})
+        bob = new_test_user(self.env, login="bob_user", groups="base.group_user")
+        # Guest should not receive users's presence: no common channel.
+        with self.assertRaises(ws._exceptions.WebSocketTimeoutException):
+            self._receive_presence(sender=bob, recipient=guest)
+        channel = self.env["discuss.channel"].channel_create(group_id=None, name="General")
+        channel.add_members(guest_ids=[guest.id], partner_ids=[bob.partner_id.id])
+        # Now that they share a channel, guest should receive users's presence.
+        self._receive_presence(sender=bob, recipient=guest)
+
+        other_guest = self.env["mail.guest"].create({"name": "OtherGuest"})
+        # Guest should not receive guest's presence: no common channel.
+        with self.assertRaises(ws._exceptions.WebSocketTimeoutException):
+            self._receive_presence(sender=other_guest, recipient=guest)
+        channel.add_members(guest_ids=[other_guest.id])
+        # Now that they share a channel, guest should receive guest's presence.
+        self._receive_presence(sender=other_guest, recipient=guest)
+
+    def test_receive_presences_as_portal(self):
+        portal = new_test_user(self.env, login="portal_user", groups="base.group_portal")
+        bob = new_test_user(self.env, login="bob_user", groups="base.group_user")
+        # Portal should not receive users's presence: no common channel.
+        with self.assertRaises(ws._exceptions.WebSocketTimeoutException):
+            self._receive_presence(sender=bob, recipient=portal)
+        channel = self.env["discuss.channel"].channel_create(group_id=None, name="General")
+        channel.add_members(partner_ids=[portal.partner_id.id, bob.partner_id.id])
+        # Now that they share a channel, portal should receive users's presence.
+        self._receive_presence(sender=bob, recipient=portal)
+
+        guest = self.env["mail.guest"].create({"name": "Guest"})
+        # Portal should not receive guest's presence: no common channel.
+        with self.assertRaises(ws._exceptions.WebSocketTimeoutException):
+            self._receive_presence(sender=guest, recipient=portal)
+        channel.add_members(guest_ids=[guest.id])
+        # Now that they share a channel, portal should receive guest's presence.
+        self._receive_presence(sender=guest, recipient=portal)
+
+    def test_receive_presences_as_internal(self):
+        internal = new_test_user(self.env, login="internal_user", groups="base.group_user")
+        guest = self.env["mail.guest"].create({"name": "Guest"})
+        # Internal can access guest's presence regardless of their channels.
+        self._receive_presence(sender=guest, recipient=internal)
+        # Internal can access users's presence regardless of their channels.
+        bob = new_test_user(self.env, login="bob_user", groups="base.group_user")
+        self._receive_presence(sender=bob, recipient=internal)


### PR DESCRIPTION
Since [1], presences are only sent when necessary. This PR greatly reduced the traffic between client and server.

This PR is a follow-up to reduce the traffic between server and client: the presences should only be sent to people sharing a chat or channel with the presence user.

[1]: https://github.com/odoo/odoo/pull/174814

enterprise: https://github.com/odoo/enterprise/pull/68099