### PR TITLE
[IMP] survey: add warning before submitting the survey

### DIFF
--- a/addons/survey/static/src/js/survey_form.js
+++ b/addons/survey/static/src/js/survey_form.js
@@ -7,6 +7,7 @@ import { scrollTo } from "@web_editor/js/common/scrolling";
 
 import SurveyPreloadImageMixin from "@survey/js/survey_preload_image_mixin";
 import { SurveyImageZoomer } from "@survey/js/survey_image_zoomer";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import {
     deserializeDate,
     deserializeDateTime,
@@ -251,18 +252,27 @@ publicWidget.registry.SurveyFormWidget = publicWidget.Widget.extend(SurveyPreloa
         }
     },
 
-    _onSubmit: function (event) {
+    _onSubmit(event) {
         event.preventDefault();
-        const options = {};
         const target = event.currentTarget;
         if (target.value === 'previous') {
-            options.previousPageId = parseInt(target.dataset['previousPageId']);
+            this._submitForm({ previousPageId: parseInt(target.dataset['previousPageId']) });
         } else if (target.value === 'next_skipped') {
-            options.nextSkipped = true;
+            this._submitForm({ nextSkipped: true });
         } else if (target.value === 'finish') {
-            options.isFinish = true;
+            // Adding pop-up before the survey is submitted
+            this.call("dialog", "add", ConfirmationDialog, {
+                title: _t("Submit confirmation"),
+                body: _t("Are you sure you want to submit the survey?"),
+                confirmLabel: _t("Submit"),
+                confirm: () => {
+                    this._submitForm({ isFinish: true });
+                },
+                cancel: () => {},
+            });
+        } else {
+            this._submitForm({});
         }
-        this._submitForm(options);
     },
 
     // Custom Events

--- a/addons/survey/static/tests/tours/certification_failure.js
+++ b/addons/survey/static/tests/tours/certification_failure.js
@@ -109,6 +109,10 @@ var failSteps = [{ // Page-1
     content: "Finish Survey",
     trigger: 'button[type="submit"]',
     run: "click",
+}, {
+    content: "Click on Submit",
+    trigger: 'button.btn-primary:contains("Submit")',
+    run: "click",
 }];
 
 var retrySteps = [{

--- a/addons/survey/static/tests/tours/certification_success.js
+++ b/addons/survey/static/tests/tours/certification_success.js
@@ -106,6 +106,10 @@ registry.category("web_tour.tours").add('test_certification_success', {
         trigger: 'button[type="submit"]',
         run: "click",
     }, {
+        content: "Click on Submit",
+        trigger: 'button.btn-primary:contains("Submit")',
+        run: "click",
+    }, {
         content: "You scored",
         trigger: 'h1:contains("You scored")',
     }, {

--- a/addons/survey/static/tests/tours/survey.js
+++ b/addons/survey/static/tests/tours/survey.js
@@ -70,6 +70,10 @@ registry.category("web_tour.tours").add('test_survey', {
         content: 'Click Submit and finish the survey',
         trigger: 'button[value="finish"]',
         run: "click",
+    }, {
+        content: "Click on Submit",
+        trigger: 'button.btn-primary:contains("Submit")',
+        run: "click",
     },
     // Final page
     {

--- a/addons/survey/static/tests/tours/survey_chained_conditional_questions.js
+++ b/addons/survey/static/tests/tours/survey_chained_conditional_questions.js
@@ -82,6 +82,10 @@ registry.category("web_tour.tours").add('test_survey_chained_conditional_questio
         content: 'Click Submit and finish the survey',
         trigger: 'button[value="finish"]',
         run: "click",
+    }, {
+        content: "Click on Submit",
+        trigger: 'button.btn-primary:contains("Submit")',
+        run: "click",
     },
     // Final page
     {

--- a/addons/survey/static/tests/tours/survey_roaming_mandatory_questions.js
+++ b/addons/survey/static/tests/tours/survey_roaming_mandatory_questions.js
@@ -41,6 +41,10 @@ registry.category('web_tour.tours').add('test_survey_roaming_mandatory_questions
         trigger: 'button.btn:contains("Submit")',
         run: "click",
     }, {
+        content: "Click on Submit",
+        trigger: 'button.btn-primary:contains("Submit")',
+        run: "click",
+    }, {
         content: 'Check if question is Q1',
         trigger: 'div.js_question-wrapper:contains("Q1")',
     }, {
@@ -71,6 +75,10 @@ registry.category('web_tour.tours').add('test_survey_roaming_mandatory_questions
     }, {
         content: 'Click on Submit',
         trigger: 'button.btn:contains("Submit")',
+        run: "click",
+    }, {
+        content: "Click on Submit",
+        trigger: 'button.btn-primary:contains("Submit")',
         run: "click",
     }, {
         content: 'Check if the survey is done',

--- a/addons/survey/views/survey_templates_management.xml
+++ b/addons/survey/views/survey_templates_management.xml
@@ -176,6 +176,7 @@
             <button
                 t-att-disabled="not can_go_forward"
                 type="submit" class="btn border-0 p-0 shadow-none o_survey_navigation_submit" t-att-value="'next' if not survey_last else 'finish'">
+                <t t-if="survey_last">Submit</t>
                 <i class="oi oi-chevron-right p-2" />
             </button>
         </div>

--- a/addons/test_website_slides_full/static/tests/tours/slides_certification_member.js
+++ b/addons/test_website_slides_full/static/tests/tours/slides_certification_member.js
@@ -54,6 +54,10 @@ var failCertificationSteps = [{
     content: 'Survey: submitting the certification with wrong answers',
     trigger: 'button:contains("Submit")',
     run: "click",
+}, {
+    content: "Click on Submit",
+    trigger: 'button.btn-primary:contains("Submit")',
+    run: "click",
 }];
 
 var retrySteps = [{
@@ -85,6 +89,10 @@ var succeedCertificationSteps = [{
 }, {
     content: 'Survey: submitting the certification with correct answers',
     trigger: 'button:contains("Submit")',
+    run: "click",
+}, {
+    content: "Click on Submit",
+    trigger: 'button.btn-primary:contains("Submit")',
     run: "click",
 }];
 


### PR DESCRIPTION
**Specifications:**
Add a warning pop-up for users before they submit the survey using the next button when they are at the last page.

**After this commit:**
Users will be informed before submitting their survey, giving them the option to review their previous answers before final submission.

Task-4106727