### PR TITLE
[FIX] account: Ensure internal user are assigned to user recipient group

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3720,7 +3720,7 @@ class AccountMove(models.Model):
             button_access = {'url': access_link} if access_link else {}
             recipient_group = (
                 'additional_intended_recipient',
-                lambda pdata: pdata['id'] in msg_vals.get('partner_ids', []) and pdata['id'] != self.partner_id.id,
+                lambda pdata: pdata['id'] in msg_vals.get('partner_ids', []) and pdata['id'] != self.partner_id.id and pdata['type'] != 'user',
                 {
                     'has_button_access': True,
                     'button_access': button_access,


### PR DESCRIPTION
In case a user logs an internal note on an invoice and pings another internal user, who happens to manage notifications by email, the link to the document inside the email was directing to the portal instead of the backend.

This happens because of the override of _notify_get_groups in the account module adds an extra recipient group 'additional_intended_recipient' in the first position of the groups list. This group is based on 'portal_customer' but its validation function will evaluate to True for internal users.

In any case, the recipient group for user must be considered first as only internal user will be validated through its function. The recipient group portal_customer can then be added in the second position, ie after user but before portal, and the eventual additional_intended_recipient can be set before portal_customer as it is the case now.

Description of the issue/feature this PR addresses:

Steps to reproduce:
1. Have a internal user that manages notifications by email
2. On a customer invoice log a note and ping this user using '@'

Current behavior before PR:

The email contains a link to the portal

Desired behavior after PR is merged:

The email contains a link to the backend


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
