### PR TITLE
[FIX] website_blog: hide tags option on blogs (keep on posts)

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2356,6 +2356,14 @@ var SnippetsMenu = Widget.extend({
             $logoHeightOptions.insertAfter($logoTypeSelector);
         }
 
+        // TODO adapt in master. This patches the BlogPostTagSelection option
+        // in stable versions. Done here to avoid converting the html back to
+        // a string.
+        const optionEl = $html.find('[data-js="BlogPostTagSelection"][data-selector=".o_wblog_post_page_cover"]')[0];
+        if (optionEl) {
+            optionEl.dataset.selector = '.o_wblog_post_page_cover[data-res-model="blog.post"]';
+        }
+
         this.templateOptions = [];
         var selectors = [];
         var $styles = $html.find('[data-selector]');


### PR DESCRIPTION
When a blog cover is edited, a tag option is displayed while there is no `tag_ids` inside the `blog.blog` model because the `o_wblog_post_page_cover` appears on both the `blog.blog` covers and on the `blog.post` covers.

This commit hides the blog tags option if the model of the cover is `blog.blog`.

Steps to reproduce:
- Go to blogs.
- Select the "Travel" blog.
- Edit.
- Select the blog's cover.

=> A tag option could be specified.

opw-4107748
