### PR TITLE
[FIX] mail: avoid assigning unauthorized company

### DIFF
--- a/addons/mail/controllers/mail.py
+++ b/addons/mail/controllers/mail.py
@@ -88,8 +88,8 @@ class MailController(http.Controller):
                     if not suggested_company:
                         raise AccessError('')
                     cids = cids + [suggested_company.id]
-                    request.future_response.set_cookie('cids', '-'.join([str(cid) for cid in cids]))
                     record_sudo.with_user(uid).with_context(allowed_company_ids=cids).check_access_rule('read')
+                    request.future_response.set_cookie('cids', '-'.join([str(cid) for cid in cids]))
             except AccessError:
                 return cls._redirect_to_messaging()
             else:


### PR DESCRIPTION
As of #157399, the /mail/view route attempts to expand the `cids` cookie with the "suggested_company", which should be the company of the target record, if the current companies for the users aren't sufficient to access it.

Unfortunately, the target record may belong to a company the user does not have access to, so expanding `cids` would lead to an error page, due to accessing a forbidden company.

Previously though, the expanded `cids` would be passed via query params to the redirected URL. It would lead to an error page, but wouldn't permanently impact the user session.

After #157399, the updated `cids` cookie is permanent for the session, and the user will be permanently locked out, each attempt at navigating the backend leading to an error page. For example, going to `/web` will lead to an access error, redirecting the user instantly to `/web/login?error=access`.

To fix this we should first do the access check with the updated `allowed_company_ids`, and only update the cookie if that worked. In case of failure, the user will have an error page, but there will be no impact to their session.