### PR TITLE
[FIX] auth_passkey: unable to login with passkey on error

### DIFF
--- a/addons/auth_passkey/static/src/login_passkeys.js
+++ b/addons/auth_passkey/static/src/login_passkeys.js
@@ -12,7 +12,7 @@ publicWidget.registry.passkeyLogin = publicWidget.Widget.extend({
         const serverOptions = await rpc("/auth/passkey/start-auth");
         const auth = await startAuthentication(serverOptions).catch(e => console.error(e));
         if(!auth) return false;
-        const form = document.querySelector('form[class="oe_login_form"]');
+        const form = document.querySelector('form.oe_login_form');
         form.querySelector('input[name="webauthn_response"]').value = JSON.stringify(auth);
         form.querySelector('input[name="type"]').value = 'webauthn';
         form.submit();


### PR DESCRIPTION
Whenever an AccessDenied error is raised in the login form, a space gets added to class="oe_login_form", causing the querySelector to fail.

Switching to a non-exact match solves this issue.