### PR TITLE
[FIX] purchase_mrp: round total cost_share to precision

### DIFF
--- a/addons/purchase_mrp/models/mrp_bom.py
+++ b/addons/purchase_mrp/models/mrp_bom.py
@@ -3,6 +3,7 @@
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
+from odoo.tools import float_compare
 
 
 class MrpBom(models.Model):
@@ -16,7 +17,7 @@ class MrpBom(models.Model):
                 continue
             if any(bl.cost_share < 0 for bl in bom.bom_line_ids):
                 raise UserError(_("Components cost share have to be positive or equals to zero."))
-            if sum(bom.bom_line_ids.mapped('cost_share')) != 100:
+            if float_compare(sum(bom.bom_line_ids.mapped('cost_share')), 100, precision_digits=2) != 0:
                 raise UserError(_("The total cost share for a BoM's component have to be 100"))
         return res
 

--- a/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
+++ b/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
@@ -1021,3 +1021,25 @@ class TestPurchaseMrpFlow(AccountTestInvoicingCommon):
         svl = po.picking_ids[0].move_ids.stock_valuation_layer_ids
         self.assertEqual(svl[0].unit_cost, 67.5)
         self.assertEqual(svl[1].unit_cost, 135000000)
+
+    def test_total_cost_share_rounded_to_precision(self):
+        kit, compo01, compo02 = self.env['product.product'].create([{
+            'name': name,
+            'standard_price': price,
+            'type': 'product',
+        } for name, price in [('Kit', 30), ('Compo 01', 10), ('Compo 02', 20)]])
+
+        bom = self.env['mrp.bom'].create({
+            'product_tmpl_id': kit.product_tmpl_id.id,
+            'type': 'phantom',
+            'bom_line_ids': [(0, 0, {
+                'product_id': compo01.id,
+                'product_qty': 1,
+                'cost_share': 99.99,
+            }), (0, 0, {
+                'product_id': compo02.id,
+                'product_qty': 1,
+                'cost_share': 0.01,
+            })],
+        })
+        self.assertTrue(bom)


### PR DESCRIPTION
## Issue:
- When creating a kit BoM with two components that the total  of their cost share is 100, we get this UserError when saving:  'The total cost share for a BoM's components has to be 100%.'"

## Steps To Reproduce:
- Create a BoM of type Kit.
- Add 2 components.
- Set their cost shares to 99.99 and 0.01.
- Save and Notice the error: "The total cost share for a BoM's component have to be 100"

## Solution:
- After saving, the [`float_round`](https://github.com/odoo/odoo/blob/048ed950ad32187a8e7ae7811a5afc87d9ce8ac8/odoo/tools/float_utils.py#L35) method is eventually called. When it reaches the line [`result = rounded_value * rounding_factor`](https://github.com/odoo/odoo/blob/048ed950ad32187a8e7ae7811a5afc87d9ce8ac8/odoo/tools/float_utils.py#L113) with `rounded_value = 9999.0` and `rounding_factor = 0.01`,  it returns `99.99000001`.
- A possible fix is to modify the `float_round` method to include a condition before returning the result:
    ``` python
    if precision_digits or precision_rounding:
           decimal_places = precision_digits or len(str(precision_rounding).split('.')[1])
           return round(result, decimal_places)```
- However, I believe it might be too low-level, so I kept it simple by rounding the `bom.lines` before summing them and returning the UserError`.

opw-4100375
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
