### PR TITLE
[FIX] pos_sale: prevent an error while choosing furnitures scenario card

### DIFF
--- a/addons/pos_sale/models/pos_config.py
+++ b/addons/pos_sale/models/pos_config.py
@@ -26,8 +26,9 @@ class PosConfig(models.Model):
     @api.model
     def _ensure_downpayment_product(self):
         pos_config = self.env.ref('point_of_sale.pos_config_main', raise_if_not_found=False)
-        if pos_config:
-            pos_config.write({'down_payment_product_id': self.env.ref('pos_sale.default_downpayment_product').id})
+        downpayment_product = self.env.ref('pos_sale.default_downpayment_product', raise_if_not_found=False)
+        if pos_config and downpayment_product:
+            pos_config.write({'down_payment_product_id': downpayment_product.id})
 
     @api.model
     def load_onboarding_furniture_scenario(self):


### PR DESCRIPTION
Currently, an error occurs when trying to load onboarding 'Furnitures' without a product name 'Down Payment (POS).

Step to produce:

- Install the 'pos_sale' module.
- Delete a product name 'Down Payment (POS)'.
- Open a point of sale and archive all sessions, Click on the 'Furnitures' scenario card.

Traceback On Sentry:

```
ValueError: No record found for unique ID pos_sale.default_downpayment_product. It may have been deleted.
  File "odoo/http.py", line 2373, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1903, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1966, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1933, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2177, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 223, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 754, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 35, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 459, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/pos_sale/models/pos_config.py", line 35, in load_onboarding_furniture_scenario
    self._ensure_downpayment_product()
  File "addons/pos_sale/models/pos_config.py", line 30, in _ensure_downpayment_product
    pos_config.write({'down_payment_product_id': self.env.ref('pos_sale.default_downpayment_product').id})
  File "odoo/api.py", line 593, in ref
    raise ValueError('No record found for unique ID %s. It may have been deleted.' % (xml_id))

```

An error occurs when the system tries to retrieve an external ID of product 'Down Payment (POS)' at [1] When opening a 'Furnitures' scenario card in POS, but it is not available.

To handle this issue, add 'raise_if_not_found=False' so that if the external id of a product 'Down Payment (POS)' is not found, then it will return a None value instead of raising an error.

Sentry-5690826936

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
