### PR TITLE
stock: added account move access for inventory

### DIFF
--- a/addons/stock_account/security/ir.model.access.csv
+++ b/addons/stock_account/security/ir.model.access.csv
@@ -7,3 +7,4 @@ access_stock_move_invoicing_payments_readonly,stock.move,model_stock_move,accoun
 access_stock_move_invoicing_payments,stock.move,model_stock_move,account.group_account_invoice,1,1,1,0
 access_stock_valuation_layer,access_stock_valuation_layer,model_stock_valuation_layer,stock.group_stock_manager,1,1,1,0
 access_stock_valuation_layer_revaluation,access_stock_valuation_layer_revaluation,model_stock_valuation_layer_revaluation,stock.group_stock_manager,1,1,1,0
+access_account_move_stock_manager,account.move stock manager,account.model_account_move,stock.group_stock_manager,1,0,0,0


### PR DESCRIPTION
This PR  will fix this issue [166958](https://github.com/odoo/odoo/issues/166958)

There is no group access for the account.move, so system can't able to read the data from the account.move model,
I grated the to the Inventory manager group. 
Now, user within the inventory access can able to read the data from the account.move model.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
