### PR TITLE
[FIX] web: graph: suggested min and max

### DIFF
--- a/addons/web/static/src/views/graph/graph_renderer.js
+++ b/addons/web/static/src/views/graph/graph_renderer.js
@@ -87,37 +87,6 @@ const gridOnTop = {
 };
 
 /**
- * Used to generate the min/max value of the grid (line & bar charts).
- * The purpose is to keep a bit of space between the lowest/highest data
- * and the bottom/top of the grid.
- * @param {Object[]} datasets
- * @param {Boolean} isStacked
- * @returns {{ min: number, max: number }}
- */
-function getMinMaxValue(datasets, isStacked) {
-    const values = [];
-    if (isStacked) {
-        datasets.forEach((dataset) => {
-            dataset.data.forEach((value, index) => {
-                values[index] = (values[index] || 0) + value;
-            });
-        });
-    } else {
-        datasets.forEach((dataset) => {
-            dataset.data.forEach((value) => {
-                values.push(value);
-            });
-        });
-    }
-    const min = Math.min(...values);
-    const max = Math.max(...values);
-    return {
-        min: min < 0 ? 1.1 * min : 0.9 * min,
-        max: max < 0 ? 0.9 * max : 1.1 * max,
-    };
-}
-
-/**
  * @param {Object} chartArea
  * @returns {string}
  */
@@ -588,7 +557,7 @@ export class GraphRenderer extends Component {
      * @returns {Object}
      */
     getScaleOptions() {
-        const { datasets, labels } = this.model.data;
+        const { labels } = this.model.data;
         const { fieldAttrs, measure, measures, mode, stacked } = this.model.metaData;
         if (mode === "pie") {
             return {};
@@ -609,7 +578,6 @@ export class GraphRenderer extends Component {
                 display: false,
             },
         };
-        const { min: suggestedMin, max: suggestedMax } = getMinMaxValue(datasets, stacked);
         const yAxe = {
             beginAtZero: true,
             type: "linear",
@@ -632,8 +600,8 @@ export class GraphRenderer extends Component {
             border: {
                 display: false,
             },
-            suggestedMax,
-            suggestedMin,
+            suggestedMax: 0,
+            suggestedMin: 0,
         };
         return { x: xAxe, y: yAxe };
     }

--- a/addons/web/static/tests/views/graph/graph_view.test.js
+++ b/addons/web/static/tests/views/graph/graph_view.test.js
@@ -900,7 +900,7 @@ test("format total in hh:mm when measure is unit_amount", async () => {
     checkLegend(view, "Unit Amount");
     checkLabels(view, ["Total"]);
     expect(fieldAttrs[measure].widget).toBe("float_time", { message: "should be a float_time widget" });
-    checkYTicks(view, ["00:00", "01:00", "02:00", "03:00", "04:00", "05:00", "06:00", "07:00", "08:00", "09:00"]);
+    checkYTicks(view, ["00:00", "01:00", "02:00", "03:00", "04:00", "05:00", "06:00", "07:00", "08:00"]);
     checkTooltip(view, { title: "Unit Amount", lines: [{ label: "Total", value: "08:00" }] }, 0);
 });
 


### PR DESCRIPTION
With the current suggested values for the y axe min and max of graph views, if a user unselect some group via the buttons drawn on the chart, the chart y axe min and max are not adapted. This can lead to an unreadable chart if the group removed takes bigger values that the others. In that case, a lot of spaces is unused and the other groups are not very visible while they could be.
Here we reset the suggested min and max to the values they had before https://github.com/odoo/odoo/commit/dc67385f95b3480011da335f51431e0b916f5ba6.
