### PR TITLE
[FIX] purchase: dont aggregate order_id in report

### DIFF
--- a/addons/purchase/report/purchase_report_views.xml
+++ b/addons/purchase/report/purchase_report_views.xml
@@ -6,7 +6,7 @@
             <field name="arch" type="xml">
                 <pivot string="Purchase Analysis" display_quantity="1" sample="1">
                     <field name="category_id" type="row"/>
-                    <field name="order_id" type="measure"/>
+                    <field name="order_id" type="row"/>
                     <field name="untaxed_total" type="measure"/>
                     <field name="price_total" type="measure"/>
                 </pivot>


### PR DESCRIPTION
**Current behavior:**
In the purchase report pivot view, grouping by order does not display the order reference on the row's label.

**Expected behavior:**
Rows corresponding to a purchase order should be labeled with the order reference (name).

**Steps to reproduce:**
1. In the Purchase app, go to Reporting -> Purchase

2. Switch to the pivot view

3. Expand the row to Add Custom Group -> Order

4. See that the reference does not get displayed

**Cause of the issue:**
When we select group by for the `order` option, the rows are aggregated via `count_distinct`, so the label for the pivot becomes '1' (as they are grouped by id which is unique).

**Fix:**
Make the order_id field in the view `type=row` instead of `type=measure` so that they do not get aggregated.

opw-4075321