### PR TITLE
[IMP] spreadsheet: company-dependant currency rate

### DIFF
--- a/addons/spreadsheet/static/src/currency/formulas.js
+++ b/addons/spreadsheet/static/src/currency/formulas.js
@@ -2,7 +2,7 @@
 
 import { _t } from "@web/core/l10n/translation";
 import * as spreadsheet from "@odoo/o-spreadsheet";
-const { arg, toString, toJsDate } = spreadsheet.helpers;
+const { arg, toString, toJsDate, toNumber } = spreadsheet.helpers;
 const { functionRegistry } = spreadsheet.registries;
 
 functionRegistry.add("ODOO.CURRENCY.RATE", {
@@ -10,16 +10,18 @@ functionRegistry.add("ODOO.CURRENCY.RATE", {
         "This function takes in two currency codes as arguments, and returns the exchange rate from the first currency to the second as float."
     ),
     category: "Odoo",
-    compute: function (currencyFrom, currencyTo, date) {
+    compute: function (currencyFrom, currencyTo, date, companyId) {
         const from = toString(currencyFrom);
         const to = toString(currencyTo);
         const _date = date ? toJsDate(date, this.locale) : undefined;
-        return this.getters.getCurrencyRate(from, to, _date);
+        const _companyId = companyId ? toNumber(companyId) : undefined;
+        return this.getters.getCurrencyRate(from, to, _date, _companyId);
     },
     args: [
         arg("currency_from (string)", _t("First currency code.")),
         arg("currency_to (string)", _t("Second currency code.")),
         arg("date (date, optional)", _t("Date of the rate.")),
+        arg("company_id (number, optional)", _t("The company to take the exchange rate from.")),
     ],
     returns: ["NUMBER"],
 });

--- a/addons/spreadsheet/static/src/currency/plugins/currency.js
+++ b/addons/spreadsheet/static/src/currency/plugins/currency.js
@@ -48,14 +48,16 @@ export class CurrencyPlugin extends OdooUIPlugin {
      * Get the currency rate between the two given currencies
      * @param {string} from Currency from
      * @param {string} to Currency to
-     * @param {string} date
+     * @param {string | undefined} date
+     * @param {number | undefined} companyId
      * @returns {number|string}
      */
-    getCurrencyRate(from, to, date) {
+    getCurrencyRate(from, to, date, companyId) {
         const data = this.serverData.batch.get("res.currency.rate", "get_rates_for_spreadsheet", {
             from,
             to,
             date: date ? toServerDateString(date) : undefined,
+            company_id: companyId,
         });
         const rate = data !== undefined ? data.rate : undefined;
         if (rate === false) {


### PR DESCRIPTION
This commit adds the possibility to specify a company when using the `ODOO.CURRENCY.RATE` function, to get the currency rate for a specific company.

Task: [4100297](https://www.odoo.com/web#id=4100297&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
