### PR TITLE
[IMP] web: redirect user to the first embedded action

### DIFF
--- a/addons/web/static/src/search/control_panel/control_panel.js
+++ b/addons/web/static/src/search/control_panel/control_panel.js
@@ -175,10 +175,14 @@ export class ControlPanel extends Component {
         onMounted(async () => {
             if (this.state.embeddedInfos.embeddedActions?.length > 0) {
                 // If there is no visible embedded actions, the current action (if it exists) is put by default
+                const embeddedActionKey =
+                    this.state.embeddedInfos.currentEmbeddedAction?.id || false;
                 if (
-                    !Object.keys(this.state.embeddedInfos.visibleEmbeddedActions).includes("false")
+                    !Object.keys(this.state.embeddedInfos.visibleEmbeddedActions).includes(
+                        embeddedActionKey.toString()
+                    )
                 ) {
-                    this._setVisibility(false);
+                    this._setVisibility(embeddedActionKey);
                 }
                 const embeddedOrderLocalStorageKey = browser.localStorage.getItem(
                     this.embeddedOrderKey
@@ -237,14 +241,10 @@ export class ControlPanel extends Component {
     }
 
     getDropdownClass(action) {
-        const isSelected =
-            (!this.env.isSmall && this._checkValueLocalStorage(action)) ||
+        return (!this.env.isSmall && this._checkValueLocalStorage(action)) ||
             (this.env.isSmall && this.state.embeddedInfos.currentEmbeddedAction?.id === action.id)
-                ? "selected"
-                : "";
-        const isClickable =
-            action.id === false && !this.env.isSmall ? "cursor-default text-muted" : "";
-        return `${isSelected} ${isClickable}`;
+            ? "selected"
+            : "";
     }
 
     getScrollingElement() {
@@ -604,19 +604,16 @@ export class ControlPanel extends Component {
      * @param {HTMLElement} params.previous
      */
     _sortEmbeddedActionDrop({ element, previous }) {
-        const order = this.state.embeddedInfos.embeddedActions
-            .map((el) => el.id)
-            .filter((el) => el !== false);
-        const elementId = Number(element.dataset.id);
+        const order = this.state.embeddedInfos.embeddedActions.map((el) => el.id);
+        const elementId = Number(element.dataset.id) || false;
         const elementIndex = order.indexOf(elementId);
         order.splice(elementIndex, 1);
         if (previous) {
-            const prevIndex = order.indexOf(Number(previous.dataset.id));
+            const prevIndex = order.indexOf(Number(previous.dataset.id) || false);
             order.splice(prevIndex + 1, 0, elementId);
         } else {
             order.splice(0, 0, elementId);
         }
-        order.unshift(false);
         this._sortEmbeddedActions(order);
         browser.localStorage.setItem(this.embeddedOrderKey, JSON.stringify(order));
     }

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -7,8 +7,8 @@
                 <div class="o_embedded_actions overflow-hidden d-flex flex-wrap w-100 align-items-center justify-content-center gap-2" t-att-class="transition.className">
                     <t t-foreach="state.embeddedInfos.embeddedActions" t-as="action" t-key="action.id">
                         <t t-if="_checkValueLocalStorage(action)">
-                            <button class="btn btn-secondary"
-                                    t-att-class="{ 'active': state.embeddedInfos.currentEmbeddedAction?.id === action.id, 'o_draggable': !!action.id}"
+                            <button class="btn btn-secondary o_draggable"
+                                    t-att-class="{ 'active': state.embeddedInfos.currentEmbeddedAction?.id === action.id}"
                                     t-on-click="() => this.onEmbeddedActionClick(action)"
                                     t-att-data-id="action.id"
                             >
@@ -135,7 +135,7 @@
                 <t t-foreach="state.embeddedInfos.embeddedActions" t-as="action" t-key="action.id">
                     <DropdownItem 
                         class="this.getDropdownClass(action)"
-                        onSelected="() => this.env.isSmall ? this.onEmbeddedActionClick(action) : action.id ? this._setVisibility(action.id) : {}"
+                        onSelected="() => this.env.isSmall ? this.onEmbeddedActionClick(action) : this._setVisibility(action.id)"
                         closingMode="'none'"
                     >
                         <div class="d-flex p-0 pe-1 align-items-center justify-content-between">


### PR DESCRIPTION
# [IMP] web: redirect user to the first embedded action
The main goal of this commit is to add a feature in the action service, allowing for redirecting the user directly to the first embedded action of the loaded action.

This commit adds three context keys to change the behavior of embedded actions in the control panel :

- load_first_embedded_action: this key will trigger the mentioned behavior
- main_embedded_action_movable: this key allows the user to change the order of the main embedded action in the control panel.
- main_embedded_action_unselectable: this key allows the user to unselect the main embedded action in the embedded action's dropdown.

The way it works is by checking the context keys in the "doActionButton" method. If the "load_first_embedded_action" key is present, it will proceed to load the first embedded action by retrieving the order from the localStorage.

This commit also changes the "_setVisibility" call when mounting the control panel. Usually, the logic is to display the current embedded action if none is checked in the dropdown, by switching the visibility of the embedded action with id "false" to true. However, calling "doActionButton" with a custom context (e.g. different "current_embedded_action_id") makes this logic wrong, since the id of the current embedded action is not false.

task-4109914