### PR TITLE
[FIX] web_tour: rainbowManMessage visibility

### DIFF
--- a/addons/web/static/src/core/effects/rainbow_man.xml
+++ b/addons/web/static/src/core/effects/rainbow_man.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.RainbowMan">
-        <div class="o_reward position-absolute top-0 bottom-0 start-0 end-0 w-100 h-100" t-att-class="{ o_reward_fading: state.isFading }" t-on-animationend="onAnimationEnd">
+        <div class="o_reward position-fixed top-0 start-0 w-100 h-100" t-att-class="{ o_reward_fading: state.isFading }" t-on-animationend="onAnimationEnd">
             <svg class="o_reward_rainbow_man position-absolute top-0 bottom-0 start-0 end-0 m-auto overflow-visible" viewBox="0 0 400 400">
                 <defs>
                     <radialGradient id="o_reward_gradient_bg" cx="200" cy="200" r="200" gradientUnits="userSpaceOnUse">

--- a/addons/web_tour/static/tests/tour_service.test.js
+++ b/addons/web_tour/static/tests/tour_service.test.js
@@ -1334,3 +1334,49 @@ test("check tooltip position", async () => {
         button3.getBoundingClientRect().top
     );
 });
+
+test("check rainbowManMessage", async () => {
+    registry.category("web_tour.tours").add("rainbow_tour", {
+        sequence: 87,
+        fadeout: "no",
+        rainbowManMessage: () => {
+            return "Congratulations !";
+        },
+        steps: () => [
+            {
+                trigger: ".button0",
+                run: "click",
+            },
+            {
+                trigger: ".button1",
+                run: "click",
+            },
+            {
+                trigger: ".button2",
+                run: "click",
+            },
+        ],
+    });
+    class Root extends Component {
+        static components = {};
+        static template = xml/*html*/ `
+            <t>
+                <div class="container">
+                    <div class="p-3"><button class="button0">Button 0</button></div>
+                    <div class="p-3"><button class="button1">Button 1</button></div>
+                    <div class="p-3"><button class="button2">Button 2</button></div>
+                </div>
+            </t>
+        `;
+        static props = ["*"];
+    }
+    await mountWithCleanup(Root);
+    getService("tour_service").startTour("rainbow_tour", { mode: "manual" });
+    await contains(".button0").click();
+    await contains(".button1").click();
+    await contains(".button2").click();
+    const rainbowMan = await waitFor(".o_reward_rainbow_man");
+    expect(rainbowMan.getBoundingClientRect().width).toBe(400);
+    expect(rainbowMan.getBoundingClientRect().height).toBe(400);
+    expect(".o_reward_msg_content").toHaveText("Congratulations !");
+});


### PR DESCRIPTION
In this commit, we fix the rainbowMan css so that it is visible through a container that is 0x0.
To do this, we need to change the position to fixed instead of absolute.