### PR TITLE
[FIX] stock_account: validate picking with branch company

### DIFF
--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -549,7 +549,8 @@ class StockMove(models.Model):
             'stock_move_id': self.id,
             'stock_valuation_layer_ids': [(6, None, [svl_id])],
             'move_type': 'entry',
-            'is_storno': self.env.context.get('is_returned') and self.env.company.account_storno,
+            'is_storno': self.env.context.get('is_returned') and self.company_id.account_storno,
+            'company_id': self.company_id.id,
         }
 
     def _account_analytic_entry_move(self):


### PR DESCRIPTION
We get an error when validating a stock picking with
a branch company

Steps:

- Create a company C with a branch B
- Set env.companies to both C and B, and env.company to either C or B
- Create product P with company set as B, a standard_price > 0 and a
  product category set to 'Automated' and valuation != 'standard'
- Make a stock picking from/to B for product P
- Try to validate picking
-> UserError: 'Incompatible companies on records'

This is because the account move is created with main company instead
of branch company.

opw-4105551
