### PR TITLE
[FIX] point_of_sale,pos_sale: move wrong field used in correct module

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1498,8 +1498,6 @@ class PosOrderLine(models.Model):
                 # Trigger the Scheduler for Pickings
                 tracked_lines = order.lines.filtered(lambda l: l.product_id.tracking != 'none')
                 lines_by_tracked_product = groupby(sorted(tracked_lines, key=lambda l: l.product_id.id), key=lambda l: l.product_id.id)
-                for line in order.lines:
-                    line.sale_order_line_id.move_ids.mapped("move_line_ids").unlink()
                 pickings_to_confirm.action_confirm()
                 for product_id, lines in lines_by_tracked_product:
                     lines = self.env['pos.order.line'].concat(*lines)

--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -174,3 +174,10 @@ class PosOrderLine(models.Model):
             order_line = self.env['sale.order.line'].search([('id', '=', vals['sale_order_line_id']['id'])], limit=1)
             vals['sale_order_line_id'] = order_line.id if order_line else False
         return result
+
+    def _launch_stock_rule_from_pos_order_lines(self):
+        orders = self.mapped('order_id')
+        for order in orders:
+            for line in order.lines:
+                line.sale_order_line_id.move_ids.mapped("move_line_ids").unlink()
+        return super()._launch_stock_rule_from_pos_order_lines()


### PR DESCRIPTION
A field from sale was used in point_of_sale. Introduced here https://github.com/odoo/odoo/pull/173389

opw-4005925-1
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
