### PR TITLE
[FIX] web: topbar/embedded transition fix

### DIFF
--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -3,7 +3,7 @@
 
     <t t-name="web.ControlPanel">
         <div class="o_control_panel d-flex flex-column gap-3 px-3 pt-2 pb-3" t-ref="root" data-command-category="actions">
-            <Transition t-if="!env.isSmall" visible="state.embeddedInfos.showEmbedded" name="'o-fade'" t-slot-scope="transition" leaveDuration="500">
+            <Transition t-if="!env.isSmall" visible="state.embeddedInfos.showEmbedded" name="'o-fade'" t-slot-scope="transition" leaveDuration="500" transitionWhenMounted="false">
                 <div class="o_embedded_actions overflow-hidden d-flex flex-wrap w-100 align-items-center justify-content-center gap-2" t-att-class="transition.className">
                     <t t-foreach="state.embeddedInfos.embeddedActions" t-as="action" t-key="action.id">
                         <t t-if="_checkValueLocalStorage(action)">

--- a/addons/web/static/tests/core/transition.test.js
+++ b/addons/web/static/tests/core/transition.test.js
@@ -81,3 +81,66 @@ test("Transition HOC", async () => {
     await animationFrame();
     expect(".test").toHaveCount(0);
 });
+
+test("test transitionWhenMounted attribute in Transition/useTransition", async () => {
+    patchWithCleanup(transitionConfig, {
+        disabled: false,
+    });
+    class Parent extends Component {
+        static template = xml`
+            <Transition name="'test'" visible="state.show" t-slot-scope="transition" onLeave="onLeave" transitionWhenMounted="false">
+                <div t-att-class="transition.className" class="hello"/>
+            </Transition>
+        `;
+        static components = { Transition };
+        static props = ["*"];
+        setup() {
+            this.state = useState({ show: false });
+        }
+        onLeave() {
+            expect.step("leave");
+        }
+    }
+
+    class ParentModified extends Parent {
+        setup() {
+            this.state = useState({ show: true });
+        }
+    }
+
+    // Consider Parent as a component which is not visible when component
+    // is rendered.
+    // Whereas ParentModified is a component which is already mounted when
+    // component is rendered or normal component which can stay mounted when
+    // switching views or a component which uses Transition and can stay
+    // mounted after refreshing.
+
+    // noMainContainer, because the await for the mount of the main container
+    // will already change the transition
+    const parent = await mountWithCleanup(Parent, { noMainContainer: false });
+
+    parent.state.show = true;
+
+    // Normal Behaviour
+    await animationFrame();
+    // Mounted with -enter but not -enter-active
+    expect(".test.test-enter:not(.test-enter-active)").toHaveCount(1);
+    await animationFrame();
+    expect(".test.test-enter-active:not(.test-enter)").toHaveCount(1);
+
+    // Consider we did reload here and resulting component to be rendered would be ParentModified
+    const parentExtended = await mountWithCleanup(ParentModified, { noMainContainer: false });
+
+    // Comes to skip state as the component is already mounted.
+    expect(".test.test-skip:not(.test-enter-active)").toHaveCount(1);
+
+    parentExtended.state.show = false;
+    await animationFrame();
+    // Leaving: -leave but not -enter-active
+    expect(".test.test-leave:not(.test-enter-active)").toHaveCount(1);
+
+    expect.verifySteps([]);
+    await runAllTimers();
+    expect.verifySteps(["leave"]);
+    await animationFrame();
+});


### PR DESCRIPTION
Steps to reproduce:

- Open project app and select a project
- Click on top bar button
- Now either change the view or embedded action.

Issue:

- The whole transition is reapplied every time we change view or embedded action

Reason:

- The whole ```ControlPanel``` component is destroyed and rendered when we either click on the embedded action or view.
- Transition Component doesn't have any specification for skipping a transition.

Fix:

- Adding ```transitionWhenMounted``` option to Transition Component and Service as well.

task-4035839