### PR TITLE
[IMP] mrp_production: Prevent unnecessary replanning of workorders

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -797,8 +797,8 @@ class MrpProduction(models.Model):
                 joined_move_ids.append(move_finished)
             vals['move_finished_ids'] = joined_move_ids
             del vals['move_byproduct_ids']
-        if 'workorder_ids' in self:
-            production_to_replan = self.filtered(lambda p: p.is_planned)
+
+        production_to_replan = self.filtered(lambda p: p.is_planned)
         if 'move_raw_ids' in vals and self.state not in ['draft', 'cancel', 'done']:
             # When adding a move raw, it should have the source location's `warehouse_id`.
             # Before, it was handle by an onchange, now it's forced if not already in vals.


### PR DESCRIPTION

This change removes the check for workorder_ids in production order as the field is always present in this model.

opw-4101030

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
