### PR TITLE
[FIX] point_of_sale: overflowing barcode scanner

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/camera_barcode_scanner.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/camera_barcode_scanner.js
@@ -8,6 +8,7 @@ export class CameraBarcodeScanner extends BarcodeVideoScanner {
         this.barcodeScanner = useService("barcode_reader");
         this.sound = useService("sound");
         this.props = {
+            ...this.props,
             facingMode: "environment",
             onResult: (result) => this.onResult(result),
             onError: console.error,


### PR DESCRIPTION
After the redesign of pos, opening the barcode
scanner on mobile would cause an issue in the
page alignment.

before:
![image](https://github.com/user-attachments/assets/0be25a61-6581-4819-9878-9e5fe79c6c68)

after
![image](https://github.com/user-attachments/assets/73c631bb-0203-4080-a855-63ea60823a88)


Task: 4110781





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
