### PR TITLE
[FIX] base: Display values when updating m2o and m2m fields

### DIFF
--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -343,6 +343,7 @@
                             <field name="evaluation_type" class="oe_inline"/>
                             <field name="update_path" widget="DynamicModelFieldSelectorChar" class="oe_inline" options="{'model': 'model_name'}"/>
                             <field name="update_field_id" invisible="True"/>  <!-- The field is store=True and readonly=False, in this view we want to save the value from compute/onchange -->
+                            <field name="update_related_model_id" invisible="True"/> <!-- This field is required for 'resource_ref' to compute possible m2m and m2o values -->
                             <span invisible="evaluation_type != 'value' or not update_field_type == 'many2many'">by</span>
                             <field name="update_m2m_operation" class="oe_inline" invisible="evaluation_type != 'value' or not update_field_type == 'many2many'" required="update_field_type == 'many2many'"/>
                             <span invisible="evaluation_type != 'value' or update_field_type == 'many2many'">to</span>


### PR DESCRIPTION
Version: saas-17.4

Current behavior:
Unable to select a value when trying to update a m2o or m2m field in a server action and automated rules.

Purpose of this PR:
To be able to select a value when updating.

Steps to reproduce on Runbot:
1) Create a Server Action and select 'Update Record'. 
2) Add action to update a m2m or m2o field.
3) Observe that there is no input to select the value for the field.

opw-4113558
opw-4097630
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
