### PR TITLE
[FIX] website_sale: revert of 2d6e7c75eeb87cd85fa28ca0519a9734554c3437

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import SUPERUSER_ID, _, _lt, api, fields, models, tools
-from odoo.exceptions import UserError
 from odoo.http import request
 from odoo.osv import expression
 
@@ -361,16 +360,6 @@ class Website(models.Model):
         pricelist_id = False
 
         partner_sudo = self.env.user.partner_id
-
-        if partner_sudo.company_id and not partner_sudo.filtered_domain(
-            self.env['res.partner']._check_company_domain(self.company_id)
-        ):
-            raise UserError(_(
-                "Your account is not allowed to pay in company %s."
-                " Please log out and create a new account for this website, or contact the website"
-                " administrator.",
-                self.company_id.name,
-            ))
 
         # cart creation was requested
         if not sale_order_sudo:


### PR DESCRIPTION
Steps to reproduce:
- Install `website_sale`, `sale_purchase_inter_company_rules`
- Set the second website for "My Company (Chicago)" and as the domain put "http://2.localhost:8069/"
- Create an SO on San Francisco company and save it without confirming
- Execute the following SQL command:
```sql
update sale_order set website_id=2, company_id=2, pricelist_id=null where id=41; -- here put the id of the SO
```
- Now open the website app and select Website 2.

Issues:
Internal error, this is due to the fact that we're raising a UserError here.

https://github.com/odoo/odoo/blob/79ad7396b15a9e26e812f2f2151241fa5bf76e18/addons/website_sale/models/website.py#L365-L373

While a better solution is searched the best one for stable is to remove the
UserError.

opw-4054699