### PR TITLE
[FIX] account: Invoice Order on Payment Receipt

### DIFF
--- a/addons/account/views/report_payment_receipt_templates.xml
+++ b/addons/account/views/report_payment_receipt_templates.xml
@@ -34,8 +34,7 @@
                     </div>
                 </div>
 
-                <t t-set="partials" t-value="o.move_id._get_reconciled_invoices_partials()"/>
-                <t t-set="invoices" t-value="{partial[2].move_id for partial in partials}"/>
+                <t t-set="invoices" t-value="o.reconciled_invoice_ids"/>
                 <!-- Check if invoices include different currencies -->
                 <t t-foreach="invoices" t-as="inv">
                     <t t-if="any(inv.currency_id != par[2].currency_id for par in inv._get_reconciled_invoices_partials())" t-set="otherCurrency" t-value="True"/>


### PR DESCRIPTION
Before this commit:
Invoices reconciled with a single payment appeared in a random order on the Payment Receipt. This was caused by the use of a set, which does not preserve the order of invoices.

After this commit:
Invoices are displayed in the order defined by the account.move model, ensuring a consistent and logical sequence.

Steps to reproduce:
- Create four invoices for the same customer on different dates.
- Register a customer payment covering the total amount of the four invoices.
- Reconcile the payment with the invoices.
- Print the Payment Receipt for the payment.

opw-4096451