### PR TITLE
[FIX] stock_picking_batch: validate batch with partially done pickings

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking.py
+++ b/addons/stock_picking_batch/models/stock_picking.py
@@ -138,9 +138,10 @@ class StockPicking(models.Model):
         return res
 
     def _create_backorder(self):
+        pickings_to_detach = self.env['stock.picking'].browse(self.env.context.get('pickings_to_detach'))
         for picking in self:
             # Avoid inconsistencies in states of the same batch when validating a single picking in a batch.
-            if picking.batch_id and picking.state != 'done' and any(p not in self for p in picking.batch_id.picking_ids):
+            if picking.batch_id and picking.state != 'done' and any(p not in self for p in picking.batch_id.picking_ids - pickings_to_detach):
                 picking.batch_id = None
         return super()._create_backorder()
 

--- a/addons/stock_picking_batch/tests/test_batch_picking.py
+++ b/addons/stock_picking_batch/tests/test_batch_picking.py
@@ -1000,6 +1000,138 @@ class TestBatchPicking02(TransactionCase):
             {'quantity': 2.0, 'picked': True},
         ])
 
+    def test_backorder_batching_3(self):
+        """
+        Check that pickings are still linked to the batch after validation
+        when backorders are skipped in autobacth
+        """
+        warehouse = self.env.ref('stock.warehouse0')
+        warehouse.int_type_id.write({
+            'auto_batch': True,
+            'batch_group_by_destination': True,
+        })
+        productA, productB = self.productA, self.productB
+        partner = self.env['res.partner'].create({'name': 'Mr. Belougat'})
+
+        # Create and validate a batch with 2 pickings where 1 of them is to partially backorder
+        pickings = self.env['stock.picking'].create([
+            {
+                'picking_type_id': warehouse.int_type_id.id,
+                'company_id': self.env.company.id,
+                'partner_id': partner.id,
+            } for _ in range(2)
+        ])
+        self.env['stock.move'].create([
+            {
+                'name': productA.name,
+                'product_id': productA.id,
+                'product_uom_qty': 1.0,
+                'product_uom': productA.uom_id.id,
+                'picking_id': pickings[0].id,
+                'location_id': pickings[0].location_id.id,
+                'location_dest_id': pickings[0].location_dest_id.id,
+            },
+            {
+                'name': productB.name,
+                'product_id': productB.id,
+                'product_uom_qty': 4.0,
+                'product_uom': productB.uom_id.id,
+                'picking_id': pickings[0].id,
+                'location_id': pickings[0].location_id.id,
+                'location_dest_id': pickings[0].location_dest_id.id,
+            },
+            {
+                'name': productA.name,
+                'product_id': productA.id,
+                'product_uom_qty': 1.0,
+                'product_uom': productA.uom_id.id,
+                'picking_id': pickings[1].id,
+                'location_id': pickings[1].location_id.id,
+                'location_dest_id': pickings[1].location_dest_id.id,
+            },
+        ])
+        pickings.action_confirm()
+        batch = self.env['stock.picking.batch'].create({
+            'picking_ids': [Command.link(pickings[0].id), Command.link(pickings[1].id)],
+            'picking_type_id': warehouse.int_type_id.id,
+        })
+        batch.action_confirm()
+        # Partially pick the quantities of only one of the 2 pickings
+        # The second picking should be removed from the batch and added to an other one
+        pickings.move_ids.filtered(lambda m: m.product_id == productA).quantity = 1.0
+        moveB = pickings.move_ids.filtered(lambda m: m.product_id == productB)
+        moveB.quantity = 4.0
+        moveB.picked = True
+        batch.with_context(skip_backorder=True).action_done()
+        self.assertEqual(batch.picking_ids, pickings[0])
+        self.assertEqual(batch.state, 'done')
+        self.assertTrue(pickings[1].batch_id)
+
+    def test_backorder_batching_4(self):
+        """
+        Check that pickings are still linked to the batch after validation
+        when backorders are skipped without autobacth
+        """
+        warehouse = self.env.ref('stock.warehouse0')
+        warehouse.int_type_id.auto_batch = False
+        productA, productB = self.productA, self.productB
+        partner = self.env['res.partner'].create({'name': 'Mr. Belougat'})
+
+        # Create and validate a batch with 2 pickings where 1 of them is to partially backorder
+        pickings = self.env['stock.picking'].create([
+            {
+                'picking_type_id': warehouse.int_type_id.id,
+                'company_id': self.env.company.id,
+                'partner_id': partner.id,
+            } for _ in range(2)
+        ])
+        self.env['stock.move'].create([
+            {
+                'name': productA.name,
+                'product_id': productA.id,
+                'product_uom_qty': 1.0,
+                'product_uom': productA.uom_id.id,
+                'picking_id': pickings[0].id,
+                'location_id': pickings[0].location_id.id,
+                'location_dest_id': pickings[0].location_dest_id.id,
+            },
+            {
+                'name': productB.name,
+                'product_id': productB.id,
+                'product_uom_qty': 4.0,
+                'product_uom': productB.uom_id.id,
+                'picking_id': pickings[0].id,
+                'location_id': pickings[0].location_id.id,
+                'location_dest_id': pickings[0].location_dest_id.id,
+            },
+            {
+                'name': productA.name,
+                'product_id': productA.id,
+                'product_uom_qty': 1.0,
+                'product_uom': productA.uom_id.id,
+                'picking_id': pickings[1].id,
+                'location_id': pickings[1].location_id.id,
+                'location_dest_id': pickings[1].location_dest_id.id,
+            },
+        ])
+        pickings.action_confirm()
+        batch = self.env['stock.picking.batch'].create({
+            'picking_ids': [Command.link(pickings[0].id), Command.link(pickings[1].id)],
+            'picking_type_id': warehouse.int_type_id.id,
+        })
+        batch.action_confirm()
+        # Partially pick the quantities of only one of the 2 pickings
+        # The second picking should be removed from the batch but not added to any other one
+        pickings.move_ids.filtered(lambda m: m.product_id == productA).quantity = 1.0
+        moveB = pickings.move_ids.filtered(lambda m: m.product_id == productB)
+        moveB.quantity = 4.0
+        moveB.picked = True
+        batch.with_context(skip_backorder=True).action_done()
+        self.assertEqual(batch.picking_ids, pickings[0])
+        self.assertEqual(batch.state, 'done')
+        self.assertFalse(pickings[1].batch_id)
+
+
 
 @tagged('post_install', '-at_install')
 class TestBatchPickingSynchronization(HttpCase):


### PR DESCRIPTION
### Steps to reproduce:

- Enable Multi-Step Routes and Batch Transfers in the settings
- Inventory > Configuration > Warehouse Management > Operation Types
- Click on internal transfer: Enable Auomatic batches group by dest
- Create a internal transfer with two moves: 1 x screw and 1 x bolt
- Mark the transfer as Todo, duplicate it and `mark as Todo`
> the two transfers should be added to a batch
- In the barcode app, batch transfers, go on your batch
- Add a single screw and validate
> A pop up appears to tell you that the rest will be backordered
- Validate

### Bug:

Instead of being redirected to the barcode app, you are left on the old version of the batch. If you go back the barcode app you will see that your old batch is actually empty (0 lines) and its state is "in progress" instead of being done. If you click on the the empty batch you get a traceback since its picking_type is nowhere to be found by owl

### Cause of the issue:

When you added your screw via the barcode app, you marked the move of the picking as picked. When you validated the batch, you are going to mark this move as done and to back order its picking since only part of it was completed. However, since one of its move is 'done' and the other one is 'assigned', its state will not be done and the picking to backorder will be removed from the original batch y these lines: https://github.com/odoo/odoo/blob/686e0f40f28b81ec99ad41f784a06d0ff231b01c/addons/stock_picking_batch/models/stock_picking.py#L140-L144 It would make sense if the the other pickings were to stay in the batch, which is what the "any" part of the if condition is trying to check. However the other picking of the batch is going to be removed later by these lines (since none of its move are picked so that it is considered to be empty):
https://github.com/odoo/odoo/blob/686e0f40f28b81ec99ad41f784a06d0ff231b01c/addons/stock_picking_batch/models/stock_picking_batch.py#L233-L234 https://github.com/odoo/odoo/blob/686e0f40f28b81ec99ad41f784a06d0ff231b01c/addons/stock_picking_batch/models/stock_picking.py#L120-L121 This is the cause of all the issues since the old batch is now emptied from all of its picking so that its state will stay in progress and its picking_type_id can't be found from its pickings.

### Expected behavior:

The part of the picking that was marked as done should have stayed in the old batch.

### Fix:

The any part of this if condition should take into account the pickings that are going to be detached from the batch.
https://github.com/odoo/odoo/blob/686e0f40f28b81ec99ad41f784a06d0ff231b01c/addons/stock_picking_batch/models/stock_picking.py#L140-L144

opw-4088846
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
