### PR TITLE
[FIX] stock: consistency fixes for validation and UI

### DIFF
--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -84,6 +84,19 @@ class PurchaseOrderLine(models.Model):
                 if virtual_available < 0:
                     line.forecasted_issue = True
 
+    @api.onchange('product_qty')
+    def _onchange_product_qty_warning(self):
+        if self.product_id.tracking == 'serial':
+            quantity = self.product_qty
+            self.product_qty = rounded = float_round(quantity, precision_digits=0)
+            if rounded != quantity:
+                return {
+                    'warning': {
+                        'title': _("Fractional quantity"),
+                        'message': _("Products tracked with serial numbers cannot be invoiced in fractional amounts."),
+                    }
+                }
+
     @api.model_create_multi
     def create(self, vals_list):
         lines = super(PurchaseOrderLine, self).create(vals_list)

--- a/addons/repair/data/repair_demo.xml
+++ b/addons/repair/data/repair_demo.xml
@@ -21,7 +21,7 @@
             'name': obj().env.ref('product.product_product_11').get_product_multiline_description_sale(),
             'product_id': obj().env.ref('product.product_product_11').id,
             'product_uom': obj().env.ref('uom.product_uom_unit').id,
-            'product_uom_qty': '1.0',
+            'product_uom_qty': 1.0,
             'state': 'draft',
             'repair_line_type': 'add',
             'company_id': obj().env.ref('base.main_company').id,

--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 
 from odoo import api, fields, models, _
 from odoo.osv import expression
-from odoo.tools import float_compare
+from odoo.tools import float_compare, float_round
 from odoo.exceptions import UserError
 
 
@@ -242,6 +242,19 @@ class SaleOrderLine(models.Model):
         super()._compute_customer_lead() # Reset customer_lead when the product is modified
         for line in self:
             line.customer_lead = line.product_id.sale_delay
+
+    @api.onchange('product_uom_qty')
+    def _onchange_product_uom_qty_warning(self):
+        if self.product_id.tracking == 'serial':
+            quantity = self.product_uom_qty
+            self.product_uom_qty = rounded = float_round(quantity, precision_digits=0)
+            if rounded != quantity:
+                return {
+                    'warning': {
+                        'title': _("Fractional quantity"),
+                        'message': _("Products tracked with serial numbers cannot be sold in fractional amounts."),
+                    }
+                }
 
     def _inverse_customer_lead(self):
         for line in self:

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -11,7 +11,7 @@ from odoo import _, api, fields, models, SUPERUSER_ID
 from odoo.exceptions import UserError, ValidationError
 from odoo.osv import expression
 from odoo.tools import SQL, check_barcode_encoding, format_list, groupby
-from odoo.tools.float_utils import float_compare, float_is_zero
+from odoo.tools.float_utils import float_compare, float_is_zero, float_round
 
 _logger = logging.getLogger(__name__)
 
@@ -860,7 +860,14 @@ class StockQuant(models.Model):
         if product_packaging_id and product_id.product_tmpl_id.categ_id.packaging_reserve_method == "full":
             available_quantity = product_packaging_id._check_qty(available_quantity, product_id.uom_id, "DOWN")
 
-        quantity = min(quantity, available_quantity)
+        # Products tracked with serial numbers cannot be reserved in fractional amounts. Rounding is necessary.
+        if product_id.tracking == 'serial':
+            if (reservable := float_round(available_quantity, precision_digits=0, rounding_method='DOWN')) < quantity:
+                quantity = reservable
+            else:
+                quantity = float_round(quantity, precision_digits=0, rounding_method='UP')
+        else:
+            quantity = min(quantity, available_quantity)
 
         # `quantity` is in the quants unit of measure. There's a possibility that the move's
         # unit of measure won't be respected if we blindly reserve this quantity, a common usecase
@@ -873,10 +880,6 @@ class StockQuant(models.Model):
         if not strict and uom_id and product_id.uom_id != uom_id:
             quantity_move_uom = product_id.uom_id._compute_quantity(quantity, uom_id, rounding_method='DOWN')
             quantity = uom_id._compute_quantity(quantity_move_uom, product_id.uom_id, rounding_method='HALF-UP')
-
-        if product_id.tracking == 'serial':
-            if float_compare(quantity, int(quantity), precision_rounding=rounding) != 0:
-                quantity = 0
 
         reserved_quants = []
 

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -3104,24 +3104,11 @@ class StockMove(TransactionCase):
         backorder = self.env['stock.picking'].search([('backorder_id', '=', picking_pack_cust.id)])
         backordered_move = backorder.move_ids
 
-        # due to the rounding, the backordered quantity is 0.999 ; we shoudln't be able to reserve
-        # 0.999 on a tracked by serial number quant
+        # Due to the rounding, the backordered quantity is 0.999, which will be
+        # rounded up to reserve 1.0 because the product is tracked with serial numbers.
         backordered_move._action_assign()
-        self.assertEqual(backordered_move.quantity, 0)
+        self.assertEqual(backordered_move.quantity, 1.0)
 
-        # force the serial number and validate
-        lot3 = self.env['stock.lot'].search([('name', '=', "lot3")])
-        backorder.write({'move_line_ids': [(0, 0, {
-            'product_id': self.product_serial.id,
-            'product_uom_id': self.uom_unit.id,
-            'quantity': 1,
-            'lot_id': lot3.id,
-            'package_id': False,
-            'result_package_id': False,
-            'location_id': backordered_move.location_id.id,
-            'location_dest_id': backordered_move.location_dest_id.id,
-            'move_id': backordered_move.id,
-        })]})
         backorder.move_ids.picked = True
         backorder.button_validate()
 

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -447,18 +447,6 @@
             </field>
         </record>
 
-        <record id="action_unreserve_picking" model="ir.actions.server">
-            <field name="name">Unreserve</field>
-            <field name="model_id" ref="stock.model_stock_picking"/>
-            <field name="binding_model_id" ref="stock.model_stock_picking"/>
-            <field name="binding_view_types">list,form</field>
-            <field name="state">code</field>
-            <field name="code">
-            if records:
-                records.do_unreserve()
-            </field>
-        </record>
-
         <record id="action_print_labels" model="ir.actions.server">
             <field name="name">Labels</field>
             <field name="model_id" ref="stock.model_stock_picking"/>

--- a/addons/stock/wizard/stock_orderpoint_snooze_views.xml
+++ b/addons/stock/wizard/stock_orderpoint_snooze_views.xml
@@ -22,6 +22,5 @@
         <field name="name">Snooze</field>
         <field name="res_model">stock.orderpoint.snooze</field>
         <field name="view_mode">form</field>
-        <field name="target">new</field>
     </record>
 </odoo>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: This PR fixes five inventory bugs provided in task [4037390](https://www.odoo.com/odoo/project/966/tasks/4037390).

Current behavior before PR: The description of the bugs are as follows (quoted):
1. When a new reordering rule is created, the order icon appears but doesn't disappear after clicking to place the order. It should vanish once the order is placed.
2. When snoozing a product, it currently shows all reordering rules. It should only display the reordering rules set specifically for that product.
3. When creating a SO/PO, serial-tracked products should not allow decimal quantities to prevent incomplete back orders and invalid error.
4. By default, adding a product in a transfer shows demand as "0". After adding a quantity and saving, the forecast button turns "red" even if the quantity is in stock (being it’s not reserved). It should display "blue" when on hand is available and "red" when it's not.
5. Remove "unreserve" from the actions menu when selecting a transfer, as there is already a dedicated unreserve button available.

Desired behavior after PR is merged:
1. This one appears to have been fixed at some point.
2. Snoozing a product no longer directs the user to the `new` replenishment view but returns to the current item's reordering rules (default behaviour).
3. There are now validation checks across `purchase`, `sale` and `stock` that prevent fractional quantities for products tracked by serial numbers.
4. **TODO** This one is a work in progress.
5. The redundant 'unreserve' button was removed.

Task ID: [4037390](https://www.odoo.com/odoo/project/966/tasks/4037390)