### PR TITLE
[FIX] l10n_mx: New account for deferred expenses

### DIFF
--- a/addons/l10n_mx/data/template/account.account-mx.csv
+++ b/addons/l10n_mx/data/template/account.account-mx.csv
@@ -17,6 +17,7 @@
 "cuenta119_03","IEPS due","119.03.01","asset_current","True","l10n_mx.tag_debit_balance_account","IEPS pendiente"
 "cuenta120_01","Advance to national suppliers","120.01.01","asset_current","True","l10n_mx.tag_debit_balance_account","Anticipo a proveedores nacional"
 "cuenta120_02","Advance payment to foreign suppliers","120.02.01","asset_current","True","l10n_mx.tag_debit_balance_account","Anticipo a proveedores extranjero"
+"cuenta173_01","Deferred expenses","173.01.01","asset_current","True","l10n_mx.tag_debit_balance_account","Gastos diferidos"
 "cuenta201_01","National suppliers","201.01.01","liability_payable","True","l10n_mx.tag_credit_balance_account","Proveedores nacionales"
 "cuenta205_06_01","Goods Received - No Invoices","205.06.01","liability_current","True","l10n_mx.tag_credit_balance_account","Mercancías Recibidas - No Facturas"
 "cuenta206_01","Domestic customer advance","206.01.01","liability_current","True","l10n_mx.tag_credit_balance_account","Anticipo de cliente nacional"

--- a/addons/l10n_mx/models/template_mx.py
+++ b/addons/l10n_mx/models/template_mx.py
@@ -33,6 +33,7 @@ class AccountChartTemplate(models.AbstractModel):
                 'account_default_pos_receivable_account_id': 'cuenta105_02',
                 'income_currency_exchange_account_id': 'cuenta702_01',
                 'expense_currency_exchange_account_id': 'cuenta701_01',
+                'deferred_expense_account_id': 'cuenta173_01',
                 'account_journal_early_pay_discount_loss_account_id': 'cuenta9993',
                 'account_journal_early_pay_discount_gain_account_id': 'cuenta9994',
                 'tax_cash_basis_journal_id': 'cbmx',


### PR DESCRIPTION
Version: 17.0+

Current behavior:
The default account for Deferred Expense on res.config.setting is "inappropriate". 
A new account should be established according to account codes by SAT mexico, http://omawww.sat.gob.mx/fichas_tematicas/buzon_tributario/Documents/codigo_agrupador.pdf

Purpose of this PR:
To introduce an appropriate account to be used for Deferred expenses and automatically selected upon l10n_mx installation.

Steps to reproduce on Runbot:
1) install l10n_mx
2) Accounting Settings > incorrect account selected for Deferred Expense

opw-4105993