### PR TITLE
[IMP] website: implement form fields validations

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/form.js
+++ b/addons/website/static/src/snippets/s_website_form/form.js
@@ -737,9 +737,15 @@ export class Form extends Interaction {
                 return value.name === "";
         }
 
-        const format = value.includes(":")
-            ? localization.dateTimeFormat
-            : localization.dateFormat;
+        let format = "";
+        const currentDate = new Date();
+        const xYearAgo = new Date();
+        if (value.includes(":")) {
+            format = localization.dateTimeFormat;
+        } else {
+            format = localization.dateFormat;
+            xYearAgo.setHours(0, 0, 0, 0);
+        }
         // Date & Date Time comparison requires formatting the value
         const dateTime = DateTime.fromFormat(value, format);
         // If invalid, any value other than "NaN" would cause certain
@@ -765,6 +771,10 @@ export class Form extends Interaction {
                 return !(value >= comparable && value <= between);
             case "equal or after":
                 return value >= comparable;
+            case "lessyears":
+                xYearAgo.setFullYear(currentDate.getFullYear() - comparable);
+                value = new Date(value * 1000);
+                return value > xYearAgo;
         }
     }
 

--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -1400,10 +1400,10 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
                 && ['between', '!between'].includes(this.$target[0].dataset.visibilityComparator);
             case 'hidden_condition_additional_datetime':
                 return dependencyEl?.closest(".s_website_form_datetime")
-                && !['set', '!set'].includes(this.$target[0].dataset.visibilityComparator);
+                && !['set', '!set', "lessyears"].includes(this.$target[0].dataset.visibilityComparator);
             case 'hidden_condition_additional_date':
                 return dependencyEl && dependencyEl?.closest(".s_website_form_date")
-                && !['set', '!set'].includes(this.$target[0].dataset.visibilityComparator);
+                && !['set', '!set', "lessyears"].includes(this.$target[0].dataset.visibilityComparator);
             case 'hidden_condition_additional_text':
                 if (!this.$target[0].classList.contains('s_website_form_field_hidden_if') ||
                 (dependencyEl && (['checkbox', 'radio'].includes(dependencyEl.type) || dependencyEl.nodeName === 'SELECT'))) {
@@ -1413,7 +1413,7 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
                     return true;
                 }
                 if (dependencyEl?.classList.contains("datetimepicker-input")) {
-                    return false;
+                    return this.$target[0].dataset.visibilityComparator === "lessyears";
                 }
                 return (['text', 'email', 'tel', 'url', 'search', 'password', 'number'].includes(dependencyEl.type)
                     || dependencyEl.nodeName === 'TEXTAREA') && !['set', '!set'].includes(this.$target[0].dataset.visibilityComparator);

--- a/addons/website/static/src/xml/website_form.xml
+++ b/addons/website/static/src/xml/website_form.xml
@@ -16,6 +16,13 @@
         </span>
     </t>
 
+    <t t-name="website.s_website_form_status_custom_error">
+        <span class="s_website_form_custom_error me-2 small text-danger">
+            <i class="fa fa-close me-1" role="img" aria-hidden="true" title="Error"/>
+            <t t-out="message"/>
+        </span>
+    </t>
+
     <!-- A block containing the file name and a cross to delete the file. -->
     <t t-name="website.file_block">
         <div class="o_file_block col-4">

--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -237,6 +237,74 @@
                 data-apply-to="input[type='file']"
                 data-unit="MB"/>
 
+            <we-row data-name="require_condition_opt" string="Requirement">
+                <we-select data-name="require_condition_text_opt" data-attribute-name="requirementComparator" data-no-preview="true">
+                    <!-- str comparator possibilities -->
+                    <we-button data-select-data-attribute="" data-name="no_requirement_opt">None</we-button>
+                    <we-button data-select-data-attribute="substring">Contains</we-button>
+                    <we-button data-select-data-attribute="!substring">Doesn't contain</we-button>
+                </we-select>
+                <we-select data-name="require_condition_num_opt" data-attribute-name="requirementComparator" data-no-preview="true">
+                    <!-- number comparator possibilities -->
+                    <we-button data-select-data-attribute="" data-name="no_requirement_opt">None</we-button>
+                    <we-button data-select-data-attribute="greater">Is number greater than</we-button>
+                    <we-button data-select-data-attribute="less">Is number less than</we-button>
+                    <we-button data-select-data-attribute="greater or equal">Is number greater than or equal to</we-button>
+                    <we-button data-select-data-attribute="less or equal">Is number less than or equal to</we-button>
+                </we-select>
+                <we-select data-name="require_condition_time_comparators_opt" data-attribute-name="requirementComparator" data-no-preview="true">
+                    <!-- date & datetime comparator possibilities -->
+                    <we-button data-select-data-attribute="" data-name="no_requirement_opt">None</we-button>
+                    <we-button data-select-data-attribute="after">Is date after</we-button>
+                    <we-button data-select-data-attribute="before">Is date before</we-button>
+                    <we-button data-select-data-attribute="equal or after">Is date after or equal to</we-button>
+                    <we-button data-select-data-attribute="equal or before">Is date before or equal to</we-button>
+                    <we-button data-select-data-attribute="between">Is date between (included)</we-button>
+                    <we-button data-select-data-attribute="!between">Is date not between (excluded)</we-button>
+                </we-select>
+                <we-button class="fa fa-eye-slash"
+                    data-dependencies="!no_requirement_opt"
+                    title="Add predefined error message"
+                    data-attribute-name="customError"
+                    data-select-data-attribute="true"
+                    data-name="error_message_opt"
+                    data-no-preview="true"/>
+            </we-row>
+            <!-- Condition possible values  -->
+            <we-input string="Enter Condition"
+                class="o_we_sublevel_1 o_we_large"
+                data-name="require_condition_additional_text"
+                data-attribute-name="requirementCondition"
+                data-select-data-attribute=""/>
+            <we-datetimepicker string="Enter Date"
+                class="o_we_sublevel_1 o_we_large"
+                data-name="require_condition_additional_datetime_1"
+                data-attribute-name="requirementCondition"
+                data-select-data-attribute="" />
+            <we-datepicker string="Enter Date"
+                class="o_we_sublevel_1 o_we_large"
+                data-name="require_condition_additional_date"
+                data-attribute-name="requirementCondition"
+                data-select-data-attribute=""/>
+            <we-datetimepicker string="End Date"
+                class="o_we_sublevel_1 o_we_large"
+                data-name="require_condition_additional_datetime_2"
+                data-attribute-name="requirementBetween"
+                data-select-data-attribute=""/>
+            <we-datepicker string="End Date"
+                class="o_we_sublevel_1 o_we_large"
+                data-name="require_condition_additional_date_end"
+                data-attribute-name="requirementBetween"
+                data-select-data-attribute="" />
+            <!-- Error message -->
+            <we-input string="Error Message"
+                class="o_we_sublevel_1 o_we_large"
+                placeholder="Write custom error message"
+                data-request-focus="true"
+                data-attribute-name="errorMessage"
+                data-select-data-attribute=""
+                data-name="error_message_input_opt"
+                data-dependencies="error_message_opt"/>
             <we-select string="Visibility" data-no-preview="true">
                 <we-button data-set-visibility="visible" data-select-class="">Always Visible</we-button>
                 <we-button data-set-visibility="hidden" data-select-class="s_website_form_field_hidden">Hidden</we-button>

--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -352,6 +352,7 @@
                     <we-button data-select-data-attribute="!set">Is not set</we-button>
                     <we-button data-select-data-attribute='between'>Is between (included)</we-button>
                     <we-button data-select-data-attribute='!between'>Is not between (excluded)</we-button>
+                    <we-button data-select-data-attribute="lessyears">Is within the last X years</we-button>
                 </we-select>
                 <we-select data-name="hidden_condition_file_opt" data-attribute-name="visibilityComparator" data-no-preview="true">
                     <!-- file comparator possibilities -->


### PR DESCRIPTION
Specification:
- Introduce restrictions/validations on form fields.
- Allow users to display custom error messages when validations are triggered.
- Add a new conditional visibility option, "Less than X years ago," for date and datetime fields.
- Ensure error messages appear directly below the respective fields.

Before this PR:
- There was no way to enforce field restrictions, such as requiring the age to be 18 or above.
- Custom error messages could not be added because the validation/restriction feature was unavailable.
- The conditional visibility option "Less than X years ago" did not exist.
- Error messages were displayed at the bottom of the form or as tooltips.

After this PR:
- A new "Requirements" option has been added to allow the configuration of field validations/restrictions.
- A button with the "fa-eye" icon has been introduced to enable and manage custom error messages for user-defined requirements.
- The "Less than X years ago" conditional visibility option has been added to date and datetime fields.
- Error messages now appear directly below the relevant field, or as tooltips, depending on whether it's a requirement failure or a default browser validation.

task-3791206

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
