### PR TITLE
[IMP] base_vat,partner_autocomplete: add logging when calling VIES service

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -122,6 +122,7 @@ class ResPartner(models.Model):
     def _check_vies(self, vat):
         # Store the VIES result in the cache. In case an exception is raised during the request
         # (e.g. service unavailable), the fallback on simple_vat_check is not kept in cache.
+        _logger.info('Calling VIES service to check VAT for validation: %s', vat)
         return check_vies(vat)
 
     @api.model

--- a/addons/partner_autocomplete/models/res_partner.py
+++ b/addons/partner_autocomplete/models/res_partner.py
@@ -135,6 +135,7 @@ class ResPartner(models.Model):
         else:
             vies_result = None
             try:
+                _logger.info('Calling VIES service to check VAT for autocomplete: %s', vat)
                 vies_result = check_vies(vat, timeout=timeout)
             except Exception:
                 _logger.exception("Failed VIES VAT check.")


### PR DESCRIPTION
More logging is required to track calls to VIES services to enable tracking databases triggering VIES limitations.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
