### PR TITLE
[FIX] point_of_sale,pos_sale: ship later disabled by default

### DIFF
--- a/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js
+++ b/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js
@@ -444,15 +444,6 @@ export class SaleOrderManagementScreen extends ControlButtonsMixin(Component) {
         const sale_lines = await this._getSOLines(sale_order.order_line);
         sale_order.order_line = sale_lines;
 
-        if (sale_order.picking_ids[0]) {
-            const [picking] = await this.orm.read(
-                "stock.picking",
-                [sale_order.picking_ids[0]],
-                ["scheduled_date"]
-            );
-            sale_order.shipping_date = picking.scheduled_date;
-        }
-
         return sale_order;
     }
 

--- a/addons/pos_sale/static/tests/tours/PosSaleTour.js
+++ b/addons/pos_sale/static/tests/tours/PosSaleTour.js
@@ -10,6 +10,7 @@ const ProductScreen = { ...ProductScreenPos, ...ProductScreenSale };
 const ReceiptScreen = { ...ReceiptScreenPos, ...ReceiptScreenSale };
 import * as TicketScreen from "@point_of_sale/../tests/tours/helpers/TicketScreenTourMethods";
 import * as Order from "@point_of_sale/../tests/tours/helpers/generic_components/OrderWidgetMethods";
+import { negateStep } from "@point_of_sale/../tests/tours/helpers/utils";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("PosSettleOrder", {
@@ -262,5 +263,18 @@ registry.category("web_tour.tours").add("PoSDownPaymentLinesPerTax", {
                 quantity: "1.0",
                 price: "3.00",
             }),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("PosShipLaterNoDefault", {
+    test: true,
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.clickQuotationButton(),
+            ProductScreen.selectFirstOrder(),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.isShown(),
+            negateStep(PaymentScreen.shippingLaterHighlighted()),
         ].flat(),
 });

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -689,3 +689,27 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosSettleDraftOrder', login="accountman")
+
+    def test_ship_later_no_default(self):
+        """ Verify that when settling an order the ship later is not activated by default"""
+        product = self.env['product.product'].create({
+            'name': 'Product',
+            'available_in_pos': True,
+            'type': 'product',
+            'lst_price': 10.0,
+            'taxes_id': False,
+        })
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.env['res.partner'].create({'name': 'Test Partner'}).id,
+            'order_line': [(0, 0, {
+                'product_id': product.id,
+                'name': product.name,
+                'product_uom_qty': 4,
+                'price_unit': product.lst_price,
+            })],
+        })
+        sale_order.action_confirm()
+        self.main_pos_config.write({'ship_later': True})
+        self.main_pos_config.open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosShipLaterNoDefault', login="accountman")


### PR DESCRIPTION
When settling a sale order in the PoS the shiplater option was always turned on.

Steps to reproduce:
-------------------
* Activate ship later option in PoS config
* Create a sale order and confirm it
* Open the PoS
* Settle the order
* Click on pay
> Observation: The ship later button is already activated

Why the fix:
------------
The button activation is based on the presence or not of a delivery date to fix it we just make sure not to import the delivery date from the original sale order.

opw-3987515
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
