### PR TITLE
[IMP] mail: quickly add reaction to reacted message

### DIFF
--- a/addons/mail/static/src/core/common/message_reaction_list.xml
+++ b/addons/mail/static/src/core/common/message_reaction_list.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <template xml:space="preserve">
     <t t-name="mail.MessageReactionList">
-        <Dropdown state="preview" position="'bottom-start'" menuClass="'bg-view border-0 p-0 mt-1 overflow-visible shadow-sm'" manual="true">
+        <Dropdown state="preview" position="'top-middle'" menuClass="'bg-view border-0 p-0 mt-1 overflow-visible shadow-sm'" manual="true">
             <t t-call="mail.MessageReactionList.button" />
             <t t-set-slot="content">
                 <t t-call="mail.MessageReactionList.preview"/>
@@ -23,7 +23,7 @@
     
     <t t-name="mail.MessageReactionList.preview">
         <div class="o-mail-MessageReactionList-preview px-0 py-1 border cursor-pointer" t-on-click="(ev) => this.props.openReactionMenu(props.reaction)" t-ref="reactionList">
-            <div class="text-truncate mx-2">
+            <div class="text-truncate mx-2 small">
                 <span t-esc="previewText(props.reaction)"/>
             </div>
         </div>

--- a/addons/mail/static/src/core/common/message_reactions.js
+++ b/addons/mail/static/src/core/common/message_reactions.js
@@ -1,7 +1,8 @@
-import { Component, useState } from "@odoo/owl";
+import { Component, useRef, useState } from "@odoo/owl";
 
 import { MessageReactionList } from "@mail/core/common/message_reaction_list";
 import { useService } from "@web/core/utils/hooks";
+import { useEmojiPicker } from "@web/core/emoji_picker/emoji_picker";
 
 export class MessageReactions extends Component {
     static props = ["message", "openReactionMenu"];
@@ -12,5 +13,17 @@ export class MessageReactions extends Component {
         super.setup();
         this.store = useState(useService("mail.store"));
         this.ui = useService("ui");
+        this.addRef = useRef("add");
+        this.emojiPicker = useEmojiPicker(this.addRef, {
+            onSelect: (emoji) => {
+                const reaction = this.props.message.reactions.find(
+                    ({ content, personas }) =>
+                        content === emoji && personas.find((persona) => persona.eq(this.store.self))
+                );
+                if (!reaction) {
+                    this.props.message.react(emoji);
+                }
+            },
+        });
     }
 }

--- a/addons/mail/static/src/core/common/message_reactions.scss
+++ b/addons/mail/static/src/core/common/message_reactions.scss
@@ -1,3 +1,7 @@
+.o-mail-MessageReactions:not(.o-emojiPickerOpen):not(:hover) .o-mail-MessageReactions-add {
+    visibility: hidden;
+}
+
 .o-mail-MessageReaction.o-selfReacted {
     background: mix($o-brand-primary, $o-view-background-color, 10%);
 }

--- a/addons/mail/static/src/core/common/message_reactions.xml
+++ b/addons/mail/static/src/core/common/message_reactions.xml
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
 <t t-name="mail.MessageReactions">
-    <div class="position-relative d-flex flex-wrap"
+    <div class="o-mail-MessageReactions position-relative d-flex flex-wrap"
         t-att-class="{
             'flex-row-reverse me-3': env.inChatWindow and env.alignedRight,
             'ms-3': !(env.inChatWindow and env.alignedRight) and (props.message.is_discussion),
+            'o-emojiPickerOpen': emojiPicker.isOpen,
         }"
         t-attf-class="{{ props.message.is_discussion ? 'mt-n1' : 'mt-1' }}">
         <t t-foreach="props.message.reactions" t-as="reaction" t-key="reaction.content">
             <MessageReactionList message="this.props.message" openReactionMenu="this.props.openReactionMenu" reaction="reaction"/>
         </t>
+        <button class="o-mail-MessageReactions-add btn bg-inherit d-flex px-1 py-0 border-0 rounded-0 mb-1 align-items-center fs-5 opacity-75 opacity-100-hover" title="Add Reaction" t-ref="add"><i class="oi fa-fw oi-smile-add"/></button>
     </div>
 </t>
 </templates>

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -597,6 +597,29 @@ test("Two users reacting with the same emoji", async () => {
     await contains(".o-mail-MessageReaction", { text: "😅2" });
 });
 
+test("Can quickly add a reaction", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_type: "channel",
+        name: "channel1",
+    });
+    pyEnv["mail.message"].create({
+        body: "Hello world",
+        res_id: channelId,
+        message_type: "comment",
+        model: "discuss.channel",
+    });
+    await start();
+    await openDiscuss(channelId);
+    await click("[title='Add a Reaction']");
+    await click(".o-Emoji", { text: "😅" });
+    await contains(".o-mail-MessageReaction", { text: "😅1" });
+    await hover(".o-mail-MessageReactions");
+    await click("button[title='Add Reaction']");
+    await click(".o-Emoji", { text: "😏" });
+    await contains(".o-mail-MessageReaction", { text: "😏1" });
+});
+
 test("Reaction summary", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.js
@@ -30,7 +30,15 @@ import { useAutofocus, useService } from "@web/core/utils/hooks";
  */
 export function useEmojiPicker(ref, props, options = {}) {
     const targets = [];
-    const popover = usePopover(EmojiPicker, { ...options, animation: false });
+    const state = useState({ isOpen: false });
+    const newOptions = {
+        ...options,
+        onClose: () => {
+            state.isOpen = false;
+            options.onClose?.();
+        },
+    };
+    const popover = usePopover(EmojiPicker, { ...newOptions, animation: false });
     props.storeScroll = {
         scrollValue: 0,
         set: (value) => {
@@ -61,6 +69,7 @@ export function useEmojiPicker(ref, props, options = {}) {
         if (popover.isOpen) {
             popover.close();
         } else {
+            state.isOpen = true;
             popover.open(ref.el, { ...props, onSelect });
         }
     }
@@ -95,12 +104,8 @@ export function useEmojiPicker(ref, props, options = {}) {
             ref.el.addEventListener("mouseenter", loadEmoji);
         }
     });
-    return {
-        add,
-        get isOpen() {
-            return popover.isOpen;
-        },
-    };
+    Object.assign(state, { add });
+    return state;
 }
 
 export const loader = {


### PR DESCRIPTION
With this commit, when a message has at least one reaction, users can quickly add new reaction by mouse hovering on reaction. A new button "Add reaction" shows an emoji picker.

This button has the advantage to be very convenient to use, as new reaction on a reacted message are usually incentivised by current reaction, so users usually have their mouse already on existing reactions.

This button is only available on reacted message, and its visiblity is lower than message actions, so this doesn't really replace the "add a reaction" on message action list. Also we keep the "Add a reaction" on action list of reacted message because it can be confusing for users not aware of the quick-react feature.

Task-4107310

<img width="345" alt="Screenshot 2024-08-09 at 14 42 52 (3)" src="https://github.com/user-attachments/assets/194e6f95-d259-4301-ac62-65a8170bd26e">
