### PR TITLE
[FIX] website_sale: sync extra step with correct view

### DIFF
--- a/addons/website_sale/models/res_config_settings.py
+++ b/addons/website_sale/models/res_config_settings.py
@@ -87,7 +87,7 @@ class ResConfigSettings(models.TransientModel):
         for record in self:
             website = record.with_context(website_id=record.website_id.id).website_id
             record.enabled_extra_checkout_step = website.is_view_active(
-                'website_sale.extra_info_option'
+                'website_sale.extra_info'
             )
             record.enabled_buy_now_button = website.is_view_active(
                 'website_sale.product_buy_now'


### PR DESCRIPTION
Extra checkout step was unable to be enabled because of a change (commit 533325a2) that was made to sync it with the active state of the extra info view. However, the view that was being checked was actually a view that did not exist. Correctly changed the view name to be extra_info instead of extra_info_option so the setting could be enabled.

opw-4113506
