### PR TITLE
[FIX] web_editor, website: fix handling of quotes in background images

### DIFF
--- a/addons/web_editor/static/src/js/common/utils.js
+++ b/addons/web_editor/static/src/js/common/utils.js
@@ -367,10 +367,10 @@ function _getBgImageURL(el) {
 function _backgroundImageCssToParts(css) {
     const parts = {};
     css = css || '';
-    if (css.startsWith('url(')) {
-        const urlEnd = css.indexOf(')') + 1;
-        parts.url = css.substring(0, urlEnd).trim();
-        const commaPos = css.indexOf(',', urlEnd);
+    const matchedUrl = /^url\((['"]?)(.*?)\1\)/.exec(css);
+    if (matchedUrl) {
+        parts.url = matchedUrl[0];
+        const commaPos = css.indexOf(',', matchedUrl[0].length);
         css = commaPos > 0 ? css.substring(commaPos + 1) : '';
     }
     if (_isColorGradient(css)) {

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -8074,7 +8074,7 @@ registry.BackgroundImage = SnippetOptionWidget.extend({
     _setBackground(backgroundURL) {
         const parts = backgroundImageCssToParts(this.$target.css('background-image'));
         if (backgroundURL) {
-            parts.url = `url('${backgroundURL}')`;
+            parts.url = `url("${CSS.escape(backgroundURL)}")`;
             this.$target.addClass('oe_img_bg o_bg_img_center');
         } else {
             delete parts.url;

--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -988,7 +988,16 @@ export class WysiwygAdapterComponent extends Wysiwyg {
                     res_model: 'ir.ui.view',
                 },
             );
-            cssBgImage = `url(${attachment.image_src})`;
+            cssBgImage = `url("${CSS.escape(attachment.image_src)}")`;
+        } else {
+            // When retrieving backgroundImage, CSS escaping is potentially
+            // lost, we therefore need to re-escape before reusing the URL
+            // given that the `"` are removed for an unknown reason dating back
+            // to the long lost origins of the cover concept.
+            const match = /^url\((['"])(.*?)\1\)$/.exec(cssBgImage);
+            if (match) {
+                cssBgImage = `url("${CSS.escape(match[1])}")`;
+            }
         }
         var coverProps = {
             'background-image': cssBgImage.replace(/"/g, '').replace(window.location.protocol + "//" + window.location.host, ''),

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -3000,7 +3000,7 @@ options.registry.CoverProperties = options.Class.extend({
                     this.$image[0].classList.add("o_b64_image_to_save");
                 }
             }
-            this.$image.css('background-image', `url('${widgetValue}')`);
+            this.$image.css("background-image", `url("${CSS.escape(widgetValue)}")`);
             this.$target.addClass('o_record_has_cover');
             const $defaultSizeBtn = this.$el.find('.o_record_cover_opt_size_default');
             $defaultSizeBtn.click();


### PR DESCRIPTION
With [1] the single quotes in `image_src` were not escaped anymore. This led to issues related the handling of CSS `background-image` which did not escape nor quote those values.

This commit addresses this issue on the Javascript side by using `CSS.escape` on URLs used in `background-image`.

Steps to reproduce:
Scenario 1:
- Use Werkzeug 3.0.1.
- Drop a text block.
- Upload a background image that contains a `'` in its name.

=> Image did not appear.

Scenario 2:
- Use Werkzeug 3.0.1.
- Create a blog post with a `'` in its name.
- 2.1: Upload a non-webp cover image.
- 2.2: Upload a webp cover image with a `'` in its name.
- Save.

=> Cover image disappeared.

opw-4086602
opw-4098841
opw-4095728
opw-4100352
