### PR TITLE
[FIX] hr: use correct mail activity template summary

### DIFF
--- a/addons/hr/data/hr_data.xml
+++ b/addons/hr/data/hr_data.xml
@@ -42,7 +42,7 @@
         </record>
 
         <record id="offboarding_setup_compute_out_delais" model="hr.plan.activity.type">
-            <field name="summary">Compute Out Delais</field>
+            <field name="summary">Organize knowledge transfer inside the team</field>
             <field name="responsible">manager</field>
         </record>
 


### PR DESCRIPTION
A mail activity template in the hr modules has the summary "Compute out Delais" which doesn't mean anything in english. This commit replaces that with something more meaningful.

task-4088643

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
