### PR TITLE
[IMP] {stock, mrp, repair}: allow picking_type change after confirm

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -530,7 +530,7 @@
                         <page string="Miscellaneous" name="miscellaneous">
                             <group>
                                 <group>
-                                    <field name="picking_type_id" readonly="state != 'draft'"/>
+                                    <field name="picking_type_id" readonly="state not in ('draft', 'confirmed')"/>
                                     <field name="location_src_id" groups="stock.group_stock_multi_locations" options="{'no_create': True}" readonly="state != 'draft'"/>
                                     <field name="location_src_id" groups="!stock.group_stock_multi_locations" invisible="1"/>
                                     <field name="warehouse_id" invisible="1"/>

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -181,7 +181,7 @@
                     </page>
                     <page string="Miscellaneous" name="page_miscellaneous">
                         <group>
-                            <field name="picking_type_id" options="{'no_create': True}" readonly="state != 'draft'"/>
+                            <field name="picking_type_id" options="{'no_create': True}" readonly="state in ('done', 'cancel')"/>
                         </group>
                         <group string="Locations" groups="stock.group_stock_multi_locations" name="locations">
                             <field name="location_id" readonly="state != 'draft'" options="{'no_create': True}"/>

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -708,6 +708,15 @@ Please change the quantity done or the rounding precision of your unit of measur
                     move_to_check_location.procure_method = 'make_to_stock'
                     move_to_check_location.move_orig_ids = [Command.clear()]
                     ml.unlink()
+        if 'location_id' in vals or 'location_dest_id' in vals:
+            wh_by_moves = defaultdict(self.env['stock.move'].browse)
+            for move in self:
+                move_warehouse = move.location_id.warehouse_id or move.location_dest_id.warehouse_id
+                if move_warehouse == move.warehouse_id:
+                    continue
+                wh_by_moves[move_warehouse] |= move
+            for warehouse, moves in wh_by_moves.items():
+                moves.warehouse_id = warehouse.id
         if move_to_confirm:
             move_to_confirm._action_assign()
         if receipt_moves_to_reassign:

--- a/addons/stock/tests/test_packing.py
+++ b/addons/stock/tests/test_packing.py
@@ -1728,34 +1728,6 @@ class TestPacking(TestPackingCommon):
         with self.assertRaises(UserError):
             pack_1.location_id = self.shelf1
 
-    def test_compute_hide_picking_type_multiple_records(self):
-        """
-        Create two pickings and compute their respective hide picking types together.
-        """
-        picking1 = self.env['stock.picking'].create({
-            'location_id': self.stock_location.id,
-            'location_dest_id': self.customer_location.id,
-            'picking_type_id': self.env.ref('stock.picking_type_out').id,
-        })
-        self.env['stock.move'].create({
-            'name': self.productA.name,
-            'product_id': self.productA.id,
-            'product_uom_qty': 10,
-            'product_uom': self.productA.uom_id.id,
-            'picking_id': picking1.id,
-            'location_id': self.stock_location.id,
-            'location_dest_id': self.customer_location.id,
-        })
-        picking1.action_confirm()
-        picking2 = self.env['stock.picking'].create({
-            'location_id': self.stock_location.id,
-            'location_dest_id': self.customer_location.id,
-            'picking_type_id': self.env.ref('stock.picking_type_out').id,
-        })
-        (picking1 | picking2).with_context(default_picking_type_id=self.ref('stock.picking_type_out'))._compute_hide_picking_type()
-        self.assertTrue(picking1.hide_picking_type)
-        self.assertFalse(picking2.hide_picking_type)
-
     def test_action_split_transfer(self):
         """ Check Split Picking if quantity `0 <= done < demand`
         """

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -222,9 +222,8 @@
                             </div>
                             <field name="partner_id" nolabel="1" readonly="state in ['cancel', 'done']" placeholder="e.g. Lumber Inc"/>
                             <field name="picking_type_id" options="{'no_open': True}"
-                                   invisible="hide_picking_type"
-                                   readonly="state != 'draft' and id"
-                                   domain="context.get('restricted_picking_type_code') and [('code', '=', context.get('restricted_picking_type_code'))] or [(1,'=',1)]"/>
+                                   readonly="state in ('done', 'cancel')"
+                                   domain="[('code', 'in', ('incoming', 'outgoing', 'internal'))]" />
                             <field name="location_id" groups="!stock.group_stock_multi_locations" invisible="1" readonly="state == 'done'"/>
                             <field name="location_dest_id" groups="!stock.group_stock_multi_locations" invisible="1" readonly="state == 'done'"/>
                             <field name="location_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations" invisible="picking_type_code == 'incoming'" readonly="state == 'done'"/>


### PR DESCRIPTION
Allow to change the picking type of picking, MO, RO even after they are confirmed.

task-4104915

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
