### PR TITLE
[FIX] hw_drivers: Allow accents in printer IDs

### DIFF
--- a/addons/hw_drivers/iot_handlers/interfaces/PrinterInterface.py
+++ b/addons/hw_drivers/iot_handlers/interfaces/PrinterInterface.py
@@ -51,11 +51,19 @@ class PrinterInterface(Interface):
         return dict(self.printer_devices)
 
     def get_identifier(self, path):
-        allowed_characters = '[^a-zA-Z0-9_-]'
-        if 'uuid=' in path:
-            identifier = sub(allowed_characters, '', path.split('uuid=')[1])
-        elif 'serial=' in path:
-            identifier = sub(allowed_characters, '', path.split('serial=')[1])
-        else:
-            identifier = sub(allowed_characters, '', path)
-        return identifier
+        """
+        Necessary because the path is not always a valid Cups identifier,
+        as it may contain characters typically found in URLs or paths.
+
+          - Removes characters: ':', '/', '.', '\', and space.
+          - Removes the exact strings: "uuid=" and "serial=".
+
+        Example 1:
+            Input: "ipp://printers/printer1:1234/abcd"
+            Output: "ippprintersprinter11234abcd"
+
+        Example 2:
+            Input: "uuid=1234-5678-90ab-cdef"
+            Output: "1234-5678-90ab-cdef
+        """
+        return sub(r'[:\/\.\\ ]|(uuid=)|(serial=)', '', path)


### PR DESCRIPTION
An error occurs when adding a printer with accents in its name. When trying to print, no error is shown to the user, only an error log in the console.

The issue is due to the get_identifier() function in the Printer class, which uses a regex that does not allow accents.

Steps to reproduce:
1. Add a printer with an accent in its name in Cups.
2. Synchronize the IoT box to Odoo.
3. Enable some reports printing on the IoT box for the new device.
4. Try to print a report with the new printer.
5. Then:
   1. No error is displayed for the end user.
   2. An error is logged in the console.

Solution:
Use a different regex approach by disallowing certain characters instead of allowing only specific ones.

opw-4070003
