### PR TITLE
[FIX] html_editor: missing CSS for table selection

### DIFF
--- a/addons/html_editor/static/src/main/table/table_selection.scss
+++ b/addons/html_editor/static/src/main/table/table_selection.scss
@@ -1,0 +1,11 @@
+.o_selected_table {
+    caret-color: transparent;
+
+    ::selection {
+        background-color: transparent !important;
+    }
+    .o_selected_td {
+        background-color: rgba(117, 167, 249, 0.5) !important; /* #bad3fc equivalent when over white*/
+        cursor: pointer !important;
+    }
+}

--- a/addons/html_editor/static/tests/table/misc.test.js
+++ b/addons/html_editor/static/tests/table/misc.test.js
@@ -1,7 +1,8 @@
 import { expect, test } from "@odoo/hoot";
 import { setupEditor } from "../_helpers/editor";
-import { click, waitFor } from "@odoo/hoot-dom";
-import { animationFrame } from "@odoo/hoot-mock";
+import { click, queryAll, queryFirst, waitFor } from "@odoo/hoot-dom";
+import { animationFrame, tick } from "@odoo/hoot-mock";
+import { setSelection } from "../_helpers/selection";
 
 function insertTable(editor, cols, rows) {
     editor.dispatch("INSERT_TABLE", { cols, rows });
@@ -36,5 +37,13 @@ test("can color cells", async () => {
     await animationFrame();
     expect(".o-we-toolbar").toHaveCount(1); // toolbar still open
     expect(".o_font_color_selector").toHaveCount(0); // selector closed
-    expect("td.o_selected_td").toHaveStyle({ "background-color": "rgb(107, 173, 222)" });
+
+    // Collapse selection to deselect cells
+    setSelection({ anchorNode: queryFirst("td"), anchorOffset: 0 });
+    await tick();
+
+    const cells = queryAll("td");
+    expect(cells[0]).toHaveStyle({ "background-color": "rgb(107, 173, 222)" });
+    expect(cells[1]).toHaveStyle({ "background-color": "rgb(107, 173, 222)" });
+    expect(cells[2]).not.toHaveStyle({ "background-color": "rgb(107, 173, 222)" });
 });

--- a/addons/html_editor/static/tests/table/selection.test.js
+++ b/addons/html_editor/static/tests/table/selection.test.js
@@ -1,7 +1,47 @@
-import { describe, test } from "@odoo/hoot";
-import { testEditor } from "../_helpers/editor";
+import { describe, expect, test } from "@odoo/hoot";
+import { setupEditor, testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { bold, resetSize, setColor } from "../_helpers/user_actions";
+import { getContent } from "../_helpers/selection";
+import { queryAll } from "@odoo/hoot-dom";
+
+describe("custom selection", () => {
+    test("should indicate selected cells with blue background", async () => {
+        const { el } = await setupEditor(
+            unformat(`
+            <table>
+                <tbody>
+                    <tr>
+                        <td>ab</td>
+                        <td>c[d</td>
+                        <td>e]f</td>
+                    </tr>
+                </tbody>
+            </table>`)
+        );
+        expect(getContent(el)).toBe(
+            unformat(`
+            <table class="o_selected_table">
+                <tbody>
+                    <tr>
+                        <td>ab</td>
+                        <td class="o_selected_td">c[d</td>
+                        <td class="o_selected_td">e]f</td>
+                    </tr>
+                </tbody>
+            </table>`)
+        );
+        const defaultBackgroundColor = getComputedStyle(el)["background-color"];
+        const backgroundColorTDs = queryAll("table td").map(
+            (td) => getComputedStyle(td)["background-color"]
+        );
+        // Unselected cells should have the default background color
+        expect(backgroundColorTDs[0]).toBe(defaultBackgroundColor);
+        // Selected cells should have a distinct background color
+        expect(backgroundColorTDs[1]).not.toBe(defaultBackgroundColor);
+        expect(backgroundColorTDs[2]).not.toBe(defaultBackgroundColor);
+    });
+});
 
 describe("select a full table on cross over", () => {
     describe("select", () => {


### PR DESCRIPTION
When selecting cells in a table, the selected cells should be highlighted with a blue background. This commit adds the necessary CSS to achieve this.
