### PR TITLE
[FIX] mail: channel mentions are lost when editing

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -424,8 +424,18 @@ export class Message extends Component {
     prepareMessageBody(element) {}
 
     enterEditMode() {
+        const body = document.createElement("span");
+        body.innerHTML = this.props.message.body;
+        const mentionedChannelElements = body.querySelectorAll(".o_channel_redirect");
+        const mentionedChannels = Array.from(mentionedChannelElements).map((el) =>
+            this.store.Thread.insert({
+                id: el.dataset.oeId,
+                model: el.dataset.oeModel,
+            })
+        );
         const messageContent = convertBrToLineBreak(this.props.message.body);
         this.props.message.composer = {
+            mentionedChannels,
             mentionedPartners: this.props.message.recipients,
             textInputContent: messageContent,
             selection: {

--- a/addons/mail/static/tests/message/message_tests.js
+++ b/addons/mail/static/tests/message/message_tests.js
@@ -42,6 +42,34 @@ QUnit.test("Start edition on click edit", async () => {
     await contains(".o-mail-Message-editable .o-mail-Composer-input", { value: "Hello world" });
 });
 
+QUnit.test("Editing message keeps the mentioned channels", async () => {
+    const pyEnv = await startServer();
+    const channelId1 = pyEnv["discuss.channel"].create({
+        name: "general",
+        channel_type: "channel",
+    });
+    pyEnv["discuss.channel"].create({
+        name: "other",
+        channel_type: "channel",
+    });
+    const { openDiscuss } = await start();
+    openDiscuss(channelId1);
+    await insertText(".o-mail-Composer-input", "#");
+    await click(".o-mail-Composer-suggestion strong", { text: "#other" });
+    await click(".o-mail-Composer-send:enabled");
+    await contains(".o_channel_redirect", { count: 1, text: "#other" });
+    await click(".o-mail-Message [title='Expand']");
+    await click(".o-mail-Message [title='Edit']");
+    await contains(".o-mail-Message-editable .o-mail-Composer-input", {
+        value: "#other",
+    });
+    await insertText(".o-mail-Message .o-mail-Composer-input", "#other bye", { replace: true });
+    await click(".o-mail-Message a", { text: "save" });
+    await contains(".o-mail-Message-content", { text: "#other bye" });
+    await click(".o_channel_redirect", { text: "#other" });
+    await contains(".o-mail-Discuss-threadName", { value: "other" });
+});
+
 QUnit.test("Edit message (mobile)", async () => {
     patchUiSize({ size: SIZES.SM });
     const pyEnv = await startServer();


### PR DESCRIPTION
When editing a message, the mentions of the original message were lost.

The reason is that the channel mentions were not stored with the message in the database.

The fix is to parse the body directly before editing and get mentionedChannels from it.

task-4104895


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
