### PR TITLE
[FIX] stock: set move not picked when its picking is detached from batch

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking.py
+++ b/addons/stock_picking_batch/models/stock_picking.py
@@ -118,7 +118,9 @@ class StockPicking(models.Model):
         res = super().button_validate()
         to_assign_ids = set()
         if self and self.env.context.get('pickings_to_detach'):
-            self.env['stock.picking'].browse(self.env.context['pickings_to_detach']).batch_id = False
+            pickings_to_detach = self.env['stock.picking'].browse(self.env.context['pickings_to_detach'])
+            pickings_to_detach.batch_id = False
+            pickings_to_detach.move_ids.filtered(lambda m: not m.quantity).picked = False
             to_assign_ids.update(self.env.context['pickings_to_detach'])
 
         for picking in self:

--- a/addons/stock_picking_batch/tests/test_wave_picking.py
+++ b/addons/stock_picking_batch/tests/test_wave_picking.py
@@ -509,7 +509,8 @@ class TestBatchPicking(TransactionCase):
     def test_validatation_of_partially_empty_picking(self):
         """
             Check that you can validate a wave transfer containing an empty picking,
-            that the picking stays unchanged and is removed from the transfer
+            that the picking stays unchanged (except for the 'picked' state of the move)
+            and is removed from the transfer
         """
         self.productA.tracking = 'none'
         self.productB.tracking = 'none'
@@ -545,6 +546,7 @@ class TestBatchPicking(TransactionCase):
         wave = self.env['stock.picking.batch'].create({
             'name': 'Wave transfer',
             'picking_ids': [Command.link(picking_1.id), Command.link(picking_2.id)],
+            'is_wave': True,
         })
         wave.move_ids.filtered(lambda m: m.product_id == self.productB).quantity = 0.0
         wave.move_ids.picked = True
@@ -552,7 +554,7 @@ class TestBatchPicking(TransactionCase):
         self.assertEqual(wave.state, 'done')
         self.assertEqual(wave.picking_ids, picking_1)
         self.assertEqual([picking_1.state, picking_1.move_ids.quantity, picking_1.move_ids.picked], ['done', 2.0, True])
-        self.assertEqual([picking_2.state, picking_2.move_ids.quantity, picking_2.move_ids.picked], ['assigned', 0.0, True])
+        self.assertEqual([picking_2.state, picking_2.move_ids.quantity, picking_2.move_ids.picked], ['assigned', 0.0, False])
 
     def test_add_partially_assigned_move_to_batch(self):
         """


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Create two storable products: “P1” and “P2.”
- Create a picking: - Product: “P1” - Quantity: 10
- Create a second picking: - Product: “P2” - Quantity: 10
- Confirm both pickings.
- Set both moves to picked.
- Add them to a wave.
- Go to the wave and set the quantity of P1 to 0 while keeping `picked=True`.
- Validate the wave.

**Problem:**
The picking of P1 is detached from the wave, but the move remains picked. As a result, `_compute_show_check_availability` returns `False`, causing the check availability button to stay invisible.

opw-4016209