### PR TITLE
[FIX] pos_restaurant: no need for transfer, merge options

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/alert_service.js
+++ b/addons/point_of_sale/static/src/app/generic_components/alert_service.js
@@ -3,7 +3,7 @@ import { registry } from "@web/core/registry";
 
 class Alert extends Component {
     static template = xml`
-        <div t-attf-class="alert fixed-top p-1 rounded-0 alert-{{props.type}} fade show d-flex align-items-center justify-content-center" role="alert" style="height:48px">
+        <div t-attf-class="alert navbar-height fixed-top p-1 rounded-0 alert-{{props.type}} fade show d-flex align-items-center justify-content-center" role="alert">
             <strong class="flex-grow-1 text-center" t-esc="props.message" />
         </div>
     `;

--- a/addons/point_of_sale/static/src/app/navbar/navbar.scss
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.scss
@@ -5,6 +5,10 @@
     }
 }
 
+.navbar-height {
+    height: $navbar-height;
+}
+
 .pos-centerheader {
     width: 10%;
 }

--- a/addons/point_of_sale/static/src/app/navbar/navbar.xml
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.xml
@@ -19,8 +19,7 @@
             <div t-if="!ui.isSmall"  class="pos-centerheader d-flex justify-content-center">
                 <img class="pos-logo pos-logo mw-100" height="42" t-on-click="() => debug.toggleWidget()" src="/web/static/img/logo.png" alt="Logo" />
             </div>
-            <div t-if="pos.shouldShowNavbarButtons()"
-                class="pos-rightheader d-flex justify-content-end"
+            <div class="pos-rightheader d-flex justify-content-end"
                 t-att-class="{ 'ms-auto': !ui.isSmall, 'me-1 position-absolute end-0 width-100 pos-nav-small': ui.isSmall }"
             >
                 <div class="status-buttons d-flex flex-grow-1 align-items-center justify-content-end gap-1">

--- a/addons/point_of_sale/static/src/app/navbar/navbar.xml
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="point_of_sale.Navbar">
-        <div class="pos-topheader d-flex align-items-center justify-content-between px-2 py-1 m-0 bg-white border-bottom">
+        <div class="pos-topheader navbar-height d-flex align-items-center justify-content-between px-2 py-1 m-0 bg-white border-bottom">
             <div class="pos-leftheader d-flex">
                 <t t-if="showTabs()">
                     <div t-attf-class=" d-flex overflow-x-auto {{ ui.isSmall ? 'flex-shrink-0' : 'flex-shrink-1'}}">

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1457,9 +1457,6 @@ export class PosStore extends Reactive {
             this.redirectToBackend();
         }
     }
-    shouldShowNavbarButtons() {
-        return true;
-    }
     async selectPricelist(pricelist) {
         await this.get_order().set_pricelist(pricelist);
     }

--- a/addons/point_of_sale/static/src/scss/pos_variables_extra.scss
+++ b/addons/point_of_sale/static/src/scss/pos_variables_extra.scss
@@ -1,3 +1,3 @@
 $left-pane-width: 500px !default;
 $left-pane-width-tablet: 400px !default;
-$navbar-height: 50px !default;
+$navbar-height: 61px !default;

--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
@@ -82,18 +82,6 @@
                         <i t-else="" class="fa fa-floppy-o" role="img" aria-label="Save" title="Save"/>
                     </button>
                 </div>
-                <div t-if="pos.orderToTransferUuid" class="d-flex align-items-center justify-content-between px-3 gap-2 border-bottom bg-view overflow-x-auto">
-                    <button t-attf-class="ms-auto {{editButtonClass}} btn-outline-secondary lh-lg" t-att-class="{active: !pos.isTableToMerge}" t-on-click="() => this.pos.isTableToMerge = false">
-                        <i class="fa fa-arrow-right me-2" role="img" aria-label="Transfer" title="Transfer" />Transfer</button>
-                    <button
-                        t-if="pos.models['pos.order'].find(o => o.uuid === pos.orderToTransferUuid).table_id"
-                        t-attf-class="{{editButtonClass}} btn-outline-secondary lh-lg" t-att-class="{active: pos.isTableToMerge}"
-                        t-on-click="() => this.pos.isTableToMerge = true">
-                        <i class="fa fa-link me-2" role="img" aria-label="Merge" title="Merge" />Merge</button>
-                    <button class="btn btn-primary btn-lg lh-lg ms-2" t-on-click.stop="stopOrderTransfer">
-                        Discard
-                    </button>
-                </div>
             </div>
             <div t-ref="floor-map-scroll" class="overflow-auto flex-grow-1 flex-shrink-1 flex-basis-0 w-auto" t-attf-style="background: {{activeFloor?.background_color}}"> 
                 <div t-on-click="onClickFloorMap" t-on-touchstart="_onPinchStart" t-on-touchmove="_onPinchMove" t-on-touchend="_onPinchEnd"

--- a/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.xml
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.xml
@@ -15,12 +15,12 @@
             <div t-if="pos.config.module_pos_restaurant" class="d-flex flex-shrink-0 gap-1 position-relative">
                <div class="navbar-menu d-flex d-lg-grid gap-1">
                     <t t-set="screen" t-value="pos.mainScreen.component.name" />
-                    <button class="back-button btn btn-lg lh-lg" t-att-class="{'btn-primary': screen === 'FloorScreen'}" t-on-click="() => this.pos.showScreen('FloorScreen', { floor: this.floor })">
+                    <button class="back-button btn btn-lg lh-lg" t-att-class="{'btn-primary': screen === 'FloorScreen' and !pos.orderToTransferUuid}" t-on-click="() => this.onClickPlanButton()">
                         <span t-if="!ui.isSmall">Plan</span>
                         <img t-else="" src="/pos_restaurant/static/img/plan.svg" class="navbar-icon" alt="Floor Plan"/>
                     </button>
-                    <button class="table-free-order-label btn btn-lg lh-lg" t-att-class="{'btn-primary': screen === 'ProductScreen'}" t-on-click="() => this.switchTable()">
-                        <span t-if="pos.get_order()" t-esc="pos.get_order().table_id?.table_number || pos.get_order().getFloatingOrderName()"/>
+                    <button class="table-free-order-label btn btn-lg lh-lg" t-att-class="{'btn-primary': screen === 'ProductScreen' or pos.orderToTransferUuid}" t-on-click="() => this.switchTable()">
+                        <span t-if="getOrderToDisplay()" t-esc="getOrderName()"/>
                         <span t-elif="!ui.isSmall">Table</span>
                         <img t-else="" src="/pos_restaurant/static/img/table.svg" class="navbar-icon" alt="Table Selector"/>
                     </button>

--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -335,9 +335,6 @@ patch(PosStore.prototype, {
     tableHasOrders(table) {
         return this.getActiveOrdersOnTable(table).length > 0;
     },
-    shouldShowNavbarButtons() {
-        return super.shouldShowNavbarButtons(...arguments) && !this.orderToTransferUuid;
-    },
     async transferOrder(destinationTable) {
         const order = this.models["pos.order"].getBy("uuid", this.orderToTransferUuid);
         const originalTable = order.table_id;


### PR DESCRIPTION
We don't need to Transfer and Merge buttons when there is an order-to-transfer because by default, if there is an order in the destination table, we automatically merged the order-to-transfer to it.

Also, the buttons has already been removed in
https://github.com/odoo/odoo/pull/172513.

TASK-ID: [4127214](https://www.odoo.com/odoo/project/1737/tasks/4127214)

Related: https://github.com/odoo/enterprise/pull/68921
