### PR TITLE
[FIX] pos_loyalty: enable gift-card ordering

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
@@ -3,8 +3,13 @@ import { PaymentScreen } from "@point_of_sale/app/screens/payment_screen/payment
 import { patch } from "@web/core/utils/patch";
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { omit } from "@web/core/utils/objects";
+import { useService } from "@web/core/utils/hooks";
 
 patch(PaymentScreen.prototype, {
+    setup() {
+        super.setup(...arguments);
+        this.report = useService("report");
+    },
     //@override
     async validateOrder(isForceValidate) {
         const pointChanges = {};


### PR DESCRIPTION
Steps to reproduce :
--------------------------
- Install pos and pos_loyalty
- Open a session
- Add Gift-card to cart
- Try to pay with any payment method

Issue :
--------
Traceback comes and unable to pay and get a giftcard.

Cause :
---------
Trying to call action through service which was never imported

Fix :
----
Imported needed service to generate giftcard report pdf.

task: 4103268