### PR TITLE
[FIX] web_editor, website_sale: fix padding and tooltip

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -2953,3 +2953,7 @@ we-select.o_grid we-toggler {
         }
     }
 }
+
+we-selection-items > we-title {
+    padding-left: 8px;
+}

--- a/addons/website_sale/views/snippets/snippets.xml
+++ b/addons/website_sale/views/snippets/snippets.xml
@@ -84,7 +84,7 @@
                          data-customize-website-views="website_sale.search"
                          data-no-preview="true"
                          data-reload="/"/>
-            <we-checkbox string="Prod. Desc."
+            <we-checkbox string="Product Description"
                          data-customize-website-views="website_sale.products_description"
                          data-no-preview="true"
                          data-reload="/"/>


### PR DESCRIPTION
#### Commit 1:
[FIX] web_editor: added left padding on we-title inside a selection

The two categories (Custom Fields, Existing Fields) inside field
type (when editing a field) were missing left padding.

#### Commit 2:
[FIX] website-sale: changed Prod. Desc. string to make appear tooltip

Product Description was missing tooltip when editing a product page
due to the string already being shortened

task-4080745