### PR TITLE
[FIX] mail: adjust callInvitations position to prevent scrollbar obstruction

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_invitations.xml
+++ b/addons/mail/static/src/discuss/call/common/call_invitations.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.CallInvitations">
-        <div class="o-discuss-CallInvitations position-absolute top-0 end-0 d-flex flex-column p-2">
+        <div t-if="store.discuss.ringingThreads.length > 0" class="o-discuss-CallInvitations position-absolute top-0 end-0 d-flex flex-column p-2">
             <t t-foreach="store.discuss.ringingThreads" t-as="thread" t-key="thread.localId">
                 <CallInvitation thread="thread"/>
             </t>


### PR DESCRIPTION
In versions v17 and up, a div with class `.o-discuss-CallInvitations` was causing issues by blocking the scrollbar's up arrow, preventing users from scrolling up.

To address this, the display of the `.o-discuss-CallInvitations` div is now conditional, based on `store.discuss.ringingThreads.length > 0`. This ensures the div only appears when necessary, avoiding obstruction of the scrollbar and improving usability.

opw-4108057