### PR TITLE
[FIX] spreadsheet: insert pivot with arabic dates

### DIFF
--- a/addons/spreadsheet/static/src/pivot/pivot_time_adapters.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_time_adapters.js
@@ -85,7 +85,7 @@ export function pivotTimeAdapter(groupAggregate) {
 const dayAdapter = {
     normalizeServerValue(groupBy, field, readGroupResult) {
         const serverDayValue = getGroupStartingDay(field, groupBy, readGroupResult);
-        const date = deserializeDate(serverDayValue);
+        const date = deserializeDate(serverDayValue).reconfigure({ numberingSystem: "latn" });
         return date.toFormat("MM/dd/yyyy");
     },
     normalizeFunctionValue(value) {
@@ -93,7 +93,9 @@ const dayAdapter = {
         return formatValue(date, { locale: DEFAULT_LOCALE, format: "mm/dd/yyyy" });
     },
     increment(normalizedValue, step) {
-        const date = DateTime.fromFormat(normalizedValue, "MM/dd/yyyy");
+        const date = DateTime.fromFormat(normalizedValue, "MM/dd/yyyy", {
+            numberingSystem: "latn",
+        });
         return date.plus({ days: step }).toFormat("MM/dd/yyyy");
     },
     getFormat(locale) {
@@ -150,7 +152,7 @@ const weekAdapter = {
 const monthAdapter = {
     normalizeServerValue(groupBy, field, readGroupResult) {
         const firstOfTheMonth = getGroupStartingDay(field, groupBy, readGroupResult);
-        const date = deserializeDate(firstOfTheMonth);
+        const date = deserializeDate(firstOfTheMonth).reconfigure({ numberingSystem: "latn" });
         return date.toFormat("MM/yyyy");
     },
     normalizeFunctionValue(value) {
@@ -158,7 +160,7 @@ const monthAdapter = {
         return formatValue(date, { DEFAULT_LOCALE, format: "mm/yyyy" });
     },
     increment(normalizedValue, step) {
-        return DateTime.fromFormat(normalizedValue, "MM/yyyy")
+        return DateTime.fromFormat(normalizedValue, "MM/yyyy", { numberingSystem: "latn" })
             .plus({ months: step })
             .toFormat("MM/yyyy");
     },


### PR DESCRIPTION
Steps to reproduce:
- Switch the user language to arabic
- Go to CRM
- Insert the CRM lead pivot in spreadsheet => the values are in #ERROR

The reason is that `toFormat` returns the date with arabic numbers,
which can't be parsed by the spreadsheet engine.

Similartly, we have to tell `.fromFormat` to parse the string
using latn numbering system.


Task: 4102957


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
