### PR TITLE
[FIX] l10n_fr_invoice_addr: show siret fr invoice report

### DIFF
--- a/addons/l10n_fr_invoice_addr/views/report_invoice.xml
+++ b/addons/l10n_fr_invoice_addr/views/report_invoice.xml
@@ -1,14 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="report_invoice_document" inherit_id="account.report_invoice_document">
-        <xpath expr="//address" position="after">
-            <div class="mb-3" t-if="o.l10n_fr_is_company_french and o.partner_id.commercial_partner_id.siret">
+        <xpath expr="(//address)[1]" position="after">
+            <div class="mb-0" t-if="o.l10n_fr_is_company_french and o.partner_id.commercial_partner_id.siret">
                 SIRET: <t t-esc="o.partner_id.commercial_partner_id.siret"/>
             </div>
         </xpath>
-
-        <xpath expr="//address" position="attributes">
-            <attribute name="t-attf-class">{{'mb-0' if o.l10n_fr_is_company_french and o.partner_id.commercial_partner_id.siret else ''}}</attribute>
+        <xpath expr="(//address)[2]" position="after">
+            <div class="mb-0" t-if="o.l10n_fr_is_company_french and o.partner_id.commercial_partner_id.siret">
+                SIRET: <t t-esc="o.partner_id.commercial_partner_id.siret"/>
+            </div>
+        </xpath>
+        <xpath expr="(//address)[3]" position="after">
+            <div class="mb-0" t-if="o.l10n_fr_is_company_french and o.partner_id.commercial_partner_id.siret">
+                SIRET: <t t-esc="o.partner_id.commercial_partner_id.siret"/>
+            </div>
         </xpath>
 
         <xpath expr="//div[@id='informations']" position="inside">


### PR DESCRIPTION
Steps to reproduce:
- Install module 'France - Adding Mandatory Invoice Mentions'
- Switch to FR company
- Contacts > Create french company
- Sales & Purchase tab > set SIRET value
- Create an invoice for this company > Print it

The SIRET number does not show up anywhere on the invoice, despite the conditions being met.
The SIRET number has been mandatory since July 1st 2024 in France

This sometimes happens because the xpath only edits one of the 3
possible address tags added in 16.0. There is no need to edit the margin
because the address already has mb-0 in its classes.

opw-3865644

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
