### PR TITLE
[FIX] website: use default label width in form when no field exists

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -114,7 +114,7 @@ const FormEditor = options.Class.extend({
      */
     _getDefaultFormat: function () {
         return {
-            labelWidth: this.$target[0].querySelector('.s_website_form_label').style.width,
+            labelWidth: this.$target[0].querySelector('.s_website_form_label')?.style.width || "200px",
             labelPosition: 'left',
             multiPosition: 'horizontal',
             requiredMark: this._isRequiredMark(),


### PR DESCRIPTION
When adding a new field to a website form, the label width is copied from the first label inside the form. This fails if all fields have been deleted.
One form where all fields can be deleted is the extra info step in eCommerce.

This commit fixes this by using the default "200px" width (which is the default value inside the form templates) when there are no more field labels inside the form.

Steps to reproduce:
- Install eCommerce.
- In Settings/Website, enable the extra info step.
- Go in shop, add a product to the cart and proceed until you reach the extra info step.
- Edit the extra info page.
- Remove all form fields.
- Add a field to the form.

=> An error dialog was displayed.

opw-4102127
