### PR TITLE
[FIX] base: validate the translation import

### DIFF
--- a/odoo/addons/base/wizard/base_import_language_views.xml
+++ b/odoo/addons/base/wizard/base_import_language_views.xml
@@ -11,6 +11,7 @@
                         <field name="name" placeholder="e.g. English"/>
                         <field name="code" string="Code" placeholder="e.g. en_US"/>
                         <field name="data" filename="filename" options="{'accepted_file_extensions': '.csv,.po'}"/>
+                        <field name="filename" invisible="1"/>
                         <field name="overwrite" groups="base.group_no_one"/>
                     </group>
                     <footer>


### PR DESCRIPTION
This [commit](https://github.com/odoo/odoo/commit/5639ed865c5a3b82bab25b0ecac28c68c02e9306) broke the validation of the translation when importing: commit link. The filename field should not be removed.

Steps to reproduce:

- Enable developer mode on saas-17.4.
- Go to Settings > Translations > Import Translations.
- Import any translation file (.po).
- A validation error will arise, stating that the filename field is mandatory.

opw-4096366

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
