### PR TITLE
[IMP] mail: improve chat window style

### DIFF
--- a/addons/mail/static/src/core/common/chat_bubble.scss
+++ b/addons/mail/static/src/core/common/chat_bubble.scss
@@ -91,6 +91,12 @@
     background-color: transparent;
 }
 
+.o-mail-ChatBubble-unreadIndicator {
+    font-size: .5rem;
+    bottom: 40%;
+    right: -2px;
+}
+
 @keyframes o-mail-ChatBubble-bouncing { 
     from { 
         transform: translate3d(0, 0, 0); 

--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -11,7 +11,8 @@
     </t>
 
     <t t-name="mail.ChatBubble.core">
-        <button class="o-mail-ChatBubble" t-att-name="props.chatWindow.displayName" t-att-class="{ 'o-bouncing': state.bouncing, 'position-fixed': env.embedLivechat, 'position-relative': !env.embedLivechat, 'o-active': preview.isOpen }" t-att-style="env.embedLivechat ? `top: ${ position.top }; left: ${ position.left };` : ''" t-on-click="() => props.chatWindow.open()" t-on-animationend="() => state.bouncing = false" t-ref="root">
+        <button class="o-mail-ChatBubble bg-view position-relative" t-att-name="props.chatWindow.displayName" t-att-class="{ 'o-bouncing': state.bouncing, 'position-fixed': env.embedLivechat, 'position-relative': !env.embedLivechat, 'o-active': preview.isOpen }" t-att-style="env.embedLivechat ? `top: ${ position.top }; left: ${ position.left };` : ''" t-on-click="() => props.chatWindow.open()" t-on-animationend="() => state.bouncing = false" t-ref="root">
+            <span class="o-mail-ChatBubble-unreadIndicator position-absolute" t-att-class="{ 'opacity-50': thread?.isUnread, 'opacity-0': !thread?.isUnread }"><i class="fa fa-circle"/></span>
             <div t-if="thread?.importantCounter > 0" class="o-mail-ChatBubble-counter position-absolute badge rounded-pill fw-bold o-discuss-badge shadow" t-out="thread?.importantCounter"/>
             <button t-if="state.showClose and !env.embedLivechat" class="o-mail-ChatBubble-close position-absolute shadow rounded-circle fw-bold bg-view" title="Close Chat Window" t-on-click.stop="() => this.props.chatWindow.close()"><i class="oi oi-close"/></button>
             <ImStatus t-if="thread?.correspondent?.persona?.im_status and thread?.correspondent?.persona?.im_status != 'offline'" className="'o-mail-ChatBubble-status position-absolute o-mail-brighter'" member="thread.correspondent"/>

--- a/addons/mail/static/src/core/common/chat_window.dark.scss
+++ b/addons/mail/static/src/core/common/chat_window.dark.scss
@@ -1,3 +1,7 @@
+.o-mail-ChatWindow {
+    --mail-ChatWindow-desktopBorderOpacity: 0.3;
+}
+
 .o-mail-ChatWindow-command {
     &:hover, &.o-active {
         background-color: $gray-200;

--- a/addons/mail/static/src/core/common/chat_window.scss
+++ b/addons/mail/static/src/core/common/chat_window.scss
@@ -11,13 +11,10 @@
     &.o-mobile {
         z-index: 1001; // above messaging menu (chat window takes whole screen)
     }
-    box-shadow: -5px -5px 10px rgba(#000000, 0.09);
-    outline: none;
-
-    &.o-folded {
-        height: $o-mail-Discuss-headerHeight;
+    &:not(.o-mobile) {
+        --border-opacity: var(--mail-ChatWindow-desktopBorderOpacity, .15);
     }
-
+    outline: none;
 }
 
 .o-mail-ChatWindow-command {
@@ -35,17 +32,9 @@
     padding: 3px 6px;
 }
 
-.o-mail-ChatWindow-header {
-    height: $o-mail-Discuss-headerHeight;
-
-    &:not(.o-folded) {
-        box-shadow: 0px 3px 12px -3px rgba(50, 50, 50, 0.15);
-    }
-
-    .o-mail-ChatWindow-threadAvatar img {
-        height: 28px;
-        width: 28px;
-    }
+.o-mail-ChatWindow-header .o-mail-ChatWindow-threadAvatar img {
+    height: $o-mail-Avatar-sizeSmall;
+    width: $o-mail-Avatar-sizeSmall;
 }
 
 .o-mail-ChatWindow-typing {

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -2,35 +2,34 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.ChatWindow">
-    <div class="o-mail-ChatWindow fixed-bottom overflow-hidden d-flex flex-column"
+    <div class="o-mail-ChatWindow fixed-bottom overflow-hidden d-flex flex-column shadow-sm"
         t-att-style="style"
         t-att-class="{
             'w-100 h-100 o-mobile': ui.isSmall,
-            'o-folded': props.chatWindow.folded,
-            'rounded-top-3': !ui.isSmall,
+            'rounded-top-3 border border-bottom-0 border-dark': !ui.isSmall,
             'o-large': store.chatHub.isBig,
         }"
         t-on-keydown="onKeydown"
         tabindex="1"
     >
-        <div class="o-mail-ChatWindow-header d-flex align-items-center flex-shrink-0 bg-100 border-bottom z-1" t-on-click="onClickHeader" t-att-class="{ 'cursor-pointer': !ui.isSmall, 'o-folded': props.chatWindow.folded }">
+        <div class="o-mail-ChatWindow-header d-flex align-items-center flex-shrink-0 bg-100 z-1" t-on-click="onClickHeader" t-att-class="{ 'cursor-pointer': !ui.isSmall }">
             <t t-if="threadActions.actions.length > 3">
                 <div class="d-flex text-truncate">
                     <Dropdown position="'left-start'" onStateChanged="isOpen => this.onActionsMenuStateChanged(isOpen)" menuClass="'d-flex flex-column py-0'">
                         <button
-                            class="o-mail-ChatWindow-command btn rounded-0 d-flex align-items-center px-1 py-2 m-0 opacity-75 opacity-100-hover w-100"
+                            class="o-mail-ChatWindow-command btn rounded-0 d-flex align-items-center px-1 py-2 m-0 w-100"
                             t-att-class="{ 'ps-2 pe-1 rounded-top-3': !ui.isSmall, 'o-active': state.actionsMenuOpened }"
                             t-att-disabled="state.editingName"
                             t-att-title="actionsMenuTitleText"
                         >
                             <t t-call="mail.ChatWindow.headerContent"/>
-                            <i class="fa fa-fw fa-caret-down opacity-50 ms-1"/>
+                            <i t-if="!state.editingName" class="fa fa-fw fa-caret-down opacity-50 ms-1"/>
                         </button>
                         <t t-set-slot="content">
                             <t t-if="ui.isSmall" t-set="actions" t-value="threadActions.actions.slice(1, -1)"/>
                             <t t-else="" t-set="actions" t-value="threadActions.actions.slice(1, -2)"/>
                             <DropdownItem t-foreach="actions" t-as="action" t-key="action.id"
-                                class="'o-mail-ChatWindow-command btn rounded-0 d-flex align-items-center px-2 py-2 m-0 opacity-75 opacity-100-hover'"
+                                class="'o-mail-ChatWindow-command btn rounded-0 d-flex align-items-center px-2 py-2 m-0'"
                                 attrs="{ title: action.name }"
                                 onSelected="() => action.onSelect()"
                             >
@@ -42,12 +41,13 @@
                 </div>
                 <AutoresizeInput
                     t-if="state.editingName"
-                    className="'text-truncate fw-bold flex-shrink-1 me-1 py-0'"
+                    className="'text-truncate fw-bold flex-shrink-1 me-1 py-0 ' + (ui.isSmall ? 'fs-4' : '')"
                     enabled="true"
                     autofocus="true"
                     onValidate.bind="renameThread"
                     value="props.chatWindow.displayName"
                 />
+                <i t-if="state.editingName" class="fa fa-fw fa-caret-down opacity-50 ms-1"/>
             </t>
             <t t-else="">
                 <t t-call="mail.ChatWindow.headerContent"/>
@@ -109,6 +109,6 @@
         <img class="rounded" t-att-src="thread.avatarUrl" alt="Thread Image"/>
     </div>
     <ThreadIcon t-if="thread and thread.channel_type === 'chat' and thread.correspondent" thread="thread"/>
-    <div t-if="!state.editingName" class="text-truncate fw-bold border border-transparent me-1 my-0" t-att-title="props.chatWindow.displayName" t-esc="props.chatWindow.displayName" t-att-class="thread ? 'ms-1' : 'ms-3'"/>
+    <div t-if="!state.editingName" class="text-truncate fw-bolder border border-transparent me-1 my-0" t-att-title="props.chatWindow.displayName" t-esc="props.chatWindow.displayName" t-att-class="{ 'ms-1': thread, 'ms-3': !thread, 'fs-4': ui.isSmall }"/>
 </t>
 </templates>

--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -74,10 +74,14 @@
 }
 
 .o-mail-Composer-compactContainer {
+    --border-opacity: 0.75;
+
     &.o-mobile:not(:focus-within) {
-        margin-bottom: map-get($spacers, 4) + map-get($spacers, 2);
+        margin-bottom: map-get($spacers, 5) !important;
     }
-    &:not(.o-mobile) {
-        box-shadow: 0px -3px 25px 3px rgba(50, 50, 50, 0.1);
+
+    &:has(textarea:focus) {
+        --border-opacity: 0.35;
+        border-color: rgba($o-action, var(--border-opacity)) !important;
     }
 }

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -26,16 +26,13 @@
                 </span>
                 <i class="fa fa-lg fa-times-circle rounded-circle p-0 ms-1 cursor-pointer" title="Stop replying" t-on-click="() => props.messageToReplyTo.cancel()"/>
             </div>
-            <div class="o-mail-Composer-coreMain d-flex flex-nowrap align-items-start flex-grow-1"
-                t-att-class="{ 'flex-column' : extended }"
-            >
-                <div class="d-flex bg-view flex-grow-1"
+            <div class="o-mail-Composer-coreMain d-flex flex-nowrap align-items-start flex-grow-1" t-att-class="{ 'flex-column' : extended }">
+                <div class="d-flex bg-view flex-grow-1 border"
                     t-att-class="{
-                        'o-mail-Composer-compactContainer border-top': compact and !props.composer.message,
-                        'o-mobile border-bottom': isMobileOS,
-                        'border': props.composer.message,
-                        'border rounded-3' : normal,
-                        'border rounded-3 align-self-stretch flex-column' : extended,
+                        'o-mail-Composer-compactContainer m-1 shadow-sm border-secondary': compact and !props.composer.message,
+                        'o-mobile rounded-3': isMobileOS,
+                        'rounded-3' : normal,
+                        'rounded-3 align-self-stretch flex-column' : extended,
                     }"
                 >
                     <div class="position-relative flex-grow-1">

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -384,7 +384,10 @@ export class Message extends Component {
     }
 
     getAvatarContainerAttClass() {
-        return { "opacity-50": this.message.isPending };
+        return {
+            "opacity-50": this.message.isPending,
+            "o-inChatWindow": this.env.inChatWindow,
+        };
     }
 
     exitEditMode() {

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -35,6 +35,11 @@
     flex-basis: $o-mail-Message-sidebarWidth;
     max-width: $o-mail-Message-sidebarWidth;
 
+    &.o-inChatWindow {
+        flex-basis: $o-mail-Message-sidebarSmallWidth;
+        max-width: $o-mail-Message-sidebarSmallWidth;
+    }
+
     .o-mail-Message-date {
         font-size: 0.75rem;
     }
@@ -43,6 +48,11 @@
 .o-mail-Message-avatarContainer {
     width: $o-mail-Avatar-size;
     height: $o-mail-Avatar-size;
+
+    &.o-inChatWindow {
+        width: $o-mail-Avatar-sizeSmall;
+        height: $o-mail-Avatar-sizeSmall;
+    }
 }
 
 @font-face {

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -17,7 +17,7 @@
             >
                 <MessageInReply t-if="message.parentMessage" alignedRight="isAlignedRight" message="message" onClick="props.onParentMessageClick"/>
                 <div class="o-mail-Message-core position-relative d-flex flex-shrink-0">
-                    <div class="o-mail-Message-sidebar d-flex flex-shrink-0" t-att-class="{ 'justify-content-end': isAlignedRight, 'align-items-start justify-content-start': !isAlignedRight  }">
+                    <div class="o-mail-Message-sidebar d-flex flex-shrink-0" t-att-class="{ 'justify-content-end': isAlignedRight, 'align-items-start justify-content-start': !isAlignedRight, 'o-inChatWindow': env.inChatWindow }">
                         <div t-if="!props.squashed" class="o-mail-Message-avatarContainer position-relative bg-view" t-att-class="getAvatarContainerAttClass()">
                             <img class="o-mail-Message-avatar w-100 h-100 rounded" t-att-src="authorAvatarUrl" t-att-class="authorAvatarAttClass"/>
                         </div>

--- a/addons/mail/static/src/core/common/message_in_reply.scss
+++ b/addons/mail/static/src/core/common/message_in_reply.scss
@@ -2,11 +2,19 @@
     &.o-isLeftAlign {
         left: $o-mail-Message-sidebarWidth / 2;
         border-radius: $o-RoundedRectangle-small 0 0 0;
+
+        &.o-inChatWindow {
+            left: $o-mail-Message-sidebarSmallWidth / 2;
+        }
     }
 
     &.o-isRightAlign {
         right: $o-mail-Message-sidebarWidth / 2;
         border-radius: 0 $o-RoundedRectangle-small 0 0;
+
+        &.o-inChatWindow {
+            right: $o-mail-Message-sidebarSmallWidth / 2;
+        }
     }
 }
 

--- a/addons/mail/static/src/core/common/message_in_reply.xml
+++ b/addons/mail/static/src/core/common/message_in_reply.xml
@@ -6,7 +6,7 @@
                 'd-flex justify-content-end ms-5': env.inChatWindow and props.alignedRight,
             }">
             <small class="position-relative d-block text-small mb-1" t-attf-class="{{ env.inChatWindow and props.alignedRight ? 'justify-content-end pe-5': 'ps-5' }}">
-                <span class="o-mail-MessageInReply-corner position-absolute bottom-0 top-50 pe-4 border-top text-300" t-attf-class="{{ env.inChatWindow and props.alignedRight ? 'o-isRightAlign border-end' : 'o-isLeftAlign border-start' }}" t-att-class="{ 'ms-n2': store.discuss?.isActive }"/>
+                <span class="o-mail-MessageInReply-corner position-absolute bottom-0 top-50 pe-4 border-top text-300" t-attf-class="{{ env.inChatWindow and props.alignedRight ? 'o-isRightAlign border-end' : 'o-isLeftAlign border-start' }}" t-att-class="{ 'ms-n2': store.discuss?.isActive, 'o-inChatWindow': env.inChatWindow }"/>
                 <span t-if="!props.message.parentMessage.isEmpty" class="d-inline-flex align-items-center text-muted opacity-75" t-att-class="{ 'cursor-pointer opacity-100-hover': props.onClick }" t-on-click="() => this.props.onClick?.()">
                     <img class="o-mail-MessageInReply-avatar me-2 rounded" t-att-src="authorAvatarUrl" t-att-title="props.message.parentMessage.author?.name ?? props.message.parentMessage.email_from" alt="Avatar"/>
                     <span class="o-mail-MessageInReply-content overflow-hidden smaller">

--- a/addons/mail/static/src/core/common/primary_variables.scss
+++ b/addons/mail/static/src/core/common/primary_variables.scss
@@ -1,5 +1,5 @@
 $o-mail-Avatar-size: 36px !default;
-$o-mail-Avatar-sizeSmall: 24px !default;
+$o-mail-Avatar-sizeSmall: 28px !default;
 $o-mail-ChatWindow-width: 360px !default; // same value as WINDOW
 $o-mail-ChatWindow-widthLarge: 510px !default; // same value as WINDOW_LARGE
 $o-mail-ChatHub-bubblesWidth: 56px !default; // same value as BUBBLE
@@ -16,11 +16,11 @@ $o-mail-LinkPreview-width: 320px !default;
 $o-mail-LinkPreview-height: 240px !default;
 $o-mail-LinkPreviewCard-height: 80px !default;
 
+$o-mail-Message-sidebarSmallWidth: 34px !default;
 $o-mail-Message-sidebarWidth: 42px !default;
 $o-mail-NavigableList-zIndex: 11;
 $o-mail-Chatter-minWidth: 530px !default;
 $o-mail-Discuss-inspector: 300px !default;
-$o-mail-Discuss-headerHeight: 48px !default;
 
 @mixin o-FileViewer-arrow {
     background-color: rgba(black, 0.4);

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -93,8 +93,10 @@
 </t>
 
 <t t-name="mail.NotificationMessage">
-    <div class="o-mail-NotificationMessage text-break mx-auto text-500 small px-3 text-center" t-on-click="onClickNotification" t-att-class="{
+    <div class="o-mail-NotificationMessage text-break mx-auto text-500 px-3 text-center" t-on-click="onClickNotification" t-att-class="{
         'mt-1': prevMsg and !prevMsg.isNotification,
+        'smaller': env.inChatWindow,
+        'small': !env.inChatWindow,
     }" t-ref="root">
         <i t-if="msg.notificationIcon" t-attf-class="{{ msg.notificationIcon }} me-1"/>
         <span class="o-mail-NotificationMessage-author d-inline" t-if="msg.author and !msg.body.includes(escape(msg.author.name))" t-esc="msg.author.name"/> <t t-out="msg.body"/>

--- a/addons/mail/static/src/core/public_web/discuss.scss
+++ b/addons/mail/static/src/core/public_web/discuss.scss
@@ -23,8 +23,6 @@
 }
 .o-mail-Discuss-header {
     background-color: $white;
-    height: $o-mail-Discuss-headerHeight;
-    max-height: $o-mail-Discuss-headerHeight;
     box-shadow: 0px 1px 6px -3px rgba(50, 50, 50, 0.15);
 }
 

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -5,7 +5,7 @@
     <div class="o-mail-Discuss d-flex h-100 flex-grow-1" t-att-class="{ 'flex-column align-items-center bg-view': ui.isSmall }" t-ref="root">
         <DiscussSidebar t-if="!ui.isSmall and props.hasSidebar"/>
         <div t-if="!(ui.isSmall and store.discuss.activeTab !== 'main')" class="o-mail-Discuss-content d-flex flex-column h-100 w-100 overflow-auto" t-ref="content">
-            <div class="o-mail-Discuss-header px-3 d-flex flex-shrink-0 align-items-center border-bottom z-1" t-att-class="{ 'flex-grow-1': !ui.isSmall and !store.inPublicPage }" t-ref="header">
+            <div class="o-mail-Discuss-header px-3 d-flex flex-shrink-0 align-items-center border-bottom z-1 flex-grow-0" t-ref="header">
                 <t t-if="thread">
                     <div t-if="['channel', 'group', 'chat'].includes(thread.channel_type)" class="o-mail-Discuss-threadAvatar position-relative align-self-center align-items-center mt-2 mb-2 me-2">
                         <img class="rounded" t-att-src="thread.avatarUrl" alt="Thread Image"/>

--- a/addons/mail/static/src/scss/variables/primary_variables.scss
+++ b/addons/mail/static/src/scss/variables/primary_variables.scss
@@ -1,7 +1,7 @@
 $o-mail-Avatar-size: 42px !default;
 $o-mail-ChatWindow-width: 360px !default; // same value as WINDOW
 $o-mail-Discuss-inspector: 300px !default;
-$o-mail-Avatar-sizeSmall: 24px !default;
+$o-mail-Avatar-sizeSmall: 28px !default;
 // Needed because $border-radius variations are all set to 0 in enterprise.
 $o-RoundedRectangle-small: .2rem !default;
 $o-RoundedRectangle-large: 3 * $o-RoundedRectangle-small !default;


### PR DESCRIPTION
Chat windows is narrow and should not waste precious space for messages and their content.
This commit makes the following improvements to chat windows:

1. composer has floating square visual in chat window
2. smaller chat window header height
3. smaller message avatars in chat windows
4. smaller notification messages in chat windows
5. more opaque and bolder conversation name in header
6. chat bubble with unread messages have a small indicator
7. focused composer has active outline style
8. chat windows have border in desktop

Reducing sizing of less relevant info like message notification and avatars gives more visibility to messages. Removed top/bottom borders on thread gives more room to breath, square composer makes it more obvious this is an input to type text.

<img width="995" alt="002-1" src="https://github.com/user-attachments/assets/5059f9fc-658c-470c-b5f4-59c37a28e278">
<img width="976" alt="002-2" src="https://github.com/user-attachments/assets/1d4fa8b5-5dc2-4cd1-a336-6d8e3f187756">
<img width="689" alt="002-3" src="https://github.com/user-attachments/assets/d04c7c26-6098-4016-926e-223c5c5c8fb0">
<img width="711" alt="002-4" src="https://github.com/user-attachments/assets/a7d60ac1-f825-4f22-8e66-0d5796e5f28e">
