### PR TITLE
[FIX] website: resolve page getting crash issue

### DIFF
--- a/addons/website/models/website_rewrite.py
+++ b/addons/website/models/website_rewrite.py
@@ -87,6 +87,10 @@ class WebsiteRewrite(models.Model):
                     raise ValidationError(_('"URL to" can not be empty.'))
                 if not rewrite.url_from:
                     raise ValidationError(_('"URL from" can not be empty.'))
+                if rewrite.url_to.startswith('#') or rewrite.url_from.startswith('#'):
+                    raise ValidationError(_("URL must not start with '#'."))
+                if rewrite.url_to.split('#')[0] == rewrite.url_from.split('#')[0]:
+                    raise ValidationError(_("base URL of 'URL to' should not be same as 'URL from'."))
 
             if rewrite.redirect_type == '308':
                 if not rewrite.url_to.startswith('/'):

--- a/addons/website/tests/test_redirect.py
+++ b/addons/website/tests/test_redirect.py
@@ -35,6 +35,24 @@ class TestWebsiteRedirect(TransactionCase):
             })
         self.assertIn('existing page', str(error.exception))
 
+        with self.assertRaises(ValidationError) as error:
+            self.env['website.rewrite'].create({
+                'name': 'Test Website Redirect',
+                'redirect_type': '301',
+                'url_from': '/website/info',
+                'url_to': '#',
+            })
+        self.assertIn("must not start with '#'", str(error.exception))
+
+        with self.assertRaises(ValidationError) as error:
+            self.env['website.rewrite'].create({
+                'name': 'Test Website Redirect',
+                'redirect_type': '301',
+                'url_from': '/website/info',
+                'url_to': '/website/info',
+            })
+        self.assertIn("should not be same", str(error.exception))
+
     def test_sitemap_with_redirect(self):
         self.env['website.rewrite'].create({
             'name': 'Test Website Redirect',


### PR DESCRIPTION
Steps to Reproduce :
1. Activate the developer mode
2. Create a menu from the Site ---> Menu Editor option
3. Go to Configurations ---> Redirects ​
   3.1. Select Action as : '301 Moved Permanently' ​
   3.2. URL From : '/<url_added_at_time_Menu_creation' ​
   3.3. URL To : '#'
4. Go to the Home page
5. Click on the Menu created
6. Traceback Occurs

Expected Behavior:
The page should not crash even when the paths of  'url_from' and 'url_to' are the same.

Reason:
When the paths of 'url_to' and 'url_from' are the same  and the value of 'url_to' starts with '?' or '#' , the redirection loop is created and the page is crashed.

This commit is resolving page crash issue by checking the path of
'url_to' and 'url_from' in '_serve_fallback' method, where redirection
is happening. If path is same, then we will not redirect; instead, we
will return from this method. If 'url_to' starts with '#' or '?',
In this case, we are showing validation error to the user.

task-3984211