### PR TITLE
[FIX] core: race condition in screencast finalisation

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -976,7 +976,10 @@ class ChromeBrowser:
 
     @property
     def screencasts_frames_dir(self):
-        return os.path.join(self.screencasts_dir, 'frames')
+        if screencasts_dir := self.screencasts_dir:
+            return os.path.join(screencasts_dir, 'frames')
+        else:
+            return None
 
     def signal_handler(self, sig, frame):
         if sig == signal.SIGXCPU:
@@ -987,8 +990,7 @@ class ChromeBrowser:
     def stop(self):
         if hasattr(self, 'ws'):
             self._websocket_send('Page.stopScreencast')
-            if self.screencasts_dir:
-                screencasts_frames_dir = self.screencasts_frames_dir
+            if screencasts_frames_dir := self.screencasts_frames_dir:
                 self.screencasts_dir = None
                 if os.path.isdir(screencasts_frames_dir):
                     shutil.rmtree(screencasts_frames_dir, ignore_errors=True)
@@ -1392,12 +1394,11 @@ which leads to stray network requests and inconsistencies."""
             wait()
 
     def _handle_screencast_frame(self, sessionId, data, metadata):
-        if not self.screencasts_frames_dir:
+        frames_dir = self.screencasts_frames_dir
+        if not frames_dir:
             return
         self._websocket_send('Page.screencastFrameAck', params={'sessionId': sessionId})
-        if not self.screencasts_dir:
-            return
-        outfile = os.path.join(self.screencasts_frames_dir, 'frame_%05d.b64' % len(self.screencast_frames))
+        outfile = os.path.join(frames_dir, 'frame_%05d.b64' % len(self.screencast_frames))
         try:
             with open(outfile, 'w') as f:
                 f.write(data)


### PR DESCRIPTION
It's not common, but apparently it's possible for Chrome to send a screencast frame after it's been told to stop. I assume because screencasting is asynchronous so if a frame capture is triggered before the command to stop reaches the browser, that frame capture may complete and be dispatched.

Locally this seems to occur in about 3.5% of calls to `test_screencasts` (7 out of 200 runs). In those cases, the event sequence looks like this:

    T + 0.0000s _save_screencast()
                   sends `Page.stopScreencast`
    T + 0.0002s stop
                   send `Page.stopScreencast`, unsets `screencasts_dir`
    T + 0.0100s _handle_screencast_frame
                   accesses screencasts_frames_dir

`screencasts_frames_dir` then proceed to access `screencasts_dir`, not handle it being `None`, and break.

To fix, just make `screencasts_frame_dir` return `None` if `screencasts_dir` is `None`. This makes `_handle_screencast_frame` properly no-op on the incoming frame. And remove the redundant check on `screencasts_dir` after having ack'd the frame.

Note that this issue has *not* been reported upstream for consideration, as it would require creating a bespoke test case and I can't be arsed. A search on both the tracker and the internet at large doesn't reveal anything relevant.

Example stagings failed due to this:
- https://runbot.odoo.com/runbot/build/66915127
- https://runbot.odoo.com/runbot/build/66915510

And because it's a "traceback found in the logs" it doesn't seem like the runbot is able to see / track it.