### PR TITLE
[FIX] core: crop image of small dimensions

### DIFF
--- a/odoo/addons/base/tests/test_image.py
+++ b/odoo/addons/base/tests/test_image.py
@@ -198,6 +198,10 @@ class TestImage(TransactionCase):
         fill = 0
         bg = 1
 
+        # Images with small dimensions
+        small_width = tools.image_to_base64(Image.new('RGBA', (1, 16)), 'PNG')
+        small_height = tools.image_to_base64(Image.new('RGBA', (16, 1)), 'PNG')
+
         # Format of `tests`: (original base64 image, size parameter, crop parameter, res size, res color (top, bottom, left, right), text)
         tests = [
             (self.base64_1920x1080_png, None, None, (1920, 1080), (fill, fill, bg, bg), "horizontal, verify initial"),
@@ -209,6 +213,7 @@ class TestImage(TransactionCase):
             (self.base64_1920x1080_png, (512, 512), 'bottom', (512, 512), (fill, fill, fill, fill), "horizontal, type bottom"),
             (self.base64_1920x1080_png, (512, 512), 'wrong', (512, 512), (fill, fill, fill, fill), "horizontal, wrong crop value, use center"),
             (self.base64_1920x1080_png, (192, 0), None, (192, 108), (fill, fill, bg, bg), "horizontal, not cropped, just do resize"),
+            (small_height, (25, 50), 'center', (1, 1), (fill, fill, fill, fill), "horizontal, small height, size vertical"),
 
             (self.base64_1080x1920_png, None, None, (1080, 1920), (bg, bg, fill, fill), "vertical, verify initial"),
             (self.base64_1080x1920_png, (2000, 2000), 'center', (1080, 1080), (fill, fill, fill, fill), "vertical, crop biggest possible"),
@@ -219,6 +224,7 @@ class TestImage(TransactionCase):
             (self.base64_1080x1920_png, (512, 512), 'bottom', (512, 512), (fill, bg, fill, fill), "vertical, type bottom"),
             (self.base64_1080x1920_png, (512, 512), 'wrong', (512, 512), (fill, fill, fill, fill), "vertical, wrong crop value, use center"),
             (self.base64_1080x1920_png, (108, 0), None, (108, 192), (bg, bg, fill, fill), "vertical, not cropped, just do resize"),
+            (small_width, (50, 25), 'center', (1, 1), (fill, fill, fill, fill), "vertical, small width, size horizontal"),
         ]
 
         count = 0
@@ -244,7 +250,7 @@ class TestImage(TransactionCase):
             px = (right, half_height)
             self.assertEqual(image.getpixel(px), test[4][3], "%s - color right (%s, %s)" % (test[5], px[0], px[1]))
 
-        self.assertEqual(count, 2 * 9, "ensure the loop is ran")
+        self.assertEqual(count, 2 * 10, "ensure the loop is ran")
 
     def test_15_image_process_colorize(self):
         """Test the colorize parameter of image_process."""

--- a/odoo/tools/image.py
+++ b/odoo/tools/image.py
@@ -277,6 +277,9 @@ class ImageProcess():
             if new_h > h:
                 new_w, new_h = (new_w * h) // new_h, h
 
+            # Dimensions should be at least 1.
+            new_w, new_h = max(new_w, 1), max(new_h, 1)
+
             # Correctly place the center of the crop.
             x_offset = int((w - new_w) * center_x)
             h_offset = int((h - new_h) * center_y)


### PR DESCRIPTION
Issue
-----
If an image has a width or height of 1, crop_resize will fail if we are
trying to resize it to a vertical format (max_height/max_width > 1) if
the original image has a height of 1, or to a horizontal format if the
original image has a width of 1.
This is because the calculated new_w/new_h of the cropped image will be 0.

Steps to reproduce
-----
The issue typically happens when a mail includes spacer images with a height
or width of 1 and they get uploaded as documents and a thumbnail is generated.

An easier way to reproduce in v16.0 (in v15.0 we resize to a square format):
1. Install Documents.
2. Upload an image with a width of 1.
-> Error 500

opw-4053926