### PR TITLE
[IMP] hr_holidays: add approve, validate and refuse btn in popover in calendar

### DIFF
--- a/addons/hr_holidays/static/src/views/calendar/common/calendar_common_popover.js
+++ b/addons/hr_holidays/static/src/views/calendar/common/calendar_common_popover.js
@@ -16,7 +16,7 @@ export class TimeOffCalendarCommonPopover extends CalendarCommonPopover {
         onWillStart(async () => {
             this.record = this.props.record.rawRecord;
             this.state = this.record.state;
-            this.isManager = (await user.hasGroup("hr_holidays.group_hr_holidays_user")) || this.record.leave_manager_id?.[0] === user.userId;
+            this.isManager = (await user.hasGroup("hr_holidays.group_hr_holidays_responsible")) || this.record.leave_manager_id?.[0] === user.userId;
         });
     }
 

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -141,15 +141,15 @@
                             </div>
                             <div t-if="['confirm', 'validate1'].includes(record.state.raw_value)">
                                 <button t-if="record.state.raw_value === 'confirm'" name="action_approve" type="object" class="btn btn-link btn-sm ps-0"
-                                    groups="hr_holidays.group_hr_holidays_user">
+                                    groups="hr_holidays.group_hr_holidays_responsible">
                                     <i class="fa fa-thumbs-up"/> Approve
                                 </button>
                                 <button t-if="record.state.raw_value === 'validate1'" name="action_validate" type="object" class="btn btn-link btn-sm ps-0"
-                                    groups="hr_holidays.group_hr_holidays_manager">
+                                    groups="hr_holidays.group_hr_holidays_responsible">
                                     <i class="fa fa-check"/> Validate
                                 </button>
                                 <button t-if="['confirm', 'validate1'].includes(record.state.raw_value)" name="action_refuse" type="object" class="btn btn-link btn-sm ps-0"
-                                    groups="hr_holidays.group_hr_holidays_user">
+                                    groups="hr_holidays.group_hr_holidays_responsible">
                                     <i class="fa fa-times"/> Refuse
                                 </button>
                             </div>
@@ -445,6 +445,7 @@
                 <field name="employee_id" filters="1"/>
                 <field name="is_hatched" invisible="1" />
                 <field name="is_striked" invisible="1"/>
+                <field name="state" invisible="1"/>
             </calendar>
         </field>
     </record>
@@ -473,11 +474,11 @@
                 <button string="Validate" name="action_validate" type="object"
                     icon="fa-check"
                     invisible="state != 'validate1'"
-                    groups="hr_holidays.group_hr_holidays_user"/>
+                    groups="hr_holidays.group_hr_holidays_responsible"/>
                 <button string="Refuse" name="action_refuse" type="object"
                     icon="fa-times"
                     invisible="state not in ('confirm', 'validate1')"
-                    groups="hr_holidays.group_hr_holidays_user"/>
+                    groups="hr_holidays.group_hr_holidays_responsible"/>
                 <field name="activity_exception_decoration" widget="activity_exception"/>
             </list>
         </field>


### PR DESCRIPTION
This commit, adds `state` as invisible field in view because `state` is required
for JS widget which shows Approve, Refuse and Validate button to popover in
calendar view.

task-3863607






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
