### PR TITLE
[IMP] mrp: prevent merging of post-pickings across backorders

### DIFF
--- a/addons/mrp/models/stock_picking.py
+++ b/addons/mrp/models/stock_picking.py
@@ -129,25 +129,28 @@ class StockPicking(models.Model):
     has_kits = fields.Boolean(compute='_compute_has_kits')
     production_count = fields.Integer(
         "Count of MO generated",
-        compute='_compute_mrp_production_ids',
+        compute='_compute_count_mrp_production_ids',
         groups='mrp.group_mrp_user')
 
     production_ids = fields.Many2many(
         'mrp.production',
         compute='_compute_mrp_production_ids',
-        groups='mrp.group_mrp_user')
+        groups='mrp.group_mrp_user', store=True)
 
     @api.depends('move_ids')
     def _compute_has_kits(self):
         for picking in self:
             picking.has_kits = any(picking.move_ids.mapped('bom_line_id'))
 
-    @api.depends('group_id')
+    @api.depends('group_id', 'move_ids.move_dest_ids')
     def _compute_mrp_production_ids(self):
         for picking in self:
-            production_ids = picking.group_id.mrp_production_ids | picking.move_ids.move_dest_ids.raw_material_production_id
-            # Filter out unwanted MO types
-            picking.production_ids = production_ids.filtered(lambda p: p.picking_type_id.active)
+            production_ids = picking.move_ids.move_dest_ids.raw_material_production_id | picking.move_ids.move_orig_ids.production_id
+            picking.production_ids |= production_ids.filtered(lambda p: p.picking_type_id.active)
+
+    @api.depends('production_ids')
+    def _compute_count_mrp_production_ids(self):
+        for picking in self:
             picking.production_count = len(picking.production_ids)
 
     def action_detailed_operations(self):

--- a/addons/mrp/models/stock_scrap.py
+++ b/addons/mrp/models/stock_scrap.py
@@ -88,5 +88,8 @@ class StockScrap(models.Model):
         if self.production_id and self.production_id.procurement_group_id:
             values.update({
                 'group_id': self.production_id.procurement_group_id,
+                'move_dest_ids': self.production_id.all_move_raw_ids.filtered(
+                    lambda m: m.location_id == self.location_id
+                        and m.product_id == self.product_id),
             })
         super().do_replenish(values)

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1842,6 +1842,9 @@ Please change the quantity done or the rounding precision in your settings.""",
         rounding = self.product_id.uom_id.rounding
         return dict((k, v) for k, v in available_move_lines.items() if float_compare(v, 0, precision_rounding=rounding) > 0)
 
+    def _should_clear_move_orig_ids(self):
+        return True
+
     def _action_assign(self, force_qty=False):
         """ Reserve stock moves by creating their stock move lines. A stock move is
         considered reserved once the sum of `reserved_qty` for all its move lines is

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -829,10 +829,10 @@ class StockMoveLine(models.Model):
 
         move_line_to_unlink = self.env['stock.move.line'].browse(to_unlink_candidate_ids)
         for m in (move_line_to_unlink.move_id | move_to_reassign):
-            m.write({
-                'procure_method': 'make_to_stock',
-                'move_orig_ids': [Command.clear()]
-            })
+            vals = {'procure_method': 'make_to_stock'}
+            if m._should_clear_move_orig_ids():
+                vals['move_orig_ids'] = [Command.clear()]
+            m.write(vals)
         move_line_to_unlink.unlink()
         move_to_reassign._action_assign()
 


### PR DESCRIPTION
With this commit, each backorder now displays only its own associated post-pickings.
This prevents the merging of post-pickings and ensures that cancelling a
picking or any backorder does not affect the post-pickings of other backorders.

Task Id:-4065843
