### PR TITLE
[FIX] web: control panel sticky on small screen

### DIFF
--- a/addons/web/static/src/webclient/webclient_layout.scss
+++ b/addons/web/static/src/webclient/webclient_layout.scss
@@ -44,7 +44,7 @@ html {
         @include media-breakpoint-down(md) {
           // Made the o_action scroll instead of its o_content.
           // Except when the view wants to handle the scroll itself.
-          &:not(.o_action_delegate_scroll) {
+          &:not(.o_action_delegate_scroll), .o_form_view_container {
             overflow: auto;
 
             .o_content {


### PR DESCRIPTION
Since commit odoo/odoo@adb5357e7f93f2cba70acc576a597ea78bd1de42, we have added a new DIV (`o_form_view_container`) around the form view.

But the CSS selector for the sticky control panel was not adapted so the feature was not working anymore.

This commit fixes the CSS selector.

Steps to reproduce:
* Open Odoo on small screen
* Open the Contact App
* Select a contact
* Try to scroll down and up into the form view => Bug the control panel is not sticky

Note : backport of PR 176015

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
