### PR TITLE
[FIX] web: signature yoffset out of bounds

### DIFF
--- a/addons/web/static/src/core/signature/name_and_signature.js
+++ b/addons/web/static/src/core/signature/name_and_signature.js
@@ -250,7 +250,6 @@ export class NameAndSignature extends Component {
         const options = {
             width: this.signatureRef.el.width,
             height: this.signatureRef.el.height,
-            yOffset: 30,
         };
         await this.fromDataURL(imgSrc, options);
     }


### PR DESCRIPTION
This commit removes the yOffset addition introduced in 2e9f6086ee14c3aff4c5190e8557bcd78d3bc964, as the signature was being moved out of bounds of the signature field after saas-17.4 was launched.

task-4105359