### PR TITLE
[FIX] mail: Set template body when logging while loading

### DIFF
--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -1114,6 +1114,9 @@ class MailComposer(models.TransientModel):
         self.ensure_one()
         email_mode = self.composition_mode == 'mass_mail'
 
+        if tools.is_html_empty(self.body) and self.template_id:
+            self._set_value_from_template('body_html', 'body')
+
         # Duplicate attachments linked to the email.template. Indeed, composer
         # duplicates attachments in mass mode. But in 'rendered' mode attachments
         # may come from an email template (same IDs). They also have to be


### PR DESCRIPTION
Problem:
When selecting a template while logging a note, if the template is not fully loaded (body is still empty), the message will have an empty body.

Side note:
If the user selects a template and logs an empty message (empty body), it will revert to the template body. However, this is an extreme edge case that is unlikely to occur.

Steps to reproduce:

- Open a product.
- Log a note (full composer).
- Select a template and log the note while the body is still loading (the body is empty).

opw-4084921

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
