### PR TITLE
[FIX] web_editor: save target change in ir_ui_view link

### DIFF
--- a/addons/web_editor/models/ir_ui_view.py
+++ b/addons/web_editor/models/ir_ui_view.py
@@ -216,7 +216,7 @@ class IrUiView(models.Model):
 
     @api.model
     def _get_allowed_root_attrs(self):
-        return ['style', 'class']
+        return ['style', 'class', 'target']
 
     def replace_arch_section(self, section_xpath, replacement, replace_tail=False):
         # the root of the arch section shouldn't actually be replaced as it's


### PR DESCRIPTION
Steps to reproduce the issue:
=============================
- Install website and events
- Go to events page and enable editor
- Click on customize and enable sidebar
- enable Follow us option
- Select a social media icon and enable open in a new window option
- Save
- Click on the updated icon, it still opens in the same page => the changes aren't saved.

Origin of the issue:
====================
The `target` attribute was ignored when saving and `arch_section`.

Solution
========
Add `target` attribute to the allowed root attrs.

opw-4077657