### PR TITLE
[IMP] point_of_sale: change orderline qty display

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.xml
@@ -21,7 +21,8 @@
                 </div>
                 <ul class="info-list small d-flex flex-column small">
                     <li class="price-per-unit">
-                        <span class="qty px-1 border rounded text-bg-view fw-bolder me-1">x<t t-esc="line.qty"/></span>
+                        <span class="qty px-1 border rounded text-bg-view fw-bolder me-1" t-esc="line.qty"/>
+                        x
                         <t t-if="line.price !== 0">
                             <s t-esc="line.oldUnitPrice" t-if="line.oldUnitPrice" />
                             <t t-esc="line.unitPrice" />

--- a/addons/point_of_sale/static/tests/tours/utils/generic_components/order_widget_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/generic_components/order_widget_util.js
@@ -38,7 +38,7 @@ export function hasLine({
         trigger += `:has(.product-name:contains("${productName}"))`;
     }
     if (quantity) {
-        trigger += `:has(.qty:contains("x${quantity}"))`;
+        trigger += `:has(.qty:contains("${quantity}"))`;
     }
     if (price) {
         trigger += `:has(.price:contains("${price}"))`;


### PR DESCRIPTION
Currently on the orderline the quantity is shown as `x qty $unitPrice / unit`. We are now changing this to the more intuitive `qty x $unitPrice / unit`

Task: 4122347

![image](https://github.com/user-attachments/assets/4efefb4b-2fc1-4d04-bd92-5f3c8b833868)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
