### PR TITLE
[FIX] barcodes: remove call to jQuery

### DIFF
--- a/addons/barcodes/static/src/barcode_service.js
+++ b/addons/barcodes/static/src/barcode_service.js
@@ -110,8 +110,8 @@ export const barcodeService = {
             if (ev.key === "Unidentified") {
                 return;
             }
-            if ($(document.activeElement).not('input:text, textarea, [contenteditable], ' +
-                '[type="email"], [type="number"], [type="password"], [type="tel"], [type="search"]').length) {
+            if (document.activeElement && !document.activeElement.matches('input:not([type]), input[type="text"], textarea, [contenteditable], ' +
+                '[type="email"], [type="number"], [type="password"], [type="tel"], [type="search"]')) {
                 barcodeInput.focus();
             }
             keydownHandler(ev);


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/174213, jQuery is no longer available in "web.assets_backend". Here we adapt some code in barcodeService that was still using jQuery.

