### PR TITLE
[FIX] sale_project: add missing allow_billable context to project portal

### DIFF
--- a/addons/sale_project/controllers/portal.py
+++ b/addons/sale_project/controllers/portal.py
@@ -39,3 +39,10 @@ class SaleProjectCustomerPortal(ProjectCustomerPortal):
         if search_in in ('invoice', 'all'):
             search_domain.append([('sale_order_id.invoice_ids.name', 'ilike', search)])
         return OR(search_domain)
+
+    def _prepare_project_sharing_session_info(self, project, task=None):
+        session_info = super()._prepare_project_sharing_session_info(project, task)
+        session_info['action_context'].update({
+            'allow_billable': project.allow_billable,
+        })
+        return session_info


### PR DESCRIPTION
It was missed in 481bfa74a89595df7434a9523e0afc1813b8a774 but added back in master