### PR TITLE
[FIX] website: identify /odoo/ URLs as belonging to the top window

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_preview.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.js
@@ -297,11 +297,12 @@ export class WebsitePreview extends Component {
      * @private
      */
     _isTopWindowURL({ host, pathname }) {
-        const backendRoutes = ['/web', '/web/session/logout'];
+        const backendRoutes = ['/web', '/web/session/logout', '/odoo'];
         return host !== window.location.host
             || (pathname
                 && (backendRoutes.includes(pathname)
                     || pathname.startsWith('/@/')
+                    || pathname.startsWith('/odoo/')
                     || pathname.startsWith('/web/content/')
                     // This is defined here to avoid creating a
                     // website_documents module for just one patch.


### PR DESCRIPTION
With the replacement of URLs to match the new scheme, links to return from portal preview can stop working because their new URL is not recognized as a backend URL.

This commit adds the `/odoo/` prefix in URLs identified as belonging to the backend.

Steps to reproduce:
- Install website & sale.
- Go to an Invoice.
- Click on Preview.
- If you are not in the backend view, click on "Editor".
- Click on the link to return to the backend view.

=> A cross-origin error happened because the backend was being reloaded within the website preview `iframe`.

opw-4098566
