### PR TITLE
[FIX] account: add product description to invoice

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -131,7 +131,9 @@
                                     <tr t-att-class="'bg-200 fw-bold o_line_section' if line.display_type == 'line_section' else 'fst-italic o_line_note' if line.display_type == 'line_note' else ''">
                                         <t t-if="line.display_type == 'product'" name="account_invoice_line_accountable">
                                             <td name="account_invoice_line_name">
-                                                <span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}">Bacon Burger</span>
+                                                <span t-if="line.product_id.name and line.product_id.default_code">[<t t-out="line.product_id.default_code"/>] </span>
+                                                <span t-if="line.product_id.name" t-field="line.product_id.name" t-options="{'widget': 'text'}"/>
+                                                <span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}"/>
                                             </td>
                                             <td name="td_quantity" class="text-end">
                                                 <span t-field="line.quantity">3.00</span>


### PR DESCRIPTION
Problem:

Because of this commit (https://github.com/odoo-dev/odoo/commit/c3284e4b3314895f0cfdca816accd02424f34f91) the product name was not showing in the invoice.

Steps to reproduce:

- In a fresh database, create a product (only with a name).
- Create a Sales Order (SO).
- Create an invoice from the SO.
- Print the invoice.
- You will see no descriptions for products in the invoice.

opw-4094189

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
