### PR TITLE
[FIX] l10n_*: tax report fixes for syscohada countries

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-13 10:26+0000\n"
-"PO-Revision-Date: 2024-08-13 10:26+0000\n"
+"POT-Creation-Date: 2024-08-14 16:15+0000\n"
+"PO-Revision-Date: 2024-08-14 16:15+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -1718,6 +1718,11 @@ msgid ""
 msgstr ""
 
 #. module: account
+#: model:res.groups,name:account.group_account_manager
+msgid "Accountant"
+msgstr ""
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_res_config_settings__module_account_accountant
 #: model:ir.ui.menu,name:account.account_account_menu
 #: model:ir.ui.menu,name:account.menu_finance_entries
@@ -3155,7 +3160,6 @@ msgid "Billing"
 msgstr ""
 
 #. module: account
-#: model:res.groups,name:account.group_account_manager
 msgid "Billing Administrator"
 msgstr ""
 
@@ -3205,6 +3209,11 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields.selection,name:account.selection__res_partner__invoice_warn__block
 msgid "Blocking Message"
+msgstr ""
+
+#. module: account
+#: model:res.groups,name:account.group_account_user
+msgid "Bookkeeper"
 msgstr ""
 
 #. module: account
@@ -6631,6 +6640,13 @@ msgstr ""
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_report_expression__carryover_target
+msgid ""
+"Formula in the form line_code.expression_label. This allows setting the "
+"target of the carryover for this expression (on a _carryover_*-labeled "
+"expression), in case it is different from the parent line."
+msgstr ""
+
+#. module: account
 msgid ""
 "Formula in the form line_code.expression_label. This allows setting the "
 "target of the carryover for this expression (on a _carryover_*-labeled "
@@ -11229,6 +11245,11 @@ msgid "Re-Sequence"
 msgstr ""
 
 #. module: account
+#: model:res.groups,name:account.group_account_readonly
+msgid "Read-only"
+msgstr ""
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_account_move_reversal__reason
 msgid "Reason displayed on Credit Note"
 msgstr ""
@@ -12491,7 +12512,6 @@ msgid ""
 msgstr ""
 
 #. module: account
-#: model:res.groups,name:account.group_account_readonly
 msgid "Show Accounting Features - Readonly"
 msgstr ""
 
@@ -12526,7 +12546,6 @@ msgid "Show Force Tax Included"
 msgstr ""
 
 #. module: account
-#: model:res.groups,name:account.group_account_user
 msgid "Show Full Accounting Features"
 msgstr ""
 
@@ -15657,6 +15676,15 @@ msgid ""
 msgstr ""
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/account_report.py:0
+#, python-format
+msgid ""
+"When targetting an expression for carryover, the label of that expression "
+"must starts with _applied_caryyover_"
+msgstr ""
+
+#. module: account
 #: model_terms:ir.actions.act_window,help:account.action_move_in_receipt_type
 msgid ""
 "When the purchase receipt is confirmed, you can record the\n"
@@ -16357,6 +16385,15 @@ msgstr ""
 #: code:addons/account/models/account_move_line.py:0
 #, python-format
 msgid "You cannot use taxes on lines with an Off-Balance account"
+msgstr ""
+
+#. module: account
+#. odoo-python
+#: code:addons/account/models/account_report.py:0
+#, python-format
+msgid ""
+"You cannot use the field carryover_target in an expression that does not "
+"have the label starting with _carryover_"
 msgstr ""
 
 #. module: account

--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -541,8 +541,7 @@ class AccountReportExpression(models.Model):
     carryover_target = fields.Char(
         string="Carry Over To",
         help="Formula in the form line_code.expression_label. This allows setting the target of the carryover for this expression "
-             "(on a _carryover_*-labeled expression), in case it is different from the parent line. 'custom' is also allowed as value"
-             " in case the carryover destination requires more complex logic."
+             "(on a _carryover_*-labeled expression), in case it is different from the parent line."
     )
 
     _sql_constraints = [
@@ -557,6 +556,14 @@ class AccountReportExpression(models.Model):
             "The expression label must be unique per report line."
         ),
     ]
+
+    @api.constrains('carryover_target', 'label')
+    def _check_carryover_target(self):
+        for expression in self:
+            if expression.carryover_target and not expression.label.startswith('_carryover_'):
+                raise UserError(_("You cannot use the field carryover_target in an expression that does not have the label starting with _carryover_"))
+            elif expression.carryover_target and not expression.carryover_target.split('.')[1].startswith('_applied_carryover_'):
+                raise UserError(_("When targetting an expression for carryover, the label of that expression must starts with _applied_caryyover_"))
 
     @api.constrains('formula')
     def _check_domain_formula(self):

--- a/addons/l10n_bf/data/account_tax_report_data.xml
+++ b/addons/l10n_bf/data/account_tax_report_data.xml
@@ -316,6 +316,11 @@
                         <field name="expression_ids">
                             <record id="account_tax_report_line_bf_credit_reported_balance" model="account.report.expression">
                                 <field name="label">balance</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">BF_CREDIT_REPORTED._applied_carryover_balance</field>
+                            </record>
+                            <record id="account_tax_report_line_bf_credit_reported_balance_carryover" model="account.report.expression">
+                                <field name="label">_applied_carryover_balance</field>
                                 <field name="engine">external</field>
                                 <field name="formula">most_recent</field>
                                 <field name="date_scope">previous_tax_period</field>
@@ -415,7 +420,12 @@
                         <field name="engine">aggregation</field>
                         <field name="formula">BF_DEDUCTIBLE.balance + BF_CREDIT_REPORTED.balance - BF_CREDIT_ASKED.balance + BF_OTHER_DEDUCTION.balance + BF_UNPAID_CREDIT.balance + BF_OTHER_DEDUCTION.balance - BF_GROSS_TOTAL.balance</field>
                         <field name="subformula">if_above(EUR(0))</field>
-                        <field name="carryover_target">BF_REPORTED.balance</field>
+                    </record>
+                    <record id="account_tax_report_line_bf_credit_to_report_carryover" model="account.report.expression">
+                        <field name="label">_carryover_balance</field>
+                        <field name="engine">aggregation</field>
+                        <field name="formula">BF_CREDIT_TO_REPORT.balance</field>
+                        <field name="carryover_target">BF_CREDIT_REPORTED._applied_carryover_balance</field>
                     </record>
                 </field>
             </record>

--- a/addons/l10n_bf/data/account_tax_report_data.xml
+++ b/addons/l10n_bf/data/account_tax_report_data.xml
@@ -385,7 +385,7 @@
                         </field>
                     </record>
                     <record id="account_tax_report_line_bf_unpaid_credit_carried" model="account.report.line">
-                        <field name="name">26 Unpaid VAT credit carried forward</field>
+                        <field name="name">27 Unpaid VAT credit carried forward</field>
                         <field name="code">BF_UNPAID_CREDIT</field>
                         <field name="expression_ids">
                             <record id="account_tax_report_line_bf_unpaid_credit_carried_balance" model="account.report.expression">
@@ -405,7 +405,7 @@
                     <record id="account_tax_report_line_bf_net_vat_to_pay_balance" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">aggregation</field>
-                        <field name="formula">BF_GROSS_TOTAL.balance - BF_DEDUCTIBLE.balance - BF_CREDIT_REPORTED.balance + BF_CREDIT_ASKED.balance - BF_CANCELLED.balance - BF_OTHER_DEDUCTION.balance - BF_OTHER_DEDUCTION.balance - BF_UNPAID_CREDIT.balance</field>
+                        <field name="formula">BF_GROSS_TOTAL.balance - (BF_DEDUCTIBLE.balance + BF_CREDIT_REPORTED.balance - BF_CREDIT_ASKED.balance + BF_CANCELLED.balance + BF_OTHER_DEDUCTION.balance + BF_UNPAID_CREDIT.balance)</field>
                         <field name="subformula">if_above(EUR(0))</field>
                     </record>
                 </field>
@@ -418,7 +418,7 @@
                     <record id="account_tax_report_line_bf_credit_to_report_balance" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">aggregation</field>
-                        <field name="formula">BF_DEDUCTIBLE.balance + BF_CREDIT_REPORTED.balance - BF_CREDIT_ASKED.balance + BF_OTHER_DEDUCTION.balance + BF_UNPAID_CREDIT.balance + BF_OTHER_DEDUCTION.balance - BF_GROSS_TOTAL.balance</field>
+                        <field name="formula">BF_DEDUCTIBLE.balance + BF_CREDIT_REPORTED.balance - BF_CREDIT_ASKED.balance + BF_CANCELLED.balance + BF_UNPAID_CREDIT.balance + BF_OTHER_DEDUCTION.balance - BF_GROSS_TOTAL.balance</field>
                         <field name="subformula">if_above(EUR(0))</field>
                     </record>
                     <record id="account_tax_report_line_bf_credit_to_report_carryover" model="account.report.expression">

--- a/addons/l10n_bf/data/account_tax_report_data.xml
+++ b/addons/l10n_bf/data/account_tax_report_data.xml
@@ -335,7 +335,7 @@
                                 <field name="label">balance</field>
                                 <field name="engine">external</field>
                                 <field name="formula">sum</field>
-                                <field name="subformula">editable;rounding=2</field>
+                                <field name="subformula">editable</field>
                             </record>
                         </field>
                     </record>
@@ -347,7 +347,7 @@
                                 <field name="label">balance</field>
                                 <field name="engine">external</field>
                                 <field name="formula">sum</field>
-                                <field name="subformula">editable;rounding=2</field>
+                                <field name="subformula">editable</field>
                             </record>
                         </field>
                     </record>
@@ -406,7 +406,7 @@
                         <field name="label">balance</field>
                         <field name="engine">aggregation</field>
                         <field name="formula">BF_GROSS_TOTAL.balance - (BF_DEDUCTIBLE.balance + BF_CREDIT_REPORTED.balance - BF_CREDIT_ASKED.balance + BF_CANCELLED.balance + BF_OTHER_DEDUCTION.balance + BF_UNPAID_CREDIT.balance)</field>
-                        <field name="subformula">if_above(EUR(0))</field>
+                        <field name="subformula">if_above(XOF(0))</field>
                     </record>
                 </field>
             </record>
@@ -419,7 +419,7 @@
                         <field name="label">balance</field>
                         <field name="engine">aggregation</field>
                         <field name="formula">BF_DEDUCTIBLE.balance + BF_CREDIT_REPORTED.balance - BF_CREDIT_ASKED.balance + BF_CANCELLED.balance + BF_UNPAID_CREDIT.balance + BF_OTHER_DEDUCTION.balance - BF_GROSS_TOTAL.balance</field>
-                        <field name="subformula">if_above(EUR(0))</field>
+                        <field name="subformula">if_above(XOF(0))</field>
                     </record>
                     <record id="account_tax_report_line_bf_credit_to_report_carryover" model="account.report.expression">
                         <field name="label">_carryover_balance</field>

--- a/addons/l10n_bj/data/account_tax_report_data.xml
+++ b/addons/l10n_bj/data/account_tax_report_data.xml
@@ -97,6 +97,11 @@
                         <field name="expression_ids">
                             <record id="account_tax_report_line_bj_deductible_reported_balance" model="account.report.expression">
                                 <field name="label">balance</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">BJ_REPORTED._applied_carryover_balance</field>
+                            </record>
+                            <record id="account_tax_report_line_bj_deductible_reported_balance_carryover" model="account.report.expression">
+                                <field name="label">_applied_carryover_balance</field>
                                 <field name="engine">external</field>
                                 <field name="formula">most_recent</field>
                                 <field name="date_scope">previous_tax_period</field>
@@ -210,7 +215,12 @@
                                 <field name="engine">aggregation</field>
                                 <field name="formula">BJ_VAT_DEDUCTIBLE.balance - BJ_GROSS.balance</field>
                                 <field name="subformula">if_above(EUR(0))</field>
-                        <field name="carryover_target">BJ_REPORTED.balance</field>
+                            </record>
+                            <record id="account_tax_report_line_bj_credit_to_report_carryover" model="account.report.expression">
+                                <field name="label">_carryover_balance</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">BJ_TO_REPORT.balance</field>
+                                <field name="carryover_target">BJ_REPORTED._applied_carryover_balance</field>
                             </record>
                         </field>
                     </record>

--- a/addons/l10n_bj/data/account_tax_report_data.xml
+++ b/addons/l10n_bj/data/account_tax_report_data.xml
@@ -138,7 +138,7 @@
                                 <field name="label">balance</field>
                                 <field name="engine">external</field>
                                 <field name="formula">sum</field>
-                                <field name="subformula">editable;rounding=2</field>
+                                <field name="subformula">editable</field>
                             </record>
                         </field>
                     </record>
@@ -150,7 +150,7 @@
                                 <field name="label">balance</field>
                                 <field name="engine">external</field>
                                 <field name="formula">sum</field>
-                                <field name="subformula">editable;rounding=2</field>
+                                <field name="subformula">editable</field>
                             </record>
                         </field>
                     </record>
@@ -202,7 +202,7 @@
                                 <field name="label">balance</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">BJ_GROSS.balance - BJ_VAT_DEDUCTIBLE.balance</field>
-                                <field name="subformula">if_above(EUR(0))</field>
+                                <field name="subformula">if_above(XOF(0))</field>
                             </record>
                         </field>
                     </record>
@@ -214,7 +214,7 @@
                                 <field name="label">balance</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">BJ_VAT_DEDUCTIBLE.balance - BJ_GROSS.balance</field>
-                                <field name="subformula">if_above(EUR(0))</field>
+                                <field name="subformula">if_above(XOF(0))</field>
                             </record>
                             <record id="account_tax_report_line_bj_credit_to_report_carryover" model="account.report.expression">
                                 <field name="label">_carryover_balance</field>

--- a/addons/l10n_cd/data/account_tax_report_data.xml
+++ b/addons/l10n_cd/data/account_tax_report_data.xml
@@ -380,6 +380,11 @@
                         <field name="expression_ids">
                             <record id="account_tax_report_line_cd_deductible_report_balance" model="account.report.expression">
                                 <field name="label">balance</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">CD_REPORT_CREDIT._applied_carryover_balance</field>
+                            </record>
+                            <record id="account_tax_report_line_cd_deductible_report_balance_carryover" model="account.report.expression">
+                                <field name="label">_applied_carryover_balance</field>
                                 <field name="engine">external</field>
                                 <field name="formula">most_recent</field>
                                 <field name="date_scope">previous_tax_period</field>
@@ -511,7 +516,12 @@
                                 <field name="engine">aggregation</field>
                                 <field name="formula">CD_CREDIT.balance - CD_REPAYMENT_ASKED.balance</field>
                                 <field name="subformula">if_above(EUR(0))</field>
-                                <field name="carryover_target">CD_REPORT_CREDIT.balance</field>
+                            </record>
+                            <record id="account_tax_report_line_cd_calculation_credit_reportable_carryover" model="account.report.expression">
+                                <field name="label">_carryover_balance</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">CD_CREDIT_REPORTABLE.balance</field>
+                                <field name="carryover_target">CD_REPORT_CREDIT._applied_carryover_balance</field>
                             </record>
                         </field>
                     </record>

--- a/addons/l10n_cd/data/account_tax_report_data.xml
+++ b/addons/l10n_cd/data/account_tax_report_data.xml
@@ -424,7 +424,7 @@
                                 <field name="label">balance</field>
                                 <field name="engine">external</field>
                                 <field name="formula">sum</field>
-                                <field name="subformula">editable;rounding=2</field>
+                                <field name="subformula">editable</field>
                             </record>
                         </field>
                     </record>
@@ -436,7 +436,7 @@
                                 <field name="label">balance</field>
                                 <field name="engine">external</field>
                                 <field name="formula">sum</field>
-                                <field name="subformula">editable;rounding=2</field>
+                                <field name="subformula">editable</field>
                             </record>
                         </field>
                     </record>
@@ -448,7 +448,7 @@
                                 <field name="label">balance</field>
                                 <field name="engine">external</field>
                                 <field name="formula">sum</field>
-                                <field name="subformula">editable;rounding=2</field>
+                                <field name="subformula">editable</field>
                             </record>
                         </field>
                     </record>
@@ -460,7 +460,7 @@
                                 <field name="label">balance</field>
                                 <field name="engine">external</field>
                                 <field name="formula">sum</field>
-                                <field name="subformula">editable;rounding=2</field>
+                                <field name="subformula">editable</field>
                             </record>
                         </field>
                     </record>
@@ -478,7 +478,7 @@
                             <record id="account_tax_report_line_cd_tax_calculation_to_pay_balance" model="account.report.expression">
                                 <field name="label">balance</field>
                                 <field name="engine">aggregation</field>
-                                <field name="subformula">if_above(EUR(0))</field>
+                                <field name="subformula">if_above(CDF(0))</field>
                                 <field name="formula">CD_TAX.balance + CD_IMP_SERVICE_TAX.balance + CD_REPAYMENTS.balance + CD_RECOVERY.balance - CD_DEDUCTIBLE_AMOUNT.balance - CD_ADD_DEDUCTION.balance - CD_MINING.balance - CD_PM_TAX.balance</field>
                             </record>
                         </field>
@@ -490,7 +490,7 @@
                             <record id="account_tax_report_line_cd_calculation_credit_balance" model="account.report.expression">
                                 <field name="label">balance</field>
                                 <field name="engine">aggregation</field>
-                                <field name="subformula">if_above(EUR(0))</field>
+                                <field name="subformula">if_above(CDF(0))</field>
                                 <field name="formula">CD_DEDUCTIBLE_AMOUNT.balance + CD_ADD_DEDUCTION.balance + CD_MINING.balance + CD_PM_TAX.balance - CD_TAX.balance - CD_IMP_SERVICE_TAX.balance - CD_REPAYMENTS.balance - CD_RECOVERY.balance</field>
                             </record>
                         </field>
@@ -503,7 +503,7 @@
                                 <field name="label">balance</field>
                                 <field name="engine">external</field>
                                 <field name="formula">sum</field>
-                                <field name="subformula">editable;rounding=2</field>
+                                <field name="subformula">editable</field>
                             </record>
                         </field>
                     </record>
@@ -515,7 +515,7 @@
                                 <field name="label">balance</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">CD_CREDIT.balance - CD_REPAYMENT_ASKED.balance</field>
-                                <field name="subformula">if_above(EUR(0))</field>
+                                <field name="subformula">if_above(CDF(0))</field>
                             </record>
                             <record id="account_tax_report_line_cd_calculation_credit_reportable_carryover" model="account.report.expression">
                                 <field name="label">_carryover_balance</field>
@@ -544,7 +544,7 @@
                                 <field name="label">balance</field>
                                 <field name="engine">external</field>
                                 <field name="formula">sum</field>
-                                <field name="subformula">editable;rounding=2</field>
+                                <field name="subformula">editable</field>
                             </record>
                         </field>
                     </record>

--- a/addons/l10n_ci/data/account_tax_report_data.xml
+++ b/addons/l10n_ci/data/account_tax_report_data.xml
@@ -296,6 +296,11 @@
                         <field name="expression_ids">
                             <record id="account_tax_report_line_ci_tva_credit_tax" model="account.report.expression">
                                 <field name="label">tax</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">CI_CREDIT_REPORTED._applied_carryover_tax</field>
+                            </record>
+                            <record id="account_tax_report_line_ci_tva_credit_tax_carryover" model="account.report.expression">
+                                <field name="label">_applied_carryover_tax</field>
                                 <field name="engine">external</field>
                                 <field name="formula">most_recent</field>
                                 <field name="date_scope">previous_tax_period</field>
@@ -337,7 +342,12 @@
                         <field name="engine">aggregation</field>
                         <field name="formula">CI_VAT_DEDUCT.tax - CI_GROSS.tax - CI_REIMBURSEMENT.tax</field>
                         <field name="subformula">if_above(EUR(0))</field>
-                        <field name="carryover_target">CI_CREDIT_REPORTED.tax</field>
+                    </record>
+                    <record id="account_tax_report_line_ci_to_report_carryover" model="account.report.expression">
+                        <field name="label">_carryover_tax</field>
+                        <field name="engine">aggregation</field>
+                        <field name="formula">CI_REPORT.tax</field>
+                        <field name="carryover_target">CI_CREDIT_REPORTED._applied_carryover_tax</field>
                     </record>
                 </field>
             </record>

--- a/addons/l10n_ci/data/account_tax_report_data.xml
+++ b/addons/l10n_ci/data/account_tax_report_data.xml
@@ -243,7 +243,7 @@
                         <field name="label">tax</field>
                         <field name="engine">external</field>
                         <field name="formula">sum</field>
-                        <field name="subformula">editable;rounding=2</field>
+                        <field name="subformula">editable</field>
                     </record>
                 </field>
             </record>
@@ -317,7 +317,7 @@
                         <field name="label">tax</field>
                         <field name="engine">aggregation</field>
                         <field name="formula">CI_GROSS.tax - CI_VAT_DEDUCT.tax</field>
-                        <field name="subformula">if_above(EUR(0))</field>
+                        <field name="subformula">if_above(XOF(0))</field>
                     </record>
                 </field>
             </record>
@@ -329,7 +329,7 @@
                         <field name="label">tax</field>
                         <field name="engine">external</field>
                         <field name="formula">sum</field>
-                        <field name="subformula">editable;rounding=2</field>
+                        <field name="subformula">editable</field>
                     </record>
                 </field>
             </record>
@@ -341,7 +341,7 @@
                         <field name="label">tax</field>
                         <field name="engine">aggregation</field>
                         <field name="formula">CI_VAT_DEDUCT.tax - CI_GROSS.tax - CI_REIMBURSEMENT.tax</field>
-                        <field name="subformula">if_above(EUR(0))</field>
+                        <field name="subformula">if_above(XOF(0))</field>
                     </record>
                     <record id="account_tax_report_line_ci_to_report_carryover" model="account.report.expression">
                         <field name="label">_carryover_tax</field>

--- a/addons/l10n_cm/data/account_tax_report_data.xml
+++ b/addons/l10n_cm/data/account_tax_report_data.xml
@@ -46,13 +46,13 @@
                                 <field name="label">base</field>
                                 <field name="engine">external</field>
                                 <field name="formula">sum</field>
-                                <field name="subformula">editable;rounding=2</field>
+                                <field name="subformula">editable</field>
                             </record>
                             <record id="account_tax_report_line_cm_turnover_excises_tax" model="account.report.expression">
                                 <field name="label">tax</field>
                                 <field name="engine">external</field>
                                 <field name="formula">sum</field>
-                                <field name="subformula">editable;rounding=2</field>
+                                <field name="subformula">editable</field>
                             </record>
                         </field>
                     </record>
@@ -204,7 +204,7 @@
                                 <field name="label">tax</field>
                                 <field name="engine">external</field>
                                 <field name="formula">sum</field>
-                                <field name="subformula">editable;rounding=2</field>
+                                <field name="subformula">editable</field>
                             </record>
                         </field>
                     </record>
@@ -216,7 +216,7 @@
                                 <field name="label">tax</field>
                                 <field name="engine">external</field>
                                 <field name="formula">sum</field>
-                                <field name="subformula">editable;rounding=2</field>
+                                <field name="subformula">editable</field>
                             </record>
                         </field>
                     </record>
@@ -228,7 +228,7 @@
                                 <field name="label">tax</field>
                                 <field name="engine">external</field>
                                 <field name="formula">sum</field>
-                                <field name="subformula">editable;rounding=2</field>
+                                <field name="subformula">editable</field>
                             </record>
                         </field>
                     </record>
@@ -240,7 +240,7 @@
                                 <field name="label">tax</field>
                                 <field name="engine">external</field>
                                 <field name="formula">sum</field>
-                                <field name="subformula">editable;rounding=2</field>
+                                <field name="subformula">editable</field>
                             </record>
                         </field>
                     </record>
@@ -303,7 +303,7 @@
                                 <field name="label">tax</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">CM_COLLECTED.tax - CM_DEDUCTIBLE_VAT_29.tax - CM_ADJUSTMENT_TO_DEDUCT.tax + CM_ADJUSTMENT_TO_PAY.tax</field>
-                                <field name="subformula">if_above(EUR(0))</field>
+                                <field name="subformula">if_above(XAF(0))</field>
                             </record>
                         </field>
                     </record>
@@ -315,7 +315,7 @@
                                 <field name="label">tax</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">CM_DEDUCTIBLE_VAT_29.tax + CM_ADJUSTMENT_TO_DEDUCT.tax - CM_COLLECTED.tax - CM_ADJUSTMENT_TO_PAY.tax</field>
-                                <field name="subformula">if_above(EUR(0))</field>
+                                <field name="subformula">if_above(XAF(0))</field>
                             </record>
                         </field>
                     </record>
@@ -327,7 +327,7 @@
                                 <field name="label">tax</field>
                                 <field name="engine">external</field>
                                 <field name="formula">sum</field>
-                                <field name="subformula">editable;rounding=2</field>
+                                <field name="subformula">editable</field>
                             </record>
                         </field>
                     </record>
@@ -339,7 +339,7 @@
                                 <field name="label">tax</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">CM_CREDIT.tax - CM_REIMBURSEMENT.tax</field>
-                                <field name="subformula">if_above(EUR(0))</field>
+                                <field name="subformula">if_above(XAF(0))</field>
                             </record>
                             <record id="account_tax_report_line_cm_vat_credit_to_report_carryover" model="account.report.expression">
                                 <field name="label">_carryover_tax</field>

--- a/addons/l10n_cm/data/account_tax_report_data.xml
+++ b/addons/l10n_cm/data/account_tax_report_data.xml
@@ -123,6 +123,11 @@
                         <field name="expression_ids">
                             <record id="account_tax_report_line_cm_credit_report_tax" model="account.report.expression">
                                 <field name="label">tax</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">CM_CREDIT_REPORTED._applied_carryover_tax</field>
+                            </record>
+                            <record id="account_tax_report_line_cm_credit_report_tax_carryover" model="account.report.expression">
+                                <field name="label">_applied_carryover_tax</field>
                                 <field name="engine">external</field>
                                 <field name="formula">most_recent</field>
                                 <field name="date_scope">previous_tax_period</field>
@@ -335,7 +340,12 @@
                                 <field name="engine">aggregation</field>
                                 <field name="formula">CM_CREDIT.tax - CM_REIMBURSEMENT.tax</field>
                                 <field name="subformula">if_above(EUR(0))</field>
-                                <field name="carryover_target">CM_CREDIT_REPORTED.tax</field>
+                            </record>
+                            <record id="account_tax_report_line_cm_vat_credit_to_report_carryover" model="account.report.expression">
+                                <field name="label">_carryover_tax</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">CM_CREDIT_REPORT.tax</field>
+                                <field name="carryover_target">CM_CREDIT_REPORTED._applied_carryover_tax</field>
                             </record>
                         </field>
                     </record>

--- a/addons/l10n_ga/data/account_tax_report_data.xml
+++ b/addons/l10n_ga/data/account_tax_report_data.xml
@@ -740,6 +740,11 @@
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_ga_report_credit_tax" model="account.report.expression">
                                         <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">GA_REPORT_CREDIT._applied_carryover_tax</field>
+                                    </record>
+                                    <record id="account_tax_report_line_ga_report_credit_tax_carryover" model="account.report.expression">
+                                        <field name="label">_applied_carryover_tax</field>
                                         <field name="engine">external</field>
                                         <field name="formula">most_recent</field>
                                         <field name="date_scope">previous_tax_period</field>
@@ -855,7 +860,12 @@
                                         <field name="engine">aggregation</field>
                                         <field name="formula">GA_DEDUCTIBLE.tax - GA_TOTAL_GROSS.tax</field>
                                         <field name="subformula">if_above(EUR(0))</field>
-                                        <field name="carryover_target">GA_REPORT_CREDIT.tax</field>
+                                    </record>
+                                    <record id="account_tax_report_line_ga_credit_to_report_carryover" model="account.report.expression">
+                                        <field name="label">_carryover_tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">GA_CREDIT_TO_REPORT.tax</field>
+                                        <field name="carryover_target">GA_REPORT_CREDIT._applied_carryover_tax</field>
                                     </record>
                                 </field>
                             </record>

--- a/addons/l10n_ga/data/account_tax_report_data.xml
+++ b/addons/l10n_ga/data/account_tax_report_data.xml
@@ -846,7 +846,7 @@
                                         <field name="label">tax</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">GA_TOTAL_GROSS.tax - GA_DEDUCTIBLE.tax</field>
-                                        <field name="subformula">if_above(EUR(0))</field>
+                                        <field name="subformula">if_above(XAF(0))</field>
                                     </record>
                                 </field>
                             </record>
@@ -859,7 +859,7 @@
                                         <field name="label">tax</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">GA_DEDUCTIBLE.tax - GA_TOTAL_GROSS.tax</field>
-                                        <field name="subformula">if_above(EUR(0))</field>
+                                        <field name="subformula">if_above(XAF(0))</field>
                                     </record>
                                     <record id="account_tax_report_line_ga_credit_to_report_carryover" model="account.report.expression">
                                         <field name="label">_carryover_tax</field>

--- a/addons/l10n_km/data/account_tax_report_data.xml
+++ b/addons/l10n_km/data/account_tax_report_data.xml
@@ -173,7 +173,7 @@
                         <field name="label">tax</field>
                         <field name="engine">aggregation</field>
                         <field name="formula">KM_OPERATIONS.tax - KM_PREPAYMENTS.tax - KM_CREDIT_REPORTED.tax</field>
-                        <field name="subformula">if_above(EUR(0))</field>
+                        <field name="subformula">if_above(KMF(0))</field>
                     </record>
                 </field>
             </record>
@@ -185,7 +185,7 @@
                         <field name="label">tax</field>
                         <field name="engine">aggregation</field>
                         <field name="formula">KM_PREPAYMENTS.tax + KM_CREDIT_REPORTED.tax - KM_OPERATIONS.tax</field>
-                        <field name="subformula">if_above(EUR(0))</field>
+                        <field name="subformula">if_above(KMF(0))</field>
                     </record>
                     <record id="account_tax_report_line_km_credit_to_report_carryover" model="account.report.expression">
                         <field name="label">_carryover_tax</field>

--- a/addons/l10n_km/data/account_tax_report_data.xml
+++ b/addons/l10n_km/data/account_tax_report_data.xml
@@ -154,6 +154,11 @@
                 <field name="expression_ids">
                     <record id="account_tax_report_line_km_credit_reported_tax" model="account.report.expression">
                         <field name="label">tax</field>
+                        <field name="engine">aggregation</field>
+                        <field name="formula">KM_CREDIT_REPORTED._applied_carryover_tax</field>
+                    </record>
+                    <record id="account_tax_report_line_km_credit_reported_tax_carryover" model="account.report.expression">
+                        <field name="label">_applied_carryover_tax</field>
                         <field name="engine">external</field>
                         <field name="formula">most_recent</field>
                         <field name="date_scope">previous_tax_period</field>
@@ -181,7 +186,12 @@
                         <field name="engine">aggregation</field>
                         <field name="formula">KM_PREPAYMENTS.tax + KM_CREDIT_REPORTED.tax - KM_OPERATIONS.tax</field>
                         <field name="subformula">if_above(EUR(0))</field>
-                        <field name="carryover_target">KM_CREDIT_REPORTED.tax</field>
+                    </record>
+                    <record id="account_tax_report_line_km_credit_to_report_carryover" model="account.report.expression">
+                        <field name="label">_carryover_tax</field>
+                        <field name="engine">aggregation</field>
+                        <field name="formula">KM_TO_REPORT.tax</field>
+                        <field name="carryover_target">KM_CREDIT_REPORTED._applied_carryover_tax</field>
                     </record>
                 </field>
             </record>

--- a/addons/l10n_ml/data/account_tax_report_data.xml
+++ b/addons/l10n_ml/data/account_tax_report_data.xml
@@ -226,6 +226,11 @@
                 <field name="expression_ids">
                     <record id="account_tax_report_line_ml_purchases_credit_reported_tax" model="account.report.expression">
                         <field name="label">tax</field>
+                        <field name="engine">aggregation</field>
+                        <field name="formula">ML_CREDIT_REPORTED._applied_carryover_tax</field>
+                    </record>
+                    <record id="account_tax_report_line_ml_purchases_credit_reported_tax_carryover" model="account.report.expression">
+                        <field name="label">_applied_carryover_tax</field>
                         <field name="engine">external</field>
                         <field name="formula">most_recent</field>
                         <field name="date_scope">previous_tax_period</field>
@@ -288,7 +293,12 @@
                         <field name="engine">aggregation</field>
                         <field name="formula">ML_CREDIT_REPORT.tax - ML_REIMBURSEMENT.tax</field>
                         <field name="subformula">if_above(EUR(0))</field>
-                        <field name="carryover_target">ML_CREDIT_REPORTED.tax</field>
+                    </record>
+                    <record id="account_tax_report_line_ml_credit_report_deductions_carryover" model="account.report.expression">
+                        <field name="label">_carryover_tax</field>
+                        <field name="engine">aggregation</field>
+                        <field name="formula">ML_CREDIT_REPROT_DEDU.tax</field>
+                        <field name="carryover_target">ML_CREDIT_REPORTED._applied_carryover_tax</field>
                     </record>
                 </field>
             </record>

--- a/addons/l10n_ml/data/account_tax_report_data.xml
+++ b/addons/l10n_ml/data/account_tax_report_data.xml
@@ -147,7 +147,7 @@
                         <field name="label">tax</field>
                         <field name="engine">external</field>
                         <field name="formula">sum</field>
-                        <field name="subformula">editable;rounding=2</field>
+                        <field name="subformula">editable</field>
                     </record>
                 </field>
             </record>
@@ -202,7 +202,7 @@
                                 <field name="label">tax</field>
                                 <field name="engine">external</field>
                                 <field name="formula">sum</field>
-                                <field name="subformula">editable;rounding=2</field>
+                                <field name="subformula">editable</field>
                             </record>
                         </field>
                     </record>
@@ -214,7 +214,7 @@
                                 <field name="label">tax</field>
                                 <field name="engine">external</field>
                                 <field name="formula">sum</field>
-                                <field name="subformula">editable;rounding=2</field>
+                                <field name="subformula">editable</field>
                             </record>
                         </field>
                     </record>
@@ -256,7 +256,7 @@
                         <field name="label">tax</field>
                         <field name="engine">aggregation</field>
                         <field name="formula">ML_SALES.tax - ML_DEDUCTIONS.tax</field>
-                        <field name="subformula">if_above(EUR(0))</field>
+                        <field name="subformula">if_above(XOF(0))</field>
                     </record>
                 </field>
             </record>
@@ -268,7 +268,7 @@
                         <field name="label">tax</field>
                         <field name="engine">aggregation</field>
                         <field name="formula">ML_DEDUCTIONS.tax - ML_SALES.tax</field>
-                        <field name="subformula">if_above(EUR(0))</field>
+                        <field name="subformula">if_above(XOF(0))</field>
                     </record>
                 </field>
             </record>
@@ -280,7 +280,7 @@
                         <field name="label">tax</field>
                         <field name="engine">external</field>
                         <field name="formula">sum</field>
-                        <field name="subformula">editable;rounding=2</field>
+                        <field name="subformula">editable</field>
                     </record>
                 </field>
             </record>
@@ -292,7 +292,7 @@
                         <field name="label">tax</field>
                         <field name="engine">aggregation</field>
                         <field name="formula">ML_CREDIT_REPORT.tax - ML_REIMBURSEMENT.tax</field>
-                        <field name="subformula">if_above(EUR(0))</field>
+                        <field name="subformula">if_above(XOF(0))</field>
                     </record>
                     <record id="account_tax_report_line_ml_credit_report_deductions_carryover" model="account.report.expression">
                         <field name="label">_carryover_tax</field>

--- a/addons/l10n_ne/data/account_tax_report_data.xml
+++ b/addons/l10n_ne/data/account_tax_report_data.xml
@@ -181,6 +181,11 @@
                         <field name="expression_ids">
                             <record id="account_tax_report_line_ne_deductible_reported_balance" model="account.report.expression">
                                 <field name="label">balance</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">NE_REPORTED._applied_carryover_balance</field>
+                            </record>
+                            <record id="account_tax_report_line_ne_deductible_reported_balance_carryover" model="account.report.expression">
+                                <field name="label">_applied_carryover_balance</field>
                                 <field name="engine">external</field>
                                 <field name="formula">most_recent</field>
                                 <field name="date_scope">previous_tax_period</field>
@@ -267,7 +272,12 @@
                                 <field name="engine">aggregation</field>
                                 <field name="subformula">if_above(EUR(0))</field>
                                 <field name="formula">NE_DEDUCTIBLE_TOTAL.balance + NE_DEDUCTIBLE_ADDITION.balance - NE_GROSS_VAT.balance - NE_REPAY.balance</field>
-                                <field name="carryover_target">NE_REPORTED.balance</field>
+                            </record>
+                            <record id="account_tax_report_line_ne_credit_to_report_carryover" model="account.report.expression">
+                                <field name="label">_carryover_balance</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">NE_CREDIT_TO_REPORT.balance</field>
+                                <field name="carryover_target">NE_REPORTED._applied_carryover_balance</field>
                             </record>
                         </field>
                     </record>

--- a/addons/l10n_ne/data/account_tax_report_data.xml
+++ b/addons/l10n_ne/data/account_tax_report_data.xml
@@ -233,7 +233,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">external</field>
                                         <field name="formula">sum</field>
-                                        <field name="subformula">editable;rounding=2</field>
+                                        <field name="subformula">editable</field>
                                     </record>
                                 </field>
                             </record>
@@ -245,7 +245,7 @@
                                         <field name="label">balance</field>
                                         <field name="engine">external</field>
                                         <field name="formula">sum</field>
-                                        <field name="subformula">editable;rounding=2</field>
+                                        <field name="subformula">editable</field>
                                     </record>
                                 </field>
                             </record>
@@ -258,7 +258,7 @@
                             <record id="account_tax_report_line_ne_net_to_pay_balance" model="account.report.expression">
                                 <field name="label">balance</field>
                                 <field name="engine">aggregation</field>
-                                <field name="subformula">if_above(EUR(0))</field>
+                                <field name="subformula">if_above(XOF(0))</field>
                                 <field name="formula">NE_GROSS_VAT.balance + NE_REPAY.balance - NE_DEDUCTIBLE_TOTAL.balance - NE_DEDUCTIBLE_ADDITION.balance</field>
                             </record>
                         </field>
@@ -270,7 +270,7 @@
                             <record id="account_tax_report_line_ne_credit_to_report_balance" model="account.report.expression">
                                 <field name="label">balance</field>
                                 <field name="engine">aggregation</field>
-                                <field name="subformula">if_above(EUR(0))</field>
+                                <field name="subformula">if_above(XOF(0))</field>
                                 <field name="formula">NE_DEDUCTIBLE_TOTAL.balance + NE_DEDUCTIBLE_ADDITION.balance - NE_GROSS_VAT.balance - NE_REPAY.balance</field>
                             </record>
                             <record id="account_tax_report_line_ne_credit_to_report_carryover" model="account.report.expression">

--- a/addons/l10n_sn/data/account_tax_report_data.xml
+++ b/addons/l10n_sn/data/account_tax_report_data.xml
@@ -241,7 +241,7 @@
                                 <field name="label">tax</field>
                                 <field name="engine">external</field>
                                 <field name="formula">sum</field>
-                                <field name="subformula">editable;rounding=2</field>
+                                <field name="subformula">editable</field>
                             </record>
                         </field>
                     </record>
@@ -273,7 +273,7 @@
                         <field name="label">tax</field>
                         <field name="engine">aggregation</field>
                         <field name="formula">SN_OPE.tax - SN_VAT_DEDUCT.tax</field>
-                        <field name="subformula">if_above(EUR(0))</field>
+                        <field name="subformula">if_above(XOF(0))</field>
                     </record>
                 </field>
             </record>
@@ -285,7 +285,7 @@
                         <field name="label">tax</field>
                         <field name="engine">aggregation</field>
                         <field name="formula">SN_VAT_DEDUCT.tax - SN_OPE.tax</field>
-                        <field name="subformula">if_above(EUR(0))</field>
+                        <field name="subformula">if_above(XOF(0))</field>
                     </record>
                     <record id="account_tax_report_line_sn_to_report_carryover" model="account.report.expression">
                         <field name="label">_carryover_tax</field>
@@ -303,7 +303,7 @@
                         <field name="label">tax</field>
                         <field name="engine">external</field>
                         <field name="formula">sum</field>
-                        <field name="subformula">editable;rounding=2</field>
+                        <field name="subformula">editable</field>
                     </record>
                 </field>
             </record>

--- a/addons/l10n_sn/data/account_tax_report_data.xml
+++ b/addons/l10n_sn/data/account_tax_report_data.xml
@@ -251,6 +251,11 @@
                         <field name="expression_ids">
                             <record id="account_tax_report_line_sn_tva_credit_tax" model="account.report.expression">
                                 <field name="label">tax</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">SN_CREDIT._applied_carryover_tax</field>
+                            </record>
+                            <record id="account_tax_report_line_sn_tva_credit_tax_carryover" model="account.report.expression">
+                                <field name="label">_applied_carryover_tax</field>
                                 <field name="engine">external</field>
                                 <field name="formula">most_recent</field>
                                 <field name="date_scope">previous_tax_period</field>
@@ -281,7 +286,12 @@
                         <field name="engine">aggregation</field>
                         <field name="formula">SN_VAT_DEDUCT.tax - SN_OPE.tax</field>
                         <field name="subformula">if_above(EUR(0))</field>
-                        <field name="carryover_target">SN_CREDIT.tax</field>
+                    </record>
+                    <record id="account_tax_report_line_sn_to_report_carryover" model="account.report.expression">
+                        <field name="label">_carryover_tax</field>
+                        <field name="engine">aggregation</field>
+                        <field name="formula">SN_REPORT.tax</field>
+                        <field name="carryover_target">SN_CREDIT._applied_carryover_tax</field>
                     </record>
                 </field>
             </record>

--- a/addons/l10n_tg/data/account_tax_report_data.xml
+++ b/addons/l10n_tg/data/account_tax_report_data.xml
@@ -233,7 +233,7 @@
                                 <field name="label">tax</field>
                                 <field name="engine">external</field>
                                 <field name="formula">sum</field>
-                                <field name="subformula">editable;rounding=2</field>
+                                <field name="subformula">editable</field>
                             </record>
                         </field>
                     </record>
@@ -245,7 +245,7 @@
                                 <field name="label">tax</field>
                                 <field name="engine">external</field>
                                 <field name="formula">sum</field>
-                                <field name="subformula">editable;rounding=2</field>
+                                <field name="subformula">editable</field>
                             </record>
                         </field>
                     </record>
@@ -271,7 +271,7 @@
                                 <field name="label">tax</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">TG_SALES.tax - TG_VAT_DEDUCT.tax</field>
-                                <field name="subformula">if_above(EUR(0))</field>
+                                <field name="subformula">if_above(XOF(0))</field>
                             </record>
                         </field>
                     </record>
@@ -283,7 +283,7 @@
                                 <field name="label">tax</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">TG_VAT_DEDUCT.tax - TG_SALES.tax</field>
-                                <field name="subformula">if_above(EUR(0))</field>
+                                <field name="subformula">if_above(XOF(0))</field>
                             </record>
                             <record id="account_tax_report_line_tg_to_report_tax_carryover" model="account.report.expression">
                                 <field name="label">_carryover_tax</field>

--- a/addons/l10n_tg/data/account_tax_report_data.xml
+++ b/addons/l10n_tg/data/account_tax_report_data.xml
@@ -182,6 +182,11 @@
                         <field name="expression_ids">
                             <record id="account_tax_report_line_tg_deductible_reported_tax_tag" model="account.report.expression">
                                 <field name="label">tax</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">TG_VAT_REPORTED._applied_carryover_tax</field>
+                            </record>
+                            <record id="account_tax_report_line_tg_deductible_reported_tax_tag_carryover" model="account.report.expression">
+                                <field name="label">_applied_carryover_tax</field>
                                 <field name="engine">external</field>
                                 <field name="formula">most_recent</field>
                                 <field name="date_scope">previous_tax_period</field>
@@ -279,7 +284,12 @@
                                 <field name="engine">aggregation</field>
                                 <field name="formula">TG_VAT_DEDUCT.tax - TG_SALES.tax</field>
                                 <field name="subformula">if_above(EUR(0))</field>
-                                <field name="carryover_target">TG_VAT_REPORTED.tax</field>
+                            </record>
+                            <record id="account_tax_report_line_tg_to_report_tax_carryover" model="account.report.expression">
+                                <field name="label">_carryover_tax</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">TG_REPORT.tax</field>
+                                <field name="carryover_target">TG_VAT_REPORTED._applied_carryover_tax</field>
                             </record>
                         </field>
                     </record>


### PR DESCRIPTION
[IMP] l10n_{bf,bj,cd,ci,cm,ga,km,ml,ne,sn,tg}: make report definition more consistent
    
    - Doing if_above using EUR as the currency made no sense in those countries. We instead use the domestic currency (the result is equivalent, since 0 EUR = 0 in any other currency ; it's just clearer)
    
    - specifying rounding=2 on editable monetary value had no effect (on monetary values, the rounding is always made with the decimal places of the domestic currency), and was hence misleading.

----------------------------------------------------------

[IMP] account_reports: Enforce constraint on carryover target
    
    We need to add constraints on the expression label and the carryover_target from account report so that we ensure that it is used correctly.

    Currently, it may have happened that when we used the carryover mechanism, we were using the wrong label.
    That could create some issues where the carryover would simply not work or partially.

----------------------------------------------------------

[FIX] l10n_bf: tax report: fix line name and formulas
    
    - The report contained two lines numbered 26, while one of them had 27 in its code
    - Line "Net VAT amount to pay"'s formula contained BF_OTHER_DEDUCTION twice
    - Line "Credit VAT to report"'s formula contained BF_OTHER_DEDUCTION twice, and BF_CANCELLED (grid 25) was missing
    
    We fix all those problems, and rewrite the formula of "Net VAT amount to pay" in order for it to better match the expression provided in the line name (for clarity).

-----------------------------------------------------------

[FIX] l10n_{bf, bj, cd, ci, cm, ga, km, ml, ne, sn, tg}: Fix Carryover for syscohada countries
    
    For some syscohada countries some tax report where using carryover.
    The carryover on the tax reports from these countries were not working.
    The cause was one, the label of the expression used to target the applied carryover was not prefixed with _carryover_.
    And two, is that it had no expression dedicated for carryover with label _applied_carryover and this was causing the report to miss the info tag on the line for the carryover.
    
    task-4110461