### PR TITLE
[FIX] hr : fix overlap in employee kanban card

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -321,7 +321,7 @@
                                 </div>
                                 <field name="employee_properties" widget="properties"/>
                                 <field class="hr_tags" name="category_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
-                                <footer class="fs-6 position-absolute bottom-0 end-0">
+                                <footer>
                                     <div class="d-flex ms-auto">
                                         <field name="user_id" widget="many2one_avatar_user" readonly="1" class="mb-1 ms-2"/>
                                         <field name="activity_ids" widget="kanban_activity" class="m-1 ms-2"/>


### PR DESCRIPTION
Before this commit, the kanban footer had an absolute position; who overlapped the kanban body.

task-4106928

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
