### PR TITLE
[FIX] pos_self_order: display product name without reference

### DIFF
--- a/addons/pos_self_order/models/product_product.py
+++ b/addons/pos_self_order/models/product_product.py
@@ -50,14 +50,13 @@ class ProductProduct(models.Model):
         params += ['description_self_order']
         return params
 
-    def _get_name(self) -> str:
-        """
-        Returns the name of the product without the code.
-        ex: product_sudo.display_name is '[FURN_7888] Desk Stand with Screen (Red)'
-        :return: 'Desk Stand with Screen (Red)' (we remove the [FURN_7888] part)
-        """
-        self.ensure_one()
-        return self.with_context(display_default_code=False).display_name
+    def _load_pos_self_data(self, data):
+        domain = self._load_pos_self_data_domain(data)
+        fields = self._load_pos_self_data_fields(data['pos.config']['data'][0]['id'])
+        return {
+            'data': self.with_context(display_default_code=False).search_read(domain, fields, load=False),
+            'fields': fields,
+        }
 
     def _filter_applicable_attributes(self, attributes_by_ptal_id: Dict) -> List[Dict]:
         """

--- a/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
@@ -12,6 +12,7 @@ registry.category("web_tour.tours").add("self_kiosk_each_table_takeaway_in", {
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
         LandingPage.selectLocation("Eat In"),
+        ProductPage.checkReferenceNotInProductName("Coca-Cola", "12345"),
         ProductPage.clickProduct("Coca-Cola"),
         Utils.clickBtn("Order"),
         CartPage.checkProduct("Coca-Cola", "2.53", "1"),

--- a/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
@@ -6,6 +6,13 @@ export function clickProduct(productName) {
     };
 }
 
+export function checkReferenceNotInProductName(productName, reference) {
+    return {
+        content: `Check product label has '${productName}' and not ${reference}`,
+        trigger: `.self_order_product_card span:contains('${productName}'):not(:contains("${reference}"))`,
+    };
+}
+
 export function clickCancel() {
     return [
         {

--- a/addons/pos_self_order/tests/self_order_common_test.py
+++ b/addons/pos_self_order/tests/self_order_common_test.py
@@ -44,6 +44,7 @@ class SelfOrderCommonTest(odoo.tests.HttpCase):
             'taxes_id': False,
             'available_in_pos': True,
             'pos_categ_ids': [(4, pos_categ_misc.id)],
+            'default_code': '12345',
         })
         cls.fanta = cls.env['product.product'].create({
             'name': 'Fanta',


### PR DESCRIPTION
In mobile, the display name of the product was shown with the reference which is something we do not want. This commit fixes that issue by adding the context display_default_code=False in the _load_pos_self_data method of the product model.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
