### PR TITLE
[FIX] website_sale_stock: Update out of stock message to specify unavailable products

### DIFF
--- a/addons/website_sale_stock/i18n/website_sale_stock.pot
+++ b/addons/website_sale_stock/i18n/website_sale_stock.pot
@@ -275,6 +275,13 @@ msgid "You ask for %(desired_qty)s products but only %(new_qty)s is available"
 msgstr ""
 
 #. module: website_sale_stock
+#. odoo-python
+#: code:addons/website_sale_stock/models/sale_order_line.py:0
+#, python-format
+msgid "You ask for %(desired_qty)s %(product_name)s(s) but only %(new_qty)s is available"
+msgstr ""
+
+#. module: website_sale_stock
 #. odoo-javascript
 #: code:addons/website_sale_stock/static/src/js/website_sale_reorder.js:0
 #: code:addons/website_sale_stock/static/src/js/website_sale_reorder.js:0

--- a/addons/website_sale_stock/models/sale_order_line.py
+++ b/addons/website_sale_stock/models/sale_order_line.py
@@ -9,8 +9,8 @@ class SaleOrderLine(models.Model):
     def _set_shop_warning_stock(self, desired_qty, new_qty):
         self.ensure_one()
         self.shop_warning = _(
-            'You ask for %(desired_qty)s products but only %(new_qty)s is available',
-            desired_qty=desired_qty, new_qty=new_qty
+            'You ask for %(desired_qty)s %(product_name)s(s) but only %(new_qty)s is available',
+            desired_qty=desired_qty, new_qty=new_qty, product_name=self.product_id.name
         )
         return self.shop_warning
 


### PR DESCRIPTION
Problem:
When a customer attempts to confirm their cart, and some products are no longer available in stock, an error message appears. However, the message does not specify which products are unavailable, causing confusion, especially if multiple products are in the cart.

Steps to reproduce:
- Add a product to the cart.
- Go back to product page (the one you just added)
- Update the quantity of the product to 0 (or less than the quantity in the cart).
- Attempt to confirm the cart.
- An error message will appear stating that some products are not available, but it does not specify which products.

opw-3894071

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
