### PR TITLE
[IMP] point_of_sale, pos_*: use x_commands from frontend.

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -110,8 +110,6 @@ class PosOrder(models.Model):
             pos_order = pos_order.with_company(pos_order.company_id)
         else:
             pos_order = self.env['pos.order'].browse(order.get('id'))
-            line_ids = [line[2]['id'] for line in order.get('lines') if line[2].get('id')]
-            pos_order.lines.filtered(lambda line: line.id not in line_ids).unlink()
             pos_order.write(order)
 
         pos_order._link_combo_items(combo_child_uuids_by_parent_uuid)
@@ -122,6 +120,9 @@ class PosOrder(models.Model):
     def _prepare_combo_line_uuids(self, order_vals):
         acc = {}
         for line in order_vals['lines']:
+            if line[0] not in [0, 1]:
+                continue
+
             line = line[2]
 
             if line.get('combo_line_ids'):
@@ -991,7 +992,7 @@ class PosOrder(models.Model):
 
     @api.model
     def _get_refunded_orders(self, order):
-        refunded_orderline_ids = [line[2]['refunded_orderline_id'] for line in order['lines'] if line[2].get('refunded_orderline_id')]
+        refunded_orderline_ids = [line[2]['refunded_orderline_id'] for line in order['lines'] if line[0] in [0, 1] and line[2].get('refunded_orderline_id')]
         return self.env['pos.order.line'].browse(refunded_orderline_ids).mapped('order_id')
 
     def _should_create_picking_real_time(self):

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -23,8 +23,6 @@ export class PosOrderline extends Base {
         this.uiState = {
             hasChange: true,
         };
-
-        // this.set_unit_price(this.price_unit);
     }
 
     set_full_product_name() {
@@ -167,12 +165,14 @@ export class PosOrderline extends Base {
         if (!this.product_id.to_weight && setQuantity) {
             this.set_quantity_by_lot();
         }
+        this.setDirty();
     }
 
     // FIXME related models update stuff
     set_product_lot(product) {
         this.has_product_lot = product.tracking !== "none";
         this.pack_lot_ids = this.has_product_lot && [];
+        this.setDirty();
     }
 
     set_discount(discount) {
@@ -186,6 +186,7 @@ export class PosOrderline extends Base {
         const disc = Math.min(Math.max(parsed_discount || 0, 0), 100);
         this.discount = disc;
         this.discountStr = "" + disc;
+        this.setDirty();
     }
 
     // sets the qty of the product. The qty will be rounded according to the
@@ -249,6 +250,8 @@ export class PosOrderline extends Base {
                 )
             );
         }
+
+        this.setDirty();
         return true;
     }
 
@@ -347,6 +350,7 @@ export class PosOrderline extends Base {
             parsed_price || 0,
             this.models["decimal.precision"].find((dp) => dp.name === "Product Price").digits
         );
+        this.setDirty();
     }
 
     get_unit_price() {
@@ -546,6 +550,7 @@ export class PosOrderline extends Base {
 
     set_customer_note(note) {
         this.customer_note = note || "";
+        this.setDirty();
     }
 
     get_customer_note() {
@@ -661,6 +666,7 @@ export class PosOrderline extends Base {
         return this.note || "";
     }
     setNote(note) {
+        this.setDirty();
         this.note = note;
     }
     setHasChange(isChange) {

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -286,6 +286,9 @@ export class PosStore extends Reactive {
         return true;
     }
     computeProductPricelistCache(data) {
+        if (data) {
+            data = this.models[data.model].readMany(data.ids);
+        }
         // This function is called via the addEventListener callback initiated in the
         // processServerData function when new products or pricelists are loaded into the PoS.
         // It caches the heavy pricelist calculation when there are many products and pricelists.
@@ -967,6 +970,9 @@ export class PosStore extends Reactive {
             this.preSyncAllOrders(orders);
             const context = this.getSyncAllOrdersContext(orders);
 
+            if (this.pendingOrder.delete.size) {
+                await this.deleteOrders([], Array.from(this.pendingOrder.delete));
+            }
             // Allow us to force the sync of the orders In the case of
             // pos_restaurant is usefull to get unsynced orders
             // for a specific table
@@ -979,7 +985,9 @@ export class PosStore extends Reactive {
                 order.recomputeOrderData();
             }
 
-            const serializedOrder = orders.map((order) => order.serialize({ orm: true }));
+            const serializedOrder = orders.map((order) =>
+                order.serialize({ orm: true, clear: true })
+            );
             const data = await this.data.call("pos.order", "sync_from_ui", [serializedOrder], {
                 context,
             });

--- a/addons/pos_event/models/pos_order.py
+++ b/addons/pos_event/models/pos_order.py
@@ -44,7 +44,7 @@ class PosOrder(models.Model):
     @api.model
     def _process_order(self, order, existing_order):
         res = super()._process_order(order, existing_order)
-        refunded_line_ids = [line[2].get('refunded_orderline_id') for line in order.get('lines') if line[2].get('refunded_orderline_id')]
+        refunded_line_ids = [line[2].get('refunded_orderline_id') for line in order.get('lines') if line[0] in [0, 1] and line[2].get('refunded_orderline_id')]
         refunded_orderlines = self.env['pos.order.line'].browse(refunded_line_ids)
         event_to_cancel = []
 

--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -558,12 +558,15 @@ patch(PosStore.prototype, {
     },
 
     //@override
-    async processServerData(loadedData) {
-        await super.processServerData(loadedData);
+    async processServerData() {
+        await super.processServerData();
 
         this.partnerId2CouponIds = {};
 
-        this.computeDiscountProductIdsForAllRewards(this.models["product.product"].getAll());
+        this.computeDiscountProductIdsForAllRewards({
+            model: "product.product",
+            ids: Object.keys(this.data.records["product.product"]),
+        });
 
         this.models["product.product"].addEventListener(
             "create",
@@ -584,7 +587,8 @@ patch(PosStore.prototype, {
         }
     },
 
-    computeDiscountProductIdsForAllRewards(products) {
+    computeDiscountProductIdsForAllRewards(data) {
+        const products = this.models[data.model].readMany(data.ids);
         for (const reward of this.models["loyalty.reward"].getAll()) {
             this.compute_discount_product_ids(reward, products);
         }

--- a/addons/pos_restaurant/static/src/app/product_screen/order_summary/order_summary.js
+++ b/addons/pos_restaurant/static/src/app/product_screen/order_summary/order_summary.js
@@ -2,17 +2,6 @@ import { patch } from "@web/core/utils/patch";
 import { OrderSummary } from "@point_of_sale/app/screens/product_screen/order_summary/order_summary";
 
 patch(OrderSummary.prototype, {
-    releaseTable() {
-        const orderOnTable = this.pos.models["pos.order"].filter(
-            (o) => o.table_id?.id === this.pos.selectedTable.id && o.finalized === false
-        );
-
-        for (const order of orderOnTable) {
-            this.pos.removeOrder(order);
-        }
-
-        this.pos.showScreen("FloorScreen");
-    },
     bookTable() {
         this.pos.get_order().setBooked(true);
         this.pos.showScreen("FloorScreen");
@@ -30,7 +19,7 @@ patch(OrderSummary.prototype, {
         );
     },
     unbookTable() {
-        this.pos.removeOrder(this.pos.get_order());
+        this.pos.removeOrder(this.pos.get_order(), true);
         this.pos.showScreen("FloorScreen");
     },
     showUnbookButton() {

--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -151,12 +151,12 @@ patch(PosStore.prototype, {
             const product_unit = line.product_id.uom_id;
             if (product_unit && !product_unit.is_pos_groupable) {
                 let remaining_quantity = newLine.qty;
+                newLine.delete();
                 while (!this.env.utils.floatIsZero(remaining_quantity)) {
                     const splitted_line = this.models["pos.order.line"].create(newLineValues);
                     splitted_line.set_quantity(Math.min(remaining_quantity, 1.0), true);
                     remaining_quantity -= splitted_line.qty;
                 }
-                newLine.delete();
             }
         }
     },

--- a/addons/pos_self_order/static/src/overrides/models/pos_store.js
+++ b/addons/pos_self_order/static/src/overrides/models/pos_store.js
@@ -2,10 +2,6 @@ import { PosStore } from "@point_of_sale/app/store/pos_store";
 import { patch } from "@web/core/utils/patch";
 
 patch(PosStore.prototype, {
-    // @Override
-    async processServerData(loadedData) {
-        await super.processServerData(...arguments);
-    },
     async getServerOrders() {
         if (this.session._self_ordering) {
             await this.loadServerOrders([


### PR DESCRIPTION
*: pos_sale, pos_loyalty, pos_restaurant, pos_event

Before all lines was sent to the backend to be processed, if the backend
had a line that wasn't sent by the frontend, it was removed from the
order.

Now the frontend sends only modified lines to the backend, if a line is
deleted from the frontend, it will be deleted from the backend too. But
the backend doesn't remove lines that weren't sent by the frontend.

This change was made to avoid losing information when the backend delete
a line that wasn't sent by the frontend.