### PR TITLE
[FIX] website_sale: publish product after creation

### DIFF
--- a/addons/website_sale/models/product_product.py
+++ b/addons/website_sale/models/product_product.py
@@ -139,3 +139,10 @@ class Product(models.Model):
         website = self.env['website'].get_current_website()
         return (is_product_salable and website.has_ecommerce_access()) \
                or self.env.user.has_group('base.group_system')
+
+    @api.onchange('public_categ_ids')
+    def _onchange_public_categ_ids(self):
+        if self.public_categ_ids:
+            self.website_published = True
+        else:
+            self.website_published = False

--- a/addons/website_sale/views/product_product_add.xml
+++ b/addons/website_sale/views/product_product_add.xml
@@ -13,6 +13,14 @@
             <xpath expr="//field[@name='company_id']" position="before">
                 <field name="website_url" invisible="1"/>
             </xpath>
+        </field>
+    </record>
+
+    <record id="product_product_view_form_normalized" model="ir.ui.view">
+        <field name="name">product.product.view.form.normalized.website.sale</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_product_view_form_normalized"/>
+        <field name="arch" type="xml">
             <div name="tax_info" position="after">
                 <field name="public_categ_ids" string="Website Category" class="oe_inline" widget="many2many_tags" placeholder="Unpublished"/>
             </div>


### PR DESCRIPTION
This is a follow-up for the task: 3977931.

In this commit, we make sure that the
`product.product_product_view_form_normalized`, which is the common form view
used to create a product on-the-fly from different modules, includes the Website
Category field and if it's filled, the product is automatically
`website_published`.

We accomplish this by moving the `public_categ_ids` field from
`website_sale.product_product_view_form_normalized_website_sale` to
`product.product_product_view_form_normalized`.

NOTE that `website_sale.product_product_view_form_normalized_website_sale`
should be present and remained the view used by website_sale since it uses the
`website_new_content_form` custom form view.