### PR TITLE
[FIX] l10n_es_edi_{sii|tbai}: use ClaveRegimen 17 for OSS operations

### DIFF
--- a/addons/l10n_es_edi_sii/models/account_edi_format.py
+++ b/addons/l10n_es_edi_sii/models/account_edi_format.py
@@ -286,7 +286,15 @@ class AccountEdiFormat(models.Model):
                         'NombreRazon': com_partner.name[:120],
                     }
                 export_exempts = invoice.invoice_line_ids.tax_ids.filtered(lambda t: t.l10n_es_exempt_reason == 'E2')
-                invoice_node['ClaveRegimenEspecialOTrascendencia'] = '02' if export_exempts else '01'
+                # If an invoice line contains an OSS tax, the invoice is considered as an OSS operation
+                is_oss = self._has_oss_taxes(invoice)
+
+                if is_oss:
+                    invoice_node['ClaveRegimenEspecialOTrascendencia'] = '17'
+                elif export_exempts:
+                    invoice_node['ClaveRegimenEspecialOTrascendencia'] = '02'
+                else:
+                    invoice_node['ClaveRegimenEspecialOTrascendencia'] = '01'
             else:
                 info['IDFactura']['IDEmisorFactura'] = partner_info
                 info['IDFactura']['NumSerieFacturaEmisor'] = invoice.ref[:60]
@@ -576,6 +584,14 @@ class AccountEdiFormat(models.Model):
                 }
 
         return results
+
+    def _has_oss_taxes(self, invoice):
+        oss_tax_groups = self.env['ir.model.data'].search([
+            ('module', '=', 'l10n_eu_oss'),
+            ('model', '=', 'account.tax.group')])
+        lines = invoice.invoice_line_ids.filtered(lambda line: line.display_type not in ('line_section', 'line_note'))
+        tax_groups = lines.mapped('tax_ids.tax_group_id')
+        return bool(set(tax_groups.ids) & set(oss_tax_groups.mapped('res_id')))
 
     # -------------------------------------------------------------------------
     # EDI OVERRIDDEN METHODS

--- a/addons/l10n_es_edi_tbai/models/account_edi_format.py
+++ b/addons/l10n_es_edi_tbai/models/account_edi_format.py
@@ -384,7 +384,12 @@ class AccountEdiFormat(models.Model):
         # NOTE there's 11 more codes to implement, also there can be up to 3 in total
         # See https://www.gipuzkoa.eus/documents/2456431/13761128/Anexo+I.pdf/2ab0116c-25b4-f16a-440e-c299952d683d
         com_partner = invoice.commercial_partner_id
-        if not com_partner.country_id or com_partner.country_id.code in self.env.ref('base.europe').country_ids.mapped('code'):
+        # If an invoice line contains an OSS tax, the invoice is considered as an OSS operation
+        is_oss = self._has_oss_taxes(invoice)
+
+        if is_oss:
+            values['regime_key'] = ['17']
+        elif not com_partner.country_id or com_partner.country_id.code in self.env.ref('base.europe').country_ids.mapped('code'):
             values['regime_key'] = ['01']
         else:
             values['regime_key'] = ['02']


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting, l10n_eu_oss and l10n_es_edi_tbai
- Switch to a Spanish company (e.g. ES Company)
- Create an invoice for a Portugese customer:
  * Customer: [a Portugese customer]
  * Invoice Lines: [a line with OSS tax "23.0% PT VAT (Goods)"]
- Confirm the invoice
- Process the invoice by E-invoicing service: TicketBAI (ES)
- Check the generated EDI document

**Issue:**
The value of "ClaveRegimenIvaOpTrascendencia" is "01". It should be "17" for OSS operations.

**Solution:**
Check if a tax from "l10n_eu_oss" module is used in one of the invoice lines. If it is the case, set "ClaveRegimenIvaOpTrascendencia" to "17".

opw-4034659




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
