### PR TITLE
[FIX] hr_holidays : recompute number_of_days for accrual allocation

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -860,7 +860,7 @@ class HolidaysAllocation(models.Model):
     # before every run, as if it was run from date_from, after an optional change in the allocation value
     # the user can simply confirm and validate the allocation. The record is in correct state for the next
     # call of the cron job.
-    @api.onchange('date_from', 'accrual_plan_id', 'date_to')
+    @api.onchange('date_from', 'accrual_plan_id', 'date_to', 'employee_id')
     def _onchange_date_from(self):
         if not self.date_from or self.allocation_type != 'accrual' or self.state == 'validate' or not self.accrual_plan_id\
            or not self.employee_id:


### PR DESCRIPTION
### Steps to reproduce:
	- Install Time-off module
	- Create new allocation
	- If there is a default employee set remove it
	- Select Accrual Allocation
	- Set start date to a year ago
	- Set an employee

### Current behavior before PR:
The allocation days is not getting computed onchange of employees. This is happening because it is computed only when we trigger _onchange_date_from and employee_id is not one of the fields that triggers this onchange method.

### Desired behavior after PR is merged:
Since we are checking if we have an employee_id or not in _onchange_date_from we added the employee_id to be one of the fields that triggers the onchange then to recompute the allocation days

opw-4100075