### PR TITLE
[FIX] sale_product_configurator: quantity not updating correctly

### DIFF
--- a/addons/sale_product_configurator/static/src/js/product/product.js
+++ b/addons/sale_product_configurator/static/src/js/product/product.js
@@ -2,6 +2,7 @@
 
 import { Component } from "@odoo/owl";
 import { formatCurrency } from "@web/core/currency";
+import { useDebounced } from "@web/core/utils/timing";
 import {
     ProductTemplateAttributeLine as PTAL
 } from "../product_template_attribute_line/product_template_attribute_line";
@@ -25,6 +26,10 @@ export class Product extends Component {
         parent_product_tmpl_ids: { type: Array, element: Number, optional: true },
     };
 
+    setup() {
+        this.debouncedSetQuantity = useDebounced(this.setQuantity, 300);
+    }
+
     //--------------------------------------------------------------------------
     // Handlers
     //--------------------------------------------------------------------------
@@ -43,6 +48,15 @@ export class Product extends Component {
      */
     setQuantity(event) {
         this.env.setQuantity(this.props.product_tmpl_id, parseFloat(event.target.value));
+    }
+
+    /**
+     * Set the quantity of the product in the state with debouncing.
+     *
+     * @param {Event} event
+     */
+    debouncedSetQuantity(event) {
+        this.debouncedSetQuantity(event);
     }
 
     /**

--- a/addons/sale_product_configurator/static/src/js/product/product.xml
+++ b/addons/sale_product_configurator/static/src/js/product/product.xml
@@ -41,7 +41,7 @@
                     name="product_quantity"
                     type="number"
                     t-att-value="this.props.quantity"
-                    t-on-change="setQuantity"/>
+                    t-on-input="debouncedSetQuantity"/>
                 <button
                     class="btn btn-secondary d-none d-md-inline-block"
                     aria-label="Add one"


### PR DESCRIPTION
Steps to reproduce:
- Create a new quotation.
- Choose a product with variants.
- Change the quantity in the product configurator.
- Click confirm.

Issue:
The quantity input in the product configurator does not update correctly when the 'Confirm' button is clicked. The changes are only applied after clicking outside the input field or pressing the 'Tab' key.

Cause:
The issue is caused by the reliance on the `t-on-change` event, which only triggers when the input loses focus.

Fix:
Replaced t-on-change with t-on-input to ensure immediate quantity updates as the user types, without requiring additional interactions.

opw-4049363

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
