### PR TITLE
[FIX] point_of_sale: prevent quantity override when it's not needed

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
@@ -187,19 +187,16 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
             if (!this.currentOrder) {
                 this.env.pos.add_new_order();
             }
-            let product, quantity;
-            if (event.detail.product && event.detail.quantity !== undefined) {
-                product = event.detail.product;
-                quantity = event.detail.quantity;
-            } else {
-                product = event.detail;
-                quantity = 1;
-            }
+            const product = event.detail.product || event.detail;
             const options = await this._getAddProductOptions(product);
             // Do not add product if options is undefined.
             if (!options) return;
+            // Update the quantity if the event has a quantity.
+            if (event.detail.quantity !== undefined) {
+                options.quantity = event.detail.quantity;
+            }
             // Add the product after having the extra information.
-            await this._addProduct(product, { ...options, quantity });
+            await this._addProduct(product, options);
             NumberBuffer.reset();
         }
         _setNumpadMode(event) {


### PR DESCRIPTION
Before this commit, in the `_clickProduct` method, if a product was added without specifying a quantity and the product was weighed using a scale, the quantity would be overridden with 1, even if the scale provided a different quantity.

Enterprise PR: https://github.com/odoo/enterprise/pull/68165

opw-4100289

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
