### PR TITLE
[FIX] web_editor: placeholder loop when removing image

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -625,12 +625,15 @@ export const editorCommands = {
             !descendants(block).some(descendant => selectedBlocks.includes(descendant))
         ));
         for (const node of deepestSelectedBlocks) {
-            if (node.nodeType === Node.TEXT_NODE && isWhitespace(node) && closestElement(node).isContentEditable) {
+            let nodeToToggle = closestBlock(node);
+            if (
+                ![...paragraphRelatedElements, 'LI'].includes(nodeToToggle.nodeName) &&
+                node.nodeType === Node.TEXT_NODE && isWhitespace(node) && closestElement(node).isContentEditable
+            ) {
                 node.remove();
             } else {
                 // Ensure nav-item lists are excluded from toggling
                 const isNavItemList = node => node.nodeName === 'LI' && node.classList.contains('nav-item');
-                let nodeToToggle = closestBlock(node);
                 nodeToToggle = isNavItemList(nodeToToggle) ? node : nodeToToggle;
                 if (!['OL', 'UL'].includes(nodeToToggle.tagName) && (nodeToToggle.isContentEditable || nodeToToggle.nodeType === Node.TEXT_NODE)) {
                     const closestLi = closestElement(nodeToToggle, 'li');

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -896,12 +896,7 @@ export function getSelectedNodes(editable) {
  */
 export function getDeepRange(editable, { range, sel, splitText, select, correctTripleClick } = {}) {
     sel = sel || editable.parentElement && editable.ownerDocument.getSelection();
-    if (
-        sel &&
-        sel.isCollapsed &&
-        sel.anchorNode &&
-        (sel.anchorNode.nodeName === "BR" || (sel.anchorNode.nodeType === Node.TEXT_NODE && sel.anchorNode.textContent === ''))
-    ) {
+    if (sel && sel.isCollapsed && sel.anchorNode && sel.anchorNode.nodeName === "BR") {
         setSelection(sel.anchorNode.parentElement, childNodeIndex(sel.anchorNode));
     }
     range = range ? range.cloneRange() : sel && sel.rangeCount && sel.getRangeAt(0).cloneRange();


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Commit [1] fixed a bug where selecting across two paragraphs separated by
whitespace resulted in multiple indented lists. However, this fix introduced
a new issue: if a first child of block node was whitespace followed by a `<br>`,
the list was not created on the first attempt. Instead, only the whitespace was
removed, and the list was created on the second attempt.

Commit [2] addressed this issue but introduced a new problem: if a block node had
whitespace as its first child, the placeholder for that block would enter an
infinite loop, causing the page to become unresponsive.

This commit reverts the changes made in Commit [2] and introduces a new approach
that resolves the list creation issue when a block node had whitespace as its
first child, without causing the placeholder to get stuck in a loop.

[1]: https://github.com/odoo-dev/odoo-editor/commit/58a7fadcaaaa7322c6177276ddc22b62da96d1f5
[2]: https://github.com/odoo/odoo/commit/1e982dab025fb86e759b249433f41619a442b5cf

task-4082867

