### PR TITLE
[FIX] account: allow xls,xlsx,csv attachment from alias

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -32,6 +32,7 @@ from odoo.tools import (
     is_html_empty,
     create_index,
 )
+from odoo.addons.base_import.models.base_import import FILE_TYPE_DICT
 
 _logger = logging.getLogger(__name__)
 
@@ -3152,6 +3153,7 @@ class AccountMove(models.Model):
                 file_data['type'] == 'binary'
                 and self._context.get('from_alias')
                 and not attachments_by_invoice.get(file_data['attachment'])
+                and file_data['attachment'].mimetype not in FILE_TYPE_DICT
             ):
                 close_file(file_data)
                 continue
@@ -3189,7 +3191,7 @@ class AccountMove(models.Model):
                         invoice = current_invoice or self.create({})
                         success = decoder(invoice, file_data, new)
 
-                        if success or file_data['type'] == 'pdf':
+                        if success or file_data['type'] == 'pdf' or file_data['attachment'].mimetype in FILE_TYPE_DICT:
                             invoice._link_bill_origin_to_purchase_orders(timeout=4)
                             invoices |= invoice
                             current_invoice = self.env['account.move']


### PR DESCRIPTION
Set up email alias for Vendor Bill journal
Send email with xls attachment to alias
Bill is created
Issue: No attachment is present

This occurs because after https://github.com/odoo/odoo/commit/9b735f7597d75412a8ea6c4e541b05eb8849bd9c
the system will not add binary attachments to the created bill
The change was meant to filter out rogue images often present in emails
but it is too restrictive so this commit add a second check with
the mimetype of the parsed attachment in order to keep useful
attachments

opw-4092311