### PR TITLE
[FIX] web_editor: Correct issue preventing deletion of space before inline element

### DIFF
--- a/addons/web_editor/models/ir_qweb.py
+++ b/addons/web_editor/models/ir_qweb.py
@@ -389,7 +389,7 @@ class HTML(models.AbstractModel):
             content.append(element.text)
         content.extend(html.tostring(child, encoding='unicode')
                        for child in element.iterchildren(tag=etree.Element))
-        return '\n'.join(content)
+        return ''.join(content)
 
 
 class Image(models.AbstractModel):


### PR DESCRIPTION

Description:
This fix resolves an issue where users are unable to delete a space character that appears before an inline element.

Steps to Reproduce:
1. Navigate to the "/shop" page.
2. Click on any product to view its details.
3. Enter the editor mode.
4. In the product description section, add text enclosed in double quotation marks, with a space immediately following the opening quotation mark. For example, "_test" (where _ represents a space), and apply bold formatting to the text content (i.e., "test").
5. Save the changes.
6. Re-enter the editor, attempt to delete the space character after the opening quotation mark, and save again. The space will not be deleted.

Example:
Given the string:
"_test"
Where _ represents a space and "test" is bolded.

Attempting to delete the space ("_") will not succeed. Instead, the space is reintroduced after saving.

Technical Explanation:
The issue stems from how the ```from_html``` method processes content. After attempting to delete the space, the method returns the content with a newline character (\n) inserted, which HTML interprets as a space.

For example, after removing the space in the string "_test", the content is parsed as a list: [", <strong>test</strong>]. When joined, the newline character is inserted between the two elements, effectively reintroducing a space into the HTML. This creates a loop where the space persists despite the deletion attempt.

Solution:
This fix addresses the issue by modifying the joining logic in the ```from_html``` method. Instead of joining content with a newline character, content is now joined using an empty string. This prevents the unwanted space from being reinserted into the HTML, allowing users to successfully delete the space before inline elements.

opw-4008582

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
