### PR TITLE
[FIX] project_timesheet_holidays: Correct employees holiday values

### DIFF
--- a/addons/hr_holidays/tests/test_company_leave.py
+++ b/addons/hr_holidays/tests/test_company_leave.py
@@ -321,7 +321,7 @@ class TestCompanyLeave(TransactionCase):
         })
         company_leave._compute_date_from_to()
 
-        with self.assertQueryCount(__system__=830):  # 770 community
+        with self.assertQueryCount(__system__=1133):  # 770 community
             # Original query count: 1987
             # Without tracking/activity context keys: 5154
             company_leave.action_validate()


### PR DESCRIPTION
Steps to reproduce the issue:
- Configure the runbot to automatically create a timesheet entry when a time off is logged.
- Create a time off type that generates a task within a project.
- Change the timezone for an employee (Bob) so that it differs from the system timezone.
- Create a time off for an employee and assign it to multiple employees, including Bob.
- Approve and validate the time off.

When there is a discrepancy between an employee's timezone and the timezone configured in their working hours, the
employee may only receive a portion of the allocated hours due to the time difference.

This occurs because of an error in the computation of the `number_of_days`, `date_from` and `date_to` fields for the
leave. These fields are calculated in the general record (not specific to any employee) using the standard timezone, and
then duplicated to create a leave entry for each employee. After duplication, the dates remain unchanged, leading to
incorrect durations and dates for employees with different timezones.

This issue is already fixed in version 17.0 with a part of commit https://github.com/odoo/odoo/commit/81c8a0564d54c981e65a6ed3b2c70dd792d59a46
and in version 16.0 with this commit https://github.com/odoo/odoo/commit/37c3cf44dbcaca67d099f855bc6d3a0ddf7bfe73

opw-4078450