### PR TITLE
[FIX] point_of_sale: exclude action screen from order

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/action_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/action_screen.js
@@ -5,6 +5,7 @@ import { ActionContainer } from "@web/webclient/actions/action_container";
 export class ActionScreen extends Component {
     static components = { ActionContainer };
     static props = {};
+    static storeOnOrder = false;
     static template = xml`
         <ActionContainer/>
     `;


### PR DESCRIPTION
Screens are saved on order so that when an order is reselected, the order is rendered on its last recorded screen. In this commit, we exclude the ActionScreen since it doesn't make sense (for now) for it to be a screen for the current order.

Steps to reproduce:

1. Install pos_restaurant_appointment.
2. Open a session for the Restaurant config.
3. Open an order by clicking a table.
4. Click Booking button from the navbar.
5. Click the table selector and select the table you selected in step 2.
6. ISSUE: The screen is blank.

Test is in enterprise: https://github.com/odoo/enterprise/pull/68209

