### PR TITLE
[FIX] mail: flicker when expanding direct messages in sidebar

### DIFF
--- a/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.scss
+++ b/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.scss
@@ -5,6 +5,10 @@
     }
 }
 
+.o-mail-DiscussSidebarCategory-item {
+    line-height: 2.45; // so that same height as actions, so folding doesn't resize
+}
+
 .o-mail-DiscussSidebar-item {
     &:hover .o-mail-DiscussSidebarChannel-commands {
         display: flex !important;

--- a/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.xml
@@ -12,7 +12,7 @@
 
     <t t-name="mail.DiscussSidebarCategory">
         <div class="o-mail-DiscussSidebarCategory d-flex align-items-center my-1" t-att-class="category.extraClass">
-            <button class="btn btn-link text-reset flex-grow-1 d-flex align-items-baseline mx-1 p-0 text-start opacity-100-hover opacity-75" t-on-click="() => this.toggleCategory(category)">
+            <button class="btn btn-link o-mail-DiscussSidebarCategory-item text-reset flex-grow-1 d-flex align-items-baseline mx-1 p-0 text-start opacity-100-hover opacity-75" t-on-click="() => this.toggleCategory(category)">
                 <span t-if="store.channels.status === 'fetching'" class="o-visible-short-delay"><i class="o-mail-DiscussSidebarCategory-icon o-smaller me-1 fa fa-fw fa-circle-o-notch fa-spin opacity-50"/></span>
                 <i t-else="" class="o-mail-DiscussSidebarCategory-icon o-smaller me-1" t-att-class="category.open ? 'oi oi-chevron-down' : 'oi oi-chevron-right'"/>
                 <span class="btn-sm p-0 text-uppercase text-break fw-bolder o-smaller"><t t-esc="category.name"/></span>


### PR DESCRIPTION
**Current behavior before PR:**

The title "Direct Messages" in the discuss sidebar used to flicker (move up and down) when expanding or folding the section.

**Desired behavior after PR is merged:**

The flickering issue is fixed, so now the title "Direct Messages" remains in place when the section is expanded or folded.

**task**:4100682

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
