### PR TITLE
[FIX] l10n_{ar,pe}_pos,point_of_sale: prevent templating issue

### DIFF
--- a/addons/l10n_ar_pos/views/templates.xml
+++ b/addons/l10n_ar_pos/views/templates.xml
@@ -19,7 +19,7 @@
             <attribute name="t-if">pos_order.company_id.country_code != 'AR'</attribute>
         </xpath>
         <xpath expr="//div[@id='get_info_div']" position="after">
-                <t t-else="">
+                <t t-elif="pos_order.company_id.country_code == 'AR'">
                     <h4> Please
                     <a role="button" t-att-href="'/web/login?redirect=/pos/ticket/validate?access_token=%s' % access_token" style="margin-top: -11px"> Sign in</a>
                     in order to save your contact info</h4>

--- a/addons/l10n_pe_pos/views/templates.xml
+++ b/addons/l10n_pe_pos/views/templates.xml
@@ -23,7 +23,7 @@
             <attribute name="t-if" add="(pos_order.company_id.country_code != 'PE')" separator=" and " />
         </xpath>
         <xpath expr="//div[@id='get_info_div']" position="after">
-            <h4 t-else="">
+            <h4 t-elif="pos_order.company_id.country_code == 'PE'">
                 Please
                 <a
                     role="button"


### PR DESCRIPTION
Steps to reproduce:
- Install `l10n_{ar,pe}_pos` and `l10n_ec_edi_pos`
- Enable "Use QR Code on ticket"
- Make an order and validate it inside the POS
- Open in an incognito window the link given by the QR Code

Issues:
Internal error, the cause is the multiple else that are added to the `get_info_div` block.

This problem is blocking #175591 and #175593

related enterprise PR: https://github.com/odoo/enterprise/pull/68432