### PR TITLE
[FIX] stock: save SM detailled operation when dirty

### DIFF
--- a/addons/stock/static/src/views/picking_form/stock_move_one2many.js
+++ b/addons/stock/static/src/views/picking_form/stock_move_one2many.js
@@ -49,10 +49,7 @@ export class StockMoveX2ManyField extends X2ManyField {
     async openRecord(record) {
         if (this.canOpenRecord && !record.isNew) {
             const dirty = await record.isDirty();
-            if (await record._parentRecord.isDirty()){
-                await record._parentRecord.save({ reload: true });
-            }
-            if (dirty && 'quantity' in record._changes) {
+            if (await record._parentRecord.isDirty() || (dirty && 'quantity' in record._changes)) {
                 await record._parentRecord.save({ reload: true });
                 record = record._parentRecord.data[this.props.name].records.find(e => e.resId === record.resId);
                 if (!record) {

--- a/addons/stock/static/tests/tours/stock_picking_tour.js
+++ b/addons/stock/static/tests/tours/stock_picking_tour.js
@@ -288,6 +288,31 @@ registry.category("web_tour.tours").add('test_edit_existing_line', {
     ]
 });
 
+registry.category("web_tour.tours").add('test_edit_existing_lines_2', {
+    test: true,
+    steps: () => [
+        { trigger: ".o_data_row:has(.o_data_cell[data-tooltip='Product a']) .fa-list" },
+        { trigger: ".o_data_cell[name=lot_name]" },
+        {
+            trigger: ".o_field_widget[name=lot_name] input",
+            run: 'text SNa001',
+        },
+        { trigger: ".o_form_view.modal-content .o_form_button_save" },
+        { trigger: ".o_data_row:has(.o_data_cell[data-tooltip='Product b']) .fa-list" },
+        { trigger: ".o_data_cell[name=lot_name]" },
+        {
+            trigger: ".o_field_widget[name=lot_name] input",
+            run: 'text SNb001',
+        },
+        { trigger: ".o_form_view.modal-content .o_form_button_save" },
+        { trigger: ".o_form_view:not(.modal-content) .o_form_button_save" },
+        {
+            trigger: ".o_form_renderer.o_form_saved",
+            isCheck: true,
+        },
+    ]
+});
+
 registry.category("web_tour.tours").add('test_onchange_twice_lot_ids', {
     test: true,
     steps: () => [

--- a/addons/stock/tests/test_picking_tours.py
+++ b/addons/stock/tests/test_picking_tours.py
@@ -164,6 +164,48 @@ class TestStockPickingTour(HttpCase):
         names = self.receipt.move_ids.move_line_ids.mapped('lot_name')
         self.assertEqual(names, ["one", "two"])
 
+    def test_edit_existing_lines_2(self):
+        self.uom_unit = self.env.ref('uom.product_uom_unit')
+        product_a, product_b = self.env["product.product"].create([
+            {
+                'name': 'Product a',
+                'type': 'product',
+                'tracking': 'serial',
+            },
+            {
+                'name': 'Product b',
+                'type': 'product',
+                'tracking': 'serial',
+            }
+        ])
+
+        self.receipt.write({
+            "move_ids": [
+                Command.create({
+                    "name": "Product a",
+                    "product_id": product_a.id,
+                    "location_id": self.receipt.location_id.id,
+                    "location_dest_id": self.receipt.location_dest_id.id,
+                    "product_uom_qty": 1,
+                }),
+                Command.create({
+                    "name": "Product b",
+                    "product_id": product_b.id,
+                    "location_id": self.receipt.location_id.id,
+                    "location_dest_id": self.receipt.location_dest_id.id,
+                    "product_uom_qty": 1,
+                }),
+            ]
+        })
+
+        self.receipt.action_confirm()
+
+        url = self._get_picking_url(self.receipt.id)
+        self.start_tour(url, 'test_edit_existing_lines_2', login='admin', timeout=60)
+
+        names = self.receipt.move_ids.move_line_ids.mapped('lot_name')
+        self.assertEqual(names, ["SNa001", "SNb001"])
+
     def test_onchange_serial_lot_ids(self):
         """
         Checks that onchange behaves correctly with respect to multiple unlinks


### PR DESCRIPTION
### Steps to reproduce

- Create 2 products tracked by Lots
- Create and "mark as to do" a receipt with two lines:
  - 1 x Product 1
  - 1 x Product 2
- Click on the list icon (details Operation) of the first line
- Add a Lot name to the line and save (on the Open stock move dialog)
- Click on the list icon (details Operation) of the second line
- Add a Lot name to the line and save (on the Open stock move dialog)
- Click on the list icon (details Operation) of the second line

#### > the lot_name has not been saved

### Cause of the issue

When calling openRecord, if the parent of the record is dirty (the picking), it is saved and reload before proceeding: https://github.com/odoo/odoo/blob/709ad381120ab7a7b9ff14ec473b410a53f39e28/addons/stock/static/src/views/picking_form/stock_move_one2many.js#L49-L54 This is what happens when you open the second line since you changed the content of the first line.

However, when we proceed with this called, the `super.openRecord` will be called on the record on which we started the call with rather than the corresponding record of the reload. So that its change will not be saved.

### Solution:

A similar issue has already been solved by commit 127e735 and the same fix can be used by restructuring the code + it allows to reload the record only once.

opw-4097653
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
