### PR TITLE
[FIX] spreadsheet: group by day

### DIFF
--- a/addons/spreadsheet/static/src/pivot/pivot_time_adapters.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_time_adapters.js
@@ -61,8 +61,7 @@ const odooNumberDateAdapter = {
 const odooDayAdapter = {
     normalizeServerValue(groupBy, field, readGroupResult) {
         const serverDayValue = getGroupStartingDay(field, groupBy, readGroupResult);
-        const date = deserializeDate(serverDayValue).reconfigure({ numberingSystem: "latn" });
-        return date.toFormat("MM/dd/yyyy");
+        return toNumber(serverDayValue, DEFAULT_LOCALE);
     },
     increment(normalizedValue, step) {
         return normalizedValue + step;

--- a/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
+++ b/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
@@ -874,12 +874,12 @@ test("PIVOT formulas with monetary measure are correctly formatted at evaluation
     expect(getEvaluatedCell(model, "B3").format).toBe("#,##0.00[$€]");
 });
 
-test("PIVOT.HEADER day_of_month are correctly formatted at evaluation", async function () {
+test("PIVOT day_of_month are correctly formatted at evaluation", async function () {
     const { model, pivotId } = await createSpreadsheetWithPivot({
         arch: /* xml */ `
                 <pivot>
                     <field name="date" interval="day" type="col"/>
-                    <field name="foo" type="measure"/>
+                    <field name="probability" type="measure"/>
                 </pivot>`,
     });
     updatePivot(model, pivotId, {
@@ -887,30 +887,37 @@ test("PIVOT.HEADER day_of_month are correctly formatted at evaluation", async fu
     });
     await animationFrame();
     setCellContent(model, "B1", `=PIVOT.HEADER(1, "date:day_of_month", 1)`);
+    setCellContent(model, "B2", `=PIVOT.VALUE(1, "probability", "date:day_of_month", 11)`);
     expect(getEvaluatedCell(model, "B1").format).toBe("0");
     expect(getEvaluatedCell(model, "B1").value).toBe(1);
     expect(getEvaluatedCell(model, "B1").formattedValue).toBe("1");
+    expect(getEvaluatedCell(model, "B2").format).toBe("#,##0.00");
+    expect(getEvaluatedCell(model, "B2").value).toBe(15);
+    expect(getEvaluatedCell(model, "B2").formattedValue).toBe("15.00");
 });
 
-test("PIVOT.HEADER day are correctly formatted at evaluation", async function () {
+test("PIVOT day are correctly formatted at evaluation", async function () {
     const { model } = await createSpreadsheetWithPivot({
         arch: /* xml */ `
                 <pivot>
                     <field name="date" interval="day" type="col"/>
-                    <field name="foo" type="measure"/>
+                    <field name="probability" type="measure"/>
                 </pivot>`,
     });
     expect(getEvaluatedCell(model, "B1").format).toBe("m/d/yyyy");
     expect(getEvaluatedCell(model, "B1").value).toBe(42474);
     expect(getEvaluatedCell(model, "B1").formattedValue).toBe("4/14/2016");
+    expect(getEvaluatedCell(model, "B3").format).toBe("#,##0.00");
+    expect(getEvaluatedCell(model, "B3").value).toBe(10);
+    expect(getEvaluatedCell(model, "B3").formattedValue).toBe("10.00");
 });
 
-test("PIVOT.HEADER iso_week_number are correctly formatted at evaluation", async function () {
+test("PIVOT iso_week_number are correctly formatted at evaluation", async function () {
     const { model, pivotId } = await createSpreadsheetWithPivot({
         arch: /* xml */ `
                 <pivot>
                     <field name="date" interval="day" type="col"/>
-                    <field name="foo" type="measure"/>
+                    <field name="probability" type="measure"/>
                 </pivot>`,
     });
     updatePivot(model, pivotId, {
@@ -918,30 +925,37 @@ test("PIVOT.HEADER iso_week_number are correctly formatted at evaluation", async
     });
     await animationFrame();
     setCellContent(model, "B1", `=PIVOT.HEADER(1, "date:iso_week_number", 1)`);
+    setCellContent(model, "B2", `=PIVOT.VALUE(1, "probability", "date:iso_week_number", 15)`);
     expect(getEvaluatedCell(model, "B1").format).toBe("0");
     expect(getEvaluatedCell(model, "B1").value).toBe(1);
     expect(getEvaluatedCell(model, "B1").formattedValue).toBe("1");
+    expect(getEvaluatedCell(model, "B2").format).toBe("#,##0.00");
+    expect(getEvaluatedCell(model, "B2").value).toBe(10);
+    expect(getEvaluatedCell(model, "B2").formattedValue).toBe("10.00");
 });
 
-test("PIVOT.HEADER week are correctly formatted at evaluation", async function () {
+test("PIVOT week are correctly formatted at evaluation", async function () {
     const { model } = await createSpreadsheetWithPivot({
         arch: /* xml */ `
                 <pivot>
                     <field name="date" interval="week" type="col"/>
-                    <field name="foo" type="measure"/>
+                    <field name="probability" type="measure"/>
                 </pivot>`,
     });
     expect(getEvaluatedCell(model, "B1").format).toBe(undefined);
     expect(getEvaluatedCell(model, "B1").value).toBe("W15 2016");
     expect(getEvaluatedCell(model, "B1").formattedValue).toBe("W15 2016");
+    expect(getEvaluatedCell(model, "B3").format).toBe("#,##0.00");
+    expect(getEvaluatedCell(model, "B3").value).toBe(10);
+    expect(getEvaluatedCell(model, "B3").formattedValue).toBe("10.00");
 });
 
-test("PIVOT.HEADER month_number are correctly formatted at evaluation", async function () {
+test("PIVOT month_number are correctly formatted at evaluation", async function () {
     const { model, pivotId } = await createSpreadsheetWithPivot({
         arch: /* xml */ `
                 <pivot>
                     <field name="date" interval="day" type="col"/>
-                    <field name="foo" type="measure"/>
+                    <field name="probability" type="measure"/>
                 </pivot>`,
     });
     updatePivot(model, pivotId, {
@@ -949,30 +963,37 @@ test("PIVOT.HEADER month_number are correctly formatted at evaluation", async fu
     });
     await animationFrame();
     setCellContent(model, "B1", `=PIVOT.HEADER(1, "date:month_number", 1)`);
+    setCellContent(model, "B2", `=PIVOT.VALUE(1, "probability", "date:month_number", 4)`);
     expect(getEvaluatedCell(model, "B1").format).toBe("0");
     expect(getEvaluatedCell(model, "B1").value).toBe("January");
     expect(getEvaluatedCell(model, "B1").formattedValue).toBe("January");
+    expect(getEvaluatedCell(model, "B2").format).toBe("#,##0.00");
+    expect(getEvaluatedCell(model, "B2").value).toBe(10);
+    expect(getEvaluatedCell(model, "B2").formattedValue).toBe("10.00");
 });
 
-test("PIVOT.HEADER month are correctly formatted at evaluation", async function () {
+test("PIVOT month are correctly formatted at evaluation", async function () {
     const { model } = await createSpreadsheetWithPivot({
         arch: /* xml */ `
                 <pivot>
                     <field name="date" interval="month" type="col"/>
-                    <field name="foo" type="measure"/>
+                    <field name="probability" type="measure"/>
                 </pivot>`,
     });
     expect(getEvaluatedCell(model, "B1").format).toBe("mmmm yyyy");
     expect(getEvaluatedCell(model, "B1").value).toBe(42461);
     expect(getEvaluatedCell(model, "B1").formattedValue).toBe("April 2016");
+    expect(getEvaluatedCell(model, "B3").format).toBe("#,##0.00");
+    expect(getEvaluatedCell(model, "B3").value).toBe(10);
+    expect(getEvaluatedCell(model, "B3").formattedValue).toBe("10.00");
 });
 
-test("PIVOT.HEADER quarter_number are correctly formatted at evaluation", async function () {
+test("PIVOT quarter_number are correctly formatted at evaluation", async function () {
     const { model, pivotId } = await createSpreadsheetWithPivot({
         arch: /* xml */ `
                 <pivot>
                     <field name="date" interval="day" type="col"/>
-                    <field name="foo" type="measure"/>
+                    <field name="probability" type="measure"/>
                 </pivot>`,
     });
     updatePivot(model, pivotId, {
@@ -980,35 +1001,45 @@ test("PIVOT.HEADER quarter_number are correctly formatted at evaluation", async 
     });
     await animationFrame();
     setCellContent(model, "B1", `=PIVOT.HEADER(1, "date:quarter_number", 1)`);
+    setCellContent(model, "B2", `=PIVOT.VALUE(1, "probability", "date:quarter_number", 2)`);
     expect(getEvaluatedCell(model, "B1").format).toBe("0");
     expect(getEvaluatedCell(model, "B1").value).toBe("Q1");
     expect(getEvaluatedCell(model, "B1").formattedValue).toBe("Q1");
+    expect(getEvaluatedCell(model, "B2").format).toBe("#,##0.00");
+    expect(getEvaluatedCell(model, "B2").value).toBe(10);
+    expect(getEvaluatedCell(model, "B2").formattedValue).toBe("10.00");
 });
 
-test("PIVOT.HEADER quarter are correctly formatted at evaluation", async function () {
+test("PIVOT quarter are correctly formatted at evaluation", async function () {
     const { model } = await createSpreadsheetWithPivot({
         arch: /* xml */ `
                 <pivot>
                     <field name="date" interval="quarter" type="col"/>
-                    <field name="foo" type="measure"/>
+                    <field name="probability" type="measure"/>
                 </pivot>`,
     });
     expect(getEvaluatedCell(model, "B1").format).toBe(undefined);
     expect(getEvaluatedCell(model, "B1").value).toBe("Q2 2016");
     expect(getEvaluatedCell(model, "B1").formattedValue).toBe("Q2 2016");
+    expect(getEvaluatedCell(model, "B3").format).toBe("#,##0.00");
+    expect(getEvaluatedCell(model, "B3").value).toBe(10);
+    expect(getEvaluatedCell(model, "B3").formattedValue).toBe("10.00");
 });
 
-test("PIVOT.HEADER year are correctly formatted at evaluation", async function () {
+test("PIVOT year are correctly formatted at evaluation", async function () {
     const { model } = await createSpreadsheetWithPivot({
         arch: /* xml */ `
                 <pivot>
                     <field name="date" interval="year" type="col"/>
-                    <field name="foo" type="measure"/>
+                    <field name="probability" type="measure"/>
                 </pivot>`,
     });
     expect(getEvaluatedCell(model, "B1").format).toBe("0");
     expect(getEvaluatedCell(model, "B1").value).toBe(2016);
     expect(getEvaluatedCell(model, "B1").formattedValue).toBe("2016");
+    expect(getEvaluatedCell(model, "B3").format).toBe("#,##0.00");
+    expect(getEvaluatedCell(model, "B3").value).toBe(131);
+    expect(getEvaluatedCell(model, "B3").formattedValue).toBe("131.00");
 });
 
 test("PIVOT.HEADER formulas are correctly formatted at evaluation", async function () {


### PR DESCRIPTION
Steps to reproduce:
- go to any pivot view
- group by any date field, with "day" granularity
- insert the pivot in a spreadsheet => the values are not displayed.

opw-4106739




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
