### PR TITLE
[Fix] POS: check if sale_order_line_id exists

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1499,7 +1499,8 @@ class PosOrderLine(models.Model):
                 tracked_lines = order.lines.filtered(lambda l: l.product_id.tracking != 'none')
                 lines_by_tracked_product = groupby(sorted(tracked_lines, key=lambda l: l.product_id.id), key=lambda l: l.product_id.id)
                 for line in order.lines:
-                    line.sale_order_line_id.move_ids.mapped("move_line_ids").unlink()
+                    if line._fields.get('sale_order_line_id'):
+                        line.sale_order_line_id.move_ids.mapped("move_line_ids").unlink()
                 pickings_to_confirm.action_confirm()
                 for product_id, lines in lines_by_tracked_product:
                     lines = self.env['pos.order.line'].concat(*lines)


### PR DESCRIPTION
Issue found when following [tests](https://runbot.odoo.com/runbot/build/66632082) broke

We need to make sure that sale_order_line_id exists in pos, as if pos_sale is not installed on database, it will crash.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
