### PR TITLE
[FIX] stock: forbid line creation on locked done picking

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -959,6 +959,7 @@ class Picking(models.Model):
             'views': [(view_id, 'tree')],
             'domain': [('id', 'in', self.move_line_ids.ids)],
             'context': {
+                'create': self.state != 'done' or not self.is_locked,
                 'default_picking_id': self.id,
                 'default_location_id': self.location_id.id,
                 'default_location_dest_id': self.location_dest_id.id,


### PR DESCRIPTION
### Steps to reproduce:

- Create and validate a delivery order for some product
- Click on the "Detailed Operations" button on top of the picking form

#### > You are able to create new move lines on your picking even thought it is done and locked.

### Cause of the issue:

The `create` attribute of the view determines if the record can or can not be created. However, it is currently not set in the context of the view called by the `action_detailed_operations`.

### Note:

This  `action_detailed_operations` did not exist in 16.0.

opw-4103700
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
