### PR TITLE
 [FIX] stock: protect quant adjust diff at creation

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -628,7 +628,7 @@ class StockMoveLine(models.Model):
                         taken_from_untracked_qty = min(untracked_qty, abs(quantity))
                         Quant._update_available_quantity(ml.product_id, ml.location_id, -taken_from_untracked_qty, lot_id=False, package_id=ml.package_id, owner_id=ml.owner_id)
                         Quant._update_available_quantity(ml.product_id, ml.location_id, taken_from_untracked_qty, lot_id=ml.lot_id, package_id=ml.package_id, owner_id=ml.owner_id)
-                Quant._update_available_quantity(ml.product_id, ml.location_dest_id, quantity, lot_id=ml.lot_id, package_id=ml.result_package_id, owner_id=ml.owner_id, in_date=in_date)
+                Quant.with_context(protect_quant_diff=True)._update_available_quantity(ml.product_id, ml.location_dest_id, quantity, lot_id=ml.lot_id, package_id=ml.result_package_id, owner_id=ml.owner_id, in_date=in_date)
             ml_ids_to_ignore.add(ml.id)
         # Reset the reserved quantity as we just moved it to the destination location.
         mls_todo.with_context(bypass_reservation_update=True).write({


### PR DESCRIPTION
Problem
---
When we create new quants, `_compute_inventory_diff_quantity` may get
wrongly triggered at flush-time.
Usually we don't see the consequences because in the inventory
adjustment quant view, we hide the diff unless the count was set,
and the diff is reset when we do set it.
But if we group the quants, the aggregate sum will show the wrong
diff.

Steps
---
* create a receipt for 1 unit of a storable product we do not yet have
  any of in stock (e.g. a newly created product)
* *Mark as Todo* > *Validate*
* go to *Inventory Adjustments* > group by product
* on the summary line for quants of the product, the total diff is -1

Fix
---
In the affected path, flush new quants early while protecting the diff,
so that later flushes don't affect it.

opw-3944310