### PR TITLE
[FIX] base: don't raise error when create a new view

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -461,6 +461,8 @@ actual arch.
         for view in self:
             view.warning_info = ''
             try:
+                if not view.id:
+                    continue
                 if view.inherit_id:
                     view_arch = etree.fromstring(view.arch)
                     view._valid_inheritance(view_arch)


### PR DESCRIPTION
It is not necessary to add a warning in the view editing interface if the view has not yet been created in the database.The error comes from the method to combine inherited arch which uses a custom sql query.

issue: Go to the settings menu and try to create a view

opw-4107450