### PR TITLE
[FIX] l10n_latam_check: third party checks payment methods.

### DIFF
--- a/addons/l10n_latam_check/models/account_payment_method.py
+++ b/addons/l10n_latam_check/models/account_payment_method.py
@@ -7,7 +7,7 @@ class AccountPaymentMethod(models.Model):
     @api.model
     def _get_payment_method_information(self):
         res = super()._get_payment_method_information()
-        res['new_third_party_checks'] = {'mode': 'multi', 'domain': [('type', '=', 'cash')]}
-        res['in_third_party_checks'] = {'mode': 'multi', 'domain': [('type', '=', 'cash')]}
-        res['out_third_party_checks'] = {'mode': 'multi', 'domain': [('type', '=', 'cash')]}
+        res['new_third_party_checks'] = {'mode': 'unique', 'domain': [('type', '=', 'cash')]}
+        res['in_third_party_checks'] = {'mode': 'unique', 'domain': [('type', '=', 'cash')]}
+        res['out_third_party_checks'] = {'mode': 'unique', 'domain': [('type', '=', 'cash')]}
         return res


### PR DESCRIPTION
**Description of the issue/feature this PR addresses**:
It is not allowed to repeat third party checks payment methods on cash journals.

**Current behavior before PR**:
It is allowed to repeat third party checks payment methods on cash journals.

**Desired behavior after PR is merged**:
It is not allowed to repeat third party checks payment methods on cash journals.

_Task Adhoc side_: 42346




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
