### PR TITLE
[IMP] account_payment: process payments with early discount from portal

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -16852,3 +16852,8 @@ msgid ""
 "{{ object.company_id.name }} Payment Receipt (Ref {{ object.name or 'n/a' "
 "}})"
 msgstr ""
+
+#. module: account
+#: model_terms:ir.ui.view,arch_db:account.portal_invoice_page
+msgid "An early payment discount is available for this invoice!"
+msgstr ""

--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -113,7 +113,20 @@
                 <t t-call="portal.portal_record_sidebar">
                     <t t-set="classes" t-value="'col-lg-3 col-xl-4 d-print-none me-lg-auto'"/>
                     <t t-set="title">
-                        <h2>
+                        <div t-if="early_payment" class="alert alert-info" role="alert">
+                            An early payment discount is available for this invoice!
+                        </div>
+                        <h2 t-if="amount">
+                            <t t-if="early_payment">
+                                <span t-esc="amount_without_discount" t-attf-class="ms-1 h5" style="text-decoration: line-through; color: grey;" t-options='{"widget": "monetary", "display_currency": invoice.currency_id}'/>
+                                <span t-esc="amount"
+                                      t-options='{"widget": "monetary", "display_currency": invoice.currency_id}'/>
+                            </t>
+                            <t t-else="1">
+                                <span t-esc="amount" t-options='{"widget": "monetary", "display_currency": invoice.currency_id}'/>
+                            </t>
+                        </h2>
+                        <h2 t-if="0">
                             <span t-if="invoice.amount_residual > 0" t-field="invoice.amount_residual"/>
                             <span t-else="1" t-field="invoice.amount_total"/>
                         </h2>

--- a/addons/account_payment/models/payment_transaction.py
+++ b/addons/account_payment/models/payment_transaction.py
@@ -147,31 +147,61 @@ class PaymentTransaction(models.Model):
 
         payment_method_line = self.provider_id.journal_id.inbound_payment_method_line_ids\
             .filtered(lambda l: l.payment_provider_id == self.provider_id)
-        payment_values = {
-            'amount': abs(self.amount),  # A tx may have a negative amount, but a payment must >= 0
-            'payment_type': 'inbound' if self.amount > 0 else 'outbound',
-            'currency_id': self.currency_id.id,
-            'partner_id': self.partner_id.commercial_partner_id.id,
-            'partner_type': 'customer',
-            'journal_id': self.provider_id.journal_id.id,
-            'company_id': self.provider_id.company_id.id,
-            'payment_method_line_id': payment_method_line.id,
-            'payment_token_id': self.token_id.id,
-            'payment_transaction_id': self.id,
-            'ref': reference,
-            **extra_create_values,
-        }
-        payment = self.env['account.payment'].create(payment_values)
-        payment.action_post()
-
-        # Track the payment to make a one2one.
-        self.payment_id = payment
 
         # Reconcile the payment with the source transaction's invoices in case of a partial capture.
         if self.operation == self.source_transaction_id.operation:
             invoices = self.source_transaction_id.invoice_ids
         else:
             invoices = self.invoice_ids
+
+        today = fields.Date.context_today(self)
+        invoices_with_epd = invoices.filtered(lambda inv: inv._is_eligible_for_early_payment_discount(inv.currency_id, today))
+        if invoices_with_epd:
+            wizard = self.env['account.payment.register'].with_context(
+                active_model='account.move',
+                active_ids=invoices.ids,
+            ).create({
+                'journal_id': self.provider_id.journal_id.id,
+                'payment_date': fields.Date.context_today(self),
+                'communication': reference,
+                'partner_type': 'customer',
+                'payment_method_line_id': payment_method_line.id,
+                'early_payment_discount_mode': True,
+                'partner_id': self.partner_id.commercial_partner_id.id,
+                'group_payment': True,
+                'can_edit_wizard': True,
+            })
+            batch_result = wizard._get_batches()[0]
+            payment_values = wizard._create_payment_vals_from_batch(batch_result)
+            payment = self.env['account.payment'].create({
+                **payment_values,
+                'payment_token_id': self.token_id.id,
+                'payment_transaction_id': self.id,
+                **extra_create_values,
+            })
+            payment.action_post()
+
+        else:
+            payment_values = {
+                'amount': abs(self.amount),  # A tx may have a negative amount, but a payment must >= 0
+                'payment_type': 'inbound' if self.amount > 0 else 'outbound',
+                'currency_id': self.currency_id.id,
+                'partner_id': self.partner_id.commercial_partner_id.id,
+                'partner_type': 'customer',
+                'journal_id': self.provider_id.journal_id.id,
+                'company_id': self.provider_id.company_id.id,
+                'payment_method_line_id': payment_method_line.id,
+                'payment_token_id': self.token_id.id,
+                'payment_transaction_id': self.id,
+                'ref': reference,
+                **extra_create_values,
+            }
+            payment = self.env['account.payment'].create(payment_values)
+            payment.action_post()
+
+        # Track the payment to make a one2one.
+        self.payment_id = payment
+
         if invoices:
             invoices.filtered(lambda inv: inv.state == 'draft').action_post()
 

--- a/addons/account_payment/tests/test_account_payment.py
+++ b/addons/account_payment/tests/test_account_payment.py
@@ -1,4 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from datetime import datetime, timedelta
 
 from unittest.mock import patch
 
@@ -227,3 +228,271 @@ class TestAccountPayment(AccountPaymentCommon):
             copy_provider_pml = get_payment_method_line(copy_provider)
             with self.assertRaises(ValidationError):
                 journal.inbound_payment_method_line_ids = [Command.update(copy_provider_pml.id, {'payment_provider_id': provider.id})]
+
+    #   ////////////////////////////////////////////////////////
+    #   Tests for payments with early payments discount
+    #   ///////////////////////////////////////////////////////
+    def create_payment_term_with_early_discount(self, **kwargs):
+        return self.env['account.payment.term'].create({
+            'name': "early_payment_term",
+            'company_id': self.company_data['company'].id,
+            'discount_percentage': 10,
+            'discount_days': 10,
+            'early_discount': True,
+            'line_ids': [
+                Command.create({
+                    'value': 'percent',
+                    'value_amount': 100,
+                    'nb_days': 20,
+                }),
+            ],
+            **kwargs,
+        })
+
+    def create_invoice_with_early_discount(self, payment_term_id=None, **kwargs):
+        invoice_with_early_discount = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner.id,
+            'invoice_date': datetime.now().date(),
+            'currency_id': self.currency.id,
+            'invoice_payment_term_id': payment_term_id or self.create_payment_term_with_early_discount().id,
+            'invoice_line_ids': [Command.create({
+                'name': 'test line',
+                'price_unit': 100.0,
+                'tax_ids': [],
+            })],
+            **kwargs
+        })
+        invoice_with_early_discount.action_post()
+        return invoice_with_early_discount
+
+    def assert_invoice_payment(self, payment, invoice, expected_values):
+        self.assertEqual(payment.amount, expected_values['payment_amount'])
+        self.assertEqual(payment.amount_total, expected_values['payment_amount_total'])
+        self.assertEqual(invoice.payment_state, expected_values['invoice_payment_state'])
+        self.assertEqual(invoice.amount_paid, expected_values['invoice_amount_paid'])
+        self.assertRecordValues(payment.invoice_line_ids, expected_values['payment_invoice_line_ids'])
+
+    def test_eligible_invoice_no_tax(self):
+        """
+        This test verifies the correct application of early payment discount on an eligible invoice without taxes.
+        """
+        invoice_eligible = self.create_invoice_with_early_discount()
+        payment = self._create_transaction(
+            reference='payment_1',
+            flow='direct',
+            state='done',
+            amount=invoice_eligible.invoice_payment_term_id._get_amount_due_after_discount(
+                total_amount=invoice_eligible.amount_residual,      # 100.0
+                untaxed_amount=invoice_eligible.amount_tax,         # 0.0
+            ),                                                      # 90.0
+            invoice_ids=[invoice_eligible.id],
+        )._create_payment()
+
+        self.assert_invoice_payment(
+            payment=payment,
+            invoice=invoice_eligible,
+            expected_values={
+                'payment_amount': 90.0,
+                'payment_amount_total': 100.0,
+                'invoice_payment_state': 'in_payment',
+                'invoice_amount_paid': 90.0,
+                'payment_invoice_line_ids': [
+                    {'account_type': 'asset_current', 'amount_currency': 90.0},
+                    {'account_type': 'asset_receivable', 'amount_currency': -100.0},
+                    {'account_type': 'expense', 'amount_currency': 10.0},
+                ],
+            }
+        )
+
+    def test_ineligible_invoice_past_discount_date(self):
+        """
+        This test ensures no discount is applied to an invoice past the early payment discount date.
+        """
+        invoice_ineligible = self.create_invoice_with_early_discount(
+            invoice_date=(datetime.now() - timedelta(days=30)).date(),
+        )
+        payment = self._create_transaction(
+            reference='payment_2',
+            flow='direct',
+            state='done',
+            amount=invoice_ineligible.amount_residual,  # 100.0
+            invoice_ids=[invoice_ineligible.id],
+        )._create_payment()
+
+        self.assert_invoice_payment(
+            payment=payment,
+            invoice=invoice_ineligible,
+            expected_values={
+                'payment_amount': 100.0,
+                'payment_amount_total': 100.0,
+                'invoice_payment_state': 'in_payment',
+                'invoice_amount_paid': 100.0,
+                'payment_invoice_line_ids': [
+                    {'account_type': 'asset_current', 'amount_currency': 100.0},
+                    {'account_type': 'asset_receivable', 'amount_currency': -100.0},
+                ],
+            }
+        )
+
+    def test_eligible_invoice_with_tax(self):
+        """
+        This test checks the correct calculation of early payment discount on an eligible invoice with taxes.
+        """
+        invoice_eligible_with_tax = self.create_invoice_with_early_discount(
+            invoice_line_ids=[Command.create({
+                'name': 'test line',
+                'price_unit': 100.0,
+                'tax_ids': [(6, 0, self.company_data['default_tax_sale'].ids)],  # 15%
+            })],
+        )
+        payment = self._create_transaction(
+            reference='payment_3',
+            flow='direct',
+            state='done',
+            amount=invoice_eligible_with_tax.invoice_payment_term_id._get_amount_due_after_discount(
+                total_amount=invoice_eligible_with_tax.amount_residual,     # 100.0
+                untaxed_amount=invoice_eligible_with_tax.amount_tax,        # 15.0
+            ),                                                              # 115.0 - 10% -> 115 * (1 - 0.1) = 103.5
+            invoice_ids=[invoice_eligible_with_tax.id],
+        )._create_payment()
+
+        self.assert_invoice_payment(
+            payment=payment,
+            invoice=invoice_eligible_with_tax,
+            expected_values={
+                'payment_amount': 103.5,
+                'payment_amount_total': 115.0,
+                'invoice_payment_state': 'in_payment',
+                'invoice_amount_paid': 103.5,
+                'payment_invoice_line_ids': [
+                    {'account_type': 'asset_current', 'amount_currency': 103.5},
+                    {'account_type': 'asset_receivable', 'amount_currency': -115},
+                    {'account_type': 'expense', 'amount_currency': 10.0},
+                    {'account_type': 'liability_current', 'amount_currency': 1.5}
+                ],
+            }
+        )
+
+    def test_ineligible_invoice_mixed_discount_computation_and_tax(self):
+        """
+        This test validates the behavior of mixed discount computation on an ineligible invoice with taxes.
+        The early discount should be applied on the untaxed amount past the early payment discount date.
+        "The tax is always reduced. The base amount used to compute the tax is the discounted amount,
+        whether the customer benefits from the discount or not." (cf Cash discounts and tax reduction documentation)
+        """
+        payment_term_with_mixed_discount_computation = self.create_payment_term_with_early_discount(
+            early_pay_discount_computation='mixed',
+        )
+        invoice_ineligible_with_mixed_and_tax = self.create_invoice_with_early_discount(
+            payment_term_id=payment_term_with_mixed_discount_computation.id,
+            invoice_date=(datetime.now() - timedelta(days=30)).date(),
+            invoice_line_ids=[Command.create({
+                'name': 'test line',
+                'price_unit': 100.0,
+                'tax_ids': [(6, 0, self.company_data['default_tax_sale'].ids)],  # 15%
+            })],
+        )
+        payment = self._create_transaction(
+            reference='payment_4',
+            flow='direct',
+            state='done',
+            amount=invoice_ineligible_with_mixed_and_tax.amount_residual,  # 100 + (15 * (1 - 0.1)) = 113.5
+            invoice_ids=[invoice_ineligible_with_mixed_and_tax.id],
+        )._create_payment()
+
+        self.assert_invoice_payment(
+            payment=payment,
+            invoice=invoice_ineligible_with_mixed_and_tax,
+            expected_values={
+                'payment_amount': 113.5,
+                'payment_amount_total': 113.5,
+                'invoice_payment_state': 'in_payment',
+                'invoice_amount_paid': 113.5,
+                'payment_invoice_line_ids': [
+                    {'account_type': 'asset_current', 'amount_currency': 113.5},
+                    {'account_type': 'asset_receivable', 'amount_currency': -113.5},
+                ],
+            }
+        )
+
+    def test_eligible_invoice_excluded_discount_computation_and_tax(self):
+        """
+        This test validates the behavior of excluded discount computation method on an eligible invoice with taxes.
+        "The tax is never reduced. The base amount used to compute the tax is the full amount,
+        whether the customer benefits from the discount or not." (cf Cash discounts and tax reduction documentation)
+        """
+        payment_term_with_excluded_discount_computation = self.create_payment_term_with_early_discount(
+            early_pay_discount_computation='excluded',
+        )
+        invoice_eligible_with_excluded_and_tax = self.create_invoice_with_early_discount(
+            payment_term_id=payment_term_with_excluded_discount_computation.id,
+            invoice_line_ids=[Command.create({
+                'name': 'test line',
+                'price_unit': 100.0,
+                'tax_ids': [(6, 0, self.company_data['default_tax_sale'].ids)],  # 15%
+            })],
+        )
+        payment = self._create_transaction(
+            reference='payment_5',
+            flow='direct',
+            state='done',
+            amount=invoice_eligible_with_excluded_and_tax.invoice_payment_term_id._get_amount_due_after_discount(
+                total_amount=invoice_eligible_with_excluded_and_tax.amount_residual,    # 100.0
+                untaxed_amount=invoice_eligible_with_excluded_and_tax.amount_tax,       # 15.0
+            ),                                                                          # (100 - 10%), 90 + 15 = 105
+            invoice_ids=[invoice_eligible_with_excluded_and_tax.id],
+        )._create_payment()
+
+        self.assert_invoice_payment(
+            payment=payment,
+            invoice=invoice_eligible_with_excluded_and_tax,
+            expected_values={
+                'payment_amount': 105.0,
+                'payment_amount_total': 115.0,
+                'invoice_payment_state': 'in_payment',
+                'invoice_amount_paid': 105.0,
+                'payment_invoice_line_ids': [
+                    {'account_type': 'asset_current', 'amount_currency': 105.0},
+                    {'account_type': 'asset_receivable', 'amount_currency': -115.0},
+                    {'account_type': 'expense', 'amount_currency': 10},
+                ],
+            }
+        )
+
+    def test_eligible_invoice_foreign_currency(self):
+        """
+        This test checks the correct calculation of early payment discount on an eligible invoice in a foreign currency.
+        """
+        foreign_currency = self.currency_data['currency']  # Gold Coin currency
+        invoice_eligible_with_foreign_currency = self.create_invoice_with_early_discount(
+            currency_id=foreign_currency.id,
+            company_currency_id=self.currency.id,
+        )
+        payment = self._create_transaction(
+            reference='payment_6',
+            flow='direct',
+            state='done',
+            amount=invoice_eligible_with_foreign_currency.invoice_payment_term_id._get_amount_due_after_discount(
+                total_amount=invoice_eligible_with_foreign_currency.amount_residual,    # 100.0 gold    / 50.0$
+                untaxed_amount=invoice_eligible_with_foreign_currency.amount_tax,       # 0.0 gold      / 0.0$
+            ),                                                                          # 90.0 gold     / 45.0$
+            currency_id=foreign_currency.id,
+            invoice_ids=[invoice_eligible_with_foreign_currency.id],
+        )._create_payment()
+
+        self.assert_invoice_payment(
+            payment=payment,
+            invoice=invoice_eligible_with_foreign_currency,
+            expected_values={
+                'payment_amount': 90,
+                'payment_amount_total': 100,
+                'invoice_payment_state': 'in_payment',
+                'invoice_amount_paid': 90,
+                'payment_invoice_line_ids': [
+                    {'account_type': 'asset_current', 'amount_currency': 90, 'balance': 45},
+                    {'account_type': 'asset_receivable', 'amount_currency': -100, 'balance': -50},
+                    {'account_type': 'expense', 'amount_currency': 10, 'balance': 5},
+                ],
+            }
+        )

--- a/addons/account_payment/views/account_portal_templates.xml
+++ b/addons/account_payment/views/account_portal_templates.xml
@@ -60,6 +60,11 @@
     </template>
 
     <template id="portal_invoice_page_inherit_payment" name="Payment on My Invoices" inherit_id="account.portal_invoice_page">
+        <xpath expr="//t[@t-if='early_payment']" position="after">
+            <t t-elif="invoice.payment_state in ('paid', 'in_payment')">
+                <span t-esc="invoice.amount_paid" t-options='{"widget": "monetary", "display_currency": invoice.currency_id}' />
+            </t>
+        </xpath>
         <xpath expr="//t[@t-call='portal.portal_record_sidebar']//h2[1]" position="after">
             <t t-set="pending_txs" t-value="invoice.transaction_ids.filtered(lambda tx: tx.state in ('pending', 'authorized') and tx.provider_code not in ('none', 'custom'))"/>
             <div class="d-grid">


### PR DESCRIPTION
When an invoice (not paid), set to a payment term with an early payment discount enabled, is displayed in the portal view. The early discount is not shown in the side bar and the customer will pay in full.

Steps to reproduce:
- Go to accounting > configuration > payment terms > NEW
- Create a new payment terms with Early Discount checked > confirm
- Go to customer > invoices > NEW
- Create a new invoice with the payment terms selected > confirm.
- When clicking "Restiger Payment" to manually pay, the modal will display the early discount informations if the invoice is eligible.
- Click on Preview (short cut to access to the invoice through the portal)
- Assuming the invoice is eligible for early payment discount, the informations are not displayed in the side bar.
- Click on pay > select a payment provider > confirm
- Notice how the full payment was registered in accounting chart of account.

Cause:
the early discount feature is not properly handled in the portal view.

Analysis:
When previewing the transaction, the context sent `amount` is not well computed (contoller portal). This `amount` context is the one used when creating the transaction https://github.com/odoo/odoo/blob/3ef9310ec36f1d5abd3f55e92eedb2ac7133d97a/addons/account_payment/controllers/payment.py#L40-L42 Therefore, we need to make sure that the `amount` defined in the view is the discounted amount if early_payment and the full amount if not.

solution:

- Everything has been implemented correctly for the payment.register:
* Therefore, we'll use as much as possible the logic of payment.register to deduct the `amount` and `amount_without_discount` if we are in an early payment mode. -> To do that, part of the computation is moved to the `account.move` model While it is not the cleanest approach, it is the safest in stable.

- XML (to be changed in Master): we keep the the `t-if="0"` to not break Xpath in stable
- XML: `t-if="amount"` just to make sure it does not break for a credit note https://github.com/odoo/odoo/blob/17.0/addons/account_payment/controllers/portal.py#L14-L16
+ the view for a credit note is more coherent since no more amount (only the Download button).

Todo:
In Master, we should harmonize better the way we register payment and create transaction by migrating the relevant methods into `account.move` (`_get_batches`,`_get_total_amount_in_wizard_currency_to_full_reconcile`) in order to have the same business logic

opw-3632594

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
