### PR TITLE
[FIX] portal: add filename to inline browser preview

### DIFF
--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -506,9 +506,12 @@ class CustomerPortal(Controller):
             'Content-Type': 'application/pdf' if report_type == 'pdf' else 'text/html',
             'Content-Length': len(report),
         }
-        if report_type == 'pdf' and download:
+        if report_type == 'pdf':
             filename = "%s.pdf" % (re.sub(r'\W+', '-', model._get_report_base_filename()))
-            headers['Content-Disposition'] = content_disposition(filename)
+            if download:
+                headers['Content-Disposition'] = content_disposition(filename)
+            else:
+                headers['Content-Disposition'] = "inline; filename*=UTF-8''" + filename
         return headers
 
 def get_error(e, path=''):


### PR DESCRIPTION
Issue -->

On the customer preview of a Sale Order, when the customer selects `View Details`, an attachment is opened on a new tab, and upon downloading it, the file name is different than if the report was downloaded via the Sale Order form view.

Solution -->

Add the `inline` option to the 'Content-Disposition' response header so that the file name is added in the case that a customer decides to download the attachment from the attachment preview.

opw-4091262
