### PR TITLE
[FIX] hw_drivers: fallback old display detection method

### DIFF
--- a/addons/hw_drivers/iot_handlers/interfaces/DisplayInterface_L.py
+++ b/addons/hw_drivers/iot_handlers/interfaces/DisplayInterface_L.py
@@ -3,10 +3,14 @@
 
 import logging
 import os
+import subprocess
+
 try:
     import screeninfo
 except ImportError:
     screeninfo = None
+    import RPi.GPIO as GPIO
+    from vcgencmd import Vcgencmd
 
 from odoo.addons.hw_drivers.interface import Interface
 
@@ -19,31 +23,46 @@ class DisplayInterface(Interface):
 
     def get_devices(self):
         display_devices = {}
+        dummy_display = {
+            'distant_display': {
+                'identifier': 'distant_display',
+                'name': 'Distant Display',
+            }
+        }
 
         if screeninfo is None:
             # On IoT image < 24.10 we don't have screeninfo installed, so we can't get the connected displays
-            # We return a single display with x_screen = 0, to open a browser anyway, in case one is connected
-            display_identifier = 'hdmi_0'
-            display_devices[display_identifier] = {
-                'identifier': display_identifier,
-                'name': 'Display - ' + display_identifier,
-                'x_screen': '0',
-            }
-            return display_devices
+            # We use old method to get the connected display
+            hdmi_ports = {'hdmi_0': 2, 'hdmi_1': 7} if 'Pi 4' in GPIO.RPI_INFO.get('TYPE') else {'hdmi_0': 2}
+            try:
+                for x_screen, port in enumerate(hdmi_ports):
+                    if Vcgencmd().display_power_state(hdmi_ports.get(port)) == 'on':
+                        display_devices[port] = self._add_device(port, x_screen)
+            except subprocess.CalledProcessError:
+                _logger.warning('Vcgencmd "display_power_state" method call failed')
+
+            return display_devices or dummy_display
 
         try:
             os.environ['DISPLAY'] = ':0'
             for x_screen, monitor in enumerate(screeninfo.get_monitors()):
-                display_identifier = monitor.name
-                display_devices[display_identifier] = {
-                    'identifier': display_identifier,
-                    'name': 'Display - ' + display_identifier,
-                    'x_screen': str(x_screen),
-                }
+                display_devices[monitor.name] = self._add_device(monitor.name, x_screen)
+            return display_devices or dummy_display
         except screeninfo.common.ScreenInfoError:
             # If no display is connected, screeninfo raises an error, we return the distant display
-            display_devices['distant_display'] = {
-                'name': "Distant Display",
-            }
+            return dummy_display
 
-        return display_devices
+    @classmethod
+    def _add_device(cls, display_identifier, x_screen):
+        """Creates a display_device dict.
+
+        :param display_identifier: the identifier of the display
+        :param x_screen: the x screen number
+        :return: the display device dict
+        """
+
+        return {
+            'identifier': display_identifier,
+            'name': 'Display - ' + display_identifier,
+            'x_screen': str(x_screen),
+        }


### PR DESCRIPTION
In this PR: [https://github.com/odoo/odoo/pull/169633](https://github.com/odoo/odoo/pull/169633)
We updated the method to detect displays to use a safer and better maintained lib. 
For older images (<24.08), that don't have this lib, we chose to create a display anyway as a fallback in case people had one.

We now use the old method as a fallback of the new one to avoid creating a display and starting a browser instance if no screen is plugged in.

