### PR TITLE
[IMP] base: Make the company address compute on the related partner

### DIFF
--- a/doc/cla/individual/mavi-tux.md
+++ b/doc/cla/individual/mavi-tux.md
@@ -1,0 +1,11 @@
+Belgium, 2024-10-10
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Mathis Vinit mathis3869@gmail.com

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -115,10 +115,8 @@ class Company(models.Model):
     # partner's contact address
     def _compute_address(self):
         for company in self.filtered(lambda company: company.partner_id):
-            address_data = company.partner_id.sudo().address_get(adr_pref=['contact'])
-            if address_data['contact']:
-                partner = company.partner_id.browse(address_data['contact']).sudo()
-                company.update(company._get_company_address_update(partner))
+            partner = company.partner_id.sudo()
+            company.update(company._get_company_address_update(partner))
 
     def _inverse_street(self):
         for company in self:


### PR DESCRIPTION
The address computation for a company was incorrectly using the address of a partner of type "contact" instead of the partner directly linked to the company. This fix ensures that the computation is based on the correct partner, improving the accuracy of company address updates.

Issue observed in versions 15.0, 16.0, and 17.0.

Simplified the _compute_address method to directly use the linked partner for address updates.

Description of the issue/feature this PR addresses:

Current behavior before PR:
The address computation for my company is being based on the partner of type "contact" instead of the partner linked to my company.

Desired behavior after PR is merged:
The expected behavior would be for the computation to be based on the linked partner.

I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)