### PR TITLE
[FIX] account: reverse moves on payslip cancel

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3457,6 +3457,25 @@ class AccountMove(models.Model):
 
         return reverse_moves
 
+    def _can_be_unlinked(self):
+        self.ensure_one()
+        lock_date = self.company_id._get_user_fiscal_lock_date()
+        return not self.inalterable_hash and self.date > lock_date
+
+    def _unlink_or_reverse(self):
+        if not self:
+            return
+        to_reverse = self.env['account.move']
+        to_unlink = self.env['account.move']
+        for move in self:
+            if move._can_be_unlinked():
+                to_unlink += move
+            else:
+                to_reverse += move
+        to_unlink.filtered(lambda m: m.state in ('posted', 'cancel')).button_draft()
+        to_unlink.filtered(lambda m: m.state == 'draft').unlink()
+        return to_reverse._reverse_moves(cancel=True)
+
     def _post(self, soft=True):
         """Post/Validate the documents.
 

--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -119,6 +119,10 @@ class AccountMove(models.Model):
         if any(m.country_code == 'IN' and m.posted_before for m in self) and not self._context.get('force_delete'):
             raise UserError(_("To keep the audit trail, you can not delete journal entries once they have been posted.\nInstead, you can cancel the journal entry."))
 
+    def _can_be_unlinked(self):
+        self.ensure_one()
+        return (self.country_code != 'IN' or not self.posted_before) and super()._can_be_unlinked()
+
     def unlink(self):
         # Add logger here becouse in api ondelete account.move.line is deleted and we can't get total amount
         logger_msg = False


### PR DESCRIPTION
Create a new payslip
Select Employee and contract
Compute Sheet
Create Draft Entry > Post Draft Entry
Cancel payslip

Issue: The system will attempt to reset to draft and unlink the associated invoice
In some cases this is not ideal: In Indian government for example, requires audit trail report for private limited companies, so user can't delete journal entries after posting once.

Backporting method `_unlink_or_reverse` from 17.0 [1] to be used in the related PR https://github.com/odoo/enterprise/pull/68044

[1] https://github.com/odoo/odoo/blob/66bfab54748a56072ed9ff144f4a39366b606a06/addons/account/models/account_move.py#L3772-L3785

opw-4075244

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
