### PR TITLE
[FIX] bus: send missed presences to current user only

### DIFF
--- a/addons/bus/controllers/websocket.py
+++ b/addons/bus/controllers/websocket.py
@@ -36,7 +36,8 @@ class WebsocketController(Controller):
         elif 'is_websocket_session' not in request.session:
             raise SessionExpiredException()
         subscribe_data = request.env["ir.websocket"]._prepare_subscribe_data(channels, last)
-        subscribe_data["missed_presences"]._send_presence()
+        if bus_target := request.env["ir.websocket"]._get_missed_presences_bus_target():
+            subscribe_data["missed_presences"]._send_presence(bus_target=bus_target)
         channels_with_db = [channel_with_db(request.db, c) for c in subscribe_data["channels"]]
         notifications = request.env["bus.bus"]._poll(channels_with_db, subscribe_data["last"])
         return {"channels": channels_with_db, "notifications": notifications}

--- a/addons/bus/models/bus_presence.py
+++ b/addons/bus/models/bus_presence.py
@@ -101,7 +101,7 @@ class BusPresence(models.Model):
         self.user_id.invalidate_recordset(["im_status"])
         self.user_id.partner_id.invalidate_recordset(["im_status"])
 
-    def _send_presence(self, im_status=None):
+    def _send_presence(self, im_status=None, bus_target=None):
         """Send notification related to bus presence update.
 
         :param im_status: 'online', 'away' or 'offline'
@@ -110,10 +110,11 @@ class BusPresence(models.Model):
         for presence in self:
             identity_data = presence._get_identity_data()
             target = presence._get_bus_target()
+            target = bus_target or (target and (target, "presence"))
             if identity_data and target:
                 notifications.append(
                     (
-                        (target, "presence"),
+                        target,
                         "bus.bus/im_status_updated",
                         {"im_status": im_status or presence.status, **identity_data},
                     )

--- a/addons/bus/models/ir_websocket.py
+++ b/addons/bus/models/ir_websocket.py
@@ -39,6 +39,11 @@ class IrWebsocket(models.AbstractModel):
         # `_build_bus_channel_list`.
         return [[("user_id", "in", partners.with_context(active_test=False).sudo().user_ids.ids)]]
 
+    def _get_missed_presences_bus_target(self):
+        return (
+            self.env.user.partner_id if self.env.user and not self.env.user._is_public() else None
+        )
+
     def _build_presence_channel_list(self, presences):
         """
         Return the list of presences to subscribe to.
@@ -121,7 +126,8 @@ class IrWebsocket(models.AbstractModel):
     def _subscribe(self, og_data):
         data = self._prepare_subscribe_data(og_data["channels"], og_data["last"])
         dispatch.subscribe(data["channels"], data["last"], self.env.registry.db_name, wsrequest.ws)
-        data["missed_presences"]._send_presence()
+        if bus_target := self._get_missed_presences_bus_target():
+            data["missed_presences"]._send_presence(bus_target=bus_target)
 
     def _update_bus_presence(self, inactivity_period, im_status_ids_by_model):
         if self.env.user and not self.env.user._is_public():
@@ -133,7 +139,7 @@ class IrWebsocket(models.AbstractModel):
 
     def _on_websocket_closed(self, cookies):
         if self.env.user and not self.env.user._is_public():
-            self.env["bus.presence"].search([("user_id", "=", self.env.uid)]).unlink()
+            self.env["bus.presence"].search([("user_id", "=", self.env.uid)]).status = "offline"
 
     @classmethod
     def _authenticate(cls):

--- a/addons/bus/tests/test_ir_websocket.py
+++ b/addons/bus/tests/test_ir_websocket.py
@@ -10,6 +10,7 @@ except ImportError:
 from odoo.tests import new_test_user, tagged
 from .common import WebsocketCase
 from ..models.bus_presence import AWAY_TIMER
+from ..models.bus import channel_with_db, json_dump
 
 
 @tagged("-at_install", "post_install")
@@ -77,13 +78,20 @@ class TestIrWebsocket(WebsocketCase):
         session = self.authenticate("bob_user", "bob_user")
         websocket = self.websocket_connect(cookie=f"session_id={session.sid};")
         self.env["bus.presence"].create({"user_id": bob.id, "status": "online"})
+        self.env.cr.precommit.run()  # trigger the creation of bus.bus records
         self.subscribe(
             websocket,
             [f"odoo-presence-res.partner_{bob.partner_id.id}"],
             self.env["bus.bus"]._bus_last_id(),
         )
-        self.trigger_notification_dispatching([(bob.partner_id, "presence")])
-        message = json.loads(websocket.recv())[0]["message"]
-        self.assertEqual(message["type"], "bus.bus/im_status_updated")
-        self.assertEqual(message["payload"]["im_status"], "online")
-        self.assertEqual(message["payload"]["partner_id"], bob.partner_id.id)
+        self.trigger_notification_dispatching([bob.partner_id])
+        notification = json.loads(websocket.recv())[0]
+        self._close_websockets()
+        bus_record = self.env["bus.bus"].search([("id", "=", int(notification["id"]))])
+        self.assertEqual(
+            bus_record.channel,
+            json_dump(channel_with_db(self.env.cr.dbname, bob.partner_id)),
+        )
+        self.assertEqual(notification["message"]["type"], "bus.bus/im_status_updated")
+        self.assertEqual(notification["message"]["payload"]["im_status"], "online")
+        self.assertEqual(notification["message"]["payload"]["partner_id"], bob.partner_id.id)

--- a/addons/bus/tests/test_websocket_controller.py
+++ b/addons/bus/tests/test_websocket_controller.py
@@ -2,6 +2,7 @@
 
 from odoo.tests import JsonRpcException
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
+from odoo.addons.bus.models.bus import channel_with_db, json_dump
 
 
 class TestWebsocketController(HttpCaseWithUserDemo):
@@ -94,15 +95,33 @@ class TestWebsocketController(HttpCaseWithUserDemo):
         session = self.authenticate("demo", "demo")
         headers = {"Cookie": f"session_id={session.sid};"}
         self.env["bus.presence"].create({"user_id": self.user_demo.id, "status": "online"})
-        message = self.make_jsonrpc_request(
+        self.env.cr.precommit.run()  # trigger the creation of bus.bus records
+        # First request will get notifications and trigger the creation
+        # of the missed presences one.
+        last_id = self.env["bus.bus"]._bus_last_id()
+        self.make_jsonrpc_request(
             "/websocket/peek_notifications",
             {
                 "channels": [f"odoo-presence-res.partner_{self.partner_demo.id}"],
-                "last": self.env["bus.bus"]._bus_last_id(),
+                "last": last_id,
                 "is_first_poll": True,
             },
             headers=headers,
-        )["notifications"][0]["message"]
-        self.assertEqual(message["type"], "bus.bus/im_status_updated")
-        self.assertEqual(message["payload"]["partner_id"], self.partner_demo.id)
-        self.assertEqual(message["payload"]["im_status"], "online")
+        )
+        self.env.cr.precommit.run()  # trigger the creation of bus.bus records
+        notification = self.make_jsonrpc_request(
+            "/websocket/peek_notifications",
+            {
+                "channels": [f"odoo-presence-res.partner_{self.partner_demo.id}"],
+                "last": last_id,
+                "is_first_poll": True,
+            },
+            headers=headers,
+        )["notifications"][0]
+        bus_record = self.env["bus.bus"].search([("id", "=", int(notification["id"]))])
+        self.assertEqual(
+            bus_record.channel, json_dump(channel_with_db(self.env.cr.dbname, self.partner_demo))
+        )
+        self.assertEqual(notification["message"]["type"], "bus.bus/im_status_updated")
+        self.assertEqual(notification["message"]["payload"]["partner_id"], self.partner_demo.id)
+        self.assertEqual(notification["message"]["payload"]["im_status"], "online")

--- a/addons/mail/models/discuss/ir_websocket.py
+++ b/addons/mail/models/discuss/ir_websocket.py
@@ -29,6 +29,13 @@ class IrWebsocket(models.AbstractModel):
             identity_domain.append([("guest_id", "in", guest_ids)])
         return identity_domain
 
+    def _get_missed_presences_bus_target(self):
+        if self.env.user and not self.env.user._is_public():
+            return super()._get_missed_presences_bus_target()
+        if guest := self.env["mail.guest"]._get_guest_from_context():
+            return guest
+        return None
+
     @add_guest_to_context
     def _build_presence_channel_list(self, presences):
         channels = super()._build_presence_channel_list(presences)


### PR DESCRIPTION
Since [1], bus presences are only sent to interested users. Since notifications about presences can be missed between the subscribe client side and the subscribe server side, missed presences are sent when subscribing to new presences.

However, the missed presences are broadcasted to every subscriber while it should only be done for the user that just subscribed. This PR fixes this issue.

[1]: https://github.com/odoo/odoo/pull/175972