### PR TITLE
[IMP] mail: small style improvements in message list

### DIFF
--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -40,12 +40,19 @@
     }
 }
 
-.o-mail-Composer-input {
+@mixin o-mail-Composer-inputSizeStyle {
     padding-top: 10px; // carefully crafted to have the text in the middle in chat window
     padding-bottom: 10px;
+    padding-left: (map-get($spacers, 2) + map-get($spacers, 3)) / 2;
+    padding-right: (map-get($spacers, 2) + map-get($spacers, 3)) / 2;
+    line-height: 1.42857143 !important; // so that input is rounded to 20px = 14px (base font) * 1.42857143 (line-height)
+}
+
+.o-mail-Composer-input {
+    font-family: "text-emoji", $font-family-base;
+    @include o-mail-Composer-inputSizeStyle();
     max-height: 100px;
     resize: none;
-    line-height: 1.42857143 !important; // so that input is rounded to 20px = 14px (base font) * 1.42857143 (line-height)
 
     .o-extended & {
         max-height: Min(400px, 30vh);
@@ -63,15 +70,9 @@
 .o-mail-Composer-fake {
     height: 0;
     top: -10000px;
-    padding-top: 10px;
-    padding-bottom: 10px;
-    line-height: 1.42857143 !important; // so that input is rounded to 20px = 14px (base font) * 1.42857143 (line-height)
+    @include o-mail-Composer-inputSizeStyle();
 }
 
 .o-mail-Composer-compactContainer {
     box-shadow: 0px -3px 25px 3px rgba(50, 50, 50, 0.1);
-}
-
-.o-mail-Composer-input {
-    font-family: "text-emoji", $font-family-base;
 }

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -38,7 +38,7 @@
                     }"
                 >
                     <div class="position-relative flex-grow-1">
-                        <textarea class="o-mail-Composer-input form-control bg-view px-3 border-0 rounded-3 shadow-none overflow-auto"
+                        <textarea class="o-mail-Composer-input form-control bg-view border-0 rounded-3 shadow-none overflow-auto"
                             t-ref="textarea"
                             style="height:40px;"
                             t-on-keydown="onKeydown"
@@ -56,7 +56,7 @@
                              the textarea properly without flicker.
                         -->
                         <textarea
-                            class="o-mail-Composer-fake position-absolute"
+                            class="o-mail-Composer-fake position-absolute border-0"
                             t-model="props.composer.text"
                             t-ref="fakeTextarea"
                             disabled="1"

--- a/addons/mail/static/src/core/common/date_section.dark.scss
+++ b/addons/mail/static/src/core/common/date_section.dark.scss
@@ -1,0 +1,3 @@
+.o-mail-DateSection span {
+    opacity: 50%;
+}

--- a/addons/mail/static/src/core/common/date_section.scss
+++ b/addons/mail/static/src/core/common/date_section.scss
@@ -1,0 +1,3 @@
+.o-mail-DateSection span {
+    opacity: 75%;
+}

--- a/addons/mail/static/src/core/common/date_section.xml
+++ b/addons/mail/static/src/core/common/date_section.xml
@@ -4,7 +4,7 @@
 <t t-name="mail.DateSection">
     <div class="o-mail-DateSection d-flex align-items-center w-100 fw-bold z-1" t-attf-class="{{ props.className }}">
         <hr class="o-discuss-separator flex-grow-1"/>
-        <span class="px-3 opacity-75 small text-muted"><t t-esc="props.date"/></span>
+        <span class="px-2 smaller text-muted"><t t-esc="props.date"/></span>
         <hr class="o-discuss-separator flex-grow-1"/>
     </div>
 </t>

--- a/addons/mail/static/src/core/common/message.dark.scss
+++ b/addons/mail/static/src/core/common/message.dark.scss
@@ -1,0 +1,21 @@
+.o-mail-Message-author {
+    opacity: 75%;
+}
+
+.o-mail-Message-date {
+    opacity: 50%;
+}
+
+.o-mail-Message-bubble {
+    --border-opacity: 0;
+
+    &.o-blue {
+        background-color: mix($gray-100, $info, 85%) !important;
+    }
+    &.o-green {
+        background-color: mix($gray-100, $success, 85%) !important;
+    }
+    &.o-orange {
+        background-color: mix($gray-100, $warning, 70%) !important;
+    }
+}

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -6,6 +6,10 @@
     }
 }
 
+.o-mail-Message-date {
+    opacity: 75%;
+}
+
 .o-mail-Message-seenContainer {
     font-size: 0.65rem;
     right: 2px;
@@ -43,6 +47,12 @@
 
 .o-mail-Message-body {
     font-family: "text-emoji", $font-family-base;
+    color: mix($black, $body-color);
+
+    &:not(.o-note) {
+        padding-left: (map-get($spacers, 2) + map-get($spacers, 3)) / 2;
+        padding-right: (map-get($spacers, 2) + map-get($spacers, 3)) / 2;
+    }
 
     & > p {
         margin-bottom: 0 !important;
@@ -50,6 +60,20 @@
         &:last-of-type:has(~ .o-mail-Message-edited) {
             display: inline-block;
         }
+    }
+}
+
+.o-mail-Message-bubble {
+    --border-opacity: 0.1;
+
+    &.o-blue {
+        background-color: mix($o-view-background-color, $info, 85%) !important;
+    }
+    &.o-green {
+        background-color: mix($o-view-background-color, $success, 85%) !important;
+    }
+    &.o-orange {
+        background-color: mix($o-view-background-color, $warning, 75%) !important;
     }
 }
 

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -21,18 +21,18 @@
                         </div>
                         <t t-elif="message.isPending" t-call="mail.Message.pendingStatus"/>
                         <t t-elif="!message.is_transient">
-                            <small t-if="isActive and props.showDates" class="o-mail-Message-date text-muted opacity-75 o-smaller mt-2">
+                            <small t-if="isActive and props.showDates" class="o-mail-Message-date text-muted smaller mt-2">
                                 <t t-esc="message.dateSimple"/>
                             </small>
                         </t>
                     </div>
                     <div class="w-100 o-min-width-0" t-att-class="{ 'flex-grow-1': message.composer }" t-ref="messageContent">
                         <div t-if="!props.squashed" class="o-mail-Message-header d-flex flex-wrap align-items-baseline lh-1" t-att-class="{ 'mb-1': !message.is_note }">
-                            <span t-if="authorName and shouldDisplayAuthorName" class="o-mail-Message-author" t-att-class="getAuthorAttClass()">
+                            <span t-if="authorName and shouldDisplayAuthorName" class="o-mail-Message-author small" t-att-class="getAuthorAttClass()">
                                 <strong class="me-1" t-esc="authorName"/>
                             </span>
                             <t t-if="!isAlignedRight" t-call="mail.Message.notification"/>
-                            <small t-if="!message.is_transient" class="o-mail-Message-date text-muted opacity-75 o-smaller" t-att-title="message.datetimeShort">
+                            <small t-if="!message.is_transient" class="o-mail-Message-date text-muted smaller" t-att-title="message.datetimeShort">
                                 <t t-if="shouldDisplayAuthorName">- </t>
                                 <t t-if="message.isPending" t-call="mail.Message.pendingStatus"/>
                                 <RelativeTime t-else="" datetime="message.datetime"/>
@@ -72,14 +72,15 @@
                                             <div class="position-relative overflow-x-auto d-inline-block" t-att-class="{ 'w-100': state.isEditing }">
                                                 <div class="o-mail-Message-bubble rounded-bottom-3 position-absolute top-0 start-0 w-100 h-100" t-att-class="{
                                                     'border': state.isEditing and !message.is_note,
-                                                    'bg-info-light border border-info opacity-25': !message.isSelfAuthored and !message.is_note and !message.isHighlightedFromMention,
-                                                    'bg-success-light border border-success opacity-25': message.isSelfAuthored and !message.is_note and !message.isHighlightedFromMention,
-                                                    'bg-warning-light border border-warning opacity-50': message.isHighlightedFromMention,
+                                                    'o-blue border border-info': !message.isSelfAuthored and !message.is_note and !message.isHighlightedFromMention,
+                                                    'o-green border border-success': message.isSelfAuthored and !message.is_note and !message.isHighlightedFromMention,
+                                                    'o-orange border border-warning': message.isHighlightedFromMention,
                                                     }" t-attf-class="{{ isAlignedRight ? 'rounded-start-3' : 'rounded-end-3' }}"/>
                                                 <div class="position-relative text-break o-mail-Message-body" t-att-class="{
                                                             'p-1': message.is_note,
                                                             'fs-1': !state.isEditing and !env.inChatter and message.onlyEmojis,
-                                                            'mb-0 py-2 px-3': !message.is_note,
+                                                            'mb-0 py-2': !message.is_note,
+                                                            'o-note': message.is_note,
                                                             'align-self-start rounded-end-3 rounded-bottom-3': !state.isEditing and !message.is_note,
                                                             'o-mail-Message-editable flex-grow-1': state.isEditing,
                                                             }" t-ref="body">

--- a/addons/mail/static/src/core/common/message_in_reply.xml
+++ b/addons/mail/static/src/core/common/message_in_reply.xml
@@ -9,7 +9,7 @@
                 <span class="o-mail-MessageInReply-corner position-absolute bottom-0 top-50 pe-4 border-top text-300" t-attf-class="{{ env.inChatWindow and props.alignedRight ? 'o-isRightAlign border-end' : 'o-isLeftAlign border-start' }}" t-att-class="{ 'ms-n2': store.discuss?.isActive }"/>
                 <span t-if="!props.message.parentMessage.isEmpty" class="d-inline-flex align-items-center text-muted opacity-75" t-att-class="{ 'cursor-pointer opacity-100-hover': props.onClick }" t-on-click="() => this.props.onClick?.()">
                     <img class="o-mail-MessageInReply-avatar me-2 rounded" t-att-src="authorAvatarUrl" t-att-title="props.message.parentMessage.author?.name ?? props.message.parentMessage.email_from" alt="Avatar"/>
-                    <span class="o-mail-MessageInReply-content overflow-hidden">
+                    <span class="o-mail-MessageInReply-content overflow-hidden smaller">
                         <b>@<t t-out="props.message.parentMessage.author?.name ?? props.message.parentMessage.email_from"/></b>:
                         <br t-if="env.inChatWindow and !props.alignedRight"/>
                         <span class="o-mail-MessageInReply-message ms-1 text-break">

--- a/addons/mail/static/src/core/common/thread.scss
+++ b/addons/mail/static/src/core/common/thread.scss
@@ -5,7 +5,8 @@
     transition: opacity 0.5s;
 
     span {
-        font-size: 0.8rem;
+        font-size: 0.6rem;
+        clip-path: polygon(0% 50%, 15% 0%, 100% 0%, 100% 100%, 15% 100%);
     }
 }
 

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -22,7 +22,7 @@
                         <t t-set="currentDay" t-value="msg.dateDay"/>
                     </t>
                     <div t-if="msg.threadAsFirstUnread?.eq(props.thread)" class="o-mail-Thread-newMessage d-flex align-items-center fw-bolder z-1">
-                        <hr class="ms-2 flex-grow-1 border border-danger opacity-50"/><span class="px-2 text-danger">New messages</span><hr class="me-2 flex-grow-1 border border-danger opacity-50"/>
+                        <hr class="flex-grow-1 border-danger opacity-100"/><span class="ps-2 pe-1 bg-danger o-text-white rounded text-uppercase">New</span>
                     </div>
                     <t t-if="msg.isNotification">
                         <t t-call="mail.NotificationMessage"/>
@@ -63,7 +63,7 @@
 <t t-name="mail.Thread.jumpPresent">
     <span t-if="props.showJumpPresent and state.showJumpPresent" t-att-class="{
         'm-0 px-4 position-sticky top-0': env.inChatter,
-    }" class="o-mail-Thread-banner o-mail-Thread-bannerHover d-flex d-print-none justify-content-between alert alert-primary border-0 rounded-0 mb-0 py-1 cursor-pointer shadow-sm small fw-bold" t-on-click="() => this.jumpToPresent()">
+    }" class="o-mail-Thread-banner o-mail-Thread-bannerHover d-flex d-print-none justify-content-between alert alert-secondary border-0 rounded-0 mb-0 py-1 cursor-pointer shadow-sm small fw-bold" t-on-click="() => this.jumpToPresent()">
         <span>You're viewing older messages</span>
         <span>Jump to Present<i class="ms-2 fa" t-att-class="{ 'fa-caret-up': props.order !== 'asc', 'fa-caret-down': props.order === 'asc' }"/></span>
     </span>

--- a/addons/mail/static/src/discuss/typing/common/typing.xml
+++ b/addons/mail/static/src/discuss/typing/common/typing.xml
@@ -27,7 +27,7 @@
             </div>
             <t t-if="props.displayText">
                 <span class="ms-1"/>
-                <span class="text-truncate" t-out="text"/>
+                <span class="text-truncate smaller" t-out="text"/>
             </t>
         </t>
     </t>

--- a/addons/mail/static/tests/core/new_message_separator.test.js
+++ b/addons/mail/static/tests/core/new_message_separator.test.js
@@ -103,12 +103,12 @@ test("keep new message separator until user goes back to the thread", async () =
     await openDiscuss(channelId);
     await contains(".o-mail-Thread");
     await contains(".o-mail-Message", { text: "hello" });
-    await contains(".o-mail-Thread-newMessage hr + span", { text: "New messages" });
+    await contains(".o-mail-Thread-newMessage hr + span", { text: "New" });
     await click(".o-mail-DiscussSidebar-item", { text: "History" });
     await contains(".o-mail-Discuss-threadName", { value: "History" });
     await click(".o-mail-DiscussSidebar-item", { text: "test" });
     await contains(".o-mail-Discuss-threadName", { value: "test" });
-    await contains(".o-mail-Thread-newMessage hr + span", { count: 0, text: "New messages" });
+    await contains(".o-mail-Thread-newMessage hr + span", { count: 0, text: "New" });
 });
 
 test("show new message separator on receiving new message when out of odoo focus", async () => {
@@ -133,7 +133,7 @@ test("show new message separator on receiving new message when out of odoo focus
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Thread");
-    await contains(".o-mail-Thread-newMessage hr + span", { count: 0, text: "New messages" });
+    await contains(".o-mail-Thread-newMessage hr + span", { count: 0, text: "New" });
     // simulate receiving a message
     await withUser(userId, () =>
         rpc("/mail/message/post", {
@@ -143,7 +143,7 @@ test("show new message separator on receiving new message when out of odoo focus
         })
     );
     await contains(".o-mail-Message", { text: "hu" });
-    await contains(".o-mail-Thread-newMessage hr + span", { text: "New messages" });
+    await contains(".o-mail-Thread-newMessage hr + span", { text: "New" });
     await contains(".o-mail-Thread-newMessage ~ .o-mail-Message", { text: "hu" });
 });
 
@@ -157,11 +157,11 @@ test("keep new message separator until current user sends a message", async () =
     await contains(".o-mail-Message", { text: "hello" });
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message-moreMenu [title='Mark as Unread']");
-    await contains(".o-mail-Thread-newMessage hr + span", { count: 1, text: "New messages" });
+    await contains(".o-mail-Thread-newMessage hr + span", { count: 1, text: "New" });
     await insertText(".o-mail-Composer-input", "hey!");
     await click(".o-mail-Composer-send:enabled");
     await contains(".o-mail-Message", { count: 2 });
-    await contains(".o-mail-Thread-newMessage hr + span", { count: 0, text: "New messages" });
+    await contains(".o-mail-Thread-newMessage hr + span", { count: 0, text: "New" });
 });
 
 test("keep new message separator when switching between chat window and discuss of same thread", async () => {
@@ -222,7 +222,7 @@ test("show new message separator when message is received in chat window", async
     );
     await contains(".o-mail-ChatWindow");
     await contains(".o-mail-Message", { count: 2 });
-    await contains(".o-mail-Thread-newMessage hr + span", { text: "New messages" });
+    await contains(".o-mail-Thread-newMessage hr + span", { text: "New" });
     await contains(".o-mail-Thread-newMessage + .o-mail-Message", { text: "hu" });
 });
 
@@ -268,7 +268,7 @@ test("show new message separator when message is received while chat window is c
     await contains(".o-mail-ChatBubble");
     await contains(".o-mail-ChatBubble-counter", { text: "1" });
     await click(".o-mail-ChatBubble");
-    await contains(".o-mail-Thread-newMessage hr + span", { text: "New messages" });
+    await contains(".o-mail-Thread-newMessage hr + span", { text: "New" });
 });
 
 test("only show new message separator in its thread", async () => {

--- a/addons/mail/static/tests/thread/thread.test.js
+++ b/addons/mail/static/tests/thread/thread.test.js
@@ -336,7 +336,7 @@ test("mark channel as fetched when a new message is loaded", async () => {
     );
     await contains(".o-mail-Message");
     await assertSteps(["rpc:channel_fetch"]);
-    await contains(".o-mail-Thread-newMessage hr + span", { text: "New messages" });
+    await contains(".o-mail-Thread-newMessage hr + span", { text: "New" });
     await focus(".o-mail-Composer-input");
     await assertSteps(["rpc:mark_as_read"]);
 });
@@ -719,7 +719,7 @@ test("first unseen message should be directly preceded by the new message separa
         })
     );
     await contains(".o-mail-Message", { count: 3 });
-    await contains(".o-mail-Thread-newMessage hr + span", { text: "New messages" });
+    await contains(".o-mail-Thread-newMessage hr + span", { text: "New" });
     await contains(".o-mail-Message[aria-label='Note'] + .o-mail-Thread-newMessage");
 });
 


### PR DESCRIPTION
Message list feels too crowded, especially in dark theme. This requires more effort to read messages as necessary, due to them not being easy to get at a glance.

This commit makes the following improvements:

- Message bubble color are slightly more colorful;
- Message bubble borders are reduced in white theme, removed in dark theme;
- Text in message bubbles is slightly easier to read (darker/whiter);
- Text in message bubbles have slightly less horizontal spacing;
- Composer text input has slightly less horizontal spacing too;
- "New message" separator becomes "new" with a slightly different style;
- Author names are slightly smaller, their opacity is slightly reduced in dark theme;
- Message datetime opacity are slightly reduced in dark theme;
- Date section `hr` are closer to text, with less spacing;
- Reply-to of a message is slightly smaller;
- "Jump to present" alert is less distracting;
- "is typing" member text below composer is slightly smaller;

This reduces visibility of some information to let message content shine more. The "new" message separator style change prevents having text in the middle, which made middle part of message list too crowded. Date section is not much of a problem because it's stable and present only once a day at most.

<img width="2075" alt="a-before-after-1" src="https://github.com/user-attachments/assets/38b8dd3a-87b7-4fe5-8fd4-606fcc54c422">
<img width="2072" alt="a-before-after-2" src="https://github.com/user-attachments/assets/07345761-4362-4c1d-9375-e9b4891803d3">

