### PR TITLE
[FIX] web_editor: fix safari css print

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -12,7 +12,7 @@ const RE_OFFSET_MATCH = /(^| )offset(-[\w\d]+)*( |$)/;
 const RE_PADDING_MATCH = /[ ]*padding[^;]*;/g;
 const RE_PADDING = /([\d.]+)/;
 const RE_WHITESPACE = /[\s\u200b]*/;
-const SELECTORS_IGNORE = /(^\*$|:hover|:before|:after|:active|:link|::|'|\([^(),]+[,(])/;
+const SELECTORS_IGNORE = /(^\*$|:hover|:before|:after|:active|:link|::|'|\([^(),]+[,(])|@page/;
 // CSS properties relating to font, which Outlook seem to have trouble inheriting.
 const FONT_PROPERTIES_TO_INHERIT = [
     'color',


### PR DESCRIPTION
To reproduce:
=============
on IOS device on Safari
Sales -> Orders -> open any order -> send it by email

Problem:
========
Safari may have limitations or require specific conditions to properly interpret @page.

Solution:
=========
Skip the `@page` rule while converting the inline style

opw-4101387
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
