### PR TITLE
[FIX] bus: do not miss notifications

### DIFF
--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -1030,6 +1030,7 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
             _hook_invoice_document_before_pdf_report_render,
         ):
             self.env.ref('account.ir_cron_account_move_send').method_direct_trigger()  # force processing
+            self.env.cr.precommit.run()  # trigger the creation of bus.bus records
 
         bus_1 = self.env['bus.bus'].sudo().search(
             [('channel', 'like', f'"res.partner",{sp_partner_1.id}')],

--- a/addons/bus/models/bus.py
+++ b/addons/bus/models/bus.py
@@ -153,16 +153,18 @@ class ImBus(models.Model):
                         )
 
     @api.model
-    def _poll(self, channels, last=0):
+    def _poll(self, channels, last=0, ignore_ids=None):
         # first poll return the notification in the 'buffer'
         if last == 0:
             timeout_ago = fields.Datetime.now() - datetime.timedelta(seconds=TIMEOUT)
             domain = [('create_date', '>', timeout_ago)]
         else:  # else returns the unread notifications
             domain = [('id', '>', last)]
+        if ignore_ids:
+            domain.append(("id", "not in", ignore_ids))
         channels = [json_dump(channel_with_db(self.env.cr.dbname, c)) for c in channels]
         domain.append(('channel', 'in', channels))
-        notifications = self.sudo().search_read(domain)
+        notifications = self.sudo().search_read(domain, ["message"])
         # list of notification to return
         result = []
         for notif in notifications:

--- a/addons/bus/models/bus.py
+++ b/addons/bus/models/bus.py
@@ -8,12 +8,13 @@ import os
 import selectors
 import threading
 import time
-from psycopg2 import InterfaceError, sql
+from psycopg2 import InterfaceError
 
 import odoo
 from odoo import api, fields, models
 from odoo.service.server import CommonServer
-from odoo.tools import date_utils
+from odoo.tools import date_utils, SQL
+from odoo.tools.misc import OrderedSet
 
 _logger = logging.getLogger(__name__)
 
@@ -38,9 +39,9 @@ def get_notify_payload_max_length(default=8000):
 NOTIFY_PAYLOAD_MAX_LENGTH = get_notify_payload_max_length()
 
 
-#----------------------------------------------------------
+# ---------------------------------------------------------
 # Bus
-#----------------------------------------------------------
+# ---------------------------------------------------------
 def json_dump(v):
     return json.dumps(v, separators=(',', ':'), default=date_utils.json_default)
 
@@ -96,38 +97,60 @@ class ImBus(models.Model):
 
     @api.model
     def _sendmany(self, notifications):
-        channels = set()
-        values = []
-        for target, notification_type, message in notifications:
-            channel = channel_with_db(self.env.cr.dbname, target)
-            channels.add(channel)
-            values.append({
-                'channel': json_dump(channel),
-                'message': json_dump({
-                    'type': notification_type,
-                    'payload': message,
-                })
-            })
-        self.sudo().create(values)
-        if channels:
+        for notification in notifications:
+            self._sendone(*notification)
+
+    @api.model
+    def _sendone(self, target, notification_type, message):
+        self._ensure_hooks()
+        channel = channel_with_db(self.env.cr.dbname, target)
+        self.env.cr.precommit.data["bus.bus.values"].append(
+            {
+                "channel": json_dump(channel),
+                "message": json_dump(
+                    {
+                        "type": notification_type,
+                        "payload": message,
+                    }
+                ),
+            }
+        )
+        self.env.cr.postcommit.data["bus.bus.channels"].add(channel)
+
+    def _ensure_hooks(self):
+        if "bus.bus.values" not in self.env.cr.precommit.data:
+            self.env.cr.precommit.data["bus.bus.values"] = []
+
+            @self.env.cr.precommit.add
+            def create_bus():
+                self.sudo().create(self.env.cr.precommit.data.pop("bus.bus.values"))
+
+        if "bus.bus.channels" not in self.env.cr.postcommit.data:
+            self.env.cr.postcommit.data["bus.bus.channels"] = OrderedSet()
+
             # We have to wait until the notifications are commited in database.
             # When calling `NOTIFY imbus`, notifications will be fetched in the
             # bus table. If the transaction is not commited yet, there will be
             # nothing to fetch, and the websocket will return no notification.
             @self.env.cr.postcommit.add
             def notify():
-                with odoo.sql_db.db_connect('postgres').cursor() as cr:
-                    query = sql.SQL("SELECT {}('imbus', %s)").format(sql.Identifier(ODOO_NOTIFY_FUNCTION))
-                    payloads = get_notify_payloads(list(channels))
-                    if len(payloads) > 1:
-                        _logger.info("The imbus notification payload was too large, "
-                                     "it's been split into %d payloads.", len(payloads))
+                payloads = get_notify_payloads(
+                    list(self.env.cr.postcommit.data.pop("bus.bus.channels"))
+                )
+                if len(payloads) > 1:
+                    _logger.info(
+                        "The imbus notification payload was too large, it's been split into %d payloads.",
+                        len(payloads),
+                    )
+                with odoo.sql_db.db_connect("postgres").cursor() as cr:
                     for payload in payloads:
-                        cr.execute(query, (payload,))
-
-    @api.model
-    def _sendone(self, channel, notification_type, message):
-        self._sendmany([[channel, notification_type, message]])
+                        cr.execute(
+                            SQL(
+                                "SELECT %s('imbus', %s)",
+                                SQL.identifier(ODOO_NOTIFY_FUNCTION),
+                                payload,
+                            )
+                        )
 
     @api.model
     def _poll(self, channels, last=0):
@@ -154,9 +177,9 @@ class ImBus(models.Model):
         return last.id if last else 0
 
 
-#----------------------------------------------------------
+# ---------------------------------------------------------
 # Dispatcher
-#----------------------------------------------------------
+# ---------------------------------------------------------
 
 class BusSubscription:
     def __init__(self, channels, last):

--- a/addons/bus/tests/common.py
+++ b/addons/bus/tests/common.py
@@ -115,6 +115,7 @@ class WebsocketCase(HttpCase):
         notifications are available. Usefull since the bus is not able to do
         it during tests.
         """
+        self.env.cr.precommit.run()  # trigger the creation of bus.bus records
         channels = [
             hashable(channel_with_db(self.registry.db_name, c)) for c in channels
         ]

--- a/addons/bus/tests/test_notify.py
+++ b/addons/bus/tests/test_notify.py
@@ -1,11 +1,16 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests import BaseCase
+import json
+import selectors
+import threading
+
+import odoo
+from odoo.tests import TransactionCase
 
 from ..models.bus import json_dump, get_notify_payloads, NOTIFY_PAYLOAD_MAX_LENGTH
 
 
-class NotifyTests(BaseCase):
+class NotifyTests(TransactionCase):
 
     def test_get_notify_payloads(self):
         """
@@ -47,3 +52,39 @@ class NotifyTests(BaseCase):
                          "as it contains only 1 channel")
         with self.assertRaises(AssertionError):
             check_payloads_size(payloads)
+
+    def test_postcommit(self):
+        """Asserts all ``postcommit`` channels are fetched with a single listen."""
+        channels = []
+
+        def single_listen():
+            nonlocal channels
+            with odoo.sql_db.db_connect(
+                "postgres"
+            ).cursor() as cr, selectors.DefaultSelector() as sel:
+                cr.execute("listen imbus")
+                cr.commit()
+                conn = cr._cnx
+                sel.register(conn, selectors.EVENT_READ)
+                if sel.select(5):
+                    conn.poll()
+                    channels.extend(json.loads(conn.notifies.pop().payload))
+
+        thread = threading.Thread(target=single_listen)
+        thread.start()
+
+        self.env["bus.bus"].search([]).unlink()
+        self.env["bus.bus"]._sendone("channel 1", "test 1", {})
+        self.env["bus.bus"]._sendone("channel 2", "test 2", {})
+        self.env["bus.bus"]._sendone("channel 1", "test 3", {})
+        self.assertEqual(self.env["bus.bus"].search_count([]), 0)
+        self.assertEqual(channels, [])
+        self.env.cr.precommit.run()  # trigger the creation of bus.bus records
+        self.assertEqual(self.env["bus.bus"].search_count([]), 3)
+        self.assertEqual(channels, [])
+        self.env.cr.postcommit.run()  # notify
+        self.assertEqual(self.env["bus.bus"].search_count([]), 3)
+        self.assertEqual(
+            channels, [[self.env.cr.dbname, "channel 1"], [self.env.cr.dbname, "channel 2"]]
+        )
+        thread.join()

--- a/addons/bus/tests/test_websocket_controller.py
+++ b/addons/bus/tests/test_websocket_controller.py
@@ -74,6 +74,7 @@ class TestWebsocketController(HttpCaseWithUserDemo):
         self.env["bus.presence"]._update_presence(
             inactivity_period=0, identity_field="user_id", identity_value=self.user_demo.id
         )
+        self.env.cr.precommit.run()  # trigger the creation of bus.bus records
         self.env["bus.bus"].search([]).unlink()
         self.make_jsonrpc_request("/websocket/on_closed", {}, headers=headers)
         message = self.make_jsonrpc_request(

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -1,4 +1,5 @@
 import base64
+import bisect
 import functools
 import hashlib
 import json
@@ -223,6 +224,32 @@ class Websocket:
     # or received within CONNECTION_TIMEOUT - 15 seconds.
     CONNECTION_TIMEOUT = 60
     INACTIVITY_TIMEOUT = CONNECTION_TIMEOUT - 15
+    # How much time (in second) the history of last dispatched notifications is
+    # kept in memory for each websocket.
+    # To avoid duplicate notifications, we fetch them based on their ids.
+    # However during parallel transactions, ids are assigned immediately (whe
+    # they are requested), but the notifications are dispatched at the time of
+    # the commit. This means lower id notifications might be dispatched after
+    # higher id notifications.
+    # Simply incrementing the last id is sufficient to guarantee no duplicates,
+    # but it is not sufficient to guarantee all notifications are dispatched,
+    # and in particular not sufficient for those with a lower id coming after a
+    # higher id was dispatched.
+    # To solve the issue of missed notifications, the lowest id, stored in
+    # ``_last_notif_sent_id``, is held back by a few seconds to give time for
+    # concurrent transactions to finish. To avoid dispatching duplicate
+    # notifications, the history of already dispatched notifications during this
+    # period is kept in memory in ``_notif_history`` and the corresponding
+    # notifications are discarded from subsequent dispatching even if their id
+    # is higher than ``_last_notif_sent_id``.
+    # In practice, what is important functionally is the time between the create
+    # of the notification and the commit of the transaction in business code.
+    # If this time exceeds this threshold, the notification will never be
+    # dispatched if the target user receive any other notification in the
+    # meantime.
+    # Transactions known to be long should therefore create their notifications
+    # at the end, as close as possible to their commit.
+    MAX_NOTIFICATION_HISTORY_SEC = 10
     # How many requests can be made in excess of the given rate.
     RL_BURST = int(config['websocket_rate_limit_burst'])
     # How many seconds between each request.
@@ -244,7 +271,13 @@ class Websocket:
         # available.
         self.__notif_sock_w, self.__notif_sock_r = socket.socketpair()
         self._channels = set()
+        # For ``_last_notif_sent_id and ``_notif_history``, see
+        # ``MAX_NOTIFICATION_HISTORY_SEC`` for more details.
+        # id of the last sent notification that is no longer in _notif_history
         self._last_notif_sent_id = 0
+        # history of last sent notifications in the format (notif_id, send_time)
+        # always sorted by notif_id ASC
+        self._notif_history = []
         # Websocket start up
         self.__selector = (
             selectors.PollSelector()
@@ -314,7 +347,9 @@ class Websocket:
     def subscribe(self, channels, last):
         """ Subscribe to bus channels. """
         self._channels = channels
-        if self._last_notif_sent_id < last:
+        # Only assign the last id according to the client once: the server is
+        # more reliable later on, see ``MAX_NOTIFICATION_HISTORY_SEC``.
+        if self._last_notif_sent_id == 0:
             self._last_notif_sent_id = last
         # Dispatch past notifications if there are any.
         self.trigger_notification_dispatching()
@@ -647,10 +682,33 @@ class Websocket:
                 raise SessionExpiredException()
             # Mark the notification request as processed.
             self.__notif_sock_r.recv(1)
-            notifications = env['bus.bus']._poll(self._channels, self._last_notif_sent_id)
+            notifications = env["bus.bus"]._poll(
+                self._channels, self._last_notif_sent_id, [n[0] for n in self._notif_history]
+            )
         if not notifications:
             return
-        self._last_notif_sent_id = notifications[-1]['id']
+        for notif in notifications:
+            bisect.insort(self._notif_history, (notif["id"], time.time()), key=lambda x: x[0])
+        # Discard all the smallest notification ids that have expired and
+        # increment the last id accordingly. History can only be trimmed of ids
+        # that are below the new last id otherwise some notifications might be
+        # dispatched again.
+        # For example, if the theshold is 10s, and the state is:
+        # last id 2, history [(3, 8s), (6, 10s), (7, 7s)]
+        # If 6 is removed because it is above the threshold, the next query will
+        # be (id > 2 AND id NOT IN (3, 7)) which will fetch 6 again.
+        # 6 can only be removed after 3 reaches the threshold and is removed as
+        # well, and if 4 appears in the meantime, 3 can be removed but 6 will
+        # have to wait for 4 to reach the threshold as well.
+        last_index = -1
+        for i, notif in enumerate(self._notif_history):
+            if time.time() - notif[1] > self.MAX_NOTIFICATION_HISTORY_SEC:
+                last_index = i
+            else:
+                break
+        if last_index != -1:
+            self._last_notif_sent_id = self._notif_history[last_index][0]
+            self._notif_history = self._notif_history[last_index + 1 :]
         self._send(notifications)
 
 

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -158,7 +158,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                     "last_interest_dt": fields.Datetime.to_string(visitor_member.last_interest_dt),
                     "last_seen_dt": False,
                     "message_unread_counter": 0,
-                    "message_unread_counter_bus_id": self.env["bus.bus"]._bus_last_id(),
+                    "message_unread_counter_bus_id": self.env["bus.bus"]._bus_last_id() - 1,
                     "new_message_separator": 0,
                     "persona": {"id": test_user.partner_id.id, "type": "partner"},
                     "seen_message_id": False,
@@ -240,7 +240,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                     "last_interest_dt": fields.Datetime.to_string(operator_member.last_interest_dt),
                     "last_seen_dt": False,
                     "message_unread_counter": 0,
-                    "message_unread_counter_bus_id": self.env["bus.bus"]._bus_last_id(),
+                    "message_unread_counter_bus_id": self.env["bus.bus"]._bus_last_id() - 1,
                     "new_message_separator": 0,
                     "persona": {"id": operator.partner_id.id, "type": "partner"},
                     "seen_message_id": False,
@@ -305,7 +305,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
             },
         )
         channel = self.env["discuss.channel"].browse(data["Thread"][0]["id"])
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [(self.env.cr.dbname, "res.partner", self.env.user.partner_id.id)],
             [

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -806,12 +806,14 @@ class MailCase(MockEmail):
 
         with patch.object(ImBus, 'create', autospec=True, wraps=ImBus, side_effect=_bus_bus_create) as _bus_bus_create_mock:
             yield
+            self.env.cr.precommit.run()  # trigger the creation of bus.bus records
 
     def _init_mock_bus(self):
         self._new_bus_notifs = self.env['bus.bus'].sudo()
 
     def _reset_bus(self):
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self.env.cr.precommit.run()  # trigger the creation of bus.bus records
+        self.env["bus.bus"].sudo().search([]).unlink()
 
     @contextmanager
     def mock_mail_app(self):
@@ -1185,6 +1187,7 @@ class MailCase(MockEmail):
               }}
             }, {...}]
         """
+        self.env.cr.precommit.run()  # trigger the creation of bus.bus records
         bus_notifs = self.env['bus.bus'].sudo().search([('channel', 'in', [json_dump(channel) for channel in channels])])
         new_line = "\n"
         self.assertEqual(

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -406,9 +406,7 @@ class TestChannelInternals(MailCommon, HttpCase):
         chat = self.env['discuss.channel'].with_user(self.user_admin).channel_get((self.partner_employee | self.user_admin.partner_id).ids)
         msg_1 = self._add_messages(chat, 'Body1', author=self.user_employee.partner_id)
         member = chat.channel_member_ids.filtered(lambda m: m.partner_id == self.user_admin.partner_id)
-        last_bus_id = self.env['bus.bus'].sudo()._bus_last_id()
-
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [
                 (self.env.cr.dbname, "discuss.channel", chat.id),
@@ -422,7 +420,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                             {
                                 "id": member.id,
                                 "message_unread_counter": 0,
-                                "message_unread_counter_bus_id": last_bus_id + 1,
+                                "message_unread_counter_bus_id": 0,
                                 "new_message_separator": msg_1.id + 1,
                                 "persona": {"id": self.user_admin.partner_id.id, "type": "partner"},
                                 "syncUnread": False,
@@ -466,7 +464,7 @@ class TestChannelInternals(MailCommon, HttpCase):
             member._mark_as_read(msg_1.id)
         # There should be no channel member to be set as seen in the second time
         # So no notification should be sent
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus([], []):
             member._mark_as_read(msg_1.id)
 
@@ -594,7 +592,7 @@ class TestChannelInternals(MailCommon, HttpCase):
 
     def test_channel_write_should_send_notification(self):
         channel = self.env['discuss.channel'].create({"name": "test", "description": "test"})
-        self.env['bus.bus'].search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [(self.cr.dbname, 'discuss.channel', channel.id)],
             [{
@@ -616,7 +614,7 @@ class TestChannelInternals(MailCommon, HttpCase):
         channel.image_128 = base64.b64encode(("<svg/>").encode())
         avatar_cache_key = channel.avatar_cache_key
         channel.image_128 = False
-        self.env['bus.bus'].search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [(self.cr.dbname, 'discuss.channel', channel.id)],
             [{
@@ -794,7 +792,7 @@ class TestChannelInternals(MailCommon, HttpCase):
         """Ensures the command '/help' works in a channel"""
         channel = self.env["discuss.channel"].browse(self.test_channel.ids)
         channel.name = "<strong>R&D</strong>"
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [(self.env.cr.dbname, "res.partner", self.env.user.partner_id.id)],
             [
@@ -832,7 +830,7 @@ class TestChannelInternals(MailCommon, HttpCase):
             'channel_partner_ids': [(6, 0, test_user.partner_id.id)]
         })
         test_group.add_members(self.partner_employee_nomail.ids)
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [(self.env.cr.dbname, "res.partner", self.env.user.partner_id.id)],
             [

--- a/addons/mail/tests/discuss/test_guest_feature.py
+++ b/addons/mail/tests/discuss/test_guest_feature.py
@@ -3,10 +3,11 @@
 import json
 from odoo.tests import tagged
 from odoo.addons.bus.tests.common import WebsocketCase
+from odoo.addons.mail.tests.common import MailCommon
 
 
 @tagged("post_install", "-at_install")
-class TestGuestFeature(WebsocketCase):
+class TestGuestFeature(WebsocketCase, MailCommon):
     def test_mark_as_read_as_guest(self):
         guest = self.env["mail.guest"].create({"name": "Guest"})
         partner = self.env["res.partner"].create({"name": "John"})
@@ -34,7 +35,7 @@ class TestGuestFeature(WebsocketCase):
         self.assertEqual(guest_member.seen_message_id, channel.message_ids[0])
 
     def test_subscribe_to_guest_channel(self):
-        self.env["bus.bus"].search([]).unlink()
+        self._reset_bus()
         guest = self.env["mail.guest"].create({"name": "Guest"})
         guest_websocket = self.websocket_connect()
         self.subscribe(guest_websocket, [f"mail.guest_{guest._format_auth_cookie()}"], guest.id)
@@ -51,7 +52,7 @@ class TestGuestFeature(WebsocketCase):
             group_id=None, name="General"
         )
         channel.add_members(guest_ids=[guest.id])
-        self.env["bus.bus"].search([]).unlink()
+        self._reset_bus()
         guest_websocket = self.websocket_connect()
         self.subscribe(guest_websocket, [f"mail.guest_{guest._format_auth_cookie()}"], guest.id)
         self.env["bus.bus"]._sendone(channel, "lambda", {"foo": "bar"})

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -21,7 +21,7 @@ class TestChannelRTC(MailCommon):
         channel = self.env['discuss.channel'].channel_create(name='Test Channel', group_id=self.env.ref('base.group_user').id)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
         channel_member._rtc_join_call()
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [
                 (self.cr.dbname, 'discuss.channel', channel.id),  # update sessions
@@ -148,7 +148,7 @@ class TestChannelRTC(MailCommon):
         last_rtc_session_id = channel_member.rtc_session_ids.id
         channel_member._rtc_leave_call()
 
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [
                 (self.cr.dbname, 'discuss.channel', channel.id),  # update new session
@@ -249,7 +249,7 @@ class TestChannelRTC(MailCommon):
         last_rtc_session_id = channel_member.rtc_session_ids.id
         channel_member._rtc_leave_call()
 
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [
                 (self.cr.dbname, 'discuss.channel', channel.id),  # update new session
@@ -409,7 +409,7 @@ class TestChannelRTC(MailCommon):
         channel_member._rtc_join_call()
 
         channel_member_test_user = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == test_user.partner_id)
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [
                 (self.cr.dbname, 'res.partner', test_user.partner_id.id),  # update invitation
@@ -510,7 +510,7 @@ class TestChannelRTC(MailCommon):
             channel_member_test_user._rtc_join_call()
 
         channel_member_test_guest = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.guest_id == test_guest)
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [
                 (self.cr.dbname, 'mail.guest', test_guest.id),  # update invitation
@@ -621,7 +621,7 @@ class TestChannelRTC(MailCommon):
         channel_member._rtc_join_call()
 
         channel_member_test_user = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == test_user.partner_id)
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [
                 (self.cr.dbname, 'res.partner', test_user.partner_id.id),  # update invitation
@@ -680,7 +680,7 @@ class TestChannelRTC(MailCommon):
             channel_member_test_user._rtc_leave_call()
 
         channel_member_test_guest = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.guest_id == test_guest)
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [
                 (self.cr.dbname, 'mail.guest', test_guest.id),  # update invitation
@@ -750,7 +750,7 @@ class TestChannelRTC(MailCommon):
         channel_member_test_guest = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.guest_id == test_guest)
         channel_member._rtc_join_call()
 
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [
                 (self.cr.dbname, 'res.partner', test_user.partner_id.id),  # update invitation
@@ -876,7 +876,7 @@ class TestChannelRTC(MailCommon):
         now = fields.Datetime.now()
         with patch.object(fields.Datetime, 'now', lambda: now + relativedelta(seconds=5)):
             channel_member._rtc_join_call()
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
 
         with self.mock_bus():
             with patch.object(fields.Datetime, 'now', lambda: now + relativedelta(seconds=10)):
@@ -1041,7 +1041,7 @@ class TestChannelRTC(MailCommon):
         channel = self.env['discuss.channel'].create_group(partners_to=self.user_employee.partner_id.ids)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
         channel_member._rtc_join_call()
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [
                 (self.cr.dbname, 'discuss.channel', channel.id),  # update list of sessions
@@ -1083,7 +1083,7 @@ class TestChannelRTC(MailCommon):
         channel_member._rtc_join_call()
         channel_member.rtc_session_ids.flush_model()
         channel_member.rtc_session_ids._write({'write_date': fields.Datetime.now() - relativedelta(days=2)})
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [
                 (self.cr.dbname, 'discuss.channel', channel.id),  # update list of sessions
@@ -1121,7 +1121,7 @@ class TestChannelRTC(MailCommon):
         channel = self.env['discuss.channel'].create_group(partners_to=self.user_employee.partner_id.ids)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
         channel_member._rtc_join_call()
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [
                 (self.cr.dbname, 'discuss.channel', channel.id),  # update list of sessions
@@ -1170,7 +1170,7 @@ class TestChannelRTC(MailCommon):
         test_session.flush_model()
         test_session._write({'write_date': fields.Datetime.now() - relativedelta(days=2)})
         unused_ids = [9998, 9999]
-        self.env['bus.bus'].sudo().search([]).unlink()
+        self._reset_bus()
         with self.assertBus(
             [
                 (self.cr.dbname, 'discuss.channel', channel.id),  # update list of sessions

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -375,7 +375,7 @@ class TestDiscuss(MailCommon, TestRecipients):
         msg_2.with_user(self.user_employee).toggle_message_starred()
         self.assertIn(self.partner_admin, msg.starred_partner_ids)
         self.assertIn(self.partner_employee, msg.starred_partner_ids)
-        self.env["bus.bus"].search([]).unlink()
+        self._reset_bus()
         bus_last_id = self.env["bus.bus"].sudo()._bus_last_id()
         self.test_record._message_update_content(message=msg, body="")
         self.assertFalse(msg.starred)


### PR DESCRIPTION
Before this PR, some notifications could be missed due to the way notifications are fetched. We tracked the last fetched ID and only fetched notifications with greater IDs.

However, this approach is subject to concurrency issues because primary keys are assigned before commit. As a result, we might fetch a notification with a greater ID and miss one with a lower ID that hasn't been committed yet.

Problematic scenario:
- A bus_bus record is inserted with ID 1.
- A bus_bus record is inserted and committed with ID 2.
- A bus_bus record with ID 2 is fetched, but ID 1 is missing because it was not yet committed.
- The bus_bus record with ID 1 was missed.

To solve this issue, the WebSocket class now keeps track of notifications received within a 10-second window. Fetches will target unknown notifications with an ID greater than the smallest one in this window. This effectively prevents missing notifications, as the 10-second window is much larger than the commit concurrency.

This PR also includes a back-port of https://github.com/odoo/odoo/pull/174874 to ensure the create is done as close as possible to the commit.

Enterprise: https://github.com/odoo/enterprise/pull/68302

Note 1: the bug exists since forever (v8.0), so it should be fixed in all versions ideally.
It potentially explains a lot of strange issues we had with many collaborative features from the past and until now (discuss and longpolling back then, editor and RTC more recently, to only name a few).
Starting to fix in 17.4 now to fix our prod in priority.

Note 2: even with this fix, the order of notifications is still not guaranteed (but at least we don't miss them anymore).
If 2 notifications from 2 different commits are in the same batch of dispatch, notifications will be ordered by acquisition time of id, and not by commit time (which would be preferable most of the time, as data in db will be based on commit order).
If the same two notifications and 2 commits are in a separate dispatch, the notifications will be ordered by commit time, as the notification from the first commit will be sent immediately, even if is has a higher id, and the one from the 2nd commit will be sent afterwards.
Very order-sensitive business code should therefore enforce order either with locks or through business data. If there is an actual concurrency issue the auto-retry will probably resolve the order by itself most of the time though.