### PR TITLE
[IMP] web: add custom cancel button label in actions

### DIFF
--- a/addons/web/static/src/views/utils.js
+++ b/addons/web/static/src/views/utils.js
@@ -21,6 +21,7 @@ export const BUTTON_CLICK_PARAMS = [
     "args",
     "context",
     "close",
+    "cancel-label",
     "confirm",
     "confirm-title",
     "confirm-label",

--- a/addons/web/static/src/views/view_button/view_button_hook.js
+++ b/addons/web/static/src/views/view_button/view_button_hook.js
@@ -113,6 +113,9 @@ export function useViewButtons(ref, options = {}) {
                             ...(clickParams["confirm-label"] && {
                                 confirmLabel: clickParams["confirm-label"],
                             }),
+                            ...(clickParams["cancel-label"] && {
+                                cancelLabel: clickParams["cancel-label"],
+                            }),
                             body: clickParams.confirm,
                             confirm: () => execute(),
                             cancel: () => {},


### PR DESCRIPTION
In task-4037991, the 3rd point asks to rename the cancel button of the action to a custom value.
It was possible to do it for the confirm button, but not for the cancel one.

This commit adds the possiblity to modify the default value of the cancel button.

task-id: 4037991
