### PR TITLE
[IMP] point_of_sale: change odoo signature to receipt

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -134,7 +134,7 @@
 
             <br/>
             <div class="pos-receipt-order-data">
-                <p>Odoo Point of Sale</p>
+                <p>Powered by Odoo</p>
                 <div t-esc="props.data.name" />
                 <div id="order-date" t-esc="props.data.date" />
             </div>

--- a/addons/pos_restaurant/static/src/overrides/components/receipt_screen/order_receipt/order_receipt.xml
+++ b/addons/pos_restaurant/static/src/overrides/components/receipt_screen/order_receipt/order_receipt.xml
@@ -37,10 +37,6 @@
                 </div>
             </t>
         </xpath>
-        <xpath expr="//p[text()='Odoo Point of Sale']" position="replace">
-            <p t-if="props.data.isRestaurant">Odoo Restaurant</p>
-            <p t-else="">Odoo Point of Sale</p>
-        </xpath>
     </t>
     <t t-name="pos_restaurant.ReceiptHeader" t-inherit="point_of_sale.ReceiptHeader" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('cashier')]" position="after">


### PR DESCRIPTION
Instead of Odoo Point of Sale, the receipt is now showing Powered by Odoo.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
