### PR TITLE
[FIX] account: blank line on product/label cell

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
@@ -3,7 +3,7 @@ import { AutoComplete } from "@web/core/autocomplete/autocomplete";
 import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
 import { Many2XAutocomplete } from "@web/views/fields/relational_utils";
 import { Many2OneField, many2OneField } from "@web/views/fields/many2one/many2one_field";
-import { onPatched, useEffect, useRef, useState } from "@odoo/owl";
+import { onMounted, onPatched, onWillUnmount, useEffect, useRef, useState } from "@odoo/owl";
 import { registry } from "@web/core/registry";
 import {
     SectionAndNoteListRenderer,
@@ -114,6 +114,7 @@ export class ProductLabelSectionAndNoteField extends Many2OneField {
 
     setup() {
         super.setup();
+        this.isPrintMode = useState({ value: false });
         this.labelVisibility = useState({ value: false });
         this.switchToLabel = false;
         this.columnIsProductAndLabel = useState({ value: this.props.record.columnIsProductAndLabel });
@@ -134,6 +135,28 @@ export class ProductLabelSectionAndNoteField extends Many2OneField {
                 this.switchToLabel = false;
                 this.labelNode.el.focus();
             }
+        });
+
+        this.onBeforePrint = () => {
+            this.isPrintMode.value = true;
+        };
+
+        this.onAfterPrint = () => {
+            this.isPrintMode.value = false;
+        };
+
+        // The following hooks are used to make a div visible only in the print view. This div is necessary in the
+        // print view in order not to have scroll bars but can't be displayed in the normal view because it adds
+        // an empty line. This is done by switching an attribute to true only during the print view life cycle and
+        // including the said div in a t-if depending on that attribute.
+        onMounted(() => {
+            window.addEventListener("beforeprint", this.onBeforePrint);
+            window.addEventListener("afterprint", this.onAfterPrint);
+        });
+
+        onWillUnmount(() => {
+            window.removeEventListener("beforeprint", this.onBeforePrint);
+            window.removeEventListener("afterprint", this.onAfterPrint);
         });
     }
 

--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
@@ -145,7 +145,9 @@
                     </t>
                 </t>
             </t>
-            <div class="d-none d-print-block text-wrap" t-out="label"/>
+            <t t-if="isPrintMode.value">
+                <div class="d-none d-print-block text-wrap" t-out="label"/>
+            </t>
         </div>
     </t>
 


### PR DESCRIPTION
Description of the issue this commit addresses:

On the invoice form view, whatever the data entered in the product/label cell, an additionnal empty row is visible and brekas the resizing of the cell. The cell should be the exact size required for the data to be shown at all time

---

Steps to reproduce:

1. Install Invoicing
2. Go to a new invoice
3. Add a line with a product
4. An empty row is at the bottom of the product/label cell

---

Desired behavior after this commit is merged:

Whatever the data entered in the product/label cell, there are no more rows than required to display the whole content of the cell.

---

no task-feedback

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
