### PR TITLE
[FIX] Blog and grid mode overflow issues

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.frontend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.frontend.scss
@@ -63,6 +63,14 @@
     column-gap: 0px !important;
 }
 
+// Adapt the horizontal margins of a direct row child of a grid item, to make
+// them compensate the grid item horizontal padding (to avoid an overflow).
+.o_grid_item > .row {
+    --grid-inner-row-gutter-x: clamp(0px, 2 * var(--grid-item-padding-x), 30px);
+    margin-left: calc(-0.5 * var(--grid-inner-row-gutter-x));
+    margin-right: calc(-0.5 * var(--grid-inner-row-gutter-x));
+}
+
 .o_grid_item_image {
     img, .media_iframe_video {
         width: 100% !important;

--- a/addons/website_blog/static/src/scss/website_blog.scss
+++ b/addons/website_blog/static/src/scss/website_blog.scss
@@ -291,6 +291,13 @@ $o-wblog-loader-size: 50px;
             .o_wblog_post_cover_nocard .o_record_cover_container {
                 padding-top: 33%;
             }
+
+            @include media-breakpoint-down(md) {
+                > .row {
+                    margin-left: 0;
+                    margin-right: 0;
+                }
+            }
         }
 
     }


### PR DESCRIPTION
[FIX] website_blog: prevent "List" layout from overflowing on mobile

Steps to reproduce:
- Go to the "/blog" page.
- In edit mode, set the "Layout" option to "List" and save.
- Toggle the mobile preview or reduce the screen size at around 580px or
  below.
=> There is a horizontal scrollbar.

The scrollbar appears because the row containing the blog posts has a
bigger width than its container, which makes it overflow from it. It
happens because of the `o_container_small` class set on the container,
which has a rule forcing its horizontal padding to 0, where it was
supposed to compensate the row margins.

This commit therefore fixes this issue by forcing the row horizontal
margins to 0 for screen sizes under the `MD` screen breakpoint, which is
approximately where the blogs layout becomes mobile.

This fix also has the advantage of improving the "List" mobile layout by
making it look similar to the "Grid" layout one, that is, with a bit of
space around the posts, instead of being glued to the viewport.

opw-4052853

---
[FIX] web_editor: prevent grid item inner row child from overflowing

Steps to reproduce:
- In edit mode, drop the "Team" snippet.
- Toggle it to grid mode.
- Set the "Content Width" option to "Full".
=> A horizontal scrollbar appears.

This happens because the `.row` elements generally have a `--gutter-x`
CSS variable set to 30px that is used to compute their horizontal
margins, such that it compensates the padding of the parent (generally a
`.container` element) which is set to the same value. So the parent is
supposed to always have a padding of 15px, which is compensated by the
row margins, set to -15px.

When a row is a direct child of a grid item, the row can overflow its
parent if the grid item has a padding below 15px. Indeed, the row
expects its parent to have a 15px padding, so its margins are too big if
the value is below. A horizontal scrollbar can therefore appear, if the
snippet container takes the whole screen width.

This commit fixes this issue by making the margins of row elements that
are direct children of a grid item compensate the padding of this grid
item, while it is below 15px. When it is set to 15px or above, they are
back compensating the usual 15px.

opw-4052853
opw-3981579