### PR TITLE
[FIX] sale: fix tax included in price when changing fiscal position

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -449,7 +449,7 @@ class SaleOrderLine(models.Model):
                     product_taxes=line.product_id.taxes_id.filtered(
                         lambda tax: tax.company_id == line.env.company
                     ),
-                    fiscal_position=line.order_id.fiscal_position_id,
+                    product_taxes_after_fp=line.tax_id,
                 )
 
     def _get_display_price(self):


### PR DESCRIPTION
**Steps to reproduce:**

1. Create a Tax 20% included in price
2. Create a Tax 10% included in price
3. Create a Fiscal Position mapping the 20% Tax to the 10% Tax
4. Create a Product with the 20% Tax, and price of $ 1000
5. Create a Sale Order with the Product
6. Observe the Unit Price is 1000 (833.33 + 20%)
7. Change the Fiscal Position and Update Taxes
8. Observe the Unit Price remains 1000 (909.09 + 10%)
9. Add a new line with the same product
10. Observe the Unit Price is 916.67 (833.33 + 10%)

**Expected behavior:**

When changing the Fiscal Position, the Unit Price of the existing line should've been updated to maintain the same untaxed amount of 833.33, and to be consistent with the unit price if a new line is added.

**Runbot recording:**

https://github.com/user-attachments/assets/2a23d29a-3977-42b3-9ecb-be3ff85541ab

_(recorded in runbot v17)_

---

There was a fix attempt for this issue in 537df328, but it was later reverted in 78bcea07. I presume because the fix did not respect the Unit Prices that might have already been set on the Sale Order Lines. Instead, it simply recomputed all the prices as if the pricelist had changed, and it did so for all the lines.

However, the fix implemented here doesn't recompute the prices, it only adjusts them to keep the same untaxed amount when switching taxes, and only for the relevant lines.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
