### PR TITLE
[FIX] website: fix empty page if blocks have no text

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_preview.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.js
@@ -274,7 +274,7 @@ export class WebsitePreview extends Component {
     addWelcomeMessage() {
         if (this.websiteService.isRestrictedEditor) {
             const wrap = this.iframe.el.contentDocument.querySelector('#wrapwrap.homepage #wrap');
-            if (wrap && !wrap.textContent.trim()) {
+            if (wrap && !wrap.innerHTML.trim()) {
                 this.welcomeMessage = renderToElement('website.homepage_editor_welcome_message');
                 this.welcomeMessage.classList.add('o_homepage_editor_welcome_message', 'h-100');
                 while (wrap.firstChild) {


### PR DESCRIPTION
Steps to reproduce the bug:

- In edit mode, drop a snippet having no text (e.g. Images Wall) or remove the text of a snippet (so none of the text tags remain).
- Save the page.
- Bug: The snippet is not there. If you refresh, the snippet is here, but once you click on "Editor" (to have the purple navbar above), it disappears. It is also not there when going in edit mode.

The bug was introduced by this commit [1]. By removing jQuery, this commit replaced jQuery's ".html()" with "textContent" instead of "innerHTML". As a result, the code that detects if the page is empty to add the "welcome message" stopped working properly.

[1]: https://github.com/odoo/odoo/commit/429f9792d87892a4f5ea402ef8750bcedbe3a0d8

task-4104978