### PR TITLE
[FIX] hr_calendar: prevent error when opening calendar without timezone

### DIFF
--- a/addons/hr_calendar/models/res_partner.py
+++ b/addons/hr_calendar/models/res_partner.py
@@ -102,8 +102,8 @@ class Partner(models.Model):
         # This is the format expected by the fullcalendar library to do the overlay
         return [{
             "daysOfWeek": [interval[0].weekday() + 1],
-            "startTime":  interval[0].astimezone(timezone(self.env.user.tz)).strftime("%H:%M"),
-            "endTime": interval[1].astimezone(timezone(self.env.user.tz)).strftime("%H:%M"),
+            "startTime":  interval[0].astimezone(timezone(self.env.user.tz or 'UTC')).strftime("%H:%M"),
+            "endTime": interval[1].astimezone(timezone(self.env.user.tz or 'UTC')).strftime("%H:%M"),
         } for interval in working_intervals] if working_intervals else [{
             # 7 is used a dummy value to gray the full week
             # Returning an empty list would leave the week uncolored

--- a/addons/hr_calendar/tests/test_working_hours.py
+++ b/addons/hr_calendar/tests/test_working_hours.py
@@ -234,3 +234,23 @@ class TestWorkingHours(TestHrCalendarCommon):
             {'daysOfWeek': [5], 'startTime': '08:00', 'endTime': '12:00'},
             {'daysOfWeek': [5], 'startTime': '13:00', 'endTime': '22:00'},
         ])
+
+    def test_work_hours_of_employee_without_time_zone(self):
+        self.env.user.tz = False
+        work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
+            [self.partnerA.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        self.assertEqual(work_hours, [
+            {'daysOfWeek': [1], 'startTime': '07:00', 'endTime': '11:00'},
+            {'daysOfWeek': [1], 'startTime': '12:00', 'endTime': '15:00'},
+            {'daysOfWeek': [2], 'startTime': '07:00', 'endTime': '11:00'},
+            {'daysOfWeek': [2], 'startTime': '12:00', 'endTime': '15:00'},
+            {'daysOfWeek': [3], 'startTime': '07:00', 'endTime': '11:00'},
+            {'daysOfWeek': [3], 'startTime': '12:00', 'endTime': '15:00'},
+            {'daysOfWeek': [4], 'startTime': '07:00', 'endTime': '11:00'},
+            {'daysOfWeek': [4], 'startTime': '12:00', 'endTime': '15:00'},
+            {'daysOfWeek': [5], 'startTime': '07:00', 'endTime': '11:00'},
+            {'daysOfWeek': [5], 'startTime': '12:00', 'endTime': '15:00'},
+        ])


### PR DESCRIPTION
When customer tries to open ```calendar``` without timezone,
a traceback will appear.

Steps to reproduce the error:
- Go to My profile > In timezone, Select empty timezone
- Install ```hr_calendar```
- Open ```Calendar```

Traceback:
```
AttributeError: 'bool' object has no attribute 'upper'
  File "odoo/http.py", line 2373, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1903, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1966, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1933, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2177, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 223, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 754, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 35, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 459, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/hr_calendar/models/res_partner.py", line 99, in get_working_hours_for_all_attendees
    return self._interval_to_business_hours(reduce(Intervals.__and__, schedule_by_partner.values()))
  File "addons/hr_calendar/models/res_partner.py", line 105, in _interval_to_business_hours
    "startTime":  interval[0].astimezone(timezone(self.env.user.tz)).strftime("%H:%M"),
  File "odoo/tools/_monkeypatches_pytz.py", line 129, in timezone
    return original_pytz_timezone(name)
  File "__init__.py", line 183, in timezone
    if zone.upper() == 'UTC':
```

https://github.com/odoo/odoo/blob/3345a0b61630ee1ac11045b09717167744265a24/addons/hr_calendar/models/res_partner.py#L105
When user has an empty timezone and tries to open the ```calendar``` app,
It will give the traceback at the above line.

sentry-5707574801

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
