### PR TITLE
[FIX] web: exclude selected values from ManyToMany dropdown

### DIFF
--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
@@ -194,8 +194,12 @@ export class Many2ManyTagsField extends Component {
     }
 
     getDomain() {
+        const currentIds = this.props.record.data[this.props.name].currentIds.filter(
+            (id) => typeof id === "number"
+        );
         return Domain.and([
             getFieldDomain(this.props.record, this.props.name, this.props.domain),
+            Domain.not([["id", "in", currentIds]]),
         ]).toList(this.props.context);
     }
 }


### PR DESCRIPTION
Problem:
When opening the autocomplete dropdown for tags (or any other ManyToMany field), the currently selected values are not excluded from the dropdown list. This leads to redundancy, as the user still see and select values that have already been chosen.

Steps to reproduce:
- Open any app that has a ManyToMany field (e.g., the tags field in Project/Task).
- Select a value from the dropdown.
- Open the dropdown again.
- Observe that the selected value is still present in the list.

This fix ensures that selected values are excluded from the autocomplete dropdown, providing a clearer and more intuitive user experience.

opw-4102363

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
