### PR TITLE
[FIX] sale_pdf_quote_builder: allows multiline in form fields

### DIFF
--- a/odoo/tools/pdf.py
+++ b/odoo/tools/pdf.py
@@ -154,13 +154,6 @@ def fill_form_fields_pdf(writer, form_fields):
                     _logger.info("Fields couldn't be filled in this page.")
                     continue
 
-        for raw_annot in page.get('/Annots', []):
-            annot = raw_annot.getObject()
-            for field in form_fields:
-                # Mark filled fields as readonly to avoid the blue overlay:
-                if annot.get('/T') == field:
-                    annot.update({NameObject("/Ff"): NumberObject(1)})
-
 def rotate_pdf(pdf):
     ''' Rotate clockwise PDF (90°) into a new PDF.
     Note that the attachments are not copied.


### PR DESCRIPTION
Currently, a bug is preventing the use of multi lines input in the PDF quote builder. It'd instead 
show everything in a single line, even if the PDF form field was created as allowing multiline.

This is due to multiple reasons:

- we enforced a specific value in every form flag to correct a known problem with the library PyPDF that was showing fields as not visible in some PDF readers. This specific flag is a binary numeral used to specify many things about a form field, where each bit is associated to a boolean, such as visible/invisible (1st bit), or multiline/single line (13th bit). By setting a single value, we erased the fact that this form field might have been multiline.
- some PDF readers/writers miss flag the multiline
- we always allow multiline in our custom fields, from the sale order view, even if the initial PDF form field isn't set for multiline.

As pypdf doesn't have any utils for that, we need to manually enforce the bit value to ensure the form is multiline.

Additionally: moving the fix for the fields that were invisible to somewhere where we are already modifying the annotations improve the performance a lot.

task-4122934

See PDF documentation for more information: https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/pdfreference1.7old.pdf