### PR TITLE
[FIX] web: can't upload same file twice

### DIFF
--- a/addons/web/static/src/views/fields/file_handler.js
+++ b/addons/web/static/src/views/fields/file_handler.js
@@ -22,6 +22,7 @@ export class FileUploader extends Component {
         if (!ev.target.files.length) {
             return;
         }
+        const { target } = ev;
         for (const file of ev.target.files) {
             if (!checkFileSize(file.size, this.notification)) {
                 return null;
@@ -49,6 +50,7 @@ export class FileUploader extends Component {
                 this.state.isUploading = false;
             }
         }
+        target.value = null;
         if (this.props.multiUpload && this.props.onUploadComplete) {
             this.props.onUploadComplete({});
         }

--- a/addons/web/static/tests/views/fields/image_field_tests.js
+++ b/addons/web/static/tests/views/fields/image_field_tests.js
@@ -712,31 +712,33 @@ QUnit.module("Fields", (hooks) => {
         }
 
         assert.strictEqual(
-            target.querySelector("input[type=file]").files.length,
-            0,
-            "there shouldn't be any file"
+            target.querySelector("img[data-alt='Binary file']").dataset.src,
+            "/web/static/img/placeholder.png",
+            "image field should not be set"
         );
 
         await setFiles();
-        assert.strictEqual(
-            target.querySelector("input[type=file]").files.length,
-            1,
-            "there should be a single file"
+        assert.ok(
+            target
+                .querySelector("img[data-alt='Binary file']")
+                .dataset.src.includes("data:image/png;base64"),
+            "image field should be set"
         );
 
         await clickSave(target);
         await click(target, ".o_form_button_create");
         assert.strictEqual(
-            target.querySelector("input[type=file]").files.length,
-            0,
-            "there shouldn't be any file"
+            target.querySelector("img[data-alt='Binary file']").dataset.src,
+            "/web/static/img/placeholder.png",
+            "image field should be reset"
         );
 
         await setFiles();
-        assert.strictEqual(
-            target.querySelector("input[type=file]").files.length,
-            1,
-            "there should be a single file"
+        assert.ok(
+            target
+                .querySelector("img[data-alt='Binary file']")
+                .dataset.src.includes("data:image/png;base64"),
+            "image field should be set"
         );
     });
 


### PR DESCRIPTION
Close https://github.com/odoo/odoo/issues/175793

* STEP TO REPRODUCE: go to contact form or perrsonal profile, upload avatar with image 1.png -> Save -> Delete image uploaded -> Update that same image 1.png again -> Nothing happen
* SOLUTION: we need to clear ev.target.value just like in v17 does https://github.com/odoo/odoo/pull/117704

** NOTE: This issue is not exist in v15 and v17

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
