### PR TITLE
[FIX] mrp_subcontracting: Fix components consumption on

### DIFF
--- a/addons/mrp_subcontracting/models/stock_picking.py
+++ b/addons/mrp_subcontracting/models/stock_picking.py
@@ -73,12 +73,13 @@ class StockPicking(models.Model):
             len_amounts = len(amounts)
             # _split_production can set the qty_done, but not split it.
             # Remove the qty_done potentially set by a previous split to prevent any issue.
-            production.move_line_raw_ids.filtered(lambda l: l.state == 'assigned').write({'qty_done': 0})
+            production.move_line_raw_ids.filtered(lambda sml: sml.state not in ['done', 'cancel']).write({'qty_done': 0})
             productions = production._split_productions({production: amounts}, set_consumed_qty=True)
             for production, move_line in zip(productions, move.move_line_ids):
                 if move_line.lot_id:
                     production.lot_producing_id = move_line.lot_id
                 production.qty_producing = production.product_qty
+                production._set_qty_producing()
             productions[:len_amounts].subcontracting_has_been_recorded = True
 
         for picking in self:


### PR DESCRIPTION
Condition to reproduce:
- BoM has strict consumption
- Finished product is tracked by serial numbers.
- Component is partially available.

When these conditions are fulfilled, and you generate multiples backorder subcontracting receipt, the component consumption was incorrect.

This commit complements 2486bc11572d4bc402b423d0120bb72b4b3fe86a:
- The original issue also happened on "partially_available" move lines (due to the filtered on "assigned" moves).
- On products tracked by serial numbers, for components partially available, the available part was consumed while the one not available was not.

---

<details>
  <summary>Test result without fix</summary>

```
2024-08-13 11:01:44,787 23254 ERROR oes_test_sub odoo.addons.mrp_subcontracting.tests.test_subcontracting: FAIL: TestSubcontractingFlows.test_strict_consumption_backorders_serial
Traceback (most recent call last):
  File "/home/odoo/projects/odoo-src/multiverse/src/16.0/odoo/addons/mrp_subcontracting/tests/test_subcontracting.py", line 1162, in test_strict_consumption_backorders_serial
    self.assertRecordValues(
  File "/home/odoo/projects/odoo-src/multiverse/src/16.0/odoo/odoo/tests/common.py", line 610, in assertRecordValues
    self.fail('\n'.join(errors))
AssertionError: The records and expected_values do not match.

==== Differences at index 10 ====
--- 

+++ 

@@ -1,2 +1,2 @@

-quantity_done:5.0
-product_qty:5.0
+quantity_done:1.0
+product_qty:1.0

==== Differences at index 15 ====
--- 

+++ 

@@ -1,2 +1,2 @@

-quantity_done:0.0
-state:cancel
+quantity_done:1.0
+state:done

==== Differences at index 16 ====
--- 

+++ 

@@ -1,2 +1,2 @@

-quantity_done:0.0
-state:cancel
+quantity_done:1.0
+state:done

==== Differences at index 17 ====
--- 

+++ 

@@ -1,2 +1,2 @@

-quantity_done:0.0
-state:cancel
+quantity_done:1.0
+state:done

==== Differences at index 18 ====
--- 

+++ 

@@ -1,2 +1,2 @@

-quantity_done:0.0
-state:cancel
+quantity_done:1.0
+state:done

==== Differences at index 19 ====
--- 

+++ 

@@ -1,2 +1,2 @@

-quantity_done:0.0
-state:cancel
+quantity_done:1.0
+state:done
```
</details>

---

OPW-3838250

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
