### PR TITLE
[IMP] pos_event: ticket printing in backoffice

### DIFF
--- a/addons/pos_event/models/pos_order.py
+++ b/addons/pos_event/models/pos_order.py
@@ -60,3 +60,9 @@ class PosOrder(models.Model):
             self.env['event.registration'].browse(event_to_cancel).write({'state': 'cancel'})
 
         return res
+
+    def print_event_tickets(self):
+        return self.env.ref('event.action_report_event_registration_full_page_ticket').report_action(self.lines.event_registration_ids)
+
+    def print_event_badges(self):
+        return self.env.ref('event.action_report_event_registration_badge').report_action(self.lines.event_registration_ids)

--- a/addons/pos_event/views/pos_order_views.xml
+++ b/addons/pos_event/views/pos_order_views.xml
@@ -5,6 +5,10 @@
         <field name="model">pos.order</field>
         <field name="inherit_id" ref="point_of_sale.view_pos_pos_form"/>
         <field name="arch" type="xml">
+            <xpath expr="//header" position="inside">
+                <button name="print_event_tickets" type="object"><i class="fa fa-file-pdf-o me-1" aria-hidden="true" />Print Event Tickets</button>
+                <button name="print_event_badges" type="object"><i class="fa fa-file-pdf-o me-1" aria-hidden="true" />Print Event Badges</button>
+            </xpath>
             <xpath expr="//sheet/div[hasclass('oe_button_box')]" position="inside">
                 <button name="action_view_attendee_list" type="object"
                     class="oe_stat_button" icon="fa-users" invisible="attendee_count == 0">


### PR DESCRIPTION
In the ticket screen of pos there is an option to print tickets and badges for event tickets bought in pos.

In this commit we add these options in the backoffice view as of orders as well.

Apart from the extra functionality this adds, it will also help when replacing the ticket screen with the list view from `web`, as a part of the work will have already been done.

Task: 4116740

![image](https://github.com/user-attachments/assets/e640d499-864f-413a-ae93-524bef3b309c)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
