### PR TITLE
[FIX] website_sale: prevent error when doing payment through express checkout

### DIFF
--- a/addons/website_sale/controllers/delivery.py
+++ b/addons/website_sale/controllers/delivery.py
@@ -160,6 +160,8 @@ class Delivery(WebsiteSale):
         :rtype: dict
         """
         order_sudo = request.website.sale_get_order()
+        if not order_sudo:
+            return []
 
         self._include_country_and_state_in_address(partial_delivery_address)
         partial_delivery_address, _side_values = self._parse_form_data(partial_delivery_address)


### PR DESCRIPTION
When we are trying to make a payment through express checkout this error is occuring.

Steps to reproduce:
- Install the ``website_sale`` module
- Activate ``Demo`` payment provider
- Go to Website > Shop > Add a product to cart > View cart
- Pay with Demo > Pay
- Click the back button(chrome navbar)(Instantly)
- Again click on Pay with Demo > Pay

Traceback: 
``ValueError: Expected singleton: sale.order()``

This error occurs at [1], where we are receiving ``order_sudo`` as empty.

This commit will resolve the above error by returning empty list if no product is found in the cart.

[1]- https://github.com/odoo/odoo/blob/20d157e94d51e3d8339411a6ed15da35e9d86ab4/addons/website_sale/controllers/delivery.py#L166

sentry-5682671428

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
