### PR TITLE
[IMP] pos_restaurant: keep linked table's bg

### DIFF
--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
@@ -113,10 +113,9 @@
                         </div>
                         <div t-else="" t-ref="map" class="h-100 w-100" t-att-class="{'d-flex align-items-center justify-content-center flex-wrap': pos.floorPlanStyle == 'kanban'}">
                            <t t-foreach="activeTables.sort((a,b)=>a.id-b.id)" t-as="table" t-key="table.id" >
-                                <t t-set="isOccupied" t-value="pos.getCustomerCount(table.id) > 0 || table.uiState.orderCount > 0"/>
+                                <t t-set="isOccupied" t-value="table.getOrder() || table.uiState.orderCount > 0"/>
                                 <t t-set="isIntersecting" t-value="state.potentialLink?.child?.id === table.id"/>
                                 <t t-set="isIntersected" t-value="state.potentialLink?.parent?.id === table.id"/>
-                                <t t-set="hasBg" t-value="isOccupied or table.parent_id" />
                                 <div
                                     t-on-click.stop="(ev) => this.onClickTable(table, ev)"
                                     class="table o_draggable d-flex flex-column align-items-center justify-content-between cursor-pointer"
@@ -129,7 +128,7 @@
                                     t-attf-style="
                                                 border: 3px solid {{table.color}};
                                                 border-radius: {{table.shape === 'round' ? 1000 : 6}}px;
-                                                background: {{hasBg ? table.color || 'rgb(53, 211, 116)' : '#00000020'}};
+                                                background: {{isOccupied ? table.color || 'rgb(53, 211, 116)' : '#00000020'}};
                                                 color: {{!hasBg ? 'black' : 'white'}};
                                                 opacity: {{state.potentialLink ? (isIntersecting or isIntersected ? 1 : 0.25) : 1}};
                                                 {{pos.floorPlanStyle == 'kanban' ?

--- a/addons/pos_restaurant/static/src/app/models/restaurant_table.js
+++ b/addons/pos_restaurant/static/src/app/models/restaurant_table.js
@@ -63,7 +63,7 @@ export class RestaurantTable extends Base {
         };
     }
     getOrder() {
-        return this["<-pos.order.table_id"][0];
+        return this.parent_id?.getOrder?.() || this["<-pos.order.table_id"][0];
     }
     setPositionAsIfLinked(parent, side) {
         // console.log("132")


### PR DESCRIPTION
When 2 tables are linked, the child table is automatically given a background color. This behavior is no longer desired. In this commit we remove it.

Task: 4110510





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
