### PR TITLE
[FIX] account: Fixed invoice PDF layout

### DIFF
--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -377,7 +377,7 @@ class AccountMoveSend(models.TransientModel):
         if invoice.invoice_pdf_report_id:
             return
 
-        content, _report_format = self.env['ir.actions.report']._render('account.account_invoices', invoice.ids)
+        content, _report_format = self.env['ir.actions.report'].with_company(invoice.company_id)._render('account.account_invoices', invoice.ids)
 
         invoice_data['pdf_attachment_values'] = {
             'raw': content,
@@ -394,7 +394,7 @@ class AccountMoveSend(models.TransientModel):
         :param invoice:         An account.move record.
         :param invoice_data:    The collected data for the invoice so far.
         """
-        content, _report_format = self.env['ir.actions.report']._render('account.account_invoices', invoice.ids, data={'proforma': True})
+        content, _report_format = self.env['ir.actions.report'].with_company(invoice.company_id)._render('account.account_invoices', invoice.ids, data={'proforma': True})
 
         invoice_data['proforma_pdf_attachment_values'] = {
             'raw': content,


### PR DESCRIPTION
This commit ensures that creating an invoice PDF always uses the invoice company paperformat.

Invoice PDF could be generated in one of 2 ways (after clicking the invoice `send & print` button):
1. Non-cron: Either use a single invoice, or multiple invoices with the `download` option checked.
2. Cron: Create PDFs for multiple invoices with no `download` option.

The 2 ways would generate differently styled PDFs if the default company had a different paperformat from that of the invoice company.
This happened because the paperformat for cron-generated PDFs would be retrieved from the default company and not from the invoice company.

task-4046055


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
