### PR TITLE
[FIX] account: restore pager on document vendor bills

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -548,6 +548,7 @@
             <field name="model">account.move</field>
             <field name="mode">primary</field>
             <field name="inherit_id" ref="account.view_invoice_tree"/>
+            <field name="priority">999</field>
             <field name="arch" type="xml">
                 <xpath expr="//tree" position="attributes">
                     <attribute name="js_class">account_x2many_list</attribute>


### PR DESCRIPTION
Steps to reproduce:
- Install the documents_account module
- Documents > Finance
- Select multiple documents
- Create vendor bills
- On a bill's form view pager is 1/1

We should be able to use the pager to navigate between the bills here, but the default view is an override meant to show potential duplicates. Since duplicates can be of different record types, it isn't technically possible to use the pager on them. This behavior is overly specific for a default view hence why the priority is taken down so low.

opw-4104435

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
