### PR TITLE
[FIX] purchase_stock: Allow salesmen to confirm SOs that update PO lines

### DIFF
--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -128,15 +128,15 @@ class StockRule(models.Model):
             po_line_values = []
             for procurement in procurements:
                 po_lines = po_lines_by_product.get(procurement.product_id.id, self.env['purchase.order.line'])
-                po_line = po_lines._find_candidate(*procurement)
+                po_line = po_lines._find_candidate(*procurement).sudo()
 
                 if po_line:
-                    # If the procurement can be merge in an existing line. Directly
+                    # If the procurement can be merged in an existing line. Directly
                     # write the new values on it.
                     vals = self._update_purchase_order_line(procurement.product_id,
                         procurement.product_qty, procurement.product_uom, company_id,
                         procurement.values, po_line)
-                    po_line.sudo().write(vals)
+                    po_line.write(vals)
                 else:
                     if float_compare(procurement.product_qty, 0, precision_rounding=procurement.product_uom.rounding) <= 0:
                         # If procurement contains negative quantity, don't create a new line that would contain negative qty


### PR DESCRIPTION
**Steps to reproduce:**

- Create a product with MTO route and a seller set.
- With a plain salesman user, create a sales order with that product and confirm it.
- Do a second sales order with the same product.
- Try to confirm it.

**Current behaviour:**

You get the following error:

```
odoo.exceptions.AccessError: You are not allowed to access 'Purchase Order Line' (purchase.order.line) records.

This operation is allowed for the following groups:
        - Accounting & Finance/Billing
        - Inventory/User
        - Purchases/Administrator
        - Purchases/User
        - Technical Settings/Show Accounting Features - Readonly
        - User types/Portal

Contact your administrator to request access if necessary.
```

**Expected behaviour:**

No error.

**Explanation:**

When a matching PO line is found, there's a request to a method for getting the update vals using the PO line and other records (like product.supplierinfo), that requires specific permissions that a salesman doesn't have.

**Solution:**

Do whole operation with sudo. In fact, the write operation was done already with sudo, but not the call to `_update_purchase_order_line` method.

@Tecnativa TT50492