### PR TITLE
[FIX] point_of_sale: skip check for zero quantity moves

### DIFF
--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -241,7 +241,7 @@ class StockMove(models.Model):
 
         # Check for any conversion issues in the moves before setting quantities
         uoms_with_issues = set()
-        for move in moves_to_assign:
+        for move in moves_to_assign.filtered(lambda m: m.product_uom_qty and m.product_uom != m.product_id.uom_id):
             converted_qty = move.product_uom._compute_quantity(
                 move.product_uom_qty,
                 move.product_id.uom_id,


### PR DESCRIPTION
After the commit https://github.com/odoo/odoo/commit/6636135d5f2858e4a2bf27e5c2da91a91fa52695, an unnecessary error was triggered when a bill of materials (BOM) containing an item with zero quantity was used. This commit updates the logic to prevent this check when the item's quantity is zero and its unit of measure (UoM) matches the product's UoM, avoiding the error.

opw-4113385

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
