### PR TITLE
Use employee's working schedules to compute accrued days for accrual allocations.

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -653,8 +653,8 @@ class HrEmployee(models.Model):
 
     def _get_tz(self):
         self.ensure_one()
-        return self.tz or\
-               self.resource_calendar_id.tz or\
+        return self.resource_calendar_id.tz or\
+               self.tz or\
                self.company_id.resource_calendar_id.tz or\
                'UTC'
 

--- a/addons/hr_holidays/tests/common.py
+++ b/addons/hr_holidays/tests/common.py
@@ -1,5 +1,5 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import datetime
 
 from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.tests import common
@@ -76,3 +76,14 @@ class TestHrHolidaysCommon(common.TransactionCase):
 
         cls.rd_dept.write({'manager_id': cls.employee_hruser_id})
         cls.hours_per_day = cls.employee_emp.resource_id.calendar_id.hours_per_day or 8
+    
+    @classmethod
+    def _add_employee_emp_contract(cls):
+        employee_contract = cls.env['hr.contract'].create({
+            'name': "employee's contract",
+            'employee_id': cls.employee_emp.id,
+            'date_start': datetime.date(2010, 1, 1),
+            'date_end': False,
+            'wage': 2500
+        })
+        employee_contract.write({'state': 'open'})

--- a/addons/hr_holidays/tests/test_expiring_leaves.py
+++ b/addons/hr_holidays/tests/test_expiring_leaves.py
@@ -24,6 +24,10 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
             'allocation_validation_type': 'no_validation',
         })
 
+        if 'hr.contract' in cls.env:
+            # Days are accrued based on the working schedules set on the employee's contracts
+            super()._add_employee_emp_contract()
+
     @users('enguerran')
     def test_no_carried_over_leaves(self):
         """

--- a/addons/hr_holidays_attendance/models/hr_leave_allocation.py
+++ b/addons/hr_holidays_attendance/models/hr_leave_allocation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import datetime
@@ -67,10 +66,10 @@ class HrLeaveAllocation(models.Model):
         self.overtime_id.sudo().unlink()
         return res
 
-    def _get_accrual_plan_level_work_entry_prorata(self, level, start_period, start_date, end_period, end_date):
+    def _get_accrual_plan_level_work_entry_prorata(self, level, calendar, start_period, start_date, end_period, end_date):
         self.ensure_one()
         if level.frequency != 'hourly' or level.frequency_hourly_source != 'attendance':
-            return super()._get_accrual_plan_level_work_entry_prorata(level, start_period, start_date, end_period, end_date)
+            return super()._get_accrual_plan_level_work_entry_prorata(level, calendar, start_period, start_date, end_period, end_date)
         datetime_min_time = datetime.min.time()
         start_dt = datetime.combine(start_date, datetime_min_time)
         end_dt = datetime.combine(end_date, datetime_min_time)

--- a/addons/hr_holidays_attendance/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays_attendance/tests/test_accrual_allocations.py
@@ -23,6 +23,10 @@ class TestAccrualAllocationsAttendance(TestHrHolidaysCommon):
             'allocation_validation_type': 'hr',
         })
 
+        if 'hr.contract' in cls.env:
+            # Days are accrued based on the working schedules set on the employee's contracts
+            super()._add_employee_emp_contract()
+
     def test_frequency_hourly_attendance(self):
         with freeze_time("2017-12-5"):
             accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({

--- a/addons/hr_holidays_contract/models/hr_employee.py
+++ b/addons/hr_holidays_contract/models/hr_employee.py
@@ -1,0 +1,10 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class HrEmployee(models.AbstractModel):
+    _inherit = "hr.employee"
+
+    def _get_tz(self):
+        return self.sudo().contract_id.resource_calendar_id.tz or super()._get_tz()

--- a/addons/hr_holidays_contract/tests/__init__.py
+++ b/addons/hr_holidays_contract/tests/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_multi_contract
+from . import test_accrual_allocations_with_contracts

--- a/addons/hr_holidays_contract/tests/test_accrual_allocations_with_contracts.py
+++ b/addons/hr_holidays_contract/tests/test_accrual_allocations_with_contracts.py
@@ -1,0 +1,188 @@
+import datetime
+from freezegun import freeze_time
+
+from odoo.tests import tagged, users
+
+from odoo.addons.hr_holidays.tests.test_accrual_allocations import TestAccrualAllocations
+from odoo.addons.mail.tests.common import mail_new_test_user
+
+
+@tagged('post_install', '-at_install', 'accruals')
+class TestAccrualAllocationsWithContracts(TestAccrualAllocations):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.yearly_accrual_plan = cls.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
+            'name': 'Yearly accrual',
+            'company_id': cls.belgian_company.id,
+            'carryover_date': 'year_start',
+            'accrued_gain_time': 'end',
+            'is_based_on_worked_time': False,
+            'level_ids': [(0, 0, {
+                'added_value': 10,
+                'added_value_type': 'day',
+                'start_count': 0,
+                'start_type': 'day',
+                'frequency': 'yearly',
+                'cap_accrued_time': False,
+                'action_with_unused_accruals': 'all',
+            })],
+        })
+        cls.test_user = mail_new_test_user(
+            cls.env, login='test_user',
+            company_id=cls.belgian_company.id,
+            groups='base.group_user,hr_holidays.group_hr_holidays_manager'
+        )
+
+        cls.leave_type_without_allocation = cls.env['hr.leave.type'].create({
+            'name': 'Paid Time Off',
+            'time_type': 'leave',
+            'requires_allocation': 'no',
+            'allocation_validation_type': 'hr',
+        })
+
+        cls.resource_calendar_mid_time = cls.resource_calendar.copy({
+            'name': 'Calendar (Mid-Time)',
+            'attendance_ids': [
+                (0, 0, {'name': 'Monday Morning', 'dayofweek': '0', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Monday Afternoon', 'dayofweek': '0', 'hour_from': 13, 'hour_to': 16.6, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Tuesday Morning', 'dayofweek': '1', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Tuesday Afternoon', 'dayofweek': '1', 'hour_from': 13, 'hour_to': 16.6, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Wednesday Morning', 'dayofweek': '2', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'})
+            ]
+        })
+
+        cls.employee_with_multiple_schedules = cls.env['hr.employee'].create({
+            'name': 'Employee with different working schedules',
+            'company_id': cls.belgian_company.id,
+        })
+        first_contract = cls.env['hr.contract'].create({
+            'name': "employee's contract",
+            'employee_id': cls.employee_with_multiple_schedules.id,
+            'resource_calendar_id': cls.resource_calendar.id,
+            'date_start': datetime.date(2024, 1, 1),
+            'date_end':   datetime.date(2024, 6, 30),
+            'wage': 2500
+        })
+        first_contract.write({'state': 'close'})
+        second_contract = first_contract.copy({
+            'resource_calendar_id': cls.resource_calendar_mid_time.id,
+            'date_start': datetime.date(2024, 7, 1),
+            'date_end': False
+        })
+        second_contract.write({'state': 'open'})
+
+    @users('test_user')
+    def test_accrual_plan_with_changing_working_schedules_1(self):
+        """
+        Accrual period 1 year, accrual value = 10 days
+        Employee worked from january to june in full time, then from july to december in half time.
+
+        Accrual plan is not based on worked time. Value for the year should be 7.5.
+        0,5 (accrual period) * 10 (accrual value) * 100% = 5 days
+        + 0,5 (accrual period) * 10 (accrual value) * 50% = 2.5 days
+        """
+
+        self.leave_type['company_id'] = self.belgian_company.id
+
+        with freeze_time("2024-01-01"):
+            allocation = self.env['hr.leave.allocation'].with_context(tracking_disable=True).create({
+                'name': 'Accrual allocation for employee',
+                'employee_id': self.employee_with_multiple_schedules.id,
+                'holiday_status_id': self.leave_type.id,
+                'number_of_days': 0,
+                'allocation_type': 'accrual',
+                'accrual_plan_id': self.yearly_accrual_plan.id,
+                'date_from': datetime.date(2024, 1, 1),
+            })
+            allocation.action_approve()
+
+        with freeze_time("2025-01-01"):
+            allocation._update_accrual()
+        self.assertAlmostEqual(allocation.number_of_days, 7.5, 1)
+
+    @users('test_user')
+    def test_accrual_plan_with_changing_working_schedules_2(self):
+        """
+        Accrual period 1 year, accrual value = 10 days
+        Employee worked from january to june in full time, then from july to december in half time.
+        Unpaid period in march, april, may.
+
+        Value should be computed like this :
+        0,5 (accrual period) * 10 (accrual value) * 100% (working rate) = 5 days * (3/6) (based on worked time) = 2,5 days
+        + 0,5 (accrual period) * 10 (accrual value) * 50% (working rate) = 2,5 days * (6/6)  (based on worked time) = 2,5 days
+
+        Total number of days is 5
+        """
+
+        self.yearly_accrual_plan['is_based_on_worked_time'] = True
+
+        self.leave_type['company_id'] = self.belgian_company.id
+        self.leave_type_without_allocation['company_id'] = self.belgian_company.id
+
+        with freeze_time("2024-01-01"):
+            allocation = self.env['hr.leave.allocation'].with_context(tracking_disable=True).create({
+                'name': 'Accrual allocation for employee',
+                'employee_id': self.employee_with_multiple_schedules.id,
+                'holiday_status_id': self.leave_type.id,
+                'number_of_days': 0,
+                'allocation_type': 'accrual',
+                'accrual_plan_id': self.yearly_accrual_plan.id,
+                'date_from': datetime.date(2024, 1, 1),
+            })
+            allocation.action_approve()
+            leave = self.env['hr.leave'].with_context(tracking_disable=True).create({
+                'name': '3 months time off',
+                'employee_id': self.employee_with_multiple_schedules.id,
+                'holiday_status_id': self.leave_type_without_allocation.id,
+                'request_date_from': datetime.date(2024, 3, 1),
+                'request_date_to': datetime.date(2024, 5, 31)
+            })
+            leave.action_validate()
+
+        with freeze_time("2025-01-01"):
+            allocation._update_accrual()
+        self.assertAlmostEqual(allocation.number_of_days, 5, 1)
+
+    @users('test_user')
+    def test_accrual_plan_with_changing_working_schedules_3(self):
+        """
+        Accrual period 1 year, accrual value = 10 days
+        Employee worked from january to june in full time, then from july to december in half time.
+        Unpaid period in september, october, november.
+
+        Value should be computed like this :
+        0,5 (accrual period) * 10 (accrual value) * 100% (working rate) = 5 days * (6/6) (based on worked time) = 5 days
+        +0,5 (accrual period) * 10 (accrual value) * 50% (working rate) = 2,5 days * (3/6) (based on worked time) = 1,25 days
+
+        Total number of days is 6.25
+        """
+
+        self.yearly_accrual_plan['is_based_on_worked_time'] = True
+
+        self.leave_type['company_id'] = self.belgian_company.id
+        self.leave_type_without_allocation['company_id'] = self.belgian_company.id
+
+        with freeze_time("2024-01-01"):
+            allocation = self.env['hr.leave.allocation'].with_context(tracking_disable=True).create({
+                'name': 'Accrual allocation for employee',
+                'employee_id': self.employee_with_multiple_schedules.id,
+                'holiday_status_id': self.leave_type.id,
+                'number_of_days': 0,
+                'allocation_type': 'accrual',
+                'accrual_plan_id': self.yearly_accrual_plan.id,
+                'date_from': datetime.date(2024, 1, 1),
+            })
+            allocation.action_approve()
+            leave = self.env['hr.leave'].with_context(tracking_disable=True).create({
+                'name': '3 months time off',
+                'employee_id': self.employee_with_multiple_schedules.id,
+                'holiday_status_id': self.leave_type_without_allocation.id,
+                'request_date_from': datetime.date(2024, 9, 1),
+                'request_date_to': datetime.date(2024, 11, 30)
+            })
+            leave.action_validate()
+
+        with freeze_time("2025-01-01"):
+            allocation._update_accrual()
+        self.assertAlmostEqual(allocation.number_of_days, 6.25, 1)

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -221,10 +221,11 @@ class ResourceCalendar(models.Model):
     def _get_days_per_week(self):
         # If the employee didn't work a full day, it is still counted, i.e. 19h / week (M/T/W(half day)) -> 3 days
         self.ensure_one()
-        days = len(set(self.attendance_ids.filtered(
+        attendances = self.attendance_ids.filtered(
             lambda attendance_id: attendance_id._is_work_period() and attendance_id.duration_hours)
-            .mapped(lambda attendance_id: f"{attendance_id.week_type} {attendance_id.dayofweek}")))
-        return days / 2 if self.two_weeks_calendar else days
+        attendances_set = set(attendances.mapped(lambda attendance: (attendance.week_type, attendance.dayofweek)))
+        number_of_days = len(attendances_set)
+        return  number_of_days / 2 if self.two_weeks_calendar else number_of_days
 
     def switch_calendar_type(self):
         if not self.two_weeks_calendar:


### PR DESCRIPTION
The accrual allocations don't take the employee's working schedules into account when computing the accrued days. For example, If an employee working 100% is eligible for 2 days per month, you expect an employee working 50% to be eligible only for 1 day per month. However, the employee will be accrued 2 days per month.

After this change, the working schedules are being taken into account according to the following 2 cases: 
* If hr_contract module isn't installed, the working schedule of the employee will be used for the whole accrual period.
* If hr_contract module is installed, the accrual allocations will use the employee's contracts to retrieve the different working schedules of the employee during the accrual period. Afterwards, the accrued days will be prorated based on the different working schedules.

Example :
Accrual period 1 year, accrual value = 10 days
Employee worked from january to june in full time, then from july to december in half time. 

Previously, the employee would be accrued 10 days for the year.

After this change, the employee will be accrued 7.5 days for the year.
0,5 (accrual period) * 10 (accrual value) * 100% (working rate) = 5 days 
+ 0,5 (accrual period) * 10 (accrual value) * 50% (working rate) = 2,5 days




Also move the fields hours_per_week, full_time_required_hours, is_fulltime, work_time_rate  from `hr_payroll/resource.calendar` to the base resource model because different modules could use those fields. However, these modules shouldn't require the payroll app to be installed in order to be able to use those fields.

task-3986658