### PR TITLE
[IMP] mail: messaging menu style improvements

### DIFF
--- a/addons/mail/static/src/core/public_web/messaging_menu.dark.scss
+++ b/addons/mail/static/src/core/public_web/messaging_menu.dark.scss
@@ -1,3 +1,7 @@
+.o-mail-MessagingMenu {
+    --mail-MessagingMenu-bg: #{mix($gray-100, $gray-200)};
+}
+
 .o-mail-MessagingMenu-navbar button {
     &.o-active, &:hover {
         background-color: mix($o-gray-200, $o-gray-300);

--- a/addons/mail/static/src/core/public_web/messaging_menu.scss
+++ b/addons/mail/static/src/core/public_web/messaging_menu.scss
@@ -2,18 +2,16 @@
     width: 450px;
     min-height: 50px;
     max-height: Min(calc(#{ $o-dropdown-max-height } - 5px), 630px); // -5px for borders
+    background-color: var(--mail-MessagingMenu-bg, $o-view-background-color);
 }
 
-.o-mail-MessagingMenu-header {
-    box-shadow: 0px 7px 7px -7px rgba(50, 50, 50, 0.15);
+.o-mail-MessagingMenu-list {
+    background-color: var(--mail-MessagingMenu-bg, $o-view-background-color);
+    gap: map-get($spacers, 1) / 2;
 }
 
-.o-mail-MessagingMenu-navbar, .o-mail-MessagingMenu-header {
-    button {
-        &.o-active {
-            background-color: mix($o-gray-100, $o-gray-200);
-        }
-    }
+.o-mail-MessagingMenu-navbar button.o-active {
+    background-color: mix($o-gray-100, $o-gray-200);
 }
 
 .o-mail-MessagingMenu-navbar button:hover {

--- a/addons/mail/static/src/core/public_web/messaging_menu.xml
+++ b/addons/mail/static/src/core/public_web/messaging_menu.xml
@@ -7,7 +7,7 @@
 
 <t t-name="mail.MessagingMenu.content">
     <div t-if="!(ui.isSmall and env.inDiscussApp and store.discuss.activeTab === 'main')" t-att-class="`${discussSystray.contentClass} o-mail-MessagingMenu`">
-        <div t-if="!env.inDiscussApp or store.discuss.activeTab !== 'main'" class="d-flex flex-column overflow-auto flex-grow-1 list-group list-group-flush" t-ref="notification-list">
+        <div t-if="!env.inDiscussApp or store.discuss.activeTab !== 'main'" class="o-mail-MessagingMenu-list d-flex flex-column overflow-auto flex-grow-1 list-group list-group-flush" t-ref="notification-list">
             <t t-foreach="threads" name="threads" t-as="thread" t-key="thread.localId">
                 <t t-set="message" t-value="thread.isChatChannel or (thread.channel_type === 'channel' and thread.needactionMessages.length === 0) ? thread.newestPersistentNotEmptyOfAllMessage : thread.needactionMessages.at(-1)"/>
                 <NotificationItem

--- a/addons/mail/static/src/core/public_web/notification_item.dark.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.dark.scss
@@ -1,8 +1,15 @@
 .o-mail-NotificationItem {
+    --mail-NotificationItem-activeOutlineOpacity: 1;
+    --mail-MessagingMenu-bg: #{mix($gray-100, $gray-200)};
+
     &.o-important {
-        background-color: mix($o-gray-200, $o-gray-300) !important;
+        background-color: mix($o-gray-200, $o-info, 87.5%) !important;
     }
     &:hover, &.o-active {
-        background-color: $o-gray-300 !important;
+        background-color: mix($o-gray-200, $o-gray-300) !important;
     }
+}
+
+.o-mail-NotificationItem-unreadIndicator {
+    opacity: 100%;
 }

--- a/addons/mail/static/src/core/public_web/notification_item.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.scss
@@ -1,12 +1,20 @@
 .o-mail-NotificationItem {
+    outline: 1px solid transparent;
+    outline-offset: -1px;
+    background-color: var(--mail-MessagingMenu-bg, $o-view-background-color);
+
     &.o-important {
-        background-color: mix($o-gray-100, $o-gray-200) !important;
+        background-color: mix($o-gray-100, $o-info, 92.5%) !important;
     }
     &.o-active {
-        box-shadow: inset 0px 0px 0px 1px rgba($o-action, 0.5);
+        outline-color: rgba($o-action, var(--mail-NotificationItem-activeOutlineOpacity, 0.5));
     }
     &:hover, &.o-active {
-        background-color: $o-gray-200 !important;
+        background-color: $o-gray-100 !important;
+
+        &.o-important {
+            background-color: mix($o-gray-100, $o-info, 87.5%) !important;
+        }
     }
 }
 
@@ -30,3 +38,9 @@
     content: "\200b"; /* unicode zero width space character */
 }
 
+.o-mail-NotificationItem-unreadIndicator {
+    color: darken($info, 5%);
+    opacity: 85%;
+    font-size: 0.5rem;
+    left: map-get($spacers, 2);
+}

--- a/addons/mail/static/src/core/public_web/notification_item.xml
+++ b/addons/mail/static/src/core/public_web/notification_item.xml
@@ -3,21 +3,22 @@
 
 <t t-name="mail.NotificationItem">
     <ActionSwiper onLeftSwipe="props.onSwipeLeft ? props.onSwipeLeft : undefined" onRightSwipe="props.onSwipeRight ? props.onSwipeRight : undefined">
-        <button class="o-mail-NotificationItem list-group-item d-flex cursor-pointer align-items-center bg-view w-100 gap-2" t-att-class="{ 'o-important': props.muted === 0, 'text-muted': props.muted === 1, 'opacity-50': props.muted === 2, 'border-start-0 border-end-0': ui.isSmall, 'border-top-0': props.first, 'p-2 pe-3': !ui.isSmall, 'o-active': props.isActive }" t-on-click="onClick" t-ref="root">
+        <button class="o-mail-NotificationItem list-group-item d-flex cursor-pointer align-items-center w-100 gap-2 position-relative border-0" t-att-class="{ 'o-important': props.muted === 0, 'text-muted': props.muted === 1, 'opacity-50': props.muted === 2, 'py-3 o-small': ui.isSmall, 'border-top-0': props.first, 'px-3 py-2': !ui.isSmall, 'o-active': props.isActive }" t-on-click="onClick" t-ref="root">
+            <span class="o-mail-NotificationItem-unreadIndicator position-absolute" t-att-class="{ 'opacity-0': props.muted }"><i class="fa fa-circle"/></span>
             <div class="position-relative bg-inherit m-1 flex-shrink-0" style="width:40px;height:40px;">
                 <img class="o_avatar w-100 h-100 rounded" alt="Notification Item Image" t-att-src="props.iconSrc"/>
                 <t t-slot="icon"/>
             </div>
             <div class="d-flex flex-column flex-grow-1 align-self-start overflow-auto">
                 <div class="d-flex text-nowrap">
-                    <span class="o-mail-NotificationItem-name text-truncate fw-bold" t-esc="props.displayName"/>
+                    <span class="o-mail-NotificationItem-name text-truncate fw-bold" t-att-class="{ 'fw-bold': props.muted, 'fw-bolder': !props.muted }" t-esc="props.displayName"/>
                     <span class="flex-grow-1"/>
-                    <small t-if="props.datetime" class="o-mail-NotificationItem-date ms-2 opacity-75" t-att-class="{ 'opacity-50 fw-bold': !props.muted, 'opacity-25 text-muted': props.muted }" t-att-title="props.datetime?.toLocaleString(DateTime.DATETIME_SHORT) ?? ''">
+                    <small t-if="props.datetime" class="o-mail-NotificationItem-date ms-2 opacity-75" t-att-class="{ 'fw-bolder': !props.muted, 'text-muted': props.muted }" t-att-title="props.datetime?.toLocaleString(DateTime.DATETIME_SHORT) ?? ''">
                         <t t-esc="dateText"/>
                     </small>
                 </div>
                 <div class="d-flex">
-                    <div class="o-mail-NotificationItem-text text-truncate opacity-75">
+                    <div class="o-mail-NotificationItem-text text-truncate opacity-75" t-att-class="{ 'fw-bold': !props.muted }">
                         <t t-slot="body-icon"/>
                         <t t-if="props.body" t-esc="props.body" name="notificationBody"/>
                     </div>

--- a/addons/mail/static/src/core/web/messaging_menu_patch.scss
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.scss
@@ -1,0 +1,8 @@
+.o-mail-MessagingMenu-headerFilter {
+    border: 1px solid transparent;
+
+    &.o-active {
+        background-color: rgba($o-action, .075);
+        border-color: rgba($o-action, .1);
+    }
+}

--- a/addons/mail/static/src/core/web/messaging_menu_patch.xml
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.xml
@@ -18,13 +18,13 @@
     
     <t t-inherit="mail.MessagingMenu.content" t-inherit-mode="extension">
         <xpath expr="//*[@t-ref='notification-list']" position="before">
-            <div class="o-mail-MessagingMenu-header d-flex" t-att-class="{'border-start-0 border-end-0': ui.isSmall, 'bg-view border-bottom': !ui.isSmall, 'flex-shrink-0': !env.inDiscussApp }">
+            <div class="o-mail-MessagingMenu-header d-flex" t-att-class="{'border-start-0 border-end-0': ui.isSmall, 'flex-shrink-0': !env.inDiscussApp }">
                 <t t-if="!ui.isSmall">
                     <MessagingMenuQuickSearch t-if="state.searchOpen" onClose.bind="toggleSearch"/>
                     <t t-else="">
-                        <button class="btn btn-link py-1 rounded-0" t-att-class="store.discuss.activeTab === 'main' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'main'">All</button>
-                        <button class="btn btn-link py-1 rounded-0" t-att-class="store.discuss.activeTab === 'chat' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'chat'">Chats</button>
-                        <button class="btn btn-link py-1 rounded-0" t-att-class="store.discuss.activeTab === 'channel' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'channel'">Channels</button>
+                        <button class="o-mail-MessagingMenu-headerFilter btn btn-link px-2 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'main' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'main'">All</button>
+                        <button class="o-mail-MessagingMenu-headerFilter btn btn-link px-2 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'chat' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'chat'">Chats</button>
+                        <button class="o-mail-MessagingMenu-headerFilter btn btn-link px-2 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'channel' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'channel'">Channels</button>
                         <button t-if="threads.length >= 20 and store.channels.status !== 'fetching'" class="btn btn-link py-1 rounded-0 text-muted" type="button" title="Quick search" t-on-click="toggleSearch"><i class="fa fa-fw fa-search"/></button>
                         <button t-if="store.channels.status === 'fetching'" class="btn btn-light py-1 rounded-0" disabled="true" type="button"><i class="fa fa-fw fa-circle-o-notch fa-spin"/></button>
                     </t>
@@ -54,8 +54,8 @@
                     <t t-set-slot="requestContent">
                         <a t-if="ui.isSmall" class="btn fa fa-cloud-download" />
                         <t t-else="">
-                            <a class="btn btn-primary">Install</a>
-                            <span t-if="!hasTouch()" t-on-click.stop="() => this.pwa.decline()" class="text-dark bg-transparent fa fa-close opacity-50 opacity-100-hover" title="Dismiss"></span>
+                            <a class="btn btn-primary px-2 py-1 smaller">Install</a>
+                            <span t-if="!hasTouch()" t-on-click.stop="() => this.pwa.decline()" class="text-dark bg-transparent oi oi-close opacity-50 opacity-100-hover" title="Dismiss"></span>
                         </t>
                     </t>
                 </NotificationItem>

--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -495,7 +495,7 @@ export function useDiscussSystray() {
     return {
         class: "o-mail-DiscussSystray-class",
         get contentClass() {
-            return `d-flex flex-column flex-grow-1 bg-view ${
+            return `d-flex flex-column flex-grow-1 ${
                 ui.isSmall ? "overflow-auto w-100 mh-100" : ""
             }`;
         },

--- a/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
+++ b/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
@@ -222,7 +222,7 @@ test("installation of the PWA request can be dismissed", async () => {
     browser.dispatchEvent(new CustomEvent("beforeinstallprompt"));
     await assertSteps(["getItem pwa.installationState"]);
     await click(".o_menu_systray i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem .fa-close");
+    await click(".o-mail-NotificationItem .oi-close");
     await assertSteps([
         "getItem pwa.installationState",
         'installationState value:  {"/odoo":"dismissed"}',


### PR DESCRIPTION
Messaging menu items are not distinct enough, and it looks too crowded.

1. info/blue color on important notifications
2. blue circle as prefix of important notifications
3. bigger notifications in height in mobile
4. better separation between important items
5. text is bolder on important notification
6. filter selection in desktop is clearer
7. removed border separator between header and list

This changes make important notifications more catchy and each notification item is more distinct from each other.

<img width="930" alt="001-1" src="https://github.com/user-attachments/assets/6a221c50-f3dd-49e0-b049-6858c2b4c6be">
<img width="916" alt="001-2" src="https://github.com/user-attachments/assets/a594dda0-dbb9-4c94-97bd-bf2817d738b1">
<img width="902" alt="001-3" src="https://github.com/user-attachments/assets/acd43bea-3027-460e-895f-f795289d7636">
<img width="911" alt="001-4" src="https://github.com/user-attachments/assets/5790509d-9efe-4e25-b87a-82598f1ba4fb">
<img width="1111" alt="001-5" src="https://github.com/user-attachments/assets/b55ad250-bf72-4dc2-ac84-dfe5fa2975be">
<img width="1098" alt="001-6" src="https://github.com/user-attachments/assets/04e6ed43-120d-4940-bf72-7bc78c092d93">
