### PR TITLE
[FIX] mail: selecting an emoji should trigger notifyIsTyping

### DIFF
--- a/addons/mail/static/src/discuss/typing/common/composer_patch.js
+++ b/addons/mail/static/src/discuss/typing/common/composer_patch.js
@@ -42,15 +42,13 @@ patch(Composer.prototype, {
             );
         }
     },
-    /**
-     * @param {InputEvent} ev
-     */
-    onInput(ev) {
-        if (this.thread?.model === "discuss.channel" && ev.target.value.startsWith("/")) {
-            const [firstWord] = ev.target.value.substring(1).split(/\s/);
+    detectTyping() {
+        const value = this.props.composer.text;
+        if (this.thread?.model === "discuss.channel" && value.startsWith("/")) {
+            const [firstWord] = value.substring(1).split(/\s/);
             const command = commandRegistry.get(firstWord, false);
             if (
-                ev.target.value === "/" || // suggestions not yet started
+                value === "/" || // suggestions not yet started
                 this.hasSuggestions ||
                 (command &&
                     (!command.channel_types ||
@@ -60,7 +58,7 @@ patch(Composer.prototype, {
                 return;
             }
         }
-        if (!this.typingNotified && ev.target.value) {
+        if (!this.typingNotified && value) {
             this.typingNotified = true;
             this.notifyIsTyping();
             browser.setTimeout(() => (this.typingNotified = false), LONG_TYPING);
@@ -79,5 +77,9 @@ patch(Composer.prototype, {
             this.typingNotified = false;
             this.notifyIsTyping(false);
         }
+    },
+    addEmoji(str) {
+        super.addEmoji(str);
+        this.detectTyping();
     },
 });

--- a/addons/mail/static/src/discuss/typing/common/composer_patch.xml
+++ b/addons/mail/static/src/discuss/typing/common/composer_patch.xml
@@ -7,7 +7,7 @@
             </div>
         </xpath>
         <xpath expr="//*[hasclass('o-mail-Composer-input')]" position="attributes">
-            <attribute name="t-on-input">onInput</attribute>
+            <attribute name="t-on-input">detectTyping</attribute>
         </xpath>
     </t>
 </templates>

--- a/addons/mail/static/tests/discuss/core/composer.test.js
+++ b/addons/mail/static/tests/discuss/core/composer.test.js
@@ -49,6 +49,18 @@ test('do not send typing notification on typing after selecting suggestion from 
     await assertSteps([]); // No rpc done"
 });
 
+test("send is_typing on adding emoji", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "channel" });
+    onRpcBefore("/discuss/channel/notify_typing", () => step("notify_typing"));
+    await start();
+    await openDiscuss(channelId);
+    await click("button[aria-label='Emojis']");
+    await insertText("input[placeholder='Search for an emoji']", "Santa Claus");
+    await click(".o-Emoji", { text: "🎅" });
+    await assertSteps(["notify_typing"]);
+});
+
 test("add an emoji after a command", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({


### PR DESCRIPTION
Purpose of the commit:
Previously, when a new channel was created, sending an emoji as a message did not add the sender as a member. This was because selecting an emoji did not trigger the `notifyIsTyping`. To address this issue, `notifyIsTyping` is now triggered when an emoji is selected in the composer.

task-4100450
