### PR TITLE
[MERGE] mail: improve batch generation support

### DIFF
--- a/addons/mail/models/ir_config_parameter.py
+++ b/addons/mail/models/ir_config_parameter.py
@@ -28,6 +28,8 @@ class IrConfigParameter(models.Model):
     # * 'mail.batch_size': used in
     #   - MailComposer._action_send_mail_mass_mail(): mails generation based on records
     #   - MailThread._notify_thread_by_email(): mails generation for notification emails
+    #   - MailTemplate.send_mail_batch(): mails generation done directly from templates
+    #   to split mail generation in batches. 500 by default;
 
     # Mail Gateway
     #   * 'mail.gateway.loop.minutes' and 'mail.gateway.loop.threshold': block

--- a/addons/mail/models/ir_config_parameter.py
+++ b/addons/mail/models/ir_config_parameter.py
@@ -19,9 +19,15 @@ class IrConfigParameter(models.Model):
     #   iteration. For each iteration an SMTP server is opened and closed. It
     #   prepares data for 'send' in conjunction with auto_commit=True in order
     #   to avoid repeating batches in case of failure). 1000 by default;
-    # * 'mail.batch_size': used in MailComposer._action_send_mail_mass_mail()
-    #   to generate batch of MailMail based on res_ids. 500 by default
-    #   (see MailComposer._batch_size);
+    # * 'mail.mail.force.send.limit': used in
+    #   - MailThread._notify_thread_by_email(): notification emails flow
+    #   - MailComposer._action_send_mail_mass_mail(): mail composer in mass mail mode
+    #   to force the cron queue usage and avoid sending too much emails in a given
+    #   transaction. When 0 is set flows based on it are always using the email
+    #   queue, no direct send is performed. Default value is 100;
+    # * 'mail.batch_size': used in
+    #   - MailComposer._action_send_mail_mass_mail(): mails generation based on records
+    #   - MailThread._notify_thread_by_email(): mails generation for notification emails
 
     # Mail Gateway
     #   * 'mail.gateway.loop.minutes' and 'mail.gateway.loop.threshold': block

--- a/addons/mail/models/ir_config_parameter.py
+++ b/addons/mail/models/ir_config_parameter.py
@@ -11,6 +11,9 @@ class IrConfigParameter(models.Model):
     # While being there, let us document quickly mail ICP.
 
     # Emailing
+    # * 'mail.mail.queue.batch.size': used in MailMail.process_email_queue()
+    #   to limit maximum number of mail.mail managed by each cron call to VALUE.
+    #   10000 by default;
     # * 'mail.session.batch.size': used in MailMail._split_by_mail_configuration()
     #   to prepare batches of maximum VALUE mails to give at '_send()' at each
     #   iteration. For each iteration an SMTP server is opened and closed. It

--- a/addons/mail/models/ir_config_parameter.py
+++ b/addons/mail/models/ir_config_parameter.py
@@ -5,6 +5,60 @@ from odoo import api, models
 
 
 class IrConfigParameter(models.Model):
+    # Override of config parameter to specifically handle the template
+    # rendering group (de)activation through ICP.
+
+    # While being there, let us document quickly mail ICP.
+
+    # Emailing
+    # * 'mail.session.batch.size': used in MailMail._split_by_mail_configuration()
+    #   to prepare batches of maximum VALUE mails to give at '_send()' at each
+    #   iteration. For each iteration an SMTP server is opened and closed. It
+    #   prepares data for 'send' in conjunction with auto_commit=True in order
+    #   to avoid repeating batches in case of failure). 1000 by default;
+    # * 'mail.batch_size': used in MailComposer._action_send_mail_mass_mail()
+    #   to generate batch of MailMail based on res_ids. 500 by default
+    #   (see MailComposer._batch_size);
+
+    # Mail Gateway
+    #   * 'mail.gateway.loop.minutes' and 'mail.gateway.loop.threshold': block
+    #     emails with same email_from if gateway received more than THRESHOLD
+    #     in MINUTES. This is used to break loops e.g. when email servers bounce
+    #     each other. 20 emails / 120 minutes by default;
+    #   * 'mail.default.from_filter': default from_filter used when there is
+    #     no specific outgoing mail server used to send emails;
+    #   * 'mail.catchall.domain.allowed': optional list of email domains that
+    #     restricts right-part of aliases when used in pre-17 compatibility
+    #     mode (see MailAlias.alias_incoming_local);
+
+    # Activities
+    #   * 'mail.activity.gc.delete_overdue_years': if set, activities outdated
+    #     for more than VALUE years are gc. 0 (skipped) by default;
+    #   * 'mail.activity.systray.limit': number of activities fetched by the
+    #     systray, to avoid performance issues notably with technical users that
+    #     rarely connect. 1000 by default;
+
+    # Groups
+    #   * 'mail.restrict.template.rendering': ICP used in config settings to
+    #     add or remove 'mail.group_mail_template_editor' group to internal
+    #     users i.e. restrict or not QWeb rendering and edition by default.
+    #     Not activated by default;
+
+    # Discuss
+    #   * 'mail.link_preview_throttle': avoid storing link previews for discuss
+    #     if more than VALUE existing link previews are stored for the given
+    #     domain in the last 10 seconds. 99 by default;
+    #   * 'mail.chat_from_token': allow chat from token;
+
+    # Configuration keys
+    #   * 'mail.google_translate_api_key': key used to fetch translations using
+    #     google translate;
+    #   * 'mail.web_push_vapid_private_key' and 'mail.web_push_vapid_public_key':
+    #     configuration parameters when using web push notifications;
+    #   * 'mail.use_twilio_rtc_servers', 'mail.sfu_server_url' and 'mail.
+    #     sfu_server_key': rtc server usage and configuration;
+    #   * 'discuss.tenor_api_key', 'discuss.tenor_gif_limit' and 'discuss.
+    #     tenor_content_filter' used for gif fetch service;
     _inherit = 'ir.config_parameter'
 
     @api.model

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -220,16 +220,19 @@ class MailMail(models.Model):
            message is sent - this is not transactional and should
            not be called during another transaction!
 
-           :param list ids: optional list of emails ids to send. If passed
-                            no search is performed, and these ids are used
-                            instead.
-           :param dict context: if a 'filters' key is present in context,
-                                this value will be used as an additional
-                                filter to further restrict the outgoing
-                                messages to send (by default all 'outgoing'
-                                messages are sent).
+        A maximum of 10K MailMail (configurable using 'mail.mail.queue.batch.size'
+        optional ICP) are fetched in order to keep time under control.
+
+        :param list ids: optional list of emails ids to send. If given only
+                         scheduled and outgoing emails within this ids list
+                         are sent;
+        :param dict context: if a 'filters' key is present in context,
+                             this value will be used as an additional
+                             filter to further restrict the outgoing
+                             messages to send (by default all 'outgoing'
+                             'scheduled' messages are sent).
         """
-        filters = [
+        domain = [
             '&',
                 ('state', '=', 'outgoing'),
                 '|',
@@ -237,20 +240,18 @@ class MailMail(models.Model):
                    ('scheduled_date', '<=', datetime.datetime.utcnow()),
         ]
         if 'filters' in self._context:
-            filters.extend(self._context['filters'])
-        # TODO: make limit configurable
-        filtered_ids = self.search(filters, limit=10000).ids
-        if not ids:
-            ids = filtered_ids
-        else:
-            ids = list(set(filtered_ids) & set(ids))
-        ids.sort()
+            domain.extend(self._context['filters'])
+        batch_size = int(self.env['ir.config_parameter'].sudo().get_param('mail.mail.queue.batch.size', 10000))
+        send_ids = self.search(domain, limit=batch_size).ids
+        if ids:
+            send_ids = list(set(send_ids) & set(ids))
+        send_ids.sort()
 
         res = None
         try:
             # auto-commit except in testing mode
             auto_commit = not getattr(threading.current_thread(), 'testing', False)
-            res = self.browse(ids).send(auto_commit=auto_commit)
+            res = self.browse(send_ids).send(auto_commit=auto_commit)
         except Exception:
             _logger.exception("Failed processing mail queue")
 
@@ -529,9 +530,7 @@ class MailMail(models.Model):
 
             group_per_smtp_from[(mail_server_id, alias_domain_id, smtp_from)].extend(mail_ids)
 
-        sys_params = self.env['ir.config_parameter'].sudo()
-        batch_size = int(sys_params.get_param('mail.session.batch.size', 1000))
-
+        batch_size = int(self.env['ir.config_parameter'].sudo().get_param('mail.session.batch.size')) or 1000
         for (mail_server_id, alias_domain_id, smtp_from), record_ids in group_per_smtp_from.items():
             for batch_ids in tools.split_every(batch_size, record_ids):
                 yield mail_server_id, alias_domain_id, smtp_from, batch_ids

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -592,91 +592,137 @@ class MailTemplate(models.Model):
 
         # Grant access to send_mail only if access to related document
         self.ensure_one()
-        self._send_check_access([res_id])
-
-        Attachment = self.env['ir.attachment']  # TDE FIXME: should remove default_type from context
-
-        # create a mail_mail based on values, without attachments
-        values = self._generate_template(
+        return self.send_mail_batch(
             [res_id],
-            ('attachment_ids',
-             'auto_delete',
-             'body_html',
-             'email_cc',
-             'email_from',
-             'email_to',
-             'mail_server_id',
-             'model',
-             'partner_to',
-             'reply_to',
-             'report_template_ids',
-             'res_id',
-             'scheduled_date',
-             'subject',
-            )
-        )[res_id]
-        values['recipient_ids'] = [Command.link(pid) for pid in values.get('partner_ids', list())]
-        values['attachment_ids'] = [Command.link(aid) for aid in values.get('attachment_ids', list())]
-        values.update(email_values or {})
-        attachment_ids = values.pop('attachment_ids', [])
-        attachments = values.pop('attachments', [])
-        # add a protection against void email_from
-        if 'email_from' in values and not values.get('email_from'):
-            values.pop('email_from')
-        # encapsulate body
-        email_layout_xmlid = email_layout_xmlid or self.email_layout_xmlid
-        if email_layout_xmlid and values['body_html']:
-            record = self.env[self.model].browse(res_id)
-            model = self.env['ir.model']._get(record._name)
+            force_send=force_send,
+            raise_exception=raise_exception,
+            email_values=email_values,
+            email_layout_xmlid=email_layout_xmlid
+        )[0].id  # TDE CLEANME: return mail + api.returns ?
 
-            if self.lang:
-                lang = self._render_lang([res_id])[res_id]
-                model = model.with_context(lang=lang)
+    @api.returns('self', lambda value: value.ids)
+    def send_mail_batch(self, res_ids, force_send=False, raise_exception=False, email_values=None,
+                  email_layout_xmlid=False):
+        """ Generates new mail.mails. Batch version of 'send_mail'.'
 
-            template_ctx = {
-                # message
-                'message': self.env['mail.message'].sudo().new(dict(body=values['body_html'], record_name=record.display_name)),
-                'subtype': self.env['mail.message.subtype'].sudo(),
-                # record
-                'model_description': model.display_name,
-                'record': record,
-                'record_name': False,
-                'subtitles': False,
-                # user / environment
-                'company': 'company_id' in record and record['company_id'] or self.env.company,
-                'email_add_signature': False,
-                'signature': '',
-                'website_url': '',
-                # tools
-                'is_html_empty': is_html_empty,
-            }
-            body = model.env['ir.qweb']._render(email_layout_xmlid, template_ctx, minimal_qcontext=True, raise_if_not_found=False)
-            if not body:
-                _logger.warning(
-                    'QWeb template %s not found when sending template %s. Sending without layout.',
-                    email_layout_xmlid,
-                    self.name
+        :param list res_ids: IDs of modelrecords on which template will be rendered
+
+        :returns: newly created mail.mail
+        """
+        # Grant access to send_mail only if access to related document
+        self.ensure_one()
+        self._send_check_access(res_ids)
+        sending_email_layout_xmlid = email_layout_xmlid or self.email_layout_xmlid
+
+        mails_sudo = self.env['mail.mail'].sudo()
+        batch_size = int(
+            self.env['ir.config_parameter'].sudo().get_param('mail.batch_size')
+        ) or 500  # be sure to not have 0, as otherwise no iteration is done
+        RecordModel = self.env[self.model].with_prefetch(res_ids)
+        record_ir_model = self.env['ir.model']._get(self.model)
+
+        for res_ids_chunk in tools.split_every(batch_size, res_ids):
+            res_ids_values = self._generate_template(
+                res_ids_chunk,
+                ('attachment_ids',
+                 'auto_delete',
+                 'body_html',
+                 'email_cc',
+                 'email_from',
+                 'email_to',
+                 'mail_server_id',
+                 'model',
+                 'partner_to',
+                 'reply_to',
+                 'report_template_ids',
+                 'res_id',
+                 'scheduled_date',
+                 'subject',
                 )
+            )
+            values_list = [res_ids_values[res_id] for res_id in res_ids_chunk]
 
-            values['body_html'] = self.env['mail.render.mixin']._replace_local_links(body)
-        if 'body_html' in values:
-            values['body'] = values['body_html']
+            # get record in batch to use the prefetch
+            records = RecordModel.browse(res_ids_chunk)
+            attachments_list = []
 
-        mail = self.env['mail.mail'].sudo().create(values)
+            # lang and company is used for rendering layout
+            res_ids_langs, res_ids_companies = {}, {}
+            if sending_email_layout_xmlid:
+                if self.lang:
+                    res_ids_langs = self._render_lang(res_ids_chunk)
+                res_ids_companies = records._mail_get_companies(default=self.env.company)
 
-        # manage attachments
-        for attachment in attachments:
-            attachment_data = {
-                'name': attachment[0],
-                'datas': attachment[1],
-                'type': 'binary',
-                'res_model': 'mail.message',
-                'res_id': mail.mail_message_id.id,
-            }
-            attachment_ids.append((4, Attachment.create(attachment_data).id))
-        if attachment_ids:
-            mail.write({'attachment_ids': attachment_ids})
+            for record in records:
+                values = res_ids_values[record.id]
+                values['recipient_ids'] = [(4, pid) for pid in (values.get('partner_ids') or [])]
+                values['attachment_ids'] = [(4, aid) for aid in (values.get('attachment_ids') or [])]
+                values.update(email_values or {})
+
+                # delegate attachments after creation due to ACL check
+                attachments_list.append(values.pop('attachments', []))
+
+                # add a protection against void email_from
+                if 'email_from' in values and not values.get('email_from'):
+                    values.pop('email_from')
+
+                # encapsulate body
+                if not sending_email_layout_xmlid:
+                    values['body'] = values['body_html']
+                    continue
+
+                lang = res_ids_langs.get(record.id) or False
+                company = res_ids_companies.get(record.id) or self.env.company
+                model_lang = record_ir_model.with_context(lang=lang) if lang else record_ir_model
+
+                template_ctx = {
+                    # message
+                    'message': self.env['mail.message'].sudo().new(dict(body=values['body_html'], record_name=record.display_name)),
+                    'subtype': self.env['mail.message.subtype'].sudo(),
+                    # record
+                    'model_description': model_lang.display_name,
+                    'record': record,
+                    'record_name': False,
+                    'subtitles': False,
+                    # user / environment
+                    'company': company,
+                    'email_add_signature': False,
+                    'signature': '',
+                    'website_url': '',
+                    # tools
+                    'is_html_empty': is_html_empty,
+                }
+                body = model_lang.env['ir.qweb']._render(sending_email_layout_xmlid, template_ctx, minimal_qcontext=True, raise_if_not_found=False)
+                if not body:
+                    _logger.warning(
+                        'QWeb template %s not found when sending template %s. Sending without layout.',
+                        sending_email_layout_xmlid,
+                        self.name,
+                    )
+                    body = values['body_html']
+
+                values['body_html'] = self.env['mail.render.mixin']._replace_local_links(body)
+                values['body'] = values['body_html']
+
+            mails = self.env['mail.mail'].sudo().create(values_list)
+
+            # manage attachments
+            for mail, attachments in zip(mails, attachments_list):
+                if attachments:
+                    attachments_values = [
+                        (0, 0, {
+                            'name': name,
+                            'datas': datas,
+                            'type': 'binary',
+                            'res_model': 'mail.message',
+                            'res_id': mail.mail_message_id.id,
+                        })
+                        for (name, datas) in attachments
+                    ]
+                    mail.with_context(default_type=None).write({'attachment_ids': attachments_values})
+
+            mails_sudo += mails
 
         if force_send:
-            mail.send(raise_exception=raise_exception)
-        return mail.id  # TDE CLEANME: return mail + api.returns ?
+            mails_sudo.send(raise_exception=raise_exception)
+        return mails_sudo

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3226,8 +3226,10 @@ class MailThread(models.AbstractModel):
         emails = self.env['mail.mail'].sudo()
 
         # loop on groups (customer, portal, user,  ... + model specific like group_sale_salesman)
+        gen_batch_size = int(
+            self.env['ir.config_parameter'].sudo().get_param('mail.batch_size')
+        ) or 500  # be sure to not have 0, as otherwise no iteration is done
         notif_create_values = []
-        recipients_max = 50
         for _lang, render_values, recipients_group in self._notify_get_classified_recipients_iterator(
             message,
             partners_data,
@@ -3247,7 +3249,7 @@ class MailThread(models.AbstractModel):
             recipients_ids = recipients_group.pop('recipients')
 
             # create email
-            for recipients_ids_chunk in split_every(recipients_max, recipients_ids):
+            for recipients_ids_chunk in split_every(gen_batch_size, recipients_ids):
                 mail_values = self._notify_by_email_get_final_mail_values(
                     recipients_ids_chunk,
                     base_mail_values,
@@ -3289,8 +3291,10 @@ class MailThread(models.AbstractModel):
         #      to prevent sending email during a simple update of the database
         #      using the command-line.
         test_mode = getattr(threading.current_thread(), 'testing', False)
-        force_send = self.env.context.get('mail_notify_force_send', force_send)
-        if force_send and len(emails) < recipients_max and (not self.pool._init or test_mode):
+        if force_send := self.env.context.get('mail_notify_force_send', force_send):
+            force_send_limit = int(self.env['ir.config_parameter'].sudo().get_param('mail.mail.force.send.limit', 100))
+            force_send = len(emails) < force_send_limit
+        if force_send and (not self.pool._init or test_mode):
             # unless asked specifically, send emails after the transaction to
             # avoid side effects due to emails being sent while the transaction fails
             if not test_mode and send_after_commit:

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -67,6 +67,7 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
         build_email_origin = IrMailServer.build_email
         send_email_origin = IrMailServer.send_email
         mail_create_origin = MailMail.create
+        mail_private_send_origin = MailMail._send
         mail_unlink_origin = MailMail.unlink
         self.mail_unlink_sent = mail_unlink_sent
         self._init_mail_mock()
@@ -95,10 +96,12 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
              patch.object(IrMailServer, 'build_email', autospec=True, wraps=IrMailServer, side_effect=_ir_mail_server_build_email) as build_email_mocked, \
              patch.object(IrMailServer, 'send_email', autospec=True, wraps=IrMailServer, side_effect=send_email_origin) as send_email_mocked, \
              patch.object(MailMail, 'create', autospec=True, wraps=MailMail, side_effect=_mail_mail_create) as mail_mail_create_mocked, \
+             patch.object(MailMail, '_send', autospec=True, wraps=MailMail, side_effect=mail_private_send_origin) as mail_mail_private_send_mocked, \
              patch.object(MailMail, 'unlink', autospec=True, wraps=MailMail, side_effect=_mail_mail_unlink):
             self.build_email_mocked = build_email_mocked
             self.send_email_mocked = send_email_mocked
             self.mail_mail_create_mocked = mail_mail_create_mocked
+            self.mail_mail_private_send_mocked = mail_mail_private_send_mocked
             yield
 
     def _init_mail_mock(self):

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -728,9 +728,7 @@ class MailComposer(models.TransientModel):
         for res_ids_iter in tools.split_every(batch_size, res_ids):
             res_ids_values = list(self._prepare_mail_values(res_ids_iter).values())
 
-            iter_mails_sudo = self.env['mail.mail'].sudo()
-            for mail_values in res_ids_values:
-                iter_mails_sudo += mails_sudo.create(mail_values)
+            iter_mails_sudo = self.env['mail.mail'].sudo().create(res_ids_values)
             mails_sudo += iter_mails_sudo
 
             records = self.env[self.model].browse(res_ids_iter) if self.model and hasattr(self.env[self.model], 'message_post') else False

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -557,12 +557,22 @@ class MailComposer(models.TransientModel):
 
     @api.depends('composition_mode', 'model', 'res_domain', 'res_ids')
     def _compute_force_send(self):
-        """ It is set to True in mass mailing mode (send directly by default)
-        and in monorecord comment mode (send notifications right now). Batch
-        comment delays notification to use the email queue. """
+        """ When being in single record mode, we force_send (post on a record
+        or send a single email right away). In batch mode: comment always uses
+        the email queue (lot of potentially different emails to craft). Mass
+        mailing mode depends on number of recipients and is configurable using
+        'mail.mail.force.send.limit' configuration parameter (default=100).
+        Using a domain forces the email queue usage as it depends on actual
+        evaluation and is generally used for big batches anyway. """
         for composer in self:
-            composer.force_send = (composer.composition_mode == 'mass_mail' or
-                                   not composer.composition_batch)
+            if not composer.composition_batch:
+                composer.force_send = True
+            elif composer.composition_mode == 'comment' or composer.res_domain:
+                composer.force_send = False
+            else:
+                force_send_limit = int(self.env['ir.config_parameter'].sudo().get_param('mail.mail.force.send.limit', 100))
+                res_ids = composer._evaluate_res_ids()
+                composer.force_send = len(res_ids) <= force_send_limit
 
     @api.depends('template_id')
     def _compute_mail_server_id(self):
@@ -712,14 +722,14 @@ class MailComposer(models.TransientModel):
         sudo as it is considered as a technical model. """
         mails_sudo = self.env['mail.mail'].sudo()
 
-        batch_size = int(self.env['ir.config_parameter'].sudo().get_param('mail.batch_size')) or self._batch_size
-        sliced_res_ids = [res_ids[i:i + batch_size] for i in range(0, len(res_ids), batch_size)]
-
-        for res_ids_iter in sliced_res_ids:
-            mail_values_all = self._prepare_mail_values(res_ids_iter)
+        batch_size = int(
+            self.env['ir.config_parameter'].sudo().get_param('mail.batch_size')
+        ) or self._batch_size  # be sure to not have 0, as otherwise no iteration is done
+        for res_ids_iter in tools.split_every(batch_size, res_ids):
+            res_ids_values = list(self._prepare_mail_values(res_ids_iter).values())
 
             iter_mails_sudo = self.env['mail.mail'].sudo()
-            for _res_id, mail_values in mail_values_all.items():
+            for mail_values in res_ids_values:
                 iter_mails_sudo += mails_sudo.create(mail_values)
             mails_sudo += iter_mails_sudo
 
@@ -727,10 +737,10 @@ class MailComposer(models.TransientModel):
             if records:
                 records._message_mail_after_hook(iter_mails_sudo)
 
-            # as 'send' does not filter out scheduled mails (only 'process_email_queue'
-            # does) we need to do it manually
             if not self.force_send:
                 continue
+            # as 'send' does not filter out scheduled mails (only 'process_email_queue'
+            # does) we need to do it manually
             iter_mails_sudo_tosend = iter_mails_sudo.filtered(
                 lambda mail: (
                     not mail.scheduled_date or

--- a/addons/test_mail/tests/test_mail_template.py
+++ b/addons/test_mail/tests/test_mail_template.py
@@ -80,6 +80,18 @@ class TestMailTemplate(TestMailTemplateCommon):
         self.assertEqual(action.name, 'Send Mail (%s)' % self.test_template.name)
         self.assertEqual(action.binding_model_id.model, 'mail.test.lang')
 
+    def test_template_copy(self):
+        """ Test copying template, notably for attachments management """
+        template = self.test_template
+        self.assertEqual(template.attachment_ids.mapped("res_id"), [template.id] * 2)
+        copy = template.copy()
+        self.assertEqual(template.attachment_ids, copy.attachment_ids)
+        self.assertEqual(
+            template.attachment_ids.mapped("res_id"), [copy.id] * 2,
+            "Updated res_id, seems strange"
+        )
+        self.assertEqual(copy.attachment_ids.mapped("res_id"), [copy.id] * 2)
+
     @mute_logger('odoo.addons.mail.models.mail_mail')
     @users('employee')
     def test_template_schedule_email(self):
@@ -232,6 +244,8 @@ class TestMailTemplateLanguages(TestMailTemplateCommon):
         self.assertEqual(len(mails), 100)
         for idx, (mail, record) in enumerate(zip(mails, self.test_records_batch)):
             self.assertEqual(sorted(mail.attachment_ids.mapped('name')), ['first.txt', 'second.txt'])
+            self.assertEqual(mail.attachment_ids.mapped("res_id"), [self.test_template_wreports.id] * 2)
+            self.assertEqual(mail.attachment_ids.mapped("res_model"), [template._name] * 2)
             self.assertEqual(mail.email_cc, self.test_template.email_cc)
             self.assertEqual(mail.email_to, self.test_template.email_to)
             self.assertEqual(mail.recipient_ids, self.partner_2 | self.user_admin.partner_id)
@@ -273,6 +287,16 @@ class TestMailTemplateLanguages(TestMailTemplateCommon):
             self.assertEqual(
                 sorted(mail.attachment_ids.mapped('name')),
                 [f'TestReport for {record.name}.html', f'TestReport2 for {record.name}.html', 'first.txt', 'second.txt']
+            )
+            self.assertEqual(
+                sorted(mail.attachment_ids.mapped("res_id")),
+                sorted([self.test_template_wreports.id] * 2 + [mail.mail_message_id.id] * 2),
+                "Attachments: attachment_ids -> linked to template, attachments -> to mail.message"
+            )
+            self.assertEqual(
+                sorted(mail.attachment_ids.mapped("res_model")),
+                sorted([template._name] * 2 + ["mail.message"] * 2),
+                "Attachments: attachment_ids -> linked to template, attachments -> to mail.message"
             )
             self.assertEqual(mail.email_cc, self.test_template.email_cc)
             self.assertEqual(mail.email_to, self.test_template.email_to)

--- a/addons/test_mail/tests/test_mail_template.py
+++ b/addons/test_mail/tests/test_mail_template.py
@@ -235,7 +235,7 @@ class TestMailTemplateLanguages(TestMailTemplateCommon):
     def test_template_send_email_batch(self):
         """ Test 'send_email' on template in batch """
         self.env.invalidate_all()
-        with self.with_user(self.user_employee.login), self.assertQueryCount(908):
+        with self.with_user(self.user_employee.login), self.assertQueryCount(18):
             template = self.test_template.with_env(self.env)
             mails_sudo = template.send_mail_batch(self.test_records_batch.ids)
 
@@ -258,7 +258,7 @@ class TestMailTemplateLanguages(TestMailTemplateCommon):
         """ Test 'send_email' on template on a given record, used notably as
         contextual action, with dynamic reports involved """
         self.env.invalidate_all()
-        with self.with_user(self.user_employee.login), self.assertQueryCount(28):
+        with self.with_user(self.user_employee.login), self.assertQueryCount(24):
             mail_id = self.test_template_wreports.with_env(self.env).send_mail(self.test_record.id)
             mail = self.env['mail.mail'].sudo().browse(mail_id)
 
@@ -275,7 +275,7 @@ class TestMailTemplateLanguages(TestMailTemplateCommon):
         """ Test 'send_email' on template in batch with dynamic reports """
         self.env.invalidate_all()
 
-        with self.with_user(self.user_employee.login), self.assertQueryCount(1519):
+        with self.with_user(self.user_employee.login), self.assertQueryCount(229):
             template = self.test_template_wreports.with_env(self.env)
             mails_sudo = template.send_mail_batch(self.test_records_batch.ids)
 
@@ -387,7 +387,7 @@ class TestMailTemplateLanguages(TestMailTemplateCommon):
 
         self.env.invalidate_all()
 
-        with self.with_user(self.user_employee.login), self.assertQueryCount(26):
+        with self.with_user(self.user_employee.login), self.assertQueryCount(18):
             template = self.test_template.with_env(self.env)
             mails_sudo = template.send_mail_batch(self.test_records.ids, email_layout_xmlid='mail.test_layout')
 

--- a/addons/test_mail/tests/test_mail_template.py
+++ b/addons/test_mail/tests/test_mail_template.py
@@ -235,14 +235,12 @@ class TestMailTemplateLanguages(TestMailTemplateCommon):
     def test_template_send_email_batch(self):
         """ Test 'send_email' on template in batch """
         self.env.invalidate_all()
-        mails = self.env['mail.mail'].sudo()
         with self.with_user(self.user_employee.login), self.assertQueryCount(908):
             template = self.test_template.with_env(self.env)
-            for record in self.test_records_batch:
-                mails += mails.browse(template.send_mail(record.id))
+            mails_sudo = template.send_mail_batch(self.test_records_batch.ids)
 
-        self.assertEqual(len(mails), 100)
-        for idx, (mail, record) in enumerate(zip(mails, self.test_records_batch)):
+        self.assertEqual(len(mails_sudo), 100)
+        for idx, (mail, record) in enumerate(zip(mails_sudo, self.test_records_batch)):
             self.assertEqual(sorted(mail.attachment_ids.mapped('name')), ['first.txt', 'second.txt'])
             self.assertEqual(mail.attachment_ids.mapped("res_id"), [self.test_template_wreports.id] * 2)
             self.assertEqual(mail.attachment_ids.mapped("res_model"), [template._name] * 2)
@@ -276,14 +274,13 @@ class TestMailTemplateLanguages(TestMailTemplateCommon):
     def test_template_send_email_wreport_batch(self):
         """ Test 'send_email' on template in batch with dynamic reports """
         self.env.invalidate_all()
-        mails = self.env['mail.mail'].sudo()
+
         with self.with_user(self.user_employee.login), self.assertQueryCount(1519):
             template = self.test_template_wreports.with_env(self.env)
-            for record in self.test_records_batch:
-                mails += mails.browse(template.send_mail(record.id))
+            mails_sudo = template.send_mail_batch(self.test_records_batch.ids)
 
-        self.assertEqual(len(mails), 100)
-        for idx, (mail, record) in enumerate(zip(mails, self.test_records_batch)):
+        self.assertEqual(len(mails_sudo), 100)
+        for idx, (mail, record) in enumerate(zip(mails_sudo, self.test_records_batch)):
             self.assertEqual(
                 sorted(mail.attachment_ids.mapped('name')),
                 [f'TestReport for {record.name}.html', f'TestReport2 for {record.name}.html', 'first.txt', 'second.txt']
@@ -309,6 +306,49 @@ class TestMailTemplateLanguages(TestMailTemplateCommon):
                 self.assertEqual(mail.subject, f'SpanishSubject for {record.name}')
                 self.assertEqual(mail.body_html,
                          f'<body><p>SpanishBody for {record.name}</p> Spanish Layout para Spanish Model Description</body>')
+
+    @mute_logger('odoo.addons.mail.models.mail_mail')
+    def test_template_send_email_wreport_batch_scalability(self):
+        """ Test 'send_email' on template in batch, using configuration parameter
+        for batch rendering. """
+        for batch_size, exp_mail_create_count in [
+            (False, 1),  # unset, default is 500
+            (0, 1),  # 0: fallbacks on default
+            (30, 4),  # 100 / 30 -> 4 iterations
+        ]:
+            with self.subTest(batch_size=batch_size):
+                self.env['ir.config_parameter'].sudo().set_param(
+                    "mail.batch_size", batch_size
+                )
+                with self.with_user(self.user_employee.login), \
+                     self.mock_mail_gateway():
+                    template = self.test_template_wreports.with_env(self.env)
+                    mails_sudo = template.send_mail_batch(self.test_records_batch.ids)
+
+                self.assertEqual(self.mail_mail_create_mocked.call_count, exp_mail_create_count)
+                self.assertEqual(len(mails_sudo), 100)
+                for idx, (mail, record) in enumerate(zip(mails_sudo, self.test_records_batch)):
+                    self.assertEqual(
+                        sorted(mail.attachment_ids.mapped('name')),
+                        [f'TestReport for {record.name}.html', f'TestReport2 for {record.name}.html', 'first.txt', 'second.txt']
+                    )
+                    self.assertEqual(
+                        sorted(mail.attachment_ids.mapped("res_id")),
+                        sorted([self.test_template_wreports.id] * 2 + [mail.mail_message_id.id] * 2),
+                        "Attachments: attachment_ids -> linked to template, attachments -> to mail.message"
+                    )
+                    self.assertEqual(
+                        sorted(mail.attachment_ids.mapped("res_model")),
+                        sorted([template._name] * 2 + ["mail.message"] * 2),
+                        "Attachments: attachment_ids -> linked to template, attachments -> to mail.message"
+                    )
+                    self.assertEqual(mail.email_cc, self.test_template.email_cc)
+                    self.assertEqual(mail.email_to, self.test_template.email_to)
+                    self.assertEqual(mail.recipient_ids, self.partner_2 | self.user_admin.partner_id)
+                    if idx >= 50:
+                        self.assertEqual(mail.subject, f'EnglishSubject for {record.name}')
+                    else:
+                        self.assertEqual(mail.subject, f'SpanishSubject for {record.name}')
 
     @mute_logger('odoo.addons.mail.models.mail_mail')
     def test_template_translation_lang(self):
@@ -346,17 +386,14 @@ class TestMailTemplateLanguages(TestMailTemplateCommon):
         test_records[1].write({'customer_id': customers[1].id})
 
         self.env.invalidate_all()
-        mails = self.env['mail.mail'].sudo()
+
         with self.with_user(self.user_employee.login), self.assertQueryCount(26):
             template = self.test_template.with_env(self.env)
-            for record in self.test_records:
-                mails += mails.browse(
-                    template.send_mail(record.id, email_layout_xmlid='mail.test_layout')
-                )
+            mails_sudo = template.send_mail_batch(self.test_records.ids, email_layout_xmlid='mail.test_layout')
 
-        self.assertEqual(mails[0].body_html,
+        self.assertEqual(mails_sudo[0].body_html,
                          f'<body><p>SpanishBody for {test_records[0].name}</p> Spanish Layout para Spanish Model Description</body>')
-        self.assertEqual(mails[0].subject, f'SpanishSubject for {test_records[0].name}')
-        self.assertEqual(mails[1].body_html,
+        self.assertEqual(mails_sudo[0].subject, f'SpanishSubject for {test_records[0].name}')
+        self.assertEqual(mails_sudo[1].body_html,
                          f'<body><p>EnglishBody for {test_records[1].name}</p> English Layout for Lang Chatter Model</body>')
-        self.assertEqual(mails[1].subject, f'EnglishSubject for {test_records[1].name}')
+        self.assertEqual(mails_sudo[1].subject, f'EnglishSubject for {test_records[1].name}')

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -442,7 +442,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
                 'default_template_id': test_template.id,
             }).create({})
 
-        with self.assertQueryCount(admin=128, employee=131), self.mock_mail_gateway():
+        with self.assertQueryCount(admin=92, employee=95), self.mock_mail_gateway():
             composer._action_send_mail()
 
         self.assertEqual(len(self._new_mails), 10)

--- a/addons/website_slides/tests/test_gamification_karma.py
+++ b/addons/website_slides/tests/test_gamification_karma.py
@@ -128,7 +128,7 @@ class TestKarmaGain(common.SlidesCase):
         self.assertEqual(len(channel_partners), 4)
 
         # Set courses as completed and update karma
-        with self.assertQueryCount(54):  # com 53
+        with self.assertQueryCount(55):
             channel_partners._post_completion_update_hook()
 
         computed_karma = self.channel.karma_gen_channel_finish + self.channel_2.karma_gen_channel_finish


### PR DESCRIPTION
This PR aims at improving batch generation support in mail

-- Add / Improve configuration parameters support for email queue

Ease email queue configuration with better support of two parameters

  * 'mail.mail.queue.batch.size' which is the email queue size that will
    be used to search for outgoing emails (matching optional filters and IDs)
    and then given to 'send';
  * 'mail.session.batch.size' which is the batch size of a given segment of
    email to send using a specific server, used when splitting emails to send
    based on configuration (see '_split_by_mail_configuration');

-- Better email queue usage for mail composer

Current situation
  * post a message on a document
    * emails are sent in the same transaction if less than 50 followers and
      are postponed otherwise (using post-commit hook);
    * emails are generated by batch of 50;
  * use composer in mass mailing mode
    * emails are always sent in the same transaction;
    * emails are generated by batch of 500 (configurable using configuration
      parameter "mail.batch_size");

What we want: mass mail mode should have the same kind of behavior and force
usage of email queue if number of recipients is more than a threshold, and
use the same parameter for emails generation batch.

Changes
  * force_send threshold is now set to 100, and configurable using
    "mail.mail.force.send.limit" configuration parameter. It is used in both
    main flows: posting a message (and notifying followers), and sending a
    mailing.
  * emails generation in both flows is done by batches of 500, configurable
    using "mail.batch_size" configuration parameter. For notification emails
    it was done by batches of 50 but 500 seems acceptable, behaving like
    the mail composer;

-- Performance

When possible create mails in batch, using configurable parameters when
iterating on large number of records.

Task-3768123: Mail: Configurable cron queue size
Task-3164278: Mail: Batch send: ensure limit, avoid force
Part of Task-3084943: Event: Improve communication scheduler scalability