### PR TITLE
[FIX] sale: price tax rounding with global rounding

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1157,7 +1157,7 @@ class AccountTax(models.Model):
         for grouping_key, tax_values in global_tax_details['tax_details'].items():
             if tax_values['currency_id']:
                 currency = self.env['res.currency'].browse(tax_values['currency_id'])
-                tax_amount = currency.round(tax_values['tax_amount'])
+                tax_amount = currency.round(tax_values['tax_amount_currency'])
                 res['totals'][currency]['amount_tax'] += tax_amount
 
             if grouping_key in existing_tax_line_map:

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -797,3 +797,51 @@ class TestSalesTeam(SaleCommon):
         self.env.flush_all()
         self.assertEqual(so.amount_tax, 12.36)
         self.assertEqual(so.amount_total, 135.96)
+
+    def test_recompute_taxes_rounded_globally_currency_precision(self):
+        '''
+        Check that taxes computation are made in the currency of the company
+        configured on the SO lines.
+        '''
+        # create a currency with no decimal
+        currency_b = self.env['res.currency'].create({
+            'name': 'B',
+            'symbol': 'B',
+            'rounding': 1.000000,
+        })
+        # create a company with currency_b as currency
+        company_b = self.env['res.company'].create({
+            'name': 'Company B',
+            'tax_calculation_rounding_method': 'round_globally',
+            'currency_id': currency_b.id,
+        })
+        # set company_b as default company of current user
+        self.env.user.company_id = company_b
+
+        pricelist_b = self.env['product.pricelist'].with_company(company_b).create({
+            'name': 'pricelist b',
+            'currency_id': self.env.ref('base.USD').id,
+        })
+        tax = self.env['account.tax'].create({
+            'name': 'Tax A',
+            'amount': 19,
+            'company_id': company_b.id,
+            'country_id': self.env.ref('base.us').id,
+        })
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'company_id': company_b.id,
+            'pricelist_id': pricelist_b.id,
+            'order_line': [
+                Command.create({
+                    'product_id': self.product.id,
+                    'product_uom_qty': 1,
+                    'price_unit': 15.31,
+                    'tax_id': tax.ids,
+                }),
+            ],
+        })
+        self.assertEqual(so.amount_tax, 2.91)
+        self.assertEqual(so.amount_total, 18.22)
+        self.assertEqual(so.order_line.price_tax, 2.91)
+        self.assertEqual(so.order_line.price_total, 18.22)


### PR DESCRIPTION
Enable global rounding
Have a company currency with 0 decimal precision digits
Have a foreign currency with 2 decimal precision digits
Create a Pricelist for the foreign currency
Create a Sale Order
Set the foreign currency pricelist
Add an order line with price 15.31 and 19% tax (not included)

Issue: system will compute a price tax of 3.00, price total of the line
will be 18.31
Order total is correct (18.22)

This occurs because, when `_compute_taxes` aggregates results
https://github.com/odoo/odoo/blob/0e1e7bf9c96b8fe4a06dfe3f858a837a8fdf386d/addons/account/models/account_tax.py#L1159-L1162
it will consider a tax amount that, in global rounding,
is rounded according to company currency, that does not have the same
precision settings
https://github.com/odoo/odoo/blob/0e1e7bf9c96b8fe4a06dfe3f858a837a8fdf386d/addons/account/models/account_tax.py#L1011-L1014

A solution is to directly call `_compute_taxes_for_single_line` is order
to get the raw results for the single line

opw-4050736