### PR TITLE
[FIX] mail: small mobile fixes in Discuss

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -19,6 +19,7 @@ import { localization } from "@web/core/l10n/localization";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { Typing } from "@mail/discuss/typing/common/typing";
+import { isMobileOS } from "@web/core/browser/feature_detection";
 
 /**
  * @typedef {Object} Props
@@ -42,6 +43,7 @@ export class ChatWindow extends Component {
 
     setup() {
         super.setup();
+        this.isMobileOS = isMobileOS();
         this.store = useState(useService("mail.store"));
         this.messageEdition = useMessageEdition();
         this.messageHighlight = useMessageHighlight();

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -92,7 +92,7 @@
                             <Typing channel="thread" size="'medium'"/>
                         </div>
                     </div>
-                    <Composer composer="thread.composer" autofocus="props.chatWindow.autofocus" mode="'compact'" messageEdition="messageEdition" messageToReplyTo="messageToReplyTo" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="composerType"/>
+                    <Composer composer="thread.composer" autofocus="isMobileOS ? false : props.chatWindow.autofocus" mode="'compact'" messageEdition="messageEdition" messageToReplyTo="messageToReplyTo" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="composerType"/>
                 </t>
             </t>
         </div>

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -29,6 +29,7 @@ import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { FileUploader } from "@web/views/fields/file_handler";
 import { escape, sprintf } from "@web/core/utils/strings";
+import { isMobileOS } from "@web/core/browser/feature_detection";
 
 const EDIT_CLICK_TYPE = {
     CANCEL: "cancel",
@@ -86,6 +87,7 @@ export class Composer extends Component {
 
     setup() {
         super.setup();
+        this.isMobileOS = isMobileOS();
         this.SEND_KEYBIND_TO_SEND = markup(
             _t("<samp>%(send_keybind)s</samp><i> to send</i>", { send_keybind: this.sendKeybind })
         );

--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -74,5 +74,10 @@
 }
 
 .o-mail-Composer-compactContainer {
-    box-shadow: 0px -3px 25px 3px rgba(50, 50, 50, 0.1);
+    &.o-mobile:not(:focus-within) {
+        margin-bottom: map-get($spacers, 4) + map-get($spacers, 2);
+    }
+    &:not(.o-mobile) {
+        box-shadow: 0px -3px 25px 3px rgba(50, 50, 50, 0.1);
+    }
 }

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -32,6 +32,7 @@
                 <div class="d-flex bg-view flex-grow-1"
                     t-att-class="{
                         'o-mail-Composer-compactContainer border-top': compact and !props.composer.message,
+                        'o-mobile border-bottom': isMobileOS,
                         'border': props.composer.message,
                         'border rounded-3' : normal,
                         'border rounded-3 align-self-stretch flex-column' : extended,

--- a/addons/mail/static/src/core/public_web/messaging_menu.xml
+++ b/addons/mail/static/src/core/public_web/messaging_menu.xml
@@ -40,7 +40,7 @@
         </div>
     </div>
     <div t-if="ui.isSmall" class="o-mail-MessagingMenu-navbar d-flex border-top bg-view shadow-lg w-100 btn-group">
-        <button t-foreach="tabs" t-key="tab.id" t-as="tab" class="o-mail-MessagingMenu-tab btn d-flex flex-column align-items-center flex-grow-1 flex-basis-0 p-2 mx-0" t-att-class="{
+        <button t-foreach="tabs" t-key="tab.id" t-as="tab" class="o-mail-MessagingMenu-tab btn d-flex flex-column align-items-center flex-grow-1 flex-basis-0 p-2 mx-0 pb-4" t-att-class="{
             'text-primary fw-bolder o-active': store.discuss.activeTab === tab.id,
             'border-end': !tab_last,
         }" t-on-click="() => this.onClickNavTab(tab.id)">

--- a/addons/mail/static/src/core/web/messaging_menu_patch.js
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.js
@@ -6,6 +6,7 @@ import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { patch } from "@web/core/utils/patch";
 import { MessagingMenuQuickSearch } from "@mail/core/web/messaging_menu_quick_search";
+import { isDisplayStandalone } from "@web/core/browser/feature_detection";
 
 Object.assign(MessagingMenu.components, { MessagingMenuQuickSearch });
 
@@ -95,7 +96,8 @@ patch(MessagingMenu.prototype, {
             partner: this.store.odoobot,
             isShown:
                 this.store.discuss.activeTab === "main" &&
-                this.notification.permission === "prompt",
+                this.notification.permission === "prompt" &&
+                !isDisplayStandalone(),
         };
     },
     get tabs() {
@@ -170,7 +172,7 @@ patch(MessagingMenu.prototype, {
         if (this.canPromptToInstall) {
             value++;
         }
-        if (this.notification.permission === "prompt") {
+        if (this.notification.permission === "prompt" && !isDisplayStandalone()) {
             value++;
         }
         return value;


### PR DESCRIPTION
1. Do not show push notification prompt in messaging menu when using PWA

This feature makes no sense: the PWA manages the push notifications already, enabled by default.

2. More bottom spacing below discuss / messaging menu navbar and Composer

iOS devices have persistent swipe bar at bottom which can overlap UI that's too low on screen.
