### PR TITLE
[FIX] mrp_{account,subcontracting_dropshipping}: stop redundant multiply

### DIFF
--- a/addons/mrp_account/models/product.py
+++ b/addons/mrp_account/models/product.py
@@ -58,7 +58,7 @@ class ProductProduct(models.Model):
         for bom_line, moves_list in groupby(stock_moves.filtered(lambda sm: sm.state != 'cancel'), lambda sm: sm.bom_line_id):
             if bom_line not in bom_lines:
                 for move in moves_list:
-                    value += move.product_qty * move.product_id._compute_average_price(qty_invoiced * move.product_qty, qty_to_invoice * move.product_qty, move, is_returned=is_returned)
+                    value += move.product_id._compute_average_price(qty_invoiced * move.product_qty, qty_to_invoice * move.product_qty, move, is_returned=is_returned)
                 continue
             line_qty = bom_line.product_uom_id._compute_quantity(bom_lines[bom_line]['qty'], bom_line.product_id.uom_id)
             moves = self.env['stock.move'].concat(*moves_list)

--- a/addons/mrp_subcontracting_dropshipping/tests/test_anglo_saxon_valuation.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_anglo_saxon_valuation.py
@@ -205,3 +205,62 @@ class TestSubcontractingDropshippingValuation(ValuationReconciliationTestCommon)
                 {'reference': dropship_backorder.name, 'quantity': 0, 'value': -8000},
             ]
         )
+
+    def test_account_line_entry_kit_bom_dropship(self):
+        """ An order delivered via dropship for some kit bom product variant should result in
+        accurate journal entries in the expense and stock output accounts if the cost on the
+        purchase order line has been manually edited.
+        """
+        kit_final_prod = self.product_a
+        kit_bom = self.env['mrp.bom'].create({
+            'product_tmpl_id': kit_final_prod.product_tmpl_id.id,
+            'product_uom_id': kit_final_prod.uom_id.id,
+            'product_qty': 1.0,
+            'type': 'phantom',
+        })
+        kit_bom.bom_line_ids = [(0, 0, {
+            'product_id': self.product_b.id,
+            'product_qty': 1,
+        })]
+
+        self.env['product.supplierinfo'].create({
+            'product_id': self.product_b.id,
+            'partner_id': self.partner_a.id,
+            'price': 2000,
+        })
+
+        (kit_final_prod + self.product_b).categ_id.write({
+            'property_cost_method': 'fifo',
+            'property_valuation': 'real_time',
+        })
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner_b.id,
+            'order_line': [(0, 0, {
+                'price_unit': 900,
+                'product_id': kit_final_prod.id,
+                'route_id': self.dropship_route.id,
+                'product_uom_qty': 2.0,
+            })],
+        })
+        sale_order.action_confirm()
+        purchase_order = sale_order._get_purchase_orders()[0]
+        purchase_order.button_confirm()
+        dropship_transfer = purchase_order.picking_ids[0]
+        dropship_transfer.move_ids[0].quantity_done = 2.0
+        dropship_transfer.button_validate()
+
+        account_move = sale_order._create_invoices()
+        account_move.action_post()
+
+        self.assertRecordValues(
+            account_move.line_ids,
+            [
+                {'name': 'product_a',           'debit': 0.0,       'credit': 1800.0},
+                {'name': 'Tax 15% (Copy)',      'debit': 0.0,       'credit': 270.0},
+                {'name': 'INV/2024/00001',      'debit': 621.0,     'credit': 0.0},
+                {'name': 'INV/2024/00001',      'debit': 1449.0,    'credit': 0.0},
+                {'name': 'product_a',           'debit': 0.0,       'credit': 4000.0},
+                {'name': 'product_a',           'debit': 4000.0,    'credit': 0.0},
+            ]
+        )


### PR DESCRIPTION
**Current behavior:**
Having a product produced via kit bom with FIFO & automated costing method and valuation in a sale order with delivery via dropship:

When the orders and transfers are completed and the sale order is invoiced, the stock output and expense account on the invoice will have a credit and dedit (respectively) which is too high (the degree is proportional to the `product_qty` of each move in the dropship transfer).

**Expected behavior:**
The account entry lines should be accurate to the cost of the kit components.

**Steps to reproduce:**
1. Create a kit_product such that: - It has FIFO cost method and automated valuation - Has a component in a kit bom, also with FIFO and automated valuation as well as a vendor with non-zero price

2. Create a sale order for 2 of the kit product and set the SOL route to dropship

3. Confirm the sale order, purchase order, and validate the dropship transfer

4. Create an invoice for the sale order and confirm/post it

5. Observe that the stock output and expense accounts have a credit and debit (respectively) for 2x the correct amount

**Cause of the issue:**
The `product_qty` of each move in the dropship is errantly multiplied with the result of `_compute_average_price()`- this qty has already been taken into account.

**Fix:**
Remove this piece of the calculation.

opw-4050777