### PR TITLE
[FIX] mail: add menu_id and view_id to URL if present

### DIFF
--- a/addons/mail/controllers/mail.py
+++ b/addons/mail/controllers/mail.py
@@ -125,12 +125,16 @@ class MailController(http.Controller):
         elif not record_action['type'] == 'ir.actions.act_window':
             return cls._redirect_to_messaging()
 
+        url_params = {}
         menu_id = request.env['ir.ui.menu']._get_best_backend_root_menu_id_for_model(model)
+        if menu_id:
+            url_params['menu_id'] = menu_id
         view_id = record_sudo.get_formview_id()
+        if view_id:
+            url_params['view_id'] = view_id
         if cids:
             request.future_response.set_cookie('cids', '-'.join([str(cid) for cid in cids]))
-        params = url_encode({'menu_id': menu_id, 'view_id': view_id})
-        url = f'/odoo/{model}/{res_id}?{params}'
+        url = f'/odoo/{model}/{res_id}?{url_encode(url_params)}'
         return request.redirect(url)
 
     @http.route('/mail/view', type='http', auth='public')


### PR DESCRIPTION
Before this commit, a traceback would occur if menu_id 
or view_id was not present, because the URL contained 
view_id=False or menu_id=False.

After this commit, menu_id or view_id will be added to 
the URL only if they exist.

Related to: Task-3820230

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
