### PR TITLE
[FIX] point_of_sale: fix odoo restart on reboot

### DIFF
--- a/addons/point_of_sale/tools/posbox/configuration/wireless_ap.sh
+++ b/addons/point_of_sale/tools/posbox/configuration/wireless_ap.sh
@@ -58,10 +58,12 @@ if [ -z "${WIRED_IP}" ] ; then
 		ip addr add 10.11.12.1/24 dev wlan0
 
 		service dnsmasq restart
+		service odoo restart # As this file is executed on boot, this line is responsible for restarting odoo service on reboot
 	fi
 # wired
 else
 	killall nginx
 	service nginx restart
 	service dnsmasq stop
+	service odoo restart # As this file is executed on boot, this line is responsible for restarting odoo service on reboot
 fi


### PR DESCRIPTION
Odoo service could not restart after reboot as `service odoo restart` was missing in `wireless_ap.sh` file, which is called in `rc.local`.
