### PR TITLE
[FIX] sale_loyalty: re-allow multi rewards with discount from a coupon

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -673,10 +673,12 @@ class SaleOrder(models.Model):
                     continue
                 # Discounts are not allowed if the total is zero unless there is a payment reward, in which case we allow discounts.
                 # If the total is 0 again without the payment reward it will be removed.
-                if reward.reward_type == 'discount' and total_is_zero and (not has_payment_reward or reward.program_id.is_payment_program):
+                is_discount = reward.reward_type == 'discount'
+                is_payment_program = reward.program_id.is_payment_program
+                if is_discount and total_is_zero and (not has_payment_reward or is_payment_program):
                     continue
-                # Skip discount that has already been applied
-                if reward.reward_type == 'discount' and coupon in self.order_line.coupon_id:
+                # Skip discount that has already been applied if not part of a payment program
+                if is_discount and not is_payment_program and reward in self.order_line.reward_id:
                     continue
                 if reward.reward_type == 'product' and not reward.filtered_domain(
                     active_products_domain

--- a/addons/sale_loyalty/tests/test_loyalty.py
+++ b/addons/sale_loyalty/tests/test_loyalty.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import Command
@@ -879,17 +878,24 @@ class TestLoyalty(TestSaleCouponCommon):
         Check that discount rewards already applied won't be shown in the claimable rewards anymore.
         """
         program = self.env['loyalty.program'].create({
-            'name': '10% Discount',
+            'name': '10% Discount & Gift',
             'applies_on': 'current',
             'trigger': 'with_code',
             'program_type': 'promotion',
-            'rule_ids': [(0, 0, {'mode': 'with_code', 'code': '10PERCENT'})],
-            'reward_ids': [(0, 0, {
-                'reward_type': 'discount',
-                'discount': 10,
-                'discount_mode': 'percent',
-                'discount_applicability': 'specific',
-            })],
+            'rule_ids': [Command.create({'mode': 'with_code', 'code': '10PERCENT&GIFT'})],
+            'reward_ids': [
+                Command.create({
+                    'reward_type': 'product',
+                    'reward_product_id': self.product_B.id,
+                    'reward_product_qty': 1,
+                }),
+                Command.create({
+                    'reward_type': 'discount',
+                    'discount': 10,
+                    'discount_mode': 'percent',
+                    'discount_applicability': 'specific',
+                }),
+            ],
         })
 
         coupon = self.env['loyalty.card'].create({
@@ -901,6 +907,9 @@ class TestLoyalty(TestSaleCouponCommon):
             'order_line': [Command.create({'product_id': self.product_a.id})]
         })
 
-        self._claim_reward(order, program, coupon)
-        rewards = order._get_claimable_rewards()
-        self.assertFalse(rewards, "No program should be applicable")
+        product_reward = program.reward_ids.filtered(lambda reward: reward.reward_type == 'product')
+        discount_reward = program.reward_ids - product_reward
+        order._apply_program_reward(discount_reward, coupon)
+        rewards = order._get_claimable_rewards()[coupon]
+        msg = "Only the free product should be applicable, as the discount was already applied."
+        self.assertEqual(rewards, product_reward, msg)


### PR DESCRIPTION
Following commit 380115da5ed346333512e63093a5cb3be217eeed a bug was introduced, preventing the user from claiming a discount reward if another reward was already claimed with the same coupon.
