### PR TITLE
[FIX] web: kanban group count and progress bar out of sync

### DIFF
--- a/addons/web/static/src/model/relational_model/group.js
+++ b/addons/web/static/src/model/relational_model/group.js
@@ -83,6 +83,7 @@ export class Group extends DataPoint {
             });
         } else {
             await this.list.load({ domain: this.groupDomain });
+            this.count = this.list.isGrouped ? this.list.recordCount : this.list.count;
         }
         this.model._updateConfig(this.config, { extraDomain: filter }, { reload: false });
     }

--- a/addons/web/static/src/views/kanban/progress_bar_hook.js
+++ b/addons/web/static/src/views/kanban/progress_bar_hook.js
@@ -188,6 +188,7 @@ class ProgressBarState {
         }
         await Promise.all(proms);
         this.activeBars[group.serverValue] = nextActiveBar;
+        this.updateCounts(group);
     }
 
     _updateAggregateGroup(group, bars, activeBar) {

--- a/addons/web/static/src/views/view_components/column_progress.xml
+++ b/addons/web/static/src/views/view_components/column_progress.xml
@@ -6,7 +6,7 @@
             <t t-set="maxWidth" t-value="100 - Math.max(0, props.progressBar.bars.filter(x => x.count > 0).length - 1) * 5"/>
             <t t-foreach="props.progressBar.bars" t-as="bar" t-key="bar.value">
                 <t t-set="progressWidth" t-value="Math.max(5, bar.count / (props.group.count or 1) * 100)"/>
-                <div t-if="bar.count"
+                <div t-if="bar.count > 0"
                     role="progressbar"
                     class="progress-bar o_bar_has_records cursor-pointer"
                     t-att-class="{ 'progress-bar-animated progress-bar-striped': props.progressBar.activeBar === bar.value, 'border border-white': !props.group.isFolded and props.progressBar.activeBar }"

--- a/addons/web/static/tests/views/kanban/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban/kanban_view_tests.js
@@ -9870,6 +9870,7 @@ QUnit.module("Views", (hooks) => {
             "web_search_read",
             "web_search_read",
             "web_search_read",
+            "read_progress_bar",
         ]);
     });
 
@@ -9924,6 +9925,9 @@ QUnit.module("Views", (hooks) => {
             "web_search_read",
             "web_read_group",
             "web_search_read",
+            "read_progress_bar",
+            "web_read_group",
+            "web_read_group",
         ]);
     });
 
@@ -10129,6 +10133,7 @@ QUnit.module("Views", (hooks) => {
                 "web_read_group",
                 "web_search_read",
                 "web_search_read",
+                "read_progress_bar",
                 "web_search_read",
                 "web_search_read",
             ]);
@@ -10338,10 +10343,20 @@ QUnit.module("Views", (hooks) => {
             '["&",["bar","=",true],["foo","=","yop"]]', // perform read_group only on second column (bar=true)
             "web_search_read",
             // activate filter
-            "web_read_group", // recomputes aggregates
-            '["&",["bar","=",true],["foo","=","gnap"]]', // perform read_group only on second column (bar=true)
+            "read_progress_bar",
+            "web_read_group",
+            "[]",
+            "web_read_group",
+            '["&",["bar","=",true],["foo","=","yop"]]',
+            "web_read_group",
+            '["&",["bar","=",true],["foo","=","gnap"]]',
             "web_search_read",
             // activate another filter (switching)
+            "read_progress_bar",
+            "web_read_group",
+            "[]",
+            "web_read_group",
+            '["&",["bar","=",true],["foo","=","gnap"]]',
             "web_search_read",
         ]);
     });
@@ -10508,6 +10523,7 @@ QUnit.module("Views", (hooks) => {
             "web_search_read",
             "web_search_read",
             "web_search_read",
+            "read_progress_bar",
         ]);
     });
 
@@ -10606,7 +10622,7 @@ QUnit.module("Views", (hooks) => {
 
         assert.deepEqual(getTooltips(target), ["1 blip", "4 yop", "1 gnap", "1 blip"]);
         assert.deepEqual(getCounters(target), ["1", "4"]);
-        assert.verifySteps(["web_search_read"]);
+        assert.verifySteps(["web_search_read", "read_progress_bar"]);
 
         // Add searchdomain to something restricting progressbars' values (records still in filtered group)
         await reload(kanban, { domain: [["qux", "=", 100]], groupBy: ["bar"] });
@@ -10670,6 +10686,9 @@ QUnit.module("Views", (hooks) => {
         assert.verifySteps([
             "web_read_group", // recomputes aggregates
             "web_search_read",
+            "read_progress_bar",
+            "web_read_group",
+            "web_read_group",
         ]);
 
         // Add searchdomain to something restricting progressbars' values (records still in filtered group)
@@ -11016,6 +11035,9 @@ QUnit.module("Views", (hooks) => {
                 "web_search_read",
                 "web_read_group",
                 "web_search_read",
+                "read_progress_bar",
+                "web_read_group",
+                "web_read_group",
                 "get_views",
                 "onchange",
                 "web_save",
@@ -12084,6 +12106,7 @@ QUnit.module("Views", (hooks) => {
                 "web_search_read",
                 "web_search_read",
                 "read_progress_bar",
+                "read_progress_bar",
                 "web_read_group",
                 "web_search_read",
                 "read_progress_bar",
@@ -12180,6 +12203,7 @@ QUnit.module("Views", (hooks) => {
                 "web_search_read",
                 "web_search_read",
                 "read_progress_bar",
+                "read_progress_bar",
                 "web_read_group",
                 "web_search_read",
                 "web_search_read",
@@ -12271,6 +12295,7 @@ QUnit.module("Views", (hooks) => {
                 "web_search_read",
                 "web_search_read",
                 "web_search_read",
+                "read_progress_bar",
                 "web_save",
                 "read_progress_bar",
                 "/web/dataset/resequence",
@@ -12336,7 +12361,7 @@ QUnit.module("Views", (hooks) => {
         );
         assert.containsOnce(target, ".o_kanban_group.o_kanban_group_show .o_kanban_record");
         assert.deepEqual(getCardTexts(target, 1), ["1yop"]);
-        assert.verifySteps(["web_search_read"]);
+        assert.verifySteps(["web_search_read", "read_progress_bar"]);
 
         // Drag out its only record onto the first column
         await dragAndDrop(
@@ -13133,8 +13158,11 @@ QUnit.module("Views", (hooks) => {
                 "web_search_read",
                 "web_search_read",
                 "web_search_read",
+                "read_progress_bar",
                 "web_search_read",
+                "read_progress_bar",
                 "web_search_read",
+                "read_progress_bar",
             ]);
         }
     );
@@ -13217,10 +13245,13 @@ QUnit.module("Views", (hooks) => {
             "web_search_read",
             "web_search_read",
             "web_search_read",
+            "read_progress_bar",
             "web_save",
             "read_progress_bar",
             "web_search_read",
+            "read_progress_bar",
             "web_search_read",
+            "read_progress_bar",
         ]);
     });
 
@@ -14375,7 +14406,7 @@ QUnit.module("Views", (hooks) => {
     });
 
     QUnit.test("scroll on group unfold and progressbar click", async (assert) => {
-        assert.expect(15);
+        assert.expect(18);
 
         await makeView({
             type: "kanban",
@@ -14412,7 +14443,14 @@ QUnit.module("Views", (hooks) => {
         };
 
         await click(getProgressBars(target, 0)[0]);
-        assert.verifySteps(["web_read_group", "web_search_read", "scrolled"]);
+        assert.verifySteps([
+            "web_read_group",
+            "web_search_read",
+            "read_progress_bar",
+            "web_read_group",
+            "web_read_group",
+            "scrolled",
+        ]);
 
         const column1 = getColumn(target, 1);
         assert.hasClass(column1, "o_column_folded");


### PR DESCRIPTION
- Go to Project App;
- Add a task in any project;
- Move the task to "Cancelled State";
- Click on the progress bar above the stage.

Before this commit, the task will get hidden but load more button appears. This occurs because the group bar, and the progress bar are out of sync with the latest search read (executed when clicking on a progress bar).

Now, when filtering the progress bar is updated, and when removing the filtering the group count is updated, this maintains a correct synchronization between the current showing records and the group count and the progress bar.

Note that, this commit also prevents to shown negative values for the "Other" progress bar.

opw-3935547
