### PR TITLE
[FIX] base: prevent error when creating a new view

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -597,6 +597,8 @@ actual arch.
         Determine the views that inherit from the current recordset, and return
         them as a recordset, ordered by priority then by id.
         """
+        if not self.ids:
+            return self.browse()
         self.check_access_rights('read')
         domain = self._get_inheriting_views_domain()
         e = expression(domain, self.env['ir.ui.view'])


### PR DESCRIPTION
When the user tries to create a new view, a traceback will appear.

Steps to reproduce the error:
- Go to Settings > Technical > User Interface > Views > New

Traceback:
```
Traceback (most recent call last):
  File "/home/odoo/odoo/community/odoo/http.py", line 2373, in __call__
    response = request._serve_db()
  File "/home/odoo/odoo/community/odoo/http.py", line 1903, in _serve_db
    return self._transactioning(
  File "/home/odoo/odoo/community/odoo/http.py", line 1966, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "/home/odoo/odoo/community/odoo/service/model.py", line 134, in retrying
    result = func()
  File "/home/odoo/odoo/community/odoo/http.py", line 1933, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/home/odoo/odoo/community/odoo/http.py", line 2177, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/home/odoo/odoo/community/odoo/addons/base/models/ir_http.py", line 223, in _dispatch
    result = endpoint(**request.params)
  File "/home/odoo/odoo/community/odoo/http.py", line 754, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/home/odoo/odoo/community/addons/web/controllers/dataset.py", line 35, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/home/odoo/odoo/community/odoo/api.py", line 459, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "/home/odoo/odoo/community/addons/web/models/models.py", line 1021, in onchange
    snapshot1 = RecordSnapshot(record, fields_spec)
  File "/home/odoo/odoo/community/addons/web/models/models.py", line 1108, in __init__
    self.fetch(name)
  File "/home/odoo/odoo/community/addons/web/models/models.py", line 1123, in fetch
    self[field_name] = self.record[field_name]
  File "/home/odoo/odoo/community/odoo/models.py", line 6727, in __getitem__
    return self._fields[key].__get__(self)
  File "/home/odoo/odoo/community/odoo/fields.py", line 1263, in __get__
    self.compute_value(recs)
  File "/home/odoo/odoo/community/odoo/fields.py", line 1445, in compute_value
    records._compute_field_value(self)
  File "/home/odoo/odoo/community/odoo/models.py", line 5037, in _compute_field_value
    fields.determine(field.compute, self)
  File "/home/odoo/odoo/community/odoo/fields.py", line 101, in determine
    return needle(*args)
  File "/home/odoo/odoo/community/odoo/addons/base/models/ir_ui_view.py", line 467, in _compute_warning_info
    combined_arch = view._get_combined_arch()
  File "/home/odoo/odoo/community/odoo/addons/base/models/ir_ui_view.py", line 931, in _get_combined_arch
    tree_views = views._get_inheriting_views()
  File "/home/odoo/odoo/community/odoo/addons/base/models/ir_ui_view.py", line 634, in _get_inheriting_views
    rows = self.env.execute_query(query)
  File "/home/odoo/odoo/community/odoo/api.py", line 868, in execute_query
    self.cr.execute(query)
  File "/home/odoo/odoo/community/odoo/sql_db.py", line 347, in execute
    res = self._obj.execute(query, params)
psycopg2.errors.SyntaxError: syntax error at or near ")"
LINE 5:                 WHERE id IN () AND (("ir_ui_view"."active" =
```

When the user creates a new view, self will be NewId in "_compute_warning_info", 
so eventually in "_get_inheriting_views" method, self will be NewId,
so eventually self.ids will be [] here,
https://github.com/odoo/odoo/blob/855612ce254a4d4d547fc65b553b37c2876fcce2/odoo/addons/base/models/ir_ui_view.py#L611
so it will lead to the above traceback.

sentry-5675367115

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
