### PR TITLE
[FIX] pos_restaurant: runbot error 75426

### DIFF
--- a/addons/point_of_sale/static/tests/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/chrome_util.js
@@ -49,7 +49,7 @@ export function isSyncStatusConnected() {
 export function clickPlanButton() {
     return {
         content: "go back to the floor screen",
-        trigger: ".pos-leftheader .back-button",
+        trigger: ".pos-leftheader .back-button:not(:has(.btn-primary))",
         run: "click",
     };
 }

--- a/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.xml
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.xml
@@ -19,7 +19,7 @@
                         <span t-if="!ui.isSmall">Plan</span>
                         <img t-else="" src="/pos_restaurant/static/img/plan.svg" class="navbar-icon" alt="Floor Plan"/>
                     </button>
-                    <button class="btn btn-lg lh-lg" t-att-class="{'btn-primary': screen === 'ProductScreen'}" t-on-click="() => this.switchTable()">
+                    <button class="table-free-order-label btn btn-lg lh-lg" t-att-class="{'btn-primary': screen === 'ProductScreen'}" t-on-click="() => this.switchTable()">
                         <span t-if="pos.get_order()" t-esc="pos.get_order().table_id?.table_number || pos.get_order().getFloatingOrderName()"/>
                         <span t-elif="!ui.isSmall">Table</span>
                         <img t-else="" src="/pos_restaurant/static/img/table.svg" class="navbar-icon" alt="Table Selector"/>

--- a/addons/pos_restaurant/static/tests/tours/control_buttons_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/control_buttons_tour.js
@@ -10,6 +10,12 @@ import * as Order from "@point_of_sale/../tests/tours/utils/generic_components/o
 import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
 import { registry } from "@web/core/registry";
 
+function activeTableIs(tableNumber) {
+    return {
+        trigger: `.table-free-order-label:contains("${tableNumber}")`,
+    };
+}
+
 registry.category("web_tour.tours").add("ControlButtonsTour", {
     test: true,
     steps: () =>
@@ -17,11 +23,15 @@ registry.category("web_tour.tours").add("ControlButtonsTour", {
             // Test TransferOrderButton
             Dialog.confirm("Open session"),
             FloorScreen.clickTable("2"),
+            activeTableIs("2"),
             ProductScreen.addOrderline("Water", "5", "2", "10.0"),
             ProductScreen.clickControlButton("Transfer"),
             FloorScreen.clickTable("4"),
+            activeTableIs("4"),
+            Order.hasLine({ productName: "Water", withClass: ".selected" }),
             Chrome.clickPlanButton(),
             FloorScreen.clickTable("2"),
+            activeTableIs("2"),
             ProductScreen.orderIsEmpty(),
             Chrome.clickPlanButton(),
             FloorScreen.isShown(),


### PR DESCRIPTION
Before proceeding to any step after selecting a table, we make sure
that the table-label corresponds to the selected table.

Furthermore, to go back to the FloorScreen, the Plan button should be inactive
before clicking it otherwise the click won't be taken into account because the
moment it's click and it's active, the current screen is still the FloorScreen.