### PR TITLE
[IMP] point_of_sale: Display weighting pop-up on customer display

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/scale_screen/scale_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/scale_screen/scale_screen.xml
@@ -7,7 +7,7 @@
                     <button class="btn oi oi-arrow-left" data-bs-dismiss="modal" aria-label="Close" t-on-click="props.close" />
                 </t>
                 <h4 class="modal-title text-break text-center w-100" t-att-class="{ 'me-auto': this.env.isSmall }">
-                    <t t-esc="props.product?.display_name || 'Unnamed Product'"/>
+                    <t t-esc="props.productName || 'Unnamed Product'"/>
                 </h4>
                 <t t-if="!this.env.isSmall">
                     <button type="button" class="btn-close" aria-label="Close" tabindex="-1" t-on-click="props.close"></button>
@@ -28,17 +28,18 @@
                     </button>
                     </div>
                     <div class="d-flex flex-row justify-content-end w-50 align-items-center px-5">
-                        <input type="number" class="form-control me-2" t-model="this.state.tare" />
-                        <span class="text-end fs-3" t-esc="productUnit.name"/>
+                        <input type="number" class="form-control me-2" t-model="this.state.tare" t-on-input="handleInputChange"/>
+ 
+                        <span class="text-end fs-3" t-esc="props.uomName"/>
                     </div>
                 </div>
                 <div class="d-flex gap-2 align-items-center mb-2">
                     <div class="w-60 fs-3 me-2">Net Weight:</div>
-                    <div class="text-end fs-3 px-5 form-control-plaintext" t-esc="netWeight.toFixed(3) + ' ' + productUnit.name"></div>
+                    <div class="text-end fs-3 px-5 form-control-plaintext" t-esc="netWeight.toFixed(3) + ' ' + props.uomName"></div>
                 </div>
                 <div class="d-flex px-5 flex-row gap-2 m-2 align-items-center">
                     <div class="product-price w-50 fs-2 text-center"
-                        t-esc="productUnitPrice + '/' + productUom" />
+                        t-esc="props.productPrice + '/' + props.uomName" />
                     <div class="computed-price fd-flex flex-grow-1 p-3 rounded text-center text-bg-info bg-opacity-25 text-info fs-2 fw-bold" t-esc="computedPriceString" />
                 </div>
             </div>

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -129,6 +129,11 @@ export class PosStore extends Reactive {
         this.ready = new Promise((resolve) => {
             this.markReady = resolve;
         });
+        this.isScaleScreenVisible = false;
+        this.scaleData = null;
+        this.scaleWeight = 0;
+        this.scaleTare = 0;
+        this.totalPriceOnScale = 0;
 
         // FIXME POSREF: the hardwareProxy needs the pos and the pos needs the hardwareProxy. Maybe
         // the hardware proxy should just be part of the pos service?
@@ -722,14 +727,26 @@ export class PosStore extends Reactive {
         // This actions cannot be handled inside pos_order.js or pos_order_line.js
         if (values.product_id.to_weight && this.config.iface_electronic_scale && configure) {
             if (values.product_id.isScaleAvailable) {
-                const weight = await makeAwaitable(this.env.services.dialog, ScaleScreen, {
-                    product: values.product_id,
-                    taxIncluded: this.config.iface_tax_included === "total",
-                });
+                this.isScaleScreenVisible = true;
+                this.scaleData = {
+                    productName: values.product_id?.display_name,
+                    uomName: values.product_id.uom_id?.name,
+                    uomRounding: values.product_id.uom_id?.rounding,
+                    productPrice: this.getProductPrice(values.product_id),
+                };
+                const weight = await makeAwaitable(
+                    this.env.services.dialog,
+                    ScaleScreen,
+                    this.scaleData
+                );
                 if (!weight) {
                     return;
                 }
                 values.qty = weight;
+                this.isScaleScreenVisible = false;
+                this.scaleWeight = 0;
+                this.scaleTare = 0;
+                this.totalPriceOnScale = 0;
             } else {
                 await values.product_id._onScaleNotAvailable();
             }
@@ -825,6 +842,12 @@ export class PosStore extends Reactive {
         } else {
             this.selectedCategory = this.models["pos.category"].get(categoryId);
         }
+    }
+    setScaleWeight(weight) {
+        this.scaleWeight = weight;
+    }
+    setScaleTare(tare) {
+        this.scaleTare = tare;
     }
 
     /**

--- a/addons/point_of_sale/static/src/customer_display/customer_display.js
+++ b/addons/point_of_sale/static/src/customer_display/customer_display.js
@@ -6,6 +6,7 @@ import { MainComponentsContainer } from "@web/core/main_components_container";
 import { session } from "@web/session";
 import { useService } from "@web/core/utils/hooks";
 import { mountComponent } from "@web/env";
+import { roundPrecision as round_pr } from "@web/core/utils/numbers";
 
 export class CustomerDisplay extends Component {
     static template = "point_of_sale.CustomerDisplay";
@@ -13,7 +14,16 @@ export class CustomerDisplay extends Component {
     static props = [];
     setup() {
         this.session = session;
+        this.dialog = useService("dialog");
         this.order = useState(useService("customer_display_data"));
+    }
+
+    get netWeight() {
+        const weight = round_pr(this.order.weight || 0, this.order.uomRounding);
+        const weightRound = weight.toFixed(
+            Math.ceil(Math.log(1.0 / this.order.scaleData.uomRounding) / Math.log(10))
+        );
+        return weightRound - parseFloat(this.order.tare);
     }
 }
 whenReady(() => mountComponent(CustomerDisplay, document.body));

--- a/addons/point_of_sale/static/src/customer_display/customer_display.xml
+++ b/addons/point_of_sale/static/src/customer_display/customer_display.xml
@@ -24,6 +24,33 @@
                 <div t-else="" class="d-flex flex-column align-items-center justify-content-center h-100 w-100">
                     <h1 class="display-2 w-75 mt-2 fw-bold text-center text-muted">Thank you.</h1>
                 </div>
+                <div t-if="order.isScaleScreenVisible">
+                    <t t-set-slot="header">
+                        <h4 class="modal-title text-break text-center w-100" t-att-class="{ 'me-auto': this.env.isSmall }">
+                            <t t-esc="'Scaling Product: ' + order.scaleData.productName || 'Unnamed Product'"/>
+                        </h4>
+                    </t>
+                    <div class="d-flex flex-column px-3">
+                        <div class="d-flex justify-content-between align-items-center mb-2">
+                            <div class="w-60 fs-5 me-2 form-control-plaintext">Gross Weight:</div>
+                            <div class="weight fs-5 js-weight text-end form-control-plaintext" t-esc="order.weight + ' ' + order.scaleData.uomName"></div>
+                        </div>
+                        <div class="d-flex justify-content-between align-items-center mb-2">
+                            <div class="w-60 fs-5 me-2 form-control-plaintext">Tare Weight:</div>
+                            <div class="weight fs-5 js-weight text-end form-control-plaintext" t-esc="order.tare + ' ' + order.scaleData.uomName"></div>
+                        </div>
+                        <div class="d-flex justify-content-between align-items-center mb-2">
+                            <div class="w-60 fs-5 me-2 form-control-plaintext">Net Weight:</div>
+                            <div class="text-end fs-5 form-control-plaintext" t-esc="netWeight.toFixed(3) + ' ' + order.scaleData.uomName"></div>
+                        </div>
+                        <div class="d-flex px-5 flex-row gap-2 m-2 align-items-center">
+                            <div class="product-price w-50 fs-5 text-center"
+                                t-esc="order.scaleData.productPrice + '/' + order.scaleData.uomName" />
+                            <div class="computed-price fd-flex flex-grow-1 p-2 rounded text-center text-bg-info bg-opacity-25 text-info fs-5 fw-bold" t-esc="order.totalPriceOnScale" />
+                        </div>
+                    </div>
+                </div>
+
                 <div t-if="order.amount and !order.finalized" class="py-3 px-4 bg-view border-top">
                     <div class="d-flex flex-column justify-content-center gap-1 w-100 w-sm-50 ms-auto">
                         <div class="row fs-2 fw-bolder">


### PR DESCRIPTION
In compliance with EU legislation that mandates proper communication with scales, we have introduced a feature to display the weighting pop-up on the customer screen. This improvement ensures that customers can see the exact weight being processed, minimizing the risk of cashier errors.

- Added functionality to display the weighting screen data on the customer-facing screen.
- Enhanced user interface to support real-time weight display during transactions.

Related: https://github.com/odoo/enterprise/pull/68115
Task ID: 4091330




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
