### PR TITLE
[IMP] website: add a new columns category within snippets selection modal

### DIFF
--- a/addons/website/static/src/img/snippets_thumbs/s_text_image.svg
+++ b/addons/website/static/src/img/snippets_thumbs/s_text_image.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="82" height="60" viewBox="0 0 82 60">
+  <defs>
+    <rect id="path-1" width="23.077" height="18.116" x="0" y="0"/>
+    <linearGradient id="linearGradient-3" x1="72.875%" x2="40.332%" y1="46.509%" y2="34.249%">
+      <stop offset="0%" stop-color="#008374"/>
+      <stop offset="100%" stop-color="#006A59"/>
+    </linearGradient>
+    <linearGradient id="linearGradient-4" x1="88.517%" x2="50%" y1="39.469%" y2="50%">
+      <stop offset="0%" stop-color="#00AA89"/>
+      <stop offset="100%" stop-color="#009989"/>
+    </linearGradient>
+    <rect id="path-5" width="25" height="2" x="0" y="0"/>
+    <filter id="filter-6" width="104%" height="200%" x="-2%" y="-25%" filterUnits="objectBoundingBox">
+      <feOffset dy="1" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feComposite in="shadowOffsetOuter1" in2="SourceAlpha" operator="out" result="shadowOffsetOuter1"/>
+      <feColorMatrix in="shadowOffsetOuter1" values="0 0 0 0 1   0 0 0 0 1   0 0 0 0 1  0 0 0 0.292012675 0"/>
+    </filter>
+    <path id="path-7" d="M23 12v1H0v-1h23zm-4-3v1H0V9h19zm4-3v1H0V6h23z"/>
+    <filter id="filter-8" width="104.3%" height="128.6%" x="-2.2%" y="-7.1%" filterUnits="objectBoundingBox">
+      <feOffset dy="1" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feComposite in="shadowOffsetOuter1" in2="SourceAlpha" operator="out" result="shadowOffsetOuter1"/>
+      <feColorMatrix in="shadowOffsetOuter1" values="0 0 0 0 1   0 0 0 0 1   0 0 0 0 1  0 0 0 0.0995137675 0"/>
+    </filter>
+  </defs>
+  <g fill="none" fill-rule="evenodd" class="snippets_thumbs">
+    <g class="s_text_image">
+      <rect width="82" height="60" class="bg"/>
+      <g class="group" transform="translate(15 21)">
+        <g class="image_1_border" transform="translate(29)">
+          <rect width="24" height="19" fill="#FFF" class="rectangle"/>
+          <g class="oval___oval_mask" transform="translate(.462 .442)">
+            <mask id="mask-2" fill="#fff">
+              <use xlink:href="#path-1"/>
+            </mask>
+            <use fill="#79D1F2" class="mask" xlink:href="#path-1"/>
+            <ellipse cx="17.769" cy="4.64" fill="#F3EC60" class="oval" mask="url(#mask-2)" rx="3.462" ry="3.314"/>
+            <ellipse cx="23.308" cy="19.884" fill="url(#linearGradient-3)" class="oval" mask="url(#mask-2)" rx="10.846" ry="6.628"/>
+            <ellipse cx=".231" cy="20.105" fill="url(#linearGradient-4)" class="oval" mask="url(#mask-2)" rx="17.308" ry="10.384"/>
+          </g>
+          <path fill="#FFF" d="M24 0v19H0V0h24zm-1 1H1v17h22V1z" class="rectangle_2"/>
+        </g>
+        <g class="rectangle">
+          <use fill="#000" filter="url(#filter-6)" xlink:href="#path-5"/>
+          <use fill="#FFF" fill-opacity=".78" xlink:href="#path-5"/>
+        </g>
+        <g class="combined_shape">
+          <use fill="#000" filter="url(#filter-8)" xlink:href="#path-7"/>
+          <use fill="#FFF" fill-opacity=".348" xlink:href="#path-7"/>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/addons/website/static/src/js/tours/homepage.js
+++ b/addons/website/static/src/js/tours/homepage.js
@@ -11,7 +11,7 @@ const snippets = [
     {
         id: 's_three_columns',
         name: 'Columns',
-        groupName: "Content",
+        groupName: "Columns",
     },
     {
         id: 's_text_image',

--- a/addons/website/static/tests/tours/link_tools.js
+++ b/addons/website/static/tests/tours/link_tools.js
@@ -133,7 +133,7 @@ wTourUtils.registerWebsitePreviewTour('link_tools', {
     ...wTourUtils.dragNDrop({
         id: 's_three_columns',
         name: 'Columns',
-        groupName: "Content",
+        groupName: "Columns",
     }),
     {
         content: "Click on the first image.",

--- a/addons/website/static/tests/tours/snippet_popup_and_animations.js
+++ b/addons/website/static/tests/tours/snippet_popup_and_animations.js
@@ -16,7 +16,7 @@ const snippets = [
     {
         id: "s_three_columns",
         name: "Columns",
-        groupName: "Content",
+        groupName: "Columns",
     },
 ];
 
@@ -91,8 +91,8 @@ wTourUtils.registerWebsitePreviewTour("snippet_popup_and_animations", {
         trigger: ".o_website_preview.editor_enable.editor_has_snippets",
     },
     {
-        content: "Drag the Content snippet group and drop it at the bottom of the popup.",
-        trigger: '#oe_snippets .oe_snippet[name="Content"] .oe_snippet_thumbnail:not(.o_we_already_dragging)',
+        content: "Drag the Columns snippet group and drop it at the bottom of the popup.",
+        trigger: '#oe_snippets .oe_snippet[name="Columns"] .oe_snippet_thumbnail:not(.o_we_already_dragging)',
         run: "drag_and_drop :iframe #wrap .s_popup .modal-content.oe_structure .oe_drop_zone:last",
     },
     {

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -937,7 +937,7 @@ function editContactUs(steps) {
             trigger: ".o_we_add_snippet_btn",
             run: "click",
         },
-        ...wTourUtils.dragNDrop({id: "s_three_columns", name: "Columns", groupName: "Content"}),
+        ...wTourUtils.dragNDrop({id: "s_three_columns", name: "Columns", groupName: "Columns"}),
         {
             content: "Select the first column",
             trigger: ":iframe .s_three_columns .row > :nth-child(1)",

--- a/addons/website/static/tests/tours/website_update_column_count.js
+++ b/addons/website/static/tests/tours/website_update_column_count.js
@@ -41,7 +41,7 @@ wTourUtils.registerWebsitePreviewTour("website_update_column_count", {
 ...wTourUtils.dragNDrop({
     id: "s_three_columns",
     name: "Columns",
-    groupName: "Content",
+    groupName: "Columns",
 }),
 ...wTourUtils.clickOnSnippet({
     id: "s_three_columns",
@@ -161,7 +161,7 @@ wTourUtils.registerWebsitePreviewTour("website_mobile_order_with_drag_and_drop",
     url: "/",
     edition: true,
 }, () => [
-    ...wTourUtils.dragNDrop({id: "s_three_columns", name: "Columns", groupName: "Content"}),
+    ...wTourUtils.dragNDrop({id: "s_three_columns", name: "Columns", groupName: "Columns"}),
     ...wTourUtils.dragNDrop({id: "s_text_image", name: "Text - Image", groupName: "Content"}),
     ...wTourUtils.toggleMobilePreview(true),
     // Add a mobile order to the "Columns" snippet columns.

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -14,8 +14,10 @@
                     t-thumbnail="/website/static/src/img/snippets_thumbs/s_media_list.svg"/>
                 <t snippet-group="intro" t-snippet="website.s_snippet_group" string="Intro"
                     t-thumbnail="/website/static/src/img/snippets_thumbs/s_cover.svg"/>
-                <t snippet-group="content" t-snippet="website.s_snippet_group" string="Content"
+                <t snippet-group="columns" t-snippet="website.s_snippet_group" string="Columns"
                     t-thumbnail="/website/static/src/img/snippets_thumbs/s_three_columns.svg"/>
+                <t snippet-group="content" t-snippet="website.s_snippet_group" string="Content"
+                    t-thumbnail="/website/static/src/img/snippets_thumbs/s_text_image.svg"/>
                 <t snippet-group="images" t-snippet="website.s_snippet_group" string="Images"
                     t-thumbnail="/website/static/src/img/snippets_thumbs/s_picture.svg"/>
                 <t snippet-group="people" t-snippet="website.s_snippet_group" string="People"
@@ -82,7 +84,7 @@
                 <t t-snippet="website.s_numbers" string="Numbers" group="content">
                     <keywords>statistics, stats, KPI</keywords>
                 </t>
-                <t t-snippet="website.s_three_columns" string="Columns" group="content">
+                <t t-snippet="website.s_three_columns" string="Columns" group="columns">
                     <keywords>columns, description</keywords>
                 </t>
                 <t t-snippet="website.s_features" string="Features" group="content">


### PR DESCRIPTION
This PR introduces a new `Colums` category of snippets within the
snippet selection modal.

- requires https://github.com/odoo/design-themes/pull/872

When we introduced the new drag and drop system for snippets, with the
selection modal, this `Columns` category was planned but not introduced
due to the lack of snippets for it.

As we are moving forward in the deployment of these new building blocks,
we now have snippets to showcase within that new category.

This PR has three objectives :

- Introduce a new category within the modal;
- Introduce a thumbnail for that category within the editor right panel;
- Adapt selector within tests to target the `s_three_columns` snippet
within the `Columns` category rather than the `Content` one.

task-4119460
follow-up of task-3919405

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
