### PR TITLE
[FIX] point_of_sale: responsive list container

### DIFF
--- a/addons/point_of_sale/static/src/app/utils/hooks.js
+++ b/addons/point_of_sale/static/src/app/utils/hooks.js
@@ -152,20 +152,18 @@ export function useTrackedAsync(asyncFn) {
     };
 }
 
-export function useIsChildLarger(childRefName) {
-    const child = useRef(childRefName);
+export function useIsChildLarger(child) {
     const state = useState({
         isLarger: false,
     });
     useEffect(
         (child) => {
-            const updateDimensions = () => {
+            const resizeObserver = new ResizeObserver(() => {
                 state.isLarger = child.el.scrollWidth > child.el.parentElement.clientWidth;
-            };
-            updateDimensions();
-            window.addEventListener("resize", updateDimensions);
+            });
+            resizeObserver.observe(child.el);
             return () => {
-                window.removeEventListener("resize", updateDimensions);
+                resizeObserver.unobserve(child.el);
             };
         },
         () => [child]


### PR DESCRIPTION
The `ListContainer` component did not work correctly when the size of
the list of elements to be displayed changed. This commit fixes the
issue.

Steps to reproduce:
1. Create a couple of tabs ( in desktop mode )
2. Notice that when there are too many tabs, the "view more" button does
   not appear

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
