### PR TITLE
[IMP] website_sale: dont show empty image in cart

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1820,9 +1820,10 @@
                          t-att-src="image_data_uri(line.product_id.image_128)"
                          class="o_image_64_max  img rounded"
                          t-att-alt="line.name_short"/>
-                    <div t-else=""
+                    <div t-elif="line.product_id.image_128"
                          t-field="line.product_id.image_128"
                          t-options="{'widget': 'image', 'qweb_img_responsive': False, 'class': 'o_image_64_max rounded'}"/>
+                    <div t-else="" class="o_image_64_contain invisible"/>
                     <div class="flex-grow-1">
                         <t t-call="website_sale.cart_line_product_link">
                             <h6 t-field="line.name_short" class="d-inline align-top h6 fw-bold"/>


### PR DESCRIPTION
Prior this commit:
An empty placeholder image was displayed in the cart when no image was defined for a product.

Post this commit:
The empty placeholder image is no longer displayed in the cart when no image is defined for a product.

task-3983679

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
