### PR TITLE
[REF] mail, *: return single-id in Store whenever possible

### DIFF
--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -104,7 +104,7 @@ class TestImLivechatMessage(HttpCase, MailCommon):
                         "thread": {"id": channel_livechat_1.id, "model": "discuss.channel"},
                         "parentMessage": False,
                         "pinned_at": False,
-                        "rating_id": {"id": record_rating.id},
+                        "rating_id": record_rating.id,
                         "recipients": [],
                         "record_name": "test1 Ernest Employee",
                         "res_id": channel_livechat_1.id,

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -10,6 +10,7 @@ from odoo import _, api, fields, models, modules, tools
 from odoo.exceptions import AccessError
 from odoo.osv import expression
 from odoo.tools import clean_context, groupby, SQL
+from odoo.tools.misc import OrderedSet
 from odoo.addons.mail.tools.discuss import Store
 
 _logger = logging.getLogger(__name__)
@@ -876,16 +877,28 @@ class Message(models.Model):
     # MESSAGE READ / FETCH / FAILURE API
     # ------------------------------------------------------
 
+    def _records_by_model_name(self):
+        ids_by_model = defaultdict(OrderedSet)
+        prefetch_ids_by_model = defaultdict(OrderedSet)
+        prefetch_messages = self | self.browse(self._prefetch_ids)
+        for message in prefetch_messages.filtered(lambda m: m.model and m.res_id):
+            target = ids_by_model if message in self else prefetch_ids_by_model
+            target[message.model].add(message.res_id)
+        return {
+            model_name: self.env[model_name]
+            .browse(ids)
+            .with_prefetch(tuple(ids_by_model[model_name] | prefetch_ids_by_model[model_name]))
+            for model_name, ids in ids_by_model.items()
+        }
+
     def _record_by_message(self):
-        record_ids_by_model_name = defaultdict(set)
-        for message in self:
-            if message.model and message.res_id:
-                record_ids_by_model_name[message.model].add(message.res_id)
-        record_by_message = {}
-        for message in self:
-            if message.model and message.res_id:
-                record_by_message[message] = self.env[message.model].browse(message.res_id).with_prefetch(record_ids_by_model_name[message.model])
-        return record_by_message
+        records_by_model_name = self._records_by_model_name()
+        return {
+            message: self.env[message.model]
+            .browse(message.res_id)
+            .with_prefetch(records_by_model_name[message.model]._prefetch_ids)
+            for message in self.filtered(lambda m: m.model and m.res_id)
+        }
 
     def _to_store(
         self,

--- a/addons/mail/static/src/model/record_list.js
+++ b/addons/mail/static/src/model/record_list.js
@@ -212,6 +212,10 @@ export class RecordListInternal {
     insert(recordList, val, fn, { inv = true, mode = "ADD" } = {}) {
         const inverse = getInverse(recordList);
         const targetModel = getTargetModel(recordList);
+        if (typeof val !== "object") {
+            // single-id data
+            val = { [recordList._store[targetModel].id]: val };
+        }
         if (inverse && inv) {
             // special command to call addNoinv/deleteNoInv, to prevent infinite loop
             const target = isRecord(val) && val._raw === val ? val._proxy : val;

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -1259,7 +1259,7 @@ class Store {
         if (records._name === "res.partner") {
             return { id: record.id, type: "partner" };
         }
-        return { id: record.id };
+        return record.id;
     }
 }
 

--- a/addons/mail/static/tests/mock_server/mock_models/mail_activity.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_activity.js
@@ -101,12 +101,11 @@ export class MailActivity extends models.ServerModel {
                 data.display_name = data.summary;
             }
             const [user] = ResUsers.browse(data.user_id[0]);
-            data.persona = { id: user.partner_id, type: "partner" };
             data["attachment_ids"] = mailDataHelpers.Store.many(
                 this.env["ir.attachment"].browse(activity.attachment_ids),
                 makeKwArgs({ fields: ["name"] })
             );
-            data["persona"] = mailDataHelpers.Store.one(ResPartner.browse(user.partner_id));
+            data.persona = mailDataHelpers.Store.one(ResPartner.browse(user.partner_id));
             store.add(this.browse(activity.id), data);
         }
     }

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -377,9 +377,9 @@ class TestChannelInternals(MailCommon, HttpCase):
             filter(lambda d: d["id"] == self_member.id, init_data["discuss.channel.member"])
         )
         self.assertEqual(
-            self_member_info['seen_message_id']['id'],
+            self_member_info["seen_message_id"],
             msg_2.id,
-            "Last message id should have been updated"
+            "Last message id should have been updated",
         )
         self_member._mark_as_read(msg_1.id)
         final_data = Store(chat).get_result()
@@ -387,9 +387,9 @@ class TestChannelInternals(MailCommon, HttpCase):
             filter(lambda d: d["id"] == self_member.id, final_data["discuss.channel.member"])
         )
         self.assertEqual(
-            self_member_info['seen_message_id']['id'],
+            self_member_info["seen_message_id"],
             msg_2.id,
-            "Last message id should stay the same after mark channel as seen with an older message"
+            "Last message id should stay the same after mark channel as seen with an older message",
         )
 
     @users('employee')
@@ -436,7 +436,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                             {
                                 "id": member.id,
                                 "persona": {"id": self.user_admin.partner_id.id, "type": "partner"},
-                                "seen_message_id": {"id": msg_1.id},
+                                "seen_message_id": msg_1.id,
                                 "thread": {"id": chat.id, "model": "discuss.channel"},
                             },
                         ],

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -24,10 +24,12 @@ class TestChannelRTC(MailCommon):
         self._reset_bus()
         with self.assertBus(
             [
-                (self.cr.dbname, "discuss.channel", channel.id),  # update sessions
+                # update sessions
+                (self.cr.dbname, "discuss.channel", channel.id),
                 # end of previous session
                 (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),
-                (self.cr.dbname, "discuss.channel", channel.id),  # update sessions
+                # update sessions
+                (self.cr.dbname, "discuss.channel", channel.id),
             ],
             [
                 {
@@ -40,9 +42,7 @@ class TestChannelRTC(MailCommon):
                         "discuss.channel": [
                             {
                                 "id": channel.id,
-                                "rtcSessions": [
-                                    ("DELETE", [{"id": channel_member.rtc_session_ids.id}]),
-                                ],
+                                "rtcSessions": [("DELETE", [channel_member.rtc_session_ids.id])],
                             },
                         ],
                     },
@@ -53,9 +53,7 @@ class TestChannelRTC(MailCommon):
                         "discuss.channel": [
                             {
                                 "id": channel.id,
-                                "rtcSessions": [
-                                    ("ADD", [{"id": channel_member.rtc_session_ids.id + 1}]),
-                                ],
+                                "rtcSessions": [("ADD", [channel_member.rtc_session_ids.id + 1])],
                             },
                         ],
                         "discuss.channel.member": [
@@ -70,7 +68,7 @@ class TestChannelRTC(MailCommon):
                         ],
                         "discuss.channel.rtc.session": [
                             {
-                                "channelMember": {"id": channel_member.id},
+                                "channelMember": channel_member.id,
                                 "id": channel_member.rtc_session_ids.id + 1,
                             },
                         ],
@@ -95,8 +93,8 @@ class TestChannelRTC(MailCommon):
                     {
                         "id": channel.id,
                         "rtcSessions": [
-                            ("ADD", [{"id": channel_member.rtc_session_ids.id}]),
-                            ("DELETE", [{"id": channel_member.rtc_session_ids.id - 1}]),
+                            ("ADD", [channel_member.rtc_session_ids.id]),
+                            ("DELETE", [channel_member.rtc_session_ids.id - 1]),
                         ],
                     },
                 ],
@@ -112,7 +110,7 @@ class TestChannelRTC(MailCommon):
                 ],
                 "discuss.channel.rtc.session": [
                     {
-                        "channelMember": {"id": channel_member.id},
+                        "channelMember": channel_member.id,
                         "id": channel_member.rtc_session_ids.id,
                     },
                 ],
@@ -125,7 +123,7 @@ class TestChannelRTC(MailCommon):
                 ],
                 "Rtc": {
                     "iceServers": False,
-                    "selfSession": {"id": channel_member.rtc_session_ids.id},
+                    "selfSession": channel_member.rtc_session_ids.id,
                     "serverInfo": None,
                 },
             },
@@ -145,13 +143,20 @@ class TestChannelRTC(MailCommon):
         self._reset_bus()
         with self.assertBus(
             [
-                (self.cr.dbname, 'discuss.channel', channel.id),  # update new session
-                (self.cr.dbname, 'discuss.channel', channel.id),  # message_post "started a live conference" (not asserted below)
-                (self.cr.dbname, 'res.partner', self.user_employee.partner_id.id),  # update new message separator
-                (self.cr.dbname, 'discuss.channel', channel.id, "members"),  # update of pin state (not asserted below)
-                (self.cr.dbname, 'discuss.channel', channel.id),  # update of last interest (not asserted below)
-                (self.cr.dbname, 'res.partner', test_user.partner_id.id),  # incoming invitation
-                (self.cr.dbname, 'discuss.channel', channel.id),  # update list of invitations
+                # update new session
+                (self.cr.dbname, "discuss.channel", channel.id),
+                # message_post "started a live conference" (not asserted below)
+                (self.cr.dbname, "discuss.channel", channel.id),
+                # update new message separator
+                (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),
+                # update of pin state (not asserted below)
+                (self.cr.dbname, "discuss.channel", channel.id, "members"),
+                # update of last interest (not asserted below)
+                (self.cr.dbname, "discuss.channel", channel.id),
+                # incoming invitation
+                (self.cr.dbname, "res.partner", test_user.partner_id.id),
+                # update list of invitations
+                (self.cr.dbname, "discuss.channel", channel.id),
             ],
             [
                 {
@@ -160,7 +165,7 @@ class TestChannelRTC(MailCommon):
                         "discuss.channel": [
                             {
                                 "id": channel.id,
-                                "rtcSessions": [("ADD", [{"id": last_rtc_session_id + 1}])],
+                                "rtcSessions": [("ADD", [last_rtc_session_id + 1])],
                             },
                         ],
                         "discuss.channel.member": [
@@ -175,7 +180,7 @@ class TestChannelRTC(MailCommon):
                         ],
                         "discuss.channel.rtc.session": [
                             {
-                                "channelMember": {"id": channel_member.id},
+                                "channelMember": channel_member.id,
                                 "id": last_rtc_session_id + 1,
                             },
                         ],
@@ -194,7 +199,7 @@ class TestChannelRTC(MailCommon):
                         "discuss.channel": [
                             {
                                 "id": channel.id,
-                                "invitedMembers": [("ADD", [{"id": channel_member_test_user.id}])],
+                                "invitedMembers": [("ADD", [channel_member_test_user.id])],
                             }
                         ],
                         "discuss.channel.member": [
@@ -242,14 +247,22 @@ class TestChannelRTC(MailCommon):
         self._reset_bus()
         with self.assertBus(
             [
-                (self.cr.dbname, 'discuss.channel', channel.id),  # update new session
-                (self.cr.dbname, 'discuss.channel', channel.id),  # message_post "started a live conference" (not asserted below)
-                (self.cr.dbname, 'res.partner', self.user_employee.partner_id.id),  # update new message separator
-                (self.cr.dbname, 'discuss.channel', channel.id, "members"),  # update of pin state (not asserted below)
-                (self.cr.dbname, 'discuss.channel', channel.id),  # update of last interest (not asserted below)
-                (self.cr.dbname, 'res.partner', test_user.partner_id.id),  # incoming invitation
-                (self.cr.dbname, 'mail.guest', test_guest.id),  # incoming invitation
-                (self.cr.dbname, 'discuss.channel', channel.id),  # update list of invitations
+                # update new session
+                (self.cr.dbname, "discuss.channel", channel.id),
+                # message_post "started a live conference" (not asserted below)
+                (self.cr.dbname, "discuss.channel", channel.id),
+                # update new message separator
+                (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),
+                # update of pin state (not asserted below)
+                (self.cr.dbname, "discuss.channel", channel.id, "members"),
+                # update of last interest (not asserted below)
+                (self.cr.dbname, "discuss.channel", channel.id),
+                # incoming invitation
+                (self.cr.dbname, "res.partner", test_user.partner_id.id),
+                # incoming invitation
+                (self.cr.dbname, "mail.guest", test_guest.id),
+                # update list of invitations
+                (self.cr.dbname, "discuss.channel", channel.id),
             ],
             [
                 {
@@ -258,7 +271,7 @@ class TestChannelRTC(MailCommon):
                         "discuss.channel": [
                             {
                                 "id": channel.id,
-                                "rtcSessions": [("ADD", [{"id": last_rtc_session_id + 1}])],
+                                "rtcSessions": [("ADD", [last_rtc_session_id + 1])],
                             },
                         ],
                         "discuss.channel.member": [
@@ -273,7 +286,7 @@ class TestChannelRTC(MailCommon):
                         ],
                         "discuss.channel.rtc.session": [
                             {
-                                "channelMember": {"id": channel_member.id},
+                                "channelMember": channel_member.id,
                                 "id": last_rtc_session_id + 1,
                             },
                         ],
@@ -292,7 +305,7 @@ class TestChannelRTC(MailCommon):
                         "discuss.channel": [
                             {
                                 "id": channel.id,
-                                "rtcSessions": [("ADD", [{"id": last_rtc_session_id + 1}])],
+                                "rtcSessions": [("ADD", [last_rtc_session_id + 1])],
                             },
                         ],
                         "discuss.channel.member": [
@@ -307,7 +320,7 @@ class TestChannelRTC(MailCommon):
                         ],
                         "discuss.channel.rtc.session": [
                             {
-                                "channelMember": {"id": channel_member.id},
+                                "channelMember": channel_member.id,
                                 "id": last_rtc_session_id + 1,
                             },
                         ],
@@ -329,10 +342,7 @@ class TestChannelRTC(MailCommon):
                                 "invitedMembers": [
                                     (
                                         "ADD",
-                                        [
-                                            {"id": channel_member_test_user.id},
-                                            {"id": channel_member_test_guest.id},
-                                        ],
+                                        [channel_member_test_user.id, channel_member_test_guest.id],
                                     )
                                 ],
                             },
@@ -397,9 +407,12 @@ class TestChannelRTC(MailCommon):
         self._reset_bus()
         with self.assertBus(
             [
-                (self.cr.dbname, "res.partner", test_user.partner_id.id),  # update invitation
-                (self.cr.dbname, "discuss.channel", channel.id),  # update list of invitations
-                (self.cr.dbname, "discuss.channel", channel.id),  # update sessions
+                # update invitation
+                (self.cr.dbname, "res.partner", test_user.partner_id.id),
+                # update list of invitations
+                (self.cr.dbname, "discuss.channel", channel.id),
+                # update sessions
+                (self.cr.dbname, "discuss.channel", channel.id),
             ],
             [
                 {
@@ -414,9 +427,7 @@ class TestChannelRTC(MailCommon):
                         "discuss.channel": [
                             {
                                 "id": channel.id,
-                                "invitedMembers": [
-                                    ("DELETE", [{"id": channel_member_test_user.id}])
-                                ],
+                                "invitedMembers": [("DELETE", [channel_member_test_user.id])],
                             },
                         ],
                         "discuss.channel.member": [
@@ -447,9 +458,7 @@ class TestChannelRTC(MailCommon):
                         "discuss.channel": [
                             {
                                 "id": channel.id,
-                                "rtcSessions": [
-                                    ("ADD", [{"id": channel_member.rtc_session_ids.id + 1}]),
-                                ],
+                                "rtcSessions": [("ADD", [channel_member.rtc_session_ids.id + 1])],
                             },
                         ],
                         "discuss.channel.member": [
@@ -467,7 +476,7 @@ class TestChannelRTC(MailCommon):
                         ],
                         "discuss.channel.rtc.session": [
                             {
-                                "channelMember": {"id": channel_member_test_user.id},
+                                "channelMember": channel_member_test_user.id,
                                 "id": channel_member.rtc_session_ids.id + 1,
                             },
                         ],
@@ -488,9 +497,12 @@ class TestChannelRTC(MailCommon):
         self._reset_bus()
         with self.assertBus(
             [
-                (self.cr.dbname, "mail.guest", test_guest.id),  # update invitation
-                (self.cr.dbname, "discuss.channel", channel.id),  # update list of invitations
-                (self.cr.dbname, "discuss.channel", channel.id),  # update sessions
+                # update invitation
+                (self.cr.dbname, "mail.guest", test_guest.id),
+                # update list of invitations
+                (self.cr.dbname, "discuss.channel", channel.id),
+                # update sessions
+                (self.cr.dbname, "discuss.channel", channel.id),
             ],
             [
                 {
@@ -505,9 +517,7 @@ class TestChannelRTC(MailCommon):
                         "discuss.channel": [
                             {
                                 "id": channel.id,
-                                "invitedMembers": [
-                                    ("DELETE", [{"id": channel_member_test_guest.id}]),
-                                ],
+                                "invitedMembers": [("DELETE", [channel_member_test_guest.id])],
                             },
                         ],
                         "discuss.channel.member": [
@@ -538,9 +548,7 @@ class TestChannelRTC(MailCommon):
                         "discuss.channel": [
                             {
                                 "id": channel.id,
-                                "rtcSessions": [
-                                    ("ADD", [{"id": channel_member.rtc_session_ids.id + 2}]),
-                                ],
+                                "rtcSessions": [("ADD", [channel_member.rtc_session_ids.id + 2])],
                             },
                         ],
                         "discuss.channel.member": [
@@ -558,7 +566,7 @@ class TestChannelRTC(MailCommon):
                         ],
                         "discuss.channel.rtc.session": [
                             {
-                                "channelMember": {"id": channel_member_test_guest.id},
+                                "channelMember": channel_member_test_guest.id,
                                 "id": channel_member.rtc_session_ids.id + 2,
                             },
                         ],
@@ -589,8 +597,10 @@ class TestChannelRTC(MailCommon):
         self._reset_bus()
         with self.assertBus(
             [
-                (self.cr.dbname, "res.partner", test_user.partner_id.id),  # update invitation
-                (self.cr.dbname, "discuss.channel", channel.id),  # update list of invitations
+                # update invitation
+                (self.cr.dbname, "res.partner", test_user.partner_id.id),
+                # update list of invitations
+                (self.cr.dbname, "discuss.channel", channel.id),
             ],
             [
                 {
@@ -605,9 +615,7 @@ class TestChannelRTC(MailCommon):
                         "discuss.channel": [
                             {
                                 "id": channel.id,
-                                "invitedMembers": [
-                                    ("DELETE", [{"id": channel_member_test_user.id}]),
-                                ],
+                                "invitedMembers": [("DELETE", [channel_member_test_user.id])],
                             },
                         ],
                         "discuss.channel.member": [
@@ -640,8 +648,10 @@ class TestChannelRTC(MailCommon):
         self._reset_bus()
         with self.assertBus(
             [
-                (self.cr.dbname, "mail.guest", test_guest.id),  # update invitation
-                (self.cr.dbname, "discuss.channel", channel.id),  # update list of invitations
+                # update invitation
+                (self.cr.dbname, "mail.guest", test_guest.id),
+                # update list of invitations
+                (self.cr.dbname, "discuss.channel", channel.id),
             ],
             [
                 {
@@ -656,9 +666,7 @@ class TestChannelRTC(MailCommon):
                         "discuss.channel": [
                             {
                                 "id": channel.id,
-                                "invitedMembers": [
-                                    ("DELETE", [{"id": channel_member_test_guest.id}]),
-                                ],
+                                "invitedMembers": [("DELETE", [channel_member_test_guest.id])],
                             },
                         ],
                         "discuss.channel.member": [
@@ -702,11 +710,16 @@ class TestChannelRTC(MailCommon):
         self._reset_bus()
         with self.assertBus(
             [
-                (self.cr.dbname, "res.partner", test_user.partner_id.id),  # update invitation
-                (self.cr.dbname, "mail.guest", test_guest.id),  # update invitation
-                (self.cr.dbname, "discuss.channel", channel.id),  # update list of invitations
-                (self.cr.dbname, "discuss.channel", channel.id),  # update sessions
-                (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),  # end session
+                # update invitation
+                (self.cr.dbname, "res.partner", test_user.partner_id.id),
+                # update invitation
+                (self.cr.dbname, "mail.guest", test_guest.id),
+                # update list of invitations
+                (self.cr.dbname, "discuss.channel", channel.id),
+                # update sessions
+                (self.cr.dbname, "discuss.channel", channel.id),
+                # end session
+                (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),
             ],
             [
                 {
@@ -734,10 +747,7 @@ class TestChannelRTC(MailCommon):
                                 "invitedMembers": [
                                     (
                                         "DELETE",
-                                        [
-                                            {"id": channel_member_test_user.id},
-                                            {"id": channel_member_test_guest.id},
-                                        ],
+                                        [channel_member_test_user.id, channel_member_test_guest.id],
                                     )
                                 ],
                             },
@@ -788,9 +798,7 @@ class TestChannelRTC(MailCommon):
                         "discuss.channel": [
                             {
                                 "id": channel.id,
-                                "rtcSessions": [
-                                    ("DELETE", [{"id": channel_member.rtc_session_ids.id}]),
-                                ],
+                                "rtcSessions": [("DELETE", [channel_member.rtc_session_ids.id])],
                             },
                         ],
                     },
@@ -853,7 +861,7 @@ class TestChannelRTC(MailCommon):
                         "discuss.channel": [
                             {
                                 "id": channel.id,
-                                "rtcInvitingSession": {"id": channel_member.rtc_session_ids.id},
+                                "rtcInvitingSession": channel_member.rtc_session_ids.id,
                             },
                         ],
                         "discuss.channel.member": [
@@ -868,7 +876,7 @@ class TestChannelRTC(MailCommon):
                         ],
                         "discuss.channel.rtc.session": [
                             {
-                                "channelMember": {"id": channel_member.id},
+                                "channelMember": channel_member.id,
                                 "id": channel_member.rtc_session_ids.id,
                             },
                         ],
@@ -887,7 +895,7 @@ class TestChannelRTC(MailCommon):
                         "discuss.channel": [
                             {
                                 "id": channel.id,
-                                "rtcInvitingSession": {"id": channel_member.rtc_session_ids.id},
+                                "rtcInvitingSession": channel_member.rtc_session_ids.id,
                             },
                         ],
                         "discuss.channel.member": [
@@ -902,7 +910,7 @@ class TestChannelRTC(MailCommon):
                         ],
                         "discuss.channel.rtc.session": [
                             {
-                                "channelMember": {"id": channel_member.id},
+                                "channelMember": channel_member.id,
                                 "id": channel_member.rtc_session_ids.id,
                             },
                         ],
@@ -924,10 +932,7 @@ class TestChannelRTC(MailCommon):
                                 "invitedMembers": [
                                     (
                                         "ADD",
-                                        [
-                                            {"id": channel_member_test_user.id},
-                                            {"id": channel_member_test_guest.id},
-                                        ],
+                                        [channel_member_test_user.id, channel_member_test_guest.id],
                                     )
                                 ],
                             }
@@ -985,8 +990,10 @@ class TestChannelRTC(MailCommon):
         self._reset_bus()
         with self.assertBus(
             [
-                (self.cr.dbname, "discuss.channel", channel.id),  # update list of sessions
-                (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),  # end session
+                # update list of sessions
+                (self.cr.dbname, "discuss.channel", channel.id),
+                # end session
+                (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),
             ],
             [
                 {
@@ -999,9 +1006,7 @@ class TestChannelRTC(MailCommon):
                         "discuss.channel": [
                             {
                                 "id": channel.id,
-                                "rtcSessions": [
-                                    ("DELETE", [{"id": channel_member.rtc_session_ids.id}]),
-                                ],
+                                "rtcSessions": [("DELETE", [channel_member.rtc_session_ids.id])],
                             },
                         ],
                     },
@@ -1024,8 +1029,10 @@ class TestChannelRTC(MailCommon):
         self._reset_bus()
         with self.assertBus(
             [
-                (self.cr.dbname, "discuss.channel", channel.id),  # update list of sessions
-                (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),  # session ended
+                # update list of sessions
+                (self.cr.dbname, "discuss.channel", channel.id),
+                # session ended
+                (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),
             ],
             [
                 {
@@ -1038,9 +1045,7 @@ class TestChannelRTC(MailCommon):
                         "discuss.channel": [
                             {
                                 "id": channel.id,
-                                "rtcSessions": [
-                                    ("DELETE", [{"id": channel_member.rtc_session_ids.id}]),
-                                ],
+                                "rtcSessions": [("DELETE", [channel_member.rtc_session_ids.id])],
                             },
                         ],
                     },
@@ -1059,8 +1064,10 @@ class TestChannelRTC(MailCommon):
         self._reset_bus()
         with self.assertBus(
             [
-                (self.cr.dbname, "discuss.channel", channel.id),  # update list of sessions
-                (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),  # session ended
+                # update list of sessions
+                (self.cr.dbname, "discuss.channel", channel.id),
+                # session ended
+                (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),
             ],
             [
                 {
@@ -1073,9 +1080,7 @@ class TestChannelRTC(MailCommon):
                         "discuss.channel": [
                             {
                                 "id": channel.id,
-                                "rtcSessions": [
-                                    ("DELETE", [{"id": channel_member.rtc_session_ids.id}]),
-                                ],
+                                "rtcSessions": [("DELETE", [channel_member.rtc_session_ids.id])],
                             },
                         ],
                     },
@@ -1105,8 +1110,10 @@ class TestChannelRTC(MailCommon):
         self._reset_bus()
         with self.assertBus(
             [
-                (self.cr.dbname, "discuss.channel", channel.id),  # update list of sessions
-                (self.cr.dbname, "mail.guest", test_guest.id),  # session ended
+                # update list of sessions
+                (self.cr.dbname, "discuss.channel", channel.id),
+                # session ended
+                (self.cr.dbname, "mail.guest", test_guest.id),
             ],
             [
                 {
@@ -1117,17 +1124,14 @@ class TestChannelRTC(MailCommon):
                     "type": "mail.record/insert",
                     "payload": {
                         "discuss.channel": [
-                            {
-                                "id": channel.id,
-                                "rtcSessions": [("DELETE", [{"id": test_session.id}])],
-                            },
+                            {"id": channel.id, "rtcSessions": [("DELETE", [test_session.id])]},
                         ],
                     },
                 },
             ],
         ):
             current_rtc_sessions, outdated_rtc_sessions = channel_member._rtc_sync_sessions(
-                check_rtc_session_ids=[join_call_values["Rtc"]["selfSession"]["id"]] + unused_ids
+                check_rtc_session_ids=[join_call_values["Rtc"]["selfSession"]] + unused_ids
             )
         self.assertEqual(channel_member.rtc_session_ids, current_rtc_sessions)
         self.assertEqual(unused_ids, outdated_rtc_sessions.ids)

--- a/addons/mail/tests/test_link_preview.py
+++ b/addons/mail/tests/test_link_preview.py
@@ -137,7 +137,7 @@ class TestLinkPreview(MailCommon):
                                     {
                                         "id": message.link_preview_ids.id,
                                         "image_mimetype": False,
-                                        "message": {"id": message.id},
+                                        "message": message.id,
                                         "og_description": self.og_description,
                                         "og_image": self.og_image,
                                         "og_mimetype": False,
@@ -150,7 +150,7 @@ class TestLinkPreview(MailCommon):
                                 "mail.message": self._filter_messages_fields(
                                     {
                                         "id": message.id,
-                                        "linkPreviews": [{"id": message.link_preview_ids.id}],
+                                        "linkPreviews": [message.link_preview_ids.id],
                                     },
                                 ),
                             },

--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -225,4 +225,4 @@ class Store:
             return {"id": record.id, "type": "guest"}
         if record._name == "res.partner":
             return {"id": record.id, "type": "partner"}
-        return {"id": record.id}
+        return record.id

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -622,7 +622,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "defaultDisplayMode": False,
                 "description": False,
                 "group_based_subscription": False,
-                "invitedMembers": [["ADD", [{"id": member_0.id}]]],
+                "invitedMembers": [["ADD", [member_0.id]]],
                 "is_editable": True,
                 "is_pinned": True,
                 "last_interest_dt": last_interest_dt,
@@ -630,9 +630,9 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "message_needaction_counter_bus_id": bus_last_id,
                 "name": "group restricted channel 1",
                 # sudo: discuss.channel.rtc.session - reading a session in a test file
-                "rtcInvitingSession": {"id": member_2.sudo().rtc_session_ids.id},
+                "rtcInvitingSession": member_2.sudo().rtc_session_ids.id,
                 # sudo: discuss.channel.rtc.session - reading a session in a test file
-                "rtcSessions": [["ADD", [{"id": member_2.sudo().rtc_session_ids.id}]]],
+                "rtcSessions": [["ADD", [member_2.sudo().rtc_session_ids.id]]],
                 "custom_notifications": False,
                 "mute_until_dt": False,
                 "state": "closed",
@@ -836,7 +836,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "is_editable": True,
                 "is_pinned": True,
                 "last_interest_dt": last_interest_dt,
-                "livechatChannel": {"id": self.im_livechat_channel.id},
+                "livechatChannel": self.im_livechat_channel.id,
                 "message_needaction_counter": 0,
                 "message_needaction_counter_bus_id": bus_last_id,
                 "name": "test1 Ernest Employee",
@@ -871,7 +871,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "is_editable": True,
                 "is_pinned": True,
                 "last_interest_dt": last_interest_dt,
-                "livechatChannel": {"id": self.im_livechat_channel.id},
+                "livechatChannel": self.im_livechat_channel.id,
                 "message_needaction_counter": 0,
                 "message_needaction_counter_bus_id": bus_last_id,
                 "name": "anon 2 Ernest Employee",
@@ -918,7 +918,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         if channel == self.channel_channel_public_1 and partner == self.users[0].partner_id:
             return {
                 "create_date": member_0_create_date,
-                "fetched_message_id": {"id": last_message.id},
+                "fetched_message_id": last_message.id,
                 "id": member_0.id,
                 "last_interest_dt": member_0_last_interest_dt,
                 "message_unread_counter": 0,
@@ -926,13 +926,13 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "last_seen_dt": member_0_last_seen_dt,
                 "new_message_separator": last_message.id + 1,
                 "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
-                "seen_message_id": {"id": last_message.id},
+                "seen_message_id": last_message.id,
                 "thread": {"id": channel.id, "model": "discuss.channel"},
             }
         if channel == self.channel_channel_public_2 and partner == self.users[0].partner_id:
             return {
                 "create_date": member_0_create_date,
-                "fetched_message_id": {"id": last_message.id},
+                "fetched_message_id": last_message.id,
                 "id": member_0.id,
                 "last_interest_dt": member_0_last_interest_dt,
                 "message_unread_counter": 0,
@@ -940,13 +940,13 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "last_seen_dt": member_0_last_seen_dt,
                 "new_message_separator": last_message.id + 1,
                 "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
-                "seen_message_id": {"id": last_message.id},
+                "seen_message_id": last_message.id,
                 "thread": {"id": channel.id, "model": "discuss.channel"},
             }
         if channel == self.channel_channel_group_1 and partner == self.users[0].partner_id:
             return {
                 "create_date": member_0_create_date,
-                "fetched_message_id": {"id": last_message.id},
+                "fetched_message_id": last_message.id,
                 "id": member_0.id,
                 "last_interest_dt": member_0_last_interest_dt,
                 "message_unread_counter": 0,
@@ -954,7 +954,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "last_seen_dt": member_0_last_seen_dt,
                 "new_message_separator": last_message.id + 1,
                 "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
-                "seen_message_id": {"id": last_message.id},
+                "seen_message_id": last_message.id,
                 "thread": {"id": channel.id, "model": "discuss.channel"},
             }
         if channel == self.channel_channel_group_1 and partner == self.users[2].partner_id:
@@ -966,7 +966,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         if channel == self.channel_channel_group_2 and partner == self.users[0].partner_id:
             return {
                 "create_date": member_0_create_date,
-                "fetched_message_id": {"id": last_message.id},
+                "fetched_message_id": last_message.id,
                 "id": member_0.id,
                 "last_interest_dt": member_0_last_interest_dt,
                 "message_unread_counter": 0,
@@ -974,7 +974,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "last_seen_dt": member_0_last_seen_dt,
                 "new_message_separator": last_message.id + 1,
                 "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
-                "seen_message_id": {"id": last_message.id},
+                "seen_message_id": last_message.id,
                 "thread": {"id": channel.id, "model": "discuss.channel"},
             }
         if channel == self.channel_group_1 and partner == self.users[0].partner_id:
@@ -1116,11 +1116,11 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             return {
                 "create_date": fields.Datetime.to_string(member_1.create_date),
                 "last_seen_dt": fields.Datetime.to_string(member_1.last_seen_dt),
-                "fetched_message_id": {"id": last_message.id},
+                "fetched_message_id": last_message.id,
                 "id": member_1.id,
                 "is_bot": False,
                 "persona": {"id": self.users[1].partner_id.id, "type": "partner"},
-                "seen_message_id": {"id": last_message.id},
+                "seen_message_id": last_message.id,
                 "thread": {"id": channel.id, "model": "discuss.channel"},
             }
         if channel == self.channel_livechat_2 and partner == self.users[0].partner_id:
@@ -1142,11 +1142,11 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             return {
                 "create_date": fields.Datetime.to_string(member_g.create_date),
                 "last_seen_dt": fields.Datetime.to_string(member_g.last_seen_dt),
-                "fetched_message_id": {"id": last_message.id},
+                "fetched_message_id": last_message.id,
                 "id": member_g.id,
                 "is_bot": False,
                 "persona": {"id": guest.id, "type": "guest"},
-                "seen_message_id": {"id": last_message.id},
+                "seen_message_id": last_message.id,
                 "thread": {"id": channel.id, "model": "discuss.channel"},
             }
         return {}
@@ -1184,7 +1184,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "message_type": "comment",
                 "model": "discuss.channel",
                 "needaction": True,
-                "notifications": [{"id": last_message.notification_ids.id}],
+                "notifications": [last_message.notification_ids.id],
                 "thread": {"id": channel.id, "model": "discuss.channel"},
                 "parentMessage": False,
                 "pinned_at": False,
@@ -1367,7 +1367,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             return {
                 "failure_type": False,
                 "id": last_message.notification_ids.id,
-                "message": {"id": last_message.id},
+                "message": last_message.id,
                 "notification_status": "sent",
                 "notification_type": "inbox",
                 "persona": {"id": self.users[0].partner_id.id, "type": "partner"},
@@ -1511,7 +1511,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         if channel == self.channel_channel_group_1 and user == self.users[2]:
             return {
                 # sudo: discuss.channel.rtc.session - reading a session in a test file
-                "channelMember": {"id": member_2.id},
+                "channelMember": member_2.id,
                 "id": member_2.sudo().rtc_session_ids.id,
                 "isCameraOn": False,
                 "isDeaf": False,

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -124,7 +124,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - fetch im_livechat_channel
     #       - fetch country (anonymous_country)
     #   - _get_last_messages
-    #   18: message _to_store:
+    #   13: message _to_store:
     #       - search mail_message_schedule
     #       - fetch mail_message
     #       - search mail_message_reaction
@@ -137,8 +137,8 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - search mail_tracking_value
     #       - search mail_message_res_partner_starred_rel
     #       - search rating_rating
-    #       6: _compute_rating_stats
-    _query_count_discuss_channels = 56
+    #       - _compute_rating_stats
+    _query_count_discuss_channels = 51
 
     def setUp(self):
         super().setUp()

--- a/addons/test_mail/tests/test_mail_followers.py
+++ b/addons/test_mail/tests/test_mail_followers.py
@@ -898,7 +898,7 @@ class UnfollowFromInboxTest(MailCommon, HttpCase):
                     "message_type": "notification",
                     "model": "mail.test.simple",
                     "needaction": True,
-                    "notifications": [{"id": notif.id}],
+                    "notifications": [notif.id],
                     "pinned_at": False,
                     "rating_id": False,
                     "reactions": [],
@@ -918,7 +918,7 @@ class UnfollowFromInboxTest(MailCommon, HttpCase):
                 {
                     "failure_type": False,
                     "id": notif.id,
-                    "message": {"id": message.id},
+                    "message": message.id,
                     "notification_status": "sent",
                     "notification_type": "inbox",
                     "persona": {"id": self.env.user.partner_id.id, "type": "partner"},
@@ -966,7 +966,7 @@ class UnfollowFromInboxTest(MailCommon, HttpCase):
                 "partner": {"id": self.env.user.partner_id.id, "type": "partner"},
             },
         ]
-        expected_with_follower["mail.thread"][0]["selfFollower"] = {"id": follower.id}
+        expected_with_follower["mail.thread"][0]["selfFollower"] = follower.id
         self.assertEqual(data, expected_with_follower)
 
         # The user doesn't follow the record anymore

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -393,7 +393,7 @@ class TestDiscuss(MailCommon, TestRecipients):
                                 "counter": 1,
                                 "counter_bus_id": bus_last_id,
                                 "id": "starred",
-                                "messages": [["DELETE", [{"id": msg.id}]]],
+                                "messages": [["DELETE", [msg.id]]],
                                 "model": "mail.box",
                             }
                         ],
@@ -407,7 +407,7 @@ class TestDiscuss(MailCommon, TestRecipients):
                                 "counter": 0,
                                 "counter_bus_id": bus_last_id,
                                 "id": "starred",
-                                "messages": [["DELETE", [{"id": msg.id}]]],
+                                "messages": [["DELETE", [msg.id]]],
                                 "model": "mail.box",
                             }
                         ],

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1387,7 +1387,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     "message_type": "comment",
                                     "model": "mail.test.simple",
                                     "needaction": True,
-                                    "notifications": [{"id": notif_1.id}, {"id": notif_2.id}],
+                                    "notifications": [notif_1.id, notif_2.id],
                                     "pinned_at": False,
                                     "rating_id": False,
                                     "reactions": [],
@@ -1407,7 +1407,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                 {
                                     "failure_type": False,
                                     "id": notif_1.id,
-                                    "message": {"id": message.id},
+                                    "message": message.id,
                                     "notification_status": "sent",
                                     "notification_type": "inbox",
                                     "persona": {
@@ -1418,7 +1418,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                 {
                                     "failure_type": False,
                                     "id": notif_2.id,
-                                    "message": {"id": message.id},
+                                    "message": message.id,
                                     "notification_status": "sent",
                                     "notification_type": "inbox",
                                     "persona": {
@@ -1433,7 +1433,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     "model": "mail.test.simple",
                                     "module_icon": "/base/static/description/icon.png",
                                     "name": "Test",
-                                    "selfFollower": {"id": follower_1.id},
+                                    "selfFollower": follower_1.id,
                                 },
                             ),
                             "res.partner": self._filter_partners_fields(
@@ -1490,7 +1490,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     "message_type": "comment",
                                     "model": "mail.test.simple",
                                     "needaction": True,
-                                    "notifications": [{"id": notif_1.id}, {"id": notif_2.id}],
+                                    "notifications": [notif_1.id, notif_2.id],
                                     "pinned_at": False,
                                     "rating_id": False,
                                     "reactions": [],
@@ -1510,7 +1510,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                 {
                                     "failure_type": False,
                                     "id": notif_1.id,
-                                    "message": {"id": message.id},
+                                    "message": message.id,
                                     "notification_status": "sent",
                                     "notification_type": "inbox",
                                     "persona": {
@@ -1521,7 +1521,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                 {
                                     "failure_type": False,
                                     "id": notif_2.id,
-                                    "message": {"id": message.id},
+                                    "message": message.id,
                                     "notification_status": "sent",
                                     "notification_type": "inbox",
                                     "persona": {
@@ -1536,7 +1536,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     "model": "mail.test.simple",
                                     "module_icon": "/base/static/description/icon.png",
                                     "name": "Test",
-                                    "selfFollower": {"id": follower_2.id},
+                                    "selfFollower": follower_2.id,
                                 },
                             ),
                             "res.partner": self._filter_partners_fields(


### PR DESCRIPTION
\* = im_livechat, test_discuss_full, test_mail

Now that data are flat, there is no need to pass `{ id: 123 }` format in relations, just giving `123` is enough.

Part of task-3605717

https://github.com/odoo/enterprise/pull/68508