### PR TITLE
[FIX] hw_drivers: improve readability of unhandled IoT tracebacks

### DIFF
--- a/addons/hw_drivers/exception_logger.py
+++ b/addons/hw_drivers/exception_logger.py
@@ -1,23 +1,34 @@
-# -*- coding: utf-8 -*-
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from io import StringIO
 
 import logging
 import sys
 
+_logger = logging.getLogger(__name__)
+
 
 class ExceptionLogger:
     """
-    Redirect Exceptions to the logger to keep track of them in the log file.
+    Redirect any unhandled python exception to the logger to keep track of them in the log file.
     """
-
     def __init__(self):
-        self.logger = logging.getLogger()
+        self._buffer = StringIO()
 
     def write(self, message):
-        if message != '\n':
-            self.logger.error(message)
+        self._buffer.write(message)
+        if message.endswith('\n'):
+            self._flush_buffer()
+
+    def _flush_buffer(self):
+        self._buffer.seek(0)
+        _logger.error(self._buffer.getvalue().rstrip('\n'))
+        self._buffer = StringIO()  # Reset the buffer
 
     def flush(self):
-        pass
+        if self._buffer.tell() > 0:
+            self._flush_buffer()
+
+    def close(self):
+        self.flush()
 
 sys.stderr = ExceptionLogger()


### PR DESCRIPTION
Before this commit:
 Unhandled python traceback will be tough to read as there is too much line breaks which was forcing each line to be logged.

 e.g:
```py
2024-08-12 09:33:49,426 2466 ERROR ? root: Exception in thread
2024-08-12 09:33:49,428 2466 ERROR ? root: Thread-9
2024-08-12 09:33:49,429 2466 ERROR ? root: :

2024-08-12 09:33:49,430 2466 ERROR ? root:
2024-08-12 09:33:49,430 2466 ERROR ? root: Traceback (most recent call last):

2024-08-12 09:33:49,430 2466 ERROR ? root:
2024-08-12 09:33:49,430 2466 ERROR ? root:   File "/usr/lib/python3.11/threading.py", line 1038, in _bootstrap_inner

2024-08-12 09:33:49,439 2466 ERROR ? root:
2024-08-12 09:33:49,439 2466 ERROR ? root:
2024-08-12 09:33:49,457 2466 ERROR ? root: self.run()
2024-08-12 09:33:49,459 2466 ERROR ? root:
2024-08-12 09:33:49,459 2466 ERROR ? root:   File "/home/pi/odoo/addons/hw_drivers/interface.py", line 31, in run

2024-08-12 09:33:49,460 2466 ERROR ? root:
2024-08-12 09:33:49,461 2466 ERROR ? root:
2024-08-12 09:33:49,465 2466 ERROR ? root: self.update_iot_devices(self.get_devices())
2024-08-12 09:33:49,466 2466 ERROR ? root:
2024-08-12 09:33:49,467 2466 ERROR ? root:
2024-08-12 09:33:49,467 2466 ERROR ? root:
2024-08-12 09:33:49,467 2466 ERROR ? root:
2024-08-12 09:33:49,468 2466 ERROR ? root:
2024-08-12 09:33:49,468 2466 ERROR ? root:
2024-08-12 09:33:49,468 2466 ERROR ? root:
2024-08-12 09:33:49,468 2466 ERROR ? root:
2024-08-12 09:33:49,468 2466 ERROR ? root:
2024-08-12 09:33:49,469 2466 ERROR ? root:
2024-08-12 09:33:49,469 2466 ERROR ? root:
2024-08-12 09:33:49,470 2466 ERROR ? root:
2024-08-12 09:33:49,473 2466 ERROR ? root:
2024-08-12 09:33:49,474 2466 ERROR ? root:
2024-08-12 09:33:49,474 2466 ERROR ? root:
2024-08-12 09:33:49,474 2466 ERROR ? root:
2024-08-12 09:33:49,480 2466 ERROR ? root:
2024-08-12 09:33:49,482 2466 ERROR ? root:
2024-08-12 09:33:49,487 2466 ERROR ? root:
2024-08-12 09:33:49,488 2466 ERROR ? root:
2024-08-12 09:33:49,488 2466 ERROR ? root:
2024-08-12 09:33:49,488 2466 ERROR ? root:
2024-08-12 09:33:49,488 2466 ERROR ? root:
2024-08-12 09:33:49,488 2466 ERROR ? root:
2024-08-12 09:33:49,495 2466 ERROR ? root:
2024-08-12 09:33:49,495 2466 ERROR ? root:
2024-08-12 09:33:49,496 2466 ERROR ? root:
2024-08-12 09:33:49,496 2466 ERROR ? root:
2024-08-12 09:33:49,497 2466 ERROR ? root:
2024-08-12 09:33:49,497 2466 ERROR ? root: ^
2024-08-12 09:33:49,498 2466 ERROR ? root: ^
2024-08-12 09:33:49,499 2466 ERROR ? root: ^
2024-08-12 09:33:49,502 2466 ERROR ? root: ^
2024-08-12 09:33:49,502 2466 ERROR ? root: ^
2024-08-12 09:33:49,503 2466 ERROR ? root: ^
2024-08-12 09:33:49,503 2466 ERROR ? root: ^
2024-08-12 09:33:49,503 2466 ERROR ? root: ^
2024-08-12 09:33:49,503 2466 ERROR ? root: ^
2024-08-12 09:33:49,504 2466 ERROR ? root: ^
2024-08-12 09:33:49,504 2466 ERROR ? root: ^
2024-08-12 09:33:49,504 2466 ERROR ? root: ^
2024-08-12 09:33:49,504 2466 ERROR ? root: ^
2024-08-12 09:33:49,504 2466 ERROR ? root: ^
2024-08-12 09:33:49,504 2466 ERROR ? root: ^
2024-08-12 09:33:49,505 2466 ERROR ? root: ^
2024-08-12 09:33:49,505 2466 ERROR ? root: ^
2024-08-12 09:33:49,505 2466 ERROR ? root: ^
2024-08-12 09:33:49,505 2466 ERROR ? root:
2024-08-12 09:33:49,505 2466 ERROR ? root:   File "/home/pi/odoo/addons/hw_drivers/iot_handlers/interfaces/PrinterInterface_L.py", line 21, in get_devices

2024-08-12 09:33:49,506 2466 ERROR ? root:
2024-08-12 09:33:49,506 2466 ERROR ? root:
2024-08-12 09:33:49,507 2466 ERROR ? root: 0/0
2024-08-12 09:33:49,507 2466 ERROR ? root:
2024-08-12 09:33:49,507 2466 ERROR ? root:
2024-08-12 09:33:49,507 2466 ERROR ? root:
2024-08-12 09:33:49,508 2466 ERROR ? root:
2024-08-12 09:33:49,508 2466 ERROR ? root:
2024-08-12 09:33:49,508 2466 ERROR ? root: ~
2024-08-12 09:33:49,508 2466 ERROR ? root: ^
2024-08-12 09:33:49,508 2466 ERROR ? root: ~
2024-08-12 09:33:49,508 2466 ERROR ? root:
2024-08-12 09:33:49,508 2466 ERROR ? root: ZeroDivisionError
2024-08-12 09:33:49,509 2466 ERROR ? root: :
2024-08-12 09:33:49,509 2466 ERROR ? root: division by zero
```

After this commit:
 New lines are logged only if necessary, like in a regular tb:
```py
2024-08-12 09:41:06,197 3093 ERROR ? odoo.addons.hw_drivers.exception_logger: Exception in thread Thread-9:
2024-08-12 09:41:06,199 3093 ERROR ? odoo.addons.hw_drivers.exception_logger: Traceback (most recent call last):
2024-08-12 09:41:06,201 3093 ERROR ? odoo.addons.hw_drivers.exception_logger:   File "/usr/lib/python3.11/threading.py", line 1038, in _bootstrap_inner
2024-08-12 09:41:06,222 3093 ERROR ? odoo.addons.hw_drivers.exception_logger:     self.run()
2024-08-12 09:41:06,223 3093 ERROR ? odoo.addons.hw_drivers.exception_logger:   File "/home/pi/odoo/addons/hw_drivers/interface.py", line 31, in run
2024-08-12 09:41:06,233 3093 ERROR ? odoo.addons.hw_drivers.exception_logger:     self.update_iot_devices(self.get_devices())
2024-08-12 09:41:06,234 3093 ERROR ? odoo.addons.hw_drivers.exception_logger:                             ^^^^^^^^^^^^^^^^^^
2024-08-12 09:41:06,234 3093 ERROR ? odoo.addons.hw_drivers.exception_logger:   File "/home/pi/odoo/addons/hw_drivers/iot_handlers/interfaces/PrinterInterface_L.py", line 21, in get_devices
2024-08-12 09:41:06,235 3093 ERROR ? odoo.addons.hw_drivers.exception_logger:     0/0
2024-08-12 09:41:06,236 3093 ERROR ? odoo.addons.hw_drivers.exception_logger:     ~^~
2024-08-12 09:41:06,237 3093 ERROR ? odoo.addons.hw_drivers.exception_logger: ZeroDivisionError: division by zero
```

opw-4110599
