### PR TITLE
[FIX] point_of_sale: add webclient css

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -126,6 +126,7 @@
             ('include', 'point_of_sale.base_app'),
 
             'web/static/src/core/colorlist/colorlist.scss',
+            'web/static/src/webclient/webclient_layout.scss',
 
             'web/static/src/webclient/icons.scss',
 

--- a/addons/point_of_sale/static/src/app/screens/action_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/action_screen.js
@@ -6,7 +6,9 @@ export class ActionScreen extends Component {
     static components = { ActionContainer };
     static props = {};
     static template = xml`
-        <ActionContainer/>
+        <div class="o_web_client">
+            <ActionContainer/>
+        </div>
     `;
 }
 registry.category("pos_screens").add("ActionScreen", ActionScreen);

--- a/addons/point_of_sale/static/src/scss/pos.scss
+++ b/addons/point_of_sale/static/src/scss/pos.scss
@@ -186,3 +186,7 @@ button {
     background-color: #fff;
     border: 0;
 }
+// this is to override the property in `web/static/src/webclient/webclient_layout.scss'
+body.modal-open {
+    position: initial !important;
+}


### PR DESCRIPTION
In 38d741f6b1d9ba2911632185bd81bf6cb6d98383 we added the functionality to render fullscreen actions, but failed to include the appropriate css assets. One of the impacts of this is the incorrect scrolling of the gantt view for booking management.

In this commit we add the correct css assets.

Task: 4106537




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
