### PR TITLE
[FIX] pos_loyalty: ignore combo line for cheapest line discount

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/loyalty.js
+++ b/addons/pos_loyalty/static/src/overrides/models/loyalty.js
@@ -1127,7 +1127,7 @@ patch(Order.prototype, {
      */
     _getCheapestLine() {
         let cheapestLine;
-        for (const line of this.get_orderlines()) {
+        for (const line of this.get_orderlines().filter((line) => !line.comboLines)) {
             if (line.reward_id || !line.get_quantity()) {
                 continue;
             }

--- a/addons/pos_loyalty/static/tests/tours/PosLoyaltyLoyaltyProgramTour.js
+++ b/addons/pos_loyalty/static/tests/tours/PosLoyaltyLoyaltyProgramTour.js
@@ -2,6 +2,8 @@
 
 import * as PosLoyalty from "@pos_loyalty/../tests/tours/PosLoyaltyTourMethods";
 import * as ProductScreen from "@point_of_sale/../tests/tours/helpers/ProductScreenTourMethods";
+import * as combo from "@point_of_sale/../tests/tours/helpers/ComboPopupMethods";
+import * as Order from "@point_of_sale/../tests/tours/helpers/generic_components/OrderWidgetMethods";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram1", {
@@ -205,4 +207,23 @@ registry.category("web_tour.tours").add("PosLoyaltyDontGrantPointsForRewardOrder
           PosLoyalty.orderTotalIs('5.10'),
           PosLoyalty.finalizeOrder('Cash', '5.10'),
         ].flat()
+});
+
+
+registry.category("web_tour.tours").add("PosComboCheapestRewardProgram", {
+    test: true,
+    url: "/pos/web",
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.clickHomeCategory(),
+            ProductScreen.clickDisplayedProduct("Office Combo"),
+            combo.isPopupShown(),
+            combo.select("Combo Product 1"),
+            combo.select("Combo Product 4"),
+            combo.select("Combo Product 6"),
+            combo.confirm(),
+            Order.hasLine({ productName: "10% on the cheapest product" }),
+            PosLoyalty.orderTotalIs("59.09"),
+        ].flat(),
 });

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -6,6 +6,7 @@ from odoo import Command
 from odoo.tests import tagged
 
 from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
+from odoo.addons.point_of_sale.tests.common_setup_methods import setup_pos_combo_items
 
 
 @tagged("post_install", "-at_install")
@@ -2189,3 +2190,25 @@ class TestUi(TestPointOfSaleHttpCommon):
             "PosLoyaltyGiftCardNoPoints",
             login="accountman",
         )
+
+    def test_cheapest_product_reward_pos_combo(self):
+        setup_pos_combo_items(self)
+        self.office_combo.write({'lst_price': 50})
+        self.env['loyalty.program'].search([]).write({'active': False})
+        self.env['loyalty.program'].create({
+            'name': 'Auto Promo Program - Cheapest Product',
+            'program_type': 'promotion',
+            'trigger': 'auto',
+            'rule_ids': [(0, 0, {
+                'minimum_qty': 2,
+            })],
+            'reward_ids': [(0, 0, {
+                'reward_type': 'discount',
+                'discount': 10,
+                'discount_mode': 'percent',
+                'discount_applicability': 'cheapest',
+            })]
+        })
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'PosComboCheapestRewardProgram', login="pos_user")


### PR DESCRIPTION
When using a loyalty program that apply a discount on the cheapest line the combo "title" would always be selected as it's price is 0. And the reward would then not be applied.

Steps to reproduce:
-------------------
* Create a combo product with atleast 2 combo choices
* Create a loyalty program that gives a discount on the cheapest line
* Open a PoS and add the combo product
> Observation: The reward cannot be applied

Why the fix:
------------
When tryin to apply the discount, in the `_getCheapestLine` function we make sure to filter lines that are combo "title"

opw-4033960
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
