### PR TITLE
[FIX] website: remove remaining JQuery from configurator wizard

### DIFF
--- a/addons/website/static/src/client_actions/configurator/configurator.js
+++ b/addons/website/static/src/client_actions/configurator/configurator.js
@@ -470,7 +470,7 @@ class ThemeSelectionScreen extends ApplyConfiguratorScreen {
                         }, {once: true});
                     }));
                 }
-                $(this.themeSVGPreviews[idx].el).append(svgEl);
+                this.themeSVGPreviews[idx].el.appendChild(svgEl);
             });
             // When all the images inside the svgs are loaded then remove the
             // loading effect.

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -447,6 +447,7 @@ function registerThemeHomepageTour(name, steps) {
         url: '/',
         sequence: 50,
         saveAs: "homepage",
+        test: true, // disable manual mode for theme homepage tours - FIXME
         },
         () => [
             ...clickOnEditAndWaitEditMode(),


### PR DESCRIPTION
Since [1] JQuery is not available in backend screens anymore, but a call
did remain in the theme selection of the website configurator.

This commit replaces that JQuery call.

Steps to reproduce:
- Launch Odoo with design-themes.
- Create a new website.
- Follow the configurator.

=> An error got triggered instead of displaying the theme selection.

[1]: https://github.com/odoo/odoo/commit/b8fc93ea97b8870459063214d5cf468a6a3c6efe
