### PR TITLE
[IMP] mail: join channel action button

### DIFF
--- a/addons/im_livechat/static/tests/join_livechat_needing_help.test.js
+++ b/addons/im_livechat/static/tests/join_livechat_needing_help.test.js
@@ -25,13 +25,13 @@ test("Show join button when help is required and self is not a member", async ()
     await start();
     await openDiscuss(channel);
     await contains(".o-livechat-LivechatStatusSelection .active", { text: "Looking for help" });
-    await click("button[name='join-livechat-needing-help']");
+    await click("button[name='join-channel']");
     await contains(".o-livechat-LivechatStatusSelection .active", { text: "In progress" });
-    await contains("button[name='join-livechat-needing-help']", { count: 0 });
+    await contains("button[name='join-channel']", { count: 0 });
     await click("button", { text: "Looking for help" });
     await contains(".o-livechat-LivechatStatusSelection .active", { text: "Looking for help" });
     // Now that we are members, the button is not shown, even if help is required.
-    await contains("button[name='join-livechat-needing-help']", { count: 0 });
+    await contains("button[name='join-channel']", { count: 0 });
 });
 
 test("Show notification when joining a channel that already received help", async () => {
@@ -54,7 +54,7 @@ test("Show notification when joining a channel that already received help", asyn
     });
     await openDiscuss(channel);
     await contains(".o-livechat-LivechatStatusSelection .active", { text: "Looking for help" });
-    await click("button[name='join-livechat-needing-help']");
+    await click("button[name='join-channel']");
     expect.waitForSteps(["warning - Someone has already joined this conversation"]);
 });
 
@@ -83,10 +83,10 @@ test("Hide 'help already received' notification when channel is not visible", as
     });
     await openDiscuss(channel);
     await contains(".o-livechat-LivechatStatusSelection .active", { text: "Looking for help" });
-    await click("button[name='join-livechat-needing-help']");
+    await click("button[name='join-channel']");
     expect.waitForSteps(["warning - Someone has already joined this conversation"]);
     canRespondDeferred = new Deferred();
-    await click("button[name='join-livechat-needing-help']");
+    await click("button[name='join-channel']");
     await click(".o-mail-DiscussSidebar-item", { text: "Inbox" });
     await contains(".o-mail-DiscussContent-threadName[title='Inbox']");
     canRespondDeferred.resolve();

--- a/addons/mail/static/src/discuss/core/web/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/web/thread_actions.js
@@ -1,7 +1,25 @@
+import { ACTION_TAGS } from "@mail/core/common/action";
 import { registerThreadAction } from "@mail/core/common/thread_actions";
 
 import { _t } from "@web/core/l10n/translation";
 
+export const joinChannelAction = {
+    condition: ({ thread }) =>
+        thread &&
+        !thread.self_member_id &&
+        !["chat", "group"].includes(thread.channel_type) &&
+        thread.model !== "mail.box",
+    open: ({ store, thread }) =>
+        store.env.services.orm.call("discuss.channel", "add_members", [[thread.id]], {
+            partner_ids: [store.self.id],
+        }),
+    icon: "fa fa-fw fa-sign-in",
+    name: _t("Join Channel"),
+    sequence: 20,
+    sequenceGroup: ({ owner }) => (owner.isDiscussContent ? undefined : 5),
+    tags: [ACTION_TAGS.SUCCESS],
+};
+registerThreadAction("join-channel", joinChannelAction);
 registerThreadAction("expand-discuss", {
     condition: ({ owner, store, thread }) =>
         thread &&

--- a/addons/mail/static/tests/discuss/core/web/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/web/discuss.test.js
@@ -18,6 +18,7 @@ import { describe, test } from "@odoo/hoot";
 import {
     asyncStep,
     Command,
+    getService,
     onRpc,
     serverState,
     waitForSteps,
@@ -241,4 +242,23 @@ test("Create channel must have a name", async () => {
     await click("input[placeholder='Channel name']");
     await triggerHotkey("Enter");
     await contains(".invalid-feedback", { text: "Channel must have a name." });
+});
+
+test("Can join accessible channel via thread action", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "Very cool channel",
+        channel_member_ids: [],
+    });
+    await start();
+    await openDiscuss();
+    await getService("action").doAction({
+        context: { active_id: channelId },
+        tag: "mail.action_discuss",
+        type: "ir.actions.client",
+    });
+    await contains(".o-mail-ActionPanel:has(.o-mail-ActionPanel-header:contains('Members'))");
+    await contains(".o-discuss-ChannelMember", { count: 0 });
+    await click("[title='Join Channel']");
+    await contains(".o-discuss-ChannelMember", { count: 1, text: "Mitchell Admin" });
 });


### PR DESCRIPTION
Currently when opening a channel through an internal link there is no direct way to join said channel.

This commit adds an action button that lets you join the channel without having to perform an action that will trigger the automatic joining of the channel.

task-4103051
