### PR TITLE
[FIX] website_links: prevent error while adding old code in link tracker

### DIFF
--- a/addons/website_links/controller/main.py
+++ b/addons/website_links/controller/main.py
@@ -16,11 +16,14 @@ class WebsiteUrl(http.Controller):
     def shorten_url(self, **post):
         return request.render("website_links.page_shorten_url", post)
 
+    def _search_link_tracker_code(self, domain):
+        return request.env['link.tracker.code'].search(domain, limit=1)
+
     @http.route('/website_links/add_code', type='json', auth='user')
     def add_code(self, **post):
-        link_id = request.env['link.tracker.code'].search([('code', '=', post['init_code'])], limit=1).link_id.id
-        new_code = request.env['link.tracker.code'].search_count([('code', '=', post['new_code']), ('link_id', '=', link_id)])
-        if new_code > 0:
+        link_id = self._search_link_tracker_code([('code', '=', post['init_code'])]).link_id.id
+        new_code = self._search_link_tracker_code([('code', '=', post['new_code']), ('link_id', '=', link_id)])
+        if new_code:
             return new_code.read()
         else:
             return request.env['link.tracker.code'].create({'code': post['new_code'], 'link_id': link_id})[0].read()
@@ -31,7 +34,7 @@ class WebsiteUrl(http.Controller):
 
     @http.route('/r/<string:code>+', type='http', auth="user", website=True)
     def statistics_shorten_url(self, code, **post):
-        code = request.env['link.tracker.code'].search([('code', '=', code)], limit=1)
+        code = self._search_link_tracker_code([('code', '=', code)])
 
         if code:
             return request.render("website_links.graphs", code.link_id.read()[0])


### PR DESCRIPTION
Currently, an error will occur when the user adds an old code in the edit link tracker.

Steps to produce:
- Install Link Tracker (website_links) and open website
- Click on Promote > Link Tracker
- Fill Link Tracker form and click 'Get tracked link'
- Edit code of your link by clicking the pencil icon > click ok
- again edit it and put old value > Click Ok >>> Error occurs

Stack Trace:
```
AttributeError: 'int' object has no attribute 'read'
  File "odoo/http.py", line 2373, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1903, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1966, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1933, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2177, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 223, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 754, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/website_links/controller/main.py", line 24, in add_code
    return new_code.read()
```

This error will occur because code [1] is used as the new_code.read() try to call read() int object because 'search_count' returns count of record, not an record set.

This commit will fix the above issue by using search instead of search_count and also improve the code by creating the `_search_link_tracker_code` method, which returns a search result of 'link.tracker.code' as per the passed domain.

[1] - https://github.com/odoo/odoo/blob/903b2674305fedc25cf7e2a02a9dd9a6c307af35/addons/website_links/controller/main.py#L24

sentry-5708922107

