### PR TITLE
[FIX] web: small layout of Tree Editor

### DIFF
--- a/addons/web/static/src/core/tree_editor/tree_editor.xml
+++ b/addons/web/static/src/core/tree_editor/tree_editor.xml
@@ -5,7 +5,7 @@
         <div class="o_tree_editor w-100" aria-atomic="true" t-att-class="className">
             <div t-attf-class="o_tree_editor_node d-flex flex-column #{props.readonly ? (props.isSubTree ? 'gap-0' : 'gap-2') : 'gap-1'}">
                 <t t-set="node" t-value="tree" />
-                <div class="o_tree_editor_row d-flex align-items-center" t-att-class="{'ps-4': props.isSubTree}">
+                <div class="o_tree_editor_row d-flex align-items-center flex-wrap" t-att-class="{'ps-4': props.isSubTree}">
                     <div class="o_tree_editor_connector d-flex flex-grow-1 align-items-center">
                         <t t-if="node.children.length">
                             <span t-if="!props.isSubTree">Match</span>


### PR DESCRIPTION
When using a Tree Editor, the layout of the editor is not optimal when there is not much space available. This commits adds a `flex-wrap` to improve it.

Before: 
![image](https://github.com/user-attachments/assets/d8de6435-8d30-4580-bdb0-cc497eb8aa47)

After:
![image](https://github.com/user-attachments/assets/7adabf6e-46f2-487f-bc10-24ebb620170f)

Task: [4109635](https://www.odoo.com/web#id=4109635&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
