### PR TITLE
[FIX] bus: non deterministic ir websocket test

### DIFF
--- a/addons/bus/tests/test_ir_websocket.py
+++ b/addons/bus/tests/test_ir_websocket.py
@@ -29,13 +29,8 @@ class TestIrWebsocket(WebsocketCase):
         websocket = self.websocket_connect(cookie=f"session_id={session.sid};")
         self.subscribe(websocket, [], self.env["bus.bus"]._bus_last_id())
         # offline => online
-        websocket.send(
-            json.dumps(
-                {
-                    "event_name": "update_presence",
-                    "data": {"inactivity_period": 0, "im_status_ids_by_model": {}},
-                }
-            )
+        self.env["bus.presence"]._update_presence(
+            inactivity_period=0, identity_field="user_id", identity_value=bob.id
         )
         self.trigger_notification_dispatching([group_user])
         message = json.loads(websocket.recv())[0]["message"]
@@ -45,16 +40,10 @@ class TestIrWebsocket(WebsocketCase):
         # online => away
         away_timer_later = datetime.now() + timedelta(seconds=AWAY_TIMER + 1)
         with freeze_time(away_timer_later):
-            websocket.send(
-                json.dumps(
-                    {
-                        "event_name": "update_presence",
-                        "data": {
-                            "inactivity_period": (AWAY_TIMER + 1) * 1000,
-                            "im_status_ids_by_model": {},
-                        },
-                    }
-                )
+            self.env["bus.presence"]._update_presence(
+                inactivity_period=(AWAY_TIMER + 1) * 1000,
+                identity_field="user_id",
+                identity_value=bob.id,
             )
             self.trigger_notification_dispatching([group_user])
             message = json.loads(websocket.recv())[0]["message"]
@@ -64,15 +53,10 @@ class TestIrWebsocket(WebsocketCase):
         # away => online
         ten_minutes_later = datetime.now() + timedelta(minutes=10)
         with freeze_time(ten_minutes_later):
-            websocket.send(
-                json.dumps(
-                    {
-                        "event_name": "update_presence",
-                        "data": {"inactivity_period": 0, "im_status_ids_by_model": {}},
-                    }
-                )
+            self.env["bus.presence"]._update_presence(
+                inactivity_period=0, identity_field="user_id", identity_value=bob.id
             )
-            self.trigger_notification_dispatching([self.env.ref("base.group_user")])
+            self.trigger_notification_dispatching([group_user])
             message = json.loads(websocket.recv())[0]["message"]
             self.assertEqual(message["type"], "bus.bus/im_status_updated")
             self.assertEqual(message["payload"]["im_status"], "online")
@@ -80,14 +64,15 @@ class TestIrWebsocket(WebsocketCase):
         # online => online, nothing happens
         ten_minutes_later = datetime.now() + timedelta(minutes=10)
         with freeze_time(ten_minutes_later):
-            websocket.send(
-                json.dumps(
-                    {
-                        "event_name": "update_presence",
-                        "data": {"inactivity_period": 0, "im_status_ids_by_model": {}},
-                    }
-                )
+            self.env["bus.presence"]._update_presence(
+                inactivity_period=0, identity_field="user_id", identity_value=bob.id
             )
             self.trigger_notification_dispatching([group_user])
-            with self.assertRaises(ws._exceptions.WebSocketTimeoutException):
-                message = json.loads(websocket.recv())[0]["message"]
+            timeout_occurred = False
+            # Save point rollback of `assertRaises` can compete with `on_websocket_close`
+            # leading to `InvalidSavepoint` errors. We need to avoid it.
+            try:
+                websocket.recv()
+            except ws._exceptions.WebSocketTimeoutException:
+                timeout_occurred = True
+            self.assertTrue(timeout_occurred)


### PR DESCRIPTION
The `test_notify_on_status_change` ensures user presences are received when updated. To do so, they send a websocket message to the server. However, there is no guarantee the presence was updated after sending the message as the processing is asynchronous.

This PR fixes the issue by directly calling `_update_presence` and waitng for the answer through the websocket.

runbot-74017