### PR TITLE
[FIX] pos_loyalty: adjust finalizeOrder in tests

### DIFF
--- a/addons/pos_loyalty/static/src/tours/EWalletProgramTours.js
+++ b/addons/pos_loyalty/static/src/tours/EWalletProgramTours.js
@@ -133,5 +133,5 @@ ProductScreen.exec.addOrderline("product_a", "1");
 PosLoyalty.check.eWalletButtonState({ highlighted: true, text: getEWalletText("Pay") });
 PosLoyalty.do.clickEWalletButton(getEWalletText("Pay"));
 PosLoyalty.check.pointsAwardedAre("100"),
-PosLoyalty.exec.finalizeOrder("Cash", "90.00");
+PosLoyalty.exec.finalizeOrder("Cash", "90");
 Tour.register("PosLoyaltyPointsEwallet", { test: true, url: "/pos/web" }, getSteps());

--- a/addons/pos_loyalty/static/src/tours/PosLoyaltyLoyaltyProgramTour.js
+++ b/addons/pos_loyalty/static/src/tours/PosLoyaltyLoyaltyProgramTour.js
@@ -159,7 +159,7 @@ PosLoyalty.do.clickRewardButton();
 PosLoyalty.check.hasRewardLine('Free Product - Whiteboard Pen', '0.0', '2.00');
 
 PosLoyalty.check.orderTotalIs('10.2');
-PosLoyalty.exec.finalizeOrder('Cash', '10.2');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 Tour.register('PosLoyaltyLoyaltyProgram3', { test: true, url: '/pos/web' }, getSteps());
 
@@ -182,7 +182,7 @@ ProductScreen.do.clickHomeCategory();
 
 // Generates 10.2 points and use points to get the reward product with zero sale price
 ProductScreen.exec.addOrderline('Desk Organizer', '3');
-PosLoyalty.exec.finalizeOrder('Cash', '15.3');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 Tour.register('PosLoyaltyNextOrderCouponExpirationDate', { test: true, url: '/pos/web' }, getSteps());
 
@@ -200,6 +200,6 @@ ProductScreen.exec.addOrderline('Whiteboard Pen', '1');
 PosLoyalty.do.clickRewardButton();
 
 PosLoyalty.check.orderTotalIs('5.10');
-PosLoyalty.exec.finalizeOrder('Cash', '5.10');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 Tour.register('PosLoyaltyDontGrantPointsForRewardOrderLines', { test: true, url: '/pos/web' }, getSteps());

--- a/addons/pos_loyalty/static/src/tours/PosLoyaltyTour.js
+++ b/addons/pos_loyalty/static/src/tours/PosLoyaltyTour.js
@@ -291,7 +291,7 @@ PosLoyalty.check.customerIs('AAA Partner');
 ProductScreen.exec.addOrderline('Product Test', '3');
 ProductScreen.check.totalAmountIs('150.00');
 PosLoyalty.check.isRewardButtonHighlighted(false);
-PosLoyalty.exec.finalizeOrder('Cash', '150');
+PosLoyalty.exec.finalizeOrder('Cash');
 
 Tour.register('PosLoyaltyTour11.1', { test: true, url: '/pos/web' }, getSteps());
 
@@ -366,7 +366,7 @@ function createOrderCoupon(totalAmount, couponName, couponAmount, loyaltyPoints)
         PosLoyalty.check.hasRewardLine(`${couponName}`, `${couponAmount}`),
         PosLoyalty.check.orderTotalIs(`${totalAmount}`),
         PosLoyalty.check.pointsAwardedAre(`${loyaltyPoints}`),
-        PosLoyalty.exec.finalizeOrder("Cash", `${totalAmount}`),
+        PosLoyalty.exec.finalizeOrder("Cash"),
     ];
 }
 
@@ -405,7 +405,7 @@ ProductScreen.do.clickCustomer("partner_a");
 ProductScreen.do.clickDisplayedProduct('Test Product A');
 PosLoyalty.check.checkNoClaimableRewards();
 ProductScreen.check.selectedOrderlineHas('Test Product A', '1.00', '100.00');
-PosLoyalty.exec.finalizeOrder("Cash", "100");
+PosLoyalty.exec.finalizeOrder("Cash");
 
 Tour.register('PosLoyaltyArchivedRewardProductsInactive', {test: true, url: '/pos/web'}, getSteps());
 
@@ -417,6 +417,6 @@ ProductScreen.do.clickCustomer("partner_a");
 ProductScreen.do.clickDisplayedProduct('Test Product A');
 PosLoyalty.check.isRewardButtonHighlighted(true);
 ProductScreen.check.selectedOrderlineHas('Test Product A', '1.00', '100.00');
-PosLoyalty.exec.finalizeOrder("Cash", "100");
+PosLoyalty.exec.finalizeOrder("Cash");
 
 Tour.register('PosLoyaltyArchivedRewardProductsActive', {test: true, url: '/pos/web'}, getSteps());


### PR DESCRIPTION
After the commit https://github.com/odoo/odoo/commit/58307ad7311fbf99fe5546c4f193d2f7d824dc39, tests in pos_loyalty that use the finalizeOrder method started failing due to the addition of the payment amount. This step has become unnecessary because the total amount is automatically added during payment processing.

opw-4105634

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
