### PR TITLE
[FIX] purchase_stock: round_base in price_unit 

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -492,7 +492,7 @@ class PurchaseOrderLine(models.Model):
         price_unit_prec = self.env['decimal.precision'].precision_get('Product Price')
         if self.taxes_id:
             qty = self.product_qty or 1
-            price_unit = self.taxes_id.with_context(round=False).compute_all(
+            price_unit = self.taxes_id.with_context(round=False, round_base=False).compute_all(
                 price_unit, currency=self.order_id.currency_id, quantity=qty, product=self.product_id, partner=self.order_id.partner_id
             )['total_void']
             price_unit = price_unit / qty


### PR DESCRIPTION
Ticket to Odoo: 4120204

Description of the issue/feature this PR addresses:

We found that when we changed quantities in an PO line with taxes, if the price_unit has a price with various digits (ex: 45,9457), when we change the quantity of the PO line, instead of changing quantities on the 'IN' picking, Odoo creates an OUT for the quantity difference with a rounded price_unit, different to the one in the PO or the 'IN' picking.

Desired behavior after PR is merged:

When changing the PO line quantities, It will modify the 'IN' picking quantities instead of creating an 'OUT' picking for those quantities

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
