### PR TITLE
[IMP] mail: can make chat windows bigger 

### DIFF
--- a/addons/mail/static/src/core/common/chat_hub.js
+++ b/addons/mail/static/src/core/common/chat_hub.js
@@ -8,6 +8,7 @@ import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { ChatBubble } from "./chat_bubble";
+import { _t } from "@web/core/l10n/translation";
 
 export class ChatHub extends Component {
     static components = { ChatBubble, ChatWindow, Dropdown };
@@ -53,6 +54,10 @@ export class ChatHub extends Component {
         this.chatHub.onRecompute();
     }
 
+    get chatSizeTransitionText() {
+        return this.chatHub.isBig ? _t("Make chats smaller") : _t("Make chats bigger");
+    }
+
     get compactCounter() {
         let counter = 0;
         const cws = this.chatHub.opened.concat(this.chatHub.folded);
@@ -60,6 +65,10 @@ export class ChatHub extends Component {
             counter += chatWindow.thread.importantCounter > 0 ? 1 : 0;
         }
         return counter;
+    }
+
+    toggleChatSize() {
+        this.chatHub.isBig = !this.chatHub.isBig;
     }
 
     get hiddenCounter() {

--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -5,7 +5,7 @@
     <div class="o-mail-ChatHub" t-if="isShown or ui.isSmall">
         <t t-if="!store.chatHub.compact">
             <t t-foreach="chatHub.actuallyOpened" t-as="cw" t-key="cw.localId">
-                <ChatWindow chatWindow="cw" right="env.embedLivechat ? chatHub.WINDOW_GAP : (chatHub.BUBBLE_START + chatHub.BUBBLE + (chatHub.BUBBLE_OUTER*2) + (chatHub.actuallyOpened.length - cw_index - 1) * (chatHub.WINDOW + chatHub.WINDOW_INBETWEEN * 2))"/>
+                <ChatWindow chatWindow="cw" right="env.embedLivechat ? chatHub.WINDOW_GAP : (chatHub.BUBBLE_START + chatHub.BUBBLE + (chatHub.BUBBLE_OUTER*2) + (chatHub.actuallyOpened.length - cw_index - 1) * ((chatHub.isBig ? chatHub.WINDOW_LARGE : chatHub.WINDOW) + chatHub.WINDOW_INBETWEEN * 2))"/>
             </t>
         </t>
         <div t-if="isShown" class="o-mail-ChatHub-bubbles position-fixed end-0 d-flex flex-column align-content-start justify-content-end align-items-center" t-att-class="{ 'bottom-0': !store.chatHub.compact or compactPosition.top === 'auto' }" t-ref="bubbles" t-att-style="store.chatHub.compact ? `top: ${ compactPosition.top }; left: ${ compactPosition.left };` : ''">
@@ -15,10 +15,11 @@
                 </t>
                 <t t-else="">
                     <Dropdown t-if="(chatHub.opened.length + chatHub.folded.length) gt 0" state="options" position="'top-end'" menuClass="'o-mail-ChatHub-optionsMenu o-mail-ChatHub-menu d-flex flex-column bg-view shadow-sm m-0 p-0 mb-1'">
-                        <button class="o-mail-ChatHub-bubbleBtn btn o-mail-ChatHub-optionsBtn fa fa-ellipsis-h bg-view mt-1" t-att-class="{ 'opacity-0': !bubblesHover.isHover and !options.isOpen, 'o-active': bubblesHover.isHover or options.isOpen }" aria-label="Chat Hub Options"/>
+                        <button class="o-mail-ChatHub-bubbleBtn btn o-mail-ChatHub-optionsBtn fa fa-ellipsis-h bg-view mt-1" t-att-class="{ 'opacity-0': !bubblesHover.isHover and !options.isOpen, 'o-active': bubblesHover.isHover or options.isOpen }" title="Chat Options"/>
                         <t t-set-slot="content">
-                            <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.closeAll()"><i class="oi fa-fw oi-close"></i>Close all conversations</button>
-                            <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.compact = true"><i class="fa fa-fw fa-eye-slash"></i>Hide all conversations</button>
+                            <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center rounded-0 fw-normal" t-on-click="() => this.toggleChatSize()"><div class="form-check form-switch m-0 smaller" style="min-height: auto;"><input class="form-check-input" type="checkbox" role="switch" t-att-checked="this.chatHub.isBig ? 'checked' : ''" t-att-title="chatSizeTransitionText"/></div> <span>Large windows</span></button>
+                            <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.compact = true"><i class="fa fa-fw fa-eye-slash ms-1"></i>Hide all conversations</button>
+                            <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.closeAll()"><i class="oi fa-fw oi-close ms-1"></i>Close all conversations</button>
                         </t>
                     </Dropdown>
                     <t t-foreach="chatHub.actuallyFolded" t-as="cw" t-key="cw.localId">

--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -14,8 +14,8 @@
                     <t t-call="mail.ChatHub.compactButton"/>
                 </t>
                 <t t-else="">
-                    <Dropdown t-if="chatHub.actuallyFolded.length gt 1" state="options" position="'top-end'" menuClass="'o-mail-ChatHub-optionsMenu o-mail-ChatHub-menu d-flex flex-column bg-view shadow-sm m-0 p-0 mb-1'">
-                        <button class="o-mail-ChatHub-bubbleBtn btn o-mail-ChatHub-optionsBtn fa fa-ellipsis-h bg-view mt-1" t-att-class="{ 'opacity-0': !chatHub.actuallyFolded.length or !bubblesHover.isHover and !options.isOpen, 'o-active': bubblesHover.isHover or options.isOpen }" aria-label="Chat Hub Options"/>
+                    <Dropdown t-if="(chatHub.opened.length + chatHub.folded.length) gt 0" state="options" position="'top-end'" menuClass="'o-mail-ChatHub-optionsMenu o-mail-ChatHub-menu d-flex flex-column bg-view shadow-sm m-0 p-0 mb-1'">
+                        <button class="o-mail-ChatHub-bubbleBtn btn o-mail-ChatHub-optionsBtn fa fa-ellipsis-h bg-view mt-1" t-att-class="{ 'opacity-0': !bubblesHover.isHover and !options.isOpen, 'o-active': bubblesHover.isHover or options.isOpen }" aria-label="Chat Hub Options"/>
                         <t t-set-slot="content">
                             <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.closeAll()"><i class="oi fa-fw oi-close"></i>Close all conversations</button>
                             <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.compact = true"><i class="fa fa-fw fa-eye-slash"></i>Hide all conversations</button>

--- a/addons/mail/static/src/core/common/chat_hub_model.js
+++ b/addons/mail/static/src/core/common/chat_hub_model.js
@@ -9,6 +9,7 @@ export class ChatHub extends Record {
     WINDOW_GAP = 10; // for a single end, multiply by 2 for left and right together.
     WINDOW_INBETWEEN = 5;
     WINDOW = 360; // same value as $o-mail-ChatWindow-width
+    WINDOW_LARGE = 510; // same value as $o-mail-ChatWindow-widthLarge
 
     /** @returns {import("models").ChatHub} */
     static get(data) {
@@ -18,7 +19,22 @@ export class ChatHub extends Record {
     static insert(data) {
         return super.insert(...arguments);
     }
-
+    isBig = Record.attr(false, {
+        compute() {
+            return browser.localStorage.getItem("mail.user_setting.chat_window_big") === "true";
+        },
+        onUpdate() {
+            /** @this {import("models").ChatHub} */
+            if (this.isBig) {
+                browser.localStorage.setItem(
+                    "mail.user_setting.chat_window_big",
+                    this.isBig.toString()
+                );
+            } else {
+                browser.localStorage.removeItem("mail.user_setting.chat_window_big");
+            }
+        },
+    });
     compact = false;
     /** From left to right. Right-most will actually be folded */
     opened = Record.many("ChatWindow", {
@@ -78,7 +94,9 @@ export class ChatHub extends Record {
         const available = browser.innerWidth - startGap - endGap - chatBubblesWidth;
         const maxAmountWithoutHidden = Math.max(
             1,
-            Math.floor(available / (this.WINDOW + this.WINDOW_INBETWEEN))
+            Math.floor(
+                available / ((this.isBig ? this.WINDOW_LARGE : this.WINDOW) + this.WINDOW_INBETWEEN)
+            )
         );
         return maxAmountWithoutHidden;
     }

--- a/addons/mail/static/src/core/common/chat_window.scss
+++ b/addons/mail/static/src/core/common/chat_window.scss
@@ -1,6 +1,12 @@
 .o-mail-ChatWindow {
     height: 480px;
     width: $o-mail-ChatWindow-width;
+
+    &.o-large {
+        height: 680px;
+        width: $o-mail-ChatWindow-widthLarge;
+    }
+
     z-index: 999; // messaging menu is dropdown (1000)
     &.o-mobile {
         z-index: 1001; // above messaging menu (chat window takes whole screen)

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -8,6 +8,7 @@
             'w-100 h-100 o-mobile': ui.isSmall,
             'o-folded': props.chatWindow.folded,
             'rounded-top-3': !ui.isSmall,
+            'o-large': store.chatHub.isBig,
         }"
         t-on-keydown="onKeydown"
         tabindex="1"

--- a/addons/mail/static/src/core/common/primary_variables.scss
+++ b/addons/mail/static/src/core/common/primary_variables.scss
@@ -1,6 +1,7 @@
 $o-mail-Avatar-size: 36px !default;
 $o-mail-Avatar-sizeSmall: 24px !default;
 $o-mail-ChatWindow-width: 360px !default; // same value as WINDOW
+$o-mail-ChatWindow-widthLarge: 510px !default; // same value as WINDOW_LARGE
 $o-mail-ChatHub-bubblesWidth: 56px !default; // same value as BUBBLE
 $o-mail-ChatHub-bubblesMargin: 10px !default; // same value as BUBBLE_OUTER
 $o-mail-ChatHub-bubblesStart: 15px !default; // same value as BUBBLE_START

--- a/addons/mail/static/src/core/public_web/discuss_app_model.js
+++ b/addons/mail/static/src/core/public_web/discuss_app_model.js
@@ -1,5 +1,4 @@
 import { Record } from "@mail/core/common/record";
-import { onChange } from "@mail/utils/common/misc";
 import { browser } from "@web/core/browser/browser";
 import { _t } from "@web/core/l10n/translation";
 
@@ -33,19 +32,6 @@ export class DiscussApp extends Record {
                 addHotkey: "d",
             },
         });
-        const isDiscussSidebarCompact =
-            browser.localStorage.getItem("mail.user_setting.discuss_sidebar_compact") === "true";
-        res.isSidebarCompact = isDiscussSidebarCompact;
-        onChange(res, "isSidebarCompact", () => {
-            if (res.isSidebarCompact) {
-                browser.localStorage.setItem(
-                    "mail.user_setting.discuss_sidebar_compact",
-                    res.isSidebarCompact.toString()
-                );
-            } else {
-                browser.localStorage.removeItem("mail.user_setting.discuss_sidebar_compact");
-            }
-        });
         return res;
     }
     /** @returns {import("models").DiscussApp} */
@@ -61,7 +47,24 @@ export class DiscussApp extends Record {
     activeTab = "main";
     searchTerm = "";
     isActive = false;
-    isSidebarCompact = false;
+    isSidebarCompact = Record.attr(false, {
+        compute() {
+            return (
+                browser.localStorage.getItem("mail.user_setting.discuss_sidebar_compact") === "true"
+            );
+        },
+        /** @this {import("models").DiscussApp} */
+        onUpdate() {
+            if (this.isSidebarCompact) {
+                browser.localStorage.setItem(
+                    "mail.user_setting.discuss_sidebar_compact",
+                    this.isSidebarCompact.toString()
+                );
+            } else {
+                browser.localStorage.removeItem("mail.user_setting.discuss_sidebar_compact");
+            }
+        },
+    });
     allCategories = Record.many("DiscussAppCategory", {
         inverse: "app",
         sort: (c1, c2) =>

--- a/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
+++ b/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
@@ -325,7 +325,7 @@ test("Can close all chat windows at once", async () => {
     await contains(".o-mail-ChatBubble", { count: 8 }); // max reached
     await contains(".o-mail-ChatBubble", { text: "+13" });
     await hover(".o-mail-ChatHub-hiddenBtn");
-    await click("button.fa.fa-ellipsis-h[aria-label='Chat Hub Options']");
+    await click("button.fa.fa-ellipsis-h[title='Chat Options']");
     await click("button.o-mail-ChatHub-option", { text: "Close all conversations" });
     await contains(".o-mail-ChatBubble", { count: 0 });
 });
@@ -345,7 +345,7 @@ test("Can compact chat hub", async () => {
     await contains(".o-mail-ChatBubble", { count: 8 }); // max reached
     await contains(".o-mail-ChatBubble", { text: "+13" });
     await hover(".o-mail-ChatHub-hiddenBtn");
-    await click("button.fa.fa-ellipsis-h[aria-label='Chat Hub Options']");
+    await click("button.fa.fa-ellipsis-h[title='Chat Options']");
     await click("button.o-mail-ChatHub-option", { text: "Hide all conversations" });
     await contains(".o-mail-ChatBubble i.fa.fa-commenting");
     await click(".o-mail-ChatBubble i.fa.fa-commenting");


### PR DESCRIPTION
With this commit, chat windows can be resized to be bigger.

By default, they keep the same size. In chat hub bubble zone, where the folded chat windows are, the options button "..." at the top now has a new togglable option "Large windows". Enabling it increases width and height of open chat windows as follow:

 small  chat windows:  360px width, 480px height
 bigger chat windows: 510px width, 680px height

Task-4103405

![bigger-chat-windows](https://github.com/user-attachments/assets/42f256a1-7bbd-46ba-ba85-f5984b12d301)
