### PR TITLE
[FIX] sale: factor in pos down payments when settling in sale

### DIFF
--- a/addons/pos_sale/static/tests/tours/PosSaleTour.js
+++ b/addons/pos_sale/static/tests/tours/PosSaleTour.js
@@ -295,3 +295,16 @@ registry.category("web_tour.tours").add("PoSDownPaymentLinesPerTax", {
             }),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("PoSApplyDownpayment", {
+    test: true,
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            ProductScreen.controlButton("Quotation/Order"),
+            ProductScreen.downPaymentFirstOrder(),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+        ].flat(),
+});

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -753,3 +753,27 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         })
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PoSDownPaymentLinesPerTax', login="accountman")
+
+    def test_settle_so_with_pos_downpayment(self):
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [
+                (0, 0, {
+                    'name': self.product_a.name,
+                    'product_id': self.product_a.id,
+                    'product_uom_qty': 1.0,
+                    'product_uom': self.product_a.uom_id.id,
+                    'price_unit': 100,
+                    'tax_id': False,
+                })],
+        })
+        so.action_confirm()
+
+        # Apply 10% down payment
+        self.main_pos_config.open_ui()
+        self.main_pos_config.down_payment_product_id = self.env.ref("pos_sale.default_downpayment_product")
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PoSApplyDownpayment', login="accountman")
+
+        invoice = so._create_invoices(final=True)
+        invoice.action_post()
+        self.assertEqual(invoice.amount_total, 90)

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1155,8 +1155,9 @@ class SaleOrderLine(models.Model):
             'is_downpayment': self.is_downpayment,
         }
         self._set_analytic_distribution(res, **optional_values)
-        if self.is_downpayment:
-            res['account_id'] = self.invoice_lines.filtered('is_downpayment').account_id[:1].id
+        downpayment_lines = self.invoice_lines.filtered('is_downpayment')
+        if self.is_downpayment and downpayment_lines:
+            res['account_id'] = downpayment_lines.account_id[:1].id
         if optional_values:
             res.update(optional_values)
         if self.display_type:


### PR DESCRIPTION
Steps to reproduce:
- Sale > Quotations > New
- Set customer and product
- POS > Quotation/Order > Apply down payment > Pay
- Sale > Quotation > Create invoice > Create draft

Error because the down payment line is missing an account_id, as a result of this commit 50ce3ce1d98958241667d1122273abccd59874b7 we would pass account_id = False in vals_list sometimes, causing the account_id not to be filled in or inferred later.

opw-4064906

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
