### PR TITLE
[FIX] sale: Hide buttons below order lines on locked Sale Orders

### DIFF
--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -669,7 +669,7 @@
                             </kanban>
                         </field>
                         <div class="float-end d-flex gap-1 mb-2 ms-1"
-                             name="so_button_below_order_lines">
+                             name="so_button_below_order_lines" invisible="locked">
                             <button string="Discount"
                                     name="action_open_discount_wizard"
                                     type="object"

--- a/doc/cla/individual/fasilwdr.md
+++ b/doc/cla/individual/fasilwdr.md
@@ -1,0 +1,11 @@
+India, 2024-08-16
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Fasil | Python/Odoo Developer fasilwdr@hotmail.com https://github.com/fasilwdr


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
When a Sale Order is locked, it is still possible to add a discount, coupon code, rewards, or shipping. This behavior is inconsistent with the expected functionality, as locked orders should not be modifiable.

**Current behavior before PR:**
Users can add a discount, coupon code, rewards, and shipping to a Sale Order even when it is locked.

**Desired behavior after PR is merged:**
The buttons(`class="so_button_below_order_lines"`) for applying discounts, coupon codes, rewards, and shipping will be hidden when the Sale Order is locked, preventing any modifications and ensuring data integrity.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
