### PR TITLE
[FIX] stock: display the quantity of quants in "grouped by" list views

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -312,6 +312,15 @@ class StockQuant(models.Model):
         """ Only allowed fields should be modified """
         return super(StockQuant, self.with_context(inventory_mode=True))._load_records_write(values)
 
+    @api.model
+    def read_group(self, domain, fields, groupby, offset=0, limit=None, orderby=False, lazy=True):
+        """
+        Override to display the inventory_quantity_auto_apply:sum in group by of the list view
+        """
+        if 'inventory_quantity_auto_apply' in fields and 'quantity' not in fields:
+            fields.append('inventory_quantity_auto_apply:sum')
+        return super().read_group(domain, fields, groupby, offset=offset, limit=limit, orderby=orderby, lazy=lazy)
+
     def _read_group_select(self, aggregate_spec, query):
         if aggregate_spec == 'inventory_quantity:sum' and self.env.context.get('inventory_report_mode'):
             return SQL("NULL"), []

--- a/addons/stock/tests/test_quant_inventory_mode.py
+++ b/addons/stock/tests/test_quant_inventory_mode.py
@@ -327,3 +327,36 @@ class TestEditableQuant(TransactionCase):
         self.assertEqual(len(move_lines), 2, "Two inventory adjustment move lines should have been created")
         move_lines.action_revert_inventory()
         self.assertEqual(self.product.qty_available, 0, "After revert multi inventory adjustment qty is not zero")
+
+    def test_group_quants(self):
+        """
+        Check that the `inventory_quantity_auto_apply` is read in read_group even
+        if it is not stored.
+        """
+        self.Quant.create([
+            {
+            'product_id': self.product.id,
+            'location_id': self.env.ref('stock.warehouse0').lot_stock_id.id,
+            'quantity': 100,
+            },
+            {
+            'product_id': self.product2.id,
+            'location_id': self.env.ref('stock.warehouse0').lot_stock_id.id,
+            'quantity': 50,
+            },
+        ])
+        fields = [
+            "product_id",
+            "inventory_quantity_auto_apply",
+            "reserved_quantity",
+        ]
+        context = {
+            "inventory_mode": True,
+            "inventory_report_mode": True
+        }
+        groupby = ['product_id']
+        groups = self.Quant.with_context(**context).read_group(domain=[('product_id', 'in', (self.product.id, self.product2.id))], fields=fields, groupby=groupby, limit=2)
+        group1 = next(filter(lambda g: g['product_id'][0] == self.product.id, groups))
+        self.assertEqual(group1['inventory_quantity_auto_apply'], 100)
+        group2 = next(filter(lambda g: g['product_id'][0] == self.product2.id, groups))
+        self.assertEqual(group2['inventory_quantity_auto_apply'], 50)


### PR DESCRIPTION
### Steps to reproduce:

- Enable multi-steps route in the settings
- Go to Inventory > Reporting > Locations
- Group the records by "product"

#### > the On hand quantity is only displayed on the records of each group

### Cause of the issue:

The `inventory_quantity_auto_apply` field of the `stock.quant` model is a non-stored computed fields. As such, even if this line: https://github.com/odoo/odoo/blob/7a80215435f98a771065ba41310ac643aeffdaf5/addons/stock/views/stock_quant_views.xml#L147 tries to add its sum to the list view of quants, the `inventory_quantity_auto_apply:sum` will not be present in the `fields` of the `read_group` nor will be added to the `aggregates` of the `_read_group` by these lines:
https://github.com/odoo/odoo/blob/7a80215435f98a771065ba41310ac643aeffdaf5/odoo/models.py#L2711-L2713 Prior to 17.0, this `inventory field` was rather treated by an override of the `read_group` in the `stock_quant` model.
https://github.com/odoo/odoo/blob/3d3155e94ec886e2fdc9a635c4732e8e56179db1/addons/stock/models/stock_quant.py#L309-L312 In 17.0, in commit 687d0ed, this override was replaced by an override of the `_read_group_select` which, to work properly, expects the `inventory_quantity_auto_apply:sum` to appear in the aggregates of the `_read_group` to be called by the `_read_group_select`. Since issue appears, because it is not the case.

### Note:

The issue is only reproducible in 17.0 and saas-17.1 since after saas-17.2 (included), the `inventory_quantity_auto_apply:sum` will appear in the fields of the the `read_group` and hence in the aggregates of the `_read_group`.

opw-4073708
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
