### PR TITLE
[FIX] loyalty: Validate company in loyalty programs

### DIFF
--- a/addons/loyalty/models/loyalty_program.py
+++ b/addons/loyalty/models/loyalty_program.py
@@ -136,6 +136,15 @@ class LoyaltyProgram(models.Model):
         if any(not program.reward_ids for program in self):
             raise ValidationError(_('A program must have at least one reward.'))
 
+    @api.constrains('company_id')
+    def _validate_company(self):
+        if products := self.reward_ids.discount_line_product_id.filtered(lambda r: r.company_id and r.company_id != self.company_id):
+            raise UserError(
+                _("You cannot edit the company because some of the reward products are specific"
+                  " to a company. Please remove the company for this products first: %(product_names)s.",
+                  product_names=', '.join(products.with_context(display_default_code=False).mapped('display_name')))
+            )
+
     def _compute_total_order_count(self):
         self.total_order_count = 0
 

--- a/addons/loyalty/models/product_template.py
+++ b/addons/loyalty/models/product_template.py
@@ -20,3 +20,19 @@ class ProductTemplate(models.Model):
                 " Please archive it instead.",
                 name=product.with_context(display_default_code=False).display_name
             ))
+
+    @api.constrains("company_id")
+    def _check_loyalty_company_conflict(self):
+        if self.company_id and self.env["loyalty.reward"].sudo().search(
+            [
+                ("discount_line_product_id", "=", self.product_variant_id.id),
+                ("company_id", "!=", self.company_id.id),
+            ]
+        ):
+            raise UserError(
+                _(
+                    "You cannot change the company of '%(product_name)s' because it is used in "
+                    "'Coupons & Loyalty' with a different company/without company.",
+                    product_name=self.with_context(display_default_code=False).display_name,
+                )
+            )


### PR DESCRIPTION
Issue:
A company mismatch error occurred when a product linked to a loyalty reward was assigned to a different company than the one associated with the loyalty program.

Steps to reproduce:
- Create two companies (e.g., Company A and Company B)
- Set up a loyalty program for Company A
- Assign the program's product to Company B
- Attempt to use the POS with Company A
- An error will occur

Fix: Ensure that when modifying the company of a product linked to a loyalty program, the company's consistency with the program is validated. Similarly, raise an error if a loyalty program's company is changed and any of its rewards are linked to a specific company.

opw-4106024
