### PR TITLE
[FIX] l10n_eg_edi_eta: rate warning due to float point error

### DIFF
--- a/addons/l10n_eg_edi_eta/models/res_currency_rate.py
+++ b/addons/l10n_eg_edi_eta/models/res_currency_rate.py
@@ -3,6 +3,7 @@
 
 
 from odoo import models, api, _
+from odoo.tools import float_compare
 
 
 class ResCurrencyRate(models.Model):
@@ -11,7 +12,10 @@ class ResCurrencyRate(models.Model):
     @api.onchange('company_rate')
     def _onchange_rate_warning(self):
         # We send the ETA a rate that is 5 decimal accuracy, so to ensure consistency, Odoo should also operate with 5 decimal accuracy rate
-        if self.company_id.account_fiscal_country_id.code == 'EG' and self.inverse_company_rate != round(self.inverse_company_rate, 5):
+        if (
+            self.company_id.account_fiscal_country_id.code == 'EG' and
+            float_compare(self.inverse_company_rate, round(self.inverse_company_rate, 5), precision_digits=10) != 0
+            ):
             return {
                 'warning': {
                     'title': _("Warning for %s", self.currency_id.name),


### PR DESCRIPTION
Backport of 2867a68534212efd8549764a03c26e86c5109381

Have an Egyptian company setup
Go to Currencies > USD
Add a new entry with Unit per EGP 0.03232062055591467

Issue: Warning will raise
"Please make sure that the EGP per unit is within 5 decimal accuracy. Higher decimal accuracy might lead to inconsistency with the ETA invoicing portal!"

Even if the shown EGP per Unit is 30.940000000000 it is actually 30.940000000000005 and it will fail the equal-to-rounding test

opw-4096393