### PR TITLE
[FIX] html_editor: unregister link shortcut and assign conflict category

### DIFF
--- a/addons/html_editor/static/src/main/link/command_category.js
+++ b/addons/html_editor/static/src/main/link/command_category.js
@@ -1,0 +1,10 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+
+const commandCategoryRegistry = registry.category("command_categories");
+// A shortcut conflict occurs when actions are bound to the same
+// shortcut as the command palette. To avoid this, those actions can be
+// added to the command palette itself within this high priority category
+// so that they appear first in the results.
+commandCategoryRegistry.add("shortcut_conflict", {}, { sequence: 5 });

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -128,17 +128,24 @@ export class LinkPlugin extends Plugin {
                 this.handleAutomaticLinkInsertion();
             }
         });
-        this.services.command.add(
+        // link creation is added to the command service because of a shortcut conflict,
+        // as ctrl+k is used for invoking the command palette
+        this.removeLinkShortcut = this.services.command.add(
             "Create link",
             () => {
                 this.toggleLinkTools();
             },
             {
                 hotkey: "control+k",
+                category: "shortcut_conflict",
                 isAvailable: () => this.shared.getEditableSelection().inEditable,
             }
         );
         this.ignoredClasses = new Set(this.resources["link_ignore_classes"] || []);
+    }
+
+    destroy() {
+        this.removeLinkShortcut();
     }
 
     handleCommand(command, payload) {

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -2,7 +2,7 @@ import { describe, expect, test } from "@odoo/hoot";
 import { animationFrame, tick } from "@odoo/hoot-mock";
 import { setContent, getContent, setSelection } from "../_helpers/selection";
 import { setupEditor } from "../_helpers/editor";
-import { waitUntil, waitFor, click, queryOne, press, select } from "@odoo/hoot-dom";
+import { waitUntil, waitFor, click, queryOne, press, select, queryText } from "@odoo/hoot-dom";
 import { insertText, splitBlock, insertLineBreak } from "../_helpers/user_actions";
 import { contains, onRpc } from "@web/../tests/web_test_helpers";
 import { cleanLinkArtifacts } from "../_helpers/format";
@@ -500,6 +500,17 @@ describe("Link formatting in the popover", () => {
 });
 
 describe("shortcut", () => {
+    test("create link shortcut should be at the first", async () => {
+        const { editor } = await setupEditor(`<p>[]</p>`);
+        editor.services.command.add("A test command", () => {}, {
+            hotkey: "alt+k",
+            category: "app",
+        });
+
+        press(["ctrl", "k"]);
+        await animationFrame();
+        expect(queryText(".o_command_name:first")).toBe("Create link");
+    });
     test("create a link with shortcut", async () => {
         const { el } = await setupEditor(`<p>[]</p>`);
 

--- a/addons/web_editor/static/src/js/backend/command_category.js
+++ b/addons/web_editor/static/src/js/backend/command_category.js
@@ -1,6 +1,0 @@
-/** @odoo-module **/
-
-import { registry } from "@web/core/registry";
-
-const commandCategoryRegistry = registry.category("command_categories");
-commandCategoryRegistry.add("shortcut_conflict", {}, { sequence: 5 });


### PR DESCRIPTION
The shortcut command should be unregistered upon destruction to prevent
its isAvailable function from being executed multiple times when
switching records.

Additionally, assign the conflict category to ensure that the create
link shortcut appears first in the command palette



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
