### PR TITLE
[FIX] hr_holidays : validate draft leaves when changing the dates

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -996,7 +996,7 @@ Attempting to double-book your time off won't magically make your vacation 2x be
             if 'date_to' in values:
                 values['request_date_to'] = values['date_to']
         result = super(HolidaysRequest, self).write(values)
-        if any(field in values for field in ['request_date_from', 'date_from', 'request_date_from', 'date_to', 'holiday_status_id', 'employee_id']):
+        if any(field in values for field in ['request_date_from', 'date_from', 'request_date_from', 'date_to', 'holiday_status_id', 'employee_id', 'state']):
             self._check_validity()
         if not self.env.context.get('leave_fast_create'):
             for holiday in self:


### PR DESCRIPTION
### Steps to reproduce:
	- Install Time-off module
	- Create new allocation for an employee for 1 day
	- Create a leave for this employee with more than 1 day -error will be raised-
	- Edit the leave to be for just one day and validate it
	- Refuse this leave and mark it as draft
	- Change the dates to be more than 1 day

### Current behavior before PR:
It is expected to raise an Error each time an employee tries to have a leave which has more days than the allocation he has but this is not happening when the leave is in draft state. So the employee can submit a leave with days more than the allocation.

This issue is happening because when checking if there is excess days in the leave we don't take leaves in draft state into considertion. https://github.com/odoo/odoo/blob/17.0/addons/hr_holidays/models/hr_employee.py#L387:L391

### Desired behavior after PR is merged:
After editing the leaves_domain we are now taking draft leaves into cosideration when we are checking the leave validity.

opw-4090572