### PR TITLE
[FIX] hr_holidays: Time Off Officer right's issue

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -82,10 +82,9 @@ class HolidaysType(models.Model):
         ('hr', 'By Time Off Officer'),
         ('manager', "By Employee's Approver"),
         ('both', "By Employee's Approver and Time Off Officer")], default='hr', string='Approval',
-        help="""Select the level of approval needed in case of request by employee
-            #     - No validation needed: The employee's request is automatically approved.
-            #     - Approved by Time Off Officer: The employee's request need to be manually approved
-            #       by the Time Off Officer, Employee's Approver or both.""")
+        help="Select the level of approval needed in case of request by employee"
+            "- No validation needed: The employee's request is automatically approved."
+            "- Approved by Time Off Officer, Employee's Approver or both: The employee's request must be manually approved by the Time Off Officer, Employee's Approver or both.")
 
     has_valid_allocation = fields.Boolean(compute='_compute_valid', search='_search_valid', help='This indicates if it is still possible to use this type of leave')
     time_type = fields.Selection([('other', 'Worked Time'), ('leave', 'Absence')], default='leave', string="Kind of Time Off",


### PR DESCRIPTION
Currently, every Time Off Officer is able to validate all time offs, regardless of their Time off type approval validation method.

They should not be able to validate a Time off request if its approval is "By Employee's Approver" and if they are not the employee's approver.

In the same way, they should not be able to validate the first step of a "By Employee's Approver and Time Off Officer" time off if they are not the Employee's approver

task-3072621

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
