### PR TITLE
[CHG] core: patch out database's `now()`

### DIFF
--- a/odoo/addons/base/data/base_data.sql
+++ b/odoo/addons/base/data/base_data.sql
@@ -138,3 +138,11 @@ select setval('res_users_id_seq', 1);
 insert into res_groups (id, name) VALUES (1, '{"en_US": "Employee"}');
 insert into ir_model_data (name, module, model, noupdate, res_id) VALUES ('group_user', 'base', 'res.groups', true, 1);
 select setval('res_groups_id_seq', 1);
+
+-- ALTER FUNCTION public.now() RENAME TO now_builtin;
+-- CREATE FUNCTION now() RETURNS timestamptz AS $$
+--     SELECT coalesce(
+--         current_setting('odoo.now', true)::timestamptz,
+--         now_builtin()
+--     );
+-- $$ LANGUAGE sql;


### PR DESCRIPTION
Dates are a major source of non-deterministic behavior, and while we can relatively easily manage dates in Python, that is not the case in Postgres: the database lives outside our reach, in a separate process with its own rules and foibles.

Or does it? In this story we take the database's reality, crush it underfoot, and substitute it with our own.

Although I will readily confess that I don't understand why it seems to work: according to postgres's documentation[1],

> the current session's temporary-table schema, pg_temp_nnn, is always
> searched if it exists. [...] However, the temporary schema is only
> searched for relation (table, view, sequence, etc) and data type
> names. **It is never searched for function or operator names.**

Emphasis mine. And yet, it moves. But only in Odoo, in a shell it fails.

Task 2788989

[1]: https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-SEARCH-PATH
