### PR TITLE
[FIX] website: use current website's domain in account creation e-mail

### DIFF
--- a/addons/website/data/mail_mail_data.xml
+++ b/addons/website/data/mail_mail_data.xml
@@ -17,4 +17,6 @@
         'attachment_ids',
         ]"/>
     </function>
+    <function model="mail.template" name="apply_website_domain">
+    </function>
 </odoo>

--- a/addons/website/models/__init__.py
+++ b/addons/website/models/__init__.py
@@ -13,6 +13,7 @@ from . import ir_model_data
 from . import ir_module_module
 from . import ir_qweb
 from . import ir_qweb_fields
+from . import mail_template
 from . import mixins
 from . import website
 from . import website_menu

--- a/addons/website/models/mail_template.py
+++ b/addons/website/models/mail_template.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class MailTemplate(models.Model):
+    _inherit = 'mail.template'
+
+    @api.model
+    def apply_website_domain(self):
+        changed = False
+        for template in self.search([('body_html', 'like', ' t-attf-href="/web/login')]):
+            # Replace does not work on markup safe
+            html = str(template.body_html)
+            html = html.replace(
+                ' t-attf-href="/web/login',
+                ' t-attf-href="{{object.env[\'website\'].get_current_website().domain}}/web/login'
+            )
+            template.body_html = html
+            changed = True
+        return changed


### PR DESCRIPTION
The confirmation e-mails when creating a new account contain a link back to the login page on the main domain of the server. When an account is created from a specific website for which a specific domain was specified, this link sends the user to the wrong location.

This commit patches the mail templates in order to target the current website's domain instead.

Steps to reproduce:
- Set up several domains on several websites.
- Activate self-service sign-up.
- Log out.
- Create an account on one of the websites.

=> Received email did contain a link to the wrong domain.

opw-3955350
