### PR TITLE
[FIX] base: round monetary value when checking if different

### DIFF
--- a/odoo/api.py
+++ b/odoo/api.py
@@ -1163,6 +1163,8 @@ class Cache(object):
             except KeyError:
                 ids.append(record_id)
             else:
+                if field.type == "monetary":
+                    value = field.convert_to_cache(value, records.browse(record_id))
                 if val != value:
                     ids.append(record_id)
         return records.browse(ids)


### PR DESCRIPTION
**Issue:**
When several invoices are selected and sent via "Send & print"
action, it happens that some invoices are sent several times.
It seems to be caused by a serialization failure on an invoice
in "_compute_debit_credit" when a concurrent write operation is
executed on an invoice being sent.
This serialization failure cause a retry on the batch being sent,
resulting on the invoice to be re-sent.

**Cause:**
"Send & print" action triggers "_compute_debit_credit" method that
writes on debit and credit fields.
The values are generally the same, so no write is really performed.
However, for some values (e.g. 14.79), there is a floating point
issue (i.e. 14.790000000000001) and the "get_records_different_from"
method considers the record as different and triggeres an actual
write.

**Solution:**
In "get_records_different_from" method, for monetary fields, apply
the same rounding to the current value than the one applied when the
value is converted to cache.

opw-3773287




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
