### PR TITLE
[FIX] website, test_http: assertURLEqual in tests

### DIFF
--- a/addons/test_website/tests/test_page.py
+++ b/addons/test_website/tests/test_page.py
@@ -35,7 +35,7 @@ class WithContext(HttpCase):
         r = self.url_open(home_url)
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.history[0].status_code, 303)
-        self.assertEqual(r.url, contactus_url_full)
+        self.assertURLEqual(r.url, contactus_url_full)
         self.assertIn(contactus_content, r.content)
 
         # same with 403
@@ -55,5 +55,5 @@ class WithContext(HttpCase):
         r = self.url_open(home_url)
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.history[0].status_code, 303)
-        self.assertEqual(r.url, contactus_url_full)
+        self.assertURLEqual(r.url, contactus_url_full)
         self.assertIn(contactus_content, r.content)

--- a/addons/test_website/tests/test_redirect.py
+++ b/addons/test_website/tests/test_redirect.py
@@ -6,7 +6,6 @@ from odoo.tools import mute_logger
 from odoo.addons.http_routing.models.ir_http import slug
 
 from unittest.mock import patch
-from urllib.parse import urlparse
 
 
 @tagged('-at_install', 'post_install')
@@ -81,27 +80,27 @@ class TestRedirect(HttpCase):
             # published
             resp = self.url_open(f"/test_website/200/name-{rec_published.id}", allow_redirects=False)
             self.assertEqual(resp.status_code, 308)
-            self.assertEqual(urlparse(resp.headers.get('Location', '')).path, f"/test_website/308/name-{rec_published.id}")
+            self.assertURLEqual(resp.headers.get('Location'), f"/test_website/308/name-{rec_published.id}")
 
             resp = self.url_open(f"/test_website/308/name-{rec_published.id}", allow_redirects=False)
             self.assertEqual(resp.status_code, 200)
 
             resp = self.url_open(f"/test_website/200/xx-{rec_published.id}", allow_redirects=False)
             self.assertEqual(resp.status_code, 308)
-            self.assertEqual(resp.headers.get('Location'), f"{self.base_url()}/test_website/308/xx-{rec_published.id}")
+            self.assertURLEqual(resp.headers.get('Location'), f"/test_website/308/xx-{rec_published.id}")
 
             resp = self.url_open(f"/test_website/308/xx-{rec_published.id}", allow_redirects=False)
             self.assertEqual(resp.status_code, 301)
-            self.assertEqual(urlparse(resp.headers.get('Location'), '').path, f"/test_website/308/name-{rec_published.id}")
+            self.assertURLEqual(resp.headers.get('Location'), f"/test_website/308/name-{rec_published.id}")
 
             resp = self.url_open(f"/test_website/200/xx-{rec_published.id}", allow_redirects=True)
             self.assertEqual(resp.status_code, 200)
-            self.assertEqual(resp.url, f"{self.base_url()}/test_website/308/name-{rec_published.id}")
+            self.assertURLEqual(resp.url, f"/test_website/308/name-{rec_published.id}")
 
             # unexisting
             resp = self.url_open("/test_website/200/name-100", allow_redirects=False)
             self.assertEqual(resp.status_code, 308)
-            self.assertEqual(resp.headers.get('Location'), f"{self.base_url()}/test_website/308/name-100")
+            self.assertURLEqual(resp.headers.get('Location'), "/test_website/308/name-100")
 
             resp = self.url_open("/test_website/308/name-100", allow_redirects=False)
             self.assertEqual(resp.status_code, 404)
@@ -109,7 +108,7 @@ class TestRedirect(HttpCase):
 
             resp = self.url_open("/test_website/200/xx-100", allow_redirects=False)
             self.assertEqual(resp.status_code, 308)
-            self.assertEqual(resp.headers.get('Location'), f"{self.base_url()}/test_website/308/xx-100")
+            self.assertURLEqual(resp.headers.get('Location'), "/test_website/308/xx-100")
 
             resp = self.url_open("/test_website/308/xx-100", allow_redirects=False)
             self.assertEqual(resp.status_code, 404)
@@ -118,7 +117,7 @@ class TestRedirect(HttpCase):
             # unpublish
             resp = self.url_open(f"/test_website/200/name-{rec_unpublished.id}", allow_redirects=False)
             self.assertEqual(resp.status_code, 308)
-            self.assertEqual(resp.headers.get('Location'), f"{self.base_url()}/test_website/308/name-{rec_unpublished.id}")
+            self.assertURLEqual(resp.headers.get('Location'), f"/test_website/308/name-{rec_unpublished.id}")
 
             resp = self.url_open(f"/test_website/308/name-{rec_unpublished.id}", allow_redirects=False)
             self.assertEqual(resp.status_code, 403)
@@ -126,7 +125,7 @@ class TestRedirect(HttpCase):
 
             resp = self.url_open(f"/test_website/200/xx-{rec_unpublished.id}", allow_redirects=False)
             self.assertEqual(resp.status_code, 308)
-            self.assertEqual(resp.headers.get('Location'), f"{self.base_url()}/test_website/308/xx-{rec_unpublished.id}")
+            self.assertURLEqual(resp.headers.get('Location'), f"/test_website/308/xx-{rec_unpublished.id}")
 
             resp = self.url_open(f"/test_website/308/xx-{rec_unpublished.id}", allow_redirects=False)
             self.assertEqual(resp.status_code, 403)
@@ -138,14 +137,14 @@ class TestRedirect(HttpCase):
 
             resp = self.url_open(f"/test_website/200/seo-name-{rec_published.id}", allow_redirects=False)
             self.assertEqual(resp.status_code, 308)
-            self.assertEqual(resp.headers.get('Location'), f"{self.base_url()}/test_website/308/seo-name-{rec_published.id}")
+            self.assertURLEqual(resp.headers.get('Location'), f"/test_website/308/seo-name-{rec_published.id}")
 
             resp = self.url_open(f"/test_website/308/seo-name-{rec_published.id}", allow_redirects=False)
             self.assertEqual(resp.status_code, 200)
 
             resp = self.url_open(f"/test_website/200/xx-{rec_unpublished.id}", allow_redirects=False)
             self.assertEqual(resp.status_code, 308)
-            self.assertEqual(resp.headers.get('Location'), f"{self.base_url()}/test_website/308/xx-{rec_unpublished.id}")
+            self.assertURLEqual(resp.headers.get('Location'), f"/test_website/308/xx-{rec_unpublished.id}")
 
             resp = self.url_open(f"/test_website/308/xx-{rec_unpublished.id}", allow_redirects=False)
             self.assertEqual(resp.status_code, 403)
@@ -153,7 +152,7 @@ class TestRedirect(HttpCase):
 
             resp = self.url_open("/test_website/200/xx-100", allow_redirects=False)
             self.assertEqual(resp.status_code, 308)
-            self.assertEqual(resp.headers.get('Location'), f"{self.base_url()}/test_website/308/xx-100")
+            self.assertURLEqual(resp.headers.get('Location'), "/test_website/308/xx-100")
 
             resp = self.url_open("/test_website/308/xx-100", allow_redirects=False)
             self.assertEqual(resp.status_code, 404)
@@ -226,11 +225,11 @@ class TestRedirect(HttpCase):
         })
         r = self.url_open(url_rec1, allow_redirects=False)
         self.assertEqual(r.status_code, 301)
-        self.assertTrue(r.headers.get('Location', '').endswith(redirect.url_to))
+        self.assertURLEqual(r.headers.get('Location'), redirect.url_to)
 
         r = self.url_open(url_rec1, allow_redirects=True)
         self.assertEqual(r.status_code, 200)
-        self.assertTrue(r.url.endswith(redirect.url_to))
+        self.assertURLEqual(r.url, redirect.url_to)
 
     def test_redirect_308_multiple_url_endpoint(self):
         self.env['website.rewrite'].create({
@@ -247,7 +246,7 @@ class TestRedirect(HttpCase):
 
         resp = self.url_open("/test_countries_308", allow_redirects=False)
         self.assertEqual(resp.status_code, 308)
-        self.assertEqual(resp.headers.get('Location'), self.base_url() + "/test_countries_308_redirected")
+        self.assertURLEqual(resp.headers.get('Location'), "/test_countries_308_redirected")
 
         resp = self.url_open(url_rec1)
         self.assertEqual(resp.status_code, 200)
@@ -276,24 +275,24 @@ class TestRedirect(HttpCase):
         # should match qs first
         resp = self.url_open("/foo?bar=1", allow_redirects=False)
         self.assertEqual(resp.status_code, 301)
-        self.assertEqual(resp.headers.get('Location'), self.base_url() + "/new-page-01?bar=1")
+        self.assertURLEqual(resp.headers.get('Location'), "/new-page-01?bar=1")
 
         # should match qs first
         resp = self.url_open("/foo?bar=2", allow_redirects=False)
         self.assertEqual(resp.status_code, 301)
-        self.assertEqual(resp.headers.get('Location'), self.base_url() + "/new-page-10?qux=2&bar=2")
+        self.assertURLEqual(resp.headers.get('Location'), "/new-page-10?qux=2&bar=2")
 
         # should match no qs
         resp = self.url_open("/foo?bar=3", allow_redirects=False)
         self.assertEqual(resp.status_code, 301)
-        self.assertEqual(resp.headers.get('Location'), self.base_url() + "/new-page-11?bar=3")
+        self.assertURLEqual(resp.headers.get('Location'), "/new-page-11?bar=3")
 
         resp = self.url_open("/foo", allow_redirects=False)
         self.assertEqual(resp.status_code, 301)
-        self.assertEqual(resp.headers.get('Location'), self.base_url() + "/new-page-11")
+        self.assertURLEqual(resp.headers.get('Location'), "/new-page-11")
 
         # we dont support wrong get order
         # purpose is to support simple case like content.asp?id=xx
         resp = self.url_open("/foo?oups=1&bar=2", allow_redirects=False)
         self.assertEqual(resp.status_code, 301)
-        self.assertEqual(resp.headers.get('Location'), self.base_url() + "/new-page-11?oups=1&bar=2")
+        self.assertURLEqual(resp.headers.get('Location'), "/new-page-11?oups=1&bar=2")

--- a/addons/website/tests/test_attachment.py
+++ b/addons/website/tests/test_attachment.py
@@ -1,5 +1,3 @@
-from urllib.parse import urlparse
-
 import odoo.tests
 from odoo.tests.common import HOST
 from odoo.tools import config
@@ -47,7 +45,7 @@ class TestWebsiteAttachment(odoo.tests.HttpCase):
 
         req = self.opener.get(base + '/web/image/test.an_image_redirect_301', allow_redirects=False)
         self.assertEqual(req.status_code, 301)
-        self.assertEqual(urlparse(req.headers.get('Location', '')).path, '/web/image/test.an_image_url')
+        self.assertURLEqual(req.headers.get('Location'), '/web/image/test.an_image_url')
 
         req = self.opener.get(base + '/web/image/test.an_image_redirect_301', allow_redirects=True)
         self.assertEqual(req.status_code, 200)

--- a/addons/website/tests/test_controllers.py
+++ b/addons/website/tests/test_controllers.py
@@ -52,7 +52,6 @@ class TestControllers(tests.HttpCase):
         self.assertEqual(set(last_modified_values), set(last_5_url_edited) - matching_pages)
 
     def test_02_client_action_iframe_url(self):
-        base_url = self.base_url()
         urls = [
             '/',  # Homepage URL (special case)
             '/contactus',  # Regular website.page URL
@@ -61,13 +60,13 @@ class TestControllers(tests.HttpCase):
         ]
         for url in urls:
             resp = self.url_open(f'/@{url}')
-            self.assertEqual(resp.url, base_url + url, "Public user should have landed in the frontend")
+            self.assertURLEqual(resp.url, url, "Public user should have landed in the frontend")
         self.authenticate("admin", "admin")
         for url in urls:
             resp = self.url_open(f'/@{url}')
             backend_params = url_encode(dict(action='website.website_preview', path=url))
-            self.assertEqual(
-                resp.url, f'{base_url}/web#{backend_params}',
+            self.assertURLEqual(
+                resp.url, f'/web#{backend_params}',
                 "Internal user should have landed in the backend")
 
     def test_03_website_image(self):

--- a/addons/website/tests/test_http_endpoint.py
+++ b/addons/website/tests/test_http_endpoint.py
@@ -2,8 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo.tests import HttpCase
 
-import werkzeug
-
 
 class TestHttpEndPoint(HttpCase):
 
@@ -36,4 +34,4 @@ class TestHttpEndPoint(HttpCase):
     def test_redirect_double_slash(self):
         res = self.url_open('/test_http//greeting', allow_redirects=False)
         self.assertIn(res.status_code, (301, 308))
-        self.assertEqual(werkzeug.urls.url_parse(res.headers.get('Location', '')).path, '/test_http/greeting')
+        self.assertURLEqual(res.headers.get('Location'), '/test_http/greeting')

--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -345,7 +345,7 @@ class WithContext(HttpCase):
             'url': '/homepage_url_test',
             'is_published': True,
         })
-        self.assertEqual(test_page.url, '/homepage_url_test')
+        self.assertURLEqual(test_page.url, '/homepage_url_test')
 
         # If one has set the `homepage_url` to a specific page URL..
         website.write({
@@ -356,7 +356,7 @@ class WithContext(HttpCase):
         home_url_full = website.domain + '/'
         r = self.url_open('/')
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.url, home_url_full)
+        self.assertURLEqual(r.url, home_url_full)
         self.assertIn(b"HomepageUrlTest", r.content)
 
         # .. and then change that page URL ..
@@ -381,7 +381,7 @@ class WithContext(HttpCase):
         self.assertEqual(website.homepage_url, '/url-changed-two')
         r = self.url_open('/')
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.url, home_url_full)
+        self.assertURLEqual(r.url, home_url_full)
         self.assertIn(b"HomepageUrlTest", r.content)
 
     def test_06_homepage_url(self):
@@ -415,7 +415,7 @@ class WithContext(HttpCase):
         # -------------------------------------------
         r = self.url_open(home_url)
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.url, home_url_full)
+        self.assertURLEqual(r.url, home_url_full)
         self.assertIn(home_content, r.content)
 
         # Case 2: Another page as homepage
@@ -427,7 +427,7 @@ class WithContext(HttpCase):
         # -------------------------------------------
         r = self.url_open(home_url)
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.url, home_url_full)
+        self.assertURLEqual(r.url, home_url_full)
         self.assertIn(contactus_content, r.content)
 
         # Case 3: Check we don't fallback on first menu if there is a / page
@@ -440,7 +440,7 @@ class WithContext(HttpCase):
         # -------------------------------------------
         r = self.url_open(home_url)
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.url, home_url_full)
+        self.assertURLEqual(r.url, home_url_full)
         self.assertIn(home_content, r.content)
 
         # Case 6: Wrong URL should fallback on first non "/" menu
@@ -457,7 +457,7 @@ class WithContext(HttpCase):
         self.assertEqual(r.status_code, 404, "The website homepage_url should be a 404")
         r = self.url_open(home_url)
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.url, contactus_url_full, "Menu fallback should be a redirect, not a reroute")
+        self.assertURLEqual(r.url, contactus_url_full, "Menu fallback should be a redirect, not a reroute")
         self.assertIn(contactus_content, r.content)
 
         # Case 4: Check first menu fallback is a redirect (and not a reroute)
@@ -471,7 +471,7 @@ class WithContext(HttpCase):
         r = self.url_open(home_url)
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.history[0].status_code, 303)
-        self.assertEqual(r.url, contactus_url_full)
+        self.assertURLEqual(r.url, contactus_url_full)
         self.assertIn(contactus_content, r.content)
 
         # Case 5: Check controller redirect and make sure it is a reroute
@@ -483,7 +483,7 @@ class WithContext(HttpCase):
         # -------------------------------------------
         r = self.url_open(home_url)
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.url, home_url_full)
+        self.assertURLEqual(r.url, home_url_full)
         self.assertIn(b'o_website_info', r.content)
 
         # Case 6: Check controller redirect which has different `auth` method
@@ -497,7 +497,7 @@ class WithContext(HttpCase):
         self.assertEqual(r.status_code, 200)
         self.assertNotIn(b'<title> My Portal', r.content)
         self.assertIn(b'<title> Contact Us', r.content)
-        self.assertEqual(r.url, contactus_url_full)
+        self.assertURLEqual(r.url, contactus_url_full)
         self.assertEqual(r.history[0].status_code, 303)
         # Now with /contactus which is a public content
         self.env['website.menu'].create({
@@ -568,7 +568,7 @@ class WithContext(HttpCase):
         self.assertEqual(r.status_code, 200, "Reaching page URL, common case")
         r2 = self.url_open('/Page_1', allow_redirects=False)
         self.assertEqual(r2.status_code, 303, "URL exists only in different casing, should redirect to it")
-        self.assertTrue(r2.headers.get('Location').endswith('/page_1'), "Should redirect /Page_1 to /page_1")
+        self.assertURLEqual(r2.headers.get('Location'), '/page_1', "Should redirect /Page_1 to /page_1")
 
 @tagged('-at_install', 'post_install')
 class TestNewPage(common.TransactionCase):

--- a/addons/website_links/tests/test_controller.py
+++ b/addons/website_links/tests/test_controller.py
@@ -1,6 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from urllib.parse import urlparse
-
 from odoo.tests import tagged
 from odoo.tests.common import HttpCase
 
@@ -32,20 +30,20 @@ class TestWebsiteLinksRussian(HttpCase):
         res = self.url_open(f'/r/{self.link.code}', allow_redirects=False)
         res.raise_for_status()
         self.assertEqual(res.status_code, 301, "Should be link-tracking redirection")
-        self.assertEqual(res.headers.get('Location'), self.link.url,
+        self.assertURLEqual(res.headers.get('Location'), self.link.url,
             "Should not be redirected to /ru")
 
     def test1_russian_link_tracker(self):
         res = self.url_open(f'/r/r/{self.link.code}', allow_redirects=False)
         res.raise_for_status()
         self.assertEqual(res.status_code, 301, "Should be a lang alias redirection")
-        self.assertEqual(urlparse(res.headers.get('Location'), '').path, f'/ru/r/{self.link.code}',
+        self.assertURLEqual(res.headers.get('Location'), f'/ru/r/{self.link.code}',
             "Should be redirected to /ru as r is an alias for ru (russian)")
 
         res = self.url_open(res.headers['Location'], allow_redirects=False)
         res.raise_for_status()
         self.assertEqual(res.status_code, 301, "Should be a link-tracking redirection")
-        self.assertEqual(res.headers.get('Location'), self.link.url,
+        self.assertURLEqual(res.headers.get('Location'), self.link.url,
             "Should not be redirected to /ru")
 
     def test2_russian_page(self):

--- a/odoo/addons/test_http/tests/test_echo_reply.py
+++ b/odoo/addons/test_http/tests/test_echo_reply.py
@@ -1,7 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
-from urllib.parse import urlparse
 
 from odoo.http import Request
 from odoo.tests import tagged
@@ -43,7 +42,7 @@ class TestHttpEchoReplyHttpNoDB(TestHttpBase):
     def test_echohttp5_post_csrf(self):
         res = self.nodb_url_open('/test_http/echo-http-csrf?race=Asgard', data={'commander': 'Thor'})
         self.assertEqual(res.status_code, 303)
-        self.assertEqual(urlparse(res.headers.get('Location', '')).path, '/web/database/selector')
+        self.assertURLEqual(res.headers.get('Location'), '/web/database/selector')
 
     def test_echohttp6_json_over_http(self):
         payload = json.dumps({'commander': 'Thor'})

--- a/odoo/addons/test_http/tests/test_misc.py
+++ b/odoo/addons/test_http/tests/test_misc.py
@@ -4,7 +4,6 @@ import json
 from io import StringIO
 from socket import gethostbyname
 from unittest.mock import patch
-from urllib.parse import urlparse
 
 import odoo
 from odoo.http import root, content_disposition
@@ -167,13 +166,13 @@ class TestHttpEnsureDb(TestHttpBase):
         res = self.multidb_url_open('/test_http/ensure_db')
         res.raise_for_status()
         self.assertEqual(res.status_code, 303)
-        self.assertEqual(urlparse(res.headers.get('Location', '')).path, '/web/database/selector')
+        self.assertURLEqual(res.headers.get('Location'), '/web/database/selector')
 
     def test_ensure_db1_grant_db(self):
         res = self.multidb_url_open('/test_http/ensure_db?db=db0')
         res.raise_for_status()
         self.assertEqual(res.status_code, 302)
-        self.assertEqual(urlparse(res.headers.get('Location', '')).path, '/test_http/ensure_db')
+        self.assertURLEqual(res.headers.get('Location'), '/test_http/ensure_db?db=db0')
         self.assertEqual(odoo.http.root.session_store.get(res.cookies['session_id']).db, 'db0')
 
         # follow the redirection
@@ -200,7 +199,7 @@ class TestHttpEnsureDb(TestHttpBase):
         res = self.multidb_url_open('/test_http/ensure_db?db=db1')
         res.raise_for_status()
         self.assertEqual(res.status_code, 302)
-        self.assertEqual(urlparse(res.headers.get('Location', '')).path, '/test_http/ensure_db')
+        self.assertURLEqual(res.headers.get('Location'), '/test_http/ensure_db?db=db1')
 
         new_session = odoo.http.root.session_store.get(res.cookies['session_id'])
         self.assertNotEqual(session.sid, new_session.sid)
@@ -220,8 +219,12 @@ class TestHttpEnsureDb(TestHttpBase):
         res = self.multidb_url_open('/test_http/ensure_db?db=basededonnée1')
         res.raise_for_status()
         self.assertEqual(res.status_code, 302)
-        self.assertEqual(urlparse(res.headers.get('Location', '')).path, '/test_http/ensure_db')
-        self.assertEqual(odoo.http.root.session_store.get(res.cookies['session_id']).db, 'basededonnée1')
+        self.assertURLEqual(
+            res.headers.get('Location'),
+            '/test_http/ensure_db?db=basededonnée1')
+        self.assertEqual(
+            odoo.http.root.session_store.get(res.cookies['session_id']).db,
+            'basededonnée1')
 
         # follow the redirection
         res = self.multidb_url_open('/test_http/ensure_db')

--- a/odoo/addons/test_http/tests/test_session.py
+++ b/odoo/addons/test_http/tests/test_session.py
@@ -3,7 +3,7 @@
 import datetime
 import json
 import pytz
-from urllib.parse import urlencode, urlparse
+from urllib.parse import urlencode
 from unittest.mock import patch
 
 import odoo
@@ -94,7 +94,7 @@ class TestHttpSession(TestHttpBase):
         ])
         self.assertFalse(session['db'])
         self.assertEqual(res.status_code, 303)
-        self.assertEqual(urlparse(res.headers['Location']).path, '/web/database/selector')
+        self.assertURLEqual(res.headers.get('Location'), '/web/database/selector')
 
     def test_session4_web_authenticate_multidb(self):
         self.db_list = [get_db_name(), 'another_database']

--- a/odoo/addons/test_http/tests/test_static.py
+++ b/odoo/addons/test_http/tests/test_static.py
@@ -138,7 +138,9 @@ class TestHttpStatic(TestHttpStaticCommon):
         res = self.db_url_open('/web/content/test_http.rickroll')
         res.raise_for_status()
         self.assertEqual(res.status_code, 301)
-        self.assertEqual(res.headers.get('Location'), 'https://www.youtube.com/watch?v=dQw4w9WgXcQ')
+        self.assertURLEqual(
+            res.headers.get('Location'),
+            'https://www.youtube.com/watch?v=dQw4w9WgXcQ')
 
     def test_static08_binary_field_attach(self):
         earth = self.env.ref('test_http.earth')


### PR DESCRIPTION
FixImp, I often add such url assertions with bugfixes, I wanna use this new function with them

Testing that we are correctly redirected to a specific URL is something recurrent in both the http framework and website. There are various competiting ways to achieve this.

In this work we propose a single go-to function that (1) takes care of sanitizing both URLs to deal with missing scheme/host and (2) ouput a nice assertion message when the urls are different.

It uses urllib3 because it parses "example.com" as `netloc="example.com"` instead of urllib that parses it as `path="example.com"`.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
