### PR TITLE
[FIX] spreadsheet: scrollbar & select dark mode colors

### DIFF
--- a/addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet_extended.dark.scss
+++ b/addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet_extended.dark.scss
@@ -2,6 +2,12 @@
 // we have the proper scss tool chain to support dark theme properly
 // in the library
 .o-spreadsheet {
+  color-scheme: light;
+  select > option {
+    color: inherit;
+    background-color: inherit;
+  }
+
   .o-spreadsheet-topbar {
       background-color: #fff !important;
   }


### PR DESCRIPTION
When setting odoo to dark mode, it should to nothing to Spreadsheet sicne we haven't implemented the dark mode yet. But the scrollbars and the selection options were both dark, and were ugly.

Task: [4111151](https://www.odoo.com/web#id=4111151&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
