### PR TITLE
[FIX] mail: click on send msg in mobile should not highlight btn

### DIFF
--- a/addons/mail/static/src/core/common/composer.dark.scss
+++ b/addons/mail/static/src/core/common/composer.dark.scss
@@ -1,3 +1,7 @@
-.o-mail-Composer-actions button:hover {
-    background-color: $gray-300;
+.o-mail-Composer-actions button {
+    @media (hover: hover) {
+        &:hover {
+            background-color: $gray-300;
+        }
+    }
 }

--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -34,9 +34,16 @@
 
 .o-mail-Composer-actions button {
     opacity: 75%;
-    &:hover {
-        background-color: $gray-200;
-        opacity: 100%;
+    @media (hover: hover) {
+        &:hover {
+            background-color: $gray-200;
+            opacity: 100%;
+        }
+    }
+    &:disabled {
+        --btn-active-color: var(--btn-disabled-color);
+        --btn-hover-color: var(--btn-disabled-color);
+        opacity: var(--btn-disabled-opacity);
     }
 }
 

--- a/addons/mail/static/src/discuss/voice_message/common/voice_recorder.xml
+++ b/addons/mail/static/src/discuss/voice_message/common/voice_recorder.xml
@@ -2,15 +2,15 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.VoiceRecorder">
-        <div class="o-mail-VoiceRecorder d-flex align-items-center" t-att-class="{ 'o-recording rounded-start-0 rounded-end': state.recording }">
-            <t t-set="title"><t t-if="!state.recording">Voice Message</t><t t-else="">Stop Recording</t></t>
+        <t t-set="title"><t t-if="!state.recording">Voice Message</t><t t-else="">Stop Recording</t></t>
+        <button class="o-mail-VoiceRecorder d-flex align-items-center btn border-0" t-att-class="{ 'o-recording rounded-start-0 rounded-end user-select-none p-0': state.recording, 'p-1 rounded-circle': !state.recording }" t-att-title="title" t-att-disabled="state.isActionPending or props.composer.voiceAttachment" t-on-click="onClick">
             <div class="o-mail-VoiceRecorder-elapsed" t-att-class="{
                 'o-active recording ms-2 me-1': state.recording,
                 'mw-0': !state.recording,
                 'text-danger': state.limitWarning,
             }" style="font-variant-numeric: tabular-nums;"><span class="d-flex text-truncate" t-esc="state.elapsed"/></div>
-            <button t-att-disabled="state.isActionPending or props.composer.voiceAttachment" class="border-0 btn rounded-pill p-1" t-att-title="title" t-on-click="onClick"><i t-att-class="!state.recording ? 'fa fa-fw fa-microphone' : 'fa fa-fw fa-circle text-danger o-mail-VoiceRecorder-dot'"/></button>
-        </div>
+            <span class="rounded-circle" t-att-class="{ 'p-1': state.recording }"><i t-att-class="!state.recording ? 'fa fa-fw fa-microphone' : 'fa fa-fw fa-circle text-danger o-mail-VoiceRecorder-dot'"/></span>
+        </button>
     </t>
 
 </templates>

--- a/addons/mail/static/tests/discuss/voice_message/voice_message.test.js
+++ b/addons/mail/static/tests/discuss/voice_message/voice_message.test.js
@@ -197,6 +197,6 @@ test("make voice message in chat", async () => {
     await contains(".o-mail-VoicePlayer button[title='Play']");
     await contains(".o-mail-VoicePlayer canvas", { count: 2 }); // 1 for global waveforms, 1 for played waveforms
     await contains(".o-mail-VoicePlayer", { text: "00 : 04" }); // duration of call_02_in_.mp3
-    await contains(".o-mail-VoiceRecorder button[title='Voice Message']:disabled");
+    await contains("button[title='Voice Message']:disabled");
     cleanUp();
 });


### PR DESCRIPTION
Before this commit, when sending a message on mobile device with the dedicated send button "fa-plane-o", the button was highligted after composer content being cleared from posted message.

This happens because the button, while being `:disabled`, has `:active` and `:hover`, both of which applies background active color and removes opacity rules of `:disabled`.

This is unintentional, so this commit fixes the issue by enforcing the `:disabled` style even when composer button actions are `:active` and `:hover`.

This commit also fixes another small UX issue where the voice recording stop button works only on red circle icon. This commit makes the whole component click acts as the trigger.

Task-4107211

<img width="855" alt="Screenshot 2024-08-13 at 11 52 12" src="https://github.com/user-attachments/assets/7ee7780b-9589-4979-a1e3-844c9e8b86c7">
