### PR TITLE
[FIX] point_of_sale: deduct change from cash payment

### DIFF
--- a/addons/point_of_sale/models/pos_payment.py
+++ b/addons/point_of_sale/models/pos_payment.py
@@ -65,7 +65,14 @@ class PosPayment(models.Model):
 
     def _create_payment_moves(self, is_reverse=False):
         result = self.env['account.move']
-        for payment in self:
+        # Get the first cash payment or, if none, the first non-change payment
+        target_payment = self.filtered(lambda p: p.payment_method_id.type == 'cash' and not p.is_change)[:1]
+        if not target_payment:
+            target_payment = self.filtered(lambda p: not p.is_change)[:1]
+        change_payment = self.filtered(lambda p: p.is_change and p.payment_method_id.type == 'cash')
+        if target_payment and change_payment:
+            target_payment.amount += change_payment.amount
+        for payment in self.filtered(lambda p: not p.is_change):
             payment_method = payment.payment_method_id
             if payment_method.type == 'pay_later' or float_is_zero(payment.amount, precision_rounding=payment.pos_order_id.currency_id.rounding):
                 continue


### PR DESCRIPTION
## Issue:

- when making a payment using 2 different payment methods (cash and bank), the change gets deducted from the bank payment not the cash payment in the invoice.

## Steps To Reproduce:

On POS, for an order totaling $120.
- Add a customer and ensure the "Invoice" box is checked.
- pay using two payments methods
        bank 100$
        Cash 50$
- the change is $30, everything looks fine on the ticket on the pos.
- Notice on the invoice on the db backend the $30 change is incorrectly deducted from the bank payment. As a result, the invoice displays:
        bank : $70
        cash: $50

## Soltution:
- In the _create_payment_moves method, I ensured that an `account.move` is not created for the change amount. Instead, the change is deducted from the first cash payment before creating the relevant `account.move`.

opw-4076246

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
