### PR TITLE
[FIX] account : correct the wrong account groups hierarchy

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -964,13 +964,13 @@ class AccountGroup(models.Model):
                    AND parent.id != child.id
                    AND parent.company_id = child.company_id
                  WHERE child.company_id IN %s
-                   AND child.parent_id IS DISTINCT FROM parent.id -- IMPORTANT avoid to update if nothing changed
               ORDER BY child.id, char_length(parent.code_prefix_start) DESC
             )
             UPDATE account_group child
                SET parent_id = relation.parent_id
               FROM relation
              WHERE child.id = relation.child_id
+               AND child.parent_id IS DISTINCT FROM relation.parent_id
          RETURNING child.id
         """, tuple(company_ids))
         self.env.cr.execute(query)

--- a/addons/account/tests/test_account_account.py
+++ b/addons/account/tests/test_account_account.py
@@ -456,3 +456,32 @@ class TestAccountAccount(AccountTestInvoicingCommon):
             {'account_id': account.id,              'balance': 1000.0,  'amount_currency': 2000.0},
             {'account_id': account.id,              'balance': -1000.0, 'amount_currency': -2000.0},
         ])
+
+    def test_account_group_hierarchy_consistency(self):
+        """ Test if the hierarchy of account groups is consistent when creating, deleting and recreating an account group """
+        def create_account_group(name, code_prefix, company):
+            return self.env['account.group'].create({
+                'name': name,
+                'code_prefix_start': code_prefix,
+                'code_prefix_end': code_prefix,
+                'company_id': company.id
+            })
+
+        group_1 = create_account_group('group_1', 1, self.env.company)
+        group_10 = create_account_group('group_10', 10, self.env.company)
+        group_100 = create_account_group('group_100', 100, self.env.company)
+        group_101 = create_account_group('group_101', 101, self.env.company)
+
+        self.assertEqual(len(group_1.parent_id), 0)
+        self.assertEqual(group_10.parent_id, group_1)
+        self.assertEqual(group_100.parent_id, group_10)
+        self.assertEqual(group_101.parent_id, group_10)
+
+        # Delete group_101 and recreate it
+        group_101.unlink()
+        group_101 = create_account_group('group_101', 101, self.env.company)
+
+        self.assertEqual(len(group_1.parent_id), 0)
+        self.assertEqual(group_10.parent_id, group_1)
+        self.assertEqual(group_100.parent_id, group_10)
+        self.assertEqual(group_101.parent_id, group_10)


### PR DESCRIPTION
### Steps to reproduce:
- Activate developer mode
- Go in Accounting > Configuration > Accounting > Account Groups
- Create 4 account groups in a specific λ configuration, for example: 
 ```
2
   \
    21 
   /   \ 
210   211
```
- Go in Accounting > Reporting > Audit Reports > Trial Balance
- In options, select "Hierarchy and Subtotals" to see the hierarchy
- The hierarchy might be wrong or not, but each time recreating the 211 group, the hierarchy will switch between these two trees:
```
2                          2
  \                      /   \
    21       <-->      210   21
  /    \                       \
210    211                      211
```
### Cause:
The way the `parent_id` field is computed is by doing a [SQL query](https://github.com/odoo/odoo/blob/5c39004a1e37b35a47ed95933060c0aa5dd83803/addons/account/models/account_account.py#L954C9-L975C33) that will:
1. retrieve all combinations of (parent group, child group) for each child, for example [(2, 210), (21, 210)]
2. sort them in decreasing order of parent code_prefix_start length, for example [(21, 210), (2, 210)]
3. select only the first one : [(21, 210)]
4. change the `parent_id` field of the child according to the values retrieved

But a [performance improvement](https://github.com/odoo/odoo/commit/82714afa463adda2b404b4dae81a27423880e499) was applied that only selected the combinations that had `child.parent_id IS DISTINCT FROM parent.id` to avoid updating if nothing changed. This caused the retrieve combinations at step 2 to only be [(2, 210)] in the example. So when updating it breaks the hierarchy.

### Solution:
Filter the records to be updated in the UPDATE.

opw-4066976
