### PR TITLE
[FIX] account: Fix bill reversing default bank

### DIFF
--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -1242,7 +1242,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
 
         bank1 = self.env['res.partner.bank'].create({
             'acc_number': 'BE43798822936101',
-            'partner_id': self.partner_a.id,
+            'partner_id': self.company_data['company'].partner_id.id,
         })
 
         move_reversal = self.env['account.move.reversal'].with_context(active_model="account.move", active_ids=self.invoice.ids).create({

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -1936,6 +1936,11 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
     def test_out_invoice_create_refund(self):
         self.invoice.action_post()
 
+        bank1 = self.env['res.partner.bank'].create({
+            'acc_number': 'BE43798822936101',
+            'partner_id': self.partner_a.id,
+        })
+
         move_reversal = self.env['account.move.reversal'].with_context(active_model="account.move", active_ids=self.invoice.ids).create({
             'date': fields.Date.from_string('2019-02-01'),
             'reason': 'no reason',
@@ -1997,6 +2002,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             'state': 'draft',
             'ref': 'Reversal of: %s, %s' % (self.invoice.name, move_reversal.reason),
             'payment_state': 'not_paid',
+            'partner_bank_id': bank1.id,
         })
 
         move_reversal = self.env['account.move.reversal'].with_context(active_model="account.move", active_ids=self.invoice.ids).create({

--- a/addons/account/wizard/account_move_reversal.py
+++ b/addons/account/wizard/account_move_reversal.py
@@ -113,15 +113,21 @@ class AccountMoveReversal(models.TransientModel):
         moves = self.move_ids
 
         # Create default values.
+        partners = moves.company_id.partner_id + moves.commercial_partner_id
+
         bank_ids = self.env['res.partner.bank'].search([
-            ('partner_id', 'in', moves.commercial_partner_id.ids),
+            ('partner_id', 'in', partners.ids),
             ('company_id', 'in', moves.company_id.ids + [False]),
         ], order='sequence DESC')
         partner_to_bank = {bank.partner_id: bank for bank in bank_ids}
         default_values_list = []
         for move in moves:
+            if move.is_outbound():
+                partner = move.company_id.partner_id
+            else:
+                partner = move.commercial_partner_id
             default_values_list.append({
-                'partner_bank_id': partner_to_bank.get(move.commercial_partner_id, self.env['res.partner.bank']).id,
+                'partner_bank_id': partner_to_bank.get(partner, self.env['res.partner.bank']).id,
                 **self._prepare_default_reversal(move),
             })
 


### PR DESCRIPTION
Problem
---------
With commit c1ea29ea79ad074aae750d26496fc6ce22cffb54, we fixed the following problem:

when reversing an invoice, the current company is used as recipient bank and not the customer's one.

However, that fix did only took into concideration reversing invoices and not bills. This commit is here to fix that.

When reversing a BILL (in_invoice), we use the company's bank. When reversing an INVOICE (out_invoice), we use the commercial partner's bank.

opw-4035448

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
