### PR TITLE
[FIX] pos_online_payment: RPC error during online payment

### DIFF
--- a/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
@@ -218,6 +218,8 @@ patch(PaymentScreen.prototype, {
             });
             return;
         }
+        this.pos.removePendingOrder(this.currentOrder);
+        this.currentOrder.state = "paid";
         this.pos.validated_orders_name_server_id_map[this.currentOrder.name] = this.currentOrder.id;
 
         // Now, do practically the normal flow


### PR DESCRIPTION
Steps:

- Configure an online payment method in `pos.config`.
- Open POS and complete the first payment using online payment.
- Place a second order and attempt to pay with online payment.
- Traceback error.

Issue:
-  An RPC error occurs when attempting to process a second online payment in POS.

Cause:
- The error is triggered by an attempt to sync the online payment order again from the pending orders list.

Fix:
- Removed the order from pending orders if it has been paid using online payment to prevent duplicate processing.

Task-4104209

