### PR TITLE
[FIX] hr_contract: get calendar interval w/out active contract

### DIFF
--- a/addons/hr_contract/tests/test_resource.py
+++ b/addons/hr_contract/tests/test_resource.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from datetime import date, datetime
 from pytz import utc, timezone
@@ -7,6 +6,7 @@ from odoo.addons.resource.models.resource import Intervals, sum_intervals
 from odoo.fields import Date
 
 from .common import TestContractCommon
+
 
 class TestResource(TestContractCommon):
 
@@ -80,6 +80,17 @@ class TestResource(TestContractCommon):
             elif calendar == self.calendar_richard:
                 self.assertFalse(richard_entries[calendar] - interval_40h, "Interval 40h should cover all calendar 40h validity")
                 self.assertFalse(interval_40h - richard_entries[calendar], "Calendar 40h validity should cover all interval 40h")
+
+        self.employee.contract_ids.state = 'close'
+        self.contract_cdi.date_end = '2021-12-31'
+        calendars = self.employee.resource_id._get_calendars_validity_within_period(
+            tz.localize(datetime(2022, 1, 1)),
+            tz.localize(datetime(2022, 1, 31)),
+        )
+        self.assertTrue(
+            calendars[self.employee.resource_id.id][self.employee.company_id.resource_calendar_id],
+            "Employee without running contract falls back on company calendar",
+        )
 
     def test_queries(self):
         employees_test = self.env['hr.employee'].create([{


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Have an employee with an active contract;
2. assign them to a future, multi-day slot in Planning;
3. set the employee's contract to expired as of today;
4. modify the planning slot end time to be 1 hour earlier.

Issue
-----
The allocated hours computed by the planning slot is set to 0.

Cause
-----
The `_get_calendars_validity_within_period` method of `resource.resource` splits resources between those with and without contracts. Our employee initially gets included as a resource with contract, but when contract-based computation happens, none of the employee's contracts get included.

Solution
--------
For employees without applicable contracts, add intervals based on the company calendar (see task-2643752 functional changes).


opw-3661308