### PR TITLE
[IMP] pos_restaurant: floating orders in table selector

### DIFF
--- a/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.js
+++ b/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.js
@@ -1,0 +1,39 @@
+import { usePos } from "@point_of_sale/app/store/pos_hook";
+import { useService } from "@web/core/utils/hooks";
+import { Component, useState } from "@odoo/owl";
+import { ListContainer } from "@point_of_sale/app/generic_components/list_container/list_container";
+
+export class OrderTabs extends Component {
+    static template = "point_of_sale.OrderTabs";
+    static components = {
+        ListContainer,
+    };
+    static props = {
+        orders: Array,
+        class: { type: String, optional: true },
+    };
+    static defaultProps = {
+        class: "",
+    };
+    setup() {
+        this.pos = usePos();
+        this.ui = useState(useService("ui"));
+        this.dialog = useService("dialog");
+    }
+    newFloatingOrder() {
+        this.pos.selectedTable = null;
+        this.pos.add_new_order();
+        this.pos.showScreen("ProductScreen");
+        if (this.env.inDialog) {
+            this.dialog.closeAll();
+        }
+    }
+    selectFloatingOrder(order) {
+        this.pos.set_order(order);
+        this.pos.selectedTable = null;
+        this.pos.showScreen("ProductScreen");
+        if (this.env.inDialog) {
+            this.dialog.closeAll();
+        }
+    }
+}

--- a/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.xml
+++ b/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="point_of_sale.OrderTabs">
+        <ListContainer items="props.orders"
+            onClickPlus="() => this.newFloatingOrder()"
+            t-slot-scope="scope"
+            class="props.class"
+            forceSmall="ui.isSmall and !env.inDialog"
+        >
+            <t t-set="order" t-value="scope.item" />
+            <button t-esc="order.getFloatingOrderName()"
+                t-attf-class="{{pos.get_order()?.id === order.id ? 'btn-secondary active' : ''}}"
+                class="btn btn-lg btn-secondary text-truncate"
+                style="min-width: 4rem;"
+                t-on-click="() => this.selectFloatingOrder(order)"
+            />
+        </ListContainer>
+    </t>
+</templates>

--- a/addons/point_of_sale/static/src/app/generic_components/list_container/list_container.js
+++ b/addons/point_of_sale/static/src/app/generic_components/list_container/list_container.js
@@ -24,10 +24,16 @@ class ListContainerDialog extends ListContainerPopover {
 export class ListContainer extends Component {
     static props = {
         items: Array,
+        onClickPlus: { type: Function, optional: true },
         slots: { type: Object },
+        class: { type: String, optional: true },
+        forceSmall: { type: Boolean, optional: true },
+    };
+    static defaultProps = {
+        class: "",
     };
     static template = xml`
-        <div class="overflow-hidden d-flex">
+        <div class="overflow-hidden d-flex" t-attf-class="{{props.class}}">
             <!-- it's important that the parent of the 'container' div not be the parent of the 'view more' div -->
             <!-- otherwise the appearance and disappearance of the 'view more' div will retrigger the resizeObserver, -->
             <!-- which will cause a glitch-->
@@ -40,12 +46,15 @@ export class ListContainer extends Component {
                     gap: 0.5rem;
                     height: {{popover.isOpen ? '0' : 'auto'}};
                 ">
-                    <t t-if="!ui.isSmall" t-foreach="props.items" t-as="item" t-key="item_index">
+                    <t t-if="!props.forceSmall" t-foreach="props.items" t-as="item" t-key="item_index">
                         <t t-slot="default" item="item"/>
                     </t>
                 </div>
             </div>
-            <button t-if="(isLarger() or ui.isSmall) and props.items.length" t-on-click="toggle"
+            <button t-if="props.onClickPlus" class="btn btn-light btn-lg" t-on-click="props.onClickPlus">
+                <i class="fa fa-fw fa-lg fa-plus-circle" aria-hidden="true"/>
+            </button>
+            <button t-if="isLarger() or props.forceSmall" t-on-click="toggle"
                 class="btn btn-secondary ms-2"
                 t-attf-class="fa {{popover.isOpen ? 'fa-caret-up' : 'fa-caret-down'}}"/>
         </div>
@@ -56,9 +65,10 @@ export class ListContainer extends Component {
         this.ui = useService("ui");
         this.dialog = useService("dialog");
         this.popover = useReactivePopover(ListContainerPopover, {
-            position: "top-fit",
+            position: "bottom-fit",
             arrow: false,
             animation: false,
+            popoverClass: "mh-50 overflow-y-auto overflow-x-hidden",
             closeOnClickAway: (target) => !target.classList.contains("fa-caret-up"),
         });
     }

--- a/addons/point_of_sale/static/src/app/generic_components/numpad/numpad.js
+++ b/addons/point_of_sale/static/src/app/generic_components/numpad/numpad.js
@@ -27,7 +27,7 @@ export const DECIMAL = {
 export const BACKSPACE = { value: "Backspace", text: "⌫" };
 export const ZERO = { value: "0" };
 export const DEFAULT_LAST_ROW = [{ value: "-", text: "+/-" }, ZERO, DECIMAL];
-export const EMPTY = {};
+export const EMPTY = { value: "" };
 
 export function getButtons(lastRow, rightColumn) {
     return [

--- a/addons/point_of_sale/static/src/app/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.js
@@ -20,8 +20,7 @@ import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { deduceUrl } from "@point_of_sale/utils";
 import { user } from "@web/core/user";
-import { TextInputPopup } from "@point_of_sale/app/utils/input_popups/text_input_popup";
-import { ListContainer } from "@point_of_sale/app/generic_components/list_container/list_container";
+import { OrderTabs } from "@point_of_sale/app/components/order_tabs/order_tabs";
 
 export class Navbar extends Component {
     static template = "point_of_sale.Navbar";
@@ -34,7 +33,7 @@ export class Navbar extends Component {
         Dropdown,
         DropdownItem,
         SyncPopup,
-        ListContainer,
+        OrderTabs,
     };
     static props = {};
     setup() {
@@ -63,35 +62,8 @@ export class Navbar extends Component {
     get showCashMoveButton() {
         return Boolean(this.pos.config.cash_control && this.pos.session._has_cash_move_perm);
     }
-    showTabs() {
-        return true;
-    }
-    newFloatingOrder() {
-        this.pos.add_new_order();
-        this.pos.showScreen("ProductScreen");
-    }
-    selectFloatingOrder(order) {
-        this.pos.set_order(order);
-        this.pos.showScreen("ProductScreen");
-    }
-    getFloatingOrders() {
+    getOrderTabs() {
         return this.pos.get_open_orders();
-    }
-    editOrderNote(order) {
-        this.dialog.add(TextInputPopup, {
-            title: _t("Edit order note"),
-            placeholder: _t("Emma's Birthday Party"),
-            startingValue: order.note || "",
-            getPayload: async (newName) => {
-                if (typeof order.id == "number") {
-                    this.pos.data.write("pos.order", [order.id], {
-                        note: newName,
-                    });
-                } else {
-                    order.note = newName;
-                }
-            },
-        });
     }
     onCashMoveButtonClick() {
         this.hardwareProxy.openCashbox(_t("Cash in / out"));

--- a/addons/point_of_sale/static/src/app/navbar/navbar.xml
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.xml
@@ -3,18 +3,8 @@
 
     <t t-name="point_of_sale.Navbar">
         <div class="pos-topheader navbar-height d-flex align-items-center justify-content-between px-2 py-1 m-0 bg-white border-bottom">
-            <div class="pos-leftheader d-flex">
-                <t t-if="showTabs()">
-                    <div t-attf-class=" d-flex overflow-x-auto {{ ui.isSmall ? 'flex-shrink-0' : 'flex-shrink-1'}}">
-                        <ListContainer items="getFloatingOrders()" t-slot-scope="scope">
-                            <t t-set="order" t-value="scope.item"/>
-                            <button t-esc="order.getFloatingOrderName()" t-attf-class="{{pos.get_order()?.id === order.id ? 'btn-secondary active' : ''}}" class="btn btn-lg lh-lg tab text-nowrap" t-on-click="() => this.selectFloatingOrder(order)"/>
-                        </ListContainer>
-                    </div>
-                    <button class="btn btn-light btn-lg border-transparent lh-lg" style="padding: 0.3125rem 0.625rem;" t-on-click="newFloatingOrder">
-                        <i class="fa fa-fw fa-lg fa-plus-circle" aria-hidden="true"/>
-                    </button>
-                </t>
+            <div class="pos-leftheader d-flex align-items-center">
+                <OrderTabs orders="getOrderTabs()"/>
             </div>
             <div t-if="!ui.isSmall"  class="pos-centerheader d-flex justify-content-center">
                 <img class="pos-logo pos-logo mw-100" height="42" t-on-click="() => debug.toggleWidget()" src="/web/static/img/logo.png" alt="Logo" />

--- a/addons/point_of_sale/static/tests/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/chrome_util.js
@@ -28,13 +28,6 @@ export function isCashMoveButtonHidden() {
         },
     ];
 }
-export function newOrder() {
-    return {
-        content: "create new order",
-        trigger: ".pos-topheader button i.fa-plus-circle",
-        run: "click",
-    };
-}
 export function endTour() {
     return {
         content: "Last tour step that avoids error mentioned in commit 443c209",

--- a/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.js
+++ b/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.js
@@ -62,7 +62,7 @@ patch(ControlButtons.prototype, {
         this.dialog.add(TextInputPopup, {
             title: _t("Edit order note"),
             placeholder: _t("Emma's Birthday Party"),
-            startingValue: order.note,
+            startingValue: order.note || "",
             getPayload: async (newName) => {
                 if (typeof order.id == "number") {
                     this.pos.data.write("pos.order", [order.id], {

--- a/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.xml
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.xml
@@ -11,7 +11,10 @@
                 Switch Floor View
             </DropdownItem>
         </xpath>
-        <xpath expr="//div[hasclass('pos-leftheader')]/t" position="before">
+        <xpath expr="//div[hasclass('pos-leftheader')]/OrderTabs" position="attributes">
+            <attribute name="t-if">!pos.config.module_pos_restaurant or !ui.isSmall</attribute>
+        </xpath>
+        <xpath expr="//div[hasclass('pos-leftheader')]/OrderTabs" position="before">
             <div t-if="pos.config.module_pos_restaurant" class="d-flex flex-shrink-0 gap-1 position-relative">
                <div class="navbar-menu d-flex d-lg-grid gap-1">
                     <t t-set="screen" t-value="pos.mainScreen.component.name" />
@@ -19,7 +22,7 @@
                         <span t-if="!ui.isSmall">Plan</span>
                         <img t-else="" src="/pos_restaurant/static/img/plan.svg" class="navbar-icon" alt="Floor Plan"/>
                     </button>
-                    <button class="table-free-order-label btn btn-lg lh-lg" t-att-class="{'btn-primary': screen === 'ProductScreen' or pos.orderToTransferUuid}" t-on-click="() => this.switchTable()">
+                    <button class="table-free-order-label btn btn-lg lh-lg" t-att-class="{'btn-primary': screen === 'ProductScreen' or pos.orderToTransferUuid}" t-on-click="() => this.onClickTableTab()">
                         <span t-if="getOrderToDisplay()" t-esc="getOrderName()"/>
                         <span t-elif="!ui.isSmall">Table</span>
                         <img t-else="" src="/pos_restaurant/static/img/table.svg" class="navbar-icon" alt="Table Selector"/>

--- a/addons/pos_restaurant/static/src/overrides/components/navbar/table_selector/table_selector.js
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/table_selector/table_selector.js
@@ -1,0 +1,12 @@
+import { usePos } from "@point_of_sale/app/store/pos_hook";
+import { OrderTabs } from "@point_of_sale/app/components/order_tabs/order_tabs";
+import { NumberPopup } from "@point_of_sale/app/utils/input_popups/number_popup";
+
+export class TableSelector extends NumberPopup {
+    static template = "pos_restaurant.TableSelector";
+    static components = { ...super.components, OrderTabs };
+    setup() {
+        this.pos = usePos();
+        super.setup();
+    }
+}

--- a/addons/pos_restaurant/static/src/overrides/components/navbar/table_selector/table_selector.xml
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/table_selector/table_selector.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="pos_restaurant.TableSelector" t-inherit="point_of_sale.NumberPopup" t-inherit-mode="primary">
+        <xpath expr="//div[hasclass('input-symbol')]" position="before">
+            <OrderTabs orders="pos.get_open_orders().filter((o) => !o.table_id)" class="'mb-3'"/>
+        </xpath>
+    </t>
+</templates>

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -60,12 +60,20 @@ registry.category("web_tour.tours").add("pos_restaurant_sync", {
             Dialog.confirm("Open session"),
 
             // Create a floating order. The idea is to have one of the draft orders be a floating order during the tour.
-            Chrome.newOrder(),
 
+            {
+                content: "open table selector",
+                trigger: ".pos-topheader button.table-free-order-label",
+                run: "click",
+            },
+            {
+                content: "create new order",
+                trigger: ".modal-body button i.fa-plus-circle",
+                run: "click",
+            },
             // Dine in / Takeaway can be toggled.
             ProductScreen.clickControlButton("Dine in"),
             ProductScreen.clickControlButton("Takeaway"),
-
             ProductScreen.clickDisplayedProduct("Coca-Cola"),
             ProductScreen.clickDisplayedProduct("Coca-Cola"),
             ProductScreen.clickDisplayedProduct("Coca-Cola"),


### PR DESCRIPTION
In this commit we move the floating orders selector from the navbar to
the table selector in pos_restaurant.
In retail pos it remains in the navbar.
![image](https://github.com/user-attachments/assets/48a4d2f6-4b88-47cd-8387-d39f4e281caf)


Task: 4091946


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
