### PR TITLE
[FIX] base: fix translate button for arch

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -653,10 +653,10 @@
                 display: none;
             }
 
-            .btn {
+            span.btn.o_field_translate {
                 width: 100% !important;
                 margin-left: 0px;
-                visibility: hidden;
+                visibility: hidden !important;
             }
 
             .btn:after {


### PR DESCRIPTION
after odoo/odoo#169782 translation button is only rendered when hover/focus but for the hack of ir.ui.view.arch which
1. is a not translatable computed field
2. borrows the translation button from ir.ui.view.arch_db
3. shows the en_US value of ir.ui.view.arch_db. The 'visibility: visible !important' in odoo/odoo#169782 when hover/focus make the dummy EN logo and the language logo for the current language appear at the same time e.g. FREN

This FIX increases the specificity of 'visibility: hidden' of the language logo for the current language in oe_no_translation_content to remove the bug.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
