### PR TITLE
[FIX] pos_self_order: correct order tracking number increment

### DIFF
--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -28,6 +28,7 @@ class PosSelfOrderController(http.Controller):
 
         order['name'] = order_reference
         order['pos_reference'] = order_reference
+        order['sequence_number'] = sequence_number
         order['user_id'] = request.session.uid
         order['date_order'] = str(fields.Datetime.now())
         order['fiscal_position_id'] = fiscal_position.id if fiscal_position else False


### PR DESCRIPTION
Before this commit:
====================
The order tracking number did not increment because the sequence number was not passed when creating an order from the UI.

After this commit:
===================
The order tracking number now increments correctly, as the sequence number is properly passed when creating an order.

task- 4104325
