### PR TITLE
[FIX] account: make fixed and percent included taxes independent

### DIFF
--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -135,19 +135,22 @@ export const accountTaxHelpers = {
 
         for (const tax_data of batch.taxes) {
             if (batch._original_price_include) {
-                if (!special_mode) {
-                    for (const other_batch of batches_before) {
-                        add_extra_base(other_batch, tax_data, -1);
-                    }
-                } else if (special_mode === "total_excluded") {
-                    for (const other_batch of batches_after) {
-                        if (!other_batch.price_include) {
-                            add_extra_base(other_batch, tax_data, 1);
+                if (!special_mode || special_mode === "total_included") {
+                    if (!batch.include_base_amount) {
+                        for (const other_batch of batches_after) {
+                            if (other_batch._original_price_include) {
+                                add_extra_base(other_batch, tax_data, -1);
+                            }
                         }
                     }
-                } else if (special_mode === "total_included") {
                     for (const other_batch of batches_before) {
                         add_extra_base(other_batch, tax_data, -1);
+                    }
+                } else {  // special_mode === "total_excluded"
+                    for (const other_batch of batches_after) {
+                        if (!other_batch._original_price_include || batch.include_base_amount) {
+                            add_extra_base(other_batch, tax_data, 1);
+                        }
                     }
                 }
             } else if (!batch._original_price_include) {
@@ -157,11 +160,14 @@ export const accountTaxHelpers = {
                             add_extra_base(other_batch, tax_data, 1);
                         }
                     }
-                } else if (special_mode === "total_included") {
+                } else {  // special_mode === "total_included"
                     if (!batch.include_base_amount) {
-                        for (const other_batch of batches_before.concat(batches_after)) {
+                        for (const other_batch of batches_after) {
                             add_extra_base(other_batch, tax_data, -1);
                         }
+                    }
+                    for (const other_batch of batches_before) {
+                        add_extra_base(other_batch, tax_data, -1);
                     }
                 }
             }

--- a/addons/account/tests/test_taxes_computation.py
+++ b/addons/account/tests/test_taxes_computation.py
@@ -845,21 +845,45 @@ class TestTax(TestTaxCommon):
 
         # tax       price_incl      incl_base_amount
         # -----------------------------------------------
+        # tax1
+        # tax2                      T
+        # tax3
+        tax2.price_include = False
+        tests.append(
+            self._prepare_taxes_computation_test(
+                tax1 + tax2 + tax3,
+                100.0,
+                {
+                    'total_included': 124.0,
+                    'total_excluded': 100.0,
+                    'taxes_data': (
+                        (100.0, 1.0),
+                        (100.0, 21.0),
+                        (121.0, 2.0),
+                    ),
+                },
+                {'rounding_method': 'round_globally'},
+            )
+        )
+
+        # tax       price_incl      incl_base_amount
+        # -----------------------------------------------
         # tax1      T
         # tax2      T               T
         # tax3
         tax1.price_include = True
+        tax2.price_include = True
         tests.append(
             self._prepare_taxes_computation_test(
                 tax1 + tax2 + tax3,
-                121.0,
+                122.0,
                 {
-                    'total_included': 123.0,
-                    'total_excluded': 99.0,
+                    'total_included': 124.0,
+                    'total_excluded': 100.0,
                     'taxes_data': (
-                        (99.0, 1.0),
+                        (100.0, 1.0),
                         (100.0, 21.0),
-                        (121.0, 2.0),
+                        (122.0, 2.0),
                     ),
                 },
                 {'rounding_method': 'round_globally'},
@@ -875,14 +899,14 @@ class TestTax(TestTaxCommon):
         tests.append(
             self._prepare_taxes_computation_test(
                 tax1 + tax2 + tax3,
-                121.0,
+                122.0,
                 {
-                    'total_included': 123.0,
-                    'total_excluded': 99.0,
+                    'total_included': 124.0,
+                    'total_excluded': 100.0,
                     'taxes_data': (
-                        (99.0, 1.0),
+                        (100.0, 1.0),
                         (100.0, 21.0),
-                        (121.0, 2.0),
+                        (122.0, 2.0),
                     ),
                 },
                 {'rounding_method': 'round_globally'},

--- a/addons/sale/tests/test_sale_prices.py
+++ b/addons/sale/tests/test_sale_prices.py
@@ -778,7 +778,7 @@ class TestSalePrices(SaleCommon):
             line.product_id = product_tmpl_c.product_variant_id
             line.product_uom_qty = 1.0
         sale_order = order_form.save()
-        self.assertRecordValues(sale_order.order_line, [{'price_unit': 100, 'price_subtotal': 84.34}])
+        self.assertRecordValues(sale_order.order_line, [{'price_unit': 100, 'price_subtotal': 84.91}])
 
         # Test Mapping (excluded,included) to (excluded, excluded)
         order_form = Form(SaleOrder)


### PR DESCRIPTION
### Steps to reproduce the issue:

1. Create two Taxes, one with Fixed "Tax Computation" and one with Percentage of Price.
2. Set "Included in Price" to True and and "Affect Base of Subsequent Taxes" to False for both.
3. Create an Invoice with one line, add both Taxes to it, make sure each Tax has a different amount.
4. Change the order of the Taxes in the Taxes menu
5. Refresh the Invoice Line (e.g.: remove and put back one of the taxes)
6. The amount of the "percent" Tax has changed along with the Untaxed Amount of the Invoice

### Explanation:

In `_prepare_taxes_computation`, taxes are preprocessed with a priority set on fixed taxes, then taxes with `price_include` set to True, both in descending order and lastly, taxes with `price_include` set to False in ascending order. In `_propagate_extra_taxes_base`, the currently preprocessed tax is also added to the base of other taxes depending on the specifications of those taxes.
When `price_include` is set to True, taxes are never being added to the base of the ones with a higher sequence, it should only be the case if `include_base_amount` is set to True as well.

### Fix reasoning:

The computation should be consistent regardless of the order of the taxes, as they are not supposed to have an influence on each other. The special modes computation are changed accordingly.
The change to the `total_included` special mode for non `_original_price_include` batches fixes an inconsistency when all taxes are excluded, added a test for it.

opw-4068781