### PR TITLE
[FIX] mail: notify author when email_cc points to its company

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2536,7 +2536,16 @@ class MailThread(models.AbstractModel):
         messages_all = self.env['mail.message']
         for record in self:
             if template:
+                # Notify author if email_cc points to him
+                if self.env.context.get('mail_notify_author'):
+                    notify_author = True
+                elif self.env.user.company_id.email:
+                    notify_author = self.env.user.company_id.email in template._render_field('email_cc', record.ids)[record.id]
+                else:
+                    notify_author = False
+
                 composer = self.env['mail.compose.message'].with_context(
+                    mail_notify_author=notify_author,
                     default_composition_mode='comment',
                     default_model=self._name,
                     default_res_ids=record.ids,

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -900,7 +900,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         template = self.env.ref('test_mail.mail_test_container_tpl')
 
         # about 20 (19 ?) queries per additional customer group
-        with self.assertQueryCount(admin=72, employee=71):
+        with self.assertQueryCount(admin=73, employee=71):
             record.message_post_with_source(
                 template,
                 message_type='comment',


### PR DESCRIPTION
[Reproduce]
- Apply diff (ref.1)  (optional)
- Install payment_demo,website_sale
- Configure email server (or Mailhog)
- Skip if applied (ref.1):
	- Change email of current company to contact@yourcompany.com
	- Update template: "Sales: Order Confirmation", so the cc field is set to the same email
- Buy something in the website shop
- BUG: email not sent to CC

(ref.1)
```diff
diff --git a/addons/sale/data/mail_template_data.xml b/addons/sale/data/mail_template_data.xml index ed191440817f..2a02d13bd312 100644
--- a/addons/sale/data/mail_template_data.xml
+++ b/addons/sale/data/mail_template_data.xml
@@ -69,6 +69,7 @@
             <field name="model_id" ref="sale.model_sale_order"/>
             <field name="subject">{{ object.company_id.name }} {{ (object.get_portal_last_transaction().state == 'pending') and 'Pending Order' or 'Order' }} (Ref {{ object.name or 'n/a' }})</field>
             <field name="email_from">{{ (object.user_id.email_formatted or object.company_id.email_formatted or user.email_formatted) }}</field>
+            <field name="email_cc">{{object.company_id.email_formatted }}</field>
```
opw-4012438