### PR TITLE
[FIX] pos_self_order: display confirmation screen after razorpay payment

### DIFF
--- a/addons/pos_online_payment_self_order/static/src/self_order_service.js
+++ b/addons/pos_online_payment_self_order/static/src/self_order_service.js
@@ -15,14 +15,8 @@ patch(SelfOrder.prototype, {
                 (o) => o.access_token === data["pos.order"][0].access_token
             );
             if (status === "success" && !this.currentOrder.access_token && order) {
-                this.finalizeOrder(order.access_token);
+                this.confirmationPage("order", this.config.self_ordering_mode, order.access_token);
             }
-        });
-    },
-    finalizeOrder(accessToken) {
-        this.router.navigate("confirmation", {
-            orderAccessToken: accessToken,
-            screenMode: "order",
         });
     },
     getOnlinePaymentUrl(

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -92,7 +92,19 @@ export class SelfOrder extends Reactive {
             this.onNotified("PAYMENT_STATUS", ({ payment_result, data }) => {
                 if (payment_result === "Success") {
                     this.models.replaceDataByKey("uuid", data);
-                    this.router.navigate("confirmation");
+                    const order = this.models["pos.order"].find(
+                        (o) => o.access_token === data["pos.order"][0].access_token
+                    );
+                    if (["paid", "invoiced", "done"].includes(order?.state)) {
+                        this.notification.add(_t("Your order has been paid"), {
+                            type: "success",
+                        });
+                        this.confirmationPage(
+                            "order",
+                            this.config.self_ordering_mode,
+                            order.access_token
+                        );
+                    }
                 } else {
                     this.paymentError = true;
                 }
@@ -289,9 +301,9 @@ export class SelfOrder extends Reactive {
             newLine.delete();
         }
     }
-    async confirmationPage(screen_mode, device) {
+    async confirmationPage(screen_mode, device, access_token = "") {
         this.router.navigate("confirmation", {
-            orderAccessToken: this.currentOrder.access_token,
+            orderAccessToken: access_token || this.currentOrder.access_token,
             screenMode: screen_mode,
         });
         if (device === "kiosk") {


### PR DESCRIPTION
Before this commit:
===================
In Kiosk mode, the confirmation screen was not displayed after payment through the Razorpay Terminal. Instead, it redirected directly to the home screen.

After this commit:
==================
In Kiosk mode, the order confirmation screen will be displayed after payment through the Razorpay Terminal, similar to normal orders.

task- 4084942
