### PR TITLE
[IMP] website_event{_track/exhibitor}: use website searchbar

### DIFF
--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -74,7 +74,19 @@
                     </t>
                 <div class="o_wevent_search d-flex w-100">
                     <div class="w-100 flex-grow-1">
-                        <t t-call="website_event.events_search_box_input"/>
+                        <t t-call="website.website_search_box_input">
+                            <t t-set="_classes" t-valuef="o_wevent_event_searchbar_form flex-grow-1"/>
+                            <t t-set="search_type">events</t>
+                            <t t-set="action" t-value="'/event/'"/>
+                            <t t-set="display_description" t-valuef="true"/>
+                            <t t-set="display_detail" t-valuef="false"/>
+                            <t t-set="search" t-value="search or searches and searches['search']"/>
+                            <t t-set="placeholder">Search an event..</t>
+                            <t t-foreach="searches" t-as="item">
+                                <input t-if="item != 'search' and item_value != 'all'" type="hidden"
+                                    t-att-name="item" t-att-value="item_value"/>
+                            </t>
+                        </t>
                     </div>
                     <button class="btn btn-light position-relative ms-2 d-lg-none"
                         data-bs-toggle="offcanvas"

--- a/addons/website_event/views/event_templates_widgets.xml
+++ b/addons/website_event/views/event_templates_widgets.xml
@@ -1,40 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-<!-- Search Box -->
-<template id="events_search_box_input" name="Events search box">
-    <t t-call="website.website_search_box_input">
-        <t t-set="_classes" t-valuef="o_wevent_event_searchbar_form flex-grow-1 #{_classes}"/>
-        <t t-set="search_type" t-valuef="events"/>
-        <t t-set="action" t-valuef="/event"/>
-        <t t-set="display_description" t-valuef="true"/>
-        <t t-set="display_detail" t-valuef="false"/>
-        <t t-set="search" t-value="search or searches and searches['search']"/>
-        <t t-set="placeholder">Search an event...</t>
-        <t t-foreach="searches" t-as="item">
-            <input t-if="item != 'search' and item_value != 'all'" type="hidden"
-                t-att-name="item" t-att-value="item_value"/>
-        </t>
-        <t t-out="0"/>
-    </t>
-</template>
-
-<template id="events_search_box" inherit_id="website.website_search_box" primary="True">
-    <xpath expr="//div[@role='search']" position="replace">
-        <form t-attf-class="o_wevent_event_searchbar_form w-100 flex-grow-1 #{_classes}"
-              t-att-action="action if action else '/event'" method="get">
-            <t t-set="search" t-value="search or _searches and _searches['search']"/>
-            <t t-set="placeholder" t-value="placeholder or _placeholder"/>
-            <t>$0</t>
-            <t t-foreach="_searches" t-as="search">
-                <input t-if="search != 'search' and search_value != 'all'" type="hidden"
-                    t-att-name="search" t-att-value="search_value"/>
-            </t>
-            <t t-out="0"/>
-        </form>
-    </xpath>
-</template>
-
 <!-- Timer widget -->
 <template id="display_timer_widget" name="Display Timer Widget">
     <t t-set="pre_countdown_display" t-value="bool(pre_countdown_text) or pre_countdown_display"/>

--- a/addons/website_event_exhibitor/models/__init__.py
+++ b/addons/website_event_exhibitor/models/__init__.py
@@ -5,4 +5,5 @@ from . import event_event
 from . import event_sponsor
 from . import event_sponsor_type
 from . import event_type
+from . import website
 from . import website_event_menu

--- a/addons/website_event_exhibitor/models/event_sponsor.py
+++ b/addons/website_event_exhibitor/models/event_sponsor.py
@@ -20,6 +20,7 @@ class EventSponsor(models.Model):
         'mail.thread',
         'mail.activity.mixin',
         'website.published.mixin',
+        'website.searchable.mixin',
         'chat.room.mixin'
     ]
 
@@ -192,6 +193,24 @@ class EventSponsor(models.Model):
             if sponsor.id:  # avoid to perform a slug on a not yet saved record in case of an onchange.
                 base_url = sponsor.event_id.get_base_url()
                 sponsor.website_url = '%s/event/%s/exhibitor/%s' % (base_url, self.env["ir.http"]._slug(sponsor.event_id), self.env["ir.http"]._slug(sponsor))
+
+    @api.model
+    def _search_get_detail(self, website, order, options):
+        event_id = self.env['ir.http']._unslug(options['event'])[1]
+        mapping = {
+            'name': {'name': 'name', 'type': 'text', 'match': True},
+            'website_url': {'name': 'website_url', 'type': 'text', 'truncate': False},
+            'description': {'name': 'website_description', 'type': 'text', 'truncate': True, 'html': True},
+        }
+        return {
+            'model': 'event.sponsor',
+            'base_domain': [[('event_id', '=', event_id), ('exhibitor_type', '!=', 'sponsor')]],
+            'search_fields': ['name', 'website_description'],
+            'fetch_fields': ['name', 'website_url', 'website_description'],
+            'mapping': mapping,
+            'icon': 'fa-black-tie',
+            'order': order,
+        }
 
     # ------------------------------------------------------------
     # CRUD

--- a/addons/website_event_exhibitor/models/website.py
+++ b/addons/website_event_exhibitor/models/website.py
@@ -1,0 +1,11 @@
+from odoo import models
+
+
+class Website(models.Model):
+    _inherit = "website"
+
+    def _search_get_details(self, search_type, order, options):
+        result = super()._search_get_details(search_type, order, options)
+        if search_type in ['sponsor', 'all'] and options.get('event'):
+            result.append(self.env['event.sponsor']._search_get_detail(self, order, options))
+        return result

--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
@@ -38,11 +38,17 @@
             <div class="o_wesponsor_topbar_filters o_wevent_index_topbar_filters d-flex gap-2"/>
         </form>
         <div class="d-flex w-100 w-lg-auto">
-            <t t-set="exhibitor_search_placeholder">Search an exhibitor ...</t>
-            <t t-call="website_event.events_search_box">
-                <t t-set="_searches" t-value="searches"/>
+            <t t-call="website.website_search_box_input">
+                <t t-set="_classes" t-valuef="o_wevent_event_sponsor_searchbar_form flex-grow-1"/>
+                <t t-set="search_type">sponsor</t>
                 <t t-set="action" t-value="'/event/%s/exhibitors' % (slug(event))"/>
-                <t t-set="_placeholder" t-value="exhibitor_search_placeholder"/>
+                <t t-set="display_detail" t-valuef="false"/>
+                <t t-set="search" t-value="search or searches and searches['search']"/>
+                <t t-set="placeholder">Search an exhibitor ...</t>
+                <t t-foreach="searches" t-as="item">
+                    <input t-if="item != 'search' and item_value != 'all'" type="hidden"
+                        t-att-name="item" t-att-value="item_value"/>
+                </t>
             </t>
             <button class="btn btn-light position-relative ms-2 d-lg-none"
                 data-bs-toggle="offcanvas"

--- a/addons/website_event_track/controllers/event_track.py
+++ b/addons/website_event_track/controllers/event_track.py
@@ -97,7 +97,7 @@ class EventTrackController(http.Controller):
         if searches.get('search'):
             search_domain = expression.AND([
                 search_domain,
-                [('name', 'ilike', searches['search'])]
+                ['|', ('name', 'ilike', searches['search']), ('partner_name', 'ilike', searches['search'])]
             ])
 
         # search on tags

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -15,7 +15,13 @@ class EventTrack(models.Model):
     _name = 'event.track'
     _description = 'Event Track'
     _order = 'priority, date'
-    _inherit = ['mail.thread', 'mail.activity.mixin', 'website.seo.metadata', 'website.published.mixin']
+    _inherit = [
+        'mail.thread',
+        'mail.activity.mixin',
+        'website.seo.metadata',
+        'website.published.mixin',
+        'website.searchable.mixin'
+    ]
 
     @api.model
     def _get_default_stage_id(self):
@@ -430,6 +436,36 @@ class EventTrack(models.Model):
             self.is_published = True
         elif stage.is_cancel:
             self.is_published = False
+
+    # ------------------------------------------------------------
+    # MIXINS
+    # ------------------------------------------------------------
+
+    @api.model
+    def _search_get_detail(self, website, order, options):
+        event_id = self.env['ir.http']._unslug(options['event'])[1]
+        domain = [
+            '&',
+            ('event_id', '=', event_id),
+            '|',
+            ('is_published', '=', True),
+            ('stage_id.is_visible_in_agenda', '=', True),
+        ]
+        mapping = {
+            'description': {'name': 'description', 'type': 'text', 'truncate': True, 'html': True},
+            'name': {'name': 'name', 'type': 'text', 'match': True},
+            'partner_name': {'name': 'partner_name', 'type': 'text', 'match': True, 'html': True},
+            'website_url': {'name': 'website_url', 'type': 'text', 'truncate': False},
+        }
+        return {
+            'model': 'event.track',
+            'base_domain': [domain],
+            'search_fields': ['name', 'partner_name'],
+            'fetch_fields': ['name', 'website_url', 'partner_name', 'description'],
+            'mapping': mapping,
+            'icon': 'fa-microphone',
+            'order': order,
+        }
 
     # ------------------------------------------------------------
     # MESSAGING

--- a/addons/website_event_track/models/website.py
+++ b/addons/website_event_track/models/website.py
@@ -57,3 +57,9 @@ class Website(models.Model):
             image.image = image.image.resize((512, 512))
             image.operationsCount += 1
             website.app_icon = base64.b64encode(image.image_quality(output_format='PNG'))
+
+    def _search_get_details(self, search_type, order, options):
+        result = super()._search_get_details(search_type, order, options)
+        if search_type in ['track', 'all'] and options.get('event'):
+            result.append(self.env['event.track']._search_get_detail(self, order, options))
+        return result

--- a/addons/website_event_track/static/src/snippets/s_searchbar/000.js
+++ b/addons/website_event_track/static/src/snippets/s_searchbar/000.js
@@ -1,0 +1,12 @@
+/** @odoo-module **/
+
+import publicWidget from '@web/legacy/js/public/public_widget';
+
+publicWidget.registry.searchBar.include({
+    /**
+     * @override
+     */
+    _getFieldsNames() {
+        return [...this._super(), 'partner_name'];
+    }
+});

--- a/addons/website_event_track/static/src/snippets/s_searchbar/000.xml
+++ b/addons/website_event_track/static/src/snippets/s_searchbar/000.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<templates xml:space="preserve">
+    <t t-inherit="website.s_searchbar.autocomplete" t-inherit-mode="extension">
+        <xpath expr="//div[@class='o_search_result_item_detail px-3']" position="inside">
+            <span t-if="result['partner_name']" class="small">
+                <span class="fa fa-fw fa-user-circle-o"/> <t t-out="result['partner_name']"/>
+            </span>
+        </xpath>
+    </t>
+</templates>

--- a/addons/website_event_track/views/event_track_templates_list.xml
+++ b/addons/website_event_track/views/event_track_templates_list.xml
@@ -53,11 +53,17 @@
                 </div>
             </div>
             <div class="o_wevent_search d-flex w-100 w-lg-auto">
-                <t t-set="event_search_placeholder">Search a talk ...</t>
-                <t t-call="website_event.events_search_box">
-                    <t t-set="_searches" t-value="searches"/>
+                <t t-call="website.website_search_box_input">
+                    <t t-set="_classes" t-valuef="o_wevent_event_track_searchbar_form flex-grow-1"/>
+                    <t t-set="search_type">track</t>
                     <t t-set="action" t-value="'/event/%s/track' % (slug(event))"/>
-                    <t t-set="_placeholder" t-value="event_search_placeholder"/>
+                    <t t-set="display_detail" t-valuef="false"/>
+                    <t t-set="search" t-value="search or searches and searches['search']"/>
+                    <t t-set="placeholder">Search a talk ...</t>
+                    <t t-foreach="searches" t-as="item">
+                        <input t-if="item != 'search' and item_value != 'all'" type="hidden"
+                            t-att-name="item" t-att-value="item_value"/>
+                    </t>
                 </t>
                 <button class="btn btn-light position-relative ms-2 d-lg-none"
                     data-bs-toggle="offcanvas"

--- a/addons/website_event_track/views/snippets.xml
+++ b/addons/website_event_track/views/snippets.xml
@@ -22,4 +22,15 @@
     </xpath>
 </template>
 
+<record id="website_event_track.s_searchbar_000_js" model="ir.asset">
+    <field name="name">Searchbar 000 JS</field>
+    <field name="bundle">web.assets_frontend</field>
+    <field name="path">website_event_track/static/src/snippets/s_searchbar/000.js</field>
+</record>
+
+<record id="website_event_track.s_searchbar_000_xml" model="ir.asset">
+    <field name="name">Searchbar 000 XML</field>
+    <field name="bundle">web.assets_frontend</field>
+    <field name="path">website_event_track/static/src/snippets/s_searchbar/000.xml</field>
+</record>
 </odoo>


### PR DESCRIPTION
For the exhibitors and tracks a custom search bar is made in the website_event by inheriting the website search bar, Due to this some of the website search bar functionality is not working properly, So rather than fixing the custom search bar, we will use the website search bar.

Specifications
===============
1) Now in website_event_track we will be able to search the track by the speaker's name or track's name and in website_exhibitor we will be able to search by the exhibitor's name.

2) The cross button in the event track and exhibitors search bar will work properly.

3) As we will be using the website search bar, the suggestions will be enabled in the track and exhibitor.

Technical
==========
**website_event_track** - In suggestions only published tracks or tracks in which
it's stage have is_visible_in_agenda is true will only be displayed.

**website_event_exhibitor** - In suggestions, we will only show the exhibitor where
Its exhibitor_type is an exhibitor or online.

Task-3758369