### PR TITLE
[FIX] website: adjust `color5` of configurator generated palette

### DIFF
--- a/addons/website/static/src/client_actions/configurator/configurator.js
+++ b/addons/website/static/src/client_actions/configurator/configurator.js
@@ -581,7 +581,7 @@ class Store {
                 color2: color2,
                 color3: mixCssColors('#FFFFFF', color2, 0.9),
                 color4: '#FFFFFF',
-                color5: mixCssColors(color1, '#000000', 0.75),
+                color5: mixCssColors(color1, '#000000', 0.125),
             };
             CUSTOM_BG_COLOR_ATTRS.forEach((attr) => {
                 recommendedPalette[attr] = recommendedPalette[this.defaultColors[attr]];


### PR DESCRIPTION
This commit is a backport of commit [1], adjusting the `color5` of the color palette generated after uploading a logo in the configurator. Indeed, this color was too light, even though it is supposed to be the darkest.

[1]: https://github.com/odoo/odoo/commit/09fd191657372da5a5220fe82c180a3d2f5a076e

Related to task-4109584