### PR TITLE
[IMP] survey: refactor survey controllers

### DIFF
--- a/addons/survey/controllers/__init__.py
+++ b/addons/survey/controllers/__init__.py
@@ -2,4 +2,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import main
+from . import compatibility
 from . import survey_session_manage

--- a/addons/survey/controllers/compatibility.py
+++ b/addons/survey/controllers/compatibility.py
@@ -1,0 +1,155 @@
+import werkzeug
+
+from odoo import http
+from odoo.http import request
+
+
+# DANE: These are compatibility controllers which will be removed in v19/20
+class Survey(http.Controller):
+    # ------------------------------------------------------------
+    # TEST / RETRY SURVEY ROUTES
+    # ------------------------------------------------------------
+
+    def _get_new_url_params(self, survey_token, answer_token=False):
+        survey_sudo = request.env['survey.survey'].with_context(active_test=False).sudo().search([('access_token', '=', survey_token)])
+        answer_sudo = request.env['survey.user_input'].sudo()
+        if not survey_sudo:
+            raise request.not_found()
+
+        if answer_token:
+            answer_sudo = request.env['survey.user_input'].sudo().search([
+                ('survey_id', '=', survey_sudo.id),
+                ('access_token', '=', answer_token)
+            ], limit=1)
+            if not answer_sudo:
+                raise request.not_found()
+        if answer_sudo:
+            return survey_sudo.id, answer_sudo.id
+        else:
+            return survey_sudo.id, None
+
+    @http.route(['/survey/test/<string:survey_token>'], type='http', auth='user', website=True)
+    def survey_test_old(self, survey_token, **kwargs):
+        survey_id, _ = self._get_new_url_params(survey_token)
+        new_url = f'/survey/test/{survey_id}/{survey_token}'
+        query_string = werkzeug.urls.url_encode(kwargs)
+        return request.redirect(f"{new_url}?{query_string}" if query_string else new_url)
+
+    @http.route(['/survey/retry/<string:survey_token>/<string:answer_token>'], type='http', auth='public', website=True)
+    def survey_retry_old(self, survey_token, answer_token, **post):
+        survey_id, answer_id = self._get_new_url_params(survey_token, answer_token)
+        new_url = f'/survey/retry/{survey_id}/{answer_id}/{survey_token}/{answer_token}'
+        query_string = werkzeug.urls.url_encode(post)
+        return request.redirect(f"{new_url}?{query_string}" if query_string else new_url)
+
+    @http.route(['/survey/start/<string:survey_token>'], type='http', auth='public', website=True)
+    def survey_start_old(self, survey_token, answer_token=None, answer_id=False, email=False, **post):
+        if not answer_token:
+            answer_token = request.cookies.get('survey_%s' % survey_token)
+
+        survey_id, answer_id = self._get_new_url_params(survey_token, answer_token)
+        new_url = f'/survey/start/{survey_id}/{survey_token}'
+        query_string = werkzeug.urls.url_encode(
+                dict(**post, answer_id=answer_id, email=email, answer_token=answer_token)
+            )
+        return request.redirect(f"{new_url}?{query_string}" if query_string else new_url)
+
+    @http.route(['/survey/<string:survey_token>/<string:answer_token>'], type='http', auth='public', website=True)
+    def survey_display_page_old(self, survey_token, answer_token, survey_id=False, answer_id=False, **post):
+        new_url = self._get_new_url(survey_token, answer_token, **post)
+        return request.redirect(new_url)
+
+    # --------------------------------------------------------------------------
+    # ROUTES to handle question images + survey background transitions + Tool
+    # --------------------------------------------------------------------------
+
+    @http.route(['/survey/<string:survey_token>/get_background_image'], type='http', auth="public", website=True, sitemap=False)
+    def survey_get_background_old(self, survey_token):
+        survey_id, _ = self._get_new_url_params(survey_token)
+        new_url = f'/survey/{survey_id}/{survey_token}/get_background_image'
+        return request.redirect(new_url)
+
+    @http.route(['/survey/<string:survey_token>/<int:section_id>/get_background_image'], type='http', auth="public", website=True, sitemap=False)
+    def survey_section_get_background_old(self, survey_token, section_id):
+        survey_id, _ = self._get_new_url_params(survey_token)
+        new_url = f'/survey/{survey_id}/{survey_token}/{section_id}/get_background_image'
+        return request.redirect(new_url)
+
+    @http.route(['/survey/get_question_image/<string:survey_token>/<string:answer_token>/<int:question_id>/<int:suggested_answer_id>'], type='http', auth="public", website=True, sitemap=False)
+    def survey_get_question_image_old(self, survey_token, answer_token, question_id, suggested_answer_id):
+        survey_id, answer_id = self._get_new_url_params(survey_token)
+        new_url = f'/survey/get_question_image/{survey_id}/{answer_id}/{survey_token}/{answer_token}/{question_id}/{suggested_answer_id}'
+        return request.redirect(new_url)
+
+    # ----------------------------------------------------------------
+    # JSON ROUTES to begin / continue survey (ajax navigation) + Tools
+    # ----------------------------------------------------------------
+
+    @http.route(['/survey/begin/<string:survey_token>/<string:answer_token>'], type='jsonrpc', auth='public', website=True)
+    def survey_begin_old(self, survey_token, answer_token, **post):
+        survey_id, answer_id = self._get_new_url_params(survey_token)
+        new_url = f'/survey/begin/{survey_id}/{answer_id}/{survey_token}/{answer_token}'
+        query_string = werkzeug.urls.url_encode(post)
+        return request.redirect(f"{new_url}?{query_string}" if query_string else new_url)
+
+    @http.route(['/survey/next_question/<string:survey_token>/<string:answer_token>'], type='jsonrpc', auth='public', website=True)
+    def survey_next_question_old(self, survey_token, answer_token, **post):
+        survey_id, answer_id = self._get_new_url_params(survey_token)
+        new_url = f'/survey/next_question/{survey_id}/{answer_id}/{survey_token}/{answer_token}'
+        query_string = werkzeug.urls.url_encode(post)
+        return request.redirect(f"{new_url}?{query_string}" if query_string else new_url)
+
+    @http.route(['/survey/submit/<string:survey_token>/<string:answer_token>'], type='jsonrpc', auth='public', website=True)
+    def survey_submit_old(self, survey_token, answer_token, **post):
+        survey_id, answer_id = self._get_new_url_params(survey_token)
+        new_url = f'/survey/submit/{survey_id}/{answer_id}/{survey_token}/{answer_token}'
+        query_string = werkzeug.urls.url_encode(post)
+        return request.redirect(f"{new_url}?{query_string}" if query_string else new_url)
+
+    # ----------------------------------------------------------------
+    # session manage controllers
+    # ----------------------------------------------------------------
+
+    @http.route('/survey/session/manage/<string:survey_token>', type='http', auth='user', website=True)
+    def survey_session_manage_old(self, survey_token, **kwargs):
+        survey_id, _ = self._get_new_url_params(survey_token)
+        new_url = f'survey/session/manage/{survey_id}/{survey_token}'
+        query_string = werkzeug.urls.url_encode(kwargs)
+        return request.redirect(f"{new_url}?{query_string}" if query_string else new_url)
+
+    @http.route('/survey/session/next_question/<string:survey_token>', type='jsonrpc', auth='user', website=True)
+    def survey_session_next_question_old(self, survey_token, go_back=False, **kwargs):
+        survey_id, _ = self._get_new_url_params(survey_token)
+        new_url = f'/survey/session/next_question/{survey_id}/{survey_token}'
+        query_string = werkzeug.urls.url_encode(dict(**kwargs, go_back=go_back))
+        return request.redirect(f"{new_url}?{query_string}" if query_string else new_url)
+
+    @http.route('/survey/session/results/<string:survey_token>', type='jsonrpc', auth='user', website=True)
+    def survey_session_results_old(self, survey_token, **kwargs):
+        survey_id, _ = self._get_new_url_params(survey_token)
+        new_url = f'/survey/session/results/{survey_id}/{survey_token}'
+        query_string = werkzeug.urls.url_encode(kwargs)
+        return request.redirect(f"{new_url}?{query_string}" if query_string else new_url)
+
+    @http.route('/survey/session/leaderboard/<string:survey_token>', type='jsonrpc', auth='user', website=True)
+    def survey_session_leaderboard_old(self, survey_token, **kwargs):
+        survey_id, _ = self._get_new_url_params(survey_token)
+        new_url = f'/survey/session/leaderboard/{survey_id}/{survey_token}'
+        query_string = werkzeug.urls.url_encode(kwargs)
+        return request.redirect(f"{new_url}?{query_string}" if query_string else new_url)
+
+    # ------------------------------------------------------------
+    # QUICK ACCESS SURVEY ROUTES
+    # ------------------------------------------------------------
+
+    @http.route('/s/<string:session_code>', type='http', auth='public', website=True)
+    def survey_start_short_old(self, session_code):
+        survey = request.env['survey.survey'].sudo().search([('session_code', '=', session_code)], limit=1)
+        new_url = f'/s/{survey.id}/{session_code}'
+        return request.redirect(new_url)
+
+    @http.route('/survey/check_session_code/<string:session_code>', type='jsonrpc', auth='public', website=True)
+    def survey_check_session_code_old(self, session_code):
+        survey = request.env['survey.survey'].sudo().search([('session_code', '=', session_code)], limit=1)
+        new_url = f'/survey/check_session_code/{survey.id}/{session_code}'
+        return request.redirect(new_url)

--- a/addons/survey/models/survey_question.py
+++ b/addons/survey/models/survey_question.py
@@ -263,7 +263,7 @@ class SurveyQuestion(models.Model):
         - For a section:
             - if a section has a background, then we create the background URL using this section's ID
             - if not, then we fallback on the survey background url """
-        base_bg_url = "/survey/%s/%s/get_background_image"
+        base_bg_url = "/survey/%s/%s/%s/get_background_image"
         for question in self:
             if question.is_page:
                 background_section_id = question.id if question.background_image else False
@@ -272,6 +272,7 @@ class SurveyQuestion(models.Model):
 
             if background_section_id:
                 question.background_image_url = base_bg_url % (
+                    question.survey_id.id,
                     question.survey_id.access_token,
                     background_section_id
                 )

--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -199,7 +199,7 @@ class SurveySurvey(models.Model):
     def _compute_background_image_url(self):
         self.background_image_url = False
         for survey in self.filtered(lambda s: s.background_image and s.access_token):
-            survey.background_image_url = "/survey/%s/get_background_image" % survey.access_token
+            survey.background_image_url = f"/survey/{survey.id}/{survey.access_token}/get_background_image"
 
     @api.depends(
         'question_and_page_ids',
@@ -328,7 +328,7 @@ class SurveySurvey(models.Model):
             if survey.session_code:
                 survey.session_link = werkzeug.urls.url_join(
                     survey.get_base_url(),
-                    '/s/%s' % survey.session_code)
+                    f'/s/{survey.id}/{survey.session_code}')
             else:
                 survey.session_link = werkzeug.urls.url_join(
                     survey.get_base_url(),
@@ -1100,7 +1100,7 @@ class SurveySurvey(models.Model):
             'type': 'ir.actions.act_url',
             'name': "Test Survey",
             'target': 'new',
-            'url': '/survey/test/%s' % self.access_token,
+            'url': f'/survey/test/{self.id}/{self.access_token}',
         }
 
     def action_survey_user_input_completed(self):
@@ -1158,7 +1158,7 @@ class SurveySurvey(models.Model):
             'type': 'ir.actions.act_url',
             'name': "Open Session Manager",
             'target': 'new',
-            'url': '/survey/session/manage/%s' % self.access_token
+            'url': f'/survey/session/manage/{self.id}/{self.access_token}'
         }
 
     def action_end_session(self):
@@ -1173,14 +1173,14 @@ class SurveySurvey(models.Model):
         self.env['bus.bus']._sendone(self.access_token, 'end_session', {})
 
     def get_start_url(self):
-        return '/survey/start/%s' % self.access_token
+        return f'/survey/start/{self.id}/{self.access_token}'
 
     def get_start_short_url(self):
         """ See controller method docstring for more details. """
-        return '/s/%s' % self.access_token[:6]
+        return f'/s/{self.id}/{self.access_token[:6]}'
 
     def get_print_url(self):
-        return '/survey/print/%s' % self.access_token
+        return f'/survey/print/{self.id}/{self.access_token}'
 
     # ------------------------------------------------------------
     # GRAPH / RESULTS

--- a/addons/survey/models/survey_user_input.py
+++ b/addons/survey/models/survey_user_input.py
@@ -197,7 +197,7 @@ class SurveyUser_Input(models.Model):
             'type': 'ir.actions.act_url',
             'name': "View Answers",
             'target': 'self',
-            'url': '/survey/print/%s?answer_token=%s' % (self.survey_id.access_token, self.access_token)
+            'url': f'/survey/print/{self.survey_id.id}/{self.survey_id.access_token}?answer_token={self.access_token}&answer_id={self.id}'
         }
 
     def action_redirect_to_attempts(self):
@@ -266,7 +266,7 @@ class SurveyUser_Input(models.Model):
 
     def get_print_url(self):
         self.ensure_one()
-        return '%s?answer_token=%s' % (self.survey_id.get_print_url(), self.access_token)
+        return '%s?answer_token=%s&answer_id=%s' % (self.survey_id.get_print_url(), self.access_token, self.id)
 
     # ------------------------------------------------------------
     # CREATE / UPDATE LINES FROM SURVEY FRONTEND INPUT

--- a/addons/survey/static/src/js/survey_form.js
+++ b/addons/survey/static/src/js/survey_form.js
@@ -346,7 +346,7 @@ publicWidget.registry.SurveyFormWidget = publicWidget.Widget.extend(SurveyPreloa
         this.preventEnterSubmit = false;
         this.readonly = false;
         this._nextScreen(
-            rpc(`/survey/next_question/${this.options.surveyToken}/${this.options.answerToken}`),
+            rpc(`/survey/next_question/${this.options.surveyId}/${this.options.answerId}/${this.options.surveyToken}/${this.options.answerToken}`),
             {
                 initTimer: true,
                 isFinish,
@@ -413,7 +413,7 @@ publicWidget.registry.SurveyFormWidget = publicWidget.Widget.extend(SurveyPreloa
         }
 
         const submitPromise = rpc(
-            `${route}/${this.options.surveyToken}/${this.options.answerToken}`,
+            `${route}/${this.options.surveyId}/${this.options.answerId}/${this.options.surveyToken}/${this.options.answerToken}`,
             params
         );
 

--- a/addons/survey/static/src/js/survey_session_leaderboard.js
+++ b/addons/survey/static/src/js/survey_session_leaderboard.js
@@ -7,6 +7,7 @@ publicWidget.registry.SurveySessionLeaderboard = publicWidget.Widget.extend({
         this._super.apply(this, arguments);
 
         this.surveyAccessToken = options.surveyAccessToken;
+        this.surveyId = options.surveyId;
         this.$sessionResults = options.sessionResults;
 
         this.BAR_MIN_WIDTH = '3rem';
@@ -42,7 +43,7 @@ publicWidget.registry.SurveySessionLeaderboard = publicWidget.Widget.extend({
             self.$('.o_survey_session_leaderboard_container').empty();
         }
 
-        var leaderboardPromise = rpc(`/survey/session/leaderboard/${this.surveyAccessToken}`);
+        var leaderboardPromise = rpc(`/survey/session/leaderboard/${this.surveyId}/${this.surveyAccessToken}`);
 
         Promise.all([fadeOutPromise, leaderboardPromise]).then(function (results) {
             var leaderboardResults = results[1];

--- a/addons/survey/static/src/js/survey_session_manage.js
+++ b/addons/survey/static/src/js/survey_session_manage.js
@@ -340,7 +340,7 @@ publicWidget.registry.SurveySessionManage = publicWidget.Widget.extend(SurveyPre
         }
 
         var nextQuestionPromise = rpc(
-            `/survey/session/next_question/${self.surveyAccessToken}`,
+            `/survey/session/next_question/${self.surveyId}/${self.surveyAccessToken}`,
             {
                 'go_back': goBack,
             }
@@ -453,7 +453,7 @@ publicWidget.registry.SurveySessionManage = publicWidget.Widget.extend(SurveyPre
         var self = this;
 
         return rpc(
-            `/survey/session/results/${self.surveyAccessToken}`
+            `/survey/session/results/${self.surveyId}/${self.surveyAccessToken}`
         ).then(function (questionResults) {
             if (questionResults) {
                 self.attendeesCount = questionResults.attendees_count;
@@ -555,6 +555,7 @@ publicWidget.registry.SurveySessionManage = publicWidget.Widget.extend(SurveyPre
         if (this.isScoredQuestion || this.isLastQuestion) {
             this.leaderBoard = new SurveySessionLeaderBoard(this, {
                 surveyAccessToken: this.surveyAccessToken,
+                surveyId: this.surveyId,
                 sessionResults: this.$('.o_survey_session_results')
             });
 

--- a/addons/survey/static/tests/tours/certification_failure.js
+++ b/addons/survey/static/tests/tours/certification_failure.js
@@ -128,5 +128,4 @@ var lastSteps = [{
 }];
 
 registry.category("web_tour.tours").add('test_certification_failure', {
-    url: '/survey/start/4ead4bc8-b8f2-4760-a682-1fde8daaaaac',
     steps: () => [].concat(patch, failSteps, retrySteps, failSteps, lastSteps) });

--- a/addons/survey/static/tests/tours/certification_success.js
+++ b/addons/survey/static/tests/tours/certification_success.js
@@ -14,7 +14,6 @@ function patchSurveyWidget() {
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('test_certification_success', {
-    url: '/survey/start/4ead4bc8-b8f2-4760-a682-1fde8daaaaac',
     steps: () => [{
         content: "Patching Survey Widget",
         trigger: 'body',

--- a/addons/survey/static/tests/tours/survey.js
+++ b/addons/survey/static/tests/tours/survey.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('test_survey', {
-    url: '/survey/start/b137640d-14d4-4748-9ef6-344caaaaaae',
     steps: () => [
     // Page-1
     {

--- a/addons/survey/static/tests/tours/survey_chained_conditional_questions.js
+++ b/addons/survey/static/tests/tours/survey_chained_conditional_questions.js
@@ -2,7 +2,6 @@ import { queryAll } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('test_survey_chained_conditional_questions', {
-    url: '/survey/start/3cfadce3-3f7e-41da-920d-10fa0eb19527',
     steps: () => [
     {
         content: 'Click on Start',

--- a/addons/survey/static/tests/tours/survey_conditional_questions_on_different_page.js
+++ b/addons/survey/static/tests/tours/survey_conditional_questions_on_different_page.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { expectHiddenQuestion } from "@survey/../tests/tours/survey_chained_conditional_questions";
 
 registry.category("web_tour.tours").add('test_survey_conditional_question_on_different_page', {
-    url: '/survey/start/1cb935bd-2399-4ed1-9e10-c649318fb4dc',
     steps: () => [
         {
             content: 'Click on Start',

--- a/addons/survey/static/tests/tours/survey_prefill.js
+++ b/addons/survey/static/tests/tours/survey_prefill.js
@@ -2,7 +2,6 @@ import { queryFirst, queryOne } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('test_survey_prefill', {
-    url: '/survey/start/b137640d-14d4-4748-9ef6-344caaaaaae',
     steps: () => [{      // Page-1
         trigger: 'button.btn.btn-primary.btn-lg:contains("Start Survey")',
         run: "click",

--- a/addons/survey/static/tests/tours/survey_roaming_mandatory_questions.js
+++ b/addons/survey/static/tests/tours/survey_roaming_mandatory_questions.js
@@ -1,7 +1,6 @@
 import { registry } from '@web/core/registry';
 
 registry.category('web_tour.tours').add('test_survey_roaming_mandatory_questions', {
-    url: '/survey/start/853ebb30-40f2-43bf-a95a-bbf0e367a365',
     steps: () => [{
         content: 'Click on Start',
         trigger: 'button.btn:contains("Start")',

--- a/addons/survey/tests/test_certification_flow.py
+++ b/addons/survey/tests/test_certification_flow.py
@@ -95,21 +95,21 @@ class TestCertificationFlow(common.TestSurveyCommon, MockEmail, HttpCase):
         answer_token = user_inputs.access_token
 
         # Employee begins survey with first page
-        response = self._access_page(certification, answer_token)
+        response = self._access_page(certification, answer_token, user_inputs.id)
         self.assertResponse(response, 200)
         csrf_token = self._find_csrf_token(response.text)
 
-        r = self._access_begin(certification, answer_token)
+        r = self._access_begin(certification, answer_token, user_inputs.id)
         self.assertResponse(r, 200)
 
         with self.mock_mail_gateway():
-            self._answer_question(q01, q01.suggested_answer_ids.ids[3], answer_token, csrf_token)
-            self._answer_question(q02, q02.suggested_answer_ids.ids[1], answer_token, csrf_token)
-            self._answer_question(q03, "I think they're great!", answer_token, csrf_token)
-            self._answer_question(q04, q04.suggested_answer_ids.ids[0], answer_token, csrf_token, button_submit='previous')
-            self._answer_question(q03, "Just kidding, I don't like it...", answer_token, csrf_token)
-            self._answer_question(q04, q04.suggested_answer_ids.ids[0], answer_token, csrf_token)
-            self._answer_question(q05, [q05.suggested_answer_ids.ids[0], q05.suggested_answer_ids.ids[1], q05.suggested_answer_ids.ids[3]], answer_token, csrf_token)
+            self._answer_question(q01, q01.suggested_answer_ids.ids[3], answer_token, user_inputs.id, csrf_token)
+            self._answer_question(q02, q02.suggested_answer_ids.ids[1], answer_token, user_inputs.id, csrf_token)
+            self._answer_question(q03, "I think they're great!", answer_token, user_inputs.id, csrf_token)
+            self._answer_question(q04, q04.suggested_answer_ids.ids[0], answer_token, user_inputs.id, csrf_token, button_submit='previous')
+            self._answer_question(q03, "Just kidding, I don't like it...", answer_token, user_inputs.id, csrf_token)
+            self._answer_question(q04, q04.suggested_answer_ids.ids[0], answer_token, user_inputs.id, csrf_token)
+            self._answer_question(q05, [q05.suggested_answer_ids.ids[0], q05.suggested_answer_ids.ids[1], q05.suggested_answer_ids.ids[3]], answer_token, user_inputs.id, csrf_token)
 
         user_inputs.invalidate_recordset()
         # Check that certification is successfully passed
@@ -206,18 +206,18 @@ class TestCertificationFlow(common.TestSurveyCommon, MockEmail, HttpCase):
         answer_token = user_inputs.access_token
 
         # Employee begins survey with first page
-        response = self._access_page(certification, answer_token)
+        response = self._access_page(certification, answer_token, user_inputs.id)
         self.assertResponse(response, 200)
         csrf_token = self._find_csrf_token(response.text)
 
-        r = self._access_begin(certification, answer_token)
+        r = self._access_begin(certification, answer_token, user_inputs.id)
         self.assertResponse(r, 200)
 
         with patch.object(IrMail_Server, 'connect'):
             question_ids = user_inputs.predefined_question_ids
             self.assertEqual(len(question_ids), 1, 'Only one question should have been selected by the randomization')
             # Whatever which question was selected, the correct answer is the first one
-            self._answer_question(question_ids, question_ids.suggested_answer_ids.ids[0], answer_token, csrf_token)
+            self._answer_question(question_ids, question_ids.suggested_answer_ids.ids[0], answer_token, user_inputs.id, csrf_token)
 
         statistics = user_inputs._prepare_statistics()[user_inputs]
         total_statistics = statistics['totals']

--- a/addons/survey/tests/test_survey_controller.py
+++ b/addons/survey/tests/test_survey_controller.py
@@ -4,8 +4,10 @@
 from odoo import Command
 from odoo.addons.survey.tests import common
 from odoo.tests.common import HttpCase
+from odoo.tests import tagged
 
 
+@tagged('post_install', '-at_install')
 class TestSurveyController(common.TestSurveyCommon, HttpCase):
 
     def test_submit_route_scoring_after_page(self):
@@ -83,11 +85,11 @@ class TestSurveyController(common.TestSurveyCommon, HttpCase):
                 user_input = self.env['survey.user_input'].search([('access_token', '=', response.url.split('/')[-1])])
                 answer_token = user_input.access_token
 
-                r = self._access_page(survey, answer_token)
+                r = self._access_page(survey, answer_token, user_input.id)
                 self.assertResponse(r, 200)
                 csrf_token = self._find_csrf_token(response.text)
 
-                r = self._access_begin(survey, answer_token)
+                r = self._access_begin(survey, answer_token, user_input.id)
                 self.assertResponse(r, 200)
 
                 post_data = {'csrf_token': csrf_token, 'token': answer_token}

--- a/addons/survey/tests/test_survey_flow.py
+++ b/addons/survey/tests/test_survey_flow.py
@@ -81,12 +81,12 @@ class TestSurveyFlow(common.TestSurveyCommon, HttpCase):
         self.assertAnswer(answers, 'new', self.env['survey.question'])
 
         # Customer begins survey with first page
-        r = self._access_page(survey, answer_token)
+        r = self._access_page(survey, answer_token, answers.id)
         self.assertResponse(r, 200)
         self.assertAnswer(answers, 'new', self.env['survey.question'])
         csrf_token = self._find_csrf_token(r.text)
 
-        r = self._access_begin(survey, answer_token)
+        r = self._access_begin(survey, answer_token, answers.id)
         self.assertResponse(r, 200)
 
         # Customer submit first page answers
@@ -104,7 +104,7 @@ class TestSurveyFlow(common.TestSurveyCommon, HttpCase):
         self.assertAnswerLines(page_0, answers, answer_data)
 
         # Customer is redirected on second page and begins filling it
-        r = self._access_page(survey, answer_token)
+        r = self._access_page(survey, answer_token, answers.id)
         self.assertResponse(r, 200)
         csrf_token = self._find_csrf_token(r.text)
 

--- a/addons/survey/tests/test_survey_flow_with_conditions.py
+++ b/addons/survey/tests/test_survey_flow_with_conditions.py
@@ -123,11 +123,11 @@ class TestSurveyFlowWithConditions(common.TestSurveyCommon, HttpCase):
         answer_token = user_inputs.access_token
 
         # User begins survey with first page
-        response = self._access_page(survey, answer_token)
+        response = self._access_page(survey, answer_token, user_inputs.id)
         self.assertResponse(response, 200)
         csrf_token = self._find_csrf_token(response.text)
 
-        r = self._access_begin(survey, answer_token)
+        r = self._access_begin(survey, answer_token, user_inputs.id)
         self.assertResponse(r, 200)
 
         answers = {
@@ -139,7 +139,7 @@ class TestSurveyFlowWithConditions(common.TestSurveyCommon, HttpCase):
             q07: q07.suggested_answer_ids[1],  # Right
         }
 
-        self._answer_page(page_0, answers, answer_token, csrf_token)
+        self._answer_page(page_0, answers, answer_token, user_inputs.id, csrf_token)
         self.assertEqual(len(user_inputs.predefined_question_ids), 6, "q04 should have been removed as not triggered.")
 
         user_inputs.invalidate_recordset()

--- a/addons/survey/tests/test_survey_security.py
+++ b/addons/survey/tests/test_survey_security.py
@@ -357,11 +357,12 @@ class TestSurveySecurityControllers(common.TestSurveyCommon, HttpCase):
         })
 
         # right short access token
-        response = self.url_open('/s/123456')
+        response = self.url_open(f'/s/{self.survey.id}/123456')
         self.assertEqual(response.status_code, 200)
         self.assertIn('The session will begin automatically when the host starts', response.text)
 
         # `like` operator injection
+        # check deprecated token-based route
         response = self.url_open('/s/______')
         self.assertFalse(self.survey.title in response.text)
 

--- a/addons/survey/tests/test_survey_ui_certification.py
+++ b/addons/survey/tests/test_survey_ui_certification.py
@@ -272,8 +272,8 @@ class TestUiCertification(HttpCaseWithUserDemo):
 
     def test_04_certification_success_tour(self):
         access_token = self.survey_certification.access_token
-        self.start_tour("/survey/start/%s" % access_token, 'test_certification_success', login="demo")
+        self.start_tour(f"/survey/start/{self.survey_certification.id}/{access_token}", 'test_certification_success', login="demo")
 
     def test_05_certification_failure_tour(self):
         access_token = self.survey_certification.access_token
-        self.start_tour("/survey/start/%s" % access_token, 'test_certification_failure', login="demo")
+        self.start_tour(f"/survey/start/{self.survey_certification.id}/{access_token}", 'test_certification_failure', login="demo")

--- a/addons/survey/tests/test_survey_ui_feedback.py
+++ b/addons/survey/tests/test_survey_ui_feedback.py
@@ -162,15 +162,15 @@ class TestUiFeedback(HttpCaseWithUserDemo):
 
     def test_01_admin_survey_tour(self):
         access_token = self.survey_feedback.access_token
-        self.start_tour("/survey/start/%s" % access_token, 'test_survey', login="admin")
+        self.start_tour(f"/survey/start/{self.survey_feedback.id}/{access_token}", 'test_survey', login="admin")
 
     def test_02_demo_survey_tour(self):
         access_token = self.survey_feedback.access_token
-        self.start_tour("/survey/start/%s" % access_token, 'test_survey', login="demo")
+        self.start_tour(f"/survey/start/{self.survey_feedback.id}/{access_token}", 'test_survey', login="demo")
 
     def test_03_public_survey_tour(self):
         access_token = self.survey_feedback.access_token
-        self.start_tour("/survey/start/%s" % access_token, 'test_survey')
+        self.start_tour(f"/survey/start/{self.survey_feedback.id}/{access_token}", 'test_survey')
 
     def test_04_public_survey_with_triggers(self):
         """ Check that chained conditional questions are correctly
@@ -237,7 +237,7 @@ class TestUiFeedback(HttpCaseWithUserDemo):
         q4.triggering_answer_ids = q1_a1
 
         access_token = survey_with_triggers.access_token
-        self.start_tour("/survey/start/%s" % access_token, 'test_survey_chained_conditional_questions')
+        self.start_tour(f"/survey/start/{survey_with_triggers.id}/{access_token}", 'test_survey_chained_conditional_questions')
 
     def test_05_public_survey_with_trigger_on_different_page(self):
         """Check that conditional questions are shown when triggered from a different page too."""
@@ -298,11 +298,11 @@ class TestUiFeedback(HttpCaseWithUserDemo):
         q3.triggering_answer_ids = q1_a1 | q2_a1
 
         access_token = survey_with_trigger_on_different_page.access_token
-        self.start_tour("/survey/start/%s" % access_token, 'test_survey_conditional_question_on_different_page')
+        self.start_tour(f"/survey/start/{survey_with_trigger_on_different_page.id}/{access_token}", 'test_survey_conditional_question_on_different_page')
 
     def test_06_survey_prefill(self):
         access_token = self.survey_feedback.access_token
-        self.start_tour("/survey/start/%s" % access_token, 'test_survey_prefill')
+        self.start_tour(f"/survey/start/{self.survey_feedback.id}/{access_token}", 'test_survey_prefill')
 
     def test_07_survey_roaming_mandatory_questions(self):
         survey_with_mandatory_questions = self.env['survey.survey'].create({
@@ -347,4 +347,4 @@ class TestUiFeedback(HttpCaseWithUserDemo):
         })
 
         access_token = survey_with_mandatory_questions.access_token
-        self.start_tour("/survey/start/%s" % access_token, 'test_survey_roaming_mandatory_questions')
+        self.start_tour(f"/survey/start/{survey_with_mandatory_questions.id}/{access_token}", 'test_survey_roaming_mandatory_questions')

--- a/addons/survey/tests/test_survey_ui_session.py
+++ b/addons/survey/tests/test_survey_ui_session.py
@@ -152,7 +152,7 @@ class TestUiSession(HttpCase):
                 'type': 'ir.actions.act_url',
                 'name': "Open Session Manager",
                 'target': 'self',
-                'url': '/survey/session/manage/%s' % self.access_token
+                'url': f'/survey/session/manage/{self.id}/{self.access_token}'
             }
 
         # =======================

--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -111,6 +111,8 @@
                 class="d-flex flex-grow-1 align-items-center"
                 t-att-data-scoring-type="survey.scoring_type"
                 t-att-data-answer-token="answer.access_token"
+                t-att-data-answer-id="answer.id"
+                t-att-data-survey-id="survey.id"
                 t-att-data-survey-token="survey.access_token"
                 t-att-data-users-can-go-back="survey.users_can_go_back and not answer.is_session_answer"
                 t-att-data-session-in-progress="answer.is_session_answer"
@@ -319,7 +321,7 @@
                             <t t-call="survey.survey_button_retake"/>
                             <p t-if="survey.scoring_type != 'scoring_without_answers'">
                                 <a role="button" class="o_survey_review btn btn-secondary btn-lg"
-                                    t-att-href="'/survey/print/%s?answer_token=%s&amp;review=True' % (survey.access_token, answer.access_token)">
+                                    t-att-href="'/survey/print/%s/%s?answer_token=%s&amp;review=True&amp;answer_id=%s' % (survey.id, survey.access_token, answer.access_token, answer.id)">
                                     Review your answers
                                 </a>
                             </p>
@@ -493,7 +495,7 @@
             <!-- Directly use field or route if the user doesn't have access rights -->
             <div t-if="not env.user.has_group('survey.group_survey_user')"
                 class="o_survey_choice_img d-flex my-3 justify-content-center">
-                <img t-att-src="'/survey/get_question_image/%s/%s/%s/%s' % (survey.access_token, answer.access_token, question.id, label.id)" class="mw-100 h-auto"/>
+                <img t-att-src="'/survey/get_question_image/%s/%s/%s/%s/%s/%s' % (survey.id, answer.id, survey.access_token, answer.access_token, question.id, label.id)" class="mw-100 h-auto"/>
             </div>
             <div t-else=""  t-field="label.value_image"
                 class="o_survey_choice_img d-flex my-3 justify-content-center"

--- a/addons/survey/views/survey_templates_management.xml
+++ b/addons/survey/views/survey_templates_management.xml
@@ -115,13 +115,13 @@
                 <t t-set="attempts_left" t-value="survey._get_number_of_attempts_lefts(answer.partner_id, answer.email, answer.invite_token)" />
                 <p t-if="attempts_left > 0">
                     <span>Number of attempts left</span>: <span t-out="attempts_left"/>
-                    <a role="button" class="btn btn-primary btn-lg ms-3" t-att-href="'/survey/retry/%s/%s' % (survey.access_token, answer.access_token)">
+                    <a role="button" class="btn btn-primary btn-lg ms-3" t-att-href="'/survey/retry/%s/%s/%s/%s' % (survey.id, answer.id, survey.access_token, answer.access_token)">
                         Retry
                     </a>
                 </p>
             </t>
             <p t-else="">
-                <a role="button" class="btn btn-primary btn-lg" t-att-href="'/survey/retry/%s/%s' % (survey.access_token, answer.access_token)">
+                <a role="button" class="btn btn-primary btn-lg" t-att-href="'/survey/retry/%s/%s/%s/%s' % (survey.id, answer.id, survey.access_token, answer.access_token)">
                     Take Again
                 </a>
             </p>


### PR DESCRIPTION
Since there are many controllers it makes sense to refactor them.
Additionally redundant `url` parameters are removed from js tests.

task-4015835

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
