### PR TITLE
base : added force save in server action.

### DIFF
--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -345,7 +345,7 @@
                             <field name="update_path" widget="DynamicModelFieldSelectorChar" class="oe_inline" options="{'model': 'model_name'}"/>
                             <field name="update_field_id" invisible="1"/>
                             <field name="value_field_to_show" invisible="1"/>
-                            <field name="update_related_model_id" invisible="1"/>
+                            <field name="update_related_model_id" invisible="1" force_save="1"/>
                             <field name="update_field_type" invisible="1"/>
                             <span invisible="evaluation_type != 'value' or not update_field_type == 'many2many'">by</span>
                             <field name="update_m2m_operation" class="oe_inline" invisible="evaluation_type != 'value' or not update_field_type == 'many2many'" required="update_field_type == 'many2many'"/>


### PR DESCRIPTION
This PR solve the [164511](https://github.com/odoo/odoo/issues/164511) issue.

**Solution Log:**
        based on the analysis for update_related_model_id field value not stored properly, So to overcome that added a **force_save** attribute in the xml.

This will solve the triggering save twice on form view.
  
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
