### PR TITLE
[IMP] sale_purchase: create new purchase order for subcontracted service

### DIFF
--- a/addons/sale_purchase/models/sale_order_line.py
+++ b/addons/sale_purchase/models/sale_order_line.py
@@ -225,11 +225,16 @@ class SaleOrderLine(models.Model):
         return suppliers[0]
 
     def _purchase_service_match_purchase_order(self, partner, company=False):
-        return self.env['purchase.order'].search([
-            ('partner_id', '=', partner.id),
-            ('state', '=', 'draft'),
-            ('company_id', '=', (company and company or self.env.company).id),
-        ], order='id desc')
+        return self.env['purchase.order.line'].search(
+            [
+                ('partner_id', '=', partner.id),
+                ('state', '=', 'draft'),
+                ('company_id', '=', (company and company or self.env.company).id),
+                ('sale_order_id', '=', self.order_id.id),
+            ],
+            order='order_id',
+            limit=1,
+        ).order_id
 
     def _create_purchase_order(self, supplierinfo):
         values = self._purchase_service_prepare_order_values(supplierinfo)

--- a/addons/sale_purchase/tests/test_sale_purchase.py
+++ b/addons/sale_purchase/tests/test_sale_purchase.py
@@ -78,7 +78,7 @@ class TestSalePurchase(TestCommonSalePurchaseNoChart):
         })
 
     def test_sale_create_purchase(self):
-        """ Confirming 2 sales orders with a service that should create a PO, then cancelling the PO should shedule 1 next activity per SO """
+        """ Confirming 2 sales orders with a service that should create two PO, then cancelling the PO should shedule 1 next activity per SO """
         self.sale_order_1.action_confirm()
         self.sale_order_2.action_confirm()
 
@@ -89,14 +89,14 @@ class TestSalePurchase(TestCommonSalePurchaseNoChart):
         purchase_lines_so2 = self.env['purchase.order.line'].search([('sale_line_id', 'in', self.sale_order_2.order_line.ids)])
         purchase_line2 = purchase_lines_so2[0]
 
-        self.assertEqual(len(purchase_order), 1, "Only one PO should have been created, from the 2 Sales orders")
+        self.assertEqual(len(purchase_order), 2, "Two PO should have been created, from the 2 Sales orders")
         self.assertEqual(len(purchase_order.order_line), 2, "The purchase order should have 2 lines")
-        self.assertIn(self.sale_order_1.name, purchase_order.origin, "The PO should have SO 1 in its source documents")
-        self.assertIn(self.sale_order_2.name, purchase_order.origin, "The PO should have SO 2 in its source documents")
+        self.assertIn(self.sale_order_1.name, purchase_order[1].origin, "The PO should have SO 1 in its source documents")
+        self.assertIn(self.sale_order_2.name, purchase_order[0].origin, "The PO should have SO 2 in its source documents")
         self.assertEqual(len(purchase_lines_so1), 1, "Only one SO line from SO 1 should have create a PO line")
         self.assertEqual(len(purchase_lines_so2), 1, "Only one SO line from SO 2 should have create a PO line")
         self.assertEqual(len(purchase_order.activity_ids), 0, "No activity should be scheduled on the PO")
-        self.assertEqual(purchase_order.state, 'draft', "The created PO should be in draft state")
+        self.assertEqual(set(purchase_order.mapped('state')), {'draft'}, "The created PO should be in draft state.")
 
         self.assertNotEqual(purchase_line1.product_id, purchase_line2.product_id, "The 2 PO line should have different products")
         self.assertEqual(purchase_line1.product_id, self.sol1_service_purchase_1.product_id, "The create PO line must have the same product as its mother SO line")

--- a/addons/sale_purchase_project/tests/test_sale_purchase_project.py
+++ b/addons/sale_purchase_project/tests/test_sale_purchase_project.py
@@ -22,9 +22,9 @@ class TestSalePurchaseProject(TestSalePurchase):
         (self.sale_order_1 + self.sale_order_2).action_confirm()
 
         purchase_order = self.env['purchase.order'].search([('partner_id', '=', self.supplierinfo1.partner_id.id), ('state', '=', 'draft')])
-        self.assertEqual(len(purchase_order), 1, "Only one PO should have been created, from the 2 Sales orders")
+        self.assertEqual(len(purchase_order), 2, "Two PO should have been created, from the 2 Sales orders")
         self.assertEqual(len(purchase_order.order_line), 2, "The purchase order should have 2 lines")
-        self.assertEqual(purchase_order.state, 'draft', "The created PO should be in draft state")
+        self.assertEqual(set(purchase_order.mapped('state')), {'draft'}, "The created PO should be in draft state.")
 
         purchase_lines_so1 = self.env['purchase.order.line'].search([('sale_line_id', 'in', self.sale_order_1.order_line.ids)])
         self.assertEqual(len(purchase_lines_so1), 1, "Only one SO line from SO 1 should have create a PO line")


### PR DESCRIPTION
After this commit the Sale Order with subcontracted service product will create a new Purchase Order,
Instead of adding products to an existing 'draft' Purchase Order of that vendor.

task-3980907

