### PR TITLE
[FIX] bus: do not miss notifications

### DIFF
--- a/addons/bus/models/bus.py
+++ b/addons/bus/models/bus.py
@@ -130,13 +130,15 @@ class ImBus(models.Model):
         self._sendmany([[channel, notification_type, message]])
 
     @api.model
-    def _poll(self, channels, last=0):
+    def _poll(self, channels, last=0, known_notification_ids=None):
         # first poll return the notification in the 'buffer'
         if last == 0:
             timeout_ago = fields.Datetime.now() - datetime.timedelta(seconds=TIMEOUT)
             domain = [('create_date', '>', timeout_ago)]
         else:  # else returns the unread notifications
             domain = [('id', '>', last)]
+        if known_notification_ids:
+            domain.append(("id", "not in", known_notification_ids))
         channels = [json_dump(channel_with_db(self.env.cr.dbname, c)) for c in channels]
         domain.append(('channel', 'in', channels))
         notifications = self.sudo().search_read(domain)


### PR DESCRIPTION
Before this PR, some notifications could be missed due to the way notifications are fetched. We tracked the last fetched ID and only fetched notifications with greater IDs.

However, this approach is subject to concurrency issues because primary keys are assigned before commit. As a result, we might fetch a notification with a greater ID and miss one with a lower ID that hasn't been committed yet.

Problematic scenario:
- A bus_bus record is inserted with ID 1.
- A bus_bus record is inserted and committed with ID 2.
- A bus_bus record with ID 2 is fetched, but ID 1 is missing because it was not yet committed.
- The bus_bus record with ID 1 was missed.

To solve this issue, the WebSocket class now keeps track of the last 500 notifications received. Fetches will target unknown notifications with an ID greater than the smallest one in this window. This should prevent missed notifications.