### PR TITLE
[FIX] html_editor: codeview button availability

### DIFF
--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -194,22 +194,6 @@ export class HtmlField extends Component {
             dynamicPlaceholder: this.dynamicPlaceholder,
             dynamicPlaceholderResModel:
                 this.props.record.data[this.props.dynamicPlaceholderModelReferenceField || "model"],
-            resources: {
-                toolbarCategory: {
-                    id: "codeview",
-                    sequence: 100,
-                },
-                toolbarItems: [
-                    {
-                        id: "codeview",
-                        category: "codeview",
-                        icon: "fa-code",
-                        action: () => {
-                            this.toggleCodeView();
-                        },
-                    },
-                ],
-            },
             direction: localization.direction || "ltr",
             getRecordInfo: () => {
                 const { resModel, resId } = this.props.record;
@@ -224,6 +208,22 @@ export class HtmlField extends Component {
             (sanitize_tags || (sanitize_tags === undefined && sanitize))
         ) {
             config.disableVideo = true; // Tag-sanitized fields remove videos.
+        }
+        if (this.props.codeview) {
+            config.resources = {
+                toolbarCategory: {
+                    id: "codeview",
+                    sequence: 100,
+                },
+                toolbarItems: {
+                    id: "codeview",
+                    category: "codeview",
+                    icon: "fa-code",
+                    action: () => {
+                        this.toggleCodeView();
+                    },
+                },
+            };
         }
         return config;
     }

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -850,7 +850,58 @@ test("'Image' command is not available when 'disableImage' = true", async () => 
     expect(queryAllTexts(".o-we-command-name")).toEqual([]);
 });
 
+test("codeview is not available by default", async () => {
+    await mountView({
+        type: "form",
+        resId: 1,
+        resModel: "partner",
+        arch: `
+            <form>
+                <field name="txt" widget="html"/>
+            </form>`,
+    });
+    const node = queryOne(".odoo-editor-editable p");
+    setSelection({ anchorNode: node, anchorOffset: 0, focusNode: node, focusOffset: 1 });
+    await waitFor(".o-we-toolbar");
+    expect(".o-we-toolbar button[name='codeview']").toHaveCount(0);
+});
+
+test("codeview is not available when not in debug mode", async () => {
+    odoo.debug = false;
+    await mountView({
+        type: "form",
+        resId: 1,
+        resModel: "partner",
+        arch: `
+            <form>
+                <field name="txt" widget="html" options="{'codeview': true}"/>
+            </form>`,
+    });
+    const node = queryOne(".odoo-editor-editable p");
+    setSelection({ anchorNode: node, anchorOffset: 0, focusNode: node, focusOffset: 1 });
+    await waitFor(".o-we-toolbar");
+    expect(".o-we-toolbar button[name='codeview']").toHaveCount(0);
+});
+
+test("codeview is available when option is active and in debug mode", async () => {
+    odoo.debug = true;
+    await mountView({
+        type: "form",
+        resId: 1,
+        resModel: "partner",
+        arch: `
+            <form>
+                <field name="txt" widget="html" options="{'codeview': true}"/>
+            </form>`,
+    });
+    const node = queryOne(".odoo-editor-editable p");
+    setSelection({ anchorNode: node, anchorOffset: 0, focusNode: node, focusOffset: 1 });
+    await waitFor(".o-we-toolbar");
+    expect(".o-we-toolbar button[name='codeview']").toHaveCount(1);
+});
+
 test("enable/disable codeview with editor toolbar", async () => {
+    odoo.debug = true;
     await mountView({
         type: "form",
         resId: 1,
@@ -883,6 +934,7 @@ test("edit and enable/disable codeview with editor toolbar", async () => {
         expect(args[1].txt).toBe("<div></div>");
         expect.step("web_save");
     });
+    odoo.debug = true;
     await mountView({
         type: "form",
         resId: 1,


### PR DESCRIPTION
The codeview button should only be available in the toolbar when the `codeview` option is set to true in the widget options and the webclient is in debug mode.

Before this commit, the codeview button was always available in the editor's toolbar for the html field, regardless of those two conditions.

