### PR TITLE
[FIX] mail: isSubjectDefault thread name is false

### DIFF
--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -203,7 +203,8 @@ export class Message extends Record {
     }
 
     get isSubjectDefault() {
-        const threadName = this.thread?.name?.trim().toLowerCase();
+        const name = this.thread?.name;
+        const threadName = name ? name.trim().toLowerCase() : "";
         const defaultSubject = this.default_subject ? this.default_subject.toLowerCase() : "";
         const candidates = new Set([defaultSubject, threadName]);
         return candidates.has(this.subject?.toLowerCase());

--- a/addons/mail/static/tests/chatter/web/chatter.test.js
+++ b/addons/mail/static/tests/chatter/web/chatter.test.js
@@ -704,3 +704,17 @@ test("form views in dialogs do not have chatter", async () => {
     await contains(".o_dialog .o_form_view");
     await contains(".o-mail-Form-Chatter", { count: 0 });
 });
+
+test("should display the subject even if the record name is false", async () => {
+    const pyEnv = await startServer();
+    const fakeId = pyEnv["res.fake"].create({ name: false });
+    pyEnv["mail.message"].create({
+        body: "not empty",
+        model: "res.fake",
+        res_id: fakeId,
+        subject: "Salutations, voyageur",
+    });
+    await start();
+    await openFormView("res.fake", fakeId);
+    await contains(".o-mail-Message", { text: "Subject: Salutations, voyageurnot empty" });
+});


### PR DESCRIPTION
Steps to reproduce:
---
1. Install mass_mailing
2. Create a wrong outgoing mail server
3. ip 127.0.0.1 port 1234
4. Create a mailing list
5. Create a mailing list contact without name
6. Make the contact join the list
7. Create a mailing, set the new mailing list
8. Click on send > "1 email(s) not sent."
9. Open the mailing list contact
10. Traceback

Cause of the issue:
---
Caused by: https://github.com/odoo/odoo/commit/5102328c3dd6e4e751ca8f906e7bd16e190fc386 
`this.originThread?.name` can be `False` instead of `Undefined`

opw-4054564

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
