### PR TITLE
[FIX] mail: no crash on ESC chat window

### DIFF
--- a/addons/mail/static/src/core/common/chat_window_model.js
+++ b/addons/mail/static/src/core/common/chat_window_model.js
@@ -53,11 +53,7 @@ export class ChatWindow extends Record {
         await this._onClose(options);
         this.delete();
         if (escape && indexAsOpened !== -1 && chatHub.actuallyOpened.length > 0) {
-            if (indexAsOpened === chatHub.actuallyOpened.length - 1) {
-                chatHub.actuallyOpened.at(indexAsOpened - 1).focus();
-            } else {
-                chatHub.actuallyOpened.at(indexAsOpened).focus();
-            }
+            chatHub.actuallyOpened[indexAsOpened === 0 ? 0 : indexAsOpened - 1].focus();
         }
     }
 

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -13,6 +13,7 @@
                     'o-isUiSmall': ui.isSmall,
                     'p-3': normal,
                     'o-hasSelfAvatar': !env.inChatWindow and thread,
+                    'o-focused': props.composer.isFocused
                 }" t-attf-class="{{ props.className }}">
             <div class="o-mail-Composer-sidebarMain flex-shrink-0" t-if="!compact and props.sidebar">
                 <img class="o-mail-Composer-avatar o_avatar rounded" t-att-src="store.self.avatarUrl" alt="Avatar of user"/>

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -344,6 +344,45 @@ test("chat window: close on ESCAPE", async () => {
     await assertSteps(["channel_fold/closed"]);
 });
 
+test("chat window: close on ESCAPE (multi)", async () => {
+    const pyEnv = await startServer();
+    pyEnv["discuss.channel"].create(
+        Array(4)
+            .keys()
+            .map((i) => ({
+                name: `channel_${i}`,
+                channel_member_ids: [
+                    Command.create({ fold_state: "open", partner_id: serverState.partnerId }),
+                ],
+            }))
+    );
+    patchUiSize({ width: 1920 });
+    await start();
+    await contains(".o-mail-ChatWindow", { count: 4 }); // expected order: 3, 2, 1, 0
+    await contains(".o-mail-ChatWindow:eq(0)", { text: "channel_3" });
+    await contains(".o-mail-ChatWindow:eq(1)", { text: "channel_2" });
+    await contains(".o-mail-ChatWindow:eq(2)", { text: "channel_1" });
+    await contains(".o-mail-ChatWindow:eq(3)", { text: "channel_0" });
+    await focus(".o-mail-Composer-input:eq(3)");
+    triggerHotkey("Escape");
+    await contains(".o-mail-ChatWindow", { count: 3 });
+    await contains(".o-mail-ChatWindow:eq(0)", { text: "channel_3" });
+    await contains(".o-mail-ChatWindow:eq(1)", { text: "channel_2" });
+    await contains(".o-mail-ChatWindow:eq(2)", { text: "channel_1" });
+    await contains(".o-mail-ChatWindow:eq(2) .o-mail-Composer.o-focused");
+    await focus(".o-mail-Composer-input:eq(0)");
+    triggerHotkey("Escape");
+    await contains(".o-mail-ChatWindow", { count: 2 });
+    await contains(".o-mail-ChatWindow:eq(0)", { text: "channel_2" });
+    await contains(".o-mail-ChatWindow:eq(1)", { text: "channel_1" });
+    await contains(".o-mail-ChatWindow:eq(0) .o-mail-Composer.o-focused");
+    triggerHotkey("Escape");
+    await contains(".o-mail-ChatWindow", { count: 1 });
+    await contains(".o-mail-ChatWindow", { text: "channel_1" });
+    triggerHotkey("Escape");
+    await contains(".o-mail-ChatWindow", { count: 0 });
+});
+
 test("Close composer suggestions in chat window with ESCAPE does not also close the chat window", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({


### PR DESCRIPTION
Before this commit, when 2 chat windows were
open, focusing the chat window on right then
pressing ESC would lead to the following crash:

```
TypeError: Cannot read properties of undefined (reading 'focus')
```

This happens because when closing a chat window, it attempts to focus the next open chat window if any exist. It remembers last index, and picks the next chat window at that index.

Problem was that checking last index was applied on new listing after close, so it was not detecting the closed chat window as last, thus calling Array.at() on a invalid index. So in scenario above with 2 chat windows, the list of indexes was `[0, 1], then `[0]` but index was `1`, so it attempted to access `[0].at(1)` which is `undefined`.

This commit fixes the issue by reliably picking the item at index of last close chat window.
