### PR TITLE
[FIX] web: pass context when duplicating records

### DIFF
--- a/addons/web/static/src/model/relational_model/dynamic_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_list.js
@@ -214,7 +214,9 @@ export class DynamicList extends DataPoint {
             resIds = await this.getResIds(true);
         }
 
-        const duplicated = await this.model.orm.call(this.resModel, "copy", [resIds]);
+        const duplicated = await this.model.orm.call(this.resModel, "copy", [resIds],{
+            context: this.context,
+        });
         if (resIds.length > duplicated.length) {
             this.model.notification.add(_t("Some records could not be duplicated"), {
                 title: _t("Warning"),

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -1,0 +1,78 @@
+import { expect, test } from "@odoo/hoot";
+import {
+    contains,
+    defineModels,
+    fields,
+    models,
+    mountView,
+    onRpc,
+    toggleActionMenu,
+    toggleMenuItem,
+} from "@web/../tests/web_test_helpers";
+
+class Partner extends models.Model {
+    _name = "res.partner";
+    _inherit = [];
+
+    name = fields.Char({
+        string: "Name",
+        default: "My little Name Value",
+        trim: true,
+    });
+
+    _records = [
+        {
+            id: 1,
+            display_name: "first record",
+            name: "yop",
+        },
+        {
+            id: 2,
+            display_name: "second record",
+            name: "blip",
+        },
+        {
+            id: 3,
+            display_name: "aaa",
+            name: "abc",
+        },
+    ];
+}
+class User extends models.Model {
+    _name = "res.users";
+
+    name = fields.Char();
+
+    has_group() {
+        return true;
+    }
+}
+
+defineModels([Partner, User]);
+
+test("Pass context when duplicating data in list view", async () => {
+
+    onRpc("copy", ({ kwargs }) => {
+        const { context } = kwargs;
+        expect(context.ctx_key).toBe('ctx_val');
+        expect.step('copy');
+    });
+    await mountView({
+        type: "list",
+        resModel: "res.partner",
+        loadActionMenus: true,
+        arch: `
+            <tree>
+                <field name="name" />
+            </tree>`,
+        context: {
+            ctx_key: "ctx_val",
+        }
+    });
+
+    const inputSelector = "tbody tr:first-child td.o_list_record_selector input";
+    await contains(inputSelector).click();
+    await toggleActionMenu();
+    await toggleMenuItem("Duplicate");
+    expect.verifySteps(["copy"]);
+});


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Adapting the fix for saas-17.2: https://github.com/odoo/odoo/pull/174137

It is found that context is never passed in '_duplicateRecords' function for list views, when making 'orm' calls from js side, while it is passed in 'duplicate' function of record.js, which is called when duplicating record from form view.

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
