### PR TITLE
[FIX] base: handle NewId when creating view from menu

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -630,8 +630,10 @@ actual arch.
         #    studio have a priority=99 to be loaded last.
         # 2/ sort by view id: the order the views were inserted in the
         #    database. e.g. base views are placed before stock ones.
-
-        rows = self.env.execute_query(query)
+        if isinstance(self.id, models.NewId):
+            rows = []
+        else:
+            rows = self.env.execute_query(query)
         views = self.browse(row[0] for row in rows)
 
         # optimization: fill in cache of inherit_id and mode


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
An error is thrown when trying to create a new view by clicking the "New" button on the ir.ui.view list view. This is due to the NewId value not registering as an ID on the record, which subsequently causes the query generated by the _get_inheriting_views method to be invalid as it will attempt to execute a query with a where clause like this: "WHERE id IN ()"
For a new view, this method will always return an empty list, so this PR aims to handle this specific case by checking if the records id is an instance of models.NewId, and if so simply setting the value to be an empty list instead of executing the query.

Current behavior before PR:
Error thrown on creation of new ir.ui.view record from the list view

Desired behavior after PR is merged:
No Error

Task-ID: 4102663

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
