### PR TITLE
[IMP] account,mrp,point_of_sale,pos_*,product,*_sale_*,stock: improve combo logic and handle loyalty and stock

### DIFF
--- a/addons/account/models/product.py
+++ b/addons/account/models/product.py
@@ -126,6 +126,13 @@ class ProductTemplate(models.Model):
                 "If you want to change its Unit of Measure, please archive this product and create a new one."
             ))
 
+    @api.onchange('type')
+    def _onchange_type(self):
+        if self.type == 'combo':
+            self.taxes_id = False
+            self.supplier_taxes_id = False
+        return super()._onchange_type()
+
     def _force_default_sale_tax(self, companies):
         default_customer_taxes = companies.filtered('account_sale_tax_id').account_sale_tax_id
         for product_grouped_by_tax in self.grouped('taxes_id').values():

--- a/addons/mrp/views/product_views.xml
+++ b/addons/mrp/views/product_views.xml
@@ -19,11 +19,11 @@
             <field name="mode">primary</field>
             <field name="inherit_id" ref="product.product_template_search_view"/>
             <field name="arch" type="xml">
-                <xpath expr="//filter[@name='goods']" position="after">
+                <filter name="combo" position="after">
                     <separator/>
                     <filter string="Manufactured Products" name="manufactured_products" domain="[('bom_ids', '!=', False)]"/>
                     <filter string="BoM Components" name="components" domain="[('bom_line_ids', '!=', False)]"/>
-                </xpath>
+                </filter>
             </field>
         </record>
 
@@ -33,11 +33,11 @@
             <field name="mode">primary</field>
             <field name="inherit_id" ref="product.product_search_form_view"/>
             <field name="arch" type="xml">
-                <xpath expr="//filter[@name='goods']" position="after">
+                <filter name="combo" position="after">
                     <separator/>
                     <filter string="Manufactured Products" name="manufactured_products" domain="[('bom_ids', '!=', False)]"/>
                     <filter string="BoM Components" name="components" domain="[('bom_line_ids', '!=', False)]"/>
-                </xpath>
+                </filter>
             </field>
         </record>
 

--- a/addons/point_of_sale/data/scenarios/clothes_data.xml
+++ b/addons/point_of_sale/data/scenarios/clothes_data.xml
@@ -373,6 +373,7 @@
             <field name="name">T-shirt &amp; Pants Combo</field>
             <field name="description_sale">Combo</field>
             <field name="type">combo</field>
+            <field name="purchase_ok">False</field>
             <field name="weight">0.01</field>
             <field name="list_price">80</field>
             <field name="uom_id" ref="uom.product_uom_unit"/>

--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -47,29 +47,6 @@ class ProductTemplate(models.Model):
                 if combo_name:
                     raise UserError(_('You must first remove this product from the %s combo', combo_name))
 
-    def _create_variant_ids(self):
-        res = super()._create_variant_ids()
-        for template in self:
-            archived_product = self.env['product.product'].search([('product_tmpl_id', '=', template.id), ('active', '=', False)], limit=1)
-            if archived_product:
-                combo_items_to_delete = self.env['product.combo.item'].search([
-                    ('product_id', '=', archived_product.id)
-                ])
-                if combo_items_to_delete:
-                    # Delete old combo item
-                    combo_ids = combo_items_to_delete.mapped('combo_id')
-                    combo_items_to_delete.unlink()
-                    # Create new combo item (one for each new variant) in each combo
-                    new_variants = template.product_variant_ids.filtered(lambda v: v.active)
-                    self.env['product.combo.item'].create([
-                        {
-                            'product_id': variant.id,
-                            'combo_id': combo_id.id,
-                        }
-                        for variant in new_variants for combo_id in combo_ids
-                    ])
-        return res
-
 
 class ProductProduct(models.Model):
     _name = 'product.product'

--- a/addons/point_of_sale/tests/test_point_of_sale.py
+++ b/addons/point_of_sale/tests/test_point_of_sale.py
@@ -87,7 +87,3 @@ class TestPointOfSale(TransactionCase):
         })
         # Check that original product should not be in combo anymore (replace by variants)
         self.assertTrue(original_product_id not in product_combo.combo_item_ids.mapped('product_id').ids, "Original product should not be in combo")
-        # Check that variants are in combo
-        variant_ids = product_template.product_variant_ids.ids
-        for variant_id in variant_ids:
-            self.assertIn(variant_id, product_combo.combo_item_ids.mapped('product_id').ids, "Variant should be in combo")

--- a/addons/pos_restaurant/data/scenarios/restaurant_data.xml
+++ b/addons/pos_restaurant/data/scenarios/restaurant_data.xml
@@ -577,6 +577,7 @@
             <field name="list_price">10</field>
             <field name="name">Burger Menu Combo</field>
             <field name="type">combo</field>
+            <field name="purchase_ok">False</field>
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="uom_po_id" ref="uom.product_uom_unit"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/combo-hamb.png"/>

--- a/addons/product/data/product_demo.xml
+++ b/addons/product/data/product_demo.xml
@@ -679,6 +679,7 @@
             <field name="list_price">160</field>
             <field name="name">Office Combo</field>
             <field name="type">combo</field>
+            <field name="purchase_ok">False</field>
             <field name="categ_id" ref="product.product_category_5"/>
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="uom_po_id" ref="uom.product_uom_unit"/>

--- a/addons/product/models/product_catalog_mixin.py
+++ b/addons/product/models/product_catalog_mixin.py
@@ -40,7 +40,7 @@ class ProductCatalogMixin(models.AbstractModel):
         :returns: A list of tuples that represents a domain.
         :rtype: list
         """
-        return [('company_id', 'in', [self.company_id.id, False])]
+        return [('company_id', 'in', [self.company_id.id, False]), ('type', '!=', 'combo')]
 
     def _get_product_catalog_record_lines(self, product_ids, child_field=False, **kwargs):
         """ Returns the record's lines grouped by product.

--- a/addons/product/models/product_combo_item.py
+++ b/addons/product/models/product_combo_item.py
@@ -14,6 +14,7 @@ class ProductComboItem(models.Model):
     product_id = fields.Many2one(
         string="Product",
         comodel_name='product.product',
+        ondelete='cascade',
         domain=[('type', '!=', 'combo')],
         required=True,
         check_company=True,

--- a/addons/product/static/src/product_catalog/order_line/order_line.xml
+++ b/addons/product/static/src/product_catalog/order_line/order_line.xml
@@ -15,7 +15,7 @@
                 t-att-title="props.warning"
                 t-out="props.warning"/>
         </div>
-        <span t-elif="props.readOnly" class="my-2 pt-3 border-top" t-out="props.warning">
+        <span t-elif="props.readOnly" class="m-2 pt-3 border-top" t-out="props.warning">
             You can't edit this product in the catalog.
         </span>
         <div t-else="" class="d-flex justify-content-end align-items-center m-2">

--- a/addons/product/views/product_combo_views.xml
+++ b/addons/product/views/product_combo_views.xml
@@ -10,19 +10,22 @@
                     <h1>
                         <field
                             name="name"
-                            placeholder="e.g. Burger Menu"
+                            placeholder="e.g. Burger Choice"
                             widget="text"
                             options="{'line_breaks': False}"
                             class="text-break"
                         />
                     </h1>
+                </div>
+                <group>
                     <field
                         name="company_id"
+                        placeholder="Visible to all"
                         groups="base.group_multi_company"
-                        optional="hide"
                         options="{'no_create': True}"
+                        class="oe_inline"
                     />
-                </div>
+                </group>
                 <field name="combo_item_ids">
                     <list editable="bottom">
                         <field name="currency_id" column_invisible="True"/>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -70,7 +70,7 @@
                             <field name="sale_ok"/>
                             <label for="sale_ok"/>
                         </span>
-                        <span class="d-inline-block">
+                        <span class="d-inline-block" invisible="type == 'combo'">
                             <field name="purchase_ok"/>
                             <label for="purchase_ok"/>
                         </span>
@@ -105,18 +105,18 @@
                                             class="oe_inline"
                                             widget="monetary"
                                             options="{'currency_field': 'currency_id', 'field_digits': True}"/>
-                                            <span
-                                                name="uom_span"
-                                                groups="uom.group_uom"
-                                                invisible="type == 'combo'"
-                                            >
-                                                per
-                                                <field
-                                                    name="uom_id"
-                                                    class="oe_inline" style="max-width:136px"
-                                                    options="{'no_create': True}"
-                                                />
-                                            </span>
+                                        <span
+                                            name="uom_span"
+                                            groups="uom.group_uom"
+                                            invisible="type == 'combo'"
+                                        >
+                                            per
+                                            <field
+                                                name="uom_id"
+                                                class="oe_inline" style="max-width:136px"
+                                                options="{'no_create': True}"
+                                            />
+                                        </span>
                                     </div>
                                     <label
                                         for="standard_price"
@@ -225,6 +225,7 @@
                 <separator/>
                 <filter string="Services" name="services" domain="[('type','=','service')]"/>
                 <filter string="Goods" name="goods" domain="[('type', '=', 'consu')]"/>
+                <filter string="Combo" name="combo" domain="[('type', '=', 'combo')]"/>
                 <separator/>
                 <filter string="Sales" name="filter_to_sell" domain="[('sale_ok','=',True)]"/>
                 <filter string="Purchase" name="filter_to_purchase" domain="[('purchase_ok', '=', True)]"/>

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -816,7 +816,7 @@ class SaleOrder(models.Model):
             )
         )
         if lines_to_delete:
-            self.order_line = [Command.unlink(line.id) for line in lines_to_delete]
+            self.order_line = [Command.delete(line.id) for line in lines_to_delete]
         for index, line in enumerate(self.order_line):
             if line.product_type == 'combo' and line.selected_combo_items:
                 linked_lines = line._get_linked_lines()
@@ -860,7 +860,7 @@ class SaleOrder(models.Model):
 
                 # Clear `selected_combo_items` to avoid applying the same changes multiple times.
                 line.selected_combo_items = False
-                self.update({'order_line': delete_commands + create_commands + update_commands})
+                self.order_line = delete_commands + create_commands + update_commands
 
     #=== CRUD METHODS ===#
 

--- a/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.js
+++ b/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.js
@@ -24,6 +24,7 @@ export class ComboConfiguratorDialog extends Component {
         company_id: { type: Number, optional: true },
         pricelist_id: { type: Number, optional: true },
         date: String,
+        price_info: { type: String, optional: true },
         edit: { type: Boolean, optional: true },
         save: Function,
         discard: Function,
@@ -80,6 +81,7 @@ export class ComboConfiguratorDialog extends Component {
                     this.state.selectedComboItems.set(comboId, selectedComboItem);
                 },
                 discard: () => {},
+                ...this._getAdditionalDialogProps(),
             });
         } else {
             this.state.selectedComboItems.set(comboId, comboItem.deepCopy());
@@ -100,6 +102,7 @@ export class ComboConfiguratorDialog extends Component {
             date: this.props.date,
             company_id: this.props.company_id,
             pricelist_id: this.props.pricelist_id,
+            ...this._getAdditionalRpcParams(),
         });
     }
 
@@ -207,5 +210,23 @@ export class ComboConfiguratorDialog extends Component {
      */
     get _selectedComboItems() {
         return Array.from(this.state.selectedComboItems.values());
+    }
+
+    /**
+     * Hook to append additional RPC params in overriding modules.
+     *
+     * @return {Object} The additional RPC params.
+     */
+    _getAdditionalRpcParams() {
+        return {};
+    }
+
+    /**
+     * Hook to append additional props in overriding modules.
+     *
+     * @return {Object} The additional props.
+     */
+    _getAdditionalDialogProps() {
+        return {};
     }
 }

--- a/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.js
+++ b/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.js
@@ -40,6 +40,7 @@ export class ComboConfiguratorDialog extends Component {
             selectedComboItems: new Map(),
             quantity: this.props.quantity,
             basePrice: this.props.price,
+            isLoading: false,
         });
         if (this.props.edit) this._initSelectedComboItems();
         this._selectSingleComboItems();
@@ -143,7 +144,10 @@ export class ComboConfiguratorDialog extends Component {
     }
 
     async confirm(options) {
-        await this.props.save(this._comboProductData, this._selectedComboItems, options);
+        this.state.isLoading = true;
+        await this.props.save(this._comboProductData, this._selectedComboItems, options).finally(
+            () => this.state.isLoading = false
+        )
         this.props.close();
     }
 
@@ -180,8 +184,9 @@ export class ComboConfiguratorDialog extends Component {
     }
 
     get _totalPrice() {
-        const extraPrice = this.state.selectedComboItems.values().map(
-            comboItem => comboItem.extra_price + comboItem.product.selectedNoVariantPtavsPriceExtra
+        const extraPrice = Array.from(
+            this.state.selectedComboItems.values(),
+            comboItem => comboItem.extra_price + comboItem.product.selectedNoVariantPtavsPriceExtra,
         ).reduce((price, comboItemExtraPrice) => price + comboItemExtraPrice, 0);
         return this.state.quantity * (this.state.basePrice + extraPrice);
     }

--- a/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.xml
+++ b/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.xml
@@ -26,7 +26,7 @@
                 <button
                     name="sale_combo_configurator_confirm_button"
                     class="btn btn-primary"
-                    t-att-disabled="!areAllCombosSelected"
+                    t-att-disabled="!areAllCombosSelected || state.isLoading"
                     t-on-click="confirm"
                 >
                     Confirm

--- a/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.xml
+++ b/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.xml
@@ -48,9 +48,16 @@
                         isMinusButtonDisabled="state.quantity === 1"
                     />
                 </div>
-                <span name="sale_combo_configurator_total" class="h4">
-                    Total: <span t-out="formattedTotalPrice"/>
-                </span>
+                <div class="d-flex flex-column justify-content-center">
+                    <span name="sale_combo_configurator_total" class="h4 mb-0">
+                        Total: <span t-out="formattedTotalPrice"/>
+                    </span>
+                    <span
+                        t-if="this.props.price_info"
+                        t-out="this.props.price_info"
+                        class="text-muted"
+                    />
+                </div>
             </t>
         </Dialog>
     </t>

--- a/addons/sale/static/src/js/models/product_product.js
+++ b/addons/sale/static/src/js/models/product_product.js
@@ -2,12 +2,19 @@ import { ProductTemplateAttributeLine } from './product_template_attribute_line'
 
 export class ProductProduct {
     /**
+     * The instance is initialized in `setup` to allow patching, as constructors can't be patched.
+     */
+    constructor(...args) {
+        this.setup(...args);
+    }
+
+    /**
      * @param {number} id
      * @param {number} product_tmpl_id
      * @param {string} display_name
      * @param {ProductTemplateAttributeLine[]|object[]} ptals
      */
-    constructor({id, product_tmpl_id, display_name, ptals}) {
+    setup({id, product_tmpl_id, display_name, ptals}) {
         this.id = id;
         this.product_tmpl_id = product_tmpl_id;
         this.display_name = display_name;

--- a/addons/sale/static/src/js/product/product.xml
+++ b/addons/sale/static/src/js/product/product.xml
@@ -75,6 +75,6 @@
             name="sale_product_configurator_formatted_price"
             class="h5 text-nowrap"
             t-out="getFormattedPrice()"/>
-        <span t-if="this.props.price_info" t-out="this.props.price_info" class="text-muted"/>
+        <div t-if="this.props.price_info" t-out="this.props.price_info" class="text-muted"/>
     </t>
 </templates>

--- a/addons/sale/static/src/js/product_card/product_card.scss
+++ b/addons/sale/static/src/js/product_card/product_card.scss
@@ -1,5 +1,10 @@
+.product-card .card-header img {
+    aspect-ratio: 1;
+    object-fit: contain;
+}
+
 .product-card:hover {
-    border: (2 * $border-width) solid $secondary;
+    border: (1 * $border-width) solid $primary;
 }
 
 .product-card.selected {

--- a/addons/sale/static/src/js/product_card/product_card.xml
+++ b/addons/sale/static/src/js/product_card/product_card.xml
@@ -2,11 +2,12 @@
 <templates id="template" xml:space="preserve">
     <t t-name="sale.ProductCard">
         <article
-            t-attf-class="product-card card rounded cursor-pointer transition-base {{props.isSelected ? 'selected' : ''}}"
+            tabindex="0"
+            t-attf-class="product-card card rounded cursor-pointer {{props.isSelected ? 'selected' : ''}}"
             t-on-keypress="(event) => event.code === 'Space' ? props.onClick() : () => {}"
             t-on-click="props.onClick"
         >
-            <div class="card-header">
+            <div class="card-header p-0">
                 <img
                     class="w-100"
                     t-attf-src="/web/image/product.product/{{props.product.id}}/image_128"

--- a/addons/sale/static/src/js/sale_product_field.js
+++ b/addons/sale/static/src/js/sale_product_field.js
@@ -254,15 +254,6 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
         });
     }
 
-    /**
-     * Hook to append additional props in overriding modules.
-     *
-     * @return {Object} - The additional props.
-     */
-    _getAdditionalDialogProps() {
-        return {};
-    }
-
     async _openComboConfigurator(edit=false) {
         const saleOrder = this.props.record.model.root.data;
         const comboLineRecord = this.props.record;
@@ -280,6 +271,7 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
             company_id: saleOrder.company_id[0],
             pricelist_id: saleOrder.pricelist_id[0],
             selected_combo_items: selectedComboItems,
+            ...this._getAdditionalRpcParams(),
         });
         this.dialog.add(ComboConfiguratorDialog, {
             combos: combos.map(combo => new ProductCombo(combo)),
@@ -304,7 +296,26 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
                 await saleOrder.order_line._sort();
             },
             discard: () => saleOrder.order_line.delete(comboLineRecord),
+            ...this._getAdditionalDialogProps(),
         });
+    }
+
+    /**
+     * Hook to append additional RPC params in overriding modules.
+     *
+     * @return {Object} The additional RPC params.
+     */
+    _getAdditionalRpcParams() {
+        return {};
+    }
+
+    /**
+     * Hook to append additional props in overriding modules.
+     *
+     * @return {Object} The additional props.
+     */
+    _getAdditionalDialogProps() {
+        return {};
     }
 
     /**

--- a/addons/sale/static/src/js/sale_utils.js
+++ b/addons/sale/static/src/js/sale_utils.js
@@ -6,7 +6,7 @@
  * @return {Boolean} Whether the 2 lines are linked.
  */
 export function areSaleOrderLinesLinked(linkingSaleOrderLine, linkedSaleOrderLine) {
-    const linkingId = linkingSaleOrderLine.isNew
+    const linkingId = linkedSaleOrderLine.isNew
         ? linkingSaleOrderLine.data.linked_virtual_id
         : linkingSaleOrderLine.data.linked_line_id[0];
     const linkedId = linkedSaleOrderLine.isNew
@@ -23,8 +23,28 @@ export function areSaleOrderLinesLinked(linkingSaleOrderLine, linkedSaleOrderLin
  */
 export function getLinkedSaleOrderLines(saleOrderLine) {
     const saleOrder = saleOrderLine.model.root;
-    // TODO(loti): this doesn't work if some combo items are on another page.
+    // TODO(loti): this leaves out any combo items that are on another page.
     return saleOrder.data.order_line.records.filter(
         record => areSaleOrderLinesLinked(record, saleOrderLine)
     );
+}
+
+/**
+ * Serialize a combo item into a format understandable by the server.
+ *
+ * @param {ProductComboItem} comboItem The combo item to serialize.
+ * @return {Object} The serialized combo item.
+ */
+export function serializeComboItem(comboItem) {
+    return {
+        combo_item_id: comboItem.id,
+        product_id: comboItem.product.id,
+        no_variant_attribute_value_ids: comboItem.product.selectedNoVariantPtavIds,
+        product_custom_attribute_values: comboItem.product.selectedCustomPtavs.map(
+            customPtav => ({
+                custom_product_template_attribute_value_id: customPtav.id,
+                custom_value: customPtav.value,
+            })
+        ),
+    }
 }

--- a/addons/sale/static/src/js/tours/product_configurator_tour_utils.js
+++ b/addons/sale/static/src/js/tours/product_configurator_tour_utils.js
@@ -163,7 +163,7 @@ function assertProductPriceInfo(productName, priceInfo) {
         trigger: `
             ${productSelector(productName)}
             td.o_sale_product_configurator_price
-            span:contains("${priceInfo}")
+            div:contains("${priceInfo}")
         `,
     };
 }
@@ -173,7 +173,7 @@ function assertOptionalProductPriceInfo(productName, priceInfo) {
         trigger: `
             ${optionalProductSelector(productName)}
             td.o_sale_product_configurator_qty
-            span:contains("${priceInfo}")
+            div:contains("${priceInfo}")
         `,
     };
 }

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -533,6 +533,7 @@
                                 <field name="linked_line_id" column_invisible="1"/>
                                 <field name="virtual_id" column_invisible="1"/>
                                 <field name="linked_virtual_id" column_invisible="1"/>
+                                <field name="selected_combo_items" column_invisible="1"/>
                                 <field name="combo_item_id" column_invisible="1"/>
                                 <field
                                     name="name"

--- a/addons/sale_timesheet/views/product_views.xml
+++ b/addons/sale_timesheet/views/product_views.xml
@@ -32,12 +32,12 @@
         <field name="inherit_id" ref="product.product_template_search_view"/>
         <field name="mode">primary</field>
         <field name="arch" type="xml">
-            <xpath expr="//filter[@name='goods']" position="after">
+            <filter name="combo" position="after">
                 <separator/>
                 <filter string="Time-based services" name="product_time_based" domain="[('type', '=', 'service'), ('invoice_policy', '=', 'delivery'), ('service_type', '=', 'timesheet')]"/>
                 <filter string="Fixed price services" name="product_service_fixed" domain="[('type', '=', 'service'), ('invoice_policy', '=', 'order'), ('service_type', '=', 'timesheet')]"/>
                 <filter string="Milestone services" name="product_service_milestone" domain="[('type', '=', 'service'), ('invoice_policy', '=', 'delivery'), ('service_type', '=', 'manual')]"/>
-            </xpath>
+            </filter>
         </field>
     </record>
 

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -88,7 +88,7 @@
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_search_view"/>
             <field name="arch" type="xml">
-                <filter name="goods" position="after">
+                <filter name="combo" position="after">
                     <filter name="is_storable" string="Inventory Management" domain="[('is_storable','=',True)]"/>
                 </filter>
             </field>

--- a/addons/website_sale/__manifest__.py
+++ b/addons/website_sale/__manifest__.py
@@ -116,6 +116,7 @@
             'sale/static/src/js/product_list/*',
             'sale/static/src/js/product_template_attribute_line/*',
             'sale/static/src/js/quantity_buttons/*',
+            'sale/static/src/js/sale_utils.js',
             'website_sale/static/src/js/combo_configurator_dialog/*',
             'website_sale/static/src/js/product/*',
             'website_sale/static/src/js/product_configurator_dialog/*',

--- a/addons/website_sale/controllers/combo_configurator.py
+++ b/addons/website_sale/controllers/combo_configurator.py
@@ -53,8 +53,17 @@ class WebsiteSaleComboConfiguratorController(SaleComboConfiguratorController, We
         website=True,
     )
     def website_sale_combo_configurator_update_cart(
-        self, combo_product_id, quantity, selected_combo_items,
+        self, combo_product_id, quantity, selected_combo_items, **kwargs
     ):
+        """ Add the provided combo product and selected combo items to the cart.
+
+        :param int combo_product_id: The combo product to add, as a `product.template` id.
+        :param int quantity: The quantity to add.
+        :param list(dict) selected_combo_items: The selected combo items to add.
+        :param dict kwargs: Locally unused data passed to `_cart_update`.
+        :rtype: dict
+        :return: A dict containing information about the cart update.
+        """
         order_sudo = request.website.sale_get_order(force_create=True)
         if order_sudo.state != 'draft':
             request.session['sale_order_id'] = None
@@ -64,6 +73,7 @@ class WebsiteSaleComboConfiguratorController(SaleComboConfiguratorController, We
             product_id=combo_product_id,
             line_id=False,  # Always create a new line for combo products.
             set_qty=quantity,
+            **kwargs,
         )
         line_ids = [values['line_id']]
 
@@ -77,7 +87,8 @@ class WebsiteSaleComboConfiguratorController(SaleComboConfiguratorController, We
                         int(value_id) for value_id in combo_item['no_variant_attribute_value_ids']
                     ],
                     linked_line_id=values['line_id'],
-                    combo_item_id=combo_item['combo_item_id']
+                    combo_item_id=combo_item['combo_item_id'],
+                    **kwargs,
                 )
                 line_ids.append(item_values['line_id'])
 

--- a/addons/website_sale/controllers/combo_configurator.py
+++ b/addons/website_sale/controllers/combo_configurator.py
@@ -62,8 +62,6 @@ class WebsiteSaleComboConfiguratorController(SaleComboConfiguratorController, We
 
         values = order_sudo._cart_update(
             product_id=combo_product_id,
-            # TODO(loti): allow merging lines if two combo products are identical? (i.e. same combo
-            # items and same no_variant ptavs).
             line_id=False,  # Always create a new line for combo products.
             set_qty=quantity,
         )

--- a/addons/website_sale/controllers/product_configurator.py
+++ b/addons/website_sale/controllers/product_configurator.py
@@ -1,7 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import json
-
 from odoo.http import request, route
 from odoo.tools import float_is_zero
 
@@ -114,6 +112,7 @@ class WebsiteSaleProductConfiguratorController(SaleProductConfiguratorController
 
         :param dict main_product: The main product to add.
         :param list(dict) optional_products: The optional products to add.
+        :param dict kwargs: Locally unused data passed to `_cart_update`.
         :rtype: dict
         :return: A dict containing information about the cart update.
         """
@@ -122,7 +121,6 @@ class WebsiteSaleProductConfiguratorController(SaleProductConfiguratorController
             request.session['sale_order_id'] = None
             order_sudo = request.website.sale_get_order(force_create=True)
 
-        main_product = json.loads(main_product)
         # The main product could theoretically have a parent, but we ignore it to avoid
         # circularities in the linked line ids.
         values = order_sudo._cart_update(
@@ -132,12 +130,11 @@ class WebsiteSaleProductConfiguratorController(SaleProductConfiguratorController
             no_variant_attribute_value_ids=[
                 int(value_id) for value_id in main_product['no_variant_attribute_value_ids']
             ],
-            **kwargs
+            **kwargs,
         )
         line_ids = {main_product['product_template_id']: values['line_id']}
 
         if optional_products and values['line_id']:
-            optional_products = json.loads(optional_products)
             for option in optional_products:
                 option_values = order_sudo._cart_update(
                     product_id=option['product_id'],
@@ -149,7 +146,7 @@ class WebsiteSaleProductConfiguratorController(SaleProductConfiguratorController
                     # Using `line_ids[...]` instead of `line_ids.get(...)` ensures that this throws
                     # if an optional product contains bad data.
                     linked_line_id=line_ids[option['parent_product_template_id']],
-                    **kwargs
+                    **kwargs,
                 )
                 line_ids[option['product_template_id']] = option_values['line_id']
 

--- a/addons/website_sale/static/src/js/website_sale_configurators.js
+++ b/addons/website_sale/static/src/js/website_sale_configurators.js
@@ -2,8 +2,6 @@
 
 import { rpc } from '@web/core/network/rpc';
 import { serializeDateTime } from '@web/core/l10n/dates';
-import { WebsiteSale } from '@website_sale/js/website_sale';
-import wSaleUtils from '@website_sale/js/website_sale_utils';
 import {
     ComboConfiguratorDialog
 } from '@sale/js/combo_configurator_dialog/combo_configurator_dialog';
@@ -11,6 +9,9 @@ import { ProductCombo } from "@sale/js/models/product_combo";
 import {
     ProductConfiguratorDialog
 } from '@sale/js/product_configurator_dialog/product_configurator_dialog';
+import { serializeComboItem } from '@sale/js/sale_utils';
+import { WebsiteSale } from '@website_sale/js/website_sale';
+import wSaleUtils from '@website_sale/js/website_sale_utils';
 
 const { DateTime } = luxon;
 
@@ -73,8 +74,8 @@ WebsiteSale.include({
                 this._trackProducts([mainProduct, ...optionalProducts]);
 
                 const values = await rpc('/website_sale/product_configurator/update_cart', {
-                    main_product: JSON.stringify(this._serializeProduct(mainProduct)),
-                    optional_products: JSON.stringify(optionalProducts.map(this._serializeProduct)),
+                    main_product: this._serializeProduct(mainProduct),
+                    optional_products: optionalProducts.map(this._serializeProduct),
                     ...this._getAdditionalRpcParams(),
                 });
                 this._onConfigured(options, values);
@@ -110,7 +111,7 @@ WebsiteSale.include({
                 const values = await rpc('/website_sale/combo_configurator/update_cart', {
                     combo_product_id: this.rootProduct.product_id,
                     quantity: comboProductData.quantity,
-                    selected_combo_items: selectedComboItems.map(this._serializeComboItem),
+                    selected_combo_items: selectedComboItems.map(serializeComboItem),
                 });
                 this._onConfigured(options, values);
             },
@@ -133,7 +134,7 @@ WebsiteSale.include({
     /**
      * Hook to append additional props in overriding modules.
      *
-     * @return {Object} - The additional props.
+     * @return {Object} The additional props.
      */
     _getAdditionalDialogProps() {
         return {};
@@ -142,7 +143,7 @@ WebsiteSale.include({
     /**
      * Hook to append additional RPC params in overriding modules.
      *
-     * @return {Object} - The additional RPC params.
+     * @return {Object} The additional RPC params.
      */
     _getAdditionalRpcParams() {
         return {};
@@ -151,8 +152,8 @@ WebsiteSale.include({
     /**
      * Serialize a product into a format understandable by the server.
      *
-     * @param {Object} product - The product to serialize.
-     * @return {Object} - The serialized product.
+     * @param {Object} product The product to serialize.
+     * @return {Object} The serialized product.
      */
     _serializeProduct(product) {
         let serializedProduct = {
@@ -187,26 +188,6 @@ WebsiteSale.include({
             .flatMap(ptal => ptal.selected_attribute_value_ids);
 
         return serializedProduct;
-    },
-
-    /**
-     * Serialize a combo item into a format understandable by the server.
-     *
-     * @param {ProductComboItem} comboItem - The combo item to serialize.
-     * @return {Object} - The serialized combo item.
-     */
-    _serializeComboItem(comboItem) {
-        return {
-            combo_item_id: comboItem.id,
-            product_id: comboItem.product.id,
-            product_custom_attribute_values: comboItem.product.selectedCustomPtavs.map(
-                customPtav => ({
-                    custom_product_template_attribute_value_id: customPtav.id,
-                    custom_value: customPtav.value,
-                })
-            ),
-            no_variant_attribute_value_ids: comboItem.product.selectedNoVariantPtavIds,
-        }
     },
 
     _trackProducts: function (products) {

--- a/addons/website_sale/static/src/js/website_sale_configurators.js
+++ b/addons/website_sale/static/src/js/website_sale_configurators.js
@@ -28,6 +28,7 @@ WebsiteSale.include({
                 product_tmpl_id: this.rootProduct.product_template_id,
                 quantity: this.rootProduct.quantity,
                 date: serializeDateTime(DateTime.now()),
+                ...this._getAdditionalRpcParams(),
             }
         );
         if (combos.length) {
@@ -112,10 +113,12 @@ WebsiteSale.include({
                     combo_product_id: this.rootProduct.product_id,
                     quantity: comboProductData.quantity,
                     selected_combo_items: selectedComboItems.map(serializeComboItem),
+                    ...this._getAdditionalRpcParams(),
                 });
                 this._onConfigured(options, values);
             },
             discard: () => {},
+            ...this._getAdditionalDialogProps(),
         });
     },
 

--- a/addons/website_sale/views/product_views.xml
+++ b/addons/website_sale/views/product_views.xml
@@ -6,7 +6,7 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_search_view"/>
         <field name="arch" type="xml">
-            <filter name="goods" position="after">
+            <filter name="combo" position="after">
                 <separator/>
                 <filter string="Published" name="published" domain="[('is_published', '=', True)]"/>
             </filter>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1847,9 +1847,13 @@
                             </button>
                         </div>
                         <t t-if="line.product_type == 'combo'">
-                            <t t-foreach="line.linked_line_ids" t-as="combo_item_line">
+                            <div
+                                t-foreach="line.linked_line_ids"
+                                t-as="combo_item_line"
+                                t-attf-class="{{'' if combo_item_line_last else 'pb-2'}}"
+                            >
                                 <t t-call="website_sale.cart_combo_item_line"/>
-                            </t>
+                            </div>
                         </t>
                     </div>
                     <div class="d-flex flex-column align-items-end">
@@ -1959,12 +1963,12 @@
         <t t-set="is_combo" t-value="line.product_type == 'combo'"/>
         <t
             t-if="website.show_line_subtotals_tax_selection == 'tax_excluded'"
-            t-set='product_price'
+            t-set="product_price"
             t-value="line._get_combo_price_subtotal() if is_combo else line.price_subtotal"
         />
         <t
             t-else=""
-            t-set='product_price'
+            t-set="product_price"
             t-value="line._get_combo_price_total() if is_combo else line.price_total"
         />
         <span

--- a/addons/website_sale_stock/__manifest__.py
+++ b/addons/website_sale_stock/__manifest__.py
@@ -30,7 +30,10 @@ Then it can be made specific at the product level.
     'auto_install': True,
     'assets': {
         'web.assets_frontend': [
+            'website_sale_stock/static/src/js/combo_configurator_dialog/*',
+            'website_sale_stock/static/src/js/models/*',
             'website_sale_stock/static/src/js/product/*',
+            'website_sale_stock/static/src/js/product_card/*',
             'website_sale_stock/static/src/js/product_configurator_dialog/*',
             'website_sale_stock/static/src/js/variant_mixin.js',
             'website_sale_stock/static/src/js/website_sale.js',

--- a/addons/website_sale_stock/controllers/__init__.py
+++ b/addons/website_sale_stock/controllers/__init__.py
@@ -1,7 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import combo_configurator
 from . import main
 from . import product_configurator
 from . import reorder
+from . import utils
 from . import variant
 from . import website_sale

--- a/addons/website_sale_stock/controllers/combo_configurator.py
+++ b/addons/website_sale_stock/controllers/combo_configurator.py
@@ -1,0 +1,34 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.http import request
+
+from odoo.addons.website_sale.controllers.combo_configurator import (
+    WebsiteSaleComboConfiguratorController,
+)
+from odoo.addons.website_sale_stock.controllers.utils import _get_stock_data
+
+
+class WebsiteSaleStockComboConfiguratorController(WebsiteSaleComboConfiguratorController):
+
+    def _get_combo_item_product_data(self, product, selected_combo_item, **kwargs):
+        """ Override of `website_sale` to append stock data.
+
+        :param product.product product: The product for which to get data.
+        :param dict selected_combo_item: The selected combo item, in the following format:
+            {
+                'id': int,
+                'no_variant_ptav_ids': list(int),
+                'custom_ptavs': list({
+                    'id': int,
+                    'value': str,
+                }),
+            }
+        :param dict kwargs: Locally unused data passed to `super` and `_get_stock_data`.
+        :rtype: dict
+        :return: A dict containing data about the specified product.
+        """
+        product_data = super()._get_combo_item_product_data(product, selected_combo_item, **kwargs)
+
+        if request.is_frontend and product.is_storable:
+            product_data.update(_get_stock_data(product, request.website, **kwargs))
+        return product_data

--- a/addons/website_sale_stock/controllers/product_configurator.py
+++ b/addons/website_sale_stock/controllers/product_configurator.py
@@ -5,6 +5,7 @@ from odoo.http import request
 from odoo.addons.website_sale.controllers.product_configurator import (
     WebsiteSaleProductConfiguratorController,
 )
+from odoo.addons.website_sale_stock.controllers.utils import _get_stock_data
 
 
 class WebsiteSaleStockProductConfiguratorController(WebsiteSaleProductConfiguratorController):
@@ -16,26 +17,16 @@ class WebsiteSaleStockProductConfiguratorController(WebsiteSaleProductConfigurat
             information.
         :param product.pricelist pricelist: The pricelist to use.
         :param product.template.attribute.value combination: The combination of the product.
-        :param dict kwargs: Locally unused data passed to `super` and `_get_product_available_qty`.
+        :param dict kwargs: Locally unused data passed to `super` and `_get_stock_data`.
         :rtype: dict
-        :return: A dict with the following structure:
-            {
-                ...  # fields from `super`.
-                'is_storable': bool,
-                'allow_out_of_stock_order': bool,
-                'free_qty': float,
-            }
+        :return: A dict containing data about the specified product.
         """
         basic_product_information = super()._get_basic_product_information(
             product_or_template, pricelist, combination, **kwargs
         )
 
         if request.is_frontend and product_or_template.is_storable:
-            basic_product_information.update({
-                'is_storable': product_or_template.is_storable,
-                'allow_out_of_stock_order': product_or_template.allow_out_of_stock_order,
-                'free_qty': request.website._get_product_available_qty(
-                    product_or_template.sudo(), **kwargs
-                ) if product_or_template.is_product_variant else 0
-            })
+            basic_product_information.update(
+                _get_stock_data(product_or_template, request.website, **kwargs)
+            )
         return basic_product_information

--- a/addons/website_sale_stock/controllers/utils.py
+++ b/addons/website_sale_stock/controllers/utils.py
@@ -1,0 +1,24 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+
+def _get_stock_data(product_or_template, website, **kwargs):
+    """ Return data about the provided product's stock.
+
+    :param product.product|product.template product_or_template: The product for which to get data.
+    :param website website: The website from which the request was made.
+    :param dict kwargs: Locally unused data passed to `_get_product_available_qty`.
+    :rtype: dict
+    :return: A dict with the following structure:
+        {
+            'free_qty': float,
+        }
+    """
+    if not product_or_template.allow_out_of_stock_order:
+        available_qty = website._get_product_available_qty(
+            product_or_template.sudo(), **kwargs
+        ) if product_or_template.is_product_variant else 0
+        cart_quantity = product_or_template._get_cart_qty(website)
+        return {
+            'free_qty': available_qty - cart_quantity,
+        }
+    return {}

--- a/addons/website_sale_stock/static/src/js/combo_configurator_dialog/combo_configurator_dialog.js
+++ b/addons/website_sale_stock/static/src/js/combo_configurator_dialog/combo_configurator_dialog.js
@@ -1,0 +1,25 @@
+import { patch } from '@web/core/utils/patch';
+import {
+    ComboConfiguratorDialog
+} from '@sale/js/combo_configurator_dialog/combo_configurator_dialog';
+
+patch(ComboConfiguratorDialog.prototype, {
+    async selectComboItem(comboId, comboItem) {
+        if (!comboItem.product.isQuantityAllowed(this.state.quantity)) {
+            return;
+        }
+        super.selectComboItem(...arguments);
+    },
+
+    /**
+     * Check whether the provided combo quantity can be added to the cart.
+     *
+     * @param {Number} quantity The quantity to check.
+     * @return {Boolean} Whether the combo quantity can be added to the cart.
+     */
+    isComboQuantityAllowed(quantity) {
+        return this._selectedComboItems.every(
+            comboItem => comboItem.product.isQuantityAllowed(quantity)
+        );
+    },
+});

--- a/addons/website_sale_stock/static/src/js/combo_configurator_dialog/combo_configurator_dialog.xml
+++ b/addons/website_sale_stock/static/src/js/combo_configurator_dialog/combo_configurator_dialog.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-inherit="sale.ComboConfiguratorDialog" t-inherit-mode="extension">
+        <ProductCard position="attributes">
+            <attribute name="quantity">state.quantity</attribute>
+        </ProductCard>
+        <QuantityButtons position="attributes">
+            <attribute name="isPlusButtonDisabled">
+                !isComboQuantityAllowed(state.quantity + 1)
+            </attribute>
+        </QuantityButtons>
+        <button name="sale_combo_configurator_confirm_button" position="attributes">
+            <attribute
+                name="t-att-disabled"
+                add="!isComboQuantityAllowed(state.quantity)"
+                separator=" || "
+            />
+        </button>
+    </t>
+</templates>

--- a/addons/website_sale_stock/static/src/js/models/product_product.js
+++ b/addons/website_sale_stock/static/src/js/models/product_product.js
@@ -1,0 +1,23 @@
+import { patch } from '@web/core/utils/patch';
+import { ProductProduct } from '@sale/js/models/product_product';
+
+patch(ProductProduct.prototype, {
+    /**
+     * @param {number} free_qty
+     * @param args Super's parameter list.
+     */
+    setup({free_qty, ...args}) {
+        super.setup(args);
+        this.free_qty = free_qty;
+    },
+
+    /**
+     * Check whether the provided quantity can be added to the cart.
+     *
+     * @param {Number} quantity The quantity to check.
+     * @return {Boolean} Whether the product quantity can be added to the cart.
+     */
+    isQuantityAllowed(quantity) {
+        return this.free_qty === undefined || this.free_qty >= quantity;
+    },
+});

--- a/addons/website_sale_stock/static/src/js/product/product.js
+++ b/addons/website_sale_stock/static/src/js/product/product.js
@@ -6,8 +6,6 @@ import { Product } from '@sale/js/product/product';
 patch(Product, {
     props: {
         ...Product.props,
-        is_storable: { type: Boolean, optional: true },
-        allow_out_of_stock_order: { type: Boolean, optional: true },
         free_qty: { type: Number, optional: true },
     },
 });

--- a/addons/website_sale_stock/static/src/js/product_card/product_card.js
+++ b/addons/website_sale_stock/static/src/js/product_card/product_card.js
@@ -1,0 +1,17 @@
+import { _t } from '@web/core/l10n/translation';
+import { patch } from '@web/core/utils/patch';
+import { ProductCard } from '@sale/js/product_card/product_card';
+
+patch(ProductCard, {
+    props: {
+        ...ProductCard.props,
+        quantity: { type: Number, optional: true },
+    },
+});
+
+patch(ProductCard.prototype, {
+    setup() {
+        super.setup(...arguments);
+        this.allQuantitySelectedTooltip = _t("All available quantity selected");
+    },
+});

--- a/addons/website_sale_stock/static/src/js/product_card/product_card.scss
+++ b/addons/website_sale_stock/static/src/js/product_card/product_card.scss
@@ -1,0 +1,17 @@
+.product-card.unselectable-card {
+    &:hover {
+        border-color: $border-color;
+    }
+
+    .card-header, .card-body {
+        opacity: 0.15;
+    }
+}
+
+.overlay-container {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}

--- a/addons/website_sale_stock/static/src/js/product_card/product_card.xml
+++ b/addons/website_sale_stock/static/src/js/product_card/product_card.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-inherit="sale.ProductCard" t-inherit-mode="extension">
+        <article position="attributes">
+            <attribute
+                name="t-attf-class"
+                remove="cursor-pointer"
+                add="{{
+                    props.product.isQuantityAllowed(props.quantity)
+                    ? 'cursor-pointer' : 'unselectable-card'
+                }}"
+                separator=" "
+            />
+        </article>
+        <article position="inside">
+            <div
+                t-if="!props.product.isQuantityAllowed(props.quantity)"
+                class="overlay-container justify-content-center text-center text-danger fw-bold p-2"
+            >
+                <i class="fa fa-times fa-2x mb-2"/>
+                <span>Requested quantity not available</span>
+            </div>
+            <div
+                t-elif="
+                    props.isSelected &amp;&amp; !props.product.isQuantityAllowed(props.quantity + 1)
+                "
+                class="overlay-container text-end text-warning fw-bold p-2"
+            >
+                <i
+                    class="fa fa-warning fa-2x"
+                    data-toggle="tooltip"
+                    data-trigger="click hover focus"
+                    t-att-title="allQuantitySelectedTooltip"
+                />
+            </div>
+        </article>
+    </t>
+</templates>

--- a/addons/website_sale_stock/static/src/js/product_configurator_dialog/product_configurator_dialog.js
+++ b/addons/website_sale_stock/static/src/js/product_configurator_dialog/product_configurator_dialog.js
@@ -31,9 +31,7 @@ patch(ProductConfiguratorDialog.prototype, {
      * @return {Boolean} - Whether the provided product quantity can be added to the cart.
      */
     _isQuantityAllowed(product, quantity) {
-        return !product.is_storable ||
-            product.allow_out_of_stock_order ||
-            product.free_qty >= quantity;
+        return product.free_qty === undefined || product.free_qty >= quantity;
     },
 
     /**


### PR DESCRIPTION
This change has 3 main parts:

1. Various improvements and fixes:
- Migrates the logic that automatically unlinks combo items which reference
unlinked variants from `point_of_sale` to `sale` (and drops the part that
automatically creates combo items for new variants),
- Speeds up sale order line CRUD operations for combo items and optional
products,
- Hides combos in `purchase`,
- Hides combos in the product catalog,
- Clears the combo item lines when changing a combo product line's product,
- Other minor fixes and cleanups.

2. Properly handle loyalty for combos:
- Combo item lines are ignored when filtering based on a rule/reward's product
domain,
- When a rule/reward's product domain matches a combo product line, its combo
item lines are used instead,
- Combo item lines are ignored when computing the cheapest line of an SO,
- When the cheapest "line" of an SO is a combo (for information, a combo's price
is the sum of its combo item lines' prices), its combo item lines are used as
the cheapest "line" (which can thus be composed of multiple lines),
- Combo item lines are ignored when checking whether a rule's minimum quantity
is reached.

3. Properly handle stock for combos:
- An "out of stock" message is displayed for combo items which are out of stock,
- A "not enough stock" message is displayed for combo items which don't have the
requested stock but aren't out of stock,
- Combo items which don't have enough stock can't be selected,
- The combo quantity can't be increased if one of the selected items doesn't
have enough stock to do so.

This change also adds the necessary hooks to support combos in rental
(enterprise).

Enterprise PR: https://github.com/odoo/enterprise/pull/69334

task-4114589