### PR TITLE
[FIX] sale: correctly recompute discount on quantity change

### DIFF
--- a/addons/product/models/product_pricelist_item.py
+++ b/addons/product/models/product_pricelist_item.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, api, fields, models, SUPERUSER_ID, tools
+from odoo import SUPERUSER_ID, _, api, fields, models, tools
 from odoo.exceptions import ValidationError
 from odoo.tools import format_datetime, formatLang
 
@@ -562,9 +562,11 @@ class PricelistItem(models.Model):
 
         return pricelist_rule._compute_base_price(*args, **kwargs)
 
+    @api.model
+    def _is_discount_feature_enabled(self):
+        superuser = self.env['res.users'].browse(SUPERUSER_ID)
+        return superuser.has_group('sale.group_discount_per_so_line')
+
     def _show_discount(self):
         self and self.ensure_one()
-        superuser = self.env['res.users'].browse(SUPERUSER_ID)
-        if not superuser.has_group('sale.group_discount_per_so_line'):
-            return False
-        return self.compute_price == 'percentage'
+        return self._is_discount_feature_enabled() and self.compute_price == 'percentage'

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -611,19 +611,17 @@ class SaleOrderLine(models.Model):
 
     @api.depends('product_id', 'product_uom', 'product_uom_qty')
     def _compute_discount(self):
+        discount_enabled = self.env['product.pricelist.item']._is_discount_feature_enabled()
         for line in self:
             if not line.product_id or line.display_type:
                 line.discount = 0.0
 
-            if not (
-                line.order_id.pricelist_id
-                and line.pricelist_item_id._show_discount()
-            ):
+            if not (line.order_id.pricelist_id and discount_enabled):
                 continue
 
             line.discount = 0.0
 
-            if not line.pricelist_item_id:
+            if not (line.pricelist_item_id and line.pricelist_item_id._show_discount()):
                 # No pricelist rule was found for the product
                 # therefore, the pricelist didn't apply any discount/change
                 # to the existing sales price.

--- a/addons/sale/tests/test_sale_prices.py
+++ b/addons/sale/tests/test_sale_prices.py
@@ -47,7 +47,6 @@ class TestSalePrices(SaleCommon):
         )
         product_price = self.product.lst_price
         product_dozen_price = product_price * 12
-        discount = 1 - self.discount/100
 
         self.empty_order.order_line = [
             Command.create({
@@ -87,6 +86,9 @@ class TestSalePrices(SaleCommon):
             discounted_lines.mapped('price_unit'),
             [product_price, product_price, product_dozen_price, product_dozen_price])
         self.assertEqual(discounted_lines.mapped('discount'), [self.discount]*len(discounted_lines))
+
+        discounted_lines[0].product_uom_qty = 3.0
+        self.assertFalse(discounted_lines[0].discount)
 
     def test_pricelist_dates(self):
         """ Verify the order date is correctly provided to the pricelist API"""
@@ -947,6 +949,7 @@ class TestSalePrices(SaleCommon):
         order_line.write({
             'product_uom_qty': 3.0,
             'price_unit': 100.0,
+            'discount': 1.0,
         })
         order.invalidate_recordset(['amount_undiscounted'])
 


### PR DESCRIPTION
Steps to reproduce:
* Create a pricelist rule giving a discount if a minimal quantity is bought
* In a sale order with that specific pricelist, add a product matching that rule, with the right quantity.
* Decrease the quantity below the minimal quantity of the rule

-> The discount doesn't disappear

Cause:
Since 2629ed0ff353362b3c01807a7dc8ce9fe6ba1de2 (and 73b80be7649746f739fbd924c94a0410d6660659), the discount_policy has been dropped on pricelists, and only the discounts given by rules of type 'percentage' are shown to the customers (and on the SO) (this doesn't apply on ecommerce flows for now).

Nevertheless, when adapting to those changes, we stopped resetting the discount if
* no rule was found
* the rule isn't a percentage rule anymore

This commit makes sure that modifying the quantity on lines will effectively reset the discount, ensuring the right prices are used.

opw-4111122
