### PR TITLE
[FIX] mail: AutoresizeInput style issue in public page

### DIFF
--- a/addons/mail/static/src/core/common/autoresize_input.scss
+++ b/addons/mail/static/src/core/common/autoresize_input.scss
@@ -1,5 +1,7 @@
 .o-mail-AutoresizeInput {
     --o-input-border-color: transparent;
+    border:$input-border-width solid var(--o-input-border-color);
+    background-color: var(--o-input-background-color, #{$input-bg});
 
     &:not([disabled]) {
         &:hover {

--- a/addons/mail/static/src/core/common/autoresize_input.xml
+++ b/addons/mail/static/src/core/common/autoresize_input.xml
@@ -3,7 +3,7 @@
 
 <t t-name="mail.AutoresizeInput">
     <input
-        class="o-mail-AutoresizeInput o_input px-1 border-1 text-truncate"
+        class="o-mail-AutoresizeInput px-1 border-1 text-truncate"
         t-attf-class="{{ props.className }}"
         t-att-placeholder="props.placeholder"
         t-att-disabled="!props.enabled"


### PR DESCRIPTION
The SCSS class `.o_input` is not available in public asset bundles and half of the attributes were bypassed anyway.
This commit get rids of this unnecessary dependency.

Before / After
<img width="317" alt="Screenshot 2024-08-07 at 11 36 24" src="https://github.com/user-attachments/assets/2751a933-c757-4700-b9f3-8299ffe59002">
<img width="288" alt="Screenshot 2024-08-07 at 11 36 10" src="https://github.com/user-attachments/assets/58f20a9d-c530-46a2-b1d0-2ac529f84eb4">

TASK-4100234