### PR TITLE
[FIX] website: adjust `header_sales_three` small btn

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1224,6 +1224,10 @@ header {
         @include o-apply-colors('header-sales_three-custom');
         @include o-add-gradient('menu-secondary-gradient');
     }
+    #wrapwrap header .o_header_sales_three_small_links .btn {
+        // Force small links to be proportional to header font size
+        font-size: MAX(12px, .75em) !important;
+    }
 } @else if o-website-value('header-template') == 'sales_four' {
     #wrapwrap .o_header_sales_four_bot {
         @include o-apply-colors('header-sales_four');

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -1150,10 +1150,10 @@
                         <t t-set="_link_class" t-valuef="me-4"/>
                     </t>
                     <div class="ms-auto">
-                        <ul class="navbar-nav justify-content-end align-items-center gap-2 w-100 o_header_separator">
+                        <ul class="o_header_sales_three_small_links navbar-nav justify-content-end align-items-center gap-2 w-100 o_header_separator">
                             <!-- Language Selector -->
                             <t t-call="website.placeholder_header_language_selector">
-                                <t t-set="_btn_class" t-valuef="nav-link btn-sm d-flex align-items-center fw-bold text-uppercase o_nav-link_secondary"/>
+                                <t t-set="_btn_class" t-valuef="nav-link d-flex align-items-center fw-bold text-uppercase o_nav-link_secondary"/>
                                 <t t-set="_txt_class" t-valuef="ms-1"/>
                                 <t t-set="_dropdown_menu_class" t-valuef="dropdown-menu-end"/>
                                 <t t-set="_item_class" t-valuef="position-relative"/>
@@ -1161,13 +1161,13 @@
                             <!-- Sign In -->
                             <t t-call="portal.placeholder_user_sign_in">
                                 <t t-set="_item_class" t-valuef="position-relative"/>
-                                <t t-set="_link_class" t-valuef="nav-link btn-sm fw-bold text-uppercase o_nav-link_secondary"/>
+                                <t t-set="_link_class" t-valuef="nav-link fw-bold text-uppercase o_nav-link_secondary"/>
                             </t>
                             <!-- User Dropdown -->
                             <t t-call="portal.user_dropdown">
                                 <t t-set="_user_name" t-value="true"/>
                                 <t t-set="_item_class" t-valuef="dropdown"/>
-                                <t t-set="_link_class" t-valuef="nav-link btn-sm d-flex align-items-center fw-bold text-uppercase o_nav-link_secondary"/>
+                                <t t-set="_link_class" t-valuef="nav-link d-flex align-items-center fw-bold text-uppercase o_nav-link_secondary"/>
                                 <t t-set="_dropdown_menu_class" t-valuef="dropdown-menu-end"/>
                             </t>
                         </ul>


### PR DESCRIPTION
Since the update of Bootstrap from 5.1 to 5.3 in commit https://github.com/odoo-dev/odoo/commit/058212e12b5079eba870bde9775fe98f27928935, the font-size of `btn-sm` wasn't taken into account because the font-size of `nav-link` had the priority. This created a layout inconsistency in `header_sales_three` template.

In addition, once the user started changing the font size of the navigation in the Web editor (by triggering the `header-font-size` value), the font size of the small buttons was removed and replaced by the regular font size.

This commit adapts and forces the font-size of small links in the `header_sales_three` template to be always proportional to header font size.


| Before | After |
|--------|--------|
| <img width="650" alt="Capture d’écran 2024-08-16 à 11 00 04" src="https://github.com/user-attachments/assets/a3883f97-9de1-4940-9c40-b1db6dda64dd"> | <img width="549" alt="Capture d’écran 2024-08-16 à 10 58 52" src="https://github.com/user-attachments/assets/6ed2c695-55de-42b3-91e3-e9ae6d77c017"> |






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
