### PR TITLE
[FIX] website: add geoip2 as an external dependency

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -20,6 +20,9 @@
         'google_recaptcha',
         'utm',
     ],
+    'external_dependencies': {
+        'python': ['geoip2'],
+    },
     'installable': True,
     'data': [
         # security.xml first, data.xml need the group to exist (checking it)


### PR DESCRIPTION
While the requirements contain `geoip2`, it's used as an optional dependency e.g. `http.py` imports it conditionally and as long as `request.geoip` is not accessed it causes no trouble.

However `website` does exactly this right in the `_frontend_pre_dispatch`, it's technically conditional but the conditions are:

- a frontend page (not an explicit route and not an attachment)
- no tz in the context (which is very likely for new frontend session)
