### PR TITLE
[IMP] project: display email address with collaborator name in share wizard

### DIFF
--- a/addons/project/wizard/project_share_wizard_views.xml
+++ b/addons/project/wizard/project_share_wizard_views.xml
@@ -16,6 +16,7 @@
                         <field name="partner_id"
                                options="{'no_create': True, 'no_open': True}"
                                domain="[('id', 'not in', parent.existing_partner_ids), ('partner_share', '=', True)]"
+                               context="{'show_email': True}"
                         />
                         <field name="access_mode"/>
                         <field name="send_invitation"/>


### PR DESCRIPTION
Currently, only the collaborator's name appears in the share wizard, which can be confusing
if there are multiple collaborators with the same name. This commit adds the email address to
the display, making it easier to identify each collaborator accurately.

task-3976470