### PR TITLE
[FIX] stock: restore groups_id on Lock/Unlock stock.picking

### DIFF
--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -514,6 +514,7 @@
             <field name="binding_model_id" ref="stock.model_stock_picking"/>
             <field name="binding_view_types">form</field>
             <field name="state">code</field>
+            <field name="groups_id" eval="[Command.link(ref('stock.group_stock_manager'))]"/>
             <field name="code">
             if records:
                 records.action_toggle_is_locked()</field>


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

In Odoo 15, only stock.group_stock_manager can use the Lock and Unlock button on stock.move
( https://github.com/odoo/odoo/blob/b361be31e446919ffc0ee14e99f8b88fae630ede/addons/stock/views/stock_picking_views.xml#L257 )

When moving the button to an ir.actions.server, the group_ids was not ported properly in #116799 .

This commit fixes it and restore the group restriction

### Current behavior before PR:
Users without the group `stock.group_stock_manager` (Administrator) can lock/unlock stock.picking

### Desired behavior after PR is merged:
Only users with that group can lock/unlock stock.picking

opw-4075127

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
