### PR TITLE
[FIX] DeserializeDate Doubling Time Offset

### DIFF
--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -274,8 +274,8 @@ export class Product extends PosModel {
         const categories = this.parent_category_ids.concat(this.categ.id);
         return (
             (!item.categ_id || categories.includes(item.categ_id[0])) &&
-            (!item.date_start || deserializeDate(item.date_start) <= date) &&
-            (!item.date_end || deserializeDate(item.date_end) >= date)
+            (!item.date_start || deserializeDate(item.date_start, {zone: "utc"}) <= date) &&
+            (!item.date_end || deserializeDate(item.date_end, {zone: "utc"}) >= date)
         );
     }
     // Port of _get_product_price on product.pricelist.

--- a/addons/web/static/src/core/l10n/dates.js
+++ b/addons/web/static/src/core/l10n/dates.js
@@ -497,8 +497,10 @@ export function parseDateTime(value, options = {}) {
  * Returns a date object parsed from the given serialized string.
  * @param {string} value serialized date string, e.g. "2018-01-01"
  */
-export function deserializeDate(value) {
-    return DateTime.fromSQL(value, { numberingSystem: "latn", zone: "default" }).reconfigure({
+export function deserializeDate(value, options = {}) {
+    const defaultDict = {numberingSystem: "latn", zone: "default"}
+    const joinedDict = {...defaultDict, ...options}
+    return DateTime.fromSQL(value, joinedDict).reconfigure({
         numberingSystem: Settings.defaultNumberingSystem,
     });
 }


### PR DESCRIPTION
Currently, when various timestamps in Odoo are processed through the `DeserializeDate` function, the offset is being doubled by mistake. The Odoo timestamps are passed as strings which have already been converted to UTC. If a user inputs a `DateTime` on a pricelist for instance, that time will be converted to its UTC equivalent before being converted to a string. The issue arises when we try to parse that string in the frontend during a PoS session. Odoo will correctly parse the timestamp, however through the `DeserializeDate` function it calls the `FromSQL` function with the parameter 
`zone: 'default'` which makes Odoo process this timestamp as being in the `SystemZone` (which is used by default in Luxon) instead of correctly recognizing that it is already in UTC. Thus, it will offset it again, which causes the functionality to fail

This commit allows the timezone in `DeserializeDate` to be passed as a parameter, so in these cases we can pass the correct timezone and avoid this issue.

Task-ID: 4106252
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
