### PR TITLE
[FIX] l10n_de: fix singleton error on multiple attachments unlink

### DIFF
--- a/addons/l10n_de/models/ir_attachment.py
+++ b/addons/l10n_de/models/ir_attachment.py
@@ -19,7 +19,7 @@ class IrAttachment(models.Model):
                 'application/xml',
             )
         )
-        id2move = self.env['account.move'].browse(audit_trail_attachments.mapped('res_id')).exists().grouped('id')
+        id2move = self.env['account.move'].browse(set(audit_trail_attachments.mapped('res_id'))).exists().grouped('id')
         for attachment in audit_trail_attachments:
             move = id2move.get(attachment.res_id)
             if move and move.posted_before and move.country_code == 'DE':


### PR DESCRIPTION
To reproduce (on runbot w/ demo datas)

- Install l10n_de
- Switch to "DE Company"
- Create an invoice and add 2 or more PDF documents
- Switch to debug mode
- Go to menu: Settings / Technical / Database Structure / Attachments
- Search for the added documents, select them all and try to delete them

=> This raise the following error:

```
Traceback (most recent call last):
  File "/data/build/odoo/odoo/models.py", line 5961, in ensure_one
    _id, = self._ids
    ^^^^
ValueError: too many values to unpack (expected 1)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  ..
  File "/data/build/odoo/odoo/addons/base/models/ir_attachment.py", line 610, in unlink
    res = super(IrAttachment, self).unlink()
  File "/data/build/odoo/odoo/models.py", line 4326, in unlink
    func(self)
  File "/data/build/odoo/addons/l10n_de/models/ir_attachment.py", line 25, in _except_audit_trail
    if move and move.posted_before and move.country_code == 'DE':
                ^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/odoo/fields.py", line 1204, in __get__
    record.ensure_one()
  File "/data/build/odoo/odoo/models.py", line 5964, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: account.move(347, 347)
```

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
