### PR TITLE
[FIX] website_profile, gamification: fix weekly/monthly leaderboards

### DIFF
--- a/addons/gamification/models/res_users.py
+++ b/addons/gamification/models/res_users.py
@@ -122,6 +122,47 @@ class Users(models.Model):
         self.env['gamification.karma.tracking'].sudo().create(create_values)
         return True
 
+    @api.model
+    def _get_user_ids_ranked_by_karma(self, user_domain, from_date=None, to_date=None, limit=30, offset=0):
+        """ Return the list of user_ids satisfying the domain, sorted by their
+        karma gain during the specified period.
+
+        This method is designed for the website leaderboard pagination. It
+        computes the ranking based on the sum of gamification.karma.tracking
+        values within the given dates."""
+
+        where_query = self.env['res.users']._where_calc(user_domain)
+        user_from_clause, user_where_clause, where_clause_params = where_query.get_sql()
+
+        params = []
+        if from_date:
+            date_from_condition = 'AND tracking.tracking_date >= %s::DATE'
+            params.append(from_date)
+        if to_date:
+            date_to_condition = "AND tracking.tracking_date < %s::DATE + interval '1' day"
+            params.append(to_date)
+        params.extend([limit, offset])
+
+        query = """
+            SELECT "res_users".id as user_id
+            FROM %(user_from_clause)s
+            LEFT JOIN "gamification_karma_tracking" as "tracking"
+                ON "res_users".id = "tracking".user_id
+            WHERE %(user_where_clause)s %(date_from_condition)s %(date_to_condition)s
+            GROUP BY "res_users".id
+            ORDER BY COALESCE(SUM("tracking".new_value - "tracking".old_value), 0) DESC, "res_users".id DESC
+            LIMIT %%s OFFSET %%s
+        """ % {
+            'user_from_clause': user_from_clause,
+            'user_where_clause': user_where_clause or (not from_date and not to_date and 'TRUE') or '',
+            'date_from_condition': date_from_condition if from_date else '',
+            'date_to_condition': date_to_condition if to_date else '',
+        }
+
+        self.env.cr.execute(query, tuple(where_clause_params + params))
+        res = self.env.cr.fetchall()
+        return [r[0] for r in res]
+
     def _get_tracking_karma_gain_position(self, user_domain, from_date=None, to_date=None):
         """ Get absolute position in term of gained karma for users. First a ranking
         of all users is done given a user_domain; then the position of each user

--- a/addons/gamification/tests/test_karma_tracking.py
+++ b/addons/gamification/tests/test_karma_tracking.py
@@ -50,6 +50,36 @@ class TestKarmaTrackingCommon(common.TransactionCase):
             old_value = new_value
             track_date = track_date + relativedelta(days=days_delta)
 
+    def test_get_user_ids_ranked_by_karma(self):
+        """Test the optimized raw SQL ranking method with various timeframes and pagination."""
+        self._create_trackings(self.test_user, 20, 2, self.test_date, days_delta=30)
+        self._create_trackings(self.test_user_2, 10, 20, self.test_date, days_delta=2)
+        domain = [("id", "in", (self.test_user.id, self.test_user_2.id))]
+
+        # All-time: test_user_2 (200) > test_user (40)
+        user_ids = self.env["res.users"]._get_user_ids_ranked_by_karma(domain)
+        self.assertEqual(user_ids, [self.test_user_2.id, self.test_user.id])
+
+        # Before specific date: test_user (20) > test_user_2 (10)
+        user_ids = self.env["res.users"]._get_user_ids_ranked_by_karma(
+            domain, to_date=self.test_date + relativedelta(day=2)
+        )
+        self.assertEqual(user_ids, [self.test_user.id, self.test_user_2.id])
+
+        # After specific date: test_user_2 (50) > test_user (20)
+        user_ids = self.env["res.users"]._get_user_ids_ranked_by_karma(
+            domain, from_date=self.test_date + relativedelta(months=1, day=1)
+        )
+        self.assertEqual(user_ids, [self.test_user_2.id, self.test_user.id])
+
+        # Limit: Returns only the top overall user (test_user_2 with 200)
+        user_ids = self.env["res.users"]._get_user_ids_ranked_by_karma(domain, limit=1)
+        self.assertEqual(user_ids, [self.test_user_2.id])
+
+        # Offset: Skips the top user, returns the 2nd overall user (test_user with 40)
+        user_ids = self.env["res.users"]._get_user_ids_ranked_by_karma(domain, limit=1, offset=1)
+        self.assertEqual(user_ids, [self.test_user.id])
+
     def test_computation_gain(self):
         self._create_trackings(self.test_user, 20, 2, self.test_date, days_delta=30)
         self._create_trackings(self.test_user_2, 10, 20, self.test_date, days_delta=2)

--- a/addons/website_profile/controllers/main.py
+++ b/addons/website_profile/controllers/main.py
@@ -232,11 +232,34 @@ class WebsiteProfile(http.Controller):
                                           scope=page_count if page_count < self._pager_max_pages else self._pager_max_pages,
                                           url_args=kwargs)
 
-            users = User.sudo().search(dom, limit=self._users_per_page, offset=pager['offset'], order='karma DESC')
-            user_values = self._prepare_all_users_values(users)
-
             # Get karma position for users (only website_published)
             position_domain = [('karma', '>', 1), ('website_published', '=', True)]
+
+            if group_by:
+                to_date = fields.Date.today()
+                if group_by == 'week':
+                    from_date = to_date - relativedelta(weeks=1)
+                elif group_by == 'month':
+                    from_date = to_date - relativedelta(months=1)
+                else:
+                    from_date = None
+                user_ids = request.env['res.users']._get_user_ids_ranked_by_karma(
+                    dom,
+                    from_date=from_date,
+                    to_date=to_date,
+                    limit=self._users_per_page,
+                    offset=pager['offset'],
+                )
+                users = User.sudo().browse(user_ids)
+            else:
+                users = User.sudo().search(
+                    dom,
+                    limit=self._users_per_page,
+                    offset=pager['offset'],
+                    order='karma DESC, id DESC',
+                )
+
+            user_values = self._prepare_all_users_values(users)
             position_map = self._get_position_map(position_domain, users, group_by)
 
             max_position = max([user_data['karma_position'] for user_data in position_map.values()], default=1)

--- a/addons/website_profile/tests/test_website_profile.py
+++ b/addons/website_profile/tests/test_website_profile.py
@@ -1,6 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from unittest.mock import patch
+from datetime import date
+from dateutil.relativedelta import relativedelta
 import odoo.tests
+
 from odoo.addons.gamification.tests.common import HttpCaseGamification
 
 
@@ -12,3 +16,59 @@ class TestWebsiteProfile(HttpCaseGamification):
             karma=100, website_published=True
         )
         self.start_tour("/", 'website_profile_description', login="admin")
+
+    @patch('odoo.addons.website_profile.controllers.main.WebsiteProfile._users_per_page', 2)
+    def test_leaderboard_pagination_by_period(self):
+        """Test that pagination works correctly when grouping by week/month/all."""
+        users = self.env['res.users']
+        for user_name in ['a', 'b', 'c', 'd']:
+            users |= odoo.tests.new_test_user(
+                self.env, f'test_user_{user_name}',
+                name=f'Test User {user_name.upper()}',
+                website_published=True,
+            )
+        user_a, user_b, user_c, user_d = users
+
+        # Wipe any stray tracking in the DB to neutralize demo/admin users
+        self.env['gamification.karma.tracking'].search([]).unlink()
+
+        one_year_ago = date.today() - relativedelta(years=1)
+        two_weeks_ago = date.today() - relativedelta(weeks=2)
+        today = date.today()
+
+        self.env['gamification.karma.tracking'].create([
+            # User A: 40k gained 1 year ago (0 recent gain)
+            {'user_id': user_a.id, 'old_value': 0, 'new_value': 40000, 'tracking_date': one_year_ago},
+            # User B: 10k gained 1 year ago, 20k gained this month
+            {'user_id': user_b.id, 'old_value': 0, 'new_value': 10000, 'tracking_date': one_year_ago},
+            {'user_id': user_b.id, 'old_value': 10000, 'new_value': 30000, 'tracking_date': two_weeks_ago},
+            # User C: 10k gained 1 year ago, 10k gained this week
+            {'user_id': user_c.id, 'old_value': 0, 'new_value': 10000, 'tracking_date': one_year_ago},
+            {'user_id': user_c.id, 'old_value': 10000, 'new_value': 20000, 'tracking_date': today},
+            # User D: 10k gained 1 year ago, 5k gained this week
+            {'user_id': user_d.id, 'old_value': 0, 'new_value': 10000, 'tracking_date': one_year_ago},
+            {'user_id': user_d.id, 'old_value': 10000, 'new_value': 15000, 'tracking_date': today},
+        ])
+
+        test_cases = [
+            # All Time Total Karma: A (40k), B (30k), C (20k), D (15k)
+            ('/profile/users', [user_a, user_b]),
+            ('/profile/users/page/2', [user_c, user_d]),
+
+            # This Month Karma Gain: B (20k), C (10k), D (5k), A (0)
+            ('/profile/users?group_by=month', [user_b, user_c]),
+            ('/profile/users/page/2?group_by=month', [user_d]),
+
+            # This Week Karma Gain: C (10k), D (5k), A (0), B (0)
+            ('/profile/users?group_by=week', [user_c, user_d]),
+            ('/profile/users/page/2?group_by=week', []),
+        ]
+
+        for url, expected_users in test_cases:
+            with self.subTest(url=url):
+                html = self.url_open(url).text
+                for user in users:
+                    if user in expected_users:
+                        self.assertIn(user.name, html)
+                    else:
+                        self.assertNotIn(user.name, html)


### PR DESCRIPTION
[FIX] website_profile, gamification: fix weekly/monthly leaderboards

Prior to this commit, the leaderboard pagination logic was flawed when
filtering by specific time periods (e.g., "This Week" or "This Month").

The system would first retrieve users sorted by their *all-time* global
karma, apply pagination (taking the top X users), and only then calculate
the karma gain for the specific period for those few users.

This caused users with high recent activity but low all-time karma to only
be displayed much later in the page order than they should.

This commit fixes the issue by introducing a pre-search step that
calculates the karma gain for the requested period at the database level.
Pagination is now applied to this specific result set, ensuring users are
correctly ranked by their actual performance during that week or month.

Note: A new method `_get_users_by_tracking_karma_gain` was added to
`res.users` to handle this logic. This approach was chosen to strictly
preserve the signature of existing methods for the stable version.
A distinct refactor to unify these calculation methods is planned for
the master branch.

Steps to reproduce:

- Install the eLearning module.
- Create a few users with different karma_points (more than 25 to have 2 pages).
- Go to /profile/users.
- Group by week.
- Paginate, and you will notice that the order is wrong; the first user on the second page might have more points than users on the first page. Also, when the logged-in user is not on that page, they do not appear at the bottom.

task-5344657
opw-3979785
