### PR TITLE
[IMP] "Past Event" link in events sidebar photos

### DIFF
--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -296,7 +296,7 @@
 <template id="index_sidebar_photos" inherit_id="website_event.index_sidebar" active="True" name="Photos" priority="40">
     <xpath expr="//div[@id='o_wevent_index_sidebar']" position="inside">
         <h6 class="o_wevent_sidebar_title">Photos</h6>
-        <a href="/event">
+        <a href="/event?date=old">
             <figure class="o_wevent_sidebar_block o_wevent_sidebar_figure figure">
                 <img class="figure-img img-fluid rounded" src="/website_event/static/src/img/event_past_0.jpg" alt=""/>
                 <figcaption class="figure-caption">A past event</figcaption>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The link of "A Past Event" wasn't working (not displaying pas events).

Current behavior before PR:
Clicking on the "A past event" link sends back to empty search.

Desired behavior after PR is merged:
Clicking on the "A past event" link filters on past events.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
