### PR TITLE
[FIX] point_of_sale: ensure optional products display from info popup

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.js
@@ -20,7 +20,7 @@ export class ProductInfoPopup extends AbstractAwaitablePopup {
     }
     searchProduct(productName) {
         this.pos.setSelectedCategoryId(0);
-        this.pos.searchProductWord = productName + ";product_tmpl_id:" + this.props.product.product_tmpl_id;
+        this.pos.searchProductWord = productName;
         this.cancel();
     }
     _hasMarginsCostsAccessRights() {

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.xml
@@ -104,7 +104,7 @@
                                         </div>
                                         <div class="d-flex flex-wrap gap-1">
                                             <t t-foreach="variant.values" t-as="attribute_value" t-key="attribute_value.name">
-                                                <span class="searchable btn btn-secondary" t-on-click="() => this.searchProduct(attribute_value.search)">
+                                                <span class="searchable btn btn-secondary" t-on-click="() => this.searchProduct(attribute_value.search + ';product_tmpl_id:' + props.product.product_tmpl_id)">
                                                     <t t-esc="attribute_value.name"/>
                                                 </span>
                                                 <t t-if="attribute_value_index lt variant.values.length - 1"> </t>


### PR DESCRIPTION
Prior to this commit, clicking on an optional product within the product info popup would fail to locate the optional product due to product template filtering applied to product variants. This commit resolves the issue by applying product template filtering exclusively for variants, ensuring optional products are correctly displayed from the product info popup.

opw-4097824

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
