### PR TITLE
[FIX] website: fix theme selection kanban's breadcrumb neutralization

### DIFF
--- a/addons/website/static/src/components/views/theme_preview.xml
+++ b/addons/website/static/src/components/views/theme_preview.xml
@@ -40,7 +40,7 @@
     </t>
 
     <t t-name="website.ThemePreviewKanban.ControlPanel" t-inherit="web.ControlPanel" t-inherit-mode="primary">
-        <xpath expr="//t[@t-call='web.Breadcrumbs']" position="replace">
+        <xpath expr="//t[@t-else]/Breadcrumbs" position="replace">
             <t t-call="website.ThemePreviewKanban.ControlPanel.BreadCrumbs"/>
         </xpath>
         <xpath expr="//div[contains(@class,'o_control_panel_navigation')]" position="replace">


### PR DESCRIPTION
Since [1] kanban breadcrumbs are rendered by the `Breadcrumbs` Owl component, but the xpath that replaces then for the theme selection kanban was not updated, making it impossible to render that template.

This commit adapts the xpath accordingly.

Steps to reproduce:
- Edit page.
- Go to Themes tab.
- Click on Switch Theme.
- Confirm popup.

=> An error dialog was displayed.

[1]: https://github.com/odoo/odoo/commit/2cad87b49977c7e341fa5fd871b3728ec85ccc9d

task-4105774
