### PR TITLE
[FIX] account : permit branch user to create product

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -559,7 +559,7 @@ class AccountTax(models.Model):
                     name += ' (%s)' % type_tax_use.get(record.type_tax_use)
                 if len(self.env.companies) > 1 and self.env.context.get('params', {}).get('model') == 'product.template':
                     name += ' (%s)' % record.company_id.display_name
-                if record.country_id != record.company_id.account_fiscal_country_id:
+                if record.country_id != record.company_id._accessible_branches()[:1].account_fiscal_country_id:
                     name += ' (%s)' % record.country_code
             record.display_name = name
 


### PR DESCRIPTION
### Steps to reproduce:
- Add a branch to the current company
- Create another user that only have the branch as "Allowed Companies"
- Give this user the right to create `product.template` for example by assigning him
as administrator in Inventory or POS
- Switch to this user
- Go in Inventory > Products > Products
- Click on the "New" button
- An access error should pop up

### Cause:
When trying to find the tax values for the product, Odoo tries to read
the values of `res.company.account_fiscal_country_id` to compute the display name of
the tax and an error is raised because the user does not have access rights to read
its parent company.

### Solution:
Read `account_fiscal_country_id` through the branch.
This was already done in this [commit](https://github.com/odoo/odoo/commit/c7729b1c657a9db0621a07657fd045598fe4c8f3).
But it was removed later.

opw-4088233