### PR TITLE
[FIX] project_timesheet_holidays: can't set timesheet_task_id when install module

### DIFF
--- a/addons/project_timesheet_holidays/__init__.py
+++ b/addons/project_timesheet_holidays/__init__.py
@@ -13,12 +13,6 @@ def post_init(cr, registry):
     from odoo import api, SUPERUSER_ID
 
     env = api.Environment(cr, SUPERUSER_ID, {})
-    for hr_leave_type in env['hr.leave.type'].search([('timesheet_generate', '=', True), ('timesheet_project_id', '=', False)]):
-        company = hr_leave_type.company_id or env.company
-        hr_leave_type.write({
-            'timesheet_project_id': company.internal_project_id.id,
-            'timesheet_task_id': company.leave_timesheet_task_id.id,
-        })
 
     type_ids_ref = env.ref('hr_timesheet.internal_project_default_stage', raise_if_not_found=False)
     type_ids = [(4, type_ids_ref.id)] if type_ids_ref else []
@@ -54,3 +48,10 @@ def post_init(cr, registry):
             company.write({
                 'leave_timesheet_task_id': task.id,
             })
+
+    for hr_leave_type in env['hr.leave.type'].search(['|', ('timesheet_project_id', '=', False), ('timesheet_task_id', '=', False)]):
+        company = hr_leave_type.company_id or env.company
+        hr_leave_type.write({
+            'timesheet_project_id': company.internal_project_id.id,
+            'timesheet_task_id': company.leave_timesheet_task_id.id,
+        })


### PR DESCRIPTION
* PROPBLEM: since https://github.com/odoo/odoo/pull/173719 we have moved from init to post_init which will make timesheet_task_id of hr.leave.type can't set value because in post_init company.leave_timesheet_task_id will be set

* SOLUTION: fill it in post_init instead

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
