### PR TITLE
[16.0] [FIX] mrp_subcontracting_purchase: kit received quantity

### DIFF
--- a/addons/mrp_subcontracting_purchase/models/__init__.py
+++ b/addons/mrp_subcontracting_purchase/models/__init__.py
@@ -4,3 +4,4 @@
 from . import stock_picking
 from . import stock_move
 from . import purchase_order
+from . import purchase_order_line

--- a/addons/mrp_subcontracting_purchase/models/purchase_order_line.py
+++ b/addons/mrp_subcontracting_purchase/models/purchase_order_line.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models, _
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = 'purchase.order.line'
+
+    def _compute_qty_received(self):
+        res = super(PurchaseOrderLine, self.with_context(override_kit_filters=True))._compute_qty_received()
+        return res

--- a/addons/mrp_subcontracting_purchase/models/stock_move.py
+++ b/addons/mrp_subcontracting_purchase/models/stock_move.py
@@ -10,3 +10,11 @@ class StockMove(models.Model):
     def _is_purchase_return(self):
         res = super()._is_purchase_return()
         return res or self._is_subcontract_return()
+
+    def _compute_kit_quantities(self, product_id, kit_qty, kit_bom, filters):
+        if self.env.context.get("override_kit_filters"):
+            filters = {
+                'incoming_moves': lambda m: not m.origin_returned_move_id or (m.origin_returned_move_id and m.to_refund),
+                'outgoing_moves': lambda m: m.to_refund
+            }
+        return super()._compute_kit_quantities(product_id, kit_qty, kit_bom, filters)

--- a/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
+++ b/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
@@ -34,6 +34,35 @@ class MrpSubcontractingPurchaseTest(TestMrpSubcontractingCommon):
                 'product_qty': 1,
             })],
         })
+        self.kit_product = self.env['product.product'].create({
+            'name': 'Kit Product',
+            'type': 'product',
+        })
+        self.bom_kit_product = self.env['mrp.bom'].create({
+            'product_tmpl_id': self.kit_product.product_tmpl_id.id,
+            'type': 'phantom',
+            'bom_line_ids': [(0, 0, {
+                    'product_id': self.comp1.id,
+                    'product_qty': 1,
+                },
+                {
+                    'product_id': self.comp2.id,
+                    'product_qty': 1,
+                }
+            )],
+        })
+        self.kit_product_2 = self.env['product.product'].create({
+            'name': 'Kit Product',
+            'type': 'product',
+        })
+        self.bom_kit_product_2 = self.env['mrp.bom'].create({
+            'product_tmpl_id': self.kit_product_2.product_tmpl_id.id,
+            'type': 'phantom',
+            'bom_line_ids': [(0, 0, {
+                'product_id': self.finished2.id,
+                'product_qty': 1,
+            })],
+        })
 
     def test_count_smart_buttons(self):
         resupply_sub_on_order_route = self.env['stock.route'].search([('name', '=', 'Resupply Subcontractor on Order')])
@@ -479,3 +508,49 @@ class MrpSubcontractingPurchaseTest(TestMrpSubcontractingCommon):
         self.assertEqual(stock_quants.filtered(lambda q: q.location_id == final_loc).quantity, 2.0)
         self.assertEqual(stock_quants.filtered(lambda q: q.location_id == subcontract_loc).quantity, 0.0)
         self.assertEqual(stock_quants.filtered(lambda q: q.location_id == production_loc).quantity, -2.0)
+
+    def test_qty_received_purchase_kit_product(self):
+        """
+            Test that the quantity received when purchasing kits is still correctly computed
+        """
+        # Buy a kit product
+        po = self.env['purchase.order'].create({
+            'partner_id': self.subcontractor_partner1.id,
+            'order_line': [Command.create({
+                'name': self.kit_product.name,
+                'product_id': self.kit_product.id,
+                'product_qty': 2.0,
+                'product_uom': self.kit_product.uom_id.id,
+                'price_unit': 100.0,
+            })],
+        })
+        po.button_confirm()
+        receipt = po.picking_ids
+        # receive the components
+        receipt.move_ids.quantity_done = 2
+        receipt.button_validate()
+
+        self.assertEqual(po.order_line[0].qty_received, 2)
+
+    def test_qty_received_purchase_kit_product_subcontracted_components(self):
+        """
+            Test the quantity received computation when purchasing a kit with a subcontracted component
+        """
+        # Buy a kit product
+        po = self.env['purchase.order'].create({
+            'partner_id': self.subcontractor_partner1.id,
+            'order_line': [Command.create({
+                'name': self.kit_product_2.name,
+                'product_id': self.kit_product_2.id,
+                'product_qty': 1.0,
+                'product_uom': self.kit_product_2.uom_id.id,
+                'price_unit': 100.0,
+            })],
+        })
+        po.button_confirm()
+        receipt = po.picking_ids
+        # receive the components
+        receipt.move_ids.quantity_done = 1
+        receipt.button_validate()
+
+        self.assertEqual(po.order_line[0].qty_received, 1)

--- a/doc/cla/corporate/forgeflow.md
+++ b/doc/cla/corporate/forgeflow.md
@@ -20,3 +20,4 @@ Jordi Masvidal jordi.masvidal@forgeflow.com https://github.com/JordiMForgeFlow
 Hector Villarreal hector.villarreal@forgeflow.com https://github.com/HviorForgeFlow
 Bernat Puig bernat.puig@forgeflow.com https://github.com/BernatPForgeFlow
 Joan Sisquella joan.sisquella@forgeflow.com https://github.com/JoanSForgeFlow
+Marina Alapont marina.alapont@forgeflow.com https://github.com/MarinaAForgeFlow


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When buying a kit product, that has subcontracted components, the qty_received on the purchase order line is not correctly updated after validating the receipt. 

Current behavior before PR:

Currently in the compute method _compute_qty_received a filter is created so that only moves with location with usage "supplier" will be taken into account for incoming moves. 

When buying a kit product with subcontracted components, the location of the moves is set to the subcontractor location, which is configured as "internal" in order to be able to track the stock of the components. Therefore, since the incoming moves are filtered by the usage "supplier", the subcontracted components moves won't be taken into account, making the kit qty_received amount incorrect.

Desired behavior after PR is merged:
The location usage is not taken into account to filter the moves, fixing like this the scenario previously mentioned. 


I also have a doubt regarding the original code. I have made sure that after removing the condition m.location_id.usage == 'supplier' the quantity received is still properly computed. I have tried with kit products with normal components, with kit products with some subcontracted and some normal components, I have tried it when the delivery is in 3 steps. So my question is, why is this condition used to filter the move? In which case it is important  to only consider moves with location usage == 'supplier' ? Am I missing a scenario where this is not accomplished?

