### PR TITLE
[FIX] mrp_subcontracting_dropshipping: make backorder affect SVL value

### DIFF
--- a/addons/mrp_subcontracting_dropshipping/models/stock_picking.py
+++ b/addons/mrp_subcontracting_dropshipping/models/stock_picking.py
@@ -31,7 +31,16 @@ class StockPicking(models.Model):
             if not dropship_svls:
                 continue
 
-            subcontract_svls = move.move_orig_ids.stock_valuation_layer_ids
+            # In a backorder chain, only generate SVLs for the latest backorder, or else their
+            # value will be cumulative.
+            if any(move.move_orig_ids.production_id.mapped('backorder_sequence')):
+                moves_with_svls = move.move_orig_ids.filtered('stock_valuation_layer_ids')
+                subcontract_svls = max(
+                    moves_with_svls,
+                    key=lambda sm: sm.production_id.backorder_sequence
+                ).stock_valuation_layer_ids
+            else:
+                subcontract_svls = move.move_orig_ids.stock_valuation_layer_ids
             subcontract_value = sum(subcontract_svls.mapped('value'))
             dropship_value = abs(sum(dropship_svls.mapped('value')))
             diff = subcontract_value - dropship_value


### PR DESCRIPTION
**Current behavior:**
In a scenario where dropshipping and subcontracting are being used to fulfill an order, if the dropship is split via backorder then the valuation layers which get created for each subsequent backorder will have a cumulative value instead of reflecting the value for the sequence portion for which they were generated.

**Expected behavior:**
The SVL records should have a value which accurately reflects the moves involved in the portion of the valuation sequence that they are being created with respect to.

**Steps to reproduce:**
1. Create a component_product such that: - is storable - category has automated valuation and avg cost method - has the `dropship subcontractor on order` route - has some vendor

2. Create a final_product such that: - is storable - category has automated valuation and avg cost method - invoice policy is on quantity delivered - has a subcontract bom that consumes some quantity of component_product - has a subcontractor vendor

3. Create a sale order for >1 of the final_product, set the route on order line to dropship, confirm the SO and the PO which is generated

4. In the dropship transfer, set the quantity to half the demand and validate -> generate the backorder

5. On the SO, create an invoice for the completed quantity and confirm it

6. Complete the rest of the order in the backordered dropship transfer and create and confirm another invoice on the SO

7. Go to the SVL tree view and observe that the latest SVL is ~2x (before the compensatory SVL difference is applied)

**Cause of the issue:**
When the SVL is created, its value is calculated by taking the difference of subcontract SVL(s) values and dropship SVL(s) values. The subcontract SVLs come from the `move_orig_ids` of the current SVL's move.

When the sequence is broken up by backorders, these moves are still used in the calculation for the value of future SVLs. This results in the inaccuracy.

**Fix:**
Only use SVLs from the move in the current move's
`move_orig_ids` which has the maximum `backorder_sequence`.

opw-4078510