### PR TITLE
[IMP] hr_expense: pwa share target basic implementation

### DIFF
--- a/addons/hr_expense/__init__.py
+++ b/addons/hr_expense/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import controllers
 from . import models
 from . import wizard

--- a/addons/hr_expense/controllers/__init__.py
+++ b/addons/hr_expense/controllers/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import webmanifest

--- a/addons/hr_expense/controllers/webmanifest.py
+++ b/addons/hr_expense/controllers/webmanifest.py
@@ -1,0 +1,22 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.web.controllers import webmanifest
+
+
+class WebManifest(webmanifest.WebManifest):
+
+    def _get_webmanifest(self):
+        manifest = super()._get_webmanifest()
+        if not manifest.get('share_target'):
+            manifest['share_target'] = {
+                'action': '/odoo?share_target=trigger',
+                'method': 'POST',
+                'enctype': 'multipart/form-data',
+                'params': {
+                    'files': [{
+                        'name': 'externalMedia',
+                        'accept': ['image/*', 'application/pdf'],
+                    }]
+                }
+            }
+        return manifest

--- a/addons/hr_expense/static/src/mixins/document_upload.js
+++ b/addons/hr_expense/static/src/mixins/document_upload.js
@@ -2,7 +2,7 @@
 
 import { _t } from "@web/core/l10n/translation";
 import { useBus, useRefListener, useService } from '@web/core/utils/hooks';
-import { useRef, useEffect, useState } from "@odoo/owl";
+import { onWillStart, useRef, useEffect, useState } from "@odoo/owl";
 
 export const ExpenseDocumentDropZone = (T) => class ExpenseDocumentDropZone extends T {
     static props = [
@@ -72,12 +72,20 @@ export const ExpenseDocumentUpload = (T) => class ExpenseDocumentUpload extends 
         this.notification = useService('notification');
         this.orm = useService('orm');
         this.http = useService('http');
+        this.shareTarget = useService("shareTarget");
         this.fileInput = useRef('fileInput');
         this.root = useRef("root");
 
         useBus(this.env.bus, "change_file_input", async (ev) => {
             this.fileInput.el.files = ev.detail.files;
             await this.onChangeFileInput();
+        });
+
+        onWillStart(async () => {
+            if (this.shareTarget.hasSharedFiles()) {
+                const files = this.shareTarget.getSharedFilesToUpload();
+                await this._onChangeFileInput(files);
+            }
         });
     }
 
@@ -101,9 +109,13 @@ export const ExpenseDocumentUpload = (T) => class ExpenseDocumentUpload extends 
     }
 
     async onChangeFileInput() {
+        await this._onChangeFileInput([...this.fileInput.el.files]);
+    }
+
+    async _onChangeFileInput(files) {
         const params = {
             csrf_token: odoo.csrf_token,
-            ufile: [...this.fileInput.el.files],
+            ufile : files,
             model: 'hr.expense',
             id: 0,
         };
@@ -113,7 +125,7 @@ export const ExpenseDocumentUpload = (T) => class ExpenseDocumentUpload extends 
         if (attachments.error) {
             throw new Error(attachments.error);
         }
-        this.onUpload(attachments);
+        await this.onUpload(attachments);
     }
 
     async onUpload(attachments) {
@@ -126,6 +138,6 @@ export const ExpenseDocumentUpload = (T) => class ExpenseDocumentUpload extends 
         }
 
         const action = await this.orm.call('hr.expense', 'create_expense_from_attachments', [attachmentIds, this.env.config.viewType]);
-        this.actionService.doAction(action);
+        await this.actionService.doAction(action);
     }
 };

--- a/addons/mrp_subcontracting/__manifest__.py
+++ b/addons/mrp_subcontracting/__manifest__.py
@@ -122,6 +122,7 @@
             'web/static/src/webclient/**/*',
             ('remove', 'web/static/src/webclient/clickbot/clickbot.js'),  # lazy loaded
             ('remove', 'web/static/src/views/form/button_box/*.scss'),
+            ('remove', 'web/static/src/webclient/share_target/*'),
 
             # remove the report code and whitelist only what's needed
             ('remove', 'web/static/src/webclient/actions/reports/**/*'),

--- a/addons/web/static/src/service_worker.js
+++ b/addons/web/static/src/service_worker.js
@@ -28,12 +28,64 @@ const navigateOrDisplayOfflinePage = async (request) => {
     }
 };
 
+const serveShareTarget = (event) => {
+    // Redirect so the user can refresh the page without resending data.
+    event.respondWith(Response.redirect("/odoo?share_target=trigger"));
+    event.waitUntil(
+        (async () => {
+            // The page sends this message to tell the service worker it's ready to receive the file.
+            await waitingMessage("odoo_share_target");
+            const client = await self.clients.get(event.resultingClientId || event.clientId);
+            const data = await event.request.formData();
+            client.postMessage({
+                shared_files: data.getAll("externalMedia") || [],
+                action: "odoo_share_target_ack",
+            });
+        })()
+    );
+};
+
 self.addEventListener("fetch", (event) => {
+    if (
+        event.request.method === "POST" &&
+        new URL(event.request.url).searchParams.has("share_target")
+    ) {
+        return serveShareTarget(event);
+    }
     if (
         (event.request.mode === "navigate" && event.request.destination === "document") ||
         // request.mode = navigate isn't supported in all browsers => check for http header accept:text/html
         event.request.headers.get("accept").includes("text/html")
     ) {
         event.respondWith(navigateOrDisplayOfflinePage(event.request));
+    }
+});
+
+/**
+ *
+ * @type {Map<String, Function[]>}
+ */
+const nextMessageMap = new Map();
+/**
+ *
+ * @param message : string
+ * @return {Promise}
+ */
+const waitingMessage = async (message) => {
+    return new Promise((resolve) => {
+        if (!nextMessageMap.has(message)) {
+            nextMessageMap.set(message, []);
+        }
+        nextMessageMap.get(message).push(resolve);
+    });
+};
+
+self.addEventListener("message", (event) => {
+    const messageNotifiers = nextMessageMap.get(event.data);
+    if (messageNotifiers) {
+        for (const messageNotified of messageNotifiers) {
+            messageNotified();
+        }
+        nextMessageMap.delete(event.data);
     }
 });

--- a/addons/web/static/src/webclient/share_target/share_target_service.js
+++ b/addons/web/static/src/webclient/share_target/share_target_service.js
@@ -1,0 +1,64 @@
+import { registry } from "@web/core/registry";
+import { browser } from "@web/core/browser/browser";
+
+/**
+ * @return {Promise<{
+ *     title:string,
+ *     text:string,
+ *     url:string,
+ *     externalMediaFiles:File[]
+ * }>}
+ */
+const getShareTargetDataFromServiceWorker = () => {
+    return new Promise((resolve) => {
+        const onmessage = (event) => {
+            if (event.data.action === "odoo_share_target_ack") {
+                resolve(event.data.shared_files);
+                browser.navigator.serviceWorker.removeEventListener("message", onmessage);
+            }
+        };
+        browser.navigator.serviceWorker.addEventListener("message", onmessage);
+        browser.navigator.serviceWorker.controller.postMessage("odoo_share_target");
+    });
+};
+
+export const shareTargetService = {
+    dependencies: ["menu"],
+    start(env, { menu }) {
+        let sharedFiles = null;
+        if (
+            browser.navigator.serviceWorker &&
+            new URL(browser.location).searchParams.get("share_target") === "trigger"
+        ) {
+            const app = menu.getApps().find((app) => "expenses" === app.actionPath);
+            if (app) {
+                const clientReadyListener = async () => {
+                    sharedFiles = await getShareTargetDataFromServiceWorker();
+                    if (sharedFiles?.length) {
+                        await menu.selectMenu(app);
+                    }
+                    env.bus.removeEventListener("WEB_CLIENT_READY", clientReadyListener);
+                };
+                env.bus.addEventListener("WEB_CLIENT_READY", clientReadyListener);
+            }
+        }
+        return {
+            /**
+             * Return true if we receive share target files from service worker
+             * @return {boolean}
+             */
+            hasSharedFiles: () => !!sharedFiles?.length,
+            /**
+             * Return the shared files retrieve for upload
+             * @return {null|File[]}
+             */
+            getSharedFilesToUpload: () => {
+                const files = sharedFiles;
+                sharedFiles = null;
+                return files;
+            },
+        };
+    },
+};
+
+registry.category("services").add("shareTarget", shareTargetService);


### PR DESCRIPTION
This commit introduces the currently experimental share_target
technology[1][2]. It's currently not working on all browsers[3] but the
majority of Android devices can handle it, so to ease the expenses flow
on mobile device, we're enabling the share_target on Odoo PWA such as:
- Select a picture / PDF of the receipt from your phone gallery
- Share the file
- Select Odoo as target
- An expense is created and the file is attached to the record (same as
  the "Scan" feature).

task-3123623

[1]: https://developer.mozilla.org/en-US/docs/Web/Manifest/share_target
[2]: https://w3c.github.io/web-share-target/
[3]: https://developer.mozilla.org/en-US/docs/Web/Manifest/share_target#browser_compatibility
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
