### PR TITLE
[FIX] l10n_es_pos: Prevent journal duplicate error

### DIFF
--- a/addons/l10n_es_pos/__init__.py
+++ b/addons/l10n_es_pos/__init__.py
@@ -9,13 +9,4 @@ def _l10n_es_pos_post_init_hook(env):
         pos_configs = env['pos.config'].search([
             *env['pos.config']._check_company_domain(company),
         ])
-        income_account = env.ref(f'account.{company.id}_account_common_7000', raise_if_not_found=False)
-        simplified_inv_journal = env['account.journal'].create({
-            'type': 'sale',
-            'name': _('Simplified Invoices'),
-            'code': 'SINV',
-            'default_account_id': income_account.id if income_account else False,
-            'company_id': company.id,
-            'sequence': 30,
-        })
-        pos_configs.l10n_es_simplified_invoice_journal_id = simplified_inv_journal
+        pos_configs.setup_defaults(company)


### PR DESCRIPTION
When the l10n_es_pos module is installed, the post_init_hook attempts to create an account journal for each Spanish company using a chart template. However, the method does not verify whether the journal already exists for the company, leading to potential duplication errors.

Steps to Reproduce:
- Create a journal for a Spanish company with the code 'SINV'.
- Install the Point of Sale module and the l10n_es_pos module.
- An error is raised because the journal 'SINV' already exists.

Solution:
This fix adds a check to ensure the journal does not already exist before attempting to create it.

opw-4108466
