### PR TITLE
[FIX] phone_validation: phone numbers in mexico

### DIFF
--- a/addons/phone_validation/lib/phonenumbers_patch/__init__.py
+++ b/addons/phone_validation/lib/phonenumbers_patch/__init__.py
@@ -50,6 +50,10 @@ else:
         # https://github.com/daviddrysdale/python-phonenumbers/blob/v8.13.31/python/phonenumbers/data/region_MU.py
         phonenumbers.phonemetadata.PhoneMetadata.register_region_loader('MU', _local_load_region)
 
+    if parse_version(phonenumbers.__version__) < parse_version('8.13.43'):
+        # https://github.com/daviddrysdale/python-phonenumbers/blob/v8.13.43/python/phonenumbers/data/region_MX.py
+        phonenumbers.phonemetadata.PhoneMetadata.register_region_loader('MX', _local_load_region)
+
     if parse_version(phonenumbers.__version__) < parse_version('8.12.43'):
         # https://github.com/daviddrysdale/python-phonenumbers/blob/v8.12.43/python/phonenumbers/data/region_PA.py
         phonenumbers.phonemetadata.PhoneMetadata.register_region_loader('PA', _local_load_region)

--- a/addons/phone_validation/lib/phonenumbers_patch/region_MX.py
+++ b/addons/phone_validation/lib/phonenumbers_patch/region_MX.py
@@ -1,0 +1,18 @@
+"""Auto-generated file, do not edit by hand. MX metadata"""
+from ..phonemetadata import NumberFormat, PhoneNumberDesc, PhoneMetadata
+
+PHONE_METADATA_MX = PhoneMetadata(id='MX', country_code=52, international_prefix='0[09]',
+    general_desc=PhoneNumberDesc(national_number_pattern='[2-9]\\d{9}', possible_length=(10,), possible_length_local_only=(7, 8)),
+    fixed_line=PhoneNumberDesc(national_number_pattern='657[12]\\d{6}|(?:2(?:0[01]|2\\d|3[1-35-8]|4[13-9]|7[1-689]|8[1-578]|9[467])|3(?:1[1-79]|[2458][1-9]|3\\d|7[1-8]|9[1-5])|4(?:1[1-57-9]|[25-7][1-9]|3[1-8]|4\\d|8[1-35-9]|9[2-689])|5(?:[56]\\d|88|9[1-79])|6(?:1[2-68]|[2-4][1-9]|5[1-3689]|6[0-57-9]|7[1-7]|8[67]|9[4-8])|7(?:[1346][1-9]|[27]\\d|5[13-9]|8[1-69]|9[17])|8(?:1\\d|2[13-689]|3[1-6]|4[124-6]|6[1246-9]|7[0-378]|9[12479])|9(?:1[346-9]|2[1-4]|3[2-46-8]|5[1348]|[69]\\d|7[12]|8[1-8]))\\d{7}', example_number='2001234567', possible_length=(10,), possible_length_local_only=(7, 8)),
+    mobile=PhoneNumberDesc(national_number_pattern='657[12]\\d{6}|(?:2(?:2\\d|3[1-35-8]|4[13-9]|7[1-689]|8[1-578]|9[467])|3(?:1[1-79]|[2458][1-9]|3\\d|7[1-8]|9[1-5])|4(?:1[1-57-9]|[25-7][1-9]|3[1-8]|4\\d|8[1-35-9]|9[2-689])|5(?:[56]\\d|88|9[1-79])|6(?:1[2-68]|[2-4][1-9]|5[1-3689]|6[0-57-9]|7[1-7]|8[67]|9[4-8])|7(?:[1346][1-9]|[27]\\d|5[13-9]|8[1-69]|9[17])|8(?:1\\d|2[13-689]|3[1-6]|4[124-6]|6[1246-9]|7[0-378]|9[12479])|9(?:1[346-9]|2[1-4]|3[2-46-8]|5[1348]|[69]\\d|7[12]|8[1-8]))\\d{7}', example_number='2221234567', possible_length=(10,), possible_length_local_only=(7, 8)),
+    toll_free=PhoneNumberDesc(national_number_pattern='8(?:00|88)\\d{7}', example_number='8001234567', possible_length=(10,)),
+    premium_rate=PhoneNumberDesc(national_number_pattern='900\\d{7}', example_number='9001234567', possible_length=(10,)),
+    shared_cost=PhoneNumberDesc(national_number_pattern='300\\d{7}', example_number='3001234567', possible_length=(10,)),
+    personal_number=PhoneNumberDesc(national_number_pattern='500\\d{7}', example_number='5001234567', possible_length=(10,)),
+    preferred_international_prefix='00',
+    number_format=[NumberFormat(pattern='(\\d{5})', format='\\1', leading_digits_pattern=['53']),
+        NumberFormat(pattern='(\\d{2})(\\d{4})(\\d{4})', format='\\1 \\2 \\3', leading_digits_pattern=['33|5[56]|81']),
+        NumberFormat(pattern='(\\d{3})(\\d{3})(\\d{4})', format='\\1 \\2 \\3', leading_digits_pattern=['[2-9]'])],
+    intl_number_format=[NumberFormat(pattern='(\\d{2})(\\d{4})(\\d{4})', format='\\1 \\2 \\3', leading_digits_pattern=['33|5[56]|81']),
+        NumberFormat(pattern='(\\d{3})(\\d{3})(\\d{4})', format='\\1 \\2 \\3', leading_digits_pattern=['[2-9]'])],
+    mobile_number_portable_region=True)

--- a/addons/phone_validation/tests/test_phonenumbers_blacklist.py
+++ b/addons/phone_validation/tests/test_phonenumbers_blacklist.py
@@ -13,3 +13,10 @@ class TestPhonenumbersBlacklist(TransactionCase):
         res = blacklist.search([('number', 'in', ['+917 5896 32587'])])
 
         self.assertEqual(len(res), 1, "There should be one result")
+
+    def test_MX_blacklist(self):
+        """ Test that we can add a MX number to the blacklist """
+        blacklist = self.env['phone.blacklist']
+        blacklist.create({'number': '+527201020711'})
+        res = blacklist.search([('number', 'in', ['+527201020711'])])
+        self.assertEqual(len(res), 1, "There should be one result")

--- a/addons/phone_validation/tests/test_phonenumbers_patch.py
+++ b/addons/phone_validation/tests/test_phonenumbers_patch.py
@@ -176,3 +176,11 @@ class TestPhonenumbersPatch(BaseCase):
             self.PhoneInputOutputLine("+22176 707 0065"),
         )
         self._assert_parsing_phonenumbers(parse_test_lines_SN)
+
+    def test_region_MX_monkey_patch(self):
+        """Makes sure that patch for Mexican phone numbers work"""
+        parse_test_lines_MX = (
+            self.PhoneInputOutputLine("+527201020711"),
+            self.PhoneInputOutputLine("+52 72 0102 0711"),
+        )
+        self._assert_parsing_phonenumbers(parse_test_lines_MX)


### PR DESCRIPTION
Mexican numbers are not handled correctly at the moment, having the regional prefix '720' will make the phone invalid, i.e. unable to add it to blacklist.

Changes have been made to the phone numbers in Mexico so we update the patcher metadata accordingly to process phone numbers.

opw-4103415