### PR TITLE
[FIX] l10n_fr_invoice_addr: Restore FR localized invoice print format

### DIFF
--- a/addons/l10n_fr_invoice_addr/views/report_invoice.xml
+++ b/addons/l10n_fr_invoice_addr/views/report_invoice.xml
@@ -28,7 +28,7 @@
                 <t t-set="has_service" t-value="'service' in tax_scopes"/>
                 <t t-set="has_consu" t-value="'consu' in tax_scopes"/>
 
-                <div t-if="has_service or has_consu" class="col mb-2" name="operation_type">
+                <div t-if="has_service or has_consu" t-attf-class="#{'col-auto col-3 mw-100' if report_type != 'html' else 'col'} mb-2" name="operation_type">
                     <strong>Operation Type:</strong>
                     <br/>
                     <span t-if="has_service and has_consu">


### PR DESCRIPTION
Steps to reproduce:
- Download french accouning localization module
- Switch company to 'FR Company'
- Invoicing > Customers > Invoice > New
- Fill in a product
- Confirm > Gear > Print > Invoice

It's the typical column formatting error where columns are squeezed to the left and overlapping (See ticket for picture).

opw-4089199

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
