### PR TITLE
[IMP] website: introduce s_key_benefits snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -45,6 +45,7 @@
         'views/snippets/s_text_block.xml',
         'views/snippets/s_features.xml',
         'views/snippets/s_three_columns.xml',
+        'views/snippets/s_key_benefits.xml',
         'views/snippets/s_picture.xml',
         'views/snippets/s_carousel.xml',
         'views/snippets/s_alert.xml',

--- a/addons/website/views/snippets/s_key_benefits.xml
+++ b/addons/website/views/snippets/s_key_benefits.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_key_benefits" name="Key benefits">
+    <section class="s_key_benefits pt48 pb48">
+        <div class="container">
+            <div class="row o_grid_mode s_nb_column_fixed" data-row-count="11" style="column-gap: 48px;">
+                <div class="o_grid_item g-col-lg-4 g-height-1 col-lg-4" style="--grid-item-padding-x: 16px; --grid-item-padding-y: 0px; grid-area: 1 / 1 / 2 / 5; z-index: 1;">
+                    <p class="lead">
+                        ✽&#160;&#160;What We Offer
+                    </p>
+                </div>
+                <div class="o_grid_item g-col-lg-12 g-height-3 col-lg-12 pb96" style="--grid-item-padding-x: 16px; --grid-item-padding-y: 0px; grid-area: 2 / 1 / 5 / 13; z-index: 2;">
+                    <h2 class="display-3">Discover our<br/>main three benefits</h2>
+                </div>
+                <div class="o_grid_item g-col-lg-4 g-height-7 col-lg-4 pt48 pb24" style="--grid-item-padding-x: 16px; grid-area: 6 / 1 / 12 / 5; z-index: 3;">
+                    <span class="display-3 text-o-color-1">1</span>
+                    <div class="s_hr pt8 pb24" data-snippet="s_hr">
+                        <hr class="w-100 mx-auto"/>
+                    </div>
+                    <h3 class="h4-fs">Fair pricing</h3>
+                    <p>We provide transparent pricing that offers great value, ensuring you always get the best deal without hidden costs.</p>
+                </div>
+                <div class="o_grid_item g-col-lg-4 g-height-7 col-lg-4 pt48 pb24" style="--grid-item-padding-x: 16px; grid-area: 6 / 5 / 12 / 9; z-index: 4;">
+                    <span class="display-3 text-o-color-1">2</span>
+                    <div class="s_hr pt8 pb24" data-snippet="s_hr">
+                        <hr class="w-100 mx-auto"/>
+                    </div>
+                    <h3 class="h4-fs">24/7 Support</h3>
+                    <p>Our support team is available 24/7 to assist with any inquiries or issues, ensuring you get help whenever you need it.</p>
+                </div>
+                <div class="o_grid_item g-col-lg-4 g-height-7 col-lg-4 pt48 pb24" style="--grid-item-padding-x: 16px; grid-area: 6 / 9 / 12 / 13; z-index: 5;">
+                    <span class="display-3 text-o-color-1">3</span>
+                    <div class="s_hr pt8 pb24" data-snippet="s_hr">
+                        <hr class="w-100 mx-auto"/>
+                    </div>
+                    <h3 class="h4-fs">Tax free</h3>
+                    <p>Benefit from tax-free shopping, simplifying your purchase and enhancing your savings without any extra costs.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -55,6 +55,14 @@
                     <keywords>gallery, carousel</keywords>
                 </t>
 
+                <!-- Columns group -->
+                <t t-snippet="website.s_three_columns" string="Columns" group="columns">
+                    <keywords>columns, description</keywords>
+                </t>
+                <t t-snippet="website.s_key_benefits" string="Key benefits" group="columns">
+                    <keywords>promotion, characteristic, quality, highlights, specs, advantages, functionalities, features, exhibit, details, capabilities, attributes, promotion, headline, content, overiew, spotlight</keywords>
+                </t>
+
                 <!-- Content group -->
                 <t t-snippet="website.s_text_image" string="Text - Image" group="content">
                     <keywords>content</keywords>
@@ -83,9 +91,6 @@
                     t-image-preview="/website/static/src/img/snippets_previews/s_embed_code_preview.png" t-thumbnail="/website/static/src/img/snippets_thumbs/s_embed_code.svg" group="content"/>
                 <t t-snippet="website.s_numbers" string="Numbers" group="content">
                     <keywords>statistics, stats, KPI</keywords>
-                </t>
-                <t t-snippet="website.s_three_columns" string="Columns" group="columns">
-                    <keywords>columns, description</keywords>
                 </t>
                 <t t-snippet="website.s_features" string="Features" group="content">
                     <keywords>promotion, characteristic, quality</keywords>


### PR DESCRIPTION
This commit introduces a new snippet named `s_key_benefits`.

- requires https://github.com/odoo/design-themes/pull/871

task-4104927
part of task-4077427

<img width="1421" alt="image" src="https://github.com/user-attachments/assets/d84daabf-dfe7-4f56-9171-0baaf82dd111">

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
