### PR TITLE
[FIX] web_editor: show translate button when hovered

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.backend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.backend.scss
@@ -59,6 +59,12 @@
     }
 }
 
+.o_form_view {
+    .o_field_html:focus-within span.o_field_translate, .o_field_html:hover span.o_field_translate {
+        visibility: visible !important;
+    }
+}
+
 .o_field_html:not(.o_readonly_modifier) {
     .o_editor_banner_icon {
         cursor: pointer;


### PR DESCRIPTION
Steps to reproduce
==================

- Install Email Marketing
- Enable debug mode
- Enable multiple languages
- Go to Email Templates
- Open any record
- Hover over the Subject field => There is a translation button at the end of the line
- Hover over the content html field => The translation button is invisible

Cause of the issue
==================

Recently, the TranslationButton was made invisible if we're not interacting with the related field https://github.com/odoo/odoo/pull/169042

The case was handled for the HtmlField inside web, but not the one from web_editor.

opw-4113284