### PR TITLE
[FIX] account: prevent error when duplicating multiple payments

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -935,14 +935,17 @@ class AccountPayment(models.Model):
         for payment in self:
             payment.display_name = payment.move_id.name if payment.move_id.name != '/' else _('Draft Payment')
 
-    def copy(self, default=None):
-        if not self.is_internal_transfer:
-            default = {
-                'journal_id': self.journal_id.id,
-                'payment_method_line_id': self.payment_method_line_id.id,
-                **(default or {}),
-            }
-        return super().copy(default=default)
+    def copy_data(self, default=None):
+        default = dict(default or {})
+        vals_list = super().copy_data(default)
+        for payment, vals in zip(self, vals_list):
+            if not payment.is_internal_transfer:
+                vals.update({
+                    'journal_id': payment.journal_id.id,
+                    'payment_method_line_id': payment.payment_method_line_id.id,
+                    **(vals or {}),
+                })
+        return vals_list
 
     # -------------------------------------------------------------------------
     # SYNCHRONIZATION account.payment <-> account.move

--- a/addons/account/tests/test_account_payment.py
+++ b/addons/account/tests/test_account_payment.py
@@ -1105,3 +1105,22 @@ class TestAccountPayment(AccountTestInvoicingCommon):
 
             payment.journal_id = default_journal
             self.assertEqual(payment.payment_method_line_id.journal_id.id, default_journal.id)
+
+    def test_payments_copy_data(self):
+        payment_1, payment_2 = self.env['account.payment'].create([
+            {
+                'partner_id': self.partner_a.id,
+                'amount': 50,
+            },
+            {
+                'partner_id': self.partner_b.id,
+                'amount': 100,
+            },
+        ])
+        duplicate_payment_1, duplicate_payment_2 = (payment_1 + payment_2).copy()
+
+        self.assertEqual(duplicate_payment_1.partner_id, payment_1.partner_id)
+        self.assertEqual(duplicate_payment_2.partner_id, payment_2.partner_id)
+
+        self.assertEqual(duplicate_payment_1.amount, payment_1.amount)
+        self.assertEqual(duplicate_payment_2.amount, payment_2.amount)


### PR DESCRIPTION
This Error occurs when a user tries to duplicate multiple payments from the 'Payments' list view.

Steps to reproduce:

- Install the 'account' module
- Go to Invoicing / Customers / Payments and create two payments.
- Come to the list view of 'Payments' and duplicate both of them.

Traceback:
```
ValueError: too many values to unpack (expected 1)
  File "odoo/models.py", line 5961, in ensure_one
    _id, = self._ids
ValueError: Expected singleton: account.payment(22, 11)
  File "odoo/http.py", line 2373, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1903, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1966, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1933, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2177, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 223, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 754, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 35, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 459, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/account/models/account_payment.py", line 939, in copy
    if not self.is_internal_transfer:
  File "odoo/fields.py", line 1204, in __get__
    record.ensure_one()
  File "odoo/models.py", line 5964, in ensure_one
    raise ValueError("Expected singleton: %s" % self)

```

An error occurs at [1], where the system receives multiple records in 'self' as duplicating of multiple payments.

link [1]:https://github.com/odoo/odoo/blob/5e28dcf717a7184f226773b3c84b409da24c1336/addons/account/models/account_payment.py#L939

To resolve this issue, Add a loop to copy multiple records one by one.

Sentry-5689633522

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
