### PR TITLE
[FIX] point_of_sale: modules to load in conf file

### DIFF
--- a/addons/point_of_sale/tools/posbox/configuration/odoo.conf
+++ b/addons/point_of_sale/tools/posbox/configuration/odoo.conf
@@ -7,3 +7,4 @@ pidfile = /var/run/odoo/odoo.pid
 limit_time_cpu = 600
 limit_time_real = 1200
 max_cron_threads = 0
+server_wide_modules=hw_drivers,hw_escpos,hw_posbox_homepage,point_of_sale,web


### PR DESCRIPTION
Added modules to load in `odoo.conf` for IoT Box v24.08 compatibility.

v24.08 PR: [https://github.com/odoo/odoo/pull/169633](https://github.com/odoo/odoo/pull/169633)
Task: 3947355
