### PR TITLE
[IMP] point_of_sale: add "Cancel Order" action

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -39,6 +39,9 @@
                     <t t-if="currentOrder?.fiscal_position_id" t-esc="currentOrder.fiscal_position_id.display_name" />
                     <t t-else="">Tax</t>
                 </button>
+                <button class="btn btn-secondary btn-lg py-5" t-on-click="() => this.pos.onDeleteOrder(this.pos.get_order())">
+                    <i class="fa fa-trash me-1" role="img" /> Cancel Order 
+                </button>
             </div>
         </t>
     </t>

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -20,7 +20,6 @@ import {
     getButtons,
     DEFAULT_LAST_ROW,
 } from "@point_of_sale/app/generic_components/numpad/numpad";
-import { ask } from "@point_of_sale/app/store/make_awaitable_dialog";
 import { PosOrderLineRefund } from "@point_of_sale/app/models/pos_order_line_refund";
 import { fuzzyLookup } from "@web/core/utils/search";
 import { parseUTCString } from "@point_of_sale/utils";
@@ -117,50 +116,6 @@ export class TicketScreen extends Component {
     onCreateNewOrder() {
         this.pos.add_new_order();
         this.pos.showScreen("ProductScreen");
-    }
-    _selectNextOrder(currentOrder) {
-        const currentOrderIndex = this._getOrderList().indexOf(currentOrder);
-        const orderList = this._getOrderList();
-        this.pos.set_order(orderList[currentOrderIndex + 1] || orderList[currentOrderIndex - 1]);
-    }
-    async onDeleteOrder(order) {
-        const screen = order.get_screen_data();
-
-        if (
-            ["ProductScreen", "PaymentScreen"].includes(screen.name) &&
-            order.get_orderlines().length > 0
-        ) {
-            const confirmed = await ask(this.dialog, {
-                title: _t("Existing orderlines"),
-                body: _t(
-                    "%s has a total amount of %s, are you sure you want to delete this order?",
-                    order.name,
-                    this.getTotal(order)
-                ),
-            });
-            if (!confirmed) {
-                return false;
-            }
-            if (this.state.selectedOrder === order) {
-                this.state.selectedOrder = null;
-            }
-        }
-
-        order.uiState.displayed = false;
-        if (order.id === this.pos.get_order()?.id) {
-            this._selectNextOrder(order);
-        }
-
-        const result = await this.pos.deleteOrders([order]);
-        if (!result) {
-            order.uiState.displayed = true;
-        } else {
-            if (this.pos.get_open_orders().length > 0) {
-                this.state.selectedOrder = this.pos.get_open_orders()[0];
-            }
-        }
-
-        return true;
     }
     async onNextPage() {
         if (this.state.page < this.getNbrPages()) {

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -75,7 +75,7 @@
                                     <div class="col narrow p-2">
                                         <div><t t-esc="getStatus(order)"></t></div>
                                     </div>
-                                    <div t-if="!shouldHideDeleteButton(order)" class="col very-narrow delete-button p-2" name="delete" t-on-click.stop="() => this.onDeleteOrder(order)">
+                                    <div t-if="!shouldHideDeleteButton(order)" class="col very-narrow delete-button p-2" name="delete" t-on-click.stop="() => this.pos.onDeleteOrder(order)">
                                         <i class="fa fa-trash" aria-hidden="true"/>
                                     </div>
                                     <div t-else="" class="col very-narrow p-2"></div>
@@ -93,7 +93,7 @@
                                         <div class="orderStatus"><t t-esc="getStatus(order)"></t></div>
                                     </div>
                                     <div class="col p-2">
-                                        <div t-if="!shouldHideDeleteButton(order)" class="col very-narrow delete-button p-2 rounded-2" name="delete" t-on-click.stop="() => this.onDeleteOrder(order)">
+                                        <div t-if="!shouldHideDeleteButton(order)" class="col very-narrow delete-button p-2 rounded-2" name="delete" t-on-click.stop="() => this.pos.onDeleteOrder(order)">
                                             <i class="fa fa-trash" aria-hidden="true"/> Delete
                                         </div>
                                     </div>

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -243,6 +243,30 @@ export class PosStore extends Reactive {
         }
     }
 
+    async onDeleteOrder(order) {
+        if (order.get_orderlines().length > 0) {
+            const confirmed = await ask(this.dialog, {
+                title: _t("Existing orderlines"),
+                body: _t(
+                    "%s has a total amount of %s, are you sure you want to delete this order?",
+                    order.name,
+                    this.env.utils.formatCurrency(order.get_total_with_tax())
+                ),
+            });
+            if (!confirmed) {
+                return false;
+            }
+        }
+        const orderIsDeleted = await this.deleteOrders([order]);
+        if (orderIsDeleted) {
+            order.uiState.displayed = false;
+            this.afterOrderDeletion();
+        }
+    }
+    afterOrderDeletion() {
+        this.set_order(this.get_open_orders().at(-1) || this.createNewOrder());
+    }
+
     async deleteOrders(orders, serverIds = []) {
         const ids = new Set();
         for (const order of orders) {

--- a/addons/pos_restaurant/static/src/overrides/components/ticket_screen/ticket_screen.js
+++ b/addons/pos_restaurant/static/src/overrides/components/ticket_screen/ticket_screen.js
@@ -48,19 +48,6 @@ patch(TicketScreen.prototype, {
         await this.pos.setTable(orderTable, order.uuid);
         this.closeTicketScreen();
     },
-    async onDeleteOrder(order) {
-        const confirmed = await super.onDeleteOrder(...arguments);
-        if (
-            confirmed &&
-            this.pos.config.module_pos_restaurant &&
-            this.pos.selectedTable &&
-            !this.pos.models["pos.order"].some(
-                (order) => order.table_id?.id === this.pos.selectedTable.id
-            )
-        ) {
-            return this.pos.showScreen("FloorScreen");
-        }
-    },
     get allowNewOrders() {
         return this.pos.config.module_pos_restaurant
             ? Boolean(this.pos.selectedTable)

--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -35,6 +35,15 @@ patch(PosStore.prototype, {
             this.getTableOrderCount();
         }
     },
+    afterOrderDeletion() {
+        if (
+            this.config.module_pos_restaurant &&
+            !this.mainScreen.component.name === "TicketScreen"
+        ) {
+            return this.showScreen("FloorScreen");
+        }
+        return super.afterOrderDeletion();
+    },
     async getTableOrderCount() {
         const result = await this.data.call(
             "pos.config",

--- a/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
@@ -17,32 +17,6 @@ registry.category("web_tour.tours").add("PosResTicketScreenTour", {
             TicketScreen.noNewTicketButton(),
             TicketScreen.clickDiscard(),
 
-            // Deleting the last order in the table brings back to floorscreen
-            FloorScreen.clickTable("4"),
-            ProductScreen.isShown(),
-            Chrome.clickMenuOption("Orders"),
-            TicketScreen.nthRowContains(2, "-0001"),
-            TicketScreen.deleteOrder("-0001"),
-
-            // Create 2 items in a table. From floorscreen, delete 1 item. Then select the other item.
-            // Correct order and screen should be displayed and the BackToFloorButton is shown.
-            FloorScreen.clickTable("2"),
-            ProductScreen.addOrderline("Minute Maid", "1", "2"),
-            ProductScreen.totalAmountIs("2.0"),
-            Chrome.clickMenuOption("Orders"),
-            TicketScreen.clickNewTicket(),
-            ProductScreen.addOrderline("Coca-Cola", "2", "2"),
-            ProductScreen.totalAmountIs("4.0"),
-            Chrome.clickPlanButton(),
-            FloorScreen.orderCountSyncedInTableIs("2", "3"),
-            Chrome.clickMenuOption("Orders"),
-            TicketScreen.deleteOrder("-0003"),
-            Dialog.confirm(),
-            TicketScreen.doubleClickOrder("-0002"),
-            ProductScreen.isShown(),
-            ProductScreen.totalAmountIs("2.0"),
-            Chrome.clickPlanButton(),
-
             // Make sure that order is deleted properly.
             FloorScreen.clickTable("5"),
             ProductScreen.addOrderline("Minute Maid", "1", "3"),
@@ -50,7 +24,7 @@ registry.category("web_tour.tours").add("PosResTicketScreenTour", {
             Chrome.clickPlanButton(),
             FloorScreen.orderCountSyncedInTableIs("5", "1"),
             Chrome.clickMenuOption("Orders"),
-            TicketScreen.deleteOrder("-0004"),
+            TicketScreen.deleteOrder("-0001"),
             Dialog.confirm(),
             TicketScreen.clickDiscard(),
             FloorScreen.isShown(),


### PR DESCRIPTION
In the point_of_sale a user can cancel an order from the ticket_screen. The plan is to to replace the ticket_screen with the standard list view. This means that orders that are not yet synced with the server will not appear there, so there will be no way for the user to cancel them.

In this commit we create a new action button, called "Cancel order".

Task: 4104387






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
