### PR TITLE
[FIX] account_tax_python : accept JS format code in Python computed taxes

### DIFF
--- a/addons/account_tax_python/tests/test_tax.py
+++ b/addons/account_tax_python/tests/test_tax.py
@@ -91,3 +91,38 @@ class TestTaxPython(TestTaxCommon):
             {'product': product2},
         ))
         self._assert_tests(tests, mode='py')
+
+    def test_different_syntaxes(self):
+        # Test the different syntaxes that are allowed: "product['standard_price']" and "product.standard_price"
+        tests = []
+        product = self.env['product.product'].create({
+            'name': "product1",
+            'standard_price': 120,
+        })
+        tax1 = self.python_tax("result = product.standard_price * 0.5")
+        tests.append(self._prepare_taxes_computation_test(
+            tax1,
+            130.0,
+            {
+                'total_included': 190.0,
+                'total_excluded': 130.0,
+                'taxes_data': (
+                    (130.0, 60.0),
+                ),
+            },
+            {'product': product},
+        ))
+        tax2 = self.python_tax("result = product['standard_price'] * 0.5")
+        tests.append(self._prepare_taxes_computation_test(
+            tax2,
+            130.0,
+            {
+                'total_included': 190.0,
+                'total_excluded': 130.0,
+                'taxes_data': (
+                    (130.0, 60.0),
+                ),
+            },
+            {'product': product},
+        ))
+        self._assert_tests(tests, mode='py')


### PR DESCRIPTION
Only in saas-17.2 the JS style of addressing product fields is not accepted. 
(`product['standard_price']` is accepted, but not `product.standard_price`)

### Steps to reproduce:
- Create a tax with "Tax Computation" at "Python Code"
- Enter `result = (price_unit - product.standard_price) * 1` as the formula
- In Sales create a SO and add this tax
- An error shows saying product dict has no field standard_price

### Cause:
The code does not consider the formula can be written in JS format.

Before saas-17.2 the information given to `safe_eval` was not a dictionary so it worked.
Since saas-17.2 the information is in a dictionary so to access it you must use the
format `dict['field']`.
In saas-17.4 the code was refactored and the formula is adapted to JS and Python: if
the JS format is used, it will change the formula to use Python format.
(commit: https://github.com/odoo/odoo/commit/5363189842674b77d03e031896cef2e5e970fdf7)

### Solution:
Change the formula to Python format each time it is used. The way to adapt the formula is the same as in saas-17.4 where the JS format is taken into account.

opw-4110562