### PR TITLE
[FIX] stock: fix saving sml on dirty picking

### DIFF
--- a/addons/stock/static/src/views/picking_form/stock_move_one2many.js
+++ b/addons/stock/static/src/views/picking_form/stock_move_one2many.js
@@ -51,6 +51,8 @@ export class StockMoveX2ManyField extends X2ManyField {
             const dirty = await record.isDirty();
             if (await record._parentRecord.isDirty()){
                 await record._parentRecord.save({ reload: true });
+                // sync up the X2ManyField's record with the new picking's sub datapoints created by the save
+                record = record._parentRecord.data[this.props.name].records.find(e => e.resId === record.resId);
             }
             if (dirty && 'quantity' in record._changes) {
                 await record._parentRecord.save({ reload: true });

--- a/addons/stock/static/tests/tours/stock_picking_tour.js
+++ b/addons/stock/static/tests/tours/stock_picking_tour.js
@@ -303,3 +303,50 @@ registry.category("web_tour.tours").add('test_onchange_twice_lot_ids', {
         },
     ]
 });
+
+registry.category("web_tour.tours").add('tour_detailed_op_2_sm_save', { test: true, steps: () => [
+    //  set lot on move 1 sml
+    {
+        trigger: "tr:contains(Product Lot 1) > td > .fa-list",
+        run: 'click',
+    },
+    {
+        // click table cell to make input cell appear
+        trigger: '.modal-body tbody tr:first-child td.o_field_cell[name=lot_name]',
+        run: 'click',
+    },
+    {
+        trigger: ".o_field_widget[name=lot_name] input",
+        run: 'text lot1',
+    },
+    {
+        trigger: ".o_form_button_save",
+        run: 'click',
+    },
+    // set lot on move 2 sml
+    {
+        trigger: "tr:contains(Product Lot 2) > td > .fa-list",
+        run: 'click',
+    },
+    {
+        trigger: '.modal-body tbody tr:first-child td.o_field_cell[name=lot_name]',
+        run: 'click',
+    },
+    {
+        trigger: ".o_field_widget[name=lot_name] input",
+        run: 'text lot2',
+    },
+    {
+        trigger: ".o_form_button_save",
+        run: 'click',
+    },
+    // Validate and Check
+    {
+        trigger: "button:contains(Validate)",
+        run: 'click',
+    },
+    {
+        trigger: ".o_control_panel_actions button:contains('Traceability')",
+        isCheck: true,
+    },
+]});


### PR DESCRIPTION
Steps
---
* install stock
* create product P, and Q tracked by lot
* create a receipt for 1 P and 1 Q > *Mark as Todo*
* go to the detailed ops for the P move (list icon on the right of the lines)
* set the lot name to 001 > *Save*
* repeat for the Q move, set the lot name to 002
* Try to save the picking 
  * => **clicking the cloud save icon does nothing**
* Try to Validate 
  * => Traceback: missing lot for the Q move

Cause
---
We try to save the picking when it is dirty when opening the move lines This will create new datapoints corresponding to the backend data, and but the datapoints linked to the inputs are still the old ones so we become out of sync

opw-4107258
