### PR TITLE
[REV] website_sale: reverting UI changes from previous commit

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -421,12 +421,6 @@ a.no-decoration {
         max-height: 90vh;
         display: flex;
         align-items: center;
-        @include media-breakpoint-down(md) {
-            height: 300px;
-        }
-        @include media-breakpoint-down(sm) {
-            height: 200px;
-        }
         .carousel-inner {
             img {
                 object-fit: contain;


### PR DESCRIPTION
In this commit (https://github.com/odoo/odoo/commit/464090d8da5e7bc59a3afe4764b9235022ee75cd), we made the container for product images and media elements responsive. However, multiple clients did not appreciate the changes and like the images being highlighted. Additionally it was not the main focus of the ticket.

opw-4056701