### PR TITLE
[FIX] base: restore selection for relational fields in server actions

### DIFF
--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -342,6 +342,7 @@
                         <div class="d-flex flex-row flex-wrap gap-2" invisible="state != 'object_write'">
                             <field name="evaluation_type" class="oe_inline"/>
                             <field name="update_path" widget="DynamicModelFieldSelectorChar" class="oe_inline" options="{'model': 'model_name'}"/>
+                            <field name="update_related_model_id" invisible="True"/>  <!-- It is required by the ReferenceField -->
                             <field name="update_field_id" invisible="True"/>  <!-- The field is store=True and readonly=False, in this view we want to save the value from compute/onchange -->
                             <span invisible="evaluation_type != 'value' or not update_field_type == 'many2many'">by</span>
                             <field name="update_m2m_operation" class="oe_inline" invisible="evaluation_type != 'value' or not update_field_type == 'many2many'" required="update_field_type == 'many2many'"/>


### PR DESCRIPTION
Steps to reproduce
==================

- Install sale_management,web_studio
- Go to sales
- Open studio
- Click on Automation
- Click on Add an action
- The Customer field is selected

=> It is not possible to select a value

Cause of the issue
==================

The `update_related_model_id` field has been removed from the view `record.data.update_related_model_id` is then undefined

Solution
========

Restore the field

opw-4107457