### PR TITLE
[IMP] mail: display mailbox message as cards

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -77,6 +77,7 @@ export class Message extends Component {
         showDates: true,
     };
     static props = [
+        "asCard?",
         "registerMessageRef?",
         "hasActions?",
         "isInChatWindow?",
@@ -189,13 +190,19 @@ export class Message extends Component {
     get attClass() {
         return {
             [this.props.className]: true,
+            "o-card p-2 mt-2 bg-view": this.props.asCard,
+            "pt-1": !this.props.asCard,
             "o-selfAuthored": this.message.isSelfAuthored && !this.env.messageCard,
             "o-selected": this.props.messageToReplyTo?.isSelected(
                 this.props.thread,
                 this.props.message
             ),
             "o-squashed": this.props.squashed,
-            "mt-1": !this.props.squashed && this.props.thread && !this.env.messageCard,
+            "mt-1":
+                !this.props.squashed &&
+                this.props.thread &&
+                !this.env.messageCard &&
+                !this.props.asCard,
             "px-2": this.props.isInChatWindow,
             "opacity-50": this.props.messageToReplyTo?.isNotSelected(
                 this.props.thread,

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -1,6 +1,11 @@
 .o-mail-Message {
     transition: background-color .2s ease-out, opacity .5s ease-out, box-shadow .5s ease-out, transform .2s ease-out;
 
+    &.o-card {
+        outline: $border-width solid $border-color;
+        outline-offset: -$border-width;
+    }
+
     &.o-highlighted {
         transform: translateY(-#{map-get($spacers, 3)});
     }

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -3,7 +3,7 @@
 
     <t t-name="mail.Message">
         <ActionSwiper onRightSwipe="hasTouch() and isInInbox ? { action: () => this.message.setDone(), bgColor: 'bg-success', icon: 'fa-check-circle' } : undefined">
-            <div class="o-mail-Message position-relative pt-1"
+            <div class="o-mail-Message position-relative"
                 t-att-class="attClass"
                 role="group"
                 t-att-aria-label="messageTypeText"

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -28,6 +28,7 @@
                         <t t-call="mail.NotificationMessage"/>
                     </t>
                     <Message t-else=""
+                        asCard="props.thread.model === 'mail.box'"
                         className="getMessageClassName(msg)"
                         isInChatWindow="props.isInChatWindow"
                         message="msg"


### PR DESCRIPTION
Messages in mailboxes come from different conversations, so there should be some visual to help and see messages are isolated from each other.

Task-4105740

Before
<img width="1274" alt="Screenshot 2024-08-08 at 18 38 23" src="https://github.com/user-attachments/assets/9be618d1-430c-4fb1-80d7-6cb248d17e92">

After
<img width="1276" alt="Screenshot 2024-08-08 at 18 36 00" src="https://github.com/user-attachments/assets/79345445-17b2-43e0-a5d7-a85c4f747367">

