### PR TITLE
[IMP] website_cf_turnstile: disable button on interactive snippet

### DIFF
--- a/addons/website_cf_turnstile/static/src/js/turnstile.js
+++ b/addons/website_cf_turnstile/static/src/js/turnstile.js
@@ -1,9 +1,9 @@
 /** @odoo-module **/
 
 import "@website/snippets/s_website_form/000";  // force deps
+import { uniqueId } from "@web/core/utils/functions";
 import publicWidget from '@web/legacy/js/public/public_widget';
 import { session } from "@web/session";
-
 publicWidget.registry.s_website_form.include({
         /**
          * @override
@@ -12,6 +12,8 @@ publicWidget.registry.s_website_form.include({
             const res = this._super(...arguments);
             this.cleanTurnstile();
             if (!this.isEditable && !this.$('.s_turnstile').length && session.turnstile_site_key) {
+                this.uniq = uniqueId("turnstile_");
+                this.el.classList.add(this.uniq);
                 const mode = new URLSearchParams(window.location.search).get('cf') == 'show' ? 'always' : 'interaction-only';
                 $(`<div class="s_turnstile cf-turnstile float-end"
                          data-action="website_form"
@@ -19,14 +21,28 @@ publicWidget.registry.s_website_form.include({
                          data-response-field-name="turnstile_captcha"
                          data-sitekey="${session.turnstile_site_key}"
                          data-error-callback="throwTurnstileError"
+                         data-before-interactive-callback="turnstileBeforeInteractive"
+                         data-after-interactive-callback="turnstileAfterInteractive"
                     ></div>
                     <script class="s_turnstile">
-                        // Rethrow the error, or we only will catch a "Script error" without any info 
+                        // Rethrow the error, or we only will catch a "Script error" without any info
                         // because of the script api.js originating from a different domain.
                         function throwTurnstileError(code) {
                             const error = new Error("Turnstile Error");
                             error.code = code;
                             throw error;
+                        }
+                        function turnstileBeforeInteractive() {
+                            const btnEl = document.querySelector('.${this.uniq} .s_website_form_send,.${this.uniq} .o_website_form_send');
+                            if (btnEl && !btnEl.classList.contains('disabled')) {
+                                btnEl.classList.add('disabled', 'cf_form_disabled');
+                            }
+                        }
+                        function turnstileAfterInteractive() {
+                            const btnEl = document.querySelector('.${this.uniq} .s_website_form_send,.${this.uniq} .o_website_form_send');
+                            if (btnEl && btnEl.classList.contains('cf_form_disabled')) {
+                                btnEl.classList.remove('disabled', 'cf_form_disabled');
+                            }
                         }
                     </script>
                     <script class="s_turnstile" src="https://challenges.cloudflare.com/turnstile/v0/api.js"></script>


### PR DESCRIPTION
When Turnstile decides to show the interactive snippet to validate that you are human, we now disable the button until the 'recaptcha' is completed. This ensures that users don't forget to complete the challenge or miss it by scrolling past it if it's located below the button.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
