### PR TITLE
[FIX] web: tests - expose and run GC after each suite

### DIFF
--- a/addons/web/static/tests/setup.js
+++ b/addons/web/static/tests/setup.js
@@ -324,28 +324,28 @@ function patchEventBus() {
 }
 
 export async function setupTests() {
-    // uncomment to debug memory leaks in qunit suite
-    // if (window.gc) {
-    //     let memoryBeforeModule;
-    //     QUnit.moduleStart(({ tests }) => {
-    //         if (tests.length) {
-    //             window.gc();
-    //             memoryBeforeModule = window.performance.memory.usedJSHeapSize;
-    //         }
-    //     });
-    //     QUnit.moduleDone(({ name }) => {
-    //         if (memoryBeforeModule) {
-    //             window.gc();
-    //             const afterGc = window.performance.memory.usedJSHeapSize;
-    //             console.log(
-    //                 `MEMINFO - After suite "${name}" - after gc: ${afterGc} delta: ${
-    //                     afterGc - memoryBeforeModule
-    //                 }`
-    //             );
-    //             memoryBeforeModule = null;
-    //         }
-    //     });
-    // }
+    if (window.gc) {
+        // uncomment to debug memory leaks in qunit suite
+        // let memoryBeforeModule;
+        QUnit.moduleStart(({ tests }) => {
+            if (tests.length) {
+                window.gc();
+                // memoryBeforeModule = window.performance.memory.usedJSHeapSize;
+            }
+        });
+        // QUnit.moduleDone(({ name }) => {
+        //     if (memoryBeforeModule) {
+        //         window.gc();
+        //         const afterGc = window.performance.memory.usedJSHeapSize;
+        //         console.log(
+        //             `MEMINFO - After suite "${name}" - after gc: ${afterGc} delta: ${
+        //                 afterGc - memoryBeforeModule
+        //             }`
+        //         );
+        //         memoryBeforeModule = null;
+        //     }
+        // });
+    }
 
     QUnit.testStart(() => {
         prepareRegistriesWithCleanup();

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1050,8 +1050,14 @@ class ChromeBrowser:
             '--user-data-dir': user_data_dir,
             '--window-size': window_size,
             '--no-first-run': '',
-            # '--enable-precise-memory-info': '', # uncomment to debug memory leaks in qunit suite
-            # '--js-flags': '--expose-gc', # uncomment to debug memory leaks in qunit suite
+            # '--enable-precise-memory-info': '',  # uncomment to debug memory leaks in unit tests
+            # FIXME: the next flag is temporarily uncommented to allow client
+            # code to manually run garbage collection. This is done as currently
+            # the Chrome unit test process doesn't have access to its available
+            # memory, so it cannot run the GC efficiently and may run out of memory
+            # and crash. These should be re-commented when the process is correctly
+            # configured.
+            '--js-flags': '--expose-gc',  # uncomment to debug memory leaks in unit tests
         }
         if headless:
             switches.update(headless_switches)


### PR DESCRIPTION
This commit is a backport of odoo/odoo#173905, but for the qunit suite. This should prevent the qunit suite from running out of memory, which sometimes happens because the Chrome process running the qunit suites doesn't have access to its available memory and cannot run the garbage collection efficiently.

Runbot error 53410

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
