### PR TITLE
[IMP] google_calendar: allow simplified credentials override

### DIFF
--- a/addons/google_account/models/google_service.py
+++ b/addons/google_account/models/google_service.py
@@ -42,13 +42,6 @@ class GoogleService(models.AbstractModel):
         ICP = self.env['ir.config_parameter'].sudo()
         return ICP.get_param('google_%s_client_id' % service)
 
-    def _has_setup_credentials(self):
-        """ Checks if both Client ID and Client Secret are defined in the database. """
-        sudo_get_param = self.env['ir.config_parameter'].sudo().get_param
-        client_id = sudo_get_param('google_calendar_client_id')
-        client_secret = sudo_get_param('google_calendar_client_secret')
-        return bool(client_id and client_secret)
-
     @api.model
     def _get_authorize_uri(self, service, scope, redirect_uri, state=None, approval_prompt=None, access_type=None):
         """ This method return the url needed to allow this instance of Odoo to access to the scope

--- a/addons/google_account/models/google_service.py
+++ b/addons/google_account/models/google_service.py
@@ -42,6 +42,13 @@ class GoogleService(models.AbstractModel):
         ICP = self.env['ir.config_parameter'].sudo()
         return ICP.get_param('google_%s_client_id' % service)
 
+    def _has_setup_credentials(self):
+        """ Checks if both Client ID and Client Secret are defined in the database. """
+        sudo_get_param = self.env['ir.config_parameter'].sudo().get_param
+        client_id = sudo_get_param('google_calendar_client_id')
+        client_secret = sudo_get_param('google_calendar_client_secret')
+        return bool(client_id and client_secret)
+
     @api.model
     def _get_authorize_uri(self, service, scope, redirect_uri, state=None, approval_prompt=None, access_type=None):
         """ This method return the url needed to allow this instance of Odoo to access to the scope

--- a/addons/google_calendar/controllers/main.py
+++ b/addons/google_calendar/controllers/main.py
@@ -63,5 +63,5 @@ class GoogleCalendarController(CalendarController):
     @http.route()
     def check_calendar_credentials(self):
         res = super().check_calendar_credentials()
-        res['google_calendar'] = request.env['google.service']._has_setup_credentials()
+        res['google_calendar'] = request.env['res.users']._has_setup_credentials()
         return res

--- a/addons/google_calendar/controllers/main.py
+++ b/addons/google_calendar/controllers/main.py
@@ -63,8 +63,5 @@ class GoogleCalendarController(CalendarController):
     @http.route()
     def check_calendar_credentials(self):
         res = super().check_calendar_credentials()
-        client_id = request.env['google.service']._get_client_id('calendar')
-        ICP_sudo = request.env['ir.config_parameter'].sudo()
-        client_secret = _get_client_secret(ICP_sudo, 'calendar')
-        res['google_calendar'] = bool(client_id and client_secret)
+        res['google_calendar'] = request.env['google.service']._has_setup_credentials()
         return res

--- a/addons/google_calendar/models/res_users.py
+++ b/addons/google_calendar/models/res_users.py
@@ -163,10 +163,7 @@ class User(models.Model):
     @api.model
     def check_calendar_credentials(self):
         res = super().check_calendar_credentials()
-        get_param = self.env['ir.config_parameter'].sudo().get_param
-        client_id = get_param('google_calendar_client_id')
-        client_secret = get_param('google_calendar_client_secret')
-        res['google_calendar'] = bool(client_id and client_secret)
+        res['google_calendar'] = self.env['google.service']._has_setup_credentials()
         return res
 
     def check_synchronization_status(self):

--- a/addons/google_calendar/models/res_users.py
+++ b/addons/google_calendar/models/res_users.py
@@ -7,6 +7,7 @@ import logging
 from odoo import api, fields, models, Command
 from odoo.addons.google_calendar.utils.google_calendar import GoogleCalendarService, InvalidSyncToken
 from odoo.addons.google_calendar.models.google_sync import google_calendar_token
+from odoo.addons.google_account.models.google_service import _get_client_secret
 from odoo.loglevels import exception_to_unicode
 from odoo.tools import str2bool
 
@@ -161,9 +162,17 @@ class User(models.Model):
         self.env['ir.config_parameter'].sudo().set_param("google_calendar_sync_paused", True)
 
     @api.model
+    def _has_setup_credentials(self):
+        """ Checks if both Client ID and Client Secret are defined in the database. """
+        ICP_sudo = self.env['ir.config_parameter'].sudo()
+        client_id = self.env['google.service']._get_client_id('calendar')
+        client_secret = _get_client_secret(ICP_sudo, 'calendar')
+        return bool(client_id and client_secret)
+
+    @api.model
     def check_calendar_credentials(self):
         res = super().check_calendar_credentials()
-        res['google_calendar'] = self.env['google.service']._has_setup_credentials()
+        res['google_calendar'] = self._has_setup_credentials()
         return res
 
     def check_synchronization_status(self):


### PR DESCRIPTION
This commit adds a boolean function that indicates if external credentials are being provided for the calendar synchronization. Adjustments on the synchronizations status in the calendar view's header were made to consider the external credentials presence (or absence).

task-3864685