### PR TITLE
[FIX] web_editor: table picker opens at wrong position

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/powerbox/Powerbox.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/powerbox/Powerbox.js
@@ -278,11 +278,7 @@ export class Powerbox {
      * @private
      */
     _resetPosition() {
-        let options = {};
-        if (this.getContextFromParentRect) {
-            options['parentContextRect'] = this.getContextFromParentRect();
-        }
-        const position = getRangePosition(this.el, this.document, options);
+        const position = getRangePosition(this.el, this.document, { getContextFromParentRect: this.getContextFromParentRect });
         if (position) {
             let { left, top } = position;
             this.el.style.left = `${left}px`;

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -3071,11 +3071,12 @@ export function getRangePosition(el, document, options = {}) {
         offset.left = marginLeft;
     }
 
-    if (options.parentContextRect) {
-        offset.left += options.parentContextRect.left;
-        offset.top += options.parentContextRect.top;
+    if (options.getContextFromParentRect) {
+        const parentContextRect = options.getContextFromParentRect();
+        offset.left += parentContextRect.left;
+        offset.top += parentContextRect.top;
         if (isRtl) {
-            offset.right += options.parentContextRect.left;
+            offset.right += parentContextRect.left;
         }
     }
 


### PR DESCRIPTION
Current behavior before PR:

When creating a table in email marketing using the powerbox command `/table`, the table picker would open at an incorrect position.

Desired behavior after PR is merged:

Now, when using the `/table` powerbox command to create a table in email marketing, the table picker will open at the cursor position.

task-4113199
