### PR TITLE
[REF] microsoft_account, microsoft_calendar: make credentials overridable

### DIFF
--- a/addons/microsoft_account/controllers/main.py
+++ b/addons/microsoft_account/controllers/main.py
@@ -20,7 +20,12 @@ class MicrosoftAuth(http.Controller):
             raise BadRequest()
 
         if kw.get('code'):
-            access_token, refresh_token, ttl = request.env['microsoft.service']._get_microsoft_tokens(kw['code'], service)
+            base_url = request.httprequest.url_root.strip('/') or request.env.user.get_base_url()
+            access_token, refresh_token, ttl = request.env['microsoft.service']._get_microsoft_tokens(
+                kw['code'],
+                service,
+                redirect_uri=f'{base_url}/microsoft_account/authentication'
+            )
             request.env.user._set_microsoft_auth_tokens(access_token, refresh_token, ttl)
             return request.redirect(url_return)
         elif kw.get('error'):

--- a/addons/microsoft_calendar/controllers/main.py
+++ b/addons/microsoft_calendar/controllers/main.py
@@ -21,7 +21,7 @@ class MicrosoftCalendarController(CalendarController):
             MicrosoftCal = request.env["calendar.event"]._get_microsoft_service()
 
             # Checking that admin have already configured Microsoft API for microsoft synchronization !
-            client_id = request.env['ir.config_parameter'].sudo().get_param('microsoft_calendar_client_id')
+            client_id = request.env['microsoft.service']._get_microsoft_client_id('calendar')
 
             if not client_id or client_id == '':
                 action_id = ''

--- a/addons/microsoft_calendar/utils/microsoft_calendar.py
+++ b/addons/microsoft_calendar/utils/microsoft_calendar.py
@@ -205,7 +205,13 @@ class MicrosoftCalendarService():
         return 'offline_access openid Calendars.ReadWrite'
 
     def _microsoft_authentication_url(self, from_url='http://www.odoo.com'):
-        return self.microsoft_service._get_authorize_uri(from_url, service='calendar', scope=self._get_calendar_scope())
+        redirect_uri = self.microsoft_service.get_base_url() + '/microsoft_account/authentication'
+        return self.microsoft_service._get_authorize_uri(
+            from_url,
+            service='calendar',
+            scope=self._get_calendar_scope(),
+            redirect_uri=redirect_uri
+        )
 
     def _can_authorize_microsoft(self, user):
         return user.has_group('base.group_erp_manager')


### PR DESCRIPTION
This commit allows to override easily api credentials by defining a function to return the client_id (within 'microsoft.service') and a private python function to retrieve the client_secret. Inspired on odoo/odoo#95744.

task-3864685