### PR TITLE
[FIX] website_forum: prevent link post to private forum

### DIFF
--- a/addons/website_forum/models/forum.py
+++ b/addons/website_forum/models/forum.py
@@ -570,6 +570,9 @@ class Post(models.Model):
 
     def write(self, vals):
         trusted_keys = ['active', 'is_correct', 'tag_ids']  # fields where security is checked manually
+        if 'forum_id' in vals:
+            forum = self.env['forum.forum'].browse(vals['forum_id'])
+            forum.check_access_rule('write')
         if 'content' in vals:
             vals['content'] = self._update_content(vals['content'], self.forum_id.id)
 


### PR DESCRIPTION
It is necessary to check access rights when linking a post to another forum, so that the user linked
to the post always has access to it.

task-4116016