### PR TITLE
[FIX] web_editor: allow synchronization of inner translation fields

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1053,6 +1053,15 @@ const Wysiwyg = Widget.extend({
                             .filter('[data-oe-field="name"]'));
                     }
 
+                    // TODO adapt in master: remove this and only use the
+                    //  `_pauseOdooFieldObservers(field)` call.
+                    this.__odooFieldObserversToPause = this.odooFieldObservers.filter(
+                        // Exclude inner translation fields observers. They
+                        // still handle translation synchronization inside the
+                        // targeted field.
+                        observerData => !observerData.field.dataset.oeTranslationInitialSha ||
+                            !field.contains(observerData.field)
+                    );
                     this._pauseOdooFieldObservers();
                     // Tag the date fields to only replace the value
                     // with the original date value once (see mouseDown event)
@@ -1086,7 +1095,11 @@ const Wysiwyg = Widget.extend({
      * Stop the field changes mutation observers.
      */
     _pauseOdooFieldObservers: function () {
-        for (let observerData of this.odooFieldObservers) {
+        // TODO adapt in master: remove this and directly exclude observers with
+        // targets inside the current field (we use `this.odooFieldObservers`
+        // as fallback for compatibility here).
+        const fieldObserversData = this.__odooFieldObserversToPause || this.odooFieldObservers;
+        for (let observerData of fieldObserversData) {
             observerData.observer.disconnect();
         }
     },


### PR DESCRIPTION
Steps to reproduce:

- Go to a website blog post page > Drop a "Table of Content" snippet
inside the blog post content.

- Switch to translation mode > Try to translate a TOC title > The 
corresponding navigation label won't be automatically updated.

- Save > The translation will be applied depending on whether the title
and the navbar item have exactly the same content or not [*].

Starting from [1], the translation of a "Table of Content" navigation
label was automatically applied (only the text content) when the
corresponding title was translated, and the user was also warned when
trying to edit them directly in "translation" mode.

This implementation relied on the field observers mechanism to
synchronize translations for the table of content navigation and content
headers.

Unfortunately, the field mutations handler doesn't take translation
fields into consideration when they are part of another field's DOM:

1. Before trying to set the updated field value on its duplicates in the
DOM, the handler is using `_pauseOdooFieldObservers()` to `disconnect()`
all the observers of other fields to prevent receiving mutations from
its own updates.

2. In translation mode, and when the updated field has some inner
translation `<span/>`s, their observers will be disconnected too, and
their mutations will never be linked to the right target.

3. Finally, the `_observeOdooFieldChanges()` is used to observe the
fields again.

Let's take the following example: 
```
<div data-oe-model="...">
    <span data-oe-translation-initial-sha="...">Text Content</span>
</div>
```

In this case, two observers are created, one for the `[data-oe-model]`
(`O1`) and the other for the `[data-oe-translation-initial-sha]` (`O2`).

When editing the "Text Content" of the `<span/>`, `O1` will be triggered
(for the parent field) and will temporarily disconnect all other fields

observers (including (`O2`)) and as a consequence, `O2` won't be able to
synchronize the value of the translation field on the ones with the same
`data-oe-translation-initial-sha` (which is the same situation as in a
"Table of Content" block).

The goal of this commit is to simply prevent disconnecting inner
translation field observers to allow the translation synchronization
inside a parent field DOM.

[*]: Remark: when a TOC title and its navigation item have different DOM
(e.g., the font color of the title changed), the code from [1] will
always temporarily set the same `data-oe-translation-initial-sha` on
both of them (and restore the original ones before saving), which
explains the different translation values when the field observers are
not working correctly.

[1]: https://github.com/odoo/odoo/commit/5776a358e1b42186d2c26c9bc25010a12811f416

opw-3990039
opw-3888871