### PR TITLE
[FIX] hr_holidays: Prevent Time Off Without Allocation (#176149)

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -807,10 +807,9 @@ Attempting to double-book your time off won't magically make your vacation 2x be
             ])
             # Check for any valid allocation covering the leave request period
             valid_allocation = any(
-                allocation.date_from <= leave.request_date_from <= leave.request_date_to <= allocation.date_to
+                allocation.date_from or datetime.min <= leave.request_date_from <= leave.request_date_to <= allocation.date_to or datetime.max
                 for leave in leaves
                 for allocation in allocation_records
-                if allocation.date_from and allocation.date_to
             )
             if not valid_allocation:
                 raise ValidationError(_("The leave dates are outside the allocation period."))

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -784,17 +784,8 @@ Attempting to double-book your time off won't magically make your vacation 2x be
             for leave in leaves:
                 employees |= leave._get_employees_from_holiday_type()
             leave_data = leave_type.get_allocation_data(employees, date_from)
-
-            # Fetch the allocation records for validation
-            allocation_records = self.env['hr.leave.allocation'].search([
-                ('holiday_status_id', '=', leave_type.id),
-                ('employee_id', 'in', employees.ids),
-                ('state', '=', 'validate')
-            ])
-            # Validate against the allocation period
-            for allocation in allocation_records:
-                if leave.request_date_from < allocation.date_from or leave.request_date_to > allocation.date_to:
-                    raise ValidationError(_("The leave dates are outside the allocation period."))
+            
+            # Check if negative allocations are allowed
             if leave_type.allows_negative:
                 max_excess = leave_type.max_allowed_negative
                 for employee in employees:
@@ -802,14 +793,38 @@ Attempting to double-book your time off won't magically make your vacation 2x be
                         raise ValidationError(_("There is no valid allocation to cover that request."))
                 continue
 
+            # Refined allocation search for relevant allocations only
+            allocation_records = self.env['hr.leave.allocation'].search([
+                ('employee_id', 'in', employees.ids),
+                ('holiday_status_id', '=', leave_type.id),
+                ('state', '=', 'validate'),  # Only consider validated allocations
+                '|',  # Logical OR to handle cases with open-ended allocation dates
+                ('date_to', '=', False),
+                ('date_to', '>=', min(leave.request_date_to for leave in leaves)),
+                '|',
+                ('date_from', '=', False),
+                ('date_from', '<=', max(leave.request_date_from for leave in leaves))
+            ])
+            # Check for any valid allocation covering the leave request period
+            valid_allocation = any(
+                allocation.date_from <= leave.request_date_from <= leave.request_date_to <= allocation.date_to
+                for leave in leaves
+                for allocation in allocation_records
+                if allocation.date_from and allocation.date_to
+            )
+            if not valid_allocation:
+                raise ValidationError(_("The leave dates are outside the allocation period."))
+            # Get previous allocation data ignoring current leave ids
             previous_leave_data = leave_type.with_context(
                 ignored_leave_ids=leaves.ids
             ).get_allocation_data(employees, date_from)
             for employee in employees:
                 previous_emp_data = previous_leave_data[employee] and previous_leave_data[employee][0][1]['virtual_excess_data']
                 emp_data = leave_data[employee] and leave_data[employee][0][1]['virtual_excess_data']
+                # Continue if there is no excess data for both current and previous allocations
                 if not previous_emp_data and not emp_data:
                     continue
+                # Raise validation error if allocation data mismatch
                 if previous_emp_data != emp_data and len(emp_data) >= len(previous_emp_data):
                     raise ValidationError(_("There is no valid allocation to cover that request."))
 


### PR DESCRIPTION
This commit addresses an issue where time off requests could be validated even when the requested dates fall outside the allocated leave period. The `_check_validity` method now correctly checks the allocation dates and raises a validation error when the dates are outside the allocation period, ensuring the integrity of time off requests.

Fixes #176149

**Description of the issue/feature this PR addresses:**
The issue addressed by this PR is that time off requests in draft state could be validated even when the requested dates fall outside the allocated leave period. This behavior leads to inconsistencies in leave management, allowing invalid requests to bypass the allocation check.

**Current behavior before PR:**
Time off requests in draft state could be validated without checking if the requested dates are within the allocated leave period, which can result in employees being granted leave that they are not entitled to.

**Desired behavior after PR is merged:**
The _check_validity method will correctly check the allocation dates for time off requests in draft state. If the requested dates fall outside the allocated leave period, a validation error will be raised, ensuring that only valid time off requests are approved.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
