### PR TITLE
[FIX] stock, mrp_subcontracting: MRP improvements

### DIFF
--- a/addons/mrp_subcontracting/models/stock_picking.py
+++ b/addons/mrp_subcontracting/models/stock_picking.py
@@ -155,7 +155,8 @@ class StockPicking(models.Model):
             'location_dest_id': subcontract_move.picking_id.partner_id.with_company(subcontract_move.company_id).property_stock_subcontractor.id,
             'product_qty': subcontract_move.product_uom_qty or subcontract_move.quantity,
             'picking_type_id': warehouse.subcontracting_type_id.id,
-            'date_start': subcontract_move.date - relativedelta(days=bom.produce_delay)
+            'date_start': subcontract_move.date - relativedelta(days=bom.produce_delay),
+            'origin': self.name,
         }
         return vals
 

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -123,6 +123,7 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
         picking_receipt.move_ids.picked = True
         picking_receipt.button_validate()
         self.assertEqual(mo.state, 'done')
+        self.assertEqual(mo.origin, picking_receipt.name)
 
         # Available quantities should be negative at the subcontracting location for each components
         avail_qty_comp1 = self.env['stock.quant']._get_available_quantity(self.comp1, self.subcontractor_partner1.property_stock_subcontractor, allow_negative=True)
@@ -203,6 +204,7 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
         picking_receipt.move_ids.picked = True
         picking_receipt.button_validate()
         self.assertEqual(mo.state, 'done')
+        self.assertEqual(mo.origin, picking_receipt.name)
 
         # Available quantities should be negative at the subcontracting location for each components
         avail_qty_comp1 = self.env['stock.quant']._get_available_quantity(self.comp1, self.subcontractor_partner1.property_stock_subcontractor, allow_negative=True)
@@ -273,6 +275,7 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
         picking_receipt.move_ids.picked = True
         picking_receipt.button_validate()
         self.assertEqual(mo.state, 'done')
+        self.assertEqual(mo.origin, picking_receipt.name)
 
         # Available quantities should be negative at the subcontracting location for each components
         avail_qty_comp1 = self.env['stock.quant']._get_available_quantity(self.comp1, self.subcontractor_partner1.property_stock_subcontractor, allow_negative=True)

--- a/addons/stock/wizard/stock_backorder_confirmation_views.xml
+++ b/addons/stock/wizard/stock_backorder_confirmation_views.xml
@@ -40,7 +40,7 @@
 
                 <footer>
                     <button name="process" string="Create Backorder" type="object" class="oe_highlight" data-hotkey="q"/>
-                    <button name="process_cancel_backorder" string="No Backorder" type="object" class="btn-danger text-uppercase" invisible="show_transfers" data-hotkey="w"/>
+                    <button name="process_cancel_backorder" string="No Backorder" type="object" class="btn-danger" invisible="show_transfers" data-hotkey="w"/>
                     <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x" />
                 </footer>
             </form>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: This PR fixes two stock bugs provided in task [4104208](https://www.odoo.com/odoo/project/966/tasks/4104208).

Current behavior before PR:
1. 'No Backorder' button is in uppercase.
2. The 'Source' field in a subcontracted MO remains empty until manually filled.

Desired behavior after PR is merged:
1. 'No Backorder' button is in title case.
2. The 'Source' field in a subcontracted MO gets automatically filled with the name of the transfer responsible for its creation.


