### PR TITLE
[FIX] mail, hr_holidays: channel members categorise correctly

### DIFF
--- a/addons/hr_holidays/static/src/thread_model_patch.js
+++ b/addons/hr_holidays/static/src/thread_model_patch.js
@@ -1,0 +1,10 @@
+/* @odoo-module */
+
+import { Thread } from "@mail/core/common/thread_model";
+import { patch } from "@web/core/utils/patch";
+
+patch(Thread, {
+    get onlineMemberStatuses() {
+        return super.onlineMemberStatuses + ["leave_online", "leave_away"];
+    },
+});

--- a/addons/hr_holidays/static/tests/channel_member_list_tests.js
+++ b/addons/hr_holidays/static/tests/channel_member_list_tests.js
@@ -1,0 +1,34 @@
+/* @odoo-module */
+
+import { startServer } from "@bus/../tests/helpers/mock_python_environment";
+
+import { Command } from "@mail/../tests/helpers/command";
+import { start } from "@mail/../tests/helpers/test_utils";
+
+import { click, contains } from "@web/../tests/utils";
+
+QUnit.module("channel member list");
+
+QUnit.test("on leave members are categorised correctly in online/offline", async () => {
+    const pyEnv = await startServer();
+    const [partnerId1, partnerId2, partnerId3] = pyEnv["res.partner"].create([
+        { name: "Online Partner", im_status: "online" },
+        { name: "On Leave Online", im_status: "leave_online" },
+        { name: "On Leave Idle", im_status: "leave_away" },
+    ]);
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "TestChanel",
+        channel_member_ids: [
+            Command.create({ partner_id: pyEnv.currentPartnerId }),
+            Command.create({ partner_id: partnerId1 }),
+            Command.create({ partner_id: partnerId2 }),
+            Command.create({ partner_id: partnerId3 }),
+        ],
+        channel_type: "channel",
+    });
+    const { openDiscuss } = await start();
+    await openDiscuss(channelId);
+    await click("[title='Show Member List']");
+    await contains(".o-discuss-ChannelMemberList h6", { text: "Online - 3" });
+    await contains(".o-discuss-ChannelMemberList h6", { text: "Offline - 1" });
+});

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -57,6 +57,10 @@ export class Thread extends Record {
         return super.insert(...arguments);
     }
 
+    static get onlineMemberStatuses() {
+        return ["away", "bot", "online"];
+    }
+
     /** @param {Object} data */
     update(data) {
         const { id, name, attachments, description, ...serverData } = data;
@@ -504,7 +508,7 @@ export class Thread extends Record {
     get offlineMembers() {
         const orderedOnlineMembers = [];
         for (const member of this.channelMembers) {
-            if (member.persona.im_status !== "online") {
+            if (!this._store.Thread.onlineMemberStatuses.includes(member.persona.im_status)) {
                 orderedOnlineMembers.push(member);
             }
         }
@@ -549,7 +553,7 @@ export class Thread extends Record {
     get onlineMembers() {
         const orderedOnlineMembers = [];
         for (const member of this.channelMembers) {
-            if (member.persona.im_status === "online") {
+            if (this._store.Thread.onlineMemberStatuses.includes(member.persona.im_status)) {
                 orderedOnlineMembers.push(member);
             }
         }

--- a/addons/mail/static/tests/discuss/core/channel_member_list_tests.js
+++ b/addons/mail/static/tests/discuss/core/channel_member_list_tests.js
@@ -67,6 +67,28 @@ QUnit.test("should have correct members in member list", async () => {
     await contains(".o-discuss-ChannelMember", { text: "Demo" });
 });
 
+QUnit.test("members should be correctly categorised into online/offline", async () => {
+    const pyEnv = await startServer();
+    const [onlinePartnerId, idlePartnerId] = pyEnv["res.partner"].create([
+        { name: "Online Partner", im_status: "online" },
+        { name: "Idle Partner", im_status: "away" },
+    ]);
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "TestChanel",
+        channel_member_ids: [
+            Command.create({ partner_id: pyEnv.currentPartnerId }),
+            Command.create({ partner_id: onlinePartnerId }),
+            Command.create({ partner_id: idlePartnerId }),
+        ],
+        channel_type: "channel",
+    });
+    const { openDiscuss } = await start();
+    await openDiscuss(channelId);
+    await click("[title='Show Member List']");
+    await contains(".o-discuss-ChannelMemberList h6", { text: "Online - 2" });
+    await contains(".o-discuss-ChannelMemberList h6", { text: "Offline - 1" });
+});
+
 QUnit.test(
     "there should be a button to hide member list in the thread view topbar when the member list is visible",
     async () => {


### PR DESCRIPTION
**Current behavior before PR:**

If a partner has `im_status` set to `away/bot` or is on leave, causing their `im_status` to be suffixed with `leave_`, they were placed into the `Offline` category. While except if they are `offline` they should have been placed in `Online` category.

**Desired behavior after PR is merged:**

If a member has `offline/im_partner` status, only then they are placed into `Offline` category.

**Task**-[4101827](https://www.odoo.com/odoo/project.task/4101827)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
