### PR TITLE
[FIX] website_sale: save/reset location carrier

### DIFF
--- a/addons/website_sale/static/tests/tours/website_free_delivery.js
+++ b/addons/website_sale/static/tests/tours/website_free_delivery.js
@@ -14,14 +14,14 @@ registry.category("web_tour.tours").add('check_free_delivery', {
         {
             content: "Check Free Delivery value to be zero",
             extra_trigger: '#delivery_carrier label:containsExact("Delivery Now Free Over 10")',
-            trigger: "#delivery_carrier span:contains('0.0')"
+            trigger: "#delivery_carrier span:contains('Free')",
         },
         // Part 2: check multiple delivery & price loaded asynchronously
         {
             content: "Ensure price was loaded asynchronously",
             extra_trigger: '#delivery_carrier input[name="delivery_type"]:checked',
-            trigger: '#delivery_method .o_delivery_carrier_select:contains("20.0"):contains("The Poste")',
-            run: function () {}, // it's a check
+            trigger: '#delivery_method .o_delivery_carrier_select:contains("The Poste")',
+            run: "click",
         },
         {
             content: "Select `Wire Transfer` payment method",


### PR DESCRIPTION
Steps to reproduce:
- Install "Sendcloud Delivery" and configure it for belgium with a
  belgium website.
- Once configured buy a product and go through the checkout process.
- During carrier selection select any "Point relais".
- Go back to the previous step (Shipping address selection).
- Go again to checkout.

Issues:
The previous location is shown but we also see available point relais as
if we didn't select it. In order to solve this issue we need to not
reset access point if `forceClickCarrier` is on.

We also call `_getCurrentLocation` before potentially clicking on the
carrier, if we found a location `forceClickCarrier` is set to false as
we have don't need to show point relais.

Another issue was also met when testing the fix. If we changed shipping
methods access point was not reseted to fix this we reset `access_point_address`
in the `/shop/cart/update_address` route.

opw-4050542