### PR TITLE
[FIX] project: ensure the quick create bar persists after refresh

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -154,6 +154,7 @@
             <field name="view_mode">kanban,tree,form,calendar,pivot,graph,activity</field>
             <field name="domain">[('project_id', '=', active_id), ('display_in_project', '=', True)]</field>
             <field name="context">{
+                'active_model': 'project.project',
                 'default_project_id': active_id,
                 'show_project_update': True,
                 'search_default_open_tasks': 1,


### PR DESCRIPTION
To reproduce the issue:
- In the project app, click on a project to enter the Kanban view
- Refresh the page

The "+ stage" button to add a stage to a project disappears upon page refresh.

This is caused by a context check that functions correctly during the normal flow. However, when directly accessing the
link or refreshing the page, the `active_model` context is lost. Since the action `act_project_project_2_project_task_all`
always filter project on active_id, we can add as a default context ´'active_model': 'project.project'´

opw-4075290