### PR TITLE
[FIX] website_sale: hide shop routes from sitemap

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -145,14 +145,33 @@ class WebsiteSale(payment_portal.PaymentPortal):
         return expression.AND(domains)
 
     def sitemap_shop(env, rule, qs):
+        website = env['website'].get_current_website()
+        # Make sure urls are not listed in sitemap when restriction is active
+        if website and website.ecommerce_access == 'logged_in':
+            return
+
         if not qs or qs.lower() in '/shop':
             yield {'loc': '/shop'}
 
         Category = env['product.public.category']
         dom = sitemap_qs2dom(qs, '/shop/category', Category._rec_name)
-        dom += env['website'].get_current_website().website_domain()
+        dom += website.website_domain()
         for cat in Category.search(dom):
             loc = '/shop/category/%s' % slug(cat)
+            if not qs or qs.lower() in loc:
+                yield {'loc': loc}
+
+    def sitemap_products(env, rule, qs):
+        website = env['website'].get_current_website()
+        # Make sure urls are not listed in sitemap when restriction is active
+        if website and website.ecommerce_access == 'logged_in':
+            return
+
+        ProductTemplate = env['product.template']
+        dom = sitemap_qs2dom(qs, '/shop', ProductTemplate._rec_name)
+        dom += website.sale_product_domain()
+        for product in ProductTemplate.search(dom):
+            loc = '/shop/%s' % slug(product)
             if not qs or qs.lower() in loc:
                 yield {'loc': loc}
 
@@ -427,7 +446,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         values.update(self._get_additional_extra_shop_values(values, **post))
         return request.render("website_sale.products", values)
 
-    @route(['/shop/<model("product.template"):product>'], type='http', auth="public", website=True, sitemap=True)
+    @route(['/shop/<model("product.template"):product>'], type='http', auth="public", website=True, sitemap=sitemap_products)
     def product(self, product, category='', search='', **kwargs):
         if not request.website.has_ecommerce_access():
             return request.redirect('/web/login')


### PR DESCRIPTION
when ecommerce access is restricted to logged in users, so that the products are not publicly accessible on the sitemap.

Fixes #165222
Finetuning of 5bde2e42c8ec5e943a779ad4b3e1b7142f2d2fcf

