### PR TITLE
[FIX] stock: show lot_ids for byproduct moves

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -285,7 +285,7 @@ class StockMove(models.Model):
         super()._compute_show_info()
         byproduct_moves = self.filtered(lambda m: m.byproduct_id or m in self.production_id.move_finished_ids)
         byproduct_moves.show_quant = False
-        byproduct_moves.show_lots_text = True
+        byproduct_moves.show_lots_m2o = True
 
     @api.depends('picking_type_id.use_create_components_lots')
     def _compute_display_assign_serial(self):

--- a/addons/mrp/tests/test_byproduct.py
+++ b/addons/mrp/tests/test_byproduct.py
@@ -470,6 +470,10 @@ class TestMrpByProduct(common.TransactionCase):
         mo.move_byproduct_ids.lot_ids = [(4, self.sn_1.id)]
         mo.move_byproduct_ids.lot_ids = [(4, self.sn_2.id)]
 
+        self.assertFalse(mo.move_byproduct_ids.show_lots_text)
+        self.assertTrue(mo.move_byproduct_ids.show_lots_m2o)
+        self.assertFalse(mo.move_byproduct_ids.show_quant)
+
         mo.button_mark_done()
         self.assertEqual(len(mo.move_byproduct_ids.move_line_ids), 2)
         self.assertEqual(mo.move_byproduct_ids.product_id, mo.move_byproduct_ids.move_line_ids.product_id)


### PR DESCRIPTION
Steps to reproduce the bug:
- Enable by-porduct option in manufacturing settings
- Create a storable product “P1” with a BoM:
   - Components: C1
   - by-product: C2 tracked by serial number
- Create a manufacturing order (MO) to produce one unit of P1.
- Confirm the MO.
- Click on the detailed operation to select the serial number for C2.

Problem:
the field "lot_id" should be displayed instead of "lot_name".
because we should be able to create and use existing SN with byproduct
moves.

opw-[4113887](https://www.odoo.com/web#id=4113887&view_type=form&model=project.task)
