### PR TITLE
[IMP] hw_posbox_hompage: copy password when generated

### DIFF
--- a/addons/hw_posbox_homepage/views/remote_connect.html
+++ b/addons/hw_posbox_homepage/views/remote_connect.html
@@ -35,6 +35,7 @@
                     data: JSON.stringify({}),
                 }).done(function(password) {
                     $('.password').val(password['result']);
+                    navigator.clipboard.writeText(password['result']);
                 });
             });
         });


### PR DESCRIPTION
Before, on the "Remote Debug" page (`/remote_connect`), users had to manually copy the password after clicking on "Generate" button. Now, if HTTPS is used, the password will automatically be copied to the clipboard.

Task: 4105552