### PR TITLE
[FIX] bus: do not check outdated version for non browsers

### DIFF
--- a/addons/bus/tests/test_websocket_caryall.py
+++ b/addons/bus/tests/test_websocket_caryall.py
@@ -286,12 +286,24 @@ class TestWebsocketCaryall(WebsocketCase):
         with patch.object(WebsocketConnectionHandler, "_VERSION", "1.0.1"), patch.object(
             self, "_WEBSOCKET_URL", f"{self._BASE_WEBSOCKET_URL}?version=1.0.0"
         ):
-            websocket = self.websocket_connect(ping_after_connect=False)
+            websocket = self.websocket_connect(
+                ping_after_connect=False, header={"User-Agent": "Chrome/126.0.0.0"}
+            )
             self.assert_close_with_code(websocket, CloseCode.CLEAN, "OUTDATED_VERSION")
 
-        # Version not passed, should be considered as outdated
+        # Version not passed, User-Agent present, should be considered as outdated
         with patch.object(WebsocketConnectionHandler, "_VERSION", "1.0.1"), patch.object(
             self, "_WEBSOCKET_URL", self._BASE_WEBSOCKET_URL
         ):
-            websocket = self.websocket_connect(ping_after_connect=False)
+            websocket = self.websocket_connect(
+                ping_after_connect=False, header={"User-Agent": "Chrome/126.0.0.0"}
+            )
             self.assert_close_with_code(websocket, CloseCode.CLEAN, "OUTDATED_VERSION")
+        # Version not passed, User-Agent not present, should not be considered
+        # as outdated
+        with patch.object(WebsocketConnectionHandler, "_VERSION", None), patch.object(
+            self, "_WEBSOCKET_URL", self._BASE_WEBSOCKET_URL
+        ):
+            websocket = self.websocket_connect()
+            websocket.ping()
+            websocket.recv_data_frame(control_frame=True)  # pong

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -941,7 +941,7 @@ class WebsocketConnectionHandler:
         """
         current_thread = threading.current_thread()
         current_thread.type = 'websocket'
-        if version != cls._VERSION:
+        if httprequest.user_agent and version != cls._VERSION:
             # Close the connection from an outdated worker. We can't use a
             # custom close code because the connection is considered successful,
             # preventing exponential reconnect backoff. This would cause old
@@ -949,6 +949,8 @@ class WebsocketConnectionHandler:
             # Clean closes don't trigger reconnections, assuming they are
             # intentional. The reason indicates to the origin worker not to
             # reconnect, preventing old workers from lingering after updates.
+            # Non browsers are ignored since IOT devices do not provide the
+            # worker version.
             websocket.disconnect(CloseCode.CLEAN, "OUTDATED_VERSION")
         for message in websocket.get_messages():
             with WebsocketRequest(db, httprequest, websocket) as req:


### PR DESCRIPTION
Since [1], outdated websocket connections are refused by the server.
However, the IOT connects to the websocket endpoint without passing
any version. In order to pass the version, IOT devices should be
updated which is cumbersome.

This PR fixes the issue by enforcing this check for browsers only.

[1]: https://github.com/odoo/odoo/pull/174962