### PR TITLE
[FIX] mail: public page title as to be thread name in Discuss

### DIFF
--- a/addons/mail/static/src/core/web/discuss_patch.js
+++ b/addons/mail/static/src/core/web/discuss_patch.js
@@ -1,4 +1,4 @@
-import { onRendered, useEffect } from "@odoo/owl";
+import { useEffect } from "@odoo/owl";
 
 import { Discuss } from "@mail/core/public_web/discuss";
 import { DiscussSidebar } from "@mail/core/web/discuss_sidebar";
@@ -14,11 +14,14 @@ patch(Discuss.prototype, {
     setup() {
         super.setup();
         this.prevInboxCounter = this.store.inbox.counter;
-        onRendered(() => {
-            if (this.thread?.displayName) {
-                this.env.config?.setDisplayName(this.thread.displayName);
-            }
-        });
+        useEffect(
+            (threadName) => {
+                if (threadName) {
+                    this.env.config?.setDisplayName(threadName);
+                }
+            },
+            () => [this.thread?.displayName]
+        );
         useEffect(
             () => {
                 if (

--- a/addons/mail/static/src/discuss/core/public/discuss_patch.js
+++ b/addons/mail/static/src/discuss/core/public/discuss_patch.js
@@ -1,0 +1,19 @@
+import { Discuss } from "@mail/core/public_web/discuss";
+import { useEffect } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+import { patch } from "@web/core/utils/patch";
+
+patch(Discuss.prototype, {
+    setup() {
+        super.setup();
+        this.title = useService("title");
+        useEffect(
+            (threadName) => {
+                if (threadName) {
+                    this.title.setParts({ action: threadName });
+                }
+            },
+            () => [this.thread?.displayName]
+        );
+    },
+});

--- a/addons/mail/static/tests/tours/discuss_channel_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_public_tour.js
@@ -22,6 +22,11 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
                     );
                 }
                 document.body.classList.add("o_discuss_channel_public_modules_loaded");
+                if (
+                    document.title !== document.querySelector(".o-mail-Discuss-threadName")?.value
+                ) {
+                    console.error("Tab title should match conversation name.");
+                }
             },
         },
         {


### PR DESCRIPTION
When Discuss is used and a channel has been selected, the page title becomes the thread name. This was not working for public pages. It is now done manually after rendering instead of relying on action service. 
Task-4100218
