### PR TITLE
[IMP] website_sale: review product page breadcrumb

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -204,6 +204,18 @@ $input-border-color: $gray-400;
             max-width: $o-wsale-dropdown-width-overflow;
         }
     }
+
+    // Remove the breadcrumb splitter '/' on small devices
+    // since show only 1 entry on the product page.
+    @include media-breakpoint-down(lg) {
+        .o_wsale_breadcrumb .breadcrumb-item {
+            padding-left: 0;
+
+            &::before {
+                content: "";
+            }
+        }
+    }
 }
 
 #product_detail ~ .oe_structure.oe_empty > section:first-child {

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1190,36 +1190,55 @@
                 <t t-set="editor_message">DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PRODUCTS</t>
                 <div class="oe_structure oe_empty oe_structure_not_nearest" id="oe_structure_website_sale_product_1" t-att-data-editor-message="editor_message"/>
                 <section id="product_detail"
-                         t-attf-class="container py-4 oe_website_sale #{'discount' if combination_info['has_discounted_price'] else ''}"
+                         t-attf-class="oe_website_sale container my-3 my-lg-4 #{'discount'
+                            if combination_info['has_discounted_price'] else ''}"
                          t-att-data-view-track="view_track and '1' or '0'"
                          t-att-data-product-tracking-info="'product_tracking_info' in combination_info and json.dumps(combination_info['product_tracking_info'])"
                 >
                     <div class="row align-items-center">
-                        <div class="col-lg-6 d-flex align-items-center">
+                        <div class="col d-flex align-items-center order-1 order-lg-0">
+                            <ol class="o_wsale_breadcrumb breadcrumb p-0 mb-4 m-lg-0">
+                                <li class="o_not_editable breadcrumb-item d-none d-lg-inline-block">
+                                    <a t-att-href="keep(category=0, attribute_value=0, tags=0)">
+                                        <i class="oi oi-chevron-left d-lg-none me-1" role="presentation"/>All Products
+                                    </a>
+                                </li>
+                                <li
+                                    t-nocache="The category does not have to be cached, as the product can be accessed via different paths."
+                                    t-if="category"
+                                    class="breadcrumb-item"
+                                >
+                                    <a
+                                        class="py-2 py-lg-0"
+                                        t-att-href="keep('/shop/category/%s' % slug(category), category=0, attribute_value=0, tags=0)"
+                                    >
+                                        <i class="oi oi-chevron-left d-lg-none me-1" role="presentation"/><t t-out="category.name"/>
+                                    </a>
+                                </li>
+                                <li t-else="" class="o_not_editable breadcrumb-item d-lg-none">
+                                    <a
+                                        class="py-2 py-lg-0"
+                                        t-att-href="keep(category=0, attribute_value=0, tags=0)"
+                                    >
+                                        <i class="oi oi-chevron-left me-1" role="presentation"/>All Products
+                                    </a>
+                                </li>
+                                <li class="breadcrumb-item d-none d-lg-inline-block active">
+                                    <span t-field="product.name" />
+                                </li>
+                            </ol>
+                        </div>
+                        <div class="col-lg-4 d-flex align-items-center">
                             <div class="d-flex justify-content-between w-100">
                                 <t t-if="is_view_active('website_sale.search')" t-call="website_sale.search">
                                     <t t-set="search" t-value="False"/>
-                                    <t t-set="_form_classes" t-valuef="mb-2 mb-lg-0"/>
+                                    <t t-set="_form_classes" t-valuef="mb-4 mb-lg-0"/>
                                     <t t-set="_classes" t-value="'me-sm-2'"/>
                                 </t>
                                 <t t-call="website_sale.pricelist_list">
                                     <t t-set="_classes" t-valuef="d-lg-inline ms-2"/>
                                 </t>
                             </div>
-                        </div>
-                        <div class="col-lg-6 d-flex align-items-center">
-                            <ol class="breadcrumb p-0 mb-2 m-lg-0">
-                                <li class="breadcrumb-item o_not_editable">
-                                    <a t-att-href="keep(category=0, attribute_value=0, tags=0)">All Products</a>
-                                </li>
-                                <li t-nocache="The category does not have to be cached, as the product can be accessed via different paths."
-                                    t-if="category" class="breadcrumb-item">
-                                    <a t-att-href="keep('/shop/category/%s' % slug(category), category=0, attribute_value=0, tags=0)" t-field="category.name" />
-                                </li>
-                                <li class="breadcrumb-item active">
-                                    <span t-field="product.name" />
-                                </li>
-                            </ol>
                         </div>
                     </div>
                     <div class="row" id="product_detail_main" data-name="Product Page"

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -503,8 +503,8 @@
 
     <template id="website_sale.sort" name="Sort-by Template">
         <div t-attf-class="o_sortby_dropdown dropdown dropdown_sorty_by {{_classes}}">
-            <small class="d-none d-lg-inline text-muted">Sort By:</small>
             <a role="button" href="#" t-attf-class="dropdown-toggle btn btn-{{navClass}}" data-bs-toggle="dropdown">
+                <small class="d-none d-lg-inline text-muted">Sort By:</small>
                 <span class="d-none d-lg-inline">
                     <t t-if="isSortingBy" t-out="isSortingBy[0][1]"/>
                     <span t-else="1" t-field="website.shop_default_sort"/>


### PR DESCRIPTION
This commit aims to improve the navigation consistency between /shop,
subcategories, and /product page.

Product page:
- Swapping breadcrumb and searchbar for consistency
- Review spacing

Minor fix on shop page:
- "Sort by" inside the filter dropdown

task-3986938
part of task-3986921

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
