### PR TITLE
[FIX] marketing_automation: rectified conflicting selector

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale_backend.scss
+++ b/addons/website_sale/static/src/scss/website_sale_backend.scss
@@ -67,7 +67,7 @@
 }
 
 // This is an ugly workaround to prevent the div content from overflowing
-.o_form_view div.float-start {
+.o_form_sheet > div.float-start {
     float: none !important;
 
     .o_inner_group {


### PR DESCRIPTION
Steps to reproduce
===================
1. Install website_sale module
2. Go to any campaign in marketing_automation
3. The kanban card of the activity will have buttons misplaced in the title

Issue
=================
With commit https://github.com/odoo/odoo/pull/165486/commits/f46e7e8bd6dc205d83a107f62d8b5944caa3d4d5, a style was applied for website_sale form mobile view. The selector also matched marketing_automation's campaign form view which removed the required float property from the element.

After this commit
=================
This commit makes the selector in website_sale more specific to match only the desired element.

Task-4110902