### PR TITLE
[FIX] mail: use correct base url

### DIFF
--- a/addons/mail/models/mail_render_mixin.py
+++ b/addons/mail/models/mail_render_mixin.py
@@ -470,8 +470,14 @@ class MailRenderMixin(models.AbstractModel):
 
         :return dict: updated version of rendered per record ID;
         """
+        # TODO make this a parameter
+        model = self.env.context.get('mail_render_postprocess_model')
+        res_ids = list(rendered.keys())
         for res_id, rendered_html in rendered.items():
-            rendered[res_id] = self._replace_local_links(rendered_html)
+            base_url = None
+            if model:
+                base_url = self.env[model].browse(res_id).with_prefetch(res_ids).get_base_url()
+            rendered[res_id] = self._replace_local_links(rendered_html, base_url)
         return rendered
 
     @api.model
@@ -512,7 +518,7 @@ class MailRenderMixin(models.AbstractModel):
             rendered = self._render_template_inline_template(template_src, model, res_ids,
                                                              add_context=add_context, options=options)
         if post_process:
-            rendered = self._render_template_postprocess(rendered)
+            rendered = self.with_context(mail_render_postprocess_model=model)._render_template_postprocess(rendered)
 
         return rendered
 

--- a/addons/mail/tests/test_mail_render.py
+++ b/addons/mail/tests/test_mail_render.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from markupsafe import Markup
+from unittest.mock import patch
 
 from odoo.addons.mail.tests import common
 from odoo.exceptions import AccessError
@@ -210,6 +211,27 @@ class TestMailRender(common.MailCommon):
                 engine='inline_template',
             )[partner.id]
             self.assertEqual(rendered, expected)
+
+    @users('employee')
+    def test_render_template_inline_template_w_post_process_custom_local_links(self):
+        def _mock_get_base_url(recordset):
+            return f"http://www.render-object-{recordset._name}-{recordset.id}-{recordset.display_name}.com"
+        partner_ids = self.env['res.partner'].sudo().create([{
+            'name': f'test partner {n}'
+        } for n in range(20)]).ids
+        with patch('odoo.models.Model.get_base_url', new=_mock_get_base_url), self.assertQueryCount(1):
+            # make sure name isn't already in cache
+            self.env['res.partner'].invalidate_cache(['name', 'display_name'], partner_ids)
+            render_results = self.env['mail.render.mixin']._render_template(
+                '<a href="/test/destination"><img src="/test/image"></a>',
+                'res.partner',
+                partner_ids,
+                engine='inline_template',
+                post_process=True,
+            )
+        for partner_id, render_result in render_results.items():
+            expected_base_url = self.env["ir.config_parameter"].sudo().get_param("web.base.url")
+            self.assertEqual(render_result, f'<a href="{expected_base_url}/test/destination"><img src="{expected_base_url}/test/image"></a>')
 
     @users('employee')
     def test_render_template_local_links(self):

--- a/addons/mail/tests/test_mail_render.py
+++ b/addons/mail/tests/test_mail_render.py
@@ -219,7 +219,7 @@ class TestMailRender(common.MailCommon):
         partner_ids = self.env['res.partner'].sudo().create([{
             'name': f'test partner {n}'
         } for n in range(20)]).ids
-        with patch('odoo.models.Model.get_base_url', new=_mock_get_base_url), self.assertQueryCount(1):
+        with patch('odoo.models.Model.get_base_url', new=_mock_get_base_url), self.assertQueryCount(7):
             # make sure name isn't already in cache
             self.env['res.partner'].invalidate_cache(['name', 'display_name'], partner_ids)
             render_results = self.env['mail.render.mixin']._render_template(
@@ -229,8 +229,10 @@ class TestMailRender(common.MailCommon):
                 engine='inline_template',
                 post_process=True,
             )
+        Partner = self.env['res.partner'].with_prefetch(partner_ids)
         for partner_id, render_result in render_results.items():
-            expected_base_url = self.env["ir.config_parameter"].sudo().get_param("web.base.url")
+            partner = Partner.browse(partner_id)
+            expected_base_url = f"http://www.render-object-{partner._name}-{partner.id}-{partner.name}.com"
             self.assertEqual(render_result, f'<a href="{expected_base_url}/test/destination"><img src="{expected_base_url}/test/image"></a>')
 
     @users('employee')

--- a/addons/product_email_template/tests/test_account_move.py
+++ b/addons/product_email_template/tests/test_account_move.py
@@ -10,7 +10,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
         self.template = Template.create({
             'name': 'Product Template',
             'subject': 'YOUR PRODUCT',
-            'model_id': self.env['ir.model']._get_id('product.template')
+            'model_id': self.env['ir.model']._get_id('account.move')
         })
         self.customer = self.env['res.partner'].create({
             'name': 'James Bond',


### PR DESCRIPTION
When rendering a template in the render mixin
urls are converted from local to full without consideration for the website of the record being processed.

We now pass the base url of the record, fetched with `get_base_url` so that email links link to the proper website when needed.

task-4104753
