### PR TITLE
[IMP] marketing_card: change category to marketing

### DIFF
--- a/addons/marketing_card/__manifest__.py
+++ b/addons/marketing_card/__manifest__.py
@@ -1,7 +1,7 @@
 {
     'name': 'Marketing Card',
     'version': '1.1',
-    'category': 'Marketing/Social Marketing',
+    'category': 'Marketing/Marketing Card',
     'summary': 'Generate dynamic shareable cards',
     'depends': ['link_tracker', 'mass_mailing', 'website'],
     'data': [

--- a/addons/marketing_card/security/marketing_card_groups.xml
+++ b/addons/marketing_card/security/marketing_card_groups.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0"?>
 <odoo noupdate="1">
-    <record id="module_category_marketing_card" model="ir.module.category">
+    <record id="base.module_category_marketing_marketing_card" model="ir.module.category">
         <field name="name">Marketing Card</field>
         <field name="description">Helps you manage marketing card campaigns.</field>
-        <field name="sequence">18</field>
+        <field name="sequence">100</field>
     </record>
 
     <record id="marketing_card_group_user" model="res.groups">
         <field name="name">Marketing Card User</field>
-        <field name="category_id" ref="module_category_marketing_card"/>
+        <field name="category_id" ref="base.module_category_marketing_marketing_card"/>
         <field name="implied_ids" eval="[(4, ref('base.group_user')), (4, ref('mass_mailing.group_mass_mailing_user'))]"/>
     </record>
 
     <record id="marketing_card_group_manager" model="res.groups">
         <field name="name">Marketing Card Manager</field>
-        <field name="category_id" ref="module_category_marketing_card"/>
+        <field name="category_id" ref="base.module_category_marketing_marketing_card"/>
         <field name="implied_ids" eval="[(4, ref('marketing_card_group_user'))]"/>
         <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
     </record>


### PR DESCRIPTION
Move the Marketing Card from the others category to the marketing category.

**Technical**
Odoo uses the "base" prefix in the module category record to enforce the specified sequence. Without this prefix, the sequence won't be honored.

Task-4116552