### PR TITLE
[FIX] ensure findInSelection returns nodes in the selection

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -275,6 +275,7 @@ export class SelectionPlugin extends Plugin {
                 direction,
                 textContent: () => (range.collapsed ? "" : selection.toString()),
                 inEditable,
+                intersectsNode: (node) => range.intersectsNode(node),
             };
         }
 

--- a/addons/html_editor/static/src/utils/selection.js
+++ b/addons/html_editor/static/src/utils/selection.js
@@ -13,6 +13,10 @@ import {
 } from "./position";
 
 /**
+ * @typedef { import("./selection_plugin").EditorSelection } EditorSelection
+ */
+
+/**
  * From selection position, checks if it is left-to-right or right-to-left.
  *
  * @param {Node} anchorNode
@@ -33,6 +37,10 @@ export function getCursorDirection(anchorNode, anchorOffset, focusNode, focusOff
         : DIRECTIONS.LEFT;
 }
 
+/**
+ * @param {EditorSelection} selection
+ * @param {string} selector
+ */
 export function findInSelection(selection, selector) {
     const selectorInStartAncestors = closestElement(selection.startContainer, selector);
     if (selectorInStartAncestors) {
@@ -42,7 +50,7 @@ export function findInSelection(selection, selector) {
         return (
             commonElementAncestor &&
             [...commonElementAncestor.querySelectorAll(selector)].find((node) =>
-                selection.commonAncestorContainer.contains(node)
+                selection.intersectsNode(node)
             )
         );
     }

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -403,6 +403,17 @@ describe("Link creation", () => {
                 '<p>a<a href="http://test.com/">bcdef[]</a></p><p>gh</p>'
             );
         });
+        test("when create a link on selection which doesn't include a link, it should create a new one", async () => {
+            await setupEditor(
+                '<p><strong>abc<a href="http://test.com/">de</a>te[st</strong> m]e</p>'
+            );
+            await waitFor(".o-we-toolbar");
+
+            click(".o-we-toolbar .fa-link");
+            await waitFor(".o-we-linkpopover");
+            expect(".o_we_label_link").toHaveValue("st m");
+            expect(".o_we_href_input_link").toHaveValue("");
+        });
     });
 });
 


### PR DESCRIPTION
Before this commit, create a link with toolbar on the selection,
`<p><strong>abc<a href=#>de</a>te[st</strong> m]e</p>`
The existing link is returned instead of creating a new one

After this commit, the new link can be correctly created

Fix: make sure the node returned in findInSelection is selected



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
