### PR TITLE
[FIX] account: `fiscal_country_codes` when creating new record

### DIFF
--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -304,6 +304,7 @@
                                     <field name="company_registry" invisible="parent_id"/>
                                     <field name="ref" string="Reference"/>
                                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" readonly="parent_id" force_save="1"/>
+                                    <field name="company_id" invisible="1"/> <!-- need to be able to to compute based on the company even without multi company groups -->
                                     <field name="industry_id" invisible="not is_company" options="{'no_create': True}"/>
                                 </group>
                             </group>


### PR DESCRIPTION
Steps to reproduce:
- Clean DB with only one Indian company
- Create a new partner
- The Indian fields are not shown  --> NOT OK
- Save the record
- The Indian fields are now shown  --> OK

Explanation:
This is because the compute method `_compute_fiscal_country_codes` is not called when creating a new record. It is only called when the record is saved.

Solution:
Set a default value to the field `fiscal_country_codes`

task-id: none
