### PR TITLE
[FIX] l10n_cl_edi, l10n_latam_edi : make the draft invoices accessible to internal users

### DIFF
--- a/addons/l10n_latam_invoice_document/security/ir.model.access.csv
+++ b/addons/l10n_latam_invoice_document/security/ir.model.access.csv
@@ -1,4 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_l10n_latam_document_type_readonly,l10n_latam.document.type.readonly,model_l10n_latam_document_type,account.group_account_readonly,1,0,0,0
-access_l10n_latam_document_type_invoice,l10n_latam.document.type.invoice,model_l10n_latam_document_type,account.group_account_invoice,1,0,0,0
+access_l10n_latam_document_type,access_l10n_latam_document_type,model_l10n_latam_document_type,base.group_user,1,0,0,0
 access_l10n_latam_document_type_account_manager,l10n_latam.document.type.all,model_l10n_latam_document_type,account.group_account_manager,1,1,1,0


### PR DESCRIPTION
Enterprise PR: https://github.com/odoo/enterprise/pull/68087

A user without any accounting access right set get an error when creating an invoice from a sale order. The user should be able to see the draft invoice when clicking on the 'Create Invoice' from a sale order, as it is the case without the l10n_cl_edi module.

### Steps to reproduce:
- Install the 'l10n_cl_edi' module
- As admin go to Settings > Manage Users, click on a User and, in Access Rights, change Accounting > Invoicing to nothing
- (Make sure the User Type is Internal User)
- Switch to this user
- Go to Sales and create a new Quotation, confirm
- Click on the 'Create Invoice' button
- An access error appears because of 'l10n_cl.account.invoice.reference'

### Cause:
The records of `l10n_cl.account.invoice.reference` are only readable by Accounting groups.

### Solution:
Make the records of `l10n_cl.account.invoice.reference` accessible to all internal users. This will raise another access error for `l10n_latam.document.type`, so we also need to make them accessible (in community).

### Note:
I noticed the access right of `l10n_cl.account.invoice.reference` were giving rights to `account.group_account_invoice` twice, where I think the second time was supposed to be `account.group_account_manager`. I don't know if this is wanted, but it doesn't make sense to have two lines for the same model and user group.
I decided to only change `group_account_invoice` to `group_account_manager` so this PR is removing the write, create, unlink rights of `account.group_account_invoice`.

opw-4078302
