### PR TITLE
[IMP] website: prevent accidental corruption of Owl templates

### DIFF
--- a/addons/web/static/src/core/templates.js
+++ b/addons/web/static/src/core/templates.js
@@ -207,3 +207,5 @@ export function setUrlFilters(filters) {
         urlFilters = prev;
     };
 }
+
+export const __test__allTemplates = templates;

--- a/addons/website/static/tests/tours/website_compile_owl_templates.js
+++ b/addons/website/static/tests/tours/website_compile_owl_templates.js
@@ -1,0 +1,37 @@
+/** @odoo-module **/
+
+// Import value made visible by _pregenerate_assets_bundles
+import { __test__allTemplates } from "@web/core/templates";
+import { registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
+
+registerWebsitePreviewTour(
+    "website_compile_owl_templates",
+    {
+        url: "/",
+        edition: true,
+    },
+    () => [
+        {
+            content: "Compile all website-related Owl templates",
+            trigger: ":iframe #wrap",
+            run: () => {
+                if (!__test__allTemplates) {
+                    console.error("Templates are not available");
+                }
+                const app = odoo.__WOWL_DEBUG__.root.__owl__.app;
+                const templateNames = Object.keys(__test__allTemplates).filter((name) =>
+                    name.includes("website")
+                );
+                console.log(`Compiling ${templateNames.length} Owl templates.`);
+                for (const name of templateNames) {
+                    try {
+                        app.getTemplate(name);
+                    } catch (e) {
+                        console.error("Issue in template", name);
+                        console.error(e);
+                    }
+                }
+            },
+        },
+    ]
+);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -712,3 +712,7 @@ class TestUi(HttpCaseWithWebsiteUser):
 
     def test_website_edit_megamenu_visibility(self):
         self.start_tour("/", 'edit_megamenu_visibility', login='admin')
+
+    def test_compile_owl_templates(self):
+        # This test should prevent accidental sabotage of website Owl templates.
+        self.start_tour('/', 'website_compile_owl_templates', login='admin')


### PR DESCRIPTION
To avoid accidental corruption of Owl templates, like what happened in [1], this commit adds a test that tries to compile all website-related Owl templates.

[1]: https://github.com/odoo/odoo/commit/2cad87b49977c7e341fa5fd871b3728ec85ccc9d

task-5187170