### PR TITLE
[IMP] website, website_sale, website_sale_comparison: use CSS grid in /shop

### DIFF
--- a/addons/website/static/src/scss/bootstrap_overridden.scss
+++ b/addons/website/static/src/scss/bootstrap_overridden.scss
@@ -31,6 +31,8 @@ $variable-prefix: '' !default;
 // Restore negative margins disabled in BS5 by default
 $enable-negative-margins: true !default;
 
+// Enable CSS grid
+$enable-cssgrid: true !default;
 
 
 // Customize the light and dark text colors for use in our color contrast function.

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1828,6 +1828,10 @@ $ribbon-padding: 100px;
     white-space: nowrap;
     text-align: center;
     pointer-events: none;
+
+    &:empty {
+        display: none;
+    }
 }
 
 .o_ribbon_right {

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -243,6 +243,8 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
         ppr = website.shop_ppr or 4
 
+        gap = website.shop_gap or "16px"
+
         request_args = request.httprequest.args
         attrib_list = request_args.getlist('attribute_value')
         attrib_values = [[int(x) for x in v.split("-")] for v in attrib_list if v]
@@ -404,6 +406,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             'bins': lazy(lambda: TableCompute().process(products, ppg, ppr)),
             'ppg': ppg,
             'ppr': ppr,
+            'gap': gap,
             'categories': categs,
             'attributes': attributes,
             'keep': keep,
@@ -2081,7 +2084,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         current_website = request.env['website'].get_current_website()
         # Restrict options we can write to.
         writable_fields = {
-            'shop_ppg', 'shop_ppr', 'shop_default_sort',
+            'shop_ppg', 'shop_ppr', 'shop_default_sort', 'shop_gap',
             'product_page_image_layout', 'product_page_image_width',
             'product_page_grid_columns', 'product_page_image_spacing'
         }

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -80,6 +80,8 @@ class Website(models.Model):
     )
     shop_ppr = fields.Integer(string="Number of grid columns on the shop", default=4)
 
+    shop_gap = fields.Char(string="Grid-gap on the shop", default="16px", required=False)
+
     shop_default_sort = fields.Selection(
         selection='_get_product_sort_mapping', required=True, default='website_sequence asc')
 

--- a/addons/website_sale/static/src/js/website_sale.editor.js
+++ b/addons/website_sale/static/src/js/website_sale.editor.js
@@ -52,6 +52,13 @@ options.registry.WebsiteSaleGridLayout = options.Class.extend({
     /**
      * @see this.selectClass for params
      */
+    setGap: function (previewMode, widgetValue, params) {
+        this.gap = widgetValue;
+        return rpc('/shop/config/website', { 'shop_gap': this.gap });
+    },
+    /**
+     * @see this.selectClass for params
+     */
     setDefaultSort: function (previewMode, widgetValue, params) {
         this.default_sort = widgetValue;
         return rpc('/shop/config/website', { 'shop_default_sort': this.default_sort });
@@ -232,8 +239,8 @@ options.registry.WebsiteSaleProductsItem = options.Class.extend({
     updateUI: async function () {
         await this._super.apply(this, arguments);
 
-        var sizeX = parseInt(this.$target.attr('colspan') || 1);
-        var sizeY = parseInt(this.$target.attr('rowspan') || 1);
+        let sizeX = parseInt(this.$target[0].dataset.colspan || 1);
+        let sizeY = parseInt(this.$target[0].dataset.rowspan || 1);
 
         var $size = this.$el.find('.o_wsale_soptions_menu_sizes');
         $size.find('tr:nth-child(-n + ' + sizeY + ') td:nth-child(-n + ' + sizeX + ')')

--- a/addons/website_sale/static/src/js/website_sale.editor.js
+++ b/addons/website_sale/static/src/js/website_sale.editor.js
@@ -114,6 +114,7 @@ options.registry.WebsiteSaleProductsItem = options.Class.extend({
     willStart: async function () {
         const _super = this._super.bind(this);
         this.ppr = this.$target.closest('[data-ppr]').data('ppr');
+        this.defaultSort = this.$target[0].closest('[data-default-sort]').dataset.defaultSort
         this.productTemplateID = parseInt(this.$target.find('[data-oe-model="product.template"]').data('oe-id'));
         this.ribbonPositionClasses = {'left': 'o_ribbon_left', 'right': 'o_ribbon_right'};
         this.ribbons = await new Promise(resolve => this.trigger_up('get_ribbons', {callback: resolve}));
@@ -308,8 +309,12 @@ options.registry.WebsiteSaleProductsItem = options.Class.extend({
      * @override
      */
     async _computeWidgetVisibility(widgetName, params) {
+        const isDefaultSortFeatured = this.defaultSort === 'website_sequence asc';
+
         if (widgetName === 'create_ribbon_opt') {
             return !this.ribbonEditMode;
+        } else if (widgetName === 'o_wsale_change_sequence_widget'){
+            return isDefaultSortFeatured;
         }
         return this._super(...arguments);
     },

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -5,44 +5,13 @@ $o-wsale-products-layout-grid-gutter-width: $grid-gutter-width / 2 !default;
 $o-wsale-products-layout-grid-gutter-width: min($grid-gutter-width / 2, $o-wsale-products-layout-grid-gutter-width);
 $input-border-color: $gray-400;
 
-@mixin wsale-break-table($-list: false) {
-    .o_wsale_products_grid_table_wrapper {
-        table, tbody {
-            display: block;
-            width: 100%;
-        }
-
-        tr {
-            display: if($-list, block, flex);
-            width: 100%;
-            flex-wrap: wrap;
-        }
-
-        td {
-            display: if($-list, block, inline-block);
-            width: if($-list, 100%, 50%);
-        }
-
-        @if ($-list == false) {
-            [data-ppr="3"] td.oe_product {
-                width: 100%;
-            }
-        }
-
-        .modal-dialog {
-            table, tbody, tr, td {
-                display: revert;
-            }
-        }
-    }
-}
-
 .oe_website_sale {
     // ==== Products list designs
     .o_wsale_design_cards {
         --o-wsale-card-border-width: 1px;
         --o-wsale-card-border-radius: #{$card-border-radius};
         --o-wsale-card-info-padding: #{map-get($spacers, 2)};
+        --o-wsale-card-info-grow: 1;
         --o-wsale-card-bg: #{$card-bg};
         --o-wsale-card-color: #{adjust-color-to-background($body-color, $card-bg)};
         --o-wsale-card-text-muted: #{adjust-color-to-background($text-muted, $card-bg, mute-color($color-contrast-light), mute-color($color-contrast-dark))};
@@ -52,14 +21,15 @@ $input-border-color: $gray-400;
     }
     .o_wsale_design_thumbs {
         --o-wsale-card-border-width: 0;
-        --o-wsale-card-info-padding: #{map-get($spacers, 3)} 0;
+        --o-wsale-card-info-padding: #{map-get($spacers, 3)} 0 0;
         --o-wsale-card-thumb-border-radius: #{$o-wsale-products-layout-grid-gutter-width * .5};
         --o-wsale-card-thumb-shadow: 0 13px 27px -5px #{scale-color(map-get($theme-colors, 'primary'), $alpha: -90%)},
                                      0 8px 16px -8px rgba(0, 0, 0, .28);
     }
     .o_wsale_design_grid {
-        --o-wsale-grid-border: 1px solid #{$card-border-color};
         --o-wsale-card-border-width: 0;
+        --o-wsale-card-info-padding: #{map-get($spacers, 2)};
+        --o-wsale-card-info-grow: 1;
     }
 
     // ==== Products list thumb options
@@ -217,6 +187,7 @@ $input-border-color: $gray-400;
 // Base style for a product card with image/description
 .oe_product_cart {
     flex-direction: var(--o-wsale-card-flex-direction, column);
+    align-items: var(--o-wsale-card-flex-align-items);
     border: $card-border-width solid $card-border-color;
     border-width: var(--o-wsale-card-border-width, 0 0 1px);
     border-radius: var(--o-wsale-card-border-radius, 0);
@@ -227,17 +198,18 @@ $input-border-color: $gray-400;
     .oe_product_image {
         min-width: var(--o-wsale-card-thumb-size);
         width: var(--o-wsale-card-thumb-size);
+        border-radius: var(--o-wsale-card-thumb-border-radius);
+        box-shadow: var(--o-wsale-card-thumb-shadow);
 
         .oe_product_image_link {
-            padding-top: calc(100% / (var(--o-wsale-card-thumb-aspect-ratio, 1)));
+            aspect-ratio: var(--o-wsale-card-thumb-aspect-ratio, 1);
 
             .oe_product_image_img_wrapper {
                 @include o-position-absolute(0, 0, 0, 0);
 
                 img {
-                    box-shadow: var(--o-wsale-card-thumb-shadow);
-                    border-radius: var(--o-wsale-card-thumb-border-radius);
                     object-fit: var(--o-wsale-card-thumb-fill-mode, contain);
+                    object-position: var(--o-wsale-card-thumb-position, center);;
                 }
             }
         }
@@ -247,14 +219,30 @@ $input-border-color: $gray-400;
         padding: var(--o-wsale-card-info-padding, #{map-get($spacers, 2)} 0);
     }
 
+    .o_wsale_product_information_text {
+        flex-grow: var(--o-wsale-card-info-grow);
+    }
+
     .oe_subdescription div {
-        min-height: calc(#{$font-size-sm * 1.1} * 2);
+        min-height: calc(#{$font-size-sm * 1.1} * 2.4);
         overflow: hidden;
         display: -webkit-box;
         text-overflow: ellipsis;
         -webkit-line-clamp: 2;
         -webkit-box-orient: vertical;
         line-height: 1.1;
+
+        // Hide empty product description in not-edition mode
+        body:not(.editor_enable) &:empty {
+            display: none;
+        }
+    }
+
+    // Outline product description boxes to ease edition
+    body.editor_enable &:hover .oe_subdescription {
+        div:has(br:first-child:last-child):not(:hover), div:empty:not(:hover) {
+            outline: $border-width dashed fade-currentColor(25%);
+        }
     }
 
     // Needed to be visible on a dark <body> background. The rule is defined on
@@ -264,12 +252,22 @@ $input-border-color: $gray-400;
         color: var(--o-wsale-card-text-muted) !important;
     }
 
-    .o_wsale_product_btn:empty {
-        display: none !important;
-    }
+    .o_wsale_product_btn {
+        .btn {
+            padding-left: .9rem;
+            padding-right: .9rem;
+            border: $border-width solid $border-color;
+            transition: none;
 
-    .o_ribbon_left, .o_ribbon_right {
-        box-shadow: 0px -10px 70px 30px rgba(black, 0.05);
+            &:hover {
+                background-color: $primary;
+                color: color-contrast($primary);
+            }
+        }
+
+        &:empty {
+            display: none !important;
+        }
     }
 
     .o_product_link {
@@ -280,40 +278,58 @@ $input-border-color: $gray-400;
 
 // ==== THE GRID
 #products_grid {
-    .o_wsale_products_grid_table_wrapper .table:not(.o_wsale_modal_table) {
-        table-layout: fixed;
+    .o_wsale_products_grid_table {
+        --o-wsale-products-grid-gap-y: calc(var(--o-wsale-products-grid-gap, 16px) * 1.25);
+        --gap: var(--o-wsale-products-grid-gap-y) var(--o-wsale-products-grid-gap, 16px);
 
-        td {
-            padding: $o-wsale-products-layout-grid-gutter-width * .5;
-            border: var(--o-wsale-grid-border, 0);
+        container-type: inline-size;
+        container-name: o-wsale-grid;
+        grid-template-rows: minmax(auto, auto);
 
-            @if $o-wsale-products-layout-grid-gutter-width <= 0 {
-                border: $card-border-width solid $card-border-color;
+        &.o_wsale_design_grid {
+            overflow: hidden;
+
+            .oe_product {
+                --line-offset-y: calc(var(--o-wsale-products-grid-gap-y) / 2);
+                --line-offset-x: calc(var(--o-wsale-products-grid-gap) / 2);
+
+                &:before, &:after {
+                    content: '';
+                    position: absolute;
+                    background-color: $gray-300;
+                }
+
+                &::before {
+                    height: calc(100% + var(--o-wsale-products-grid-gap-y));
+                    width: $border-width;
+                    left: calc(calc(var(--line-offset-x) * -1) - 1px);
+                    top: calc(var(--line-offset-y) * -1);
+                }
+
+                &::after {
+                    width: 100vw;
+                    height: $border-width;
+                    bottom: calc(var(--line-offset-y) * -1);
+                    left: calc(var(--line-offset-x) * -1);
+                }
             }
         }
     }
-
-    .o_wsale_products_grid_table_wrapper {
-        // Necessary to compensate the outer border-spacing of the table. No
-        // overflow will occur as the gutter width cannot be higher than the
-        // BS4 grid gutter and the vertical margins of the wrapper's parent are
-        // set accordingly.
-        // Note: a possible layout could also be ok by removing the wrapper
-        // related spacings and setting a background to it, thus including the
-        // outer border spacing as part of the design.
-        margin: (-$o-wsale-products-layout-grid-gutter-width / 2);
-    }
 }
 
-#products_grid:not(.o_wsale_layout_list) {
-    @include media-breakpoint-down(lg) {
-        @include wsale-break-table();
-    }
+#products_grid:where(:not(.o_wsale_layout_list)) {
+    @mixin desktop-setup {
 
-    @include media-breakpoint-up(lg) {
-        td.oe_product {
-            padding-bottom: $o-wsale-products-layout-grid-gutter-width * .5;
+        // .o_wsale_products_grid_table
+        // Necessary just to ensure that a product with custom height behaves
+        // correctly when rendered into the last row.
+        grid-auto-rows: minmax(160px, auto);
 
+        .oe_product {
+            grid-row: span var(--o-wsale-products-grid-product-col-height, 1);
+        }
+
+        .oe_product:not(.oe_product_size_stretch) {
             .o_wsale_product_btn {
                 @include o-position-absolute(auto, auto, calc(100% + #{map-get($spacers, 2)}), map-get($spacers, 2));
                 z-index: 2;
@@ -324,46 +340,130 @@ $input-border-color: $gray-400;
             }
         }
 
-        // Sliglty increase padding for larger blocks
-        @for $x from 2 through 4 {
-            [class*="o_wsale_product_grid_wrapper_#{$x}_"] {
-                --o-wsale-card-info-padding: #{map-get($spacers, 3)} 0 #{map-get($spacers, 2)};
+        // Stretch
+        .oe_product.oe_product_size_stretch {
+            --o-wsale-card-border-radius: 0;
+            --o-wsale-card-flex-direction: row;
+            --o-wsale-card-flex-align-items: start;
+            --o-wsale-card-info-padding: 0 #{map-get($spacers, 3)};
+            --o-wsale-card-thumb-size: calc(
+                calc(100cqw / var(--o-wsale-ppr)) - calc(var(--o-wsale-products-grid-gap) / 2)
+            );
+            --o-wsale-card-padding: #{0 0 $o-wsale-products-layout-grid-gutter-width};
+
+            .oe_subdescription div {
+                -webkit-line-clamp: initial;
+                line-height: inherit;
+            }
+        }
+
+        &:not(.o_wsale_context_thumb_cover) .oe_product.oe_product_size_stretch {
+            .oe_product_image img {
+                object-position: top left;
+            }
+        }
+
+        &.o_wsale_context_thumb_cover .oe_product.oe_product_size_stretch {
+            --o-wsale-card-info-grow: 1;
+
+            .o_wsale_product_information {
+                height: 100%;
             }
 
-            .o_wsale_design_cards [class*="o_wsale_product_grid_wrapper_#{$x}_"] {
-                --o-wsale-card-info-padding: #{map-get($spacers, 3)} #{map-get($spacers, 3)} #{map-get($spacers, 2)};
+            .oe_product_image, .oe_product_image_link {
+                height: 100%;
+                max-width: 100%;
+                padding: 0;
             }
+        }
+
+        &.o_wsale_design_cards .oe_product.oe_product_size_stretch {
+            --o-wsale-card-padding: 0;
+            --o-wsale-card-border-radius: #{$card-border-radius};
+            --o-wsale-card-info-padding: #{map-get($spacers, 3)};
+        }
+
+        &.o_wsale_design_grid .oe_product.oe_product_size_stretch {
+            --o-wsale-card-padding: 0;
+            --o-wsale-card-info-padding: #{map-get($spacers, 2)} #{map-get($spacers, 3)};
+
+            &[data-colspan="4"] {
+                --o-wsale-card-thumb-size: 50cqw;
+            }
+        }
+
+        .oe_product.oe_product_custom_portrait {
+            .oe_product_image, .oe_product_image_link {
+                min-height: calc(
+                    calc(90cqw / var(--o-wsale-ppr)) * var(--o-wsale-card-thumb-aspect-ratio)
+                );
+                height: 100%;
+            }
+
+            .oe_product_image_link {
+                --o-wsale-card-thumb-fill-mode: cover;
+                --o-wsale-card-thumb-aspect-ratio: auto;
+            }
+        }
+    }
+
+    .o_wsale_product_information {
+        container-type: inline-size;
+        container-name: o-wsale-grid-product-information;
+
+        .o_wsale_products_item_title {
+            font-size: unquote("clamp(0.95rem, 0.5rem + 3cqw, 1.4rem)");
+        }
+
+        .o_wsale_product_sub .product_price .h6 {
+            font-size: unquote("clamp(0.95rem, 0.5rem + 3cqw, 4rem)");
+        }
+    }
+
+    .o_wsale_products_grid_table {
+        @include media-breakpoint-up(lg) {
+            @include desktop-setup();
+        }
+    }
+
+    .o_wsale_products_grid_table_md {
+        @include media-breakpoint-only(md) {
+            @include desktop-setup();
         }
     }
 }
 
 #products_grid.o_wsale_layout_list {
-    @include wsale-break-table($-list: true);
-
     .oe_product {
-        --o-wsale-card-border-radius: 0;
         --o-wsale-card-flex-direction: row;
+        --o-wsale-card-flex-align-items: start;
         --o-wsale-card-info-padding: 0 #{map-get($spacers, 3)};
-
-        // The more an image is portait, the more its size decreases
+        --o-wsale-card-info-grow: 1;
         --o-wsale-card-thumb-size: calc(100px * var(--o-wsale-card-thumb-aspect-ratio, 1));
-
-        @include media-breakpoint-up(lg) {
-            --o-wsale-card-thumb-size: calc(160px * var(--o-wsale-card-thumb-aspect-ratio, 1));
-
-            h6, .h6 {
-                font-size: $font-size-base * 1.3;
-            }
-        }
-    }
-
-    .oe_product {
         --o-wsale-card-padding: #{0 0 $o-wsale-products-layout-grid-gutter-width};
+
+        grid-column: span $grid-columns;
+        grid-row: span 1;
     }
 
-    .o_wsale_design_cards .oe_product {
-        --o-wsale-card-padding: #{$o-wsale-products-layout-grid-gutter-width * .5};
-        --o-wsale-card-info-padding: #{map-get($spacers, 2)} #{map-get($spacers, 3)};
+    .o_wsale_design_cards, .o_wsale_design_grid {
+        .o_wsale_product_information {
+            min-height: 100%;
+        }
+
+        .oe_product_cart:where(:not(.oe_product_cart_has_description)) {
+            --o-wsale-card-padding: 0;
+            --o-wsale-card-info-padding: #{map-get($spacers, 2)} #{map-get($spacers, 3)} #{map-get($spacers, 2)} #{map-get($spacers, 2)};
+        }
+
+        .oe_product_cart.oe_product_cart_has_description {
+            --o-wsale-card-padding: #{map-get($spacers, 2)} #{map-get($spacers, 3)} #{map-get($spacers, 2)} #{map-get($spacers, 2)};
+            --o-wsale-card-thumb-position: center top;
+        }
+
+        &.o_wsale_context_thumb_cover .oe_product_cart.oe_product_cart_has_description {
+            --o-wsale-card-thumb-position: center;
+        }
     }
 }
 

--- a/addons/website_sale/views/snippets/snippets.xml
+++ b/addons/website_sale/views/snippets/snippets.xml
@@ -17,8 +17,15 @@
 <template id="snippet_options" inherit_id="website.snippet_options" name="e-commerce snippet options">
     <xpath expr="." position="inside">
         <!-- All products page -->
-        <div data-js="WebsiteSaleGridLayout" data-page-options="true" groups="website.group_website_designer" data-selector="main:has(.o_wsale_products_page)" data-no-check="true"
-            string="Products Page" data-target="#products_grid .o_wsale_products_grid_table_wrapper > table">
+        <div
+            data-js="WebsiteSaleGridLayout"
+            data-page-options="true"
+            groups="website.group_website_designer"
+            data-selector="main:has(.o_wsale_products_page)"
+            data-no-check="true"
+            string="Products Page"
+            data-target="#products_grid .o_wsale_products_grid_table_wrapper > .o_wsale_products_grid_table"
+        >
             <we-select string="Layout" data-no-preview="true" data-reload="/">
                 <we-button data-customize-website-views="" data-name="grid_view_opt">Grid</we-button>
                 <we-button data-customize-website-views="website_sale.products_list_view">List</we-button>
@@ -32,6 +39,18 @@
                     <we-button data-set-ppr="4">4</we-button>
                 </we-select>
             </we-row>
+
+            <we-range
+                string="Gap" class="o_we_sublevel_1"
+                data-select-style="0"
+                data-set-gap=""
+                data-css-property="--o-wsale-products-grid-gap"
+                data-display-range-value="true"
+                data-display-range-value-unit="px"
+                data-unit="px"
+                data-min="0"
+                data-max="28"
+            />
             <we-select string="Style" class="o_we_sublevel_1">
                 <we-button data-select-class=""
                            data-customize-website-views="">
@@ -183,7 +202,6 @@
                     </table>
                 </we-row>
             </div>
-
             <we-row string="Re-order" data-no-preview="true">
                 <we-button title="Push to top" data-change-sequence="top" class="fa fa-fw fa-angle-double-left"/>
                 <we-button title="Push up" data-change-sequence="up" class="fa fa-fw fa-angle-left"/>

--- a/addons/website_sale/views/snippets/snippets.xml
+++ b/addons/website_sale/views/snippets/snippets.xml
@@ -202,12 +202,16 @@
                     </table>
                 </we-row>
             </div>
-            <we-row string="Re-order" data-no-preview="true">
+            <we-button-group
+                data-name="o_wsale_change_sequence_widget"
+                string="Re-order"
+                data-no-preview="true"
+            >
                 <we-button title="Push to top" data-change-sequence="top" class="fa fa-fw fa-angle-double-left"/>
-                <we-button title="Push up" data-change-sequence="up" class="fa fa-fw fa-angle-left"/>
-                <we-button title="Push down" data-change-sequence="down" class="fa fa-fw fa-angle-right"/>
+                <we-button title="Push up" data-change-sequence="up" class="fa fa-fw fa-angle-left ms-1"/>
+                <we-button title="Push down" data-change-sequence="down" class="fa fa-fw fa-angle-right mx-1"/>
                 <we-button title="Push to bottom" data-change-sequence="bottom" class="fa fa-fw fa-angle-double-right"/>
-            </we-row>
+            </we-button-group>
 
             <we-row>
                 <we-select string="Ribbon" class="o_wsale_ribbon_select">

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -187,9 +187,14 @@
             <t t-set="product_href" t-value="keep(product.website_url, page=(pager['page']['num'] if pager['page']['num']&gt;1 else None)) + selected_attributes_hash" />
             <t t-set="image_type" t-value="product._get_suitable_image_size(ppr, td_product['x'], td_product['y'])"/>
 
-            <div class="oe_product_image position-relative h-100 flex-grow-0 overflow-hidden">
+            <div class="oe_product_image position-relative flex-grow-0 overflow-hidden">
                 <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()" t-nocache="The csrf token must always be up to date."/>
-                <a t-att-href="product_href" class="oe_product_image_link d-block h-100 position-relative" itemprop="url" contenteditable="false">
+                <a
+                    t-att-href="product_href"
+                    class="oe_product_image_link d-block position-relative"
+                    itemprop="url"
+                    contenteditable="false"
+                >
                     <t t-set="image_holder" t-value="product._get_image_holder()"/>
                     <span t-field="image_holder.image_1920"
                         t-options="{'widget': 'image', 'preview_image': image_type, 'itemprop': 'image', 'class': 'h-100 w-100 position-absolute'}"
@@ -206,17 +211,17 @@
                 </a>
             </div>
             <div class="o_wsale_product_information position-relative d-flex flex-column flex-grow-1 flex-shrink-1">
-                <div class="o_wsale_product_information_text flex-grow-1">
-                    <h6 class="o_wsale_products_item_title mb-2">
+                <div class="o_wsale_product_information_text">
+                    <h6 class="o_wsale_products_item_title mb-2 text-break">
                         <a class="text-primary text-decoration-none" itemprop="name" t-att-href="product_href" t-att-content="product.name" t-field="product.name" />
                         <a t-if="not product.website_published" role="button" t-att-href="product_href" class="btn btn-sm btn-danger" title="This product is unpublished.">
                             Unpublished
                         </a>
                     </h6>
                 </div>
-                <div class="o_wsale_product_sub d-flex justify-content-between align-items-end gap-2 flex-wrap pb-1">
+                <div class="o_wsale_product_sub d-flex justify-content-between align-items-end gap-2 flex-wrap">
                     <t t-set="template_price_vals" t-value="get_product_prices(product)"/>
-                    <div class="o_wsale_product_btn"/>
+                    <div class="o_wsale_product_btn d-flex gap-2"/>
                     <div class="product_price" itemprop="offers" itemscope="itemscope" itemtype="http://schema.org/Offer">
                         <span class="h6 mb-0"
                               t-if="template_price_vals['price_reduce'] or not website.prevent_zero_price_sale"
@@ -237,6 +242,9 @@
     </template>
 
     <template id="products_description" inherit_id="website_sale.products_item" active="False" name="Product Description">
+         <xpath expr="//form" position="attributes">
+            <attribute name="class" add="oe_product_cart_has_description" separator=" "/>
+        </xpath>
         <xpath expr="//*[hasclass('o_wsale_products_item_title')]" position="after">
             <div class="oe_subdescription mb-2 text-muted small" contenteditable="false">
                 <div itemprop="description" t-field="product.description_sale"/>
@@ -250,8 +258,14 @@
             <input name="product_id" t-att-value="product_variant_id" type="hidden"/>
             <input name="product_template_id" t-att-value="product.id" type="hidden"/>
             <t t-if="product_variant_id and template_price_vals['price_reduce'] or not website.prevent_zero_price_sale">
-                <a t-if="product._website_show_quick_add()"
-                   href="#" role="button" class="btn btn-primary a-submit" aria-label="Shopping cart" title="Shopping cart">
+                <a
+                    t-if="product._website_show_quick_add()"
+                    href="#"
+                    role="button"
+                    class="btn btn-light a-submit"
+                    aria-label="Shopping cart"
+                    title="Shopping cart"
+                >
                     <span class="fa fa-shopping-cart"/>
                 </a>
             </t>
@@ -408,33 +422,52 @@
                             </t>
 
                             <div t-if="products" class="o_wsale_products_grid_table_wrapper pt-3 pt-lg-0">
-                                <table class="table table-borderless h-100 m-0" t-att-data-ppg="ppg" t-att-data-ppr="ppr" t-att-data-default-sort="website.shop_default_sort" t-att-data-name="grid_block_name">
-                                    <colgroup t-ignore="true">
-                                        <!-- Force the number of columns (useful when only one row of (x < ppr) products) -->
-                                        <col t-foreach="ppr" t-as="p"/>
-                                    </colgroup>
-                                    <tbody>
-                                        <tr t-foreach="bins" t-as="tr_product">
-                                            <t t-foreach="tr_product" t-as="td_product">
-                                                <t t-if="td_product">
-                                                    <!-- We use t-attf-class here to allow easier customization -->
-                                                    <td t-att-colspan="td_product['x'] != 1 and td_product['x']"
-                                                        t-att-rowspan="td_product['y'] != 1 and td_product['y']"
-                                                        t-attf-class="oe_product"
-                                                        t-att-data-ribbon-id="td_product['ribbon'].id"
-                                                        t-att-data-name="product_block_name">
-                                                        <div t-attf-class="o_wsale_product_grid_wrapper position-relative h-100 o_wsale_product_grid_wrapper_#{td_product['x']}_#{td_product['y']}">
-                                                            <t t-call="website_sale.products_item">
-                                                                <t t-set="product" t-value="td_product['product']"/>
-                                                            </t>
-                                                        </div>
-                                                    </td>
-                                                </t>
-                                                <td t-else=""/>
+                                <t t-set="grid_md_allow_custom_cols" t-value="hasLeftColumn"/>
+                                <t t-set="grid_md_use_3col"
+                                   t-value="not hasLeftColumn and ppr == 4"/>
+
+                                <section
+                                    id="o_wsale_products_grid"
+                                    t-attf-class="o_wsale_products_grid_table grid {{grid_md_allow_custom_cols and 'o_wsale_products_grid_table_md'}}"
+                                    t-attf-style="--o-wsale-products-grid-gap: {{gap}}; --o-wsale-ppr: {{ppr}}; --o-wsale-ppg: {{ppg}}"
+                                    t-att-data-ppg="ppg"
+                                    t-att-data-ppr="ppr"
+                                    t-att-data-default-sort="website.shop_default_sort"
+                                    t-att-data-name="grid_block_name"
+                                >
+                                    <t t-foreach="bins" t-as="tr_product">
+                                        <t t-foreach="tr_product" t-as="td_product">
+                                            <t t-if="td_product">
+                                                <t t-set="col_height" t-value="td_product['y']"/>
+                                                <t t-set="col_width"
+                                                   t-value="12 // ppr * td_product['x']"/>
+                                                <t t-set="col_class_lg"
+                                                   t-value="'g-col-lg-' + str(col_width)"/>
+                                                <t t-set="col_class_md"
+                                                   t-value="grid_md_allow_custom_cols and ('g-col-md-' + str(col_width)) or grid_md_use_3col and 'g-col-md-4' or 'g-col-md-6'"/>
+                                                <t t-set="col_is_stretched"
+                                                   t-value="(td_product['x'] &gt;= td_product['y'] * 2)"/>
+                                                <t t-set="col_is_custom_portrait"
+                                                   t-value="not col_is_stretched and (col_height &gt; td_product['x'])"/>
+                                                <div
+                                                    t-attf-class="oe_product {{col_is_custom_portrait and 'oe_product_custom_portrait'}} g-col-6 {{col_class_md}} {{col_class_lg}} {{col_is_stretched and 'oe_product_size_stretch'}}"
+                                                    t-attf-style="--o-wsale-products-grid-product-col-height: {{col_height}};"
+                                                    t-att-data-ribbon-id="td_product['ribbon'].id"
+                                                    t-att-data-colspan="td_product['x'] != 1 and td_product['x']"
+                                                    t-att-data-rowspan="td_product['y'] != 1 and td_product['y']"
+                                                    t-att-data-name="product_block_name"
+                                                >
+                                                    <div t-attf-class="o_wsale_product_grid_wrapper position-relative h-100 o_wsale_product_grid_wrapper_#{td_product['x']}_#{td_product['y']}">
+                                                        <t t-call="website_sale.products_item">
+                                                            <t t-set="product"
+                                                               t-value="td_product['product']"/>
+                                                        </t>
+                                                    </div>
+                                                </div>
                                             </t>
-                                        </tr>
-                                    </tbody>
-                                </table>
+                                        </t>
+                                    </t>
+                                </section>
                             </div>
                             <div t-else="" class="text-center text-muted mt128 mb256">
                                 <t t-if="not search">
@@ -462,42 +495,42 @@
 
     <!-- (Option) Products: Enable "Card" or "Thumbnails" designs -->
     <template id="products_design_card" name="Card Design" inherit_id="website_sale.products" active="False">
-        <xpath expr="//table" position="attributes">
-            <attribute name="class" add="o_wsale_design_cards" separator=" "/>
+        <xpath expr="//section[@id='o_wsale_products_grid']" position="attributes">
+            <attribute name="t-attf-class" add="o_wsale_design_cards" separator=" "/>
         </xpath>
     </template>
     <template id="products_design_thumbs" name="Thumbnails Design" inherit_id="website_sale.products" active="False">
-        <xpath expr="//table" position="attributes">
-            <attribute name="class" add="o_wsale_design_thumbs" separator=" "/>
+        <xpath expr="//section[@id='o_wsale_products_grid']" position="attributes">
+            <attribute name="t-attf-class" add="o_wsale_design_thumbs" separator=" "/>
         </xpath>
     </template>
     <template id="products_design_grid" name="Grid Design" inherit_id="website_sale.products" active="False">
-        <xpath expr="//table" position="attributes">
-            <attribute name="class" add="o_wsale_design_grid" separator=" "/>
+        <xpath expr="//section[@id='o_wsale_products_grid']" position="attributes">
+            <attribute name="t-attf-class" add="o_wsale_design_grid" separator=" "/>
         </xpath>
     </template>
 
     <!-- (Options) Products: Define products' default image ratio -->
     <template id="products_thumb_4_3" name="thumb_4_3" inherit_id="website_sale.products" active="False">
-        <xpath expr="//table" position="attributes">
-            <attribute name="class" add="o_wsale_context_thumb_4_3" separator=" "/>
+        <xpath expr="//section[@id='o_wsale_products_grid']" position="attributes">
+            <attribute name="t-attf-class" add="o_wsale_context_thumb_4_3" separator=" "/>
         </xpath>
     </template>
     <template id="products_thumb_4_5" name="thumb_4_5" inherit_id="website_sale.products" active="False">
-        <xpath expr="//table" position="attributes">
-            <attribute name="class" add="o_wsale_context_thumb_4_5" separator=" "/>
+        <xpath expr="//section[@id='o_wsale_products_grid']" position="attributes">
+            <attribute name="t-attf-class" add="o_wsale_context_thumb_4_5" separator=" "/>
         </xpath>
     </template>
     <template id="products_thumb_2_3" name="thumb_2_3" inherit_id="website_sale.products" active="False">
-        <xpath expr="//table" position="attributes">
-            <attribute name="class" add="o_wsale_context_thumb_2_3" separator=" "/>
+        <xpath expr="//section[@id='o_wsale_products_grid']" position="attributes">
+            <attribute name="t-attf-class" add="o_wsale_context_thumb_2_3" separator=" "/>
         </xpath>
     </template>
 
     <!-- (Option) Products: Define products' images filling mode -->
     <template id="products_thumb_cover" name="thumb_cover" inherit_id="website_sale.products" active="True">
-        <xpath expr="//table" position="attributes">
-            <attribute name="class" add="o_wsale_context_thumb_cover" separator=" "/>
+        <xpath expr="//section[@id='o_wsale_products_grid']" position="attributes">
+            <attribute name="t-attf-class" add="o_wsale_context_thumb_cover" separator=" "/>
         </xpath>
     </template>
 

--- a/addons/website_sale_comparison/views/website_sale_comparison_template.xml
+++ b/addons/website_sale_comparison/views/website_sale_comparison_template.xml
@@ -5,7 +5,18 @@
         <xpath expr="//div[hasclass('o_wsale_product_btn')]" position="inside">
             <t t-set="categories" t-value="product.valid_product_template_attribute_line_ids._prepare_categories_for_display()"/>
             <t t-set="product_variant_id" t-value="product._get_first_possible_variant_id()"/>
-            <button t-if="product_variant_id and categories" type="button" role="button" class="d-none d-md-inline-block btn btn-outline-primary bg-white o_add_compare" title="Compare" aria-label="Compare" t-att-data-product-product-id="product_variant_id" data-action="o_comparelist"><span class="fa fa-exchange"></span></button>
+            <button
+                t-if="product_variant_id and categories"
+                type="button"
+                role="button"
+                class="d-none d-md-inline-block btn btn-light o_add_compare"
+                title="Compare"
+                aria-label="Compare"
+                t-att-data-product-product-id="product_variant_id"
+                data-action="o_comparelist"
+            >
+                <span class="fa fa-exchange"/>
+            </button>
         </xpath>
     </template>
 

--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -8,7 +8,7 @@
             <button t-if="product_variant_id"
                     type="button"
                     role="button"
-                    class="btn btn-outline-primary bg-white o_add_wishlist"
+                    class="btn btn btn-light o_add_wishlist"
                     t-att-disabled='in_wish or None' title="Add to Wishlist"
                     t-att-data-product-template-id="product.id"
                     t-att-data-product-product-id="product_variant_id"


### PR DESCRIPTION
This PR implements a comprehensive revamp of the `/shop` grid system along with necessary design adaptations.
The new layout is designed to improve flexibility, ease of customization, and resolve issues related to the current `<table>`-based layout.

**Specifications**

- Transition to CSS Grid: Replaced the existing `<table>` structure with  CSS Grid. 
- Retained the existing "product resizing" mechanism for consistency. 
- Introduced options to customize the grid gaps. 
- Enhanced column management for `MD` (tablet) screens. 


**Fixes & Improvements:**

- [FIX] Prevent product boxes from extending outside the grid boundaries. 
- [FIX / IMP] Allow product text size to increase when its container is larger than normal. 
- [FIX] Address the issue where longer product names caused surrounding cards to extend vertically, affecting image ratio preferences. 
- [FIX] Ensure that product images adapt according to the "Fill" option when a product has a custom size, rather than always filling the entire available height. 
- [FIX] Remove the ribbon's shadow when the banner is disabled. 
- [FIX] Correct the broken appearance of the "Thumbnail" design. 

**Technical Notes**

- Enabled Bootstrap CSS Grid in the frontend for better layout control.
- Preferred the use of CSS variables over enforced utility classes wherever possible, to enhance maintainability and customization.

Co-authored-by: @livaios 

task-3987127
part of task-3986921
prerequisite for task-3997498

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
