### PR TITLE
[FIX] web: reports: prevent pointer events on table's pseudo elements

### DIFF
--- a/addons/web/static/src/webclient/actions/reports/report_tables.scss
+++ b/addons/web/static/src/webclient/actions/reports/report_tables.scss
@@ -110,7 +110,11 @@ div#total {
         &::before {
             // Avoid inner borders overlapping the table borders
             content: '';
+            // Position absolute will place the pseudo-element
+            // above the table. We need to prevent events on this pseudo-element
+            // to avoid messing up eventual user interaction with the table itself (report editor)
             @include o-position-absolute(0, 0, 0, 0);
+            pointer-events: none;
             border: $border-width solid $gray-700;
         }
 


### PR DESCRIPTION
After commit 695b429d09887debe1a58e92abfd7e738350061d, some tables have a `::before` pseudo-element placed absolutely above the table.
This makes the interaction with the table impossible in the report editor so that nothing could be modified in the table.

This commit prevents events on the pseudo-elements to solve the problem. Another approach could have been implemented: assigning a lower z-index. This solution could have created other types of display issues.

opw-4095976

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
