### PR TITLE
[FIX] website: get the correct website in test_website_homepage_url_change

### DIFF
--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -337,7 +337,7 @@ class WithContext(HttpCase):
         website = self.env['website'].browse([1])
         self.assertFalse(website.homepage_url)
 
-        test_page = self.env['website.page'].create({
+        test_page = self.env['website.page'].with_context(website_id=website.id).create({
             'name': 'HomepageUrlTest',
             'type': 'qweb',
             'arch': '<div>HomepageUrlTest</div>',


### PR DESCRIPTION
The Issue:
Before this commit, assigning a URL to the page triggered the write function. Within this function, the get_current_website function returned a different website than the one in the test. As a result, the rest of the code applied to this incorrect website instead of the appropriate one.

The Fix:
Pass the correct website within the context

runbot-54617