### PR TITLE
[FIX] im_livechat: trigger step data wrongly inserted

### DIFF
--- a/addons/im_livechat/controllers/chatbot.py
+++ b/addons/im_livechat/controllers/chatbot.py
@@ -2,7 +2,6 @@
 
 from odoo import http
 from odoo.http import request
-from odoo.tools import is_html_empty, plaintext2html
 from odoo.addons.mail.models.discuss.mail_guest import add_guest_to_context
 from odoo.addons.mail.tools.discuss import Store
 
@@ -63,22 +62,33 @@ class LivechatChatbotScriptController(http.Controller):
             return None
 
         posted_message = next_step._process_step(discuss_channel)
-        return {
-            "data": Store(posted_message, for_current_user=True).get_result(),
-            'scriptStep': {
-                'id': next_step.id,
-                'answers': [{
-                    'id': answer.id,
-                    'label': answer.name,
-                    'redirectLink': answer.redirect_link,
-                } for answer in next_step.answer_ids],
-                'isLast': next_step._is_last_step(discuss_channel),
-                'message': plaintext2html(next_step.message) if not is_html_empty(next_step.message) else False,
-                'type': next_step.step_type,
+        store = Store(posted_message, for_current_user=True)
+        store.add(next_step)
+        store.add(
+            "ChatbotStep",
+            {
+                "id": (next_step.id, discuss_channel.id),
+                "isLast": next_step._is_last_step(discuss_channel),
+                "message": Store.one(posted_message, only_id=True),
+                "operatorFound": next_step.step_type == "forward_operator"
+                and len(discuss_channel.channel_member_ids) > 2,
+                "scriptStep": Store.one(next_step, only_id=True),
             },
-            'operatorFound': next_step.step_type == 'forward_operator' and len(
-                discuss_channel.channel_member_ids) > 2,
-        }
+        )
+        store.add(
+            "Chatbot",
+            {
+                "currentStep": {
+                    "id": (next_step.id, discuss_channel.id),
+                    "scriptStep": next_step.id,
+                    "message": posted_message.id,
+                },
+                "id": (chatbot.id, discuss_channel.id),
+                "script": Store.one(chatbot, only_id=True),
+                "thread": Store.one(discuss_channel, only_id=True),
+            },
+        )
+        return store.get_result()
 
     @http.route("/chatbot/step/validate_email", type="json", auth="public")
     @add_guest_to_context

--- a/addons/im_livechat/models/chatbot_script_answer.py
+++ b/addons/im_livechat/models/chatbot_script_answer.py
@@ -3,6 +3,7 @@
 
 from odoo import api, models, fields
 from odoo.osv import expression
+from odoo.addons.mail.tools.discuss import Store
 
 import textwrap
 
@@ -56,3 +57,8 @@ class ChatbotScriptAnswer(models.Model):
             domain = expression.AND([domain, [('chatbot_script_id', '=', force_domain_chatbot_script_id)]])
 
         return self._search(domain, limit=limit, order=order)
+
+    def _to_store(self, store: Store, /, *, fields=None):
+        if fields is None:
+            fields = ["name", "redirect_link"]
+        store.add("chatbot.script.answer", self._read_format(fields, load=False))

--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -6,6 +6,7 @@ from odoo.exceptions import ValidationError
 from odoo.fields import Command
 from odoo.osv import expression
 from odoo.tools import html2plaintext, is_html_empty, email_normalize, plaintext2html
+from odoo.addons.mail.tools.discuss import Store
 
 from collections import defaultdict
 from markupsafe import Markup
@@ -367,6 +368,21 @@ class ChatbotScriptStep(models.Model):
 
         return posted_message
 
+    def _to_store(self, store: Store, /, *, fields=None):
+        if fields is None:
+            fields = ["answer_ids", "message", "type"]
+        for step in self:
+            data = self._read_format(
+                [f for f in fields if f not in {"answer_ids", "message", "type"}], load=False
+            )[0]
+            if "answer_ids" in fields:
+                data["answers"] = Store.many(step.answer_ids)
+            if "message" in fields:
+                data["message"] = plaintext2html(step.message) if step.message else False
+            if "type" in fields:
+                data["type"] = step.step_type
+            store.add("chatbot.script.step", data)
+
     # --------------------------
     # Tooling / Misc
     # --------------------------
@@ -379,8 +395,8 @@ class ChatbotScriptStep(models.Model):
             'id': self.id,
             'answers': [{
                 'id': answer.id,
-                'label': answer.name,
-                'redirectLink': answer.redirect_link,
+                "name": answer.name,
+                "redirect_link": answer.redirect_link,
             } for answer in self.answer_ids],
             'message': plaintext2html(self.message) if not is_html_empty(self.message) else False,
             'isLast': self._is_last_step(),

--- a/addons/im_livechat/static/src/embed/common/chat_window_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/chat_window_model_patch.js
@@ -16,6 +16,9 @@ patch(ChatWindow.prototype, {
             this.open({ notifyState: this.thread?.state !== "open" });
         } else {
             await super.close(...arguments);
+            if (this.thread.isTransient) {
+                this.thread.delete();
+            }
         }
         this.store.env.services["im_livechat.livechat"].leave();
         this.store.env.services["im_livechat.chatbot"].stop();

--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
@@ -14,7 +14,12 @@ export class Chatbot extends Record {
     script = Record.one("ChatbotScript");
     currentStep = Record.one("ChatbotStep");
     steps = Record.many("ChatbotStep");
-    thread = Record.one("Thread", { inverse: "chatbot" });
+    thread = Record.one("Thread", {
+        inverse: "chatbot",
+        onDelete() {
+            this.delete();
+        },
+    });
     typingMessage = Record.one("Message", {
         compute() {
             if (this.isTyping && this.thread) {
@@ -59,10 +64,10 @@ export class Chatbot extends Record {
         if (!this.currentStep || this.currentStep.completed || !this.thread) {
             return;
         }
-        const { Message: messages = [] } = this.store.insert(this.currentStep.data, { html: true });
-        this.currentStep.message =
-            messages[0] ??
-            this.store.Message.insert(
+        if (this.thread.isTransient) {
+            // Thread is not persisted thus messages do not exist on the server,
+            // create them now on the client side.
+            this.currentStep.message = this.store.Message.insert(
                 {
                     id: this.store.getNextTemporaryId(),
                     author: this.script.partner,
@@ -71,6 +76,7 @@ export class Chatbot extends Record {
                 },
                 { html: true }
             );
+        }
         this.thread.messages.add(this.currentStep.message);
     }
 
@@ -90,18 +96,20 @@ export class Chatbot extends Record {
             return;
         }
         if (this.steps.at(-1)?.eq(this.currentStep)) {
-            const nextStep = await rpc("/chatbot/step/trigger", {
+            const storeData = await rpc("/chatbot/step/trigger", {
                 channel_id: this.thread.id,
                 chatbot_script_id: this.script.id,
             });
-            if (!nextStep) {
+            if (!storeData) {
                 this.currentStep.isLast = true;
                 return;
             }
-            this.steps.push(nextStep);
+            const { ChatbotStep: steps } = this.store.insert(storeData, { html: true });
+            this.steps.push(steps[0]);
+        } else {
+            const nextStepIndex = this.steps.lastIndexOf(this.currentStep) + 1;
+            this.currentStep = this.steps[nextStepIndex];
         }
-        const nextStepIndex = this.steps.lastIndexOf(this.currentStep) + 1;
-        this.currentStep = this.steps[nextStepIndex];
     }
 
     /**
@@ -137,26 +145,26 @@ export class Chatbot extends Record {
         if (this.currentStep.selectedAnswer) {
             return true;
         }
-        const answer = this.currentStep.answers.find(({ label }) => message.body.includes(label));
+        const answer = this.currentStep.answers.find(({ name }) => message.body.includes(name));
         this.currentStep.selectedAnswer = answer;
         await rpc("/chatbot/answer/save", {
             channel_id: this.thread.id,
             message_id: this.currentStep.message.id,
             selected_answer_id: answer.id,
         });
-        if (!answer.redirectLink) {
+        if (!answer.redirect_link) {
             return true;
         }
         let isRedirecting = false;
-        if (answer.redirectLink && URL.canParse(answer.redirectLink, window.location.href)) {
+        if (answer.redirect_link && URL.canParse(answer.redirect_link, window.location.href)) {
             const url = new URL(window.location.href);
-            const nextURL = new URL(answer.redirectLink, window.location.href);
+            const nextURL = new URL(answer.redirect_link, window.location.href);
             isRedirecting = url.pathname !== nextURL.pathname || url.origin !== nextURL.origin;
         }
-        const targetURL = new URL(answer.redirectLink, window.location.origin);
+        const targetURL = new URL(answer.redirect_link, window.location.origin);
         const redirectionAlreadyDone = targetURL.href === location.href;
         if (!redirectionAlreadyDone) {
-            browser.location.assign(answer.redirectLink);
+            browser.location.assign(answer.redirect_link);
         }
         return redirectionAlreadyDone || !isRedirecting;
     }

--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_script_model.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_script_model.js
@@ -9,6 +9,6 @@ export class ChatbotScript extends Record {
     name;
     isLivechatTourRunning = false;
     partner = Record.one("Persona");
-    welcomeSteps = Record.many("ChatbotScriptStep");
+    welcomeSteps = Record.many("chatbot.script.step");
 }
 ChatbotScript.register();

--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_script_step_answer_model.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_script_step_answer_model.js
@@ -2,12 +2,13 @@ import { Record } from "@mail/core/common/record";
 
 export class ChatbotScriptStepAnswer extends Record {
     static id = "id";
+    static _name = "chatbot.script.answer";
 
     /** @type {number} */
     id;
     /** @type {string} */
     label;
     /** @type {string|false} */
-    redirectLink;
+    redirect_link;
 }
 ChatbotScriptStepAnswer.register();

--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_script_step_model.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_script_step_model.js
@@ -2,6 +2,7 @@ import { Record } from "@mail/core/common/record";
 
 export class ChatbotScriptStep extends Record {
     static id = "id";
+    static _name = "chatbot.script.step";
 
     /** @type {number} */
     id;
@@ -10,6 +11,6 @@ export class ChatbotScriptStep extends Record {
     /** @type {"free_input_multi"|"free_input_single"|"question_email"|"question_phone"|"question_selection"|"text"|"forward_operator"} */
     type;
     isLast = false;
-    answers = Record.many("ChatbotScriptStepAnswer");
+    answers = Record.many("chatbot.script.answer");
 }
 ChatbotScriptStep.register();

--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_step_model.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_step_model.js
@@ -4,24 +4,20 @@ export class ChatbotStep extends Record {
     static id = AND("scriptStep", "message");
 
     operatorFound = false;
-    scriptStep = Record.one("ChatbotScriptStep");
+    scriptStep = Record.one("chatbot.script.step");
     message = Record.one("Message", { inverse: "chatbotStep" });
-    answers = Record.many("ChatbotScriptStepAnswer", {
+    answers = Record.many("chatbot.script.answer", {
         compute() {
             return this.scriptStep?.answers;
         },
     });
-    selectedAnswer = Record.one("ChatbotScriptStepAnswer");
+    selectedAnswer = Record.one("chatbot.script.answer");
     type = Record.attr("", {
         compute() {
             return this.scriptStep?.type;
         },
     });
-    isLast = Record.attr(false, {
-        compute() {
-            return this.scriptStep.isLast;
-        },
-    });
+    isLast = false;
 
     get expectAnswer() {
         return [

--- a/addons/im_livechat/static/src/embed/common/message_patch.js
+++ b/addons/im_livechat/static/src/embed/common/message_patch.js
@@ -19,6 +19,6 @@ patch(Message.prototype, {
      * @param {import("@im_livechat/embed/common/chatbot/chatbot_step_model").StepAnswer} answer
      */
     answerChatbot(answer) {
-        return this.props.message.thread.post(answer.label);
+        return this.props.message.thread.post(answer.name);
     },
 });

--- a/addons/im_livechat/static/src/embed/common/message_patch.xml
+++ b/addons/im_livechat/static/src/embed/common/message_patch.xml
@@ -11,7 +11,7 @@
             <ul class="p-0 m-0" t-if="props.message.chatbotStep?.answers and !props.message.chatbotStep.selectedAnswer">
                 <li
                     t-foreach="props.message.chatbotStep?.answers" t-as="answer" t-key="answer.id"
-                    t-esc="answer.label" t-on-click="() => this.answerChatbot(answer)"
+                    t-esc="answer.name" t-on-click="() => this.answerChatbot(answer)"
                     class="btn btn-outline-primary d-block mt-2 py-2"
                 />
             </ul>

--- a/addons/mail/static/src/core/common/attachment_model.js
+++ b/addons/mail/static/src/core/common/attachment_model.js
@@ -16,9 +16,9 @@ export class Attachment extends FileModelMixin(Record) {
     static insert(data) {
         return super.insert(...arguments);
     }
-    static new(data) {
+    static new() {
         /** @type {import("models").Attachment} */
-        const attachment = super.new(data);
+        const attachment = super.new(...arguments);
         Record.onChange(attachment, ["extension", "filename"], () => {
             if (!attachment.extension && attachment.filename) {
                 attachment.extension = attachment.filename.split(".").pop();

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -40,8 +40,8 @@ export class Thread extends Record {
     static insert(data) {
         return super.insert(...arguments);
     }
-    static new(data) {
-        const thread = super.new(data);
+    static new() {
+        const thread = super.new(...arguments);
         Record.onChange(thread, ["state"], () => {
             if (thread.state === "open" && !this.store.env.services.ui.isSmall) {
                 const cw = this.store.ChatWindow?.insert({ thread });

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -27,17 +27,6 @@ export class DiscussCoreCommon {
                 }),
             { once: true }
         );
-        this.busService.subscribe("discuss.channel/joined", async (payload) => {
-            const { channel, invited_by_user_id: invitedByUserId } = payload;
-            const thread = this.store.Thread.insert(channel);
-            await thread.fetchChannelInfo();
-            if (invitedByUserId && invitedByUserId !== this.store.self.userId) {
-                this.notificationService.add(
-                    _t("You have been invited to #%s", thread.displayName),
-                    { type: "info" }
-                );
-            }
-        });
         this.busService.subscribe("discuss.channel/leave", (payload) => {
             const { Thread } = this.store.insert(payload);
             const [thread] = Thread;

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_trigger_selection_tour.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_trigger_selection_tour.js
@@ -1,0 +1,39 @@
+import { registry } from "@web/core/registry";
+
+const answerBothQuestions = [
+    {
+        trigger:
+            ".o-livechat-root:shadow .o-mail-Message:contains(Hello, here is a first question?)",
+    },
+    {
+        trigger: ".o-livechat-root:shadow li:contains(Yes to first question)",
+        run: "click",
+    },
+    {
+        trigger:
+            ".o-livechat-root:shadow .o-mail-Message:contains(Hello, here is a second question?)",
+    },
+    {
+        trigger: ".o-livechat-root:shadow li:contains(No to second question)",
+        run: "click",
+    },
+];
+registry.category("web_tour.tours").add("website_livechat.chatbot_trigger_selection", {
+    test: true,
+    url: "/contactus",
+    steps: () => [
+        {
+            trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",
+            run: "click",
+        },
+        ...answerBothQuestions,
+        {
+            trigger: ".o-livechat-root:shadow button[title='Restart Conversation']",
+            run: "click",
+        },
+        ...answerBothQuestions,
+        {
+            trigger: ".o-livechat-root:shadow button[title='Restart Conversation']",
+        },
+    ],
+});

--- a/addons/website_livechat/tests/test_chatbot_ui.py
+++ b/addons/website_livechat/tests/test_chatbot_ui.py
@@ -162,3 +162,43 @@ class TestLivechatChatbotUI(TestLivechatCommon, ChatbotCase):
         default_website.channel_id = livechat_channel.id
         self.env.ref("website.default_website").channel_id = livechat_channel.id
         self.start_tour("/contactus", "website_livechat.chatbot_redirect")
+
+    def test_chatbot_trigger_selection(self):
+        chatbot_trigger_selection = self.env["chatbot.script"].create(
+            {"title": "Trigger question selection bot"}
+        )
+        question_1, question_2 = tuple(
+            self.env["chatbot.script.step"].create([
+                {
+                    "chatbot_script_id": chatbot_trigger_selection.id,
+                    "message": "Hello, here is a first question?",
+                    "step_type": "question_selection",
+                },
+                {
+                    "chatbot_script_id": chatbot_trigger_selection.id,
+                    "message": "Hello, here is a second question?",
+                    "step_type": "question_selection",
+                },
+            ])
+        )
+        self.env["chatbot.script.answer"].create([
+            {
+                "name": "Yes to first question",
+                "script_step_id": question_1.id,
+            },
+            {
+                "name": "No to second question",
+                "script_step_id": question_2.id,
+            },
+        ])
+        livechat_channel = self.env["im_livechat.channel"].create({
+            'name': 'Redirection Channel',
+            'rule_ids': [Command.create({
+                'regex_url': '/contactus',
+                'chatbot_script_id': chatbot_trigger_selection.id,
+            })]
+        })
+        default_website = self.env.ref("website.default_website")
+        default_website.channel_id = livechat_channel.id
+        self.env.ref("website.default_website").channel_id = livechat_channel.id
+        self.start_tour("/contactus", "website_livechat.chatbot_trigger_selection")


### PR DESCRIPTION
Since [1], the return type of the `/chatbot/trigger/step` route has changed. However the call site was not adapted. As a result, the chat bot fails when triggering a question selection step.

Steps to reproduce:
- Create a chat bot script with two question selections
- Enable it on the website
- Follow the steps, the second one results in a crash

This PR adapts the chat bot code to properly use the new mail store syntax.

[1]: https://github.com/odoo/odoo/pull/171585

https://github.com/odoo/enterprise/pull/68604