### PR TITLE
[FIX] mail: prevent attachment preview overlapping modal

### DIFF
--- a/addons/mail/static/src/core/common/attachment_view.scss
+++ b/addons/mail/static/src/core/common/attachment_view.scss
@@ -1,7 +1,7 @@
 @include media-breakpoint-up(xxl, $o-extra-grid-breakpoints) {
     .o_attachment_preview {
         display: block;
-        flex: 1 0 auto;
+        flex: auto;
         overflow: hidden;
         width: $o-mail-Chatter-minWidth;
 


### PR DESCRIPTION
Steps to reproduce:
- Time off > Calendar view > Double click on a day
- Sick leave > Attach document > Save
- View the leave from calendar

The attachment preview window overlaps the leave modal information, making it unreadable. The preview is only displayed above large media breakpoints (> 1550px) so make sure to fullscreen.

In 16.0 we used a custom element to render the preview which is no longer available
https://github.com/odoo/odoo/commit/824024f8aaa4a5419646d4eec7f529277869ceac#diff-a5f278935504f8e1b287b52fbb88f6e58dedc727ec2c7f1a6a04a67202f18fdaR63.

opw-4088218

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
