### PR TITLE
[FIX] stock,mrp: scrap kit

### DIFF
--- a/addons/stock/models/stock_scrap.py
+++ b/addons/stock/models/stock_scrap.py
@@ -118,7 +118,6 @@ class StockScrap(models.Model):
             'product_id': self.product_id.id,
             'product_uom': self.product_uom_id.id,
             'state': 'draft',
-            'product_uom_qty': self.scrap_qty,
             'location_id': self.location_id.id,
             'scrapped': True,
             'scrap_id': self.id,
@@ -140,6 +139,7 @@ class StockScrap(models.Model):
 
     def do_scrap(self):
         self._check_company()
+        self = self.with_context(clean_context(self.env.context))
         for scrap in self:
             scrap.name = self.env['ir.sequence'].next_by_code('stock.scrap') or _('New')
             move = self.env['stock.move'].create(scrap._prepare_move_values())


### PR DESCRIPTION
When scrapping a kit, it leads to incorrect behaviours

**Case 01:**
1. Create a storable kit with one storable component
2. Validate a scrap order with that kit
3. Open the product moves

Error: we moved the kit instead of its component

We first create a draft SM with its SML:
https://github.com/odoo/odoo/blob/72c4a2352c1184f5e8c1f238d29eb94e37d01115/addons/stock/models/stock_scrap.py#L145
https://github.com/odoo/odoo/blob/72c4a2352c1184f5e8c1f238d29eb94e37d01115/addons/stock/models/stock_scrap.py#L112

During the SML creation, we check if we should recompute the state
of the SM:
https://github.com/odoo/odoo/blob/dc0917d2a55a12e5c30d413a46e2c16190fd8a08/addons/stock/models/stock_move_line.py#L344-L355
`reservation` is `True`, the SML has a quantity -> we recompute the
state of the SM -> it is now assigned
Back to the scrap, we now `_action_done` the kit SM
https://github.com/odoo/odoo/blob/72c4a2352c1184f5e8c1f238d29eb94e37d01115/addons/stock/models/stock_scrap.py#L147
which leads to
https://github.com/odoo/odoo/blob/6ed0d0ca2f90fef8cd020380b194498a9363267c/addons/stock/models/stock_move.py#L1827-L1830
Here is the problem: the SM has a demand, its state is not draft
-> we don't confirm it
-> we don't explode it
Hence the error. This is the reason why the commit stops providing
the scrap SM with an initial demand. That way, we will explode the
SM and everything will work as expected

**Case 02:**
1. Create a consumable kit with one storable component
2. Validate a scrap order with that kit

Error: a server error is raised "Missing record [...]"

This time, `reservation` is `False` (the diff comes from the kit
type, consu vs stor, c.f. `_should_bypass_reservation`). Therefore,
we explode it. Since we are in scrap mode, we generate SM with a
zero demand:
https://github.com/odoo/odoo/blob/68f981d2a690addf0b70ddab498b556986752e49/addons/mrp/models/stock_move.py#L464-L466
https://github.com/odoo/odoo/blob/68f981d2a690addf0b70ddab498b556986752e49/addons/mrp/models/stock_move.py#L527
Back to `_action_done`, we create the extra moves if needed:
https://github.com/odoo/odoo/blob/6ed0d0ca2f90fef8cd020380b194498a9363267c/addons/stock/models/stock_move.py#L1847-L1853
Here, our component SM has a done qty greater than its demand
(reminder: it demand is zero), so we will create the extra move,
confirm it and merge it with the initial one:
https://github.com/odoo/odoo/blob/6ed0d0ca2f90fef8cd020380b194498a9363267c/addons/stock/models/stock_move.py#L1799-L1802
Buuuuut... Step 2 in the use case, we validate the scrap order.
Since we don't have such product on hand, we trigger a wizard with
some default values:
https://github.com/odoo/odoo/blob/72c4a2352c1184f5e8c1f238d29eb94e37d01115/addons/stock/models/stock_scrap.py#L204-L219
And... Now you see where I'm going: when we create the extra move,
we still have these default values in the context -> the extra move
has a demand and(!) a done qty to 1. We merge it with the initial
move: we are now scrapping a component with a demand equal to one
and a done qty equal to 2. It will later lead to other
inconsistencies (among them, the server error raised)

opw-4090951