### PR TITLE
[FIX] web: fix traceback when the user download vacrd for partner without name

### DIFF
--- a/addons/web/models/res_partner.py
+++ b/addons/web/models/res_partner.py
@@ -27,12 +27,12 @@ class ResPartner(models.Model):
         vcard = vobject.vCard()
         # Name
         n = vcard.add('n')
-        n.value = vobject.vcard.Name(family=self.name)
+        n.value = vobject.vcard.Name(family=self.name or self.complete_name or '')
         if self.title:
             n.value.prefix = self.title.name
         # Formatted Name
         fn = vcard.add('fn')
-        fn.value = self.name
+        fn.value = self.name or self.complete_name or ''
         # Address
         adr = vcard.add('adr')
         adr.value = vobject.vcard.Address(street=self.street or '', city=self.city or '', code=self.zip or '')

--- a/addons/web/tests/test_partner.py
+++ b/addons/web/tests/test_partner.py
@@ -50,6 +50,9 @@ class TestPartnerVCard(HttpCase):
             'country_id': self.env.ref('base.us').id,
             'zip': '97649',
             'website': 'https://test.example.com',
+            'child_ids': [
+                Command.create({'type': 'other'})
+            ]
         }])
         self.authenticate("admin", "admin")
 
@@ -102,3 +105,13 @@ class TestPartnerVCard(HttpCase):
             res = self.url_open('/web/partner/vcard?partner_ids=%s,%s' %
                             (self.partners[0].id, self.partners[1].id))
         self.assertEqual(res.status_code, 403)
+
+    def test_fetch_single_partner_vcard_without_name(self):
+        """
+        Test to fetch a vcard of a partner create through
+        child of another partner without name
+        """
+        partner = self.partners[1].child_ids[0]
+        res = self.url_open('/web/partner/vcard?partner_ids=%s' % partner.id)
+        vcard = vobject.readOne(res.text)
+        self.assertEqual(vcard.contents["n"][0].value.family, partner.complete_name, "Vcard will have the complete name when it dosen't have name")


### PR DESCRIPTION
Currently, a traceback is occurring when the user tries to download a card 
for a child partner of type `other` having no name.

To reproduce this issue:

1) Install `Contacts`
2) Create a record in `Contact & Addresses` of type as `Other Addresses`
   in an existing contact
3) Now open the above-created contact
4) Download the Vcard for that record

Error:- 
```
AttributeError: 'bool' object has no attribute 'replace'
```

As you can see name is only required when the type is 'contact'.
When the user creates a partner record without a name and tried to download the Vcard, it led to a traceback.

Because the name was used in the Vcard, which is false in this case. https://github.com/odoo/odoo/blob/6abe8da981e10f56eb50d07e8c53dcf97422f0c4/addons/web/models/res_partner.py#L30

**Note:-** 
Also in the below line, `/web_enterprise/partner/<model("res.partner"):partner>/vcard`
route was never used anywhere in the Odoo except in one test case.

which was also introduced from the same PR through which the above route was added.
Because `Vcard` was initially in `enterprise` and later shifted to `community`.

https://github.com/odoo/odoo/blob/6abe8da981e10f56eb50d07e8c53dcf97422f0c4/addons/web/controllers/vcard.py#L16-L17

This commit will resolve this issue by taking the `complete name` 
when the partner record failed to provide the name.

sentry-5673082917
