### PR TITLE
[FIX] point_of_sale: resumed order is not properly synced

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -91,7 +91,7 @@ export class ReceiptScreen extends Component {
         this.pos.showScreen(name, props);
     }
     isResumeVisible() {
-        return this.pos.get_open_orders().length > 1;
+        return this.pos.get_open_orders().length > 0;
     }
     async _sendReceiptToCustomer({ action }) {
         const order = this.currentOrder;

--- a/addons/pos_restaurant/static/src/overrides/components/ticket_screen/ticket_screen.js
+++ b/addons/pos_restaurant/static/src/overrides/components/ticket_screen/ticket_screen.js
@@ -40,7 +40,8 @@ patch(TicketScreen.prototype, {
         });
     },
     async _setOrder(order) {
-        if (!this.pos.config.module_pos_restaurant || this.pos.selectedTable || !order.tableId) {
+        const shouldBeOverridden = this.pos.config.module_pos_restaurant && order.table_id;
+        if (!shouldBeOverridden) {
             return super._setOrder(...arguments);
         }
         // we came from the FloorScreen

--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -247,7 +247,15 @@ patch(PosStore.prototype, {
             await this.syncAllOrders();
         } finally {
             this.loadingOrderState = false;
-            let currentOrder = this.getTableOrders(table.id).find((order) =>
+
+            const tableOrders = this.models["pos.order"].filter(
+                (o) =>
+                    o.table_id?.id === table.id &&
+                    // Include the orders that are in tipping state.
+                    (!o.finalized || o.uiState.screen_data?.value?.name === "TipScreen")
+            );
+
+            let currentOrder = tableOrders.find((order) =>
                 orderUuid ? order.uuid === orderUuid : !order.finalized
             );
 


### PR DESCRIPTION
Steps to reproduce:

1. Open a session for the restaurant config.
2. Create an order without payment in 3 tables.
3. Return to the 3rd table and pay the order.
4. When in receipt screen, you're offered a choice to "Resume Order" or create a
   "New Order". Choose "Resume Order".
5. The screen will have a search word by default without showing anything,
   however, there is an automatically selected order. Load that order by
   clicking "Load".
6. ISSUE: Pay the order. But it remained draft if you check it from the backend.

The solution is to make sure that when resuming to an order, we also set the
table linked to it as the `selectedTable`. We should run the `_setOrder`
override if the session is restaurant and the selected order is linked to a
table. Because of the mismatch of the paid order and the selected order, the
orders-to-sync are not computed properly (see `getPendingOrder` which depends on
the selected table).

Now that `setTable` is called when selecting an order, the order in TipScreen is
not properly selected because it's already ".finalized". However, the cashier
should still be able to access it to capture tips later, thus, we also need to
adapt setting of order in `setTable` to include tables orders that are in
TipScreen.

This commit also contains the following change:

- `isResumeVisible` should be true if there is at least one order to select.

TASK-ID: 4105312