### PR TITLE
[FIX] web_tour_recorder: Fix unfinished tour

### DIFF
--- a/addons/web_tour_recorder/static/tests/tour_recorder.test.js
+++ b/addons/web_tour_recorder/static/tests/tour_recorder.test.js
@@ -6,6 +6,7 @@ import {
     defineWebModels,
     getService,
     mountWithCleanup,
+    onRpc,
     patchWithCleanup,
     serverState,
 } from "@web/../tests/web_test_helpers";
@@ -498,6 +499,10 @@ test("Run custom tour", async () => {
 });
 
 test("Run a custom tour twice doesn't trigger traceback", async () => {
+    onRpc("/web/dataset/call_kw/web_tour.tour/consume", async () => {
+        return Promise.resolve(true);
+    });
+
     await mountWithCleanup(
         `
         <div class="o_parent">
@@ -541,5 +546,10 @@ test("Run a custom tour twice doesn't trigger traceback", async () => {
 
     expect("table tr td:contains('tour_name')").toHaveCount(2);
     click(".o_start_tour:eq(1)");
+    await animationFrame();
+    await advanceTime(100);
+
+    click(".o_parent > div");
+    await advanceTime(100);
     await animationFrame();
 });


### PR DESCRIPTION
The last test of tour_recorder was running a tour did not finish it. So an observer remain after the test and this observer was trying to access the fixture.

Now the tour is completed before the end of the test.

Build error: 75000

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
