### PR TITLE
[FIX] website: adjust `color-5` configurator generation

### DIFF
--- a/addons/website/static/src/client_actions/configurator/configurator.js
+++ b/addons/website/static/src/client_actions/configurator/configurator.js
@@ -596,7 +596,7 @@ class Store {
                 color2: color2,
                 color3: mixCssColors('#FFFFFF', color2, 0.9),
                 color4: '#FFFFFF',
-                color5: mixCssColors(color1, '#000000', 0.75),
+                color5: mixCssColors(color1, '#000000', 0.125),
             };
             CUSTOM_BG_COLOR_ATTRS.forEach((attr) => {
                 recommendedPalette[attr] = recommendedPalette[this.defaultColors[attr]];


### PR DESCRIPTION
---

This pr is handled by @stefanorigano 

---

  Prior to this PR, `color5` generation was sub-optimal and did not align with Bootstrap's default color-scheme. `color5` is indeed assigned to `$dark`, which is intended to be the darkest color in a compliant Bootstrap palette.

| Image provided  <img width="408" alt="image" src="https://github.com/user-attachments/assets/eb3ee7d5-c670-4e45-ad7f-ef139e62753f"> |
|--------|
| Before the fix |
| ![image](https://github.com/user-attachments/assets/8cf43942-729c-40dd-89d3-dc9fe3544b6e) |
| After the fix |
| ![image](https://github.com/user-attachments/assets/d95bce30-5799-473b-90c1-3b11edeb09d1) | 
| Bootstrap default (for reference) |
| ![image](https://github.com/user-attachments/assets/5ef17df0-cba6-4633-b8c4-46bb46761a4f) |
| Odoo defaul palette (for reference) |
| ![image](https://github.com/user-attachments/assets/49b5edca-872c-4010-ac73-e5c23a18b5d3) | 

Design-themes:
- https://github.com/odoo/design-themes/pull/862

task-4109584

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
