### PR TITLE
[DRAFT][FIX] stock: allow kit scrap when components out of stock

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -599,6 +599,8 @@ class StockMoveLine(models.Model):
         ml_ids_to_ignore = OrderedSet()
 
         for ml in mls_todo:
+            if not self.env['stock.move.line'].search([('id', '=', ml.id)]):
+                continue
             # if this move line is force assigned, unreserve elsewhere if needed
             ml._synchronize_quant(-ml.quantity_product_uom, ml.location_id, action="reserved")
             available_qty, in_date = ml._synchronize_quant(-ml.quantity_product_uom, ml.location_id)
@@ -609,10 +611,8 @@ class StockMoveLine(models.Model):
                     abs(available_qty), lot_id=ml.lot_id, package_id=ml.package_id,
                     owner_id=ml.owner_id, ml_ids_to_ignore=ml_ids_to_ignore)
             ml_ids_to_ignore.add(ml.id)
-        # Reset the reserved quantity as we just moved it to the destination location.
-        mls_todo.write({
-            'date': fields.Datetime.now(),
-        })
+            # Reset the reserved quantity as we just moved it to the destination location.
+            ml.write({'date': fields.Datetime.now()})
 
     def _synchronize_quant(self, quantity, location, action="available", in_date=False, **quants_value):
         """ quantity should be express in product's UoM"""


### PR DESCRIPTION
Steps to reproduce:
- Manufactuing > Bills of Materials > New
- Set Product to be consumable and BoM type to kit
- New storable product as component
- Operations > Scrap > New
- Scrap kit

Raises "Record does not exist or has been deleted". This only occurs if the amount of components in stock is less than what would be scrapped in the operation.

This is caused by a read on an unlinked record. When exploding the kit we create a new move for each component, these moves are given a demand of 0 and a quantity equal to the amount of the component needed for the kit (Demand is 0 specifically because this is a scrap operation).

Since we have more than the demand, extra moves are created for the surplus but when we actually try to process reservations we realize there are not enough components in stock and unreserve the extra moves. Error occurs when trying to process those unreserved moves.

opw-4090951

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
