### PR TITLE
[FIX] hr_attendance: fix the 12 hour clock on the attendance

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -8,13 +8,13 @@ from datetime import datetime, timedelta
 from operator import itemgetter
 from pytz import timezone
 
+from odoo.http import request
 from odoo import models, fields, api, exceptions, _
 from odoo.addons.resource.models.utils import Intervals
-from odoo.tools import format_datetime
 from odoo.osv.expression import AND, OR
 from odoo.tools.float_utils import float_is_zero
 from odoo.exceptions import AccessError
-from odoo.tools import format_duration
+from odoo.tools import format_duration, format_time, format_datetime
 
 def get_google_maps_url(latitude, longitude):
     return "https://maps.google.com?q=%s,%s" % (latitude, longitude)
@@ -129,18 +129,19 @@ class HrAttendance(models.Model):
 
     @api.depends('employee_id', 'check_in', 'check_out')
     def _compute_display_name(self):
+        tz = request.httprequest.cookies.get('tz') if request else None
         for attendance in self:
             if not attendance.check_out:
                 attendance.display_name = _(
                     "From %s",
-                    format_datetime(self.env, attendance.check_in, dt_format="HH:mm"),
+                    format_time(self.env, attendance.check_in, time_format=None, tz=tz, lang_code=self.env.lang),
                 )
             else:
                 attendance.display_name = _(
                     "%s : (%s-%s)",
                     format_duration(attendance.worked_hours),
-                    format_datetime(self.env, attendance.check_in, dt_format="HH:mm"),
-                    format_datetime(self.env, attendance.check_out, dt_format="HH:mm"),
+                    format_time(self.env, attendance.check_in, time_format=None, tz=tz, lang_code=self.env.lang),
+                    format_time(self.env, attendance.check_out, time_format=None, tz=tz, lang_code=self.env.lang),
                 )
 
     def _get_employee_calendar(self):

--- a/addons/hr_attendance/tests/test_hr_attendance_constraints.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_constraints.py
@@ -62,3 +62,18 @@ class TestHrAttendance(TransactionCase):
             self.open_attendance.write({
                 'check_out': time.strftime('%Y-%m-10 11:30'),
             })
+
+    def test_time_format_attendance(self):
+        self.env.user.tz = 'UTC'
+        self.env['res.lang']._activate_lang('en_US')
+        lang = self.env['res.lang']._lang_get(self.env.user.lang)
+        lang.time_format = "%I:%M %p"  # here "%I:%M %p" represents AM:PM format
+        attendance_id = self.attendance.create({
+            'employee_id': self.test_employee.id,
+            'check_in': time.strftime('%Y-%m-28 08:00'),
+            'check_out': time.strftime('%Y-%m-28 09:00'),
+        })
+        self.assertEqual(attendance_id.display_name, "01:00 : (08:00 AM-09:00 AM)")
+        lang.time_format = "%H:%M:%S"
+        attendance_id._compute_display_name()
+        self.assertEqual(attendance_id.display_name, "01:00 : (08:00:00-09:00:00)")


### PR DESCRIPTION
Before this PR, if you changed the time format in the language, the Gantt and the form view of the attendance did not follow those formats.

With this PR, the dates displayed in the Gantt and form view are based on the time format set in the language.

Task-4098672





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
