### PR TITLE
[FIX] account: fix list view edit in studio

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
@@ -162,7 +162,11 @@ export class ProductLabelSectionAndNoteField extends Many2OneField {
     }
 
     get isProductClickable() {
-        return this.props.record.model.root.data.state !== "draft";
+        if (this.props.record.model.root.data) {
+            return this.props.record.model.root.data.state !== "draft";
+        }
+        
+        return this.props.record._parentRecord.data.state !== "draft";
     }
 
     get isSectionOrNote() {


### PR DESCRIPTION
Issue -->

Traceback when clicking `Edit List View` under Invoice Lines in the `account.move` form view while using Studio.
The cause of the issue is that the props update and lose the data that we expect in the getter `isProductClickable`.

Solution -->

Use an alternate way to get the parent record (account.move) in the case that the root model is not account.move.

opw-4100711


