### PR TITLE
[FIX] website_sale: fix traceback when user select vietnam country in address

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1131,7 +1131,10 @@ class WebsiteSale(payment_portal.PaymentPortal):
             'countries': ResCountrySudo.search([]),
             'state_id': state_id,
             'country_states': country_sudo.state_ids,
-            'zip_before_city': address_fields.index('zip') < address_fields.index('city'),
+            'zip_before_city': (
+                'zip' in address_fields
+                and address_fields.index('zip') < address_fields.index('city')
+            ),
             'show_vat': (
                 address_type == 'billing'
                 and (
@@ -2117,7 +2120,10 @@ class WebsiteSale(payment_portal.PaymentPortal):
             required_fields = self._get_mandatory_delivery_address_fields(country)
         return {
             'fields': address_fields,
-            'zip_before_city': address_fields.index('zip') < address_fields.index('city'),
+            'zip_before_city': (
+                'zip' in address_fields
+                and address_fields.index('zip') < address_fields.index('city')
+            ),
             'states': [(st.id, st.name, st.code) for st in country.sudo().state_ids],
             'phone_code': country.phone_code,
             'required_fields': list(required_fields),


### PR DESCRIPTION
Currently, a traceback is occurring when the user selects Vietnam country,
while editing the billing address on the e-commerce checkout page.

To reproduce this issue:

1) Install `e-commerce`
2) Add to Cart some products on the shop page of the website 
3) Checkout to the page and you will see an edit option for the address 
4) Edit the billing address and select the country as `Vietnam`

Error:- 
```
ValueError: 'zip' is not in list
```
In the address format for Vietnam, the zip code is not there.
https://github.com/odoo/odoo/blob/90a08b0402dc2dc2c9000775845809335d990061/odoo/addons/base/data/res_country_data.xml#L1547

When the user updates the country to Vietnam a rpc call for `/shop/country_info/` triggers.

In this method, the values for `address_fields` are accessed from the `res.country` with the help of the selected country.

For Vietnam, we don't have any `ZIP`so it leads to a traceback when accessing the 'ZIP' from the address_fields

https://github.com/odoo/odoo/blob/90a08b0402dc2dc2c9000775845809335d990061/addons/website_sale/controllers/main.py#L2113-L2120

With the help of this commit, we can resolve this issue by checking whether the 'ZIP' is in address_fileds or not. Which makes the code more robust.

sentry-5668769259
