### PR TITLE
[FIX] project: prevent notification when collaborators O2M field is empty

### DIFF
--- a/addons/project/wizard/project_share_wizard.py
+++ b/addons/project/wizard/project_share_wizard.py
@@ -135,6 +135,8 @@ class ProjectShareWizard(models.TransientModel):
     def action_share_record(self):
         # Confirmation dialog is only opened if new portal user(s) need to be created in a 'on invitation' website
         self.ensure_one()
+        if not self.collaborator_ids:
+            return
         on_invite = self.env['res.users']._get_signup_invitation_scope() == 'b2b'
         new_portal_user = self.collaborator_ids.filtered(lambda c: c.send_invitation and not c.partner_id.user_ids) and on_invite
         if not new_portal_user:


### PR DESCRIPTION
Previously, when a project was shared without adding collaborators, an incorrect notification was sent, potentially confusing for the user. this commit ensures no notification is triggered if the collaborator's O2M field is empty,thereby avoiding misleading messages.

task-3956252