### PR TITLE
[FIX] base_automation: handle negative delays

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -571,7 +571,7 @@ class BaseAutomation(models.Model):
     def _get_cron_interval(self, automations=None):
         """ Return the expected time interval used by the cron, in minutes. """
         def get_delay(rec):
-            return rec.trg_date_range * DATE_RANGE_FACTOR[rec.trg_date_range_type]
+            return abs(rec.trg_date_range) * DATE_RANGE_FACTOR[rec.trg_date_range_type]
 
         if automations is None:
             automations = self.with_context(active_test=True).search([('trigger', 'in', TIME_TRIGGERS)])


### PR DESCRIPTION
Issue -->

If the Delay (`trg_date_range`) field is set to a negative number, the automation cron defaults to an interval of 1 minute. This causes an unnecessary number of cron executions, leading to minor performance issues. 

Solution -->

Use the absolute value of the Delay to calculate the cron interval.

opw-3992050

