### PR TITLE
[FIX] web: the top bar should not reappear when changing view

### DIFF
--- a/addons/web/static/src/search/control_panel/control_panel.js
+++ b/addons/web/static/src/search/control_panel/control_panel.js
@@ -115,7 +115,8 @@ export class ControlPanel extends Component {
             embeddedInfos: {
                 showEmbedded:
                     this.env.config.embeddedActions?.length > 0 &&
-                    (!!this.env.config.parentActionId ||
+                    ((!!this.env.config.parentActionId &&
+                        !!JSON.parse(browser.localStorage.getItem("showEmbeddedActions"))) ||
                         !!JSON.parse(browser.localStorage.getItem(this.embeddedVisibilityKey))),
                 embeddedActions: this.defaultEmbeddedActions || [],
                 newActionIsShared: false,
@@ -307,6 +308,7 @@ export class ControlPanel extends Component {
             browser.localStorage.setItem(this.embeddedVisibilityKey, true);
         }
         this.state.embeddedInfos.showEmbedded = !this.state.embeddedInfos.showEmbedded;
+        browser.localStorage.setItem("showEmbeddedActions", this.state.embeddedInfos.showEmbedded);
     }
 
     /**

--- a/addons/web/static/tests/webclient/actions/embedded_action.test.js
+++ b/addons/web/static/tests/webclient/actions/embedded_action.test.js
@@ -344,3 +344,20 @@ test("a view coming from a embedded can be saved in the embedded actions", async
         message: "Should have 2 embedded actions in the embedded + the dropdown button",
     });
 });
+
+test("the embedded actions should not be displayed when switching view", async () => {
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction(1);
+    browser.localStorage.clear();
+    await contains(".o_control_panel_navigation > button > i.fa-sliders").click();
+    await contains(".o_embedded_actions .dropdown").click();
+    await contains(
+        ".o_popover.dropdown-menu .dropdown-item > div > span:contains('Embedded Action 2')"
+    ).click();
+    await contains(".o_embedded_actions > button > span:contains('Embedded Action 2')").click();
+    await contains(".o_control_panel_navigation > button > i.fa-sliders").click();
+    await contains("button.o_switch_view.o_kanban").click();
+    expect(".o_embedded_actions").toHaveCount(0, {
+        message: "The embedded actions menu should not be displayed",
+    });
+});


### PR DESCRIPTION
Currently, there is a strange behavior with the following use case:

- open project app
- select any project
- press the top bar button
- add any items to the top bar
- click on the button to switch to the new action
- go back to the 'tasks' view using the top bar.
- remove the top bar by pressing the slider button
- switch from the gantt view to any other view of the task. (e.a the list view)

expected behavior:
the list view is displayed, the top bar is not

current behavior:
the list view is displayed, the top bar is displayed too

source of the issue:
By clicking on the top bar to switch action, this sets the 'actionParentId' param from the env.config. With this param set, the setup of the control panel set the showEmbedded to True by default when loading a new view.

task-4100301



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
