### PR TITLE
[FIX] base: add `filename` invisible field to import translation

### DIFF
--- a/odoo/addons/base/wizard/base_import_language_views.xml
+++ b/odoo/addons/base/wizard/base_import_language_views.xml
@@ -11,6 +11,7 @@
                         <field name="name" placeholder="e.g. English"/>
                         <field name="code" string="Code" placeholder="e.g. en_US"/>
                         <field name="data" filename="filename" options="{'accepted_file_extensions': '.csv,.po'}"/>
+                        <field name="filename" invisible="1"/> <!-- web_save doesn't provide `filename` in its parameters. `filename` is required for <field name="data" filename="filename".../> -->
                         <field name="overwrite" groups="base.group_no_one"/>
                     </group>
                     <footer>


### PR DESCRIPTION
There was no indication that the field was needed when it was removed. It is not added automatically by the orm because it is not a depend or an explicit modifier.
It is being reintroduced with a comment.


Issue: Settings > Translations > Export Translation > Select language as French > PO File > Export type module > Choose sales app as apps to export > Download the file > Import Translation > Add language name > Code fr_FR > Upload file > Overwrite existing terms checked > error message appears.

The error was introduced by:
https://github.com/odoo/odoo/commit/5639ed865c5a3b82bab25b0ecac28c68c02e9306

opw-4115861



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
