### PR TITLE
FIX] web: infinity error loop when errors on multiple actions in the URL

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -509,7 +509,7 @@ export function makeActionManager(env, router = _router) {
                     type: "ir.actions.act_window",
                     views: [[state.view_id ? state.view_id : false, "form"]],
                 };
-            } else if (state.view_type) {
+            } else {
                 // This is a window action on a multi-record view => restores it from
                 // the session storage
                 const storedAction = browser.sessionStorage.getItem("current_action");

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1498,7 +1498,7 @@ export function makeActionManager(env, router = _router) {
                 throw new Error("Attempted to restore a virtual controller whose state is invalid");
             }
             const { actionRequest, options } = actionParams;
-            options.index = index;
+            controllerStack = controllerStack.slice(0, index);
             return doAction(actionRequest, options);
         }
         if (controller.action.type === "ir.actions.act_window") {
@@ -1525,7 +1525,12 @@ export function makeActionManager(env, router = _router) {
         if (actionParams) {
             // Params valid => performs a "doAction"
             const { actionRequest, options } = actionParams;
-            options.newStack = newStack;
+            if (options.index) {
+                options.newStack = newStack.slice(0, options.index);
+                delete options.index;
+            } else {
+                options.newStack = newStack;
+            }
             await doAction(actionRequest, options);
             return true;
         }

--- a/addons/web/static/tests/legacy/webclient/actions/load_state_tests.js
+++ b/addons/web/static/tests/legacy/webclient/actions/load_state_tests.js
@@ -28,6 +28,7 @@ import { redirect } from "@web/core/utils/urls";
 import { ControlPanel } from "@web/search/control_panel/control_panel";
 import { _t } from "@web/core/l10n/translation";
 import { user } from "@web/core/user";
+import { makeServerError } from "@web/../tests/legacy/helpers/mock_server";
 
 function getBreadCrumbTexts(target) {
     return getNodesTextContent(target.querySelectorAll(".breadcrumb-item, .o_breadcrumb .active"));
@@ -687,10 +688,7 @@ QUnit.module("ActionManager", (hooks) => {
             await click(target.querySelector(".o_control_panel .breadcrumb a"));
             assert.containsOnce(target, ".o_list_view");
             assert.containsNone(target, ".o_form_view");
-            assert.verifySteps([
-                "Update the state without updating URL, nextState: actionStack,resId,action,globalState",
-                "web_search_read",
-            ]);
+            assert.verifySteps(["web_search_read"]);
             await nextTick(); // pushState is debounced
             assert.strictEqual(browser.location.href, "http://example.com/odoo/action-3");
             assert.verifySteps(["pushState http://example.com/odoo/action-3"]);
@@ -963,10 +961,7 @@ QUnit.module("ActionManager", (hooks) => {
             assert.containsN(target, ".o_list_view .o_data_row", 1);
             await nextTick(); // pushState is debounced
             assert.strictEqual(browser.location.href, "http://example.com/odoo/action-3");
-            assert.verifySteps([
-                "Update the state without updating URL, nextState: actionStack,resId,action,globalState",
-                "pushState http://example.com/odoo/action-3",
-            ]);
+            assert.verifySteps(["pushState http://example.com/odoo/action-3"]);
         }
     );
 
@@ -1019,6 +1014,34 @@ QUnit.module("ActionManager", (hooks) => {
             "url did not change"
         );
         assert.verifySteps([], "pushState was not called");
+    });
+
+    QUnit.test("all actions crashes", async (assert) => {
+        assert.expectErrors();
+        redirect("/odoo/m-partner/2/m-partner/1");
+        logHistoryInteractions(assert);
+        setupWebClientRegistries();
+
+        const mockRPC = async function (route, { method }) {
+            assert.step(method || route);
+            if (method === "web_read") {
+                throw makeServerError();
+            }
+        };
+        const env = await makeTestEnv({ serverData, mockRPC });
+
+        await mount(WebClient, getFixture(), { env });
+        await nextTick();
+        await nextTick();
+        assert.verifySteps([
+            "/web/webclient/load_menus",
+            "/web/action/load_breadcrumbs",
+            "get_views",
+            "web_read",
+            "web_read",
+        ]);
+        assert.verifyErrors(["Odoo Server Error", "Odoo Server Error"]);
+        assert.strictEqual(target.querySelector(".o_action_manager").childElementCount, 0);
     });
 
     QUnit.test(
@@ -1115,6 +1138,42 @@ QUnit.module("ActionManager", (hooks) => {
         await nextTick();
         assert.containsOnce(target, ".o_list_view");
         assert.verifySteps(["web_search_read", "pushState http://example.com/odoo/action-3"]);
+    });
+
+    QUnit.test("properly load previous action when error", async function (assert) {
+        // In this test, the _getActionParams, will not return m-partner as an actionRequest
+        // because, there is not id, or an action on the session storage.
+        // So it will try to perform the previous action : action-3 with id 1.
+        // This one will give an error, and it should directly try the previous one : action-3
+        assert.expectErrors();
+        redirect("/odoo/action-3/1/m-partner");
+        logHistoryInteractions(assert);
+        setupWebClientRegistries();
+        let webReadLoad = 0;
+        const mockRPC = async function (route, { method }) {
+            assert.step(method || route);
+            if (method === "web_read") {
+                webReadLoad++;
+                throw makeServerError();
+            }
+        };
+        const env = await makeTestEnv({ serverData, mockRPC });
+
+        await mount(WebClient, getFixture(), { env });
+        await nextTick();
+        await nextTick();
+        assert.containsOnce(target, ".o_list_view");
+        assert.expectErrors(["my error"]);
+        assert.verifySteps([
+            "/web/webclient/load_menus",
+            "/web/action/load_breadcrumbs",
+            "/web/action/load",
+            "get_views",
+            "web_read",
+            "web_search_read",
+            "pushState http://example.com/odoo/action-3",
+        ]);
+        assert.strictEqual(webReadLoad, 1);
     });
 
     QUnit.module("Load State: legacy urls");


### PR DESCRIPTION
- Open Accounting;
- Open Bank Reconciliation;
- Change the Company, to a company with not installed a chart of account.

Before this commit, an infinity access error loop was raise. This occurs,
because when an action is in an error on mounting on the action service,
we try to mount the previous action, choose from a list of previously
executed actions. The previous action, in this case, was also in error.
In these case, it should go to the before last of the list, but as the
previous one wasn't removed. It will try to mount it again, and create
an infinity loop.

opw-[4076702](https://www.odoo.com/web#id=4076702&view_type=form&model=project.task)
