### PR TITLE
[FIX] mail: reply to email message from inbox

### DIFF
--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -19,7 +19,7 @@
             </div>
             <div class="o-mail-Composer-coreHeader text-truncate small p-2" t-if="props.composer.thread and props.messageToReplyTo?.thread?.eq(props.composer.thread)">
                 <span class="cursor-pointer" t-on-click="() => env.messageHighlight?.highlightMessage(props.messageToReplyTo.message, props.composer.thread)">
-                    Replying to <b t-esc="props.messageToReplyTo.message.author.name"/>
+                    Replying to <b t-esc="props.messageToReplyTo.message.author?.name ?? props.messageToReplyTo.message.email_from"/>
                 </span>
                 <span t-if="props.messageToReplyTo.message.originThread.notEq(props.composer.thread)">
                     on: <b><t t-esc="props.messageToReplyTo.message.originThread.displayName"/></b>

--- a/addons/mail/static/tests/discuss_app/inbox_tests.js
+++ b/addons/mail/static/tests/discuss_app/inbox_tests.js
@@ -647,42 +647,71 @@ QUnit.test("emptying inbox doesn't display rainbow man in another thread", async
     await contains(".o_reward_rainbow", { count: 0 });
 });
 
-QUnit.test("Counter should be incremented by 1 when receiving a message with a mention in a channel", async () => {
+QUnit.test(
+    "Counter should be incremented by 1 when receiving a message with a mention in a channel",
+    async () => {
+        const pyEnv = await startServer();
+        const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+        const partnerId = pyEnv["res.partner"].create({ name: "Thread" });
+        const partnerUserId = pyEnv["res.partner"].create({ name: "partner1" });
+        const userId = pyEnv["res.users"].create({ partner_id: partnerUserId });
+        const messageId = pyEnv["mail.message"].create({
+            body: "not empty",
+            model: "res.partner",
+            needaction: true,
+            needaction_partner_ids: [pyEnv.currentPartnerId],
+            res_id: partnerId,
+        });
+        pyEnv["mail.notification"].create([
+            {
+                mail_message_id: messageId,
+                notification_type: "inbox",
+                res_partner_id: pyEnv.currentPartnerId,
+            },
+        ]);
+        const { openDiscuss, env } = await start();
+        await openDiscuss();
+        await contains("button", { text: "Inbox", contains: [".badge", { text: "1" }] });
+        const mention = [pyEnv.currentPartnerId];
+        const mentionName = pyEnv.currentPartner.name;
+        pyEnv.withUser(userId, () =>
+            env.services.rpc("/mail/message/post", {
+                post_data: {
+                    body: `<a href="https://www.hoot.test/web#model=res.partner&amp;id=17" class="o_mail_redirect" data-oe-id="${mention[0]}" data-oe-model="res.partner" target="_blank" contenteditable="false">@${mentionName}</a> mention`,
+                    message_type: "comment",
+                    partner_ids: mention,
+                    subtype_xmlid: "mail.mt_comment",
+                },
+                thread_id: channelId,
+                thread_model: "discuss.channel",
+            })
+        );
+        await contains("button", { text: "Inbox", contains: [".badge", { text: "2" }] });
+    }
+);
+
+QUnit.test("can reply to email message", async () => {
     const pyEnv = await startServer();
-    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
-    const partnerId = pyEnv["res.partner"].create({ name: "Thread" });
-    const partnerUserId = pyEnv["res.partner"].create({ name: "partner1" });
-    const userId = pyEnv["res.users"].create({ partner_id: partnerUserId });
+    const partnerId = pyEnv["res.partner"].create({});
     const messageId = pyEnv["mail.message"].create({
-        body: "not empty",
+        author_id: null,
+        email_from: "md@oilcompany.fr",
+        body: "an email message",
         model: "res.partner",
         needaction: true,
         needaction_partner_ids: [pyEnv.currentPartnerId],
         res_id: partnerId,
     });
-    pyEnv["mail.notification"].create([
-        {
-            mail_message_id: messageId,
-            notification_type: "inbox",
-            res_partner_id: pyEnv.currentPartnerId,
-        },
-    ]);
-    const { openDiscuss, env } = await start();
-    await openDiscuss();
-    await contains("button", { text: "Inbox", contains: [".badge", { text: "1" }] });
-    const mention = [pyEnv.currentPartnerId];
-    const mentionName = pyEnv.currentPartner.name;
-    pyEnv.withUser(userId, () =>
-        env.services.rpc("/mail/message/post", {
-            post_data: {
-                body: `<a href="https://www.hoot.test/web#model=res.partner&amp;id=17" class="o_mail_redirect" data-oe-id="${mention[0]}" data-oe-model="res.partner" target="_blank" contenteditable="false">@${mentionName}</a> mention`,
-                message_type: "comment",
-                partner_ids: mention,
-                subtype_xmlid: "mail.mt_comment",
-            },
-            thread_id: channelId,
-            thread_model: "discuss.channel",
-        })
-    );
-    await contains("button", { text: "Inbox", contains: [".badge", { text: "2" }] });
+    pyEnv["mail.notification"].create({
+        mail_message_id: messageId,
+        notification_status: "sent",
+        notification_type: "inbox",
+        res_partner_id: pyEnv.currentPartnerId,
+    });
+    const { openDiscuss } = await start();
+    openDiscuss();
+    await contains(".o-mail-Message");
+    await click("[title='Expand']");
+    await click("[title='Reply']");
+    await contains(".o-mail-Composer", { text: "Replying to md@oilcompany.fr" });
 });


### PR DESCRIPTION
Before this commit, replying to a message from email author lead to a crash.

Steps to reproduce:
- Set notification preferences to "Handle in Odoo", in user preferences
- Follow a record with chatter
- Send a message on the followed record so that it's received by another follower by email
- Follower replies to message from email client
- Open Inbox in Discuss app and click on "Reply" action on that message => Crash `Cannot read property of undefined (reading 'name')`

This happens because the reply-to text above composer when using the message reply feature assumed that the author is necessarily a partner. This is not necessarily the case: some message just have an email address as author.

This commit fixes the issue by correctly showing the address email when replying to such a message.

opw-4092015
