### PR TITLE
[IMP] mail: prevent invalid template save

### DIFF
--- a/addons/event/tests/test_event_mail_schedule.py
+++ b/addons/event/tests/test_event_mail_schedule.py
@@ -486,11 +486,15 @@ class TestMailSchedule(EventMailCommon):
     @users('user_eventmanager')
     def test_event_mail_schedule_fail_global_composer_message(self):
         """ Test message logged depending on issue when trying to send communications """
-        cron = self.env.ref("event.event_mail_scheduler").sudo()
-
         # set template write_uid
         user_admin = self.env.ref('base.user_admin')
-        self.template_reminder.with_user(user_admin).write({'name': 'Take Ownership', 'body_html': '<p>Failing <t t-out="object.evnetypo_id"/></p>'})
+        # templates are now protected, but bypass the check to force having a bad
+        # value in DB
+        with patch.object(type(self.template_reminder), '_check_can_be_rendered', return_value=True):
+            self.template_reminder.with_user(user_admin).write({
+                'name': 'Take Ownership',
+                'body_html': '<p>Failing <t t-out="object.evnetypo_id"/></p>',
+            })
 
         before_scheduler = self.test_event.event_mail_ids.filtered(lambda s: s.interval_type == "before_event")
         self.assertTrue(before_scheduler)

--- a/addons/lunch/data/mail_template_data.xml
+++ b/addons/lunch/data/mail_template_data.xml
@@ -4,10 +4,10 @@
     <record id="lunch_order_mail_supplier" model="mail.template">
         <field name="name">Lunch: Supplier Order</field>
         <field name="model_id" ref="lunch.model_lunch_supplier"/>
-        <field name="email_from">{{ ctx['order']['email_from'] }}</field>
-        <field name="partner_to">{{ ctx['order']['supplier_id'] }}</field>
+        <field name="email_from">{{ ctx.get('order', {}).get('email_from') }}</field>
+        <field name="partner_to">{{ ctx.get('order', {}).get('supplier_id') }}</field>
         <field name="use_default_to" eval="False"/>
-        <field name="subject">Orders for {{ ctx['order']['company_name'] }}</field>
+        <field name="subject">Orders for {{ ctx.get('order', {}).get('company_name') }}</field>
         <field name="lang">{{ ctx.get('default_lang') }}</field>
         <field name="description">Sent to vendor with the order of the day</field>
         <field name="body_html" type="html">
@@ -37,7 +37,7 @@
                     <td valign="top" style="font-size: 13px;">
     <div>
         <t t-set="lines" t-value="ctx.get('lines', [])"/>
-        <t t-set="order" t-value="ctx.get('order')"/>
+        <t t-set="order" t-value="ctx.get('order', {})"/>
         <t t-set="currency" t-value="user.env['res.currency'].browse(order.get('currency_id'))"/>
         <p>
         Dear <t t-out="order.get('supplier_name', '')">Laurie Poiret</t>,
@@ -87,7 +87,7 @@
                     <td></td>
                     <td></td>
                     <td style="width: 100%; font-size: 13px; border-top: 1px solid black;"><strong>Total</strong></td>
-                    <td style="width: 100%; font-size: 13px; border-top: 1px solid black;" align="right"><strong t-out="format_amount(order['amount_total'], currency) or ''">$ 10.00</strong></td>
+                    <td style="width: 100%; font-size: 13px; border-top: 1px solid black;" align="right"><strong t-out="order.get('amount_total') and format_amount(order['amount_total'], currency) or ''">$ 10.00</strong></td>
                 </tr>
             </tbody>
         </table>

--- a/addons/mail/tests/test_mail_render.py
+++ b/addons/mail/tests/test_mail_render.py
@@ -573,9 +573,9 @@ class TestMailRenderSecurity(TestMailRenderCommon):
         """Check that default template values are implicitly allowed for the specific field they define."""
         def patched_mail_template_default_values(model):
             return {
-                'email_cc': '{{ object.user_ids[0].email }}',  # inline
-                'lang': '{{ object.user_ids[0].lang }}',  # inline
-                'body_html': '<p>Hi <t t-out="object.user_ids[0].name"/></p>',  # qweb
+                'email_cc': '{{ object.user_ids and object.user_ids[0].email }}',  # inline
+                'lang': '{{ object.user_ids and object.user_ids[0].lang }}',  # inline
+                'body_html': '<p>Hi <t t-out="object.user_ids and object.user_ids[0].name"/></p>',  # qweb
             }
         template_defaults = patched_mail_template_default_values(self.env['mail.template'])
         partner_model_id = self.env['ir.model']._get_id('res.partner')

--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -77,7 +77,6 @@ class TestMailNotifyAPI(TestMessagePostCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-
         cls.test_lang_records = cls.env['mail.test.lang'].create([
             {
                 'customer_id': False,


### PR DESCRIPTION
This commit adds a constraint on the mail template to prevent saving a template with an invalid object reference.

Task-3389374
