### PR TITLE
[FIX] html_editor: load records consistently

### DIFF
--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -81,6 +81,7 @@ export class HtmlField extends Component {
                 this.state.containsComplexHTML = computeContainsComplexHTML(
                     record.data[this.props.name]
                 );
+                this.lastValue = record.data[this.props.name].toString();
             }
         });
         useRecordObserver((record) => {


### PR DESCRIPTION
This commit fixes an issue with the new html_editor which doesn't consistently load records in the 'mail.composer.message' wizard.

Inside this wizard, you can load mail templates and save new ones. The issue occurs when a user creates a brand new template, then loads another template and come back to the newly created one.

The subject is correctly changed when changing records but the body, linked to the editor, doesn't change value.
This is caused by the lastValue not being refreshed when switching records so when the newly created record is loaded, the body doesn't update.

task-4116599

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
