### PR TITLE
[FIX] auth_totp_mail_enforce: fix test for no_demo

### DIFF
--- a/addons/auth_totp_mail_enforce/tests/test_auth_signup.py
+++ b/addons/auth_totp_mail_enforce/tests/test_auth_signup.py
@@ -25,6 +25,9 @@ class TestAuthSignupFlowWith2faEnforced(HttpCaseWithUserPortal, HttpCaseWithUser
         """
         Check that registration cleanly succeeds with 2FA enabled and enforced
         """
+        # ensure the company has an email, otherwise the test fails in no_demo
+        # because there's no source address
+        self.env.company.email = "mycompany@example.com"
 
         # Get csrf_token
         self.authenticate(None, None)


### PR DESCRIPTION
A FROM email is required in order to send an email. For this email, the source email can either come from the new user's company, or from the sending user's company. In both cases it's almost certainly going to be *the* company.

The company's email comes from its partner object, which only gets one when loading the demo (via a `<function>` call in the users demo, making finding it a bit of a chore). This means without demo the totp mail send fails with somewhat unhelpful error messages (as it's on the server side of a controller call and deep into the bowels of email rendering).

The fix is to just set an email on the main company before going through the signup flow, that way there is an email_from to use and everything works out.

Runbot error 70541