### PR TITLE
[IMP] spreadsheet_dashboard: add a multi-company rule

### DIFF
--- a/addons/spreadsheet_dashboard/models/spreadsheet_dashboard.py
+++ b/addons/spreadsheet_dashboard/models/spreadsheet_dashboard.py
@@ -13,6 +13,7 @@ class SpreadsheetDashboard(models.Model):
     dashboard_group_id = fields.Many2one('spreadsheet.dashboard.group', required=True)
     sequence = fields.Integer()
     is_published = fields.Boolean(default=True)
+    company_id = fields.Many2one('res.company')
     group_ids = fields.Many2many('res.groups', default=lambda self: self.env.ref('base.group_user'))
 
 

--- a/addons/spreadsheet_dashboard/security/security.xml
+++ b/addons/spreadsheet_dashboard/security/security.xml
@@ -8,6 +8,12 @@
         <field name="domain_force">[('group_ids', 'in', user.groups_id.ids)]</field>
     </record>
 
+    <record id="spreadsheet_dashboard_rule_company" model="ir.rule">
+        <field name="name">Dashboard multi-company</field>
+        <field name="model_id" ref="model_spreadsheet_dashboard"/>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
+    </record>
+
     <record id="base.module_category_productivity_dashboard" model="ir.module.category">
         <field name="name">Dashboard</field>
         <field name="description">User access level for Dashboard module</field>

--- a/addons/spreadsheet_dashboard/views/spreadsheet_dashboard_views.xml
+++ b/addons/spreadsheet_dashboard/views/spreadsheet_dashboard_views.xml
@@ -9,6 +9,7 @@
                 <field name="sequence" widget="handle" groups="base.group_system"/>
                 <field name="name"/>
                 <field name="group_ids" widget="many2many_tags" required="1"/>
+                <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
                 <field name="is_published" widget="boolean_toggle"/>
                 <field name="dashboard_group_id" optional="hidden"/>
             </tree>


### PR DESCRIPTION
Purpose
-------

The idea would be to let people define for which companies a dashboard should be showcase. Let's say you sell teddy bears and tennis rackets, you might want to have specific dashboards for each kind of products and avoid your sales rep for tennis racket to see how many teddy bears you sold last month.

Specification
-------------
Add a company field in the configuration and display the dashboard based on the company you're set on.  

Task: 4115536


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
