### PR TITLE
[FIX] im_livechat: crash when thread name contains non-ASCII characters

### DIFF
--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_service.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_service.js
@@ -318,8 +318,8 @@ export class ChatBotService {
      * Clear outdated storage.
      */
     async clear() {
-        const chatbotStorageKey = this.livechatService.sessionCookie
-            ? `im_livechat.chatbot.state.uuid_${this.livechatService.sessionCookie.uuid}`
+        const chatbotStorageKey = this.livechatService.savedState
+            ? `im_livechat.chatbot.state.uuid_${this.livechatService.savedState.uuid}`
             : "";
         for (let i = 0; i < browser.localStorage.length; i++) {
             const key = browser.localStorage.key(i);
@@ -406,7 +406,7 @@ export class ChatBotService {
 
     get savedState() {
         const raw = browser.localStorage.getItem(
-            `im_livechat.chatbot.state.uuid_${this.livechatService.sessionCookie?.uuid}`
+            `im_livechat.chatbot.state.uuid_${this.livechatService.savedState?.uuid}`
         );
         return raw ? JSON.parse(raw) : null;
     }

--- a/addons/im_livechat/static/src/embed/common/expirable_storage.js
+++ b/addons/im_livechat/static/src/embed/common/expirable_storage.js
@@ -1,0 +1,52 @@
+/* @odoo-module */
+
+import { browser } from "@web/core/browser/browser";
+
+const BASE_STORAGE_KEY = "EXPIRABLE_STORAGE";
+const CLEAR_INTERVAL = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
+
+function cleanupExpirableStorage() {
+    const now = Date.now();
+    for (const key of Object.keys(browser.localStorage)) {
+        if (key.startsWith(BASE_STORAGE_KEY)) {
+            const item = JSON.parse(browser.localStorage.getItem(key));
+            if (item.expires && item.expires < now) {
+                browser.localStorage.removeItem(key);
+            }
+        }
+    }
+}
+
+export const expirableStorage = {
+    /** @param {string} key */
+    getItem(key) {
+        cleanupExpirableStorage();
+        const item = browser.localStorage.getItem(`${BASE_STORAGE_KEY}_${key}`);
+        if (item) {
+            return JSON.parse(item).value;
+        }
+        return null;
+    },
+    /**
+     * @param {string} key
+     * @param {string} value
+     * @param {number} ttl Number of seconds after which the item should expire.
+     */
+    setItem(key, value, ttl) {
+        let expires;
+        if (ttl) {
+            expires = Date.now() + ttl * 1000;
+        }
+        browser.localStorage.setItem(
+            `${BASE_STORAGE_KEY}_${key}`,
+            JSON.stringify({ value, expires })
+        );
+    },
+    /** @param {string} key */
+    removeItem(key) {
+        browser.localStorage.removeItem(`${BASE_STORAGE_KEY}_${key}`);
+    },
+};
+
+cleanupExpirableStorage();
+setInterval(cleanupExpirableStorage, CLEAR_INTERVAL);

--- a/addons/im_livechat/static/src/embed/common/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_service.js
@@ -1,4 +1,5 @@
 /* @odoo-module */
+import { expirableStorage } from "@im_livechat/embed/common/expirable_storage";
 
 import { Record } from "@mail/core/common/record";
 import { reactive } from "@odoo/owl";
@@ -37,6 +38,8 @@ export const ODOO_VERSION_KEY = `${location.origin.replace(
 export class LivechatService {
     static TEMPORARY_ID = "livechat_temporary_thread";
     SESSION_COOKIE = "im_livechat_session";
+    LIVECHAT_UUID_COOKIE = "im_livechat_uuid";
+    SESSION_STORAGE_KEY = "im_livechat_session";
     OPERATOR_COOKIE = "im_livechat_previous_operator_pid";
     GUEST_TOKEN_STORAGE_KEY = "im_livechat_guest_token";
     /** @type {keyof typeof SESSION_STATE} */
@@ -86,10 +89,7 @@ export class LivechatService {
             const currOdooVersion = init?.odoo_version;
             const visitorUid = this.visitorUid || false;
             const userId = session.user_id || false;
-            if (
-                prevOdooVersion !== currOdooVersion ||
-                (this.sessionCookie && visitorUid !== userId)
-            ) {
+            if (prevOdooVersion !== currOdooVersion || (this.savedState && visitorUid !== userId)) {
                 this.leaveSession({ notifyServer: false });
             }
             browser.localStorage.setItem(ODOO_VERSION_KEY, currOdooVersion);
@@ -109,14 +109,24 @@ export class LivechatService {
         if (Record.isRecord(values?.channel)) {
             values.channel = values.channel.toData();
         }
-        const session = JSON.parse(cookie.get(this.SESSION_COOKIE) ?? "{}");
+        const ONE_DAY_TTL = 60 * 60 * 24;
+        if (this.thread?.uuid) {
+            if (this.thread.uuid) {
+                cookie.set(this.LIVECHAT_UUID_COOKIE, this.thread.uuid, ONE_DAY_TTL);
+            }
+        }
+        const session = this.savedState || {};
         Object.assign(session, {
             visitor_uid: this.visitorUid,
             ...values,
         });
-        cookie.delete(this.SESSION_COOKIE);
+        expirableStorage.removeItem(this.SESSION_STORAGE_KEY);
         cookie.delete(this.OPERATOR_COOKIE);
-        cookie.set(this.SESSION_COOKIE, JSON.stringify(session).replaceAll("→", " "), 60 * 60 * 24); // 1 day cookie.
+        expirableStorage.setItem(
+            this.SESSION_STORAGE_KEY,
+            JSON.stringify(session).replaceAll("→", " "),
+            ONE_DAY_TTL
+        );
         if (session?.operator_pid) {
             cookie.set(this.OPERATOR_COOKIE, session.operator_pid[0], 7 * 24 * 60 * 60); // 1 week cookie.
         }
@@ -129,14 +139,14 @@ export class LivechatService {
      * never be called if the session was not persisted.
      */
     async leaveSession({ notifyServer = true } = {}) {
-        const session = JSON.parse(cookie.get(this.SESSION_COOKIE) ?? "{}");
+        const session = JSON.parse(expirableStorage.getItem(this.SESSION_STORAGE_KEY) ?? "{}");
         try {
             if (session?.uuid && notifyServer) {
                 this.busService.deleteChannel(session.uuid);
                 await this.rpc("/im_livechat/visitor_leave_session", { uuid: session.uuid });
             }
         } finally {
-            cookie.delete(this.SESSION_COOKIE);
+            expirableStorage.removeItem(this.SESSION_STORAGE_KEY);
             this.state = SESSION_STATE.NONE;
             this.sessionInitialized = false;
         }
@@ -182,11 +192,11 @@ export class LivechatService {
      * @returns {Promise<import("models").Thread>|undefined"}
      */
     async getOrCreateThread({ persist = false } = {}) {
-        let threadData = this.sessionCookie;
+        let threadData = this.savedState;
         let isNewlyCreated = false;
         if (!threadData || (!threadData.uuid && persist)) {
-            const chatbotScriptId = this.sessionCookie
-                ? this.sessionCookie.chatbot_script_id
+            const chatbotScriptId = this.savedState
+                ? this.savedState.chatbot_script_id
                 : this.rule.chatbot?.scriptId;
             threadData = await this.rpc(
                 "/im_livechat/get_session",
@@ -240,15 +250,29 @@ export class LivechatService {
         return true;
     }
 
+    /** @deprecated use savedState instead */
     get sessionCookie() {
-        return JSON.parse(cookie.get(this.SESSION_COOKIE) ?? "false");
+        try {
+            return cookie.get(this.SESSION_COOKIE)
+                ? JSON.parse(decodeURI(cookie.get(this.SESSION_COOKIE)))
+                : false;
+        } catch {
+            // Cookies are not supposed to contain non-ASCII characters.
+            // However, some were set in the past. Let's clean them up.
+            cookie.delete(this.SESSION_COOKIE);
+            return false;
+        }
+    }
+
+    get savedState() {
+        return JSON.parse(expirableStorage.getItem(this.SESSION_STORAGE_KEY) ?? false);
     }
 
     get shouldRestoreSession() {
         if (this.state !== SESSION_STATE.NONE) {
             return false;
         }
-        return Boolean(cookie.get(this.SESSION_COOKIE));
+        return Boolean(this.savedState);
     }
 
     /**
@@ -264,16 +288,13 @@ export class LivechatService {
     get thread() {
         return Object.values(this.store.Thread.records).find(
             ({ id, type }) =>
-                type === "livechat" &&
-                id === (this.sessionCookie?.id ?? LivechatService.TEMPORARY_ID)
+                type === "livechat" && id === (this.savedState?.id ?? LivechatService.TEMPORARY_ID)
         );
     }
 
     get visitorUid() {
-        const sessionCookie = this.sessionCookie;
-        return sessionCookie && "visitor_uid" in sessionCookie
-            ? sessionCookie.visitor_uid
-            : session.user_id;
+        const savedState = this.savedState;
+        return savedState && "visitor_uid" in savedState ? savedState.visitor_uid : session.user_id;
     }
 }
 

--- a/addons/im_livechat/static/tests/embed/autopopup_tests.js
+++ b/addons/im_livechat/static/tests/embed/autopopup_tests.js
@@ -2,12 +2,12 @@
 
 import { startServer } from "@bus/../tests/helpers/mock_python_environment";
 
-import { start, loadDefaultConfig } from "@im_livechat/../tests/embed/helper/test_utils";
+import { loadDefaultConfig, start } from "@im_livechat/../tests/embed/helper/test_utils";
+import { expirableStorage } from "@im_livechat/embed/common/expirable_storage";
 
 import { Command } from "@mail/../tests/helpers/command";
 
 import { contains } from "@web/../tests/utils";
-import { cookie } from "@web/core/browser/cookie";
 
 QUnit.module("autopopup");
 
@@ -26,7 +26,7 @@ QUnit.test("persisted session", async () => {
         livechat_operator_id: pyEnv.adminPartnerId,
     });
     const [channelInfo] = pyEnv.mockServer._mockDiscussChannelChannelInfo([channelId]);
-    cookie.set("im_livechat_session", JSON.stringify(channelInfo));
+    expirableStorage.setItem("im_livechat_session", JSON.stringify(channelInfo));
     start();
     await contains(".o-mail-ChatWindow");
 });

--- a/addons/im_livechat/static/tests/embed/livechat_service_tests.js
+++ b/addons/im_livechat/static/tests/embed/livechat_service_tests.js
@@ -10,6 +10,7 @@ import { cookie } from "@web/core/browser/cookie";
 import { click, contains, insertText } from "@web/../tests/utils";
 import { triggerHotkey } from "@web/../tests/helpers/utils";
 import { Deferred } from "@web/core/utils/concurrency";
+import { expirableStorage } from "@im_livechat/embed/common/expirable_storage";
 
 QUnit.module("livechat service");
 
@@ -28,7 +29,7 @@ QUnit.test("persisted session history", async () => {
         livechat_operator_id: pyEnv.adminPartnerId,
     });
     const [channelInfo] = pyEnv.mockServer._mockDiscussChannelChannelInfo([channelId]);
-    cookie.set("im_livechat_session", JSON.stringify(channelInfo));
+    expirableStorage.setItem("im_livechat_session", JSON.stringify(channelInfo));
     pyEnv["mail.message"].create({
         author_id: pyEnv.adminPartnerId,
         body: "Old message in history",

--- a/addons/im_livechat/static/tests/embed/livechat_session_tests.js
+++ b/addons/im_livechat/static/tests/embed/livechat_session_tests.js
@@ -39,13 +39,13 @@ QUnit.test("Thread state is saved on the session", async (assert) => {
     const env = await start();
     await click(".o-livechat-LivechatButton");
     await contains(".o-mail-Thread");
-    assert.strictEqual(env.services["im_livechat.livechat"].sessionCookie.state, "open");
+    assert.strictEqual(env.services["im_livechat.livechat"].savedState.state, "open");
     await click(".o-mail-ChatWindow-header");
     await contains(".o-mail-Thread", { count: 0 });
-    assert.strictEqual(env.services["im_livechat.livechat"].sessionCookie.state, "folded");
+    assert.strictEqual(env.services["im_livechat.livechat"].savedState.state, "folded");
     await click(".o-mail-ChatWindow-header");
     await contains(".o-mail-Thread");
-    assert.strictEqual(env.services["im_livechat.livechat"].sessionCookie.state, "open");
+    assert.strictEqual(env.services["im_livechat.livechat"].savedState.state, "open");
 });
 
 QUnit.test("Seen message is saved on the session", async (assert) => {
@@ -53,13 +53,13 @@ QUnit.test("Seen message is saved on the session", async (assert) => {
     await loadDefaultConfig();
     const env = await start();
     await click(".o-livechat-LivechatButton");
-    assert.notOk(env.services["im_livechat.livechat"].sessionCookie.seen_message_id);
+    assert.notOk(env.services["im_livechat.livechat"].savedState.seen_message_id);
     await insertText(".o-mail-Composer-input", "Hello World!");
     triggerHotkey("Enter");
     await contains(".o-mail-Message", { count: 2 });
     await nextTick(); // wait for message seen
     assert.strictEqual(
-        env.services["im_livechat.livechat"].sessionCookie.seen_message_id,
+        env.services["im_livechat.livechat"].savedState.seen_message_id,
         env.services["im_livechat.livechat"].thread.newestMessage.id
     );
 });

--- a/addons/im_livechat/static/tests/embed/unread_messages_tests.js
+++ b/addons/im_livechat/static/tests/embed/unread_messages_tests.js
@@ -3,11 +3,11 @@
 import { startServer } from "@bus/../tests/helpers/mock_python_environment";
 
 import { loadDefaultConfig, start } from "@im_livechat/../tests/embed/helper/test_utils";
+import { expirableStorage } from "@im_livechat/embed/common/expirable_storage";
 
 import { Command } from "@mail/../tests/helpers/command";
 
 import { contains, focus } from "@web/../tests/utils";
-import { cookie } from "@web/core/browser/cookie";
 
 QUnit.module("thread service");
 
@@ -26,7 +26,7 @@ QUnit.test("new message from operator displays unread counter", async () => {
         livechat_operator_id: pyEnv.adminPartnerId,
     });
     const [channelInfo] = pyEnv.mockServer._mockDiscussChannelChannelInfo([channelId]);
-    cookie.set("im_livechat_session", JSON.stringify(channelInfo));
+    expirableStorage.setItem("im_livechat_session", JSON.stringify(channelInfo));
     const env = await start();
     $(".o-mail-Composer-input").blur();
     pyEnv.withUser(pyEnv.adminUserId, () =>
@@ -54,7 +54,7 @@ QUnit.test("focus on unread livechat marks it as read", async () => {
         livechat_operator_id: pyEnv.adminPartnerId,
     });
     const [channelInfo] = pyEnv.mockServer._mockDiscussChannelChannelInfo([channelId]);
-    cookie.set("im_livechat_session", JSON.stringify(channelInfo));
+    expirableStorage.setItem("im_livechat_session", JSON.stringify(channelInfo));
     const env = await start();
     $(".o-mail-Composer-input").blur();
     pyEnv.withUser(pyEnv.adminUserId, () =>

--- a/addons/website_livechat/models/website_visitor.py
+++ b/addons/website_livechat/models/website_visitor.py
@@ -123,8 +123,7 @@ class WebsiteVisitor(models.Model):
         visitor_id, upsert = super()._upsert_visitor(access_token, force_track_values=force_track_values)
         if upsert == 'inserted':
             visitor_sudo = self.sudo().browse(visitor_id)
-            discuss_channel_uuid = json.loads(request.httprequest.cookies.get('im_livechat_session', '{}')).get('uuid')
-            if discuss_channel_uuid:
+            if discuss_channel_uuid := request.httprequest.cookies.get("im_livechat_uuid"):
                 discuss_channel = request.env["discuss.channel"].sudo().search([("uuid", "=", discuss_channel_uuid)])
                 discuss_channel.write({
                     'livechat_visitor_id': visitor_sudo.id,


### PR DESCRIPTION
The live chat uses cookies to save data about the ongoing
conversation, such as the thread name. When this information contains
non-ASCII characters, the behavior of the cookie is not consistent
across browsers.

Safari does not store it properly, and trying to parse it later on
results in a crash.

Until version 17 ([1]), the fix relied on encoding the data using the
`encodeURIComponent` method. However, cookie size is limited to 4096
bytes, and this limit can be reached.

Starting with version 17.3, the live chat does not use cookies anymore
([2]). This behavior was already backported to 17.1 and ownward but 17.0
was missed. This PR backports this behavior to 17.0 as well.

opw-3968341

[1]: https://github.com/odoo/odoo/pull/168524
[2]: https://github.com/odoo/odoo/pull/167495