### PR TITLE
[FIX] l10n_{ke_edi_oscu,it_edi}: fix autopost of bills

### DIFF
--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -172,7 +172,7 @@ class AccountMove(models.Model):
 
     def _post(self, soft=True):
         # EXTENDS 'account'
-        self.write({'l10n_it_edi_header': False})
+        self.with_context(skip_is_manually_modified=True).write({'l10n_it_edi_header': False})
         return super()._post(soft)
 
     def _extend_with_attachments(self, attachments, new=False):


### PR DESCRIPTION
In b1046c8156ee3d3699d5b229720134cc3b2532d4, we introduced a new feature to allow autoposting of bills. When a user does not modify the imported bill for 3 consecutive times, we ask the user if he wants to activate the feature.

To detect whether the user has modified the imported bill or not, we use a new field `is_manually_modified` which is always set to `True` when the bill is edited except for automatic flows (OCR, CRON, email) or when the user manually validates the bill. In the latter case, `is_manually_modified` shouldn't be set to `True` even if it is a manual flow. For this purpose, when posting, we use the special context key `skip_is_manually_modified=True` to skip the setting of `is_manually_modified`.

This was done for the `_post()` method of `account.move`, but is also required for some extensions of this method in the `l10n_` modules.

runbot error id: 74836

Enterprise PR: https://github.com/odoo/enterprise/pull/68503