### PR TITLE
[FIX] survey: show all survey types answers

### DIFF
--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -230,6 +230,7 @@
                 <field name="session_state"/>
                 <field name="success_ratio"/>
                 <field name="session_available" invisible="1"/>
+                <field name="survey_type" invisible="1"/>
                 <templates>
                     <div t-name="kanban-menu" t-if="widget.editable">
                         <a role="menuitem" type="edit" class="dropdown-item">Edit Survey</a>
@@ -275,6 +276,7 @@
                             <div t-if="!selection_mode" class="col-lg-1 col-sm-4 col-6 py-0 my-2">
                                 <a type="object"
                                    name="action_survey_user_input"
+                                   invisible="survey_type not in ['assessment', 'custom', 'live_session', 'survey']"
                                    class="fw-bold">
                                     <field name="answer_count"/><br />
                                     <span class="text-muted">Registered</span>
@@ -283,6 +285,7 @@
                             <div t-if="!selection_mode" class="col-lg-1 col-sm-4 col-6 d-none d-sm-block py-0 my-2">
                                 <a type="object"
                                    name="action_survey_user_input_completed"
+                                   invisible="survey_type not in ['assessment', 'custom', 'live_session', 'survey']"
                                    class="fw-bold">
                                     <field name="answer_done_count"/><br />
                                     <span class="text-muted">Completed</span>
@@ -303,7 +306,7 @@
                                 <button name="action_send_survey"
                                         string="Share" type="object"
                                         class="btn btn-secondary"
-                                        invisible="not active">
+                                        invisible="not active or survey_type not in ['assessment', 'custom', 'live_session', 'survey']">
                                     Share
                                 </button>
                                 <button name="action_test_survey"


### PR DESCRIPTION
Issue
-----
An user with Survey and Recruitment rights is not able to see completed answers for recruitment type surveys.

Steps
-----
[hr_recruitment_survey]
1. With admin, create a "Recruitment" type survey, answer it once.
2. Go to Surveys > Click on "1 Completed" > No answers visible. Go to Recruitment > Interviews > Click on "1 Completed" > No answers visible either.

Cause
-----
Commit 027a2a66d63225abbfaef425448188007f573ac5 overhauled rights management for surveys and the apps depending on Survey.
The view showing the answers to a survey restricts the survey types: https://github.com/odoo/odoo/blob/027a2a66d63225abbfaef425448188007f573ac5/addons/survey/views/survey_user_views.xml#L171 A user with Recruitment rights will therefore not see the answers to a Recruitment survey.

Change
-----
As a security rule exists to not allow Survey users to access Recruitment survey answers:
https://github.com/odoo/odoo/blob/027a2a66d63225abbfaef425448188007f573ac5/addons/survey/security/survey_security.xml#L104 We don't restrict the view to make other survey types work.

opw-4089308
