### PR TITLE
[IMP] website: introduce `s_striped_centertop` snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -115,6 +115,7 @@
         'views/snippets/s_cta_badge.xml',
         'views/snippets/s_unveil.xml',
         'views/snippets/s_image_hexagonal.xml',
+        'views/snippets/s_striped_center_top.xml',
         'views/new_page_template_templates.xml',
         'views/website_views.xml',
         'views/website_pages_views.xml',

--- a/addons/website/views/snippets/s_striped_center_top.xml
+++ b/addons/website/views/snippets/s_striped_center_top.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_striped_center_top" name="Striped Center Top">
+    <section class="s_striped_center_top o_cc o_cc5 pb56" data-oe-shape-data="{'shape':'web_editor/Origins/04_001','colors':{'c3': '#FFFFFF'},'flip':['y'], 'showOnMobile':true}">
+        <div class="o_we_shape o_web_editor_Origins_04_001 o_shape_show_mobile" style="background-image: url(&quot;/web_editor/shape/web_editor%2FOrigins%2F04_001.svg?c3=%23FFFFFF&amp;flip=y&quot;); background-position: 50% 100%;"/>
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-8 offset-lg-2 pt56 pb56">
+                    <h1 style="text-align: center;">Turning Vision into Reality</h1>
+                    <p class="lead" style="text-align: center;">We deliver seamless, innovative solutions that not only meet your needs but exceed expectations, driving meaningful results and lasting success.</p>
+                    <p><br /></p>
+                    <p style="text-align: center;">
+                        <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg"><t t-esc="cta_btn_text">Get started</t></a>
+                    </p>
+                </div>
+                <div class="col-lg-12 pb24" style="text-align: center;">
+                    <figure class="figure">
+                        <img src="/web/image/website.s_picture_default_image" class="figure-img img-fluid rounded" alt=""/>
+                        <figcaption class="figure-caption text-600">Crafted with precision and care</figcaption>
+                    </figure>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -57,6 +57,9 @@
                 <t t-snippet="website.s_adventure" string="Adventure" group="intro">
                     <keywords>journey, exploration, travel, outdoor, excitement, quest, start, onboarding, discovery, thrill</keywords>
                 </t>
+                <t t-snippet="website.s_striped_center_top" string="Striped Center Top" group="intro">
+                    <keywords>hero, jumbotron, headline, header, intro, home, content, picture, photo, illustration, media, visual, article, combination, trendy, pattern, design</keywords>
+                </t>
 
                 <!-- Columns group -->
                 <t t-snippet="website.s_three_columns" string="Columns" group="columns">


### PR DESCRIPTION
This commit adds the new `s_striped_centertop` snippet.

task-4105455
Part-of: task-4077427

requires: https://github.com/odoo/design-themes/pull/869

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
