### PR TITLE
[IMP] website: improve header buttons contrast

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -2770,3 +2770,13 @@ input[value*="data-oe-translation-source-sha"] {
 .form-select:not(:focus):not(:hover):has(~ .input-group-text-subtle) {
     border-right-width: 0;
 }
+
+// `nav-link` and `btn` don't have the same padding.
+// In some cases, we need to apply the padding of `btn` with the color of `nav-link`.
+// For example in "Sign In" button of `template_header_sidebar`.
+// Adding the `btn` class to `nav-link` doesn't work, as `nav-link` padding takes
+// the priority over `btn`. This class forces to keep the `btn` padding for
+// specific `nav-link`.
+.o_nav_link_btn {
+    padding: $btn-padding-y $btn-padding-x;
+}

--- a/addons/website/static/tests/tours/snippet_translation.js
+++ b/addons/website/static/tests/tours/snippet_translation.js
@@ -42,7 +42,7 @@ registerWebsitePreviewTour('snippet_translation_changing_lang', {
 }, () => [
     {
         content: "Change language to Parseltongue",
-        trigger: ':iframe .js_language_selector .btn',
+        trigger: ':iframe .js_language_selector button',
         run: "click",
     },
     {

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -1253,6 +1253,12 @@
                        data-customize-website-variable="'border-bottom'">Border Bottom</we-button>
         </we-select>
 
+        <we-select string="Additional colors" data-reload="/">
+            <we-button data-customize-website-views="">Default</we-button>
+            <we-button data-customize-website-views="website.template_header_additional_color_primary">Primary</we-button>
+            <we-button data-customize-website-views="website.template_header_additional_color_secondary">Secondary</we-button>
+        </we-select>
+
         <we-select id="option_header_dropdown" string="Sub Menus" data-dependencies="!header_hamburger_opt" data-no-preview="true">
             <we-button data-select-class="o_hoverable_dropdown"
                        data-customize-website-views="website.header_hoverable_dropdown">On Hover</we-button>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -173,6 +173,14 @@
         <t t-set="cta_btn_text" t-value="False"/>
         <t t-set="cta_btn_href">/contactus</t>
         <t t-set="extra_items_toggle_aria_label">Extra items button</t>
+        <t t-set="primary_additional_colors" t-value="False"/>
+        <t t-set="secondary_additional_colors" t-value="False"/>
+        <t t-if="primary_additional_colors">
+            <t t-set="_additional_btn_color" t-valuef="btn btn-outline-primary"/>
+        </t>
+        <t t-if="secondary_additional_colors">
+            <t t-set="_additional_btn_color" t-valuef="btn btn-outline-secondary"/>
+        </t>
     </xpath>
 
     <xpath expr="//footer" position="attributes">
@@ -383,7 +391,7 @@
                     <ul class="navbar-nav gap-2 mt-3 w-100">
                         <!-- Language Selector -->
                         <t t-call="website.placeholder_header_language_selector">
-                            <t t-set="_btn_class" t-valuef="nav-link d-flex align-items-center w-100 px-2"/>
+                            <t t-set="_btn_class" t-valuef="{{_additional_btn_color or 'nav-link'}} d-flex align-items-center w-100"/>
                             <t t-set="_txt_class" t-valuef="me-auto small"/>
                             <t t-set="_flag_class" t-valuef="me-2"/>
                             <t t-set="_div_classes" t-valuef="dropup"/>
@@ -391,14 +399,14 @@
                         </t>
                         <!-- Sign In -->
                         <t t-call="portal.placeholder_user_sign_in">
-                            <t t-set="_link_class" t-valuef="btn btn-outline-secondary w-100"/>
+                            <t t-set="_link_class" t-valuef="{{_additional_btn_color or 'nav-link o_nav_link_btn'}} w-100 border rounded text-center"/>
                         </t>
                         <!-- User Dropdown -->
                         <t t-call="portal.user_dropdown">
                             <t t-set="_icon" t-value="true"/>
                             <t t-set="_user_name" t-value="true"/>
                             <t t-set="_user_name_class" t-valuef="me-auto small"/>
-                            <t t-set="_link_class" t-valuef="btn btn-outline-secondary d-flex align-items-center border-0 px-2"/>
+                            <t t-set="_link_class" t-valuef="{{ _additional_btn_color or 'nav-link'}} d-flex align-items-center border-0"/>
                             <t t-set="_icon_class" t-valuef="me-2"/>
                             <t t-set="_item_class" t-valuef="dropdown dropup"/>
                             <t t-set="_dropdown_menu_class" t-valuef="w-100"/>
@@ -486,20 +494,18 @@
                     <t t-call="website.placeholder_header_social_links"/>
                     <!-- Language Selector -->
                     <t t-call="website.placeholder_header_language_selector">
-                        <t t-set="_btn_class" t-valuef="btn btn-outline-secondary border-0"/>
-                        <t t-set="_txt_class" t-valuef="small"/>
+                        <t t-set="_btn_class" t-value="_additional_btn_color or 'nav-link'"/>
                         <t t-set="_dropdown_menu_class" t-valuef="dropdown-menu-end"/>
                     </t>
                     <!-- Sign In -->
                     <t t-call="portal.placeholder_user_sign_in">
-                        <t t-set="_link_class" t-valuef="btn btn-outline-secondary"/>
+                        <t t-set="_link_class" t-value="_additional_btn_color or 'nav-link border rounded px-3'"/>
                     </t>
                     <!-- User Dropdown -->
                     <t t-call="portal.user_dropdown">
                         <t t-set="_user_name" t-value="True"/>
                         <t t-set="_item_class" t-valuef="dropdown"/>
-                        <t t-set="_link_class" t-valuef="btn btn-outline-secondary border-0 fw-bold"/>
-                        <t t-set="_user_name_class" t-valuef="small"/>
+                        <t t-set="_link_class" t-valuef="{{_additional_btn_color or 'nav-link'}} border-0"/>
                         <t t-set="_dropdown_menu_class" t-valuef="dropdown-menu-end"/>
                     </t>
                     <!-- Call To Action -->
@@ -594,7 +600,7 @@
                         <ul class="navbar-nav gap-2 mt-3 w-100">
                             <!-- Language Selector -->
                             <t t-call="website.placeholder_header_language_selector">
-                                <t t-set="_btn_class" t-valuef="btn btn-outline-secondary d-flex align-items-center w-100"/>
+                                <t t-set="_btn_class" t-valuef="{{_additional_btn_color or 'nav-link'}} d-flex align-items-center w-100"/>
                                 <t t-set="_txt_class" t-valuef="me-auto small"/>
                                 <t t-set="_flag_class" t-valuef="me-2"/>
                                 <t t-set="_div_classes" t-valuef="dropup"/>
@@ -1051,7 +1057,7 @@
                             </t>
                             <!-- Sign In -->
                             <t t-call="portal.placeholder_user_sign_in">
-                                <t t-set="_link_class" t-valuef="btn btn-outline-secondary"/>
+                                <t t-set="_link_class" t-valuef="{{_additional_btn_color or 'nav-link'}} ms-2 rounded border px-3"/>
                             </t>
                             <!-- User Dropdown -->
                             <t t-call="portal.user_dropdown">
@@ -1196,6 +1202,12 @@
 
 <!-- "Sales four" template -->
 <template id="template_header_sales_four" inherit_id="website.layout" name="Template Header Sale 4" active="False">
+    <xpath expr="//t[@t-if='primary_additional_colors']" position="inside">
+        <t t-set="_additional_btn_color" t-valuef="text-primary"/>
+    </xpath>
+    <xpath expr="//t[@t-if='secondary_additional_colors']" position="inside">
+        <t t-set="_additional_btn_color" t-valuef="text-secondary"/>
+    </xpath>
     <xpath expr="//header//nav" position="replace">
         <t t-call="website.navbar">
             <t t-set="_navbar_classes" t-valuef="o_header_sales_four_top o_header_force_no_radius d-none d-lg-block p-0 shadow-sm z-1"/>
@@ -1228,8 +1240,8 @@
                         </t>
                         <!-- Sign In -->
                         <t t-call="portal.placeholder_user_sign_in">
-                            <t t-set="_item_class" t-valuef="position-relative"/>
-                            <t t-set="_link_class" t-valuef="btn btn-outline-secondary d-flex align-items-center h-100 border-0"/>
+                            <t t-set="_item_class" t-valuef="position-relative small"/>
+                            <t t-set="_link_class" t-valuef="{{_additional_btn_color or 'nav-link'}} d-flex align-items-center h-100 border-0 px-2 text-decoration-none"/>
                         </t>
                         <!-- User Dropdown -->
                         <t t-call="portal.user_dropdown">
@@ -1348,7 +1360,7 @@
                         <ul class="navbar-nav gap-2 mt-3 w-100">
                             <!-- Language Selector -->
                             <t t-call="website.placeholder_header_language_selector">
-                                <t t-set="_btn_class" t-valuef="btn btn-outline-secondary d-flex align-items-center w-100 px-2"/>
+                                <t t-set="_btn_class" t-valuef="{{_additional_btn_color or 'nav-link'}} d-flex align-items-center w-100"/>
                                 <t t-set="_txt_class" t-valuef="me-auto small"/>
                                 <t t-set="_flag_class" t-valuef="me-2"/>
                                 <t t-set="_div_classes" t-valuef="dropup"/>
@@ -1356,14 +1368,14 @@
                             </t>
                             <!-- Sign In -->
                             <t t-call="portal.placeholder_user_sign_in">
-                                <t t-set="_link_class" t-valuef="btn btn-outline-secondary w-100"/>
+                                <t t-set="_link_class" t-valuef="{{_additional_btn_color or 'nav-link o_nav_link_btn'}} w-100 border rounded text-center"/>
                             </t>
                             <!-- User Dropdown -->
                             <t t-call="portal.user_dropdown">
                                 <t t-set="_icon" t-value="true"/>
                                 <t t-set="_user_name" t-value="true"/>
                                 <t t-set="_user_name_class" t-valuef="me-auto small"/>
-                                <t t-set="_link_class" t-valuef="btn btn-outline-secondary d-flex align-items-center border-0 px-2"/>
+                                <t t-set="_link_class" t-valuef="{{ _additional_btn_color or 'nav-link'}} d-flex align-items-center border-0"/>
                                 <t t-set="_icon_class" t-valuef="me-2"/>
                                 <t t-set="_item_class" t-valuef="dropdown dropup"/>
                                 <t t-set="_dropdown_menu_class" t-valuef="w-100"/>
@@ -1457,13 +1469,13 @@
                         <t t-call="website.placeholder_header_social_links"/>
                         <!-- Language Selector -->
                         <t t-call="website.placeholder_header_language_selector">
-                            <t t-set="_btn_class" t-valuef="btn btn-outline-secondary d-flex align-items-center gap-1 border-0 rounded-circle px-3"/>
+                            <t t-set="_btn_class" t-valuef="{{_additional_btn_color or 'nav-link'}} d-flex align-items-center gap-1 border-0 rounded-pill px-3"/>
                             <t t-set="_txt_class" t-valuef="small"/>
                             <t t-set="_dropdown_menu_class" t-valuef="dropdown-menu-end"/>
                         </t>
                         <!-- Sign In -->
                         <t t-call="portal.placeholder_user_sign_in">
-                            <t t-set="_link_class" t-valuef="btn btn-outline-secondary rounded-circle px-3"/>
+                            <t t-set="_link_class" t-valuef="{{_additional_btn_color or 'nav-link'}} border rounded-pill px-3"/>
                         </t>
                         <!-- User Dropdown -->
                         <t t-call="portal.user_dropdown">
@@ -1471,7 +1483,7 @@
                             <t t-set="_user_name" t-value="false"/>
                             <t t-set="_user_name_class" t-valuef="me-auto small"/>
                             <t t-set="_item_class" t-valuef="dropdown"/>
-                            <t t-set="_link_class" t-valuef="btn btn-outline-secondary d-flex align-items-center border-0 rounded-circle px-3 fw-bold"/>
+                            <t t-set="_link_class" t-valuef="{{_additional_btn_color or 'nav-link'}} d-flex align-items-center border-0 rounded-pill px-3"/>
                             <t t-set="_dropdown_menu_class" t-valuef="dropdown-menu-end"/>
                         </t>
                         <!-- Call To Action -->
@@ -1495,6 +1507,18 @@
 <template id="template_header_boxed_align_right" inherit_id="website.template_header_boxed" active="False">
     <xpath expr="//t[@t-set='_nav_class']" position="replace">
         <t t-set="_nav_class" t-valuef="ms-auto"/>
+    </xpath>
+</template>
+
+<!-- Additional colors option -->
+<template id="template_header_additional_color_primary" inherit_id="website.layout" active="False">
+    <xpath expr="//t[@t-set='primary_additional_colors']" position="attributes">
+        <attribute name="t-value">True</attribute>
+    </xpath>
+</template>
+<template id="template_header_additional_color_secondary" inherit_id="website.layout" active="False">
+    <xpath expr="//t[@t-set='secondary_additional_colors']" position="attributes">
+        <attribute name="t-value">True</attribute>
     </xpath>
 </template>
 

--- a/addons/website_sale/static/tests/tours/website_sale_shop_pricelist_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_pricelist_tour.js
@@ -14,7 +14,7 @@ registry.category("web_tour.tours").add(
             },
             {
                 content: "Go to login page",
-                trigger: ".btn:contains('Sign in')",
+                trigger: "a:contains('Sign in')",
                 run: "click",
             },
             {


### PR DESCRIPTION
Prior to this commit, some header templates used the secondary color for certain buttons and dropdowns (eg. user dropdown and language swicher). Depending on the color set as secondary, these elements were not visible enough.

These elements now use the `nav-link` color to maintain consistency with the other header elements.

However, the `nav-link` color may not be what the user wants. That's why this commit also adds the "Additional colors" option which allows the user to choose between primary and secondary colors if the default colors don't suit their website.

task-4014567

Required by : 
- https://github.com/odoo/odoo/pull/172463

|   | Before | After |
|--------|--------|--------|
| Default | ![Capture d’écran 2024-08-16 à 09 25 07](https://github.com/user-attachments/assets/8c3ed62b-22a5-42b8-a6c8-2b8d54c69e2d) | ![Capture d’écran 2024-08-16 à 09 24 14](https://github.com/user-attachments/assets/d5d80998-9d4b-4278-9ef5-1b617c2b4476) |
| Mobile | ![Capture d’écran 2024-08-16 à 09 24 50](https://github.com/user-attachments/assets/a57f2f72-383d-4b9d-a60a-07052d20a2c0) | ![Capture d’écran 2024-08-16 à 09 23 45](https://github.com/user-attachments/assets/fb57ff47-b895-412a-8ac9-d540866f7cb0) |
| Hambuger & Sidebar | ![sidebar_et_hamburger](https://github.com/user-attachments/assets/6b33a52b-cf07-417a-bd3a-1dd6a0d34a2f) | ![Capture d’écran 2024-08-16 à 09 24 30](https://github.com/user-attachments/assets/9c2ab755-8e18-482e-b0df-2b1368a1142c) |
| Sales_two | ![sales_two](https://github.com/user-attachments/assets/0d45f32f-408f-4f45-b8e6-0c7e38182b54) | ![Capture d’écran 2024-08-16 à 09 30 26](https://github.com/user-attachments/assets/0e9f8381-75d4-4895-a0cf-3d025eacf8e8) | 
| Sales_four | ![sales_four](https://github.com/user-attachments/assets/444e244b-7e56-42da-8346-8570931692f3) | ![Capture d’écran 2024-08-16 à 09 29 16](https://github.com/user-attachments/assets/456baef7-b03e-40fc-88c1-c4d7f08ed2d8) |
| Boxed | ![rounded_box](https://github.com/user-attachments/assets/a064cf4c-20d9-47ae-b2dd-d92fa9adef6d) | ![Capture d’écran 2024-08-16 à 09 34 55](https://github.com/user-attachments/assets/6790671e-3d5d-4026-933e-935ed702c3ce) |

![Capture d’écran 2024-09-12 à 13 57 08](https://github.com/user-attachments/assets/6500a546-a52c-4386-8035-ea5ceed72c09)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
