### PR TITLE
[FIX] lunch: prevent error when deleting all Location records

### DIFF
--- a/addons/lunch/i18n/lunch.pot
+++ b/addons/lunch/i18n/lunch.pot
@@ -1366,6 +1366,13 @@ msgstr ""
 
 #. module: lunch
 #. odoo-javascript
+#: code:addons/lunch/static/src/views/no_content_helper.xml:0
+#, python-format
+msgid "No location found"
+msgstr ""
+
+#. module: lunch
+#. odoo-javascript
 #: code:addons/lunch/static/src/components/lunch_dashboard.xml:0
 #, python-format
 msgid "No lunch location available."
@@ -1575,6 +1582,13 @@ msgstr ""
 #. module: lunch
 #: model:lunch.product,name:lunch.product_vege
 msgid "Pizza Vegetarian"
+msgstr ""
+
+#. module: lunch
+#. odoo-javascript
+#: code:addons/lunch/static/src/views/no_content_helper.xml:0
+#, python-format
+msgid "Please create a location to start ordering."
 msgstr ""
 
 #. module: lunch

--- a/addons/lunch/i18n/lunch.pot
+++ b/addons/lunch/i18n/lunch.pot
@@ -1365,6 +1365,13 @@ msgid "No cash move yet"
 msgstr ""
 
 #. module: lunch
+#. odoo-javascript
+#: code:addons/lunch/static/src/components/lunch_dashboard.xml:0
+#, python-format
+msgid "No lunch location available."
+msgstr ""
+
+#. module: lunch
 #: model_terms:ir.actions.act_window,help:lunch.lunch_order_action_control_suppliers
 msgid "No lunch order yet"
 msgstr ""

--- a/addons/lunch/static/src/components/lunch_dashboard.xml
+++ b/addons/lunch/static/src/components/lunch_dashboard.xml
@@ -57,13 +57,18 @@
 
     <t t-name="lunch.LunchLocation" owl="1">
         <div class="lunch_location pb-1">
-            <Many2XAutocomplete
-                value="props.location"
-                resModel="'lunch.location'"
-                getDomain="getDomain"
-                activeActions="{}"
-                update.bind="props.onUpdateLunchLocation"
-            />
+            <t t-if="props.location">
+                <Many2XAutocomplete
+                    value="props.location"
+                    resModel="'lunch.location'"
+                    getDomain="getDomain"
+                    activeActions="{}"
+                    update.bind="props.onUpdateLunchLocation"
+                />
+            </t>
+            <t t-else="">
+                <p>No lunch location available.</p>
+            </t>
         </div>
     </t>
 

--- a/addons/lunch/static/src/views/kanban.js
+++ b/addons/lunch/static/src/views/kanban.js
@@ -19,7 +19,17 @@ export class LunchKanbanRecord extends KanbanRecord {
     }
 }
 
-export class LunchKanbanRenderer extends KanbanRenderer {}
+export class LunchKanbanRenderer extends KanbanRenderer {
+    getGroupsOrRecords() {
+        const {locationId} = this.env.searchModel.lunchState;
+        if (!locationId) {
+            return [];
+        } else {
+            return super.getGroupsOrRecords(...arguments);
+        }
+    }
+}
+
 patch(LunchKanbanRenderer.prototype, 'lunch_kanban_renderer_mixin', LunchRendererMixin);
 
 LunchKanbanRenderer.template = 'lunch.KanbanRenderer';

--- a/addons/lunch/static/src/views/kanban.xml
+++ b/addons/lunch/static/src/views/kanban.xml
@@ -4,7 +4,7 @@
         <div class="o_lunch_content d-flex flex-column h-100">
             <LunchDashboard openOrderLine.bind="openOrderLine"/>
 
-            <div class="overflow-auto">
+            <div class="overflow-auto flex-grow-1">
                 <t t-call="web.KanbanRenderer"/>
             </div>
         </div>

--- a/addons/lunch/static/src/views/kanban.xml
+++ b/addons/lunch/static/src/views/kanban.xml
@@ -5,8 +5,14 @@
             <LunchDashboard openOrderLine.bind="openOrderLine"/>
 
             <div class="overflow-auto flex-grow-1">
-                <t t-call="web.KanbanRenderer"/>
+                <t t-call="lunch.WebKanbanRenderer"/>
             </div>
         </div>
+    </t>
+
+    <t t-name="lunch.WebKanbanRenderer" t-inherit="web.KanbanRenderer" t-inherit-mode="primary" owl="1">
+        <t t-if="showNoContentHelper" position="after">
+            <t t-call="lunch.NoContentHelper"/>
+        </t>
     </t>
 </templates>

--- a/addons/lunch/static/src/views/list.js
+++ b/addons/lunch/static/src/views/list.js
@@ -13,6 +13,14 @@ import { LunchSearchModel } from './search_model';
 
 
 export class LunchListRenderer extends ListRenderer {
+    setup() {
+        super.setup();
+        const {locationId} = this.env.searchModel.lunchState;
+        if (!locationId) {
+            this.props.list.records = [];
+        }
+    }
+
     onCellClicked(record, column) {
         this.openOrderLine(record.resId);
     }

--- a/addons/lunch/static/src/views/list.xml
+++ b/addons/lunch/static/src/views/list.xml
@@ -5,8 +5,14 @@
             <LunchDashboard openOrderLine.bind="openOrderLine"/>
 
             <div class="overflow-auto flex-grow-1">
-                <t t-call="web.ListRenderer"/>
+                <t t-call="lunch.WebListRenderer"/>
             </div>
         </div>
+    </t>
+
+    <t t-name="lunch.WebListRenderer" t-inherit="web.ListRenderer" t-inherit-mode="primary" owl="1">
+        <t t-call="web.ActionHelper" position="after">
+            <t t-call="lunch.NoContentHelper"/>
+        </t>
     </t>
 </templates>

--- a/addons/lunch/static/src/views/list.xml
+++ b/addons/lunch/static/src/views/list.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="lunch.ListRenderer" owl="1">
-        <div class="o_lunch_content">
+        <div class="o_lunch_content d-flex flex-column h-100">
             <LunchDashboard openOrderLine.bind="openOrderLine"/>
 
-            <div class="overflow-auto">
+            <div class="overflow-auto flex-grow-1">
                 <t t-call="web.ListRenderer"/>
             </div>
         </div>

--- a/addons/lunch/static/src/views/no_content_helper.xml
+++ b/addons/lunch/static/src/views/no_content_helper.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+
+    <t t-name="lunch.NoContentHelper" owl="1">
+        <t t-set="showNoLocationHelper" t-value="!this.env.searchModel.lunchState.locationId"/>
+
+        <div t-if="showNoLocationHelper and !showNoContentHelper" class="o_view_nocontent" style="pointer-events: all">
+            <div class="o_nocontent_help">
+                <p class="o_view_nocontent_smiling_face">
+                    No location found
+                </p>
+                <p>
+                    Please create a location to start ordering.
+                </p>
+            </div>
+        </div>
+    </t>
+</templates>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

When all Lunch location records are deleted, the LunchLocation JS component fails to build, raising an error when accessing the Lunch App.

**Steps to Reproduce:**
- Install the `lunch` module
- Go to Lunch > Configuration > Locations
- Delete all records
- Access the Lunch App again

**Traceback:** OwlError
```
Invalid props for component 'AutoComplete': 'value' is not a string
```
This error occurs at [1], where the given props are empty.

This commit will resolve the above error by displaying a text message instead of trying to build a `Many2XAutocomplete` with empty values.

opw-4104561

[1]- https://github.com/odoo/odoo/blob/503c0d6f8fad09f5de678d8692fc283feac1b061/addons/lunch/static/src/components/lunch_dashboard.xml#L61

**Current behavior before PR:**
Without any record in the `lunch.location` model, the Lunch App cannot be accessed

**Desired behavior after PR is merged:**
Without any record in the `lunch.location` model, the Lunch App can be accessed, but a message "_No lunch locations available._" will be displayed in spite of the location.

**Screenshots**
Behavior without fix, with locations not yet deleted:
![lunch locations](https://github.com/user-attachments/assets/637eb09e-0bad-4034-acb9-21bcb337ad32)
Behavior with fix, with all locations deleted:
![No locations](https://github.com/user-attachments/assets/920f1c3e-2600-4e60-9968-1f5045517502)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
