### PR TITLE
[FIX] core: fix SQL queries when value is a NewId

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3056,6 +3056,9 @@ class BaseModel(metaclass=MetaModel):
             else:
                 return SQL("(%s IS NULL OR %s = FALSE)", sql_field, sql_field)
 
+        if (field.relational or field.name == 'id') and operator in ('=', '!=') and isinstance(value, NewId):
+            return SQL("TRUE") if operator in expression.NEGATIVE_TERM_OPERATORS else SQL("FALSE")
+
         # comparison with null
         # except for some basic types, where we need to check the empty value
         if (field.relational or field.name == 'id') and operator in ('=', '!=') and not value:


### PR DESCRIPTION
Since 4a81315ef8e65b08d56be95e47a6b456c2d3599d, NewId values are considered as if they were a 0 value, because these objects are falsy.

This leads to selecting all the rows whose field has a null value (field IS NULL), which is incorrect and in some cases leads to MemoryErrors (e.g. an onchange that selects thousands of rows, and serializes that into JSON).

With this commit, we explicitely consider these special values as non-matching (or matching) all rows, depending on the operator.