### PR TITLE
[FIX] mail: seen by tooltip when no one has seen message

### DIFF
--- a/addons/mail/static/src/core/common/message_seen_indicator.js
+++ b/addons/mail/static/src/core/common/message_seen_indicator.js
@@ -47,6 +47,8 @@ export class MessageSeenIndicator extends Component {
         const seenMembers = this.props.message.channelMemberHaveSeen;
         const [user1, user2, user3] = seenMembers.map((member) => member.name);
         switch (seenMembers.length) {
+            case 0:
+                return _t("Sent");
             case 1:
                 return _t("Seen by %(user)s", { user: user1 });
             case 2:
@@ -70,6 +72,9 @@ export class MessageSeenIndicator extends Component {
     }
 
     openDialog() {
+        if (this.props.message.channelMemberHaveSeen.length === 0) {
+            return;
+        }
         this.dialog.add(MessageSeenIndicatorDialog, { message: this.props.message });
     }
 }


### PR DESCRIPTION
Before this commit, the tooltip shown upon hovering the single tick on a sent message showed "undefined".
Steps to reproduce:
- Send message on a chat with user demo as admin
- Log in as user demo
- As the admin user hover the single tick on the message

This happens because the switch case is not covering the case of the message being fetched but not seen by anybody.

This commit fixes the issue by adding a case for such instance, showing "Sent" as the tooltip.

Before:
![image](https://github.com/user-attachments/assets/e338661b-25b8-42c3-8296-c620d8a544ad)

After:
![image](https://github.com/user-attachments/assets/b7a44065-13b0-4ad1-8c3d-adcb6a704b82)
