### PR TITLE
[FIX] point_of_sale: fix resume order condition

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -91,7 +91,7 @@ export class ReceiptScreen extends Component {
         this.pos.showScreen(name, props);
     }
     isResumeVisible() {
-        return this.pos.get_open_orders().length > 1;
+        return this.pos.get_open_orders().length > 0;
     }
     async _sendReceiptToCustomer({ action }) {
         const order = this.currentOrder;


### PR DESCRIPTION
The condition for showing the resume order button on the receipt_screen was not working properly. The condition was checking if there was 2 or more open orders but we want to show it if there is 1 or more open orders.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
