### PR TITLE
[FIX] web: find closest scrollable for hidden element

### DIFF
--- a/addons/web/static/src/core/utils/scrolling.js
+++ b/addons/web/static/src/core/utils/scrolling.js
@@ -4,11 +4,11 @@
  * @param {HTMLElement} el
  * @returns {HTMLElement | null}
  */
-export function closestScrollableX(el) {
+export function closestScrollableX(el, shouldVisible = false) {
     if (!el) {
         return null;
     }
-    if (el.scrollWidth > el.clientWidth && el.clientWidth > 0) {
+    if (shouldVisible || el.scrollWidth > el.clientWidth && el.clientWidth > 0) {
         const overflow = getComputedStyle(el).getPropertyValue("overflow-x");
         if (/\bauto\b|\bscroll\b/.test(overflow)) {
             return el;
@@ -17,8 +17,8 @@ export function closestScrollableX(el) {
     return closestScrollableX(el.parentElement);
 }
 
-function isScrollableY(el) {
-    if (el && el.scrollHeight > el.clientHeight && el.clientHeight > 0) {
+function isScrollableY(el, shouldVisible = false) {
+    if (shouldVisible || el && el.scrollHeight > el.clientHeight && el.clientHeight > 0) {
         const overflow = getComputedStyle(el).getPropertyValue("overflow-y");
         if (/\bauto\b|\bscroll\b/.test(overflow)) {
             return true;
@@ -33,14 +33,14 @@ function isScrollableY(el) {
  * @param {HTMLElement} el
  * @returns {HTMLElement | null}
  */
-export function closestScrollableY(el) {
+export function closestScrollableY(el, shouldVisible = false) {
     if (!el) {
         return null;
     }
-    if (isScrollableY(el)) {
+    if (isScrollableY(el, shouldVisible)) {
         return el;
     }
-    return closestScrollableY(el.parentElement);
+    return closestScrollableY(el.parentElement, shouldVisible);
 }
 
 /**

--- a/addons/website/static/src/snippets/s_table_of_content/000.js
+++ b/addons/website/static/src/snippets/s_table_of_content/000.js
@@ -64,7 +64,7 @@ const TableOfContent = publicWidget.Widget.extend({
     async start() {
         this._stripNavbarStyles();
         await this._super(...arguments);
-        this._scrollElement = closestScrollableY(this.$target.closest(".s_table_of_content")[0]);
+        this._scrollElement = closestScrollableY(this.$target.closest(".s_table_of_content")[0], true);
         this._scrollTarget = $().getScrollingTarget(this._scrollElement)[0];
         this._tocElement = this.el.querySelector('.s_table_of_content_navbar');
         this.previousPosition = -1;
@@ -77,7 +77,7 @@ const TableOfContent = publicWidget.Widget.extend({
      * @override
      */
     destroy() {
-        this._scrollTarget.removeEventListener("scroll", this._onScrollBound);
+        this._scrollTarget?.removeEventListener("scroll", this._onScrollBound);
         const indexCallback = extraMenuUpdateCallbacks.indexOf(this._updateTableOfContentNavbarPositionBound);
         if (indexCallback >= 0) {
             extraMenuUpdateCallbacks.splice(indexCallback, 1);


### PR DESCRIPTION
steps to reproduce:
case 1:
1. Drag and drop a popup
2. Drag and drop a table of content snippet into the popup => Traceback

case 2:
1. Drag and drop table of content snippet.
2. Select the desktop invisible option
3. save the editor => Traceback

The issue arise on refactoring of jquery method `closestScrollable` to javascript.[[1]]

Before this commit, we were looking for the closest scrollbar to attach some scroll event. but it's was not working for the hidden element. To make that work, In this commit, we removed the condition of the hidden element for the `closestScrollableX` and `closestScrollableY`.

[1]: https://github.com/odoo/odoo/pull/174683/commits/f98ce02f3e904194cc87381d9e685b23c39d2b7e

task-4016426
