### PR TITLE
[FIX] calendar: pass context to form view

### DIFF
--- a/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_controller.js
+++ b/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_controller.js
@@ -33,7 +33,10 @@ export class AttendeeCalendarController extends CalendarController {
             views: [[false, 'form']],
             res_id: resId || false,
         }, {
-            additionalContext
+            additionalContext: {
+                ...this.props.context,
+                ...additionalContext
+            }
         });
     }
 


### PR DESCRIPTION
This commit restores the context passing that was lost in the rework of `calendar.event` quick create #114827.

Current behavior before PR: 
Action context is not passed to the `calendar.event` form view when accessed via the calendar popover `View` button. The `New` button above the calendar view passes the context as expected.
For example: this button opens the calendar view but the keys `example_context`, `active_id` and `active_model` are not available in the context when an existing calendar event is then viewed in a form. `<button name="calendar.action_calendar_event" type="action" context="{'example_context': True}"/>`

Desired behavior after PR is merged:
Action context is available in the `calendar.event` form view when the form is accessed via the calendar popover form.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
