### PR TITLE
[FIX] mail: remove chat bubble sub button and fix bubble background

### DIFF
--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -11,14 +11,14 @@
     </t>
 
     <t t-name="mail.ChatBubble.core">
-        <button class="o-mail-ChatBubble" t-att-name="props.chatWindow.displayName" t-att-class="{ 'o-bouncing': state.bouncing, 'position-fixed': env.embedLivechat, 'position-relative': !env.embedLivechat, 'o-active': preview.isOpen }" t-att-style="env.embedLivechat ? `top: ${ position.top }; left: ${ position.left };` : ''" t-on-click="() => props.chatWindow.open()" t-on-animationend="() => state.bouncing = false" t-ref="root">
+        <div class="o-mail-ChatBubble" t-att-name="props.chatWindow.displayName" t-att-class="{ 'o-bouncing': state.bouncing, 'position-fixed': env.embedLivechat, 'position-relative': !env.embedLivechat, 'o-active': preview.isOpen }" t-att-style="env.embedLivechat ? `top: ${ position.top }; left: ${ position.left };` : ''" t-on-click="() => props.chatWindow.open()" t-on-animationend="() => state.bouncing = false" t-ref="root">
             <div t-if="thread?.importantCounter > 0" class="o-mail-ChatBubble-counter position-absolute badge rounded-pill fw-bold o-discuss-badge shadow" t-out="thread?.importantCounter"/>
             <button t-if="state.showClose and !env.embedLivechat" class="o-mail-ChatBubble-close position-absolute shadow rounded-circle fw-bold bg-view" title="Close Chat Window" t-on-click.stop="() => this.props.chatWindow.close()"><i class="oi oi-close"/></button>
             <ImStatus t-if="thread?.correspondent?.persona?.im_status and thread?.correspondent?.persona?.im_status != 'offline'" className="'o-mail-ChatBubble-status position-absolute o-mail-brighter'" persona="thread.correspondent.persona" thread="thread"/>
-            <button class="o-mail-ChatHub-bubbleBtn btn">
+            <button class="o-mail-ChatHub-bubbleBtn btn bg-view">
                 <img class="o-mail-ChatBubble-avatar rounded-circle" t-att-class="{ 'o-big': env.embedLivechat }" t-att-src="thread?.avatarUrl" alt="Thread image" draggable="false"/>
             </button>
-        </button>
+        </div>
     </t>
 
     <t t-name="mail.ChatBubble.preview">


### PR DESCRIPTION
Before this PR, chat bubbles were using button elements inside another button element. It's not valid HTML and can be replaced by a simple div. This PR also adds a dark mode-friendly background to the bubble. This makes the bubble more visible when an image with transparency is used as a channel icon.

Before:
![image](https://github.com/user-attachments/assets/feb13fca-d8e5-4dcd-9df5-0ef3f567b5a3)
After:
![image](https://github.com/user-attachments/assets/8facd38d-c590-4af9-a511-b5d36ccb1885)

