### PR TITLE
[FIX] point_of_sale: fix missing iot dependency

### DIFF
--- a/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init_posbox_image.sh
+++ b/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init_posbox_image.sh
@@ -110,6 +110,7 @@ PKGS_TO_INSTALL="
     vim \
     x11-utils \
     xdotool \
+    xinput \
     xserver-xorg-input-evdev \
     xserver-xorg-video-dummy \
     xserver-xorg-video-fbdev"


### PR DESCRIPTION
IoT image was missing `xinput` dependency.

Required by: [https://github.com/odoo/odoo/pull/174009](https://github.com/odoo/odoo/pull/174009)