### PR TITLE
[IMP] purchase: Bill/PO matching & Down Payments

### DIFF
--- a/addons/purchase/__init__.py
+++ b/addons/purchase/__init__.py
@@ -5,3 +5,4 @@ from . import controllers
 from . import models
 from . import report
 from . import populate
+from . import wizard

--- a/addons/purchase/__manifest__.py
+++ b/addons/purchase/__manifest__.py
@@ -18,6 +18,7 @@
         'data/ir_cron_data.xml',
         'report/purchase_reports.xml',
         'views/purchase_views.xml',
+        'views/purchase_bill_line_match_views.xml',
         'views/res_config_settings_views.xml',
         'views/product_views.xml',
         'views/res_partner_views.xml',
@@ -30,6 +31,7 @@
         'report/purchase_quotation_templates.xml',
         'views/product_packaging_views.xml',
         'views/analytic_account_views.xml',
+        'wizard/bill_to_po_wizard_views.xml',
     ],
     'demo': [
         'data/purchase_demo.xml',

--- a/addons/purchase/models/__init__.py
+++ b/addons/purchase/models/__init__.py
@@ -6,6 +6,7 @@ from . import account_tax
 from . import analytic_account
 from . import analytic_applicability
 from . import ir_actions_report
+from . import purchase_bill_line_match
 from . import purchase_order
 from . import purchase_order_line
 from . import product

--- a/addons/purchase/models/purchase_bill_line_match.py
+++ b/addons/purchase/models/purchase_bill_line_match.py
@@ -1,0 +1,166 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, _
+
+from odoo.tools import format_list, SQL
+from odoo.exceptions import UserError
+
+
+class PurchaseBillMatch(models.Model):
+    _name = "purchase.bill.line.match"
+    _description = "Purchase Line and Vendor Bill line matching view"
+    _auto = False
+    _order = 'product_id, aml_id, pol_id'
+
+    pol_id = fields.Many2one(comodel_name='purchase.order.line')
+    aml_id = fields.Many2one(comodel_name='account.move.line')
+    company_id = fields.Many2one(comodel_name='res.company')
+    partner_id = fields.Many2one(comodel_name='res.partner')
+    product_id = fields.Many2one(comodel_name='product.product')
+    line_qty = fields.Float()
+    line_uom_id = fields.Many2one(comodel_name='uom.uom')
+    qty_invoiced = fields.Float()
+    purchase_order_id = fields.Many2one(comodel_name='purchase.order')
+    account_move_id = fields.Many2one(comodel_name='account.move')
+    line_amount_untaxed = fields.Monetary()
+    currency_id = fields.Many2one(comodel_name='res.currency')
+    state = fields.Char()
+
+    product_uom_id = fields.Many2one(comodel_name='uom.uom', related='product_id.uom_id')
+    product_uom_qty = fields.Float(compute='_compute_product_uom_qty')
+    billed_amount_untaxed = fields.Monetary(compute='_compute_amount_untaxed_fields', currency_field='currency_id')
+    purchase_amount_untaxed = fields.Monetary(compute='_compute_amount_untaxed_fields', currency_field='currency_id')
+    reference = fields.Char(compute='_compute_reference')
+
+    def _compute_amount_untaxed_fields(self):
+        for line in self:
+            line.billed_amount_untaxed = line.line_amount_untaxed if line.account_move_id else False
+            line.purchase_amount_untaxed = line.line_amount_untaxed if line.purchase_order_id else False
+
+    def _compute_reference(self):
+        for line in self:
+            line.reference = line.purchase_order_id.display_name or line.account_move_id.display_name
+
+    def _compute_display_name(self):
+        for line in self:
+            line.display_name = line.product_id.display_name or line.aml_id.name or line.pol_id.name
+
+    def _compute_product_uom_qty(self):
+        for line in self:
+            line.product_uom_qty = line.line_uom_id._compute_quantity(line.line_qty, line.product_uom_id)
+
+    def _select_po_line(self):
+        return SQL("""
+            SELECT pol.id,
+                   pol.id as pol_id,
+                   NULL as aml_id,
+                   pol.company_id as company_id,
+                   pol.partner_id as partner_id,
+                   pol.product_id as product_id,
+                   pol.product_qty as line_qty,
+                   pol.product_uom as line_uom_id,
+                   pol.qty_invoiced as qty_invoiced,
+                   po.id as purchase_order_id,
+                   NULL as account_move_id,
+                   pol.price_subtotal as line_amount_untaxed,
+                   pol.currency_id as currency_id,
+                   po.state as state
+              FROM purchase_order_line pol
+         LEFT JOIN purchase_order po ON pol.order_id = po.id
+             WHERE pol.state in ('purchase', 'done')
+               AND pol.product_qty > pol.qty_invoiced
+                OR ((pol.display_type = '' OR pol.display_type IS NULL) AND pol.is_downpayment AND pol.qty_invoiced > 0)
+        """)
+
+    def _select_am_line(self):
+        return SQL("""
+            SELECT -aml.id,
+                   NULL as pol_id,
+                   aml.id as aml_id,
+                   aml.company_id as company_id,
+                   aml.partner_id as partner_id,
+                   aml.product_id as product_id,
+                   aml.quantity as line_qty,
+                   aml.product_uom_id as line_uom_id,
+                   NULL as qty_invoiced,
+                   NULL as purchase_order_id,
+                   am.id as account_move_id,
+                   aml.amount_currency as line_amount_untaxed,
+                   aml.currency_id as currency_id,
+                   aml.parent_state as state
+              FROM account_move_line aml
+         LEFT JOIN account_move am on aml.move_id = am.id
+             WHERE aml.display_type = 'product'
+               AND am.move_type in ('in_invoice', 'in_refund')
+               AND aml.parent_state in ('draft', 'posted')
+               AND aml.purchase_line_id IS NULL
+        """)
+
+    @property
+    def _table_query(self):
+        return SQL("%s UNION ALL %s", self._select_po_line(), self._select_am_line())
+
+    def action_open_line(self):
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'account.move' if self.account_move_id else 'purchase.order',
+            'view_mode': 'form',
+            'res_id': self.account_move_id.id if self.account_move_id else self.purchase_order_id.id,
+        }
+
+    def action_match_lines(self):
+        if not self.pol_id or not self.aml_id:
+            raise UserError(_("You must select at least one Purchase Order line and one Vendor Bill line to match them."))
+
+        matches_found = 0
+        problem_products = self.env['product.product']
+        pol_by_product = self.pol_id.grouped('product_id')
+        aml_by_product = self.aml_id.grouped('product_id')
+
+        for product, po_lines in pol_by_product.items():
+            if len(po_lines) > 1:
+                problem_products += product
+                continue
+            matching_bill_lines = aml_by_product.get(product)
+            if matching_bill_lines:
+                matching_bill_lines.purchase_line_id = po_lines.id
+                matches_found += 1
+        if problem_products:
+            message = _("More than 1 Purchase Order line has the same product: %(products)s",
+                        products=format_list(self.env, problem_products.mapped('display_name')))
+            return {
+                'type': 'ir.actions.client',
+                'tag': 'display_notification',
+                'params': {
+                    'title': _("Unable to match"),
+                    'type': "warning",
+                    'message': message,
+                    'next': {
+                        'type': 'ir.actions.act_window_close',
+                    },
+                }
+            }
+        if not matches_found:
+            raise UserError(_("No matching products found."))
+
+    def action_add_to_po(self):
+        if not self or not self.aml_id:
+            raise UserError(_("Select Vendor Bill lines to add to a Purchase Order"))
+        context = {
+            'default_partner_id': self.partner_id.id,
+            'dialog_size': 'medium',
+            'has_products': bool(self.aml_id.product_id),
+        }
+        if len(self.purchase_order_id) > 1:
+            raise UserError(_("Vendor Bill lines can only be added to one Purchase Order."))
+        elif self.purchase_order_id:
+            context['default_purchase_order_id'] = self.purchase_order_id.id
+        return {
+            'type': 'ir.actions.act_window',
+            'name': _("Add to Purchase Order"),
+            'res_model': 'bill.to.po.wizard',
+            'target': 'new',
+            'views': [(self.env.ref('purchase.bill_to_po_wizard_form').id, 'form')],
+            'context': context,
+        }

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -77,10 +77,11 @@ class PurchaseOrderLine(models.Model):
     display_type = fields.Selection([
         ('line_section', "Section"),
         ('line_note', "Note")], default=False, help="Technical field for UX purpose.")
+    is_downpayment = fields.Boolean()
 
     _sql_constraints = [
         ('accountable_required_fields',
-            "CHECK(display_type IS NOT NULL OR (product_id IS NOT NULL AND product_uom IS NOT NULL AND date_planned IS NOT NULL))",
+            "CHECK(display_type IS NOT NULL OR is_downpayment OR (product_id IS NOT NULL AND product_uom IS NOT NULL AND date_planned IS NOT NULL))",
             "Missing required fields on accountable purchase order line."),
         ('non_accountable_null_fields',
             "CHECK(display_type IS NULL OR (product_id IS NULL AND price_unit = 0 AND product_uom_qty = 0 AND product_uom IS NULL AND date_planned is NULL))",
@@ -581,6 +582,7 @@ class PurchaseOrderLine(models.Model):
             'price_unit': self.currency_id._convert(self.price_unit, aml_currency, self.company_id, date, round=False),
             'tax_ids': [(6, 0, self.taxes_id.ids)],
             'purchase_line_id': self.id,
+            'is_downpayment': self.is_downpayment,
         }
         if self.analytic_distribution and not self.display_type:
             res['analytic_distribution'] = self.analytic_distribution

--- a/addons/purchase/security/ir.model.access.csv
+++ b/addons/purchase/security/ir.model.access.csv
@@ -8,6 +8,10 @@ access_purchase_order_line,purchase.order.line user,model_purchase_order_line,gr
 access_purchase_order_line_manager,purchase.order.line,model_purchase_order_line,group_purchase_manager,1,1,1,1
 access_purchase_order_line_invoicing_payments_readonly,purchase.order.line,model_purchase_order_line,account.group_account_readonly,1,0,0,0
 access_purchase_order_line_invoicing_payments,purchase.order.line,model_purchase_order_line,account.group_account_invoice,1,1,0,0
+access_purchase_bill_line_match,purchase.bill.line.match user,model_purchase_bill_line_match,group_purchase_user,1,0,0,0
+access_purchase_bill_line_match_readonly,purchase.bill.line.match readonly,model_purchase_bill_line_match,account.group_account_readonly,1,0,0,0
+access_purchase_bill_line_match_invoicing_payments,purchase.bill.line.match invoice,model_purchase_bill_line_match,account.group_account_invoice,1,0,0,0
+access_bill_to_po_wizard,bill.to.po.wizard user,model_bill_to_po_wizard,group_purchase_user,1,1,1,0
 access_purchase_order_line_portal,purchase.order.line.portal,purchase.model_purchase_order_line,base.group_portal,1,0,0,0
 access_account_tax_purchase_user,account.tax,account.model_account_tax,group_purchase_user,1,0,0,0
 access_account_tag_purchase_user,account.account.tag,account.model_account_account_tag,group_purchase_user,1,0,0,0

--- a/addons/purchase/tests/__init__.py
+++ b/addons/purchase/tests/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_purchase
+from . import test_purchase_downpayment
 from . import test_purchase_order_report
 from . import test_purchase_invoice
 from . import test_access_rights

--- a/addons/purchase/tests/test_purchase_downpayment.py
+++ b/addons/purchase/tests/test_purchase_downpayment.py
@@ -1,0 +1,58 @@
+from odoo import fields
+
+from odoo.addons.purchase.tests.test_purchase_invoice import TestPurchaseToInvoiceCommon
+from odoo.tests import tagged
+
+
+@tagged('-at_install', 'post_install')
+class TestPurchaseDownpayment(TestPurchaseToInvoiceCommon):
+
+    def test_downpayment_basic(self):
+        po = self.init_purchase(confirm=False, products=[self.product_order])
+        po.order_line.product_qty = 10.0
+        po.button_confirm()
+
+        dp_bill = self.init_invoice('in_invoice', amounts=[69.00], post=True)
+
+        match_lines = self.env['purchase.bill.line.match'].search([('partner_id', '=', self.partner_a.id)])
+        action = match_lines.action_add_to_po()
+
+        wizard = self.env['bill.to.po.wizard'].with_context({**action['context'], 'active_ids': match_lines.ids}).create({})
+        wizard.action_add_downpayment()
+
+        po_dp_section_line = po.order_line.filtered(lambda l: l.display_type == 'line_section' and l.is_downpayment)
+        self.assertEqual(len(po_dp_section_line), 1)
+        po_dp_line = po.order_line.filtered(lambda l: l.display_type != 'line_section' and l.is_downpayment)
+        self.assertEqual(po_dp_line.name, 'Down Payment (ref: %s)' % dp_bill.invoice_line_ids.display_name)
+        self.assertEqual(po_dp_line.sequence, po_dp_section_line.sequence + 1)
+
+        # This is not the normal flow, but we test the deduction of the downpayment
+        action_view_bill = po.action_create_invoice()
+        generated_bill = self.env['account.move'].browse(action_view_bill['res_id'])
+
+        self.assertRecordValues(generated_bill.invoice_line_ids, [
+            # pylint: disable=C0326
+            {'product_id': self.product_order.id, 'display_type': 'product',      'quantity': 10, 'is_downpayment': False, 'balance': 10.0 * self.product_order.standard_price},
+            {'product_id': False,                 'display_type': 'line_section', 'quantity': 0,  'is_downpayment': True,  'balance': 0.0},
+            {'product_id': False,                 'display_type': 'product',      'quantity': -1, 'is_downpayment': True,  'balance': -69.0},
+        ])
+
+        # Normal flow: New bill with negative down payment line
+        final_bill = generated_bill.copy()
+        generated_bill.button_cancel()
+        generated_bill.unlink()
+        final_bill.invoice_date = fields.Date.from_string('2019-01-02')
+        final_bill.action_post()
+        self.assertFalse(final_bill.line_ids.purchase_line_id)
+
+        self.env['account.move'].flush_model()
+        match_lines = self.env['purchase.bill.line.match'].search([('partner_id', '=', self.partner_a.id)])
+        match_lines.action_match_lines()
+
+        self.assertEqual(final_bill.invoice_line_ids.purchase_order_id.invoice_status, 'invoiced')
+        self.assertRecordValues(po_dp_line, [{
+            'qty_invoiced': 0,
+            'invoice_lines': dp_bill.invoice_line_ids.ids + final_bill.invoice_line_ids[-1:].ids,
+        }])
+        self.env.flush_all()
+        self.assertFalse(self.env['purchase.bill.line.match'].search([('partner_id', '=', self.partner_a.id)]))

--- a/addons/purchase/tests/test_purchase_invoice.py
+++ b/addons/purchase/tests/test_purchase_invoice.py
@@ -847,6 +847,90 @@ class TestInvoicePurchaseMatch(TestPurchaseToInvoiceCommon):
 
         self.assertTrue(invoice.id not in po.invoice_ids.ids)
 
+    def test_manual_matching(self):
+        po = self.init_purchase(confirm=True, products=[self.product_order])
+        bill = self.init_invoice('in_invoice', partner=self.partner_a, products=[self.product_order], post=True)
+
+        self.env['account.move.line'].flush_model()  # necessary to get the bill lines
+        match_lines = self.env['purchase.bill.line.match'].search([('partner_id', '=', self.partner_a.id)])
+
+        expected_ids = po.order_line.ids + [-lid for lid in bill.invoice_line_ids.ids]
+        self.assertListEqual(match_lines.ids, expected_ids)
+
+        match_lines.action_match_lines()
+        self.assertEqual(bill.invoice_line_ids.purchase_line_id, po.order_line)
+        self.assertEqual(po.order_line.qty_invoiced, bill.invoice_line_ids.quantity)
+
+    def test_manual_matching_multi(self):
+        po_1 = self.init_purchase(confirm=True, products=[self.product_order, self.product_order_var_name])
+        po_2 = self.init_purchase(confirm=True, products=[self.service_deliver])
+        po_3 = self.init_purchase(confirm=True, products=[self.service_order])
+        bill_1 = self.init_invoice('in_invoice', partner=self.partner_a, products=[self.product_order], post=True)
+        bill_2 = self.init_invoice('in_invoice', partner=self.partner_a, products=[self.product_order_var_name, self.service_deliver], post=True)
+        bill_3 = self.init_invoice('in_invoice', partner=self.partner_a, products=[self.product_deliver])
+
+        self.env['account.move.line'].flush_model()
+        match_lines = self.env['purchase.bill.line.match'].search([('partner_id', '=', self.partner_a.id)])
+        match_lines.action_match_lines()
+
+        self.env.flush_all()
+        self.assertEqual((bill_1 + bill_2).invoice_line_ids.purchase_line_id, (po_1 + po_2).order_line)
+
+        remaining_match_lines = self.env['purchase.bill.line.match'].search([('partner_id', '=', self.partner_a.id)])
+        expected_ids = po_3.order_line.ids + [-bill_3.invoice_line_ids.id]
+        self.assertListEqual(remaining_match_lines.ids, expected_ids)
+
+        po_4 = po_3.copy()
+        po_4.button_confirm()
+
+        self.env.flush_all()
+        match_lines = self.env['purchase.bill.line.match'].search([('partner_id', '=', self.partner_a.id)])
+        action = match_lines.action_match_lines()
+        self.assertTrue(action.get('type') == 'ir.actions.client' and action.get('tag') == 'display_notification')
+
+    def test_add_bill_to_po(self):
+        bill = self.init_invoice('in_invoice', partner=self.partner_a, products=[self.product_order_var_name, self.service_deliver], post=True)
+        self.env['account.move.line'].flush_model()
+
+        match_lines = self.env['purchase.bill.line.match'].search([('partner_id', '=', self.partner_a.id)])
+
+        # Use wizard to create a new PO
+        action = match_lines.action_add_to_po()
+        wizard = self.env['bill.to.po.wizard'].with_context({**action['context'], 'active_ids': match_lines.ids}).create({})
+        self.assertEqual(wizard.partner_id, self.partner_a)
+        self.assertFalse(wizard.purchase_order_id)
+
+        action = wizard.action_add_to_po()
+        po = self.env['purchase.order'].browse(action['res_id'])
+        self.assertEqual(po.partner_id, self.partner_a)
+        self.assertTrue(po.order_line.taxes_id)
+        self.assertEqual(po.order_line.taxes_id, bill.invoice_line_ids.tax_ids)
+        self.assertEqual(po.order_line.product_id, bill.invoice_line_ids.product_id)
+        self.assertEqual(po.order_line.product_id, self.product_order_var_name + self.service_deliver)
+
+        bill_2 = self.init_invoice('in_invoice', partner=self.partner_a, products=[self.product_order_other_price], post=False)
+        bill_2.invoice_line_ids.write({
+            'discount': 2.0,
+            'product_uom_id': self.env.ref('uom.product_uom_dozen').id,
+        })
+        bill_2.action_post()
+        self.env['account.move.line'].flush_model()
+
+        match_lines = self.env['purchase.bill.line.match'].search([('partner_id', '=', self.partner_a.id)])
+
+        # Use wizard to add lines to existing PO
+        match_lines.action_add_to_po()
+        wizard = self.env['bill.to.po.wizard'].with_context({
+            'default_purchase_order_id': po.id,
+            'active_ids': match_lines.ids
+        }).create({})
+
+        action = wizard.action_add_to_po()
+        self.assertEqual(action['res_id'], po.id)
+        self.assertEqual(len(po.order_line), 3)
+        self.assertEqual(po.order_line[-1:].product_id, self.product_order_other_price)
+        self.assertListEqual(po.order_line.mapped('price_total'), (bill + bill_2).invoice_line_ids.mapped('price_total'))
+
     def test_onchange_partner_currency(self):
         """
         Test that the currency of the Bill is correctly set when the partner is changed

--- a/addons/purchase/views/account_move_views.xml
+++ b/addons/purchase/views/account_move_views.xml
@@ -37,12 +37,23 @@
             </xpath>
             <xpath expr="//div[@name='button_box']" position="inside">
                 <button class="oe_stat_button"
+                        name="action_purchase_matching"
+                        type="object"
+                        groups="purchase.group_purchase_user"
+                        icon="fa-bullseye"
+                        invisible="not partner_id or move_type not in ('in_invoice', 'in_refund') or is_purchase_matched">
+                    <div class="o_field_statinfo">
+                        <span class="o_stat_text">Purchase Matching</span>
+                    </div>
+                </button>
+                <button class="oe_stat_button"
                         name="action_view_source_purchase_orders"
                         type="object"
                         groups="purchase.group_purchase_user"
                         icon="fa-pencil-square-o"
                         invisible="purchase_order_count == 0 or move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')">
-                    <field string="Purchases" name="purchase_order_count" widget="statinfo"/>
+                    <field string="Purchases" name="purchase_order_name" widget="statinfo" invisible="purchase_order_count != 1"/>
+                    <field string="Purchases" name="purchase_order_count" widget="statinfo" invisible="purchase_order_count == 1"/>
                 </button>
             </xpath>
         </field>

--- a/addons/purchase/views/purchase_bill_line_match_views.xml
+++ b/addons/purchase/views/purchase_bill_line_match_views.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="purchase_bill_line_match_tree" model="ir.ui.view">
+        <field name="name">purchase.bill.line.match.tree</field>
+        <field name="model">purchase.bill.line.match</field>
+        <field name="arch" type="xml">
+            <tree string="Purchase Bill Lines"
+                  decoration-info="pol_id != False"
+                  decoration-muted="state == 'draft'"
+                  action="action_open_line" type="object">
+                <header>
+                    <button name="action_match_lines" type="object" string="Match" groups="account.group_account_invoice" class="btn btn-primary"/>
+                    <button name="action_add_to_po" type="object" string="Add to PO" groups="purchase.group_purchase_user"/>
+                </header>
+                <field name="partner_id" string="Vendor" optional="hidden"/>
+                <field name="reference"/>
+                <field name="display_name" string="Product Description" decoration-it="not product_id"/>
+                <field name="product_uom_qty" string="Qty"/>
+                <field name="product_uom_id" groups="uom.group_uom" string="Unit"/>
+                <field name="qty_invoiced" optional="hidden"/>
+                <field name="billed_amount_untaxed" widget="monetary" string="Billed"/>
+                <field name="purchase_amount_untaxed" widget="monetary" string="Purchased"/>
+                <field name="currency_id" column_invisible="1"/>
+            </tree>
+        </field>
+    </record>
+</odoo>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -152,6 +152,16 @@
                 </header>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
+                        <button class="oe_stat_button"
+                                name="action_bill_matching"
+                                type="object"
+                                groups="account.group_account_invoice"
+                                icon="fa-bullseye"
+                                invisible="not partner_id or state not in ('purchase', 'done') or not partner_bill_count or invoice_status == 'invoiced'">
+                            <div class="o_field_statinfo">
+                                <span class="o_stat_text">Bill Matching</span>
+                            </div>
+                        </button>
                         <button type="object"  name="action_view_invoice"
                             class="oe_stat_button"
                             icon="fa-pencil-square-o" invisible="invoice_count == 0 or state in ('draft', 'sent', 'to approve')">
@@ -231,31 +241,31 @@
                                     <field
                                         name="product_id"
                                         widget="product_label_section_and_note_field"
-                                        readonly="state in ('purchase', 'to approve', 'done', 'cancel')"
-                                        required="not display_type"
+                                        readonly="state in ('purchase', 'to approve', 'done', 'cancel') or is_downpayment"
+                                        required="not display_type and not is_downpayment"
                                         context="{'partner_id':parent.partner_id, 'quantity':product_qty, 'company_id': parent.company_id}"
                                         force_save="1" domain="[('purchase_ok', '=', True)]"/>
                                     <field name="name" widget="section_and_note_text" optional="show"/>
-                                    <field name="date_planned" optional="hide" required="not display_type" force_save="1"/>
+                                    <field name="date_planned" optional="hide" required="not display_type and not is_downpayment" force_save="1" readonly="is_downpayment"/>
                                     <field name="analytic_distribution" widget="analytic_distribution"
                                            optional="hide"
                                            groups="analytic.group_analytic_accounting"
                                            options="{'product_field': 'product_id', 'business_domain': 'purchase_order', 'amount_field': 'price_subtotal'}"/>
-                                    <field name="product_qty"/>
+                                    <field name="product_qty" readonly="is_downpayment"/>
                                     <field name="qty_received_manual" column_invisible="True"/>
                                     <field name="qty_received_method" column_invisible="True"/>
-                                    <field name="qty_received" string="Received" column_invisible="parent.state not in ('purchase', 'done')" readonly="qty_received_method != 'manual'" optional="show"/>
+                                    <field name="qty_received" string="Received" column_invisible="parent.state not in ('purchase', 'done')" readonly="qty_received_method != 'manual' or is_downpayment" optional="show"/>
                                     <field name="qty_invoiced" string="Billed" column_invisible="parent.state not in ('purchase', 'done')" optional="show"/>
                                     <field name="product_uom" string="UoM" groups="uom.group_uom"
-                                        readonly="state in ('purchase', 'done', 'cancel')"
-                                        required="not display_type"
+                                        readonly="state in ('purchase', 'done', 'cancel') or is_downpayment"
+                                        required="not display_type and not is_downpayment"
                                         options="{'no_open': True}"
                                         force_save="1" optional="show"/>
                                     <field name="product_packaging_qty" invisible="not product_id or not product_packaging_id" groups="product.group_stock_packaging" optional="show"/>
                                     <field name="product_packaging_id" invisible="not product_id" context="{'default_product_id': product_id, 'tree_view_ref':'product.product_packaging_tree_view', 'form_view_ref':'product.product_packaging_form_view'}" groups="product.group_stock_packaging" optional="show"/>
                                     <field name="price_unit" readonly="qty_invoiced != 0"/>
                                     <button name="action_purchase_history" type="object" icon="fa-history" title="Purchase History" invisible="not id"/>
-                                    <field name="taxes_id" widget="many2many_tags" domain="[('type_tax_use', '=', 'purchase'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id), ('active', '=', True)]" context="{'default_type_tax_use': 'purchase', 'search_view_ref': 'account.account_tax_view_search'}" options="{'no_create': True}" optional="show"/>
+                                    <field name="taxes_id" widget="many2many_tags" domain="[('type_tax_use', '=', 'purchase'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id), ('active', '=', True)]" context="{'default_type_tax_use': 'purchase', 'search_view_ref': 'account.account_tax_view_search'}" options="{'no_create': True}" optional="show" readonly="is_downpayment"/>
                                     <field name="discount" string="Disc.%" readonly="qty_invoiced != 0" optional="hide"/>
                                     <field name="price_subtotal" string="Amount"/>
                                 </tree>
@@ -276,7 +286,7 @@
                                                 <label for="product_qty"/>
                                                 <div class="o_row">
                                                     <field name="product_qty"/>
-                                                    <field name="product_uom" groups="uom.group_uom" required="not display_type"/>
+                                                    <field name="product_uom" groups="uom.group_uom" required="not display_type and not is_downpayment"/>
                                                 </div>
                                                 <field name="qty_received_method" invisible="1"/>
                                                 <field name="qty_received" string="Received Quantity" invisible="parent.state not in ('purchase', 'done')" readonly="qty_received_method != 'manual'"/>
@@ -288,7 +298,7 @@
                                                 <field name="taxes_id" widget="many2many_tags" domain="[('type_tax_use', '=', 'purchase'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id)]" options="{'no_create': True}"/>
                                             </group>
                                             <group>
-                                                <field name="date_planned" required="not display_type"/>
+                                                <field name="date_planned" required="not display_type and not is_downpayment"/>
                                                 <field name="analytic_distribution" widget="analytic_distribution"
                                                        groups="analytic.group_analytic_accounting"
                                                        options="{'product_field': 'product_id', 'business_domain': 'purchase_order'}"/>

--- a/addons/purchase/wizard/__init__.py
+++ b/addons/purchase/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import bill_to_po_wizard

--- a/addons/purchase/wizard/bill_to_po_wizard.py
+++ b/addons/purchase/wizard/bill_to_po_wizard.py
@@ -1,0 +1,74 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import fields, models, Command, _
+from odoo.exceptions import UserError
+
+
+class BillToPO(models.TransientModel):
+    _name = 'bill.to.po.wizard'
+    _description = 'Bill to Purchase Order'
+
+    purchase_order_id = fields.Many2one(comodel_name='purchase.order')
+    partner_id = fields.Many2one(comodel_name='res.partner')
+
+    def action_add_to_po(self):
+        aml_ids = [abs(record_id) for record_id in self.env.context.get('active_ids') if record_id < 0]
+        lines_to_add = self.env['account.move.line'].browse(aml_ids).filtered(lambda l: l.product_id)
+        if not lines_to_add:
+            raise UserError(_("There are no products to add to the Purchase Order. Are these Down Payments?"))
+        line_vals = lines_to_add._prepare_line_values_for_purchase()
+        if self.purchase_order_id:
+            new_po_lines = self.env['purchase.order.line'].create([{
+                **val,
+                'order_id': self.purchase_order_id.id,
+            } for val in line_vals])
+            self.purchase_order_id.order_line += new_po_lines
+        else:
+            self.purchase_order_id = self.env['purchase.order'].create({
+                'partner_id': lines_to_add.partner_id.id,
+                'order_line': [Command.create(val) for val in line_vals],
+            })
+            new_po_lines = self.purchase_order_id.order_line
+
+        self.purchase_order_id.button_confirm()
+        for aml, pol in zip(lines_to_add, new_po_lines):
+            if aml.product_id == pol.product_id:
+                aml.purchase_line_id = pol.id
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'purchase.order',
+            'view_mode': 'form',
+            'res_id': self.purchase_order_id.id,
+        }
+
+    def action_add_downpayment(self):
+        aml_ids = [abs(record_id) for record_id in self.env.context.get('active_ids') if record_id < 0]
+        lines_to_convert = self.env['account.move.line'].browse(aml_ids)
+        context = {'lang': lines_to_convert.partner_id.lang}
+        if not self.purchase_order_id:
+            self.purchase_order_id = self.env['purchase.order'].create({
+                'partner_id': lines_to_convert.partner_id.id,
+            })
+        line_vals = [
+            {
+                'name': _("Down Payment (ref: %(ref)s)", ref=aml.display_name),
+                'product_qty': 0.0,
+                'product_uom': aml.product_uom_id.id,
+                'is_downpayment': True,
+                'price_unit': aml.price_unit,
+                'taxes_id': aml.tax_ids,
+                'order_id': self.purchase_order_id.id,
+            }
+            for aml in lines_to_convert
+        ]
+        del context
+
+        downpayment_lines = self.purchase_order_id._create_downpayments(line_vals)
+        for aml, dpl in zip(lines_to_convert, downpayment_lines):
+            aml.purchase_line_id = dpl.id
+
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'purchase.order',
+            'view_mode': 'form',
+            'res_id': self.purchase_order_id.id,
+        }

--- a/addons/purchase/wizard/bill_to_po_wizard_views.xml
+++ b/addons/purchase/wizard/bill_to_po_wizard_views.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="bill_to_po_wizard_form" model="ir.ui.view">
+        <field name="name">bill.to.po.wizard.form</field>
+        <field name="model">bill.to.po.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Add to PO">
+                <sheet>
+                    <group>
+                        <field name="purchase_order_id"
+                               domain="[('partner_id', '=', partner_id), ('state', 'in', ['purchase'])]"
+                               placeholder="or create new"
+                               context="{'show_total_amount': True}"/>
+                    </group>
+                    <footer>
+                        <button name="action_add_to_po" type="object" string="Add Products" invisible="not context.get('has_products')"/>
+                        <button name="action_add_downpayment" type="object" string="Add Down Payment"/>
+                    </footer>
+                </sheet>
+            </form>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Purpose
-------

With EDI's becoming more common, bills are typically imported automatically, thereby losing the link with the original PO.
In order to provide options to better link PO lines with Bill lines, a new view is add that allows linking these lines.

The View
--------

A new model with a non-stored table (`_auto = False`) is used to read Account Move lines and Purchase Order lines.
It displays all lines which could still be matched.
The matching view is accessible from a smart button on both Vendor Bill (when all lines haven't been matched yet), and a Purchase Order (when there are vendor bills for the partner and the PO hasn't been fully invoiced yet)
Even though it is accessed from a Bill/PO, all unmatched lines for the Vendor are displayed.

Features:
---------
1. Match existing lines: Manual linking of a Bill line, to the corresponding Purchase Order line. When multiple lines are selected, the ***Match*** button becomes visible. Many bill lines can be matched to the same po line, provided they share the same product. Note: Matching will fail when 2+ PO lines have the same product (more intelligent matching might be done in the future)

But sometimes the PO/ purchase order line doesn't exist yet

2. Add products to PO and match: products invoiced on the vendor bill can be added to an existing purchase order, or a new purchase order could be created containing those lines. This is especially useful when the stock module is installed, and a PO is the quickest way to generate an inventory receipt. To use, select bill lines with a product, and click the ***Add to PO*** button.

3. Down Payments: deposit payments are often required to confirm an order. These vendor bill lines rarely contain a product. It works similar to feature 2's ***Add to PO***, but instead choosing the ***Add Down Payments*** button in the wizard.
Note: The final bill should contain the lines for the products/services purchased and a negative down payment line to reimburse the deposit already paid, ie. reduce the amount due. These lines should also be matched using the features in 1 & 2 above, marking the Purchase Order as fully invoiced.

Typical Down Payment Flow Example
---------------------------------

- Company creates,confirms & sends a purchase order to a Vendor for 10 x Product/Service @ €100.00
- Vendor requires a 10% deposit/ down payment to confirm the order
- We receive a bill for 1 x down payment (no product) @ €100.00
- On the bill, the Purchase Matching smart button is visible, and it display both the down payment and the order lines.
- Select both and click "Add to PO" > "Add Down Payment"
- A new downpayment line with a billed qty is added to the PO. (this line shouldn't be editable)
- When we receive the inventory, we also receive the final invoice for a total of €900.00:
    - 10 x Product/Service @ €100.00
    - downpayment reduction -1 x €100.00 (no product, label only)
- Purchase Matching now displays 4 matchable lines: the PO line for products/service, the bill line with the same product, The downpayment line from the PO, the downpayment paid line from the bill
- Selecting all lines and clicking "Match" will link the down payment lines (reducing the billed qty to Zero), and the product lines and purchase order will be marked as fully invoiced.

Task-4050320
