### PR TITLE
[FIX] website_links: fix creation of new campaigns from UI

### DIFF
--- a/addons/website_links/static/src/js/website_links.js
+++ b/addons/website_links/static/src/js/website_links.js
@@ -133,7 +133,7 @@ var SelectBox = publicWidget.Widget.extend({
      * @param {String} name
      */
     _createObject: function (name) {
-        return this.orm.call("utm.mixin", "find_or_create_record", [[], this.obj, name]).then(record => {
+        return this.orm.call("utm.mixin", "find_or_create_record", [this.obj, name]).then(record => {
             this.$el.attr('value', record);
         });
     },

--- a/addons/website_links/static/tests/tours/website_links.js
+++ b/addons/website_links/static/tests/tours/website_links.js
@@ -49,6 +49,28 @@ registry.category("web_tour.tours").add('website_links_tour', {
                 document.querySelector("#o_website_links_link_tracker_form input#url").value = url;
             },
         },
+        // First try to create a new UTM campaign from the UI
+        {
+            content: "Click select2 form item",
+            trigger: ".o_website_links_utm_forms div.select2-container#s2id_campaign-select > .select2-choice",
+            run: "click",
+        },
+        {
+            content: "Enter select2 search query",
+            trigger: '.select2-drop .select2-input',
+            run: "edit Some new campaign",
+        },
+        {
+            content: "Select found select2 item",
+            trigger: ".select2-drop li:only-child div:contains(Create ') .select2-match:contains(/^Some new campaign$/)",
+            run: "click",
+        },
+        {
+            content: "Check that select2 is properly filled",
+            trigger: ".o_website_links_utm_forms div.select2-container#s2id_campaign-select .select2-chosen:contains(/^Create 'Some new campaign'$/)",
+            run: () => null,
+        },
+        // Then proceed by using existing ones
         ...fillSelect2('campaign-select', campaignValue),
         ...fillSelect2('channel-select', mediumValue),
         ...fillSelect2('source-select', sourceValue),


### PR DESCRIPTION
When accessing to the link tracker, it is possible to create a new UTM campaign, medium or source from the dropdown lists.

However, since f6e82bcce466e, instead of calling create on the object, we call a new method find_or_create_record defined by the UTM Mixin.

This method accepts two arguments model_name and name, but we were providing three from the JavaScript call. Unfortunately, this was not covered by a test, so the error hasn't been noticed before now.

With this commit, we fix the JS call and add a few steps to the tour to check that the creation happens well.