### PR TITLE
[FIX] website_sale: prevent error when checkout without delivery method

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -960,14 +960,14 @@ class WebsiteSale(payment_portal.PaymentPortal):
         if order_sudo._has_deliverable_products():
             available_dms = order_sudo._get_delivery_methods()
             checkout_page_values['delivery_methods'] = available_dms
-            delivery_method = order_sudo._get_preferred_delivery_method(available_dms)
-            rate = delivery_method.rate_shipment(order_sudo)
-            if (
-                not order_sudo.carrier_id
-                or not rate.get('success')
-                or order_sudo.amount_delivery != rate['price']
-            ):
-                order_sudo._set_delivery_method(delivery_method, rate=rate)
+            if delivery_method := order_sudo._get_preferred_delivery_method(available_dms):
+                rate = delivery_method.rate_shipment(order_sudo)
+                if (
+                    not order_sudo.carrier_id
+                    or not rate.get('success')
+                    or order_sudo.amount_delivery != rate['price']
+                ):
+                    order_sudo._set_delivery_method(delivery_method, rate=rate)
             can_skip_delivery = self.can_skip_delivery_step(order_sudo, available_dms)
 
         if try_skip_step and can_skip_delivery:


### PR DESCRIPTION
When customer tries to checkout without the delivery method,
a traceback will appear.

Steps to reproduce the error:
- Install ```website_sale```
- Go to Website > Configuration > Delivery Methods >
  unpublish all the delivery methods
- Go to Website > Shop > add one product in cart > checkout

Traceback:
```
ValueError: Expected singleton: delivery.carrier()
  File "odoo/http.py", line 2373, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1903, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1966, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1933, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2090, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 223, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 754, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/website_sale/controllers/main.py", line 964, in shop_checkout
    rate = delivery_method.rate_shipment(order_sudo)
  File "addons/delivery/models/delivery_carrier.py", line 256, in rate_shipment
    self.ensure_one()
  File "odoo/models.py", line 5964, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
```

https://github.com/odoo/odoo/blob/f2d2b02ade42fcfdb79f1ce0a01c5a0b742a775d/addons/website_sale/controllers/main.py#L964 
When customer clicks on the checkout without delivery method,
```delivery_method``` will be empty, so when it calls ```rate_shipment``` method.
It will lead to the above traceback.

sentry-5702321558

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
