### PR TITLE
[FIX] delivery_stock_picking_batch,stock_delivery: calc weight for batch

### DIFF
--- a/addons/delivery_stock_picking_batch/tests/__init__.py
+++ b/addons/delivery_stock_picking_batch/tests/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_delivery_picking_batch

--- a/addons/delivery_stock_picking_batch/tests/test_delivery_picking_batch.py
+++ b/addons/delivery_stock_picking_batch/tests/test_delivery_picking_batch.py
@@ -1,0 +1,60 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import Command
+from odoo.tests import common, tagged
+
+
+@tagged('-at_install', 'post_install')
+class TestDeliveryPickingBatch(common.TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.picking_type_out = cls.env.ref('stock.picking_type_out')
+        cls.local_delivery_carrier = cls.env.ref('delivery.delivery_local_delivery')
+        cls.stock_location = cls.env.ref('stock.stock_location_stock')
+        cls.customer_location = cls.env.ref('stock.stock_location_customers')
+
+        cls.package_type = cls.env['stock.package.type'].create({
+            'name': 'normal package',
+            'base_weight': 1.0,
+        })
+
+        cls.product_a = cls.env['product.product'].create({
+            'name': 'product_a',
+            'type': 'product',
+            'weight': 1.0,
+        })
+
+    def test_batch_picking_pack_shipping_weight_compute(self):
+        """ Having a batch transfer with 2+ of the same product across multiple pickings and adding
+        the products to the same pack should result in an accurate computed shipping weight.
+        """
+        picking_create_vals = {
+            'picking_type_id': self.picking_type_out.id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'carrier_id': self.local_delivery_carrier.id,
+        }
+
+        batch = self.env['stock.picking.batch'].create({
+            'picking_ids': [Command.create(picking_create_vals) for _ in range(2)],
+        })
+
+        for picking in batch.picking_ids:
+            picking.move_ids = self.env['stock.move'].create({
+                'name': 'TBPPSWC move',
+                'product_id': self.product_a.id,
+                'product_uom_qty': 1.0,
+                'location_id': self.stock_location.id,
+                'location_dest_id': self.customer_location.id,
+            })
+            picking.move_ids[0].quantity = 1.0
+
+        pack_wizard_vals = batch.action_put_in_pack()
+        pack_wizard = self.env[(pack_wizard_vals.get('res_model'))].with_context(pack_wizard_vals.get('context')).create({})
+        pack_wizard.delivery_package_type_id = self.package_type.id
+        self.assertEqual(pack_wizard.shipping_weight, 3.0)
+        package = pack_wizard.action_put_in_pack()
+        batch.action_done()
+        self.assertEqual(package.weight, 3.0)

--- a/addons/stock_delivery/tests/test_packing_delivery.py
+++ b/addons/stock_delivery/tests/test_packing_delivery.py
@@ -67,6 +67,7 @@ class TestPacking(TestPackingCommon):
             'quantity': 5,
             'location_id': self.stock_location.id,
             'location_dest_id': self.customer_location.id,
+            'picked': True,
         })
         pack_action = picking_ship.action_put_in_pack()
         pack_action_ctx = pack_action['context']

--- a/addons/stock_delivery/wizard/choose_delivery_package.py
+++ b/addons/stock_delivery/wizard/choose_delivery_package.py
@@ -1,7 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
-from odoo.tools import float_compare
 
 
 class ChooseDeliveryPackage(models.TransientModel):
@@ -23,10 +22,8 @@ class ChooseDeliveryPackage(models.TransientModel):
     @api.depends('delivery_package_type_id')
     def _compute_shipping_weight(self):
         for rec in self:
-            move_line_ids = rec.picking_id.move_line_ids.filtered(lambda m:
-                m.picked or not m.move_id.picked
-                and float_compare(m.quantity, 0.0, precision_rounding=m.product_uom_id.rounding) > 0
-                and not m.result_package_id
+            move_line_ids = rec.picking_id._package_move_lines(
+                batch_pack=self.env.context.get('batch_pack')
             )
             # Add package weights to shipping weight, package base weight is defined in package.type
             total_weight = rec.delivery_package_type_id.base_weight or 0.0


### PR DESCRIPTION
**Current behavior:**
Having a batch transfer with 2+ delivery pickings, opening the choose package wizard and filling out the package type will not accurately display the shipping weight for the whole batch.

**Expected behavior:**
The weight displayed on the wizard form should reflect the weight of the package plus all product that will be put inside it from the batch.

**Steps to reproduce:**
1. Enable packs in settings, create a package type with a base weight of 1 unit and some product with a weight of 1 unit

2. Create two delivery transfers with some carrier (e.g, local delivery) each with 1 of the created product

3. Add the two pickings to a new batch, on the batch click the `Put in Pack` button and select the created package type

4. Observe that in the form, only one of the products from the batch transfer has been used to calculate the shipping weight

**Cause of the issue:**
In `shipping_weight`'s compute function in the
`ChooseDeliveryPackage` wizard, we don't account for a batch package (like what is done in `action_put_in_pack()` defined on this wizard). Thus, one of the move lines in the batch is not used in the weight calculation.

**Fix:**
Look at the context to see if the user is packing a batch and if so, get all the involved move lines from it.

opw-4077546