### PR TITLE
[FIX] l10n_in: rectifiy hsn summary in report invoice layout

### DIFF
--- a/addons/l10n_in/views/report_invoice.xml
+++ b/addons/l10n_in/views/report_invoice.xml
@@ -64,15 +64,13 @@
             </t>
         </xpath>
 
-        <xpath expr="//div[@id='payment_term']" position="before">
+        <xpath expr="//div[@id='payment_term']" position="after">
             <t t-if="o.company_id.account_fiscal_country_id.code == 'IN'">
                 <t t-set="hsn_summary" t-value="o._l10n_in_get_hsn_summary_table()"/>
                 <t t-if="hsn_summary">
-                    <div name="l10n_in_hsn_summary" class="mt-3">
-                        <table class="table table-sm table-borderless col-6" style="page-break-inside: avoid;">
-                            <thead>
-                                <th t-att-colspan="hsn_summary['nb_columns']"><h3>HSN Summary</h3></th>
-                            </thead>
+                    <div name="l10n_in_hsn_summary" class="mt-3" style="page-break-inside: avoid;">
+                        <h3>HSN Summary</h3>
+                        <table class="table table-sm table-borderless col-6">
                             <thead>
                                 <th>HSN/SAC</th>
                                 <th class="text-end">Quantity</th>


### PR DESCRIPTION
Before this **PR**:
HSN Summary title was not rendering properly.

After this **PR**:
HSN Summary title now renders correctly.

Technical Reason:
HSN Summary had two thead tags.

**task**-4115362