### PR TITLE
[FIX] website: scroll to anchor link in rtl

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1753,6 +1753,7 @@ input[value*="data-oe-translation-id"] {
         // best workaround for now.
         > main {
             overflow-x: hidden;
+            overflow-y: hidden;
         }
     }
 }


### PR DESCRIPTION
Commit that introduced the issue: https://github.com/odoo/odoo/commit/2050328a37ed5dd7639273bcd60eb5006bd98cfb

Issue:
======
We can't scroll to anchor link until the animation is over in rtl language.

Steps to reproduce the issue:
=============================
- Go to a blanck web page
- Add a form on the top
- Create a link for it using the sidebar (it will be #Form)
- Add text block after it
- Add heading block
- Add any animation but make sure to add a delay (3s for example) and duration (2s for example)
- Add a text and a button after the heading
- Add the link `#Form` to the button
- Save
- Reload the page and choose arabic language for the website (not the user)
- The scroll down and click on the button, nothing happens until the animation is over and then when you click the page scrolls to the form.

Origin of the issue:
====================
By default the value `overflow-y=visible` so in `ltr` since we don't update the overlow it stays by defaylt and the JQuery doesn't detect it as scrollable.

Now in `rtl` we add `overflow-x:hidden` which update the value of `overflow-y` to `auto` which makes the JQuery detect it as scrollable which explains the difference of behavior between the two directions.

Since the closestScrollable of the element isn't the same in the two directions, then in `rtl` it will produce different offset in `scrollTo` of JQuery.

opw-4053513