### PR TITLE
[FIX] mail: scroll to unread banner not working 

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -16,8 +16,8 @@ import {
     Component,
     markup,
     onMounted,
+    onPatched,
     onWillDestroy,
-    onWillStart,
     onWillUpdateProps,
     toRaw,
     useChildSubEnv,
@@ -38,6 +38,7 @@ import { url } from "@web/core/utils/urls";
 import { useMessageActions } from "./message_actions";
 import { cookie } from "@web/core/browser/cookie";
 import { rpc } from "@web/core/network/rpc";
+import { escape } from "@web/core/utils/strings";
 
 /**
  * @typedef {Object} Props
@@ -84,6 +85,7 @@ export class Message extends Component {
         "message",
         "messageEdition?",
         "messageToReplyTo?",
+        "previousMessage?",
         "squashed?",
         "thread?",
         "messageSearch?",
@@ -95,6 +97,7 @@ export class Message extends Component {
 
     setup() {
         super.setup();
+        this.escape = escape;
         this.popover = usePopover(this.constructor.components.Popover, { position: "top" });
         this.state = useState({
             isEditing: false,
@@ -107,11 +110,11 @@ export class Message extends Component {
         /** @type {ShadowRoot} */
         this.shadowRoot;
         this.root = useRef("root");
-        onWillStart(() => this.props.registerMessageRef?.(this.props.message, this.root));
         onWillUpdateProps((nextProps) => {
             this.props.registerMessageRef?.(this.props.message, null);
-            this.props.registerMessageRef?.(nextProps.message, this.root);
         });
+        onMounted(() => this.props.registerMessageRef?.(this.props.message, this.root));
+        onPatched(() => this.props.registerMessageRef?.(this.props.message, this.root));
         onWillDestroy(() => this.props.registerMessageRef?.(this.props.message, null));
         this.hasTouch = hasTouch;
         this.messageBody = useRef("body");

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -2,7 +2,13 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.Message">
-        <ActionSwiper onRightSwipe="hasTouch() and isInInbox ? { action: () => this.message.setDone(), bgColor: 'bg-success', icon: 'fa-check-circle' } : undefined">
+        <t t-if="message.isNotification">
+            <t t-set="prevMsg" t-value="props.previousMessage"/>
+            <t t-set="msg" t-value="message"/>
+            <t t-set="onClickNotification" t-value="env.onClickNotification"/>
+            <t t-call="mail.NotificationMessage"/>
+        </t>
+        <ActionSwiper t-else="" onRightSwipe="hasTouch() and isInInbox ? { action: () => this.message.setDone(), bgColor: 'bg-success', icon: 'fa-check-circle' } : undefined">
             <div class="o-mail-Message position-relative pt-1"
                 t-att-class="attClass"
                 role="group"

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -5,10 +5,12 @@ import { useVisible } from "@mail/utils/common/hooks";
 
 import {
     Component,
+    markRaw,
     onMounted,
     onWillDestroy,
     onWillPatch,
     onWillUpdateProps,
+    reactive,
     toRaw,
     useChildSubEnv,
     useEffect,
@@ -65,7 +67,6 @@ export class Thread extends Component {
     setup() {
         super.setup();
         this.escape = escape;
-        this.refByMessageId = new Map();
         this.registerMessageRef = this.registerMessageRef.bind(this);
         this.store = useState(useService("mail.store"));
         this.state = useState({
@@ -79,6 +80,12 @@ export class Thread extends Component {
         this.messageHighlight = this.env.messageHighlight
             ? useState(this.env.messageHighlight)
             : null;
+        this.scrollingToHighlight = false;
+        this.refByMessageId = reactive(new Map(), () => this.scrollToHighlighted());
+        useEffect(
+            () => this.scrollToHighlighted(),
+            () => [this.messageHighlight?.highlightedMessageId]
+        );
         this.present = useRef("load-newer");
         /**
          * This is the reference element with the scrollbar. The reference can
@@ -145,15 +152,6 @@ export class Thread extends Component {
                 }
             },
             () => [this.state.mountedAndLoaded]
-        );
-        useEffect(
-            () => {
-                const el = this.refByMessageId.get(this.messageHighlight?.highlightedMessageId)?.el;
-                if (el) {
-                    this.messageHighlight.scrollTo(el);
-                }
-            },
-            () => [this.state.mountedAndLoaded, this.messageHighlight?.highlightedMessageId]
         );
         onMounted(() => {
             if (!this.env.chatter || this.env.chatter?.fetchMessages) {
@@ -393,7 +391,10 @@ export class Thread extends Component {
             };
         });
         useEffect(applyScroll);
-        useChildSubEnv({ onImageLoaded: applyScroll });
+        useChildSubEnv({
+            onImageLoaded: applyScroll,
+            onClickNotification: this.onClickNotification.bind(this),
+        });
         const observer = new ResizeObserver(applyScroll);
         useEffect(
             (el, mountedAndLoaded) => {
@@ -453,7 +454,7 @@ export class Thread extends Component {
     }
 
     getMessageClassName(message) {
-        return this.messageHighlight?.highlightedMessageId === message.id
+        return !message.isNotification && this.messageHighlight?.highlightedMessageId === message.id
             ? "o-highlighted bg-view shadow-lg pb-1"
             : "";
     }
@@ -485,7 +486,7 @@ export class Thread extends Component {
 
     async onClickUnreadMessagesBanner() {
         await this.props.thread.loadAround(this.props.thread.selfMember.localNewMessageSeparator);
-        this.messageHighlight.highlightMessage(
+        this.messageHighlight?.highlightMessage(
             this.props.thread.firstUnreadMessage,
             this.props.thread
         );
@@ -494,8 +495,9 @@ export class Thread extends Component {
     registerMessageRef(message, ref) {
         if (!ref) {
             this.refByMessageId.delete(message.id);
+            return;
         }
-        this.refByMessageId.set(message.id, ref);
+        this.refByMessageId.set(message.id, markRaw(ref));
     }
 
     isSquashed(msg, prevMsg) {
@@ -521,5 +523,16 @@ export class Thread extends Component {
             return false;
         }
         return msg.datetime.ts - prevMsg.datetime.ts < 60 * 1000;
+    }
+
+    scrollToHighlighted() {
+        if (!this.messageHighlight?.highlightedMessageId || this.scrollingToHighlight) {
+            return;
+        }
+        const el = this.refByMessageId.get(this.messageHighlight.highlightedMessageId)?.el;
+        if (el) {
+            this.scrollingToHighlight = true;
+            this.messageHighlight.scrollTo(el).then(() => (this.scrollingToHighlight = false));
+        }
     }
 }

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -24,13 +24,11 @@
                     <div t-if="msg.threadAsFirstUnread?.eq(props.thread)" class="o-mail-Thread-newMessage d-flex align-items-center fw-bolder z-1">
                         <hr class="flex-grow-1 border-danger opacity-100"/><span class="ps-2 pe-1 bg-danger o-text-white rounded text-uppercase">New</span>
                     </div>
-                    <t t-if="msg.isNotification">
-                        <t t-call="mail.NotificationMessage"/>
-                    </t>
-                    <Message t-else=""
+                    <Message
                         className="getMessageClassName(msg)"
                         isInChatWindow="props.isInChatWindow"
                         message="msg"
+                        previousMessage="prevMsg"
                         registerMessageRef="registerMessageRef"
                         messageToReplyTo="props.messageToReplyTo"
                         squashed="isSquashed(msg, prevMsg)"
@@ -91,10 +89,9 @@
     </div>
 </t>
 
+<!-- @this {import("@mail/core/common/message"} -->
 <t t-name="mail.NotificationMessage">
-    <div class="o-mail-NotificationMessage text-break mx-auto text-500 small px-3 text-center" t-on-click="onClickNotification" t-att-class="{
-        'mt-1': prevMsg and !prevMsg.isNotification,
-    }" t-ref="root">
+    <div class="o-mail-NotificationMessage text-break mx-auto text-500 small px-3 text-center" t-on-click="onClickNotification" t-att-class="props.className" t-ref="root">
         <i t-if="msg.notificationIcon" t-attf-class="{{ msg.notificationIcon }} me-1"/>
         <span class="o-mail-NotificationMessage-author d-inline" t-if="msg.author and !msg.body.includes(escape(msg.author.name))" t-esc="msg.author.name"/> <t t-out="msg.body"/>
     </div>

--- a/addons/mail/static/tests/thread/unread_messages_banner.test.js
+++ b/addons/mail/static/tests/thread/unread_messages_banner.test.js
@@ -1,13 +1,25 @@
 import {
+    assertSteps,
     click,
     contains,
     defineMailModels,
+    isInViewportOf,
     openDiscuss,
+    scroll,
     start,
     startServer,
+    step,
 } from "@mail/../tests/mail_test_helpers";
-import { describe, test } from "@odoo/hoot";
-import { serverState } from "@web/../tests/web_test_helpers";
+import { Thread } from "@mail/core/common/thread";
+import { describe, expect, test } from "@odoo/hoot";
+import { queryFirst } from "@odoo/hoot-dom";
+import { tick } from "@odoo/hoot-mock";
+import {
+    getService,
+    patchWithCleanup,
+    serverState,
+    withUser,
+} from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -52,4 +64,98 @@ test("mark thread as read from unread messages banner", async () => {
         parent: ["span", { text: "30 new messagesMark as Read" }],
     });
     await contains(".o-mail-Thread-jumpToUnread", { count: 0 });
+});
+
+test("scroll to the first unread message (slow ref registration)", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "general" });
+    const messageIds = [];
+    for (let i = 0; i < 201; i++) {
+        messageIds.push(
+            pyEnv["mail.message"].create({
+                body: `message ${i}`,
+                model: "discuss.channel",
+                res_id: channelId,
+            })
+        );
+    }
+    const [selfMember] = pyEnv["discuss.channel.member"].search([
+        ["partner_id", "=", serverState.partnerId],
+        ["channel_id", "=", channelId],
+    ]);
+    pyEnv["discuss.channel.member"].write([selfMember], { new_message_separator: messageIds[100] });
+    let slowRegisterMessageRef = false;
+    patchWithCleanup(Thread.prototype, {
+        async registerMessageRef() {
+            if (slowRegisterMessageRef) {
+                // Ensure scroll is made even when messages are mounted later.
+                await new Promise((res) => setTimeout(res, 500));
+            }
+            super.registerMessageRef(...arguments);
+        },
+    });
+    await start();
+    await openDiscuss(channelId);
+    await click(".o-mail-Thread-banner", {
+        text: "You're viewing older messagesJump to Present",
+    });
+    await scroll(".o-mail-Thread", "bottom");
+    await contains(".o-mail-Thread", { scroll: "bottom" });
+    slowRegisterMessageRef = true;
+    await click("span", {
+        text: "101 new messages",
+        parent: ["span", { text: "101 new messagesMark as Read" }],
+    });
+    document.addEventListener("scrollend", () => step("scrollend"), { capture: true });
+    // 1. scroll top, 2. scroll to the unread message 3. slight scroll when highlight ends.
+    await assertSteps(["scrollend", "scrollend", "scrollend"]);
+    const thread = document.querySelector(".o-mail-Thread");
+    const message = queryFirst(".o-mail-Message:contains(message 100)");
+    expect(isInViewportOf(thread, message)).toBe(true);
+});
+
+test("scroll to unread notification", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "general" });
+    const bobPartnerId = pyEnv["res.partner"].create({ name: "Bob" });
+    const bobUserId = pyEnv["res.users"].create({ name: "Bob", partner_id: bobPartnerId });
+    let lastMessageId;
+    for (let i = 0; i < 60; ++i) {
+        lastMessageId = pyEnv["mail.message"].create({
+            author_id: serverState.partnerId,
+            body: `message ${i}`,
+            model: "discuss.channel",
+            res_id: channelId,
+        });
+    }
+    const [memberId] = pyEnv["discuss.channel.member"].search([
+        ["partner_id", "=", serverState.partnerId],
+        ["channel_id", "=", channelId],
+    ]);
+    pyEnv["discuss.channel.member"].write([memberId], { new_message_separator: lastMessageId + 1 });
+    await start();
+    await withUser(bobUserId, () => {
+        getService("orm").call("discuss.channel", "add_members", [[channelId]], {
+            partner_ids: [bobPartnerId],
+        });
+    });
+    await openDiscuss(channelId);
+    await contains(".o-mail-Thread-newMessage ~ .o-mail-NotificationMessage", {
+        text: "Bob joined the channel",
+    });
+    await tick(); // wait for the scroll to first unread to complete
+    document.addEventListener("scrollend", () => step("scrollend"), { capture: true });
+    await contains(".o-mail-Thread", { scroll: "bottom" });
+    await assertSteps(["scrollend"]);
+    await scroll(".o-mail-Thread", 0);
+    await assertSteps(["scrollend"]);
+    const thread = document.querySelector(".o-mail-Thread");
+    const message = queryFirst(".o-mail-NotificationMessage:contains(Bob joined the channel)");
+    expect(isInViewportOf(thread, message)).toBe(false);
+    await click("span", {
+        text: "1 new message",
+        parent: ["span", { text: "1 new messageMark as Read" }],
+    });
+    await assertSteps(["scrollend"]);
+    expect(isInViewportOf(thread, message)).toBe(true);
 });


### PR DESCRIPTION
This PR fixes two issues related to the unread message banner.
Clicking on this banner should scroll a discuss thread to the first
unread message. However, it sometimes does nothing.

Steps to reproduce the issue:
- Connect two browsers, one with admin, one with demo
- Send enough messages in a discuss channel to get a scroll bar
- Ensure every message is read by admin
- Leave the channel with demo
- The first unread message for admin is the "user left" notification
- Scroll up and click on the banner when the unread message is out of sight
- Nothing happens

The same issue can occur if the messages are loaded after the thread
tries to scroll to the unread message, but it is harder to reproduce
as it is a race condition.

This PR fixes both issues.