### PR TITLE
[FIX] mail: remove new message banner when mark as read is done

### DIFF
--- a/addons/mail/static/src/core/common/channel_member_model.js
+++ b/addons/mail/static/src/core/common/channel_member_model.js
@@ -41,6 +41,7 @@ export class ChannelMember extends Record {
     fetched_message_id = Record.one("Message");
     seen_message_id = Record.one("Message");
     syncUnread = true;
+    syncCounterOnly = false;
     _syncUnread = Record.attr(false, {
         compute() {
             if (!this.syncUnread || !this.eq(this.thread?.selfMember)) {
@@ -54,6 +55,19 @@ export class ChannelMember extends Record {
         onUpdate() {
             if (this._syncUnread) {
                 this.localNewMessageSeparator = this.new_message_separator;
+                this.localMessageUnreadCounter = this.message_unread_counter;
+            }
+        },
+    });
+    _syncCounterOnly = Record.attr(false, {
+        compute() {
+            if (!this.syncCounterOnly || !this.eq(this.thread?.selfMember)) {
+                return false;
+            }
+            return this.localMessageUnreadCounter !== this.message_unread_counter;
+        },
+        onUpdate() {
+            if (this._syncCounterOnly) {
                 this.localMessageUnreadCounter = this.message_unread_counter;
             }
         },

--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -59,6 +59,7 @@ export class ChatWindow extends Component {
             closeActionPanel: () => this.threadActions.activeAction?.close(),
             inChatWindow: true,
             messageHighlight: this.messageHighlight,
+            isComposerFocused: this.thread?.composer.isFocused,
         });
     }
 

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -687,7 +687,7 @@ export class Composer extends Component {
     onFocusin() {
         const composer = toRaw(this.props.composer);
         composer.isFocused = true;
-        composer.thread?.markAsRead();
+        composer.thread?.markAsRead({ syncCounterOnly: true });
     }
 
     saveContent() {

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -113,10 +113,10 @@ export class Thread extends Component {
             },
             { ready: false }
         );
+        this.setupScroll();
         this.presentThresholdState = useVisible("present-treshold", () =>
             this.updateShowJumpPresent()
         );
-        this.setupScroll();
         useEffect(
             () => this.updateShowJumpPresent(),
             () => [this.props.thread.loadNewer]
@@ -300,6 +300,9 @@ export class Thread extends Component {
                     : ref.el.scrollTop < 30;
             if (isBottom) {
                 thread.scrollTop = "bottom";
+                if (this.props.thread.showUnreadBanner && this.env.isComposerFocused) {
+                    this.props.thread.markAsRead();
+                }
             } else {
                 thread.scrollTop =
                     this.props.order === "asc"

--- a/addons/mail/static/src/core/common/thread.scss
+++ b/addons/mail/static/src/core/common/thread.scss
@@ -27,8 +27,14 @@
     }
 }
 
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
 .o-mail-Thread-banner {
     z-index: $o-mail-NavigableList-zIndex - 1;
+    animation: fadeIn 0.25s ease-out;
 }
 
 .o-mail-Thread-bannerHover:hover {

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -881,7 +881,7 @@ export class Thread extends Record {
      * @param {boolean} [options.sync] Whether to sync the unread message
      * state with the server values.
      */
-    markAsRead({ sync } = {}) {
+    markAsRead({ sync, syncCounterOnly } = {}) {
         const newestPersistentMessage = this.newestPersistentOfAllMessage;
         if (!newestPersistentMessage && !this.isLoaded) {
             this.isLoadedDeferred.then(() => new Promise(setTimeout)).then(() => this.markAsRead());
@@ -889,6 +889,7 @@ export class Thread extends Record {
         const alreadyReadBySelf = newestPersistentMessage?.isReadBySelf;
         if (this.selfMember) {
             this.selfMember.syncUnread = sync ?? this.selfMember.syncUnread;
+            this.selfMember.syncCounterOnly = syncCounterOnly ?? this.selfMember.syncCounterOnly;
             this.selfMember.seen_message_id = newestPersistentMessage;
         }
         if (newestPersistentMessage && this.selfMember && !alreadyReadBySelf) {

--- a/addons/mail/static/tests/thread/unread_messages_banner.test.js
+++ b/addons/mail/static/tests/thread/unread_messages_banner.test.js
@@ -37,10 +37,11 @@ test("show unread messages banner when there are unread messages", async () => {
     }
     await start();
     await openDiscuss(channelId);
+    // discuss.channel composer is already focused on open, triggering mark_as_read
+    await contains("span", { text: "30 new messagesMark as Read" });
     await contains(".o-mail-Thread-newMessage ~ .o-mail-Message", {
         text: "message 0",
     });
-    await contains("span", { text: "30 new messagesMark as Read" });
 });
 
 test("mark thread as read from unread messages banner", async () => {
@@ -56,12 +57,13 @@ test("mark thread as read from unread messages banner", async () => {
     }
     await start();
     await openDiscuss(channelId);
-    await contains(".o-mail-Thread-newMessage ~ .o-mail-Message", {
-        text: "message 0",
-    });
-    await click("span", {
+    // discuss.channel composer is already focused on open, triggering mark_as_read
+    await contains("span", {
         text: "Mark as Read",
         parent: ["span", { text: "30 new messagesMark as Read" }],
+    });
+    await contains(".o-mail-Thread-newMessage ~ .o-mail-Message", {
+        text: "message 0",
     });
     await contains(".o-mail-Thread-jumpToUnread", { count: 0 });
 });
@@ -102,15 +104,11 @@ test("scroll to the first unread message (slow ref registration)", async () => {
     await scroll(".o-mail-Thread", "bottom");
     await contains(".o-mail-Thread", { scroll: "bottom" });
     slowRegisterMessageRef = true;
-    await click("span", {
-        text: "101 new messages",
-        parent: ["span", { text: "101 new messagesMark as Read" }],
-    });
     document.addEventListener("scrollend", () => step("scrollend"), { capture: true });
-    // 1. scroll top, 2. scroll to the unread message 3. slight scroll when highlight ends.
-    await assertSteps(["scrollend", "scrollend", "scrollend"]);
+    // 1. scroll top, 2. scroll to the unread message
+    await assertSteps(["scrollend", "scrollend"]);
     const thread = document.querySelector(".o-mail-Thread");
-    const message = queryFirst(".o-mail-Message:contains(message 100)");
+    const message = queryFirst(".o-mail-Message:contains(message 200)");
     expect(isInViewportOf(thread, message)).toBe(true);
 });
 
@@ -152,10 +150,6 @@ test("scroll to unread notification", async () => {
     const thread = document.querySelector(".o-mail-Thread");
     const message = queryFirst(".o-mail-NotificationMessage:contains(Bob joined the channel)");
     expect(isInViewportOf(thread, message)).toBe(false);
-    await click("span", {
-        text: "1 new message",
-        parent: ["span", { text: "1 new messageMark as Read" }],
-    });
-    await assertSteps(["scrollend"]);
+    await scroll(".o-mail-Thread", "bottom");
     expect(isInViewportOf(thread, message)).toBe(true);
 });


### PR DESCRIPTION
Purpose of this commit:
When a mail thread contains a banner and the composer is focused, the banner remains visible even after the `mark_as_read` action is triggered. This issue arises because the sync parameter isn't set to true when markAsRead is executed during `onFocusin`. Setting it to true would also update the `new_message_separator`, which isn't always necessary. This commit introduces a partial sync mechanism that only syncs the `localMessageUnreadCounter`, which controls the banner's visibility.

task-4102924
