### PR TITLE
[FIX] html_editor: use waitFor for inde test

### DIFF
--- a/addons/html_editor/static/tests/emoji.test.js
+++ b/addons/html_editor/static/tests/emoji.test.js
@@ -15,7 +15,7 @@ test("add an emoji with powerbox", async () => {
 
     insertText(editor, "/emoji");
     press("enter");
-    await waitFor(".o-EmojiPicker", { timeout: 500 });
+    await waitFor(".o-EmojiPicker", { timeout: 1000 });
     expect(".o-EmojiPicker").toHaveCount(1);
 
     await click(".o-EmojiPicker .o-Emoji");
@@ -32,7 +32,7 @@ test("click on emoji command to open emoji picker", async () => {
     insertText(editor, "/emoji");
     await animationFrame();
     click(".active .o-we-command-name");
-    await waitFor(".o-EmojiPicker", { timeout: 500 });
+    await waitFor(".o-EmojiPicker", { timeout: 1000 });
     expect(".o-EmojiPicker").toHaveCount(1);
 });
 
@@ -44,7 +44,7 @@ test("undo an emoji", async () => {
     insertText(editor, "test");
     insertText(editor, "/emoji");
     press("enter");
-    await waitFor(".o-EmojiPicker", { timeout: 500 });
+    await waitFor(".o-EmojiPicker", { timeout: 1000 });
     await click(".o-EmojiPicker .o-Emoji");
     expect(getContent(el)).toBe("<p>abtest😀[]</p>");
 

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -1573,7 +1573,7 @@ describe("save image", () => {
                 "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII"
             )
         );
-        await animationFrame();
+        await waitFor("img");
         const img = htmlEditor.editable.querySelector("img");
         expect(img.src.startsWith("data:image/png;base64,")).toBe(true);
         expect(img.classList.contains("o_b64_image_to_save")).toBe(true);
@@ -1631,7 +1631,7 @@ describe("save image", () => {
                 "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII"
             )
         );
-        await animationFrame();
+        await waitFor("img");
         const img = htmlEditor.editable.querySelector("img");
         expect(img.src.startsWith("data:image/png;base64,")).toBe(true);
         expect(img.classList.contains("o_b64_image_to_save")).toBe(true);
@@ -1700,7 +1700,7 @@ describe("save image", () => {
                 "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII"
             )
         );
-        await animationFrame();
+        await waitFor("img");
         const img = htmlEditor.editable.querySelector("img");
         expect(img.src.startsWith("data:image/png;base64,")).toBe(true);
         expect(img.classList.contains("o_b64_image_to_save")).toBe(true);
@@ -1758,7 +1758,7 @@ describe("save image", () => {
                 "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII"
             )
         );
-        await animationFrame();
+        await waitFor("img");
         const img = htmlEditor.editable.querySelector("img");
         expect(img.src.startsWith("data:image/png;base64,")).toBe(true);
         expect(img.classList.contains("o_b64_image_to_save")).toBe(true);


### PR DESCRIPTION
The goal of this commit is to fix the indeterminacy in the tests linked to the use of the "Emoji" powerbox command and the paste of a base64 image.

For the Emoji, waitFor can sometimes take longer.
So we're going to increase its limit.

To paste an image in base64, we'll use waitFor to wait for the image to be added to the dom.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
