### PR TITLE
[FIX] base: avoid setting the default 'es' url code when it's unwanted

### DIFF
--- a/odoo/addons/base/data/res_lang_data.xml
+++ b/odoo/addons/base/data/res_lang_data.xml
@@ -8,6 +8,8 @@
         <record id="base.lang_my" model="res.lang">
             <field name="url_code">mya</field>
         </record>
+    </data>
+    <data noupdate="1">
         <!-- es_419 is the new "generic" spanish -->
         <record id="base.lang_es" model="res.lang">
             <field name="url_code">es_ES</field>
@@ -15,7 +17,8 @@
         <record id="base.lang_es_419" model="res.lang">
             <field name="url_code">es</field>
         </record>
-
+    </data>
+    <data>
         <record id="base.lang_ar" model="res.lang">
             <field name="flag_image" type="base64" file="base/static/img/lang_flags/lang_ar.png"/>
         </record>


### PR DESCRIPTION
Steps to reproduce [`17.2`]:

- Start a fresh DB.
- Enable one of the Spanish sub-languages except the `Spanish LATAM`
(the one with default `/es` url code) e.g., `"es_AR"`.
- An error is triggered when upgrading to a `17.3+` version by the code
trying to set the `'es'` url code while it was already available in
another record.

Starting from [1], we allow using the short url code `'es'` when a
Spanish sub-language is enabled (as long as `es_419` is not) [A].

We also update the records in XML to set the Spanish LATAM (`es_419`) as
the one with the default `'es'`, assuming that the `base.lang_es` record
will always hold the `'es'` url code.

Running the XML updates again in the situation of [A] will try to set
the unique `es` url code on a record while another record (other than
`base.lang_es`) is holding it (`"es_AR"` in this case).

The goal of this commit is to simply add a `noupdate` for the XML
updates so they are only loaded on initialization.

[1]: https://github.com/odoo/odoo/commit/a992d2deab9d582cc33dc31f0b1bd610f82add0d


Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
