### PR TITLE
[16.0][FIX] account: Avoid resetting balance when amount currency is zero

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1125,7 +1125,7 @@ class AccountMoveLine(models.Model):
     @api.onchange('amount_currency', 'currency_id')
     def _inverse_amount_currency(self):
         for line in self:
-            if line.currency_id == line.company_id.currency_id and line.balance != line.amount_currency:
+            if line.currency_id == line.company_id.currency_id and line.balance != line.amount_currency and not line.currency_id.is_zero(line.amount_currency):
                 line.balance = line.amount_currency
             elif (
                 line.currency_id != line.company_id.currency_id


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Without this commit, in case a move line is created with a defined balance and an amount currency equals 0, an error will be raised due to the _check_balanced constraint.

This happens, because credit / debit are first computed based on the defined balance, but the _inverse_amount_currency function will then reset the balance to 0, what will raise an error due to wrongly unbalanced moves.

Current behavior before PR:

An error is raised.

Desired behavior after PR is merged:

No error is raised.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
