### PR TITLE
[IMP] stock: add contact to shipping documents in internal transfers

### DIFF
--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -51,6 +51,10 @@
                             <strong>Order</strong>
                             <div t-field="o.origin" class="m-0">S0001</div>
                         </div>
+                        <div t-if="o.picking_type_id.code == 'internal' and o.partner_id" class="col col-3 mw-100 mb-2" name="div_contact">
+                            <strong>Contact</strong>
+                            <div t-field="o.partner_id" class="m-0"/>
+                        </div>
                         <div t-if="o.state" class="col col-3 mw-100 mb-2" name="div_sched_date">
                             <strong>Shipping Date</strong>
                             <div t-if="o.state == 'done'" t-field="o.date_done" class="m-0"/>

--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -63,6 +63,10 @@
                                     <div t-else=""
                                         t-field="o.picking_type_id.warehouse_id.name"/>
                                     </div>
+                                <div t-if="o.picking_type_id.code == 'internal' and o.partner_id" class="col" name="div_contact">
+                                    <strong>Contact</strong>
+                                    <div t-field="o.partner_id" class="m-0"/>
+                                </div>
                                 <div name="div_state">
                                     <strong>Status:</strong>
                                     <p t-field="o.state">Draft</p>


### PR DESCRIPTION
With this commit
=================
When contact is set on internal transfers, it will be
added to respective shipping documents: picking operations and delivery slip

TaskId: 4072882