### PR TITLE
[FIX] website_sale_delivery: Avoid collect sale orders confirmed in backend

### DIFF
--- a/addons/website_sale_delivery/controllers/main.py
+++ b/addons/website_sale_delivery/controllers/main.py
@@ -65,6 +65,9 @@ class WebsiteSaleDelivery(WebsiteSale):
     @http.route()
     def cart(self, **post):
         order = request.website.sale_get_order()
+        if order and order.state != 'draft':
+            request.session['sale_order_id'] = None
+            order = request.website.sale_get_order()
         if order and order.carrier_id:
             # Express checkout is based on the amout of the sale order. If there is already a
             # delivery line, Express Checkout form will display and compute the price of the

--- a/addons/website_sale_loyalty/controllers/main.py
+++ b/addons/website_sale_loyalty/controllers/main.py
@@ -39,6 +39,9 @@ class WebsiteSale(main.WebsiteSale):
     @http.route(['/shop/cart'], type='http', auth="public", website=True)
     def cart(self, **post):
         order = request.website.sale_get_order()
+        if order and order.state != 'draft':
+            request.session['sale_order_id'] = None
+            order = request.website.sale_get_order()
         if order:
             order._update_programs_and_rewards()
             order._auto_apply_rewards()


### PR DESCRIPTION
[FIX] website_sale: Avoid collect sale orders confirmed in backend

This happens when, during a payment process, when the order is confirmed from the backend and in Website the cart icon is clicked.  What causes the error is that the request is still pinned in the session, so it identifies that certain values ​​should not be loaded and deletes them.

The cart() method identifies if it's not a draft order, and in that case it clears the session order to continue with a new one.  That causes undesired modifications in modules that inherit cart() and execute before calling super(), such as website_sale_delivery, that removes carrier from order. With this motification the method sale_get_order() will now discriminate the orders that are completed and clear ir from the session, avoiding losses of information.

Description of the issue/feature this PR addresses:

This error was detected because the carrier_id was eliminated when following the aforementioned flow. The problem is that clicking on the cart retrieves the order that is in the session, but if it has been confirmed from the backend it should not collect it since at that moment it is not a "cart".

A way to see this clearly is with the 'delivery_auto_refresh' module. This module shows the carrier_id field in sale order view (that exists but is not visible), which is collected at website. The flow that exists nowadays remove this value when we follow this steps:

[Grabación de pantalla desde 16-08-24 10:41:50.webm](https://github.com/user-attachments/assets/9ec82b67-3e73-4083-b65b-be8d59db6a5a)


In this video:
1. Customer starts an order
2. An user confirms the order at backend
3. Customer acceses to /shop/cart
4. Some fields of the sale order can be deleted, such as the delivery carrier

If we confirm the order at backend and then follow the flow shown, the value of this field will dissapear. This happens because, as I said before, clicking the cart icon recovers the confirmed sale order (which is no longer a 'cart') and deletes many values of it.

Current behavior before PR:

If you confirm an order in process from website at backend and then click on the cart icon, certain fields are eliminated.

Desired behavior after PR is merged:

The cart button identifies whether the order is in confirmed status (or quote sent), and if so removes it from the session before the fields are cleared, thus starting a new order.

FL-650-982
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
