### PR TITLE
[FIX] project: remove access token when privacy is changed

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -542,6 +542,11 @@ class Project(models.Model):
         return project
 
     def write(self, vals):
+        if 'access_token' in vals and vals['access_token'] != '':
+            self.ensure_one()  # We are not supposed to add a single access token to multiple project
+            if self.privacy_visibility != 'portal':
+                vals['access_token'] = ''
+
         # directly compute is_favorite to dodge allow write access right
         if 'is_favorite' in vals:
             vals.pop('is_favorite')
@@ -882,6 +887,7 @@ class Project(models.Model):
             portal_users = project.message_partner_ids.user_ids.filtered('share')
             project.message_unsubscribe(partner_ids=portal_users.partner_id.ids)
             project.mapped('tasks')._change_project_privacy_visibility()
+            project.access_token = ''
 
     # ---------------------------------------------------
     # Project sharing


### PR DESCRIPTION
Previously, it was still possible to access a project with an access_token even if that project is no longer in privacy="portal".

This was not consistant with the front-end that disable the access to the portal share wizard when privacy is set to anything else than 'portal'.

This change remove the token when the privacy is changed at the time of the write()

This change is done in the project module because it depends on "portal", and not the other way around.

This change can also be used as an invalidation mecanism in case of a token leak. Changing the privacy to
'private' then to 'portal' will allow for an invalidation of the previous token and the creation of new one.

opw-4104804
