### PR TITLE
[FIX] project: display user-defined task state translations

### DIFF
--- a/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.js
+++ b/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.js
@@ -72,20 +72,13 @@ export class ProjectTaskStateSelection extends StateSelectionField {
     }
 
     get options() {
-        const options = [
-            ["1_canceled", _t("Canceled")],
-            ["1_done", _t("Done")],
-        ];
+        const labels = new Map(super.options);
+        const states = ["1_canceled", "1_done"];
         const currentState = this.props.record.data[this.props.name];
         if (currentState != "04_waiting_normal") {
-            return [
-                ["01_in_progress", _t("In Progress")],
-                ["02_changes_requested", _t("Changes Requested")],
-                ["03_approved", _t("Approved")],
-                ...options,
-            ];
+            states.unshift("01_in_progress", "02_changes_requested", "03_approved");
         }
-        return options;
+        return states.map((state) => [state, labels.get(state)]);
     }
 
     get availableOptions() {
@@ -94,8 +87,8 @@ export class ProjectTaskStateSelection extends StateSelectionField {
     }
 
     get label() {
-        const fullSelection = [...this.options];
-        fullSelection.push(["04_waiting_normal", "Waiting"]);
+        const waitOption = super.options.findLast(([state, _]) => state === "04_waiting_normal");
+        const fullSelection = [...this.options, waitOption];
         return formatSelection(this.currentValue, {
             selection: fullSelection,
         });

--- a/addons/project/static/tests/views/project_task_form/project_task_form_view_tests.js
+++ b/addons/project/static/tests/views/project_task_form/project_task_form_view_tests.js
@@ -1,0 +1,72 @@
+/** @odoo-module */
+
+import { startServer } from "@bus/../tests/helpers/mock_python_environment";
+import { start } from "@mail/../tests/helpers/test_utils";
+import { click, getFixture, getNodesTextContent } from "@web/../tests/helpers/utils";
+import { setupViewRegistries } from "@web/../tests/views/helpers";
+
+let target;
+
+QUnit.module(
+    "Project Task Form View",
+    {
+        beforeEach: async function () {
+            const pyEnv = await startServer();
+            const projectId = pyEnv["project.project"].create([{ name: "Project One" }]);
+            const stageId = pyEnv["project.task.type"].create([{ name: "New" }]);
+            [this.task1, this.task2] = pyEnv["project.task"].create([
+                {
+                    name: "task one",
+                    project_id: projectId,
+                    stage_id: stageId,
+                    state: "03_approved",
+                },
+                {
+                    name: "task two",
+                    project_id: projectId,
+                    stage_id: stageId,
+                    state: "04_waiting_normal",
+                },
+            ]);
+            this.views = {
+                "project.task,false,form": `
+                    <form js_class="project_task_form">
+                        <field name="project_id"/>
+                        <field name="stage_id"/>
+                        <field name="name"/>
+                        <field name="state" widget="project_task_state_selection"/>
+                    </form>
+                `,
+            };
+            target = getFixture();
+            setupViewRegistries();
+        },
+    },
+    function () {
+        QUnit.test("project task form view", async function (assert) {
+            const clickStateButton = () => click(target.querySelector("button.o_state_button"));
+            const { task1, task2, views } = this;
+            const { openView } = await start({ serverData: { views } });
+
+            await openView({
+                res_model: "project.task",
+                res_id: task1,
+                views: [[false, "form"]],
+            }).then(clickStateButton);
+            assert.deepEqual(
+                getNodesTextContent(target.querySelectorAll("div[name='state'] .dropdown-item")),
+                ["In Progress", "Changes Requested", "Approved", "Canceled", "Done"]
+            );
+
+            await openView({
+                res_model: "project.task",
+                res_id: task2,
+                views: [[false, "form"]],
+            }).then(clickStateButton);
+            assert.deepEqual(
+                getNodesTextContent(target.querySelectorAll("div[name='state'] .dropdown-item")),
+                ["Canceled", "Done"]
+            );
+        });
+    }
+);


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Activate a second language on the database;
2. enable debug mode;
3. go to Settings / Technical / Database Structure / Fields;
4. look for the `state` field of the `project.task` model;
5. change the name's translation of the of the `01_in_progress` value;
6. go to a task to select the state.

Issue
-----
It still shows the original translation.

Cause
-----
The JS side fetches the translations straight from the .po file instead of looking for translations stored in the database.

Solution
--------
The translations of the labels are already stored in `this.props.record.fields[this.props.name].selection`, as used in `super`'s `options` getter. Retrieving these, custom translations do take effect.

opw-4009326

