### PR TITLE
[FIX] mail: 'close all conversation' persistently close chat windows

### DIFF
--- a/addons/mail/static/src/core/common/chat_hub_model.js
+++ b/addons/mail/static/src/core/common/chat_hub_model.js
@@ -51,10 +51,7 @@ export class ChatHub extends Record {
     actuallyHidden = Record.many("ChatWindow");
 
     closeAll() {
-        while (this.opened.length > 0 || this.folded.length > 0) {
-            this.opened[0]?.delete();
-            this.folded[0]?.delete();
-        }
+        [...this.opened, ...this.folded].forEach((cw) => cw.close());
     }
 
     onRecompute() {

--- a/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
+++ b/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
@@ -11,6 +11,8 @@ import {
     startServer,
     triggerHotkey,
     hover,
+    step,
+    assertSteps,
 } from "../mail_test_helpers";
 import { Command, serverState } from "@web/../tests/web_test_helpers";
 import { withUser } from "@web/../tests/_framework/mock_server/mock_server";
@@ -337,15 +339,26 @@ test("More than 7 actually folded chat windows shows a 'hidden' chat bubble menu
 });
 
 test("Can close all chat windows at once", async () => {
+    const closed = new Set();
+    onRpcBefore("/discuss/channel/fold", (args) => {
+        if (args.state === "closed") {
+            closed.add(args.channel_id);
+        }
+        if (closed.size === 20) {
+            step("ALL_CLOSED");
+        }
+    });
     const pyEnv = await startServer();
-    for (let i = 1; i <= 20; i++) {
-        pyEnv["discuss.channel"].create({
-            name: String(i),
-            channel_member_ids: [
-                Command.create({ fold_state: "folded", partner_id: serverState.partnerId }),
-            ],
-        });
-    }
+    const channelIds = pyEnv["discuss.channel"].create(
+        Array(20)
+            .keys()
+            .map((i) => ({
+                name: String(i),
+                channel_member_ids: [
+                    Command.create({ fold_state: "folded", partner_id: serverState.partnerId }),
+                ],
+            }))
+    );
     await start();
     await contains(".o-mail-ChatBubble", { count: 8 }); // max reached
     await contains(".o-mail-ChatBubble", { text: "+13" });
@@ -353,6 +366,14 @@ test("Can close all chat windows at once", async () => {
     await click("button.fa.fa-ellipsis-h[aria-label='Chat Hub Options']");
     await click("button.o-mail-ChatHub-option", { text: "Close all conversations" });
     await contains(".o-mail-ChatBubble", { count: 0 });
+    await assertSteps(["ALL_CLOSED"]);
+    const members = pyEnv["discuss.channel.member"].search_read([
+        ["channel_id", "in", channelIds],
+        ["partner_id", "=", serverState.partnerId],
+    ]);
+    expect(members.map((member) => member.fold_state)).toEqual(
+        [...Array(20).keys()].map(() => "closed")
+    );
 });
 
 test("Can compact chat hub", async () => {


### PR DESCRIPTION
Before this commit, when having several chat windows open or folded, clicking on "Close all conversations" then page reload would show these chat windows again.

This happens because the closing of chat windows and bubbles were only made client-side. Their state is saved server-side, so without telling the server to update state, they would simply have their state unchanged.
