### PR TITLE
[FIX] website_sale: fix dynamic snippet products preview

### DIFF
--- a/addons/website_sale/views/snippets/s_dynamic_snippet_products_preview_data.xml
+++ b/addons/website_sale/views/snippets/s_dynamic_snippet_products_preview_data.xml
@@ -9,7 +9,7 @@
                             <div class="o_carousel_product_card bg-transparent w-100 card border-0">
                                 <a class="o_carousel_product_img_link o_dynamic_product_hovered stretched-link" href="#">
                                     <div class="overflow-hidden rounded">
-                                        <img class="card-img-top o_img_product_square o_img_product_cover h-auto" loading="lazy" src="website_sale/static/src/img/product_previews/product_1.jpg"/>
+                                        <img class="card-img-top o_img_product_square o_img_product_cover h-auto" loading="lazy" src="/website_sale/static/src/img/product_previews/product_1.jpg"/>
                                     </div>
                                 </a>
                                 <div class="o_carousel_product_card_body d-flex flex-wrap flex-column justify-content-between h-100 p-3">
@@ -28,7 +28,7 @@
                             <div class="o_carousel_product_card bg-transparent w-100 card border-0">
                                 <a class="o_carousel_product_img_link o_dynamic_product_hovered stretched-link" href="#">
                                     <div class="overflow-hidden rounded">
-                                        <img class="card-img-top o_img_product_square o_img_product_cover h-auto" loading="lazy" src="website_sale/static/src/img/product_previews/product_2.jpg" alt="Warranty (2 year)"/>
+                                        <img class="card-img-top o_img_product_square o_img_product_cover h-auto" loading="lazy" src="/website_sale/static/src/img/product_previews/product_2.jpg" alt="Warranty (2 year)"/>
                                     </div>
                                 </a>
                                 <div class="o_carousel_product_card_body d-flex flex-wrap flex-column justify-content-between h-100 p-3">
@@ -47,7 +47,7 @@
                             <div class="o_carousel_product_card bg-transparent w-100 card border-0">
                                 <a class="o_carousel_product_img_link o_dynamic_product_hovered stretched-link" href="#">
                                     <div class="overflow-hidden rounded">
-                                        <img class="card-img-top o_img_product_square o_img_product_cover h-auto" loading="lazy" src="website_sale/static/src/img/product_previews/product_3.jpg" alt="Warranty (2 year)"/>
+                                        <img class="card-img-top o_img_product_square o_img_product_cover h-auto" loading="lazy" src="/website_sale/static/src/img/product_previews/product_3.jpg" alt="Warranty (2 year)"/>
                                     </div>
                                 </a>
                                 <div class="o_carousel_product_card_body d-flex flex-wrap flex-column justify-content-between h-100 p-3">
@@ -66,7 +66,7 @@
                             <div class="o_carousel_product_card bg-transparent w-100 card border-0">
                                 <a class="o_carousel_product_img_link o_dynamic_product_hovered stretched-link" href="#">
                                     <div class="overflow-hidden rounded">
-                                        <img class="card-img-top o_img_product_square o_img_product_cover h-auto" loading="lazy" src="website_sale/static/src/img/product_previews/product_4.jpg" alt="Warranty (2 year)"/>
+                                        <img class="card-img-top o_img_product_square o_img_product_cover h-auto" loading="lazy" src="/website_sale/static/src/img/product_previews/product_4.jpg" alt="Warranty (2 year)"/>
                                     </div>
                                 </a>
                                 <div class="o_carousel_product_card_body d-flex flex-wrap flex-column justify-content-between h-100 p-3">


### PR DESCRIPTION
Steps to reproduce the bug:

- Go to the "Customizable Desk" product page.
- Enter edit mode.
- Click on the "Products" category in the side panel.
- Bug => The preview of the "Products" snippet is not displayed.

The bug is due to the image paths in the snippet being defined as relative instead of absolute. This commit fixes that.

task-4072655