### PR TITLE
[FIX] web_editor: prevent crash on selection change

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -712,6 +712,7 @@ export function getTraversedNodes(editable, range = getDeepRange(editable)) {
         // Handle the case: <p>ab[<br>cd</p><p>ef</p>] => [br, cd, p2, ef]
         node = iterator.nextNode();
     }
+    if (!node) return [];
     const traversedNodes = new Set([node, ...descendants(node)]);
     while (node && node !== range.endContainer) {
         node = iterator.nextNode();


### PR DESCRIPTION
__Current behavior before commit:__
Since [this commit][1], `node` might be `null` in some cases.

__Description of the fix:__
Return if `node` is `null`.

__Steps to reproduce the issue on runbot:__
1. Drag a text block in the website
2. Write a word
3. Hit `Shift + Enter`
4. Go back up and select the word
5. Surround it with HTML tag by changing the font or putting it in bold
6. Place the cursor at the end of the word and hit `Shift + Enter` again

↳ `TypeError: Cannot read properties of null (reading 'childNodes')`

opw-4067887

[1]: https://github.com/odoo/odoo/commit/e71d5bff