### PR TITLE
[FIX] purchase_stock: increase unit cost precision on PO return

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -158,7 +158,7 @@ class StockMove(models.Model):
         returned_move = self.origin_returned_move_id
         pdiff_exists = bool((self | returned_move).stock_valuation_layer_ids.stock_valuation_layer_ids.account_move_line_id)
 
-        if not am_vals_list or not self.purchase_line_id or pdiff_exists:
+        if not am_vals_list or not self.purchase_line_id or pdiff_exists or float_is_zero(qty, precision_rounding=self.product_id.uom_id.rounding):
             return am_vals_list
 
         layer = self.env['stock.valuation.layer'].browse(svl_id)
@@ -167,7 +167,8 @@ class StockMove(models.Model):
         if returned_move and self._is_out() and self._is_returned(valued_type='out'):
             returned_layer = returned_move.stock_valuation_layer_ids.filtered(lambda svl: not svl.stock_valuation_layer_id)[:1]
             returned_unit_cost = returned_layer.value / returned_layer.quantity
-            unit_diff = layer.unit_cost - returned_unit_cost
+            layer_unit_cost = layer.value / layer.quantity
+            unit_diff = layer_unit_cost - returned_unit_cost
         elif returned_move and returned_move._is_out() and returned_move._is_returned(valued_type='out'):
             returned_layer = returned_move.stock_valuation_layer_ids.filtered(lambda svl: not svl.stock_valuation_layer_id)[:1]
             unit_diff = returned_layer.unit_cost - self.purchase_line_id._get_gross_price_unit()


### PR DESCRIPTION
Problem: When the value of the returned product is different from the purchased one, the stock_in account may not be emptied due to rounding applied to the stock valuation layer's unit_cost field.

Purpose: By using the stock valuation layer’s value and quantity to calculate the unit cost, the calculation should be more precise than just using the rounded unit_cost field.

Steps to Reproduce on Runbot:

1. Create a storable product, and set the Costing Method to Average Cost (AVCO) and the Inventory Valuation to Automated on its product category
2. Purchase 100 units of this product with a unit cost of 10.00
3. Receive all 100 products
4. Create and confirm the vendor bill
5. Purchase another 10 units with a unit cost of 15.00
6. Receive all 10 units
7. Create and confirm the vendor bill
8. Return 10 units from the first purchase order’s receipt
9. Create and confirm the vendor credit note
10. Navigate to the general ledger
11. Observe 0.05 cents remaining in the Stock Interim (Received) account

opw-4088271

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
