### PR TITLE
[FIX] website_slides: default section to add content

### DIFF
--- a/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_upload_category.js
+++ b/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_upload_category.js
@@ -83,6 +83,7 @@ export class SlideUploadCategory extends Component {
                 ["channel_id", "=", this.props.channelId],
             ]);
             this.state.choices.categories = categories;
+            this.state.choices.categoryId = this._getDefaultCategoryId();
             const tags = await this._fetch_choices("tag");
             this.state.choices.tags = tags;
         });
@@ -334,14 +335,23 @@ export class SlideUploadCategory extends Component {
                 );
                 result.category_id = [0, { name: category.label }];
             } else {
-                const categoryId = parseInt(this.state.choices.categoryId, 10);
+                const categoryId = this.state.choices.categoryId || this._getDefaultCategoryId();
                 result.category_id = [categoryId];
-                this.categoryID = categoryId;
             }
         } else {
             result.category_id = [this.defaultCategoryId];
         }
         return result;
+    }
+
+    /**
+     * Returns the id of the last section of the channel or null (no sections)
+     * @returns {Number|Null}
+     */
+    _getDefaultCategoryId() {
+        return this.state.choices.categories.length > 0
+            ? this.state.choices.categories[this.state.choices.categories.length - 1].value
+            : null;
     }
 
     /**


### PR DESCRIPTION
Purpose
=======

When users are editing course content and created multiple sections they are most likely working "chronologically" adding content to sections one after the other.

It seems the fix to preselect last section by default when many exist to populate new content is in regression.

How to fix
==========

Whenever a channel has sections and users has not selected one: make the last section as the default one.

task-4109586
see odoo#132934

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
