### PR TITLE
[FIX] web: color contrast last breadcrumb item on navbar (small screen)

### DIFF
--- a/addons/web/static/src/webclient/navbar/navbar.scss
+++ b/addons/web/static/src/webclient/navbar/navbar.scss
@@ -90,11 +90,14 @@
         @extend %-main-navbar-entry-spacing;
         padding-left: 0;
         font-size: $o-navbar-brand-font-size;
-        color: var(--NavBar-brand-color, #{$o-navbar-brand-color});
 
         &:hover {
             background: none;
         }
+    }
+
+    .o_menu_brand, .o_navbar_breadcrumbs {
+        color: var(--NavBar-brand-color, #{$o-navbar-brand-color});
     }
 
     .o_menu_sections {


### PR DESCRIPTION
This commit follows 80fe389347838d502addcfd2e521d7516b5e86a0, it fixes the color contrast on the last item breadcrumb test on the navbar.

Step to reproduce:

- Open "Settings"
- Check the inside the navbar the color the last breadcrumb item, it's unreadable => bug

task-3336242

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
