### PR TITLE
[FIX] website_sale: fix wishlist badge design

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -595,7 +595,9 @@ a.no-decoration {
 }
 
 .o_red_highlight {
-    background: map-get($theme-colors, 'danger') !important;
+    --background-color: #{map-get($theme-colors, 'danger')};
+    --bg-solid: var(--background-color) !important;
+
     box-shadow: 0 0 0 0 rgba(240,8,0,0.4);
     transition: all 0.5s linear;
 }

--- a/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist.js
+++ b/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist.js
@@ -396,7 +396,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
         },
         {
             content: "Added into the wishlist",
-            trigger: '.my_wish_quantity.text-bg-primary:contains(1)',
+            trigger: '.my_wish_quantity.bg-primary:contains(1)',
         },
         {
             content: "Go to '/shop",

--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -43,7 +43,7 @@
                 <a href="/shop/wishlist" t-attf-class="#{_link_class}">
                     <div t-attf-class="#{_icon_wrap_class}">
                         <i t-if="_icon" class="fa fa-1x fa-heart fa-stack"/>
-                        <sup t-esc="wishcount" t-attf-class="my_wish_quantity o_animate_blink badge text-bg-primary #{_badge_class}"/>
+                        <sup t-esc="wishcount" t-attf-class="my_wish_quantity o_animate_blink badge bg-primary #{_badge_class}"/>
                     </div>
                     <span t-if="_text" t-attf-class="#{_text_class}">Wishlist</span>
                 </a>
@@ -65,7 +65,7 @@
             <t t-call="website_sale_wishlist.header_wishlist_link">
                 <t t-set="_icon" t-value="True"/>
                 <t t-set="_link_class" t-value="'o_navlink_background_hover btn position-relative rounded-circle border-0 p-1 text-reset'"/>
-                <t t-set="_badge_class" t-value="'position-absolute top-0 end-0 mt-n1 me-n1 rounded-pill'"/>
+                <t t-set="_badge_class" t-value="'position-absolute top-0 end-0 mt-n1 me-n1'"/>
             </t>
         </xpath>
     </template>


### PR DESCRIPTION
- Requires : https://github.com/odoo/enterprise/pull/68203

This PR aims to fix a design issue on the wishlist badge inside `website_sale`.

Commit[1] recently introduced a redesign of the front-end badges and took care to provide an adaptation (make use of the old badge design) when needed, in some specific contexts.

The add to cart badge was actually adapted, but the wishlist one did not get any adaptation, resulting in a weird visual result.

This commit fixes the issue by applying the right value to the badge CSS variables. We also remove the `rounded-pill` class as all badges now use `$border-radius-pill` by default.

Commit [1]: https://github.com/odoo/odoo/commit/b4a5bf03cd81ece2a7fd21a3c5a058ee2d3336fe

task-4106164

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
