### PR TITLE
[IMP] tests: object wrapper for freezetime

### DIFF
--- a/addons/account_peppol/tests/test_peppol_messages.py
+++ b/addons/account_peppol/tests/test_peppol_messages.py
@@ -1,12 +1,11 @@
 import json
 from base64 import b64encode
 from contextlib import contextmanager
-from freezegun import freeze_time
 from requests import Session, PreparedRequest, Response
 
 from odoo.addons.account.tests.test_account_move_send import TestAccountMoveSendCommon
 from odoo.exceptions import UserError
-from odoo.tests.common import tagged
+from odoo.tests.common import tagged, freeze_time
 from odoo.tools.misc import file_open
 
 

--- a/addons/account_peppol/tests/test_peppol_participant.py
+++ b/addons/account_peppol/tests/test_peppol_participant.py
@@ -1,11 +1,10 @@
 import json
 from contextlib import contextmanager
-from freezegun import freeze_time
 from requests import Session, PreparedRequest, Response
 from psycopg2 import IntegrityError
 
 from odoo.exceptions import ValidationError, UserError
-from odoo.tests.common import tagged, TransactionCase
+from odoo.tests.common import tagged, TransactionCase, freeze_time
 from odoo.tools import mute_logger
 
 ID_CLIENT = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'

--- a/addons/account_update_tax_tags/tests/test_account_update_tax_tags_wizard.py
+++ b/addons/account_update_tax_tags/tests/test_account_update_tax_tags_wizard.py
@@ -1,9 +1,8 @@
 import time
-from freezegun import freeze_time
 
 from odoo import Command
 from odoo.exceptions import UserError
-from odoo.tests import tagged
+from odoo.tests import tagged, freeze_time
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -4,10 +4,8 @@
 from odoo import exceptions, Command, fields
 from odoo.tests import Form
 from odoo.addons.mrp.tests.common import TestMrpCommon
-from odoo.tests.common import HttpCase, tagged
+from odoo.tests.common import HttpCase, tagged, freeze_time
 from odoo.tools import float_compare, float_round, float_repr
-
-from freezegun import freeze_time
 
 
 @freeze_time(fields.Date.today())

--- a/addons/purchase_stock/tests/test_purchase_order.py
+++ b/addons/purchase_stock/tests/test_purchase_order.py
@@ -2,13 +2,12 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import re
 from datetime import datetime, timedelta
-from freezegun import freeze_time
 
 from odoo import Command
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
 from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_common import ValuationReconciliationTestCommon
 from odoo.exceptions import UserError
-from odoo.tests import Form, tagged
+from odoo.tests import Form, tagged, freeze_time
 
 
 @freeze_time("2021-01-14 09:12:15")

--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -3,11 +3,10 @@
 
 from datetime import datetime as dt, time
 from datetime import timedelta as td
-from freezegun import freeze_time
 
 from odoo import SUPERUSER_ID, Command
 from odoo.fields import Date
-from odoo.tests import Form, tagged
+from odoo.tests import Form, tagged, freeze_time
 from odoo.tests.common import TransactionCase
 from odoo.tools.date_utils import add
 from odoo.exceptions import UserError, ValidationError

--- a/addons/sale/tests/test_accrued_sale_orders.py
+++ b/addons/sale/tests/test_accrued_sale_orders.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
-from freezegun import freeze_time
 from odoo import Command
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
-from odoo.tests import tagged
+from odoo.tests import tagged, freeze_time
 from odoo.exceptions import UserError
 
 

--- a/odoo/addons/test_testing_utilities/tests/__init__.py
+++ b/odoo/addons/test_testing_utilities/tests/__init__.py
@@ -5,3 +5,4 @@ from . import test_form_impl
 from . import test_xml_tools
 from . import test_res_config
 from . import test_env
+from . import test_freeze_time

--- a/odoo/addons/test_testing_utilities/tests/test_freeze_time.py
+++ b/odoo/addons/test_testing_utilities/tests/test_freeze_time.py
@@ -1,0 +1,48 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from datetime import date, datetime
+from odoo.tests.common import tagged, TransactionCase, HttpCase, freeze_time
+
+REFERENCE_NOW = datetime.now()
+
+
+@freeze_time('2021-01-01')
+@tagged('post_install', '-at_install')
+class TestFreezeTimeClassDecorator(TransactionCase):
+
+    def test_freeze_time_class_decorator(self):
+        self.assertEqual(datetime.now().strftime('%Y-%m-%d %H:%M:%S'), '2021-01-01 00:00:00')
+
+
+@tagged('post_install', '-at_install')
+class TestFreezeTimeMethodDecorator(TransactionCase):
+
+    @freeze_time('2022-02-02')
+    def test_freeze_time_method_decorator(self):
+        self.assertEqual(datetime.now().strftime('%Y-%m-%d %H:%M:%S'), '2022-02-02 00:00:00')
+
+    @freeze_time(date(2023, 3, 3))
+    def test_freeze_time_method_decorator_with_date(self):
+        self.assertEqual(datetime.now().strftime('%Y-%m-%d %H:%M:%S'), '2023-03-03 00:00:00')
+
+
+@tagged('post_install', '-at_install')
+@freeze_time(datetime(2024, 4, 4, 4, 4))
+class TestHttpCaseFreezeTimeClassDecorator(HttpCase):
+
+    def test_http_freeze_time_class_decorator(self):
+        self.assertEqual(datetime.now().strftime('%Y-%m-%d %H:%M:%S'), '2024-04-04 04:04:00')
+
+    def test_http_freeze_time_class_decorator_two(self):
+        """Test that another method is still patched"""
+        self.assertEqual(datetime.now().strftime('%Y-%m-%d %H:%M:%S'), '2024-04-04 04:04:00')
+
+
+@tagged('post_install', '-at_install')
+class TestFreezeTimeContextManager(TransactionCase):
+
+    def test_freeze_time_context_manager(self):
+        self.assertEqual(datetime.now().strftime('%Y-%m-%d'), REFERENCE_NOW.strftime('%Y-%m-%d'))
+        with freeze_time('2025-05-05 05:05') as frozen_time:
+            self.assertEqual(datetime.now().strftime('%Y-%m-%d %H:%M:%S'), '2025-05-05 05:05:00')
+            frozen_time.move_to('2026-06-06 06:06')
+            self.assertEqual(datetime.now().strftime('%Y-%m-%d %H:%M'), '2026-06-06 06:06')

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -10,6 +10,7 @@ import base64
 import concurrent.futures
 import contextlib
 import difflib
+import freezegun
 import importlib
 import inspect
 import itertools
@@ -790,7 +791,7 @@ class TransactionCase(BaseCase):
     env: api.Environment = None
     cr: Cursor = None
     muted_registry_logger = mute_logger(odoo.modules.registry._logger.name)
-
+    freeze_time = None
 
     @classmethod
     def _gc_filestore(cls):
@@ -805,7 +806,6 @@ class TransactionCase(BaseCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-
         cls.addClassCleanup(cls._gc_filestore)
         cls.registry = odoo.registry(get_db_name())
         cls.registry_start_invalidated = cls.registry.registry_invalidated
@@ -840,6 +840,9 @@ class TransactionCase(BaseCase):
         cls.cr = cls.registry.cursor()
         cls.addClassCleanup(cls.cr.close)
 
+        if cls.freeze_time:
+            cls.startClassPatcher(freezegun.freeze_time(cls.freeze_time))
+
         def forbidden(*args, **kwars):
             traceback.print_stack()
             raise AssertionError('Cannot commit or rollback a cursor from inside a test, this will lead to a broken cursor when trying to rollback the test. Please rollback to a specific savepoint instead or open another cursor if really necessary')
@@ -865,7 +868,6 @@ class TransactionCase(BaseCase):
 
     def setUp(self):
         super().setUp()
-
         # restore environments after the test to avoid invoking flush() with an
         # invalid environment (inexistent user id) from another test
         envs = self.env.transaction.envs
@@ -2109,3 +2111,28 @@ def tagged(*tags):
             _logger.warning('A tests should be either at_install or post_install, which is not the case of %r', obj)
         return obj
     return tags_decorator
+
+
+class freeze_time:
+    """ Object to replace the freezegun in Odoo test suites
+        It properly handles the test classes decoration
+        Also, it can be used like the usual method decorator or context manager
+    """
+
+    def __init__(self, time_to_freeze):
+        self.freezer = None
+        self.time_to_freeze = time_to_freeze
+
+    def __call__(self, func):
+        if isinstance(func, MetaCase):
+            func.freeze_time = self.time_to_freeze
+            return func
+        else:
+            return freezegun.freeze_time(self.time_to_freeze)(func)
+
+    def __enter__(self):
+        self.freezer = freezegun.freeze_time(self.time_to_freeze)
+        return self.freezer.start()
+
+    def __exit__(self, *args):
+        self.freezer.stop()


### PR DESCRIPTION
Using freezegun.freeze_time decorator on a test class is discouraged.
This can lean to strange behaviors and faulty results because of the
lack of setUpClass cleanup.

With this commit, a `freeze_time` object is created in odoo test
common utilities to replace the freezegun one. It uses the real
freezegun under the hood but adds a patcher when used on a test class.

Also, it can handle most of the usages in Odoo, like the context manager
and the test method decorator. That way, the `import` from freezegun can
just be replaced by the odoo one when needed.
