### PR TITLE
[FIX] l10n_nl: fix bad forward-port of account type change

### DIFF
--- a/addons/l10n_nl/data/account.account.template.csv
+++ b/addons/l10n_nl/data/account.account.template.csv
@@ -282,7 +282,7 @@
 "4940","Kasverschillen","4940","expense","l10n_nl.l10nnl_chart_template","l10n_nl.account_tag_31","False"
 "4950","Overige baten","4950","income","l10n_nl.l10nnl_chart_template","l10n_nl.account_tag_31","False"
 "4960","Overige lasten","4960","expense","l10n_nl.l10nnl_chart_template","l10n_nl.account_tag_31","False"
-"4970","Overige baten voorgaande jaren","income","expense","l10n_nl.l10nnl_chart_template","l10n_nl.account_tag_31","False"
+"4970","Overige baten voorgaande jaren","4970","income","l10n_nl.l10nnl_chart_template","l10n_nl.account_tag_31","False"
 "4980","Overige lasten voorgaande jaren","4980","expense","l10n_nl.l10nnl_chart_template","l10n_nl.account_tag_31","False"
 "7001","Kostprijs NL handelsgoederen 1","7001","expense_direct_cost","l10n_nl.l10nnl_chart_template","l10n_nl.account_tag_10","False"
 "7002","Kostprijs binnen EU handelsgoederen 1","7002","expense_direct_cost","l10n_nl.l10nnl_chart_template","l10n_nl.account_tag_10","False"


### PR DESCRIPTION
This forward-port commit https://github.com/odoo/odoo/commit/2f64d679c87a183e13bc056164f4ea0c4d629209 modified the code instead of the type column in the csv for account 4970.
