### PR TITLE
[FIX] hr_holidays_attendance: remove unnecessary view

### DIFF
--- a/addons/hr_holidays_attendance/i18n/hr_holidays_attendance.pot
+++ b/addons/hr_holidays_attendance/i18n/hr_holidays_attendance.pot
@@ -73,7 +73,6 @@ msgstr ""
 #. module: hr_holidays_attendance
 #: model_terms:ir.ui.view,arch_db:hr_holidays_attendance.hr_attendance_holidays_hr_leave_allocation_view_form_inherit
 #: model_terms:ir.ui.view,arch_db:hr_holidays_attendance.hr_leave_view_form
-#: model_terms:ir.ui.view,arch_db:hr_holidays_attendance.hr_leave_view_form_overtime
 msgid "Extra Hours Available"
 msgstr ""
 

--- a/addons/hr_holidays_attendance/views/hr_leave_views.xml
+++ b/addons/hr_holidays_attendance/views/hr_leave_views.xml
@@ -13,18 +13,4 @@
             </xpath>
         </field>
     </record>
-
-    <record id="hr_leave_view_form_overtime" model="ir.ui.view">
-        <field name="model">hr.leave</field>
-        <field name="inherit_id" ref="hr_holidays.hr_leave_view_form" />
-        <field name="arch" type="xml">
-            <xpath expr="(//div[@name='duration_display']/div)[last()]" position="after">
-                <field name="overtime_deductible" invisible="1" />
-                <field name="employee_overtime" invisible="1" />
-                <div attrs="{'invisible': ['|', '|', ('employee_id', '=', False), ('overtime_deductible', '=', False), ('employee_overtime', '&lt;=', 0)]}">
-                    <field name="employee_overtime" nolabel="1" widget="float_time" class="text-success" style="max-width: 6rem;" /> Extra Hours Available
-                </div>
-            </xpath>
-        </field>
-    </record>
 </odoo>


### PR DESCRIPTION
Steps to reproduce (on runbot):
1. enable "extra hours" and add extra hours to an employee
2. as an admin go to management > time off
3. make a new time off and choose "extra hours" as the time off type
4. The duration of extra hours is duplicated

The issue happens because the form view inherits two identical views. This commit removes the unnecessary view.

task-4102491

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
