### PR TITLE
[FIX] sms: fix sms notification rendering with urls in tags.

### DIFF
--- a/addons/sms/tools/sms_tools.py
+++ b/addons/sms/tools/sms_tools.py
@@ -3,10 +3,13 @@
 
 import re
 
-from odoo.tools import html_escape, html_keep_url
+from odoo.tools import TEXT_URL_REGEX, create_link, html_escape
 
 
 def sms_content_to_rendered_html(text):
     """Transforms plaintext into html making urls clickable and preserving newlines"""
-    text_with_links = html_keep_url(str(html_escape(text)))
-    return re.sub(r'\r?\n|\r', '<br/>', text_with_links)
+    urls = re.findall(TEXT_URL_REGEX, text)
+    escaped_text = str(html_escape(text))
+    for url in urls:
+        escaped_text = escaped_text.replace(url, create_link(url, url))
+    return re.sub(r'\r?\n|\r', '<br/>', escaped_text)

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -309,6 +309,7 @@ def is_html_empty(html_content):
     tag_re = re.compile(r'\<\s*\/?(?:p|div|span|br|b|i|font)(?:(?=\s+\w*)[^/>]*|\s*)/?\s*\>')
     return not bool(re.sub(tag_re, '', html_content).strip())
 
+
 def html_keep_url(text):
     """ Transform the url into clickable link with <a/> tag """
     idx = 0
@@ -316,10 +317,14 @@ def html_keep_url(text):
     link_tags = re.compile(r"""(?<!["'])((ftp|http|https):\/\/(\w+:{0,1}\w*@)?([^\s<"']+)(:[0-9]+)?(\/|\/([^\s<"']))?)(?![^\s<"']*["']|[^\s<"']*</a>)""")
     for item in re.finditer(link_tags, text):
         final += text[idx:item.start()]
-        final += '<a href="%s" target="_blank" rel="noreferrer noopener">%s</a>' % (item.group(0), item.group(0))
+        final += create_link(item.group(0), item.group(0))
         idx = item.end()
     final += text[idx:]
     return final
+
+
+def create_link(url, label):
+    return f'<a href="{url}" target="_blank" rel="noreferrer noopener">{label}</a>'
 
 
 def html2plaintext(html, body_id=None, encoding='utf-8'):


### PR DESCRIPTION
A problem was left to be fixed in the previous PR: What was to be considered the url and label was sometimes incorrectly computed with html_keep_url.

As it is used in other places, we simply don't use it anymore, but extract the needed part from it: how a link is safely rendered.

Task-3502174
