### PR TITLE
[FIX] base: handle NewId when creating view from menu

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -460,6 +460,8 @@ actual arch.
     def _compute_warning_info(self):
         for view in self:
             view.warning_info = ''
+            if isinstance(view.id, models.NewId):
+                continue
             try:
                 if view.inherit_id:
                     view_arch = etree.fromstring(view.arch)


### PR DESCRIPTION
An Error is thrown when attempting to _compute_warning_info on a newly created ir.ui.view record. This is due to the NewId it is assigned being unable to be parsed by the query generated by the _get_inheriting_views method. This PR bypasses that method call when generating a NewId, as a newly created view will not need to check for inheritance.

Task-ID: 4102663

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
