### PR TITLE
[FIX] account: Remove 'Unmerge Accounts' action that doesn't work

### DIFF
--- a/addons/account/views/account_account_views.xml
+++ b/addons/account/views/account_account_views.xml
@@ -195,17 +195,5 @@ if records:
     action = records.action_merge()
             </field>
         </record>
-        <record model="ir.actions.server" id="action_unmerge_accounts">
-            <field name="name">Unmerge account</field>
-            <field name="model_id" ref="model_account_account"/>
-            <field name="groups_id" eval="[(4, ref('account.group_account_manager'))]"/>
-            <field name="binding_model_id" ref="account.model_account_account" />
-            <field name="binding_view_types">form,tree</field>
-            <field name="state">code</field>
-            <field name="code">
-if record:
-    action = record.action_merge()
-            </field>
-        </record>
     </data>
 </odoo>


### PR DESCRIPTION
The 'Unmerge Accounts' feature was taken out during review of the company-shared-accounts feature. We plan to re-introduce it, however, for the time being we remove the server action that doesn't work.

taskid: 4119457