### PR TITLE
[FIX] base, tools: fix the behaviour of inline translated elements

### DIFF
--- a/odoo/addons/base/tests/test_translate.py
+++ b/odoo/addons/base/tests/test_translate.py
@@ -329,6 +329,46 @@ class TranslationToolsTestCase(BaseCase):
         result = html_translate(lambda term: term, source)
         self.assertEqual(result, source)
 
+    def test_force_inline_translation(self):
+        """ Test xml_translate() with elements translated as a whole (using the
+            `o_translate_inline` class).
+        """
+        terms = []
+        source = """<form>
+                        <p>{}</p>
+                    </form>""".format
+        content_v1 = """<span class="o_text_highlight o_text_highlight_wavy {}">
+                        Go to the <a href="/contactus">Contact Us</a> page
+                    </span>""".format
+        content_v2 = """<span class="o_text_highlight o_text_highlight_wavy {}">
+                        <a href="/contactus">Contact Us</a>
+                    </span>""".format
+
+        source_v1 = source(content_v1(''))
+        source_inline_v1 = source(content_v1('o_translate_inline'))
+        source_inline_v2 = source(content_v2('o_translate_inline'))
+
+        # Translate an element without the `o_translate_inline` modifier.
+        result_1 = xml_translate(terms.append, source_v1)
+        self.assertEqual(result_1, source_v1)
+        self.assertItemsEqual(terms, ['Go to the', 'Contact Us', 'page'])
+
+        # Translate an element that has a non-"inline-translated" child
+        # amongst its text content.
+        terms = []
+        result_inline = xml_translate(terms.append, source_inline_v1)
+        self.assertEqual(result_inline, source_inline_v1)
+        # The `o_translate_inline` element should be translated as a whole.
+        self.assertItemsEqual(terms, [content_v1('o_translate_inline')])
+
+        # Translate an element that contains only a non-"inline-translated"
+        # child element.
+        terms = []
+        result_inline = xml_translate(terms.append, source_inline_v2)
+        self.assertEqual(result_inline, source_inline_v2)
+        # The `o_translate_inline` element should be translated as a whole.
+        self.assertItemsEqual(terms, [content_v2('o_translate_inline')])
+
 
 class TestLanguageInstall(TransactionCase):
     def test_language_install(self):

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -221,6 +221,7 @@ def translate_xml_node(node, callback, parse, serialize):
             # hierarchy breaks their functionalities. We need to force them to
             # be translated as a whole using the `o_translate_inline` class.
             "o_translate_inline" in node.attrib.get("class", "").split()
+            or bool(node.xpath("ancestor::*[contains(@class, 'o_translate_inline')]"))
             or node.tag in TRANSLATED_ELEMENTS
             and not any(key.startswith("t-") for key in node.attrib)
             and all(translatable(child) for child in node)


### PR DESCRIPTION
[FIX] base, tools: fix the behaviour of inline translated elements
Steps to reproduce:

- Go to a website page (in "Edit" mode) > Add a "Title" snippet.

- Select the whole "title" > Set a highlight effect on it.

- With the same text selected, transform it to a link and save.

- Try to translate the title into another language in the editor > You
cannot update the text or remove it.

The code from [1] introduced a feature that allows forcing some specific
elements to be "translated inline" using the `o_translate_inline` class.

It was used mainly to handle specific cases where elements DOM is
handled in JS in a way that breaks the "Translate" editor (e.g., text
highlights).

By forcing the highlight `<span/>`s to be inline translated, the fix
from [1] only handled situations where a highlight effect has a non-
"inline-translated" element (e.g., a link) amongst its text content.

E.g. This DOM structure:

```
<span class="o_text_highlight o_text_highlight_wavy o_translate_inline">
    Go to the <a href="/contactus">Contact Us</a> page
</span>
```

Which caused the translation `<span/>` to be set inside the highlight
structure [A].

Now, as explained in the steps above, there are some cases like with
this DOM:

```
<span class="o_text_highlight o_text_highlight_wavy o_translate_inline">
    <a href="/contactus">Contact Us</a>
</span>
```

That will make the translation code check the inner non-"inline
translated" children even within a `o_translate_inline` parent (see:
`translate_xml_node()` > `hastext()` | `process()`), leading to the
same issue as [A].

The goal of this commit is to prevent any similar situation causing the
translation spans to be added inside elements forced to be translated
as a whole, by automatically considering all elements inside a
`o_translate_inline` parent as inline translated too.

This commit also adds a test for the explained behavior.

[1]: https://github.com/odoo/odoo/commit/e9659e55356e5e4de63f2324eb88a7b6f07cd835

opw-4243639

linked to: opw-3980975
linked to: opw-4089482
linked to: opw-4061566