### PR TITLE
[FIX] mail: composer is hard to interact with in mobile

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -29,6 +29,7 @@ import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { FileUploader } from "@web/views/fields/file_handler";
 import { escape, sprintf } from "@web/core/utils/strings";
+import { isMobileOS } from "@web/core/browser/feature_detection";
 
 const EDIT_CLICK_TYPE = {
     CANCEL: "cancel",
@@ -86,6 +87,7 @@ export class Composer extends Component {
 
     setup() {
         super.setup();
+        this.isMobileOS = isMobileOS();
         this.SEND_KEYBIND_TO_SEND = markup(
             _t("<samp>%(send_keybind)s</samp><i> to send</i>", { send_keybind: this.sendKeybind })
         );

--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -74,5 +74,10 @@
 }
 
 .o-mail-Composer-compactContainer {
-    box-shadow: 0px -3px 25px 3px rgba(50, 50, 50, 0.1);
+    &.o-mobile:not(:focus-within) {
+        margin-bottom: map-get($spacers, 4) + map-get($spacers, 2);
+    }
+    &:not(.o-mobile) {
+        box-shadow: 0px -3px 25px 3px rgba(50, 50, 50, 0.1);
+    }
 }

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -32,6 +32,7 @@
                 <div class="d-flex bg-view flex-grow-1"
                     t-att-class="{
                         'o-mail-Composer-compactContainer border-top': compact and !props.composer.message,
+                        'o-mobile border-bottom': isMobileOS,
                         'border': props.composer.message,
                         'border rounded-3' : normal,
                         'border rounded-3 align-self-stretch flex-column' : extended,

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -8,6 +8,7 @@ import { _t } from "@web/core/l10n/translation";
 import { pyToJsLocale } from "@web/core/l10n/utils";
 import { user } from "@web/core/user";
 import { Deferred } from "@web/core/utils/concurrency";
+import { isMobileOS } from "@web/core/browser/feature_detection";
 
 /**
  * @typedef SuggestedRecipient
@@ -971,7 +972,9 @@ export class Thread extends Record {
         );
         this.store.chatHub.opened.delete(cw);
         this.store.chatHub.opened.unshift(cw);
-        cw.focus();
+        if (!isMobileOS()) {
+            cw.focus();
+        }
         this.state = "open";
         cw.notifyState();
         return cw;

--- a/addons/mail/static/src/core/web/messaging_menu.xml
+++ b/addons/mail/static/src/core/web/messaging_menu.xml
@@ -105,7 +105,7 @@
         </div>
     </div>
     <div t-if="ui.isSmall" class="o-mail-MessagingMenu-navbar d-flex border-top bg-view shadow-lg w-100 btn-group">
-        <button t-foreach="tabs" t-key="tab.id" t-as="tab" class="o-mail-MessagingMenu-tab btn d-flex flex-column align-items-center flex-grow-1 flex-basis-0 p-2 mx-0" t-att-class="{
+        <button t-foreach="tabs" t-key="tab.id" t-as="tab" class="o-mail-MessagingMenu-tab btn d-flex flex-column align-items-center flex-grow-1 flex-basis-0 p-2 mx-0 pb-4" t-att-class="{
             'text-primary fw-bolder o-active': store.discuss.activeTab === tab.id,
             'border-end': !tab_last,
         }" t-on-click="() => this.onClickNavTab(tab.id)">


### PR DESCRIPTION
iOS devices have persistent swipe bar at bottom which can overlap UI that's too low on screen. This is notably a problem with composer that is at the very bottom of screen and is only 40px in height.

This commit fixes the issue by adding some padding at the bottom of composer specifically on mobile devices.

Also fixes similar issue in mobile bottom navbar of Discuss app.

<img width="806" alt="Screenshot 2024-08-13 at 10 00 20" src="https://github.com/user-attachments/assets/5ee3860e-6a29-4217-b856-69f2e5ca8201">

