### PR TITLE
[FIX] website_sale_slides: scale down big num price

### DIFF
--- a/addons/website_sale_slides/views/website_slides_templates.xml
+++ b/addons/website_sale_slides/views/website_slides_templates.xml
@@ -88,7 +88,7 @@
         <div t-attf-class="text-center d-flex align-items-center text-center pb-1 #{'justify-content-between' if product_info['has_discounted_price'] else 'justify-content-around'}">
             <div class="css_editable_mode_hidden">
                 <!-- real price -->
-                <div class="oe_price font-weight-bold text-nowrap h2 my-2"
+                <div t-attf-class="oe_price font-weight-bold text-nowrap my-2 #{'h4' if len(str(product_info['price'])) > 10 else 'h2'}"
                      t-esc="product_info['price']"
                      t-options="{'widget': 'monetary', 'display_currency': product_info['currency_id']}"/>
                 <span itemprop="price" style="display:none;" t-esc="product_info['price']"/>


### PR DESCRIPTION
[FIX] website_sale_slides: scale down big num price

Before this commit price had h2 class always. With this commit
if price is longer than 10 digits we'll use smaller heading. 

[Reproduce]
- Install website_sale_slides
- Have a course:
	- "Enroll Policy": "On Payment"
	- It's related product's price has more than 10 digits
	- You not enrolled in it yet
- Open course page -> UX BUG: price overflows

opw-4075034