### PR TITLE
[FIX] l10n_in_ewaybill_stock: fix traceback on generating ewaybill

### DIFF
--- a/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
@@ -427,6 +427,8 @@ class Ewaybill(models.Model):
         """
             This method is used to convert date from Indian timezone to UTC
         """
+        if not str_date:
+            return False
         try:
             local_time = datetime.strptime(str_date, time_format)
         except ValueError:


### PR DESCRIPTION
Before this commit:
While generating an ewaybill we get the following traceback:
```log
  File "/home/odoo/odoo/community/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py", line 418, in _generate_ewaybill_direct
    'ewaybill_expiry_date': self._indian_timezone_to_odoo_utc(
  File "/home/odoo/odoo/community/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py", line 433, in _indian_timezone_to_odoo_utc
    local_time = datetime.strptime(str_date, time_format)
TypeError: strptime() argument 1 must be str, not None
```

After this commit:
We resolve the traceback it was caused due to
string to datetime conversion because we were
receving `None` value instead of datetime string

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
