### PR TITLE
[FIX] l10n_bd: fix loading account template

### DIFF
--- a/addons/l10n_bd/__manifest__.py
+++ b/addons/l10n_bd/__manifest__.py
@@ -11,12 +11,12 @@
         'account',
     ],
     'data': [
+        'data/account.account.tag.csv',
+        'data/res.country.state.csv',
         'data/account_tax_report_data.xml',
         'views/menu_items.xml',
     ],
     'demo': [
-        'data/account.account.tag.csv',
-        'data/res.country.state.csv',
         'demo/demo_company.xml',
     ],
     'license': 'LGPL-3',


### PR DESCRIPTION
[FIX] l10n_bd: fix loading account template

The issue is that I put the account tags templates in the manifest to load into demo section which cause issues 
when user try to load the package without demo data as It will not going to load

Solution: moving the account tags template/states to the data section

task-id#3974212

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr