### PR TITLE
[FIX] point_of_sale: use correct fp for taxed list price computation

### DIFF
--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -626,9 +626,8 @@ export class Orderline extends PosModel {
         let taxes = product.taxes_id;
 
         // Fiscal position.
-        const order = this.pos.get_order();
-        if (order.fiscal_position) {
-            taxes = this.pos.getTaxesAfterFiscalPosition(taxes, order.fiscal_position);
+        if (this.order.fiscal_position) {
+            taxes = this.pos.getTaxesAfterFiscalPosition(taxes, this.order.fiscal_position);
         }
 
         const taxesData = this.pos.getTaxesValues(taxes, priceUnit, 1, product);


### PR DESCRIPTION
Before this commit, the computation of the orderLine taxed list price incorrectly used the selected order's fiscal position, even for paid orders. This could lead to inaccurate pricing in certain scenarios.

opw-4093746

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
