### PR TITLE
[FIX] website_sale: save phone on shipping address in express checkt

### DIFF
--- a/addons/payment_stripe/static/src/js/express_checkout_form.js
+++ b/addons/payment_stripe/static/src/js/express_checkout_form.js
@@ -122,7 +122,7 @@ paymentExpressCheckoutForm.include({
                 addresses.shipping_address = {
                     name: ev.shippingAddress.recipient,
                     email: ev.payerEmail,
-                    phone: ev.shippingAddress.phone,
+                    phone: ev.shippingAddress.phone || ev.payerPhone,
                     street: ev.shippingAddress.addressLine[0],
                     street2: ev.shippingAddress.addressLine[1],
                     zip: ev.shippingAddress.postalCode,


### PR DESCRIPTION
Steps to reproduce:
- Install `payment_stripe` and `website_sale`
- Configure express checkout for stripe - Add public/secret keys and - Enable "Apple Pay" in settings (to do this comment out this block) https://github.com/odoo/odoo/blob/0527b4b2ffe7d42222334b06a22739cf4963c617/addons/payment_stripe/models/payment_provider.py#L234-L237 - Enable "Link" in Stripe and add payment domain to ngrok domain
- Go to website in incognito page and open a product
- Add it to cart and click on the express checkout button
- Complete process to pay
- Go to contact linked to sale

Issues:
Phone is missing, this is because during the creation of the shipping address `res_partner` record we don't have the phone.

https://github.com/odoo/odoo/blob/0527b4b2ffe7d42222334b06a22739cf4963c617/addons/payment_stripe/static/src/js/express_checkout_form.js#L171-L181

opw-4055084