### PR TITLE
[FIX] mail: wider composer when editing message

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -194,7 +194,13 @@ export class Composer extends Component {
                 }
             },
             pickers: { emoji: (emoji) => this.addEmoji(emoji) },
-            position: this.props.mode === "extended" ? "bottom-start" : "top-end",
+            position:
+                this.props.mode === "extended"
+                    ? "bottom-start"
+                    : this.props.composer.message
+                    ? "bottom-start"
+                    : "top-end",
+            fixed: !this.props.composer.message,
         };
     }
 
@@ -299,6 +305,10 @@ export class Composer extends Component {
             (!this.props.composer.text && attachments.length === 0) ||
             attachments.some(({ uploading }) => Boolean(uploading))
         );
+    }
+
+    get hasSendButtonNonEditing() {
+        return !this.extended;
     }
 
     get hasSuggestions() {

--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -47,17 +47,21 @@
     }
 }
 
-@mixin o-mail-Composer-inputSizeStyle {
+.o-mail-Composer-inputStyle {
     padding-top: 10px; // carefully crafted to have the text in the middle in chat window
     padding-bottom: 10px;
     padding-left: (map-get($spacers, 2) + map-get($spacers, 3)) / 2;
     padding-right: (map-get($spacers, 2) + map-get($spacers, 3)) / 2;
     line-height: 1.42857143 !important; // so that input is rounded to 20px = 14px (base font) * 1.42857143 (line-height)
+
+    .o-mail-Composer.o-editing & {
+        padding-left: map-get($spacers, 2);
+        padding-right: map-get($spacers, 2);
+    }
 }
 
 .o-mail-Composer-input {
     font-family: "text-emoji", $font-family-base;
-    @include o-mail-Composer-inputSizeStyle();
     max-height: 100px;
     resize: none;
 
@@ -77,7 +81,6 @@
 .o-mail-Composer-fake {
     height: 0;
     top: -10000px;
-    @include o-mail-Composer-inputSizeStyle();
 }
 
 .o-mail-Composer-compactContainer {

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -13,7 +13,8 @@
                     'o-isUiSmall': ui.isSmall,
                     'p-3': normal,
                     'o-hasSelfAvatar': !env.inChatWindow and thread,
-                    'o-focused': props.composer.isFocused
+                    'o-focused': props.composer.isFocused,
+                    'o-editing': props.composer.message,
                 }" t-attf-class="{{ props.className }}">
             <div class="o-mail-Composer-sidebarMain flex-shrink-0" t-if="!compact and props.sidebar">
                 <img class="o-mail-Composer-avatar o_avatar rounded" t-att-src="store.self.avatarUrl" alt="Avatar of user"/>
@@ -36,11 +37,12 @@
                         'o-mobile border-bottom': isMobileOS,
                         'border': props.composer.message,
                         'border rounded-3' : normal,
-                        'border rounded-3 align-self-stretch flex-column' : extended,
+                        'border rounded-3 align-self-stretch' : extended,
+                        'flex-column': extended or props.composer.message,
                     }"
                 >
                     <div class="position-relative flex-grow-1">
-                        <textarea class="o-mail-Composer-input form-control bg-view border-0 rounded-3 shadow-none overflow-auto"
+                        <textarea class="o-mail-Composer-input o-mail-Composer-inputStyle form-control bg-view border-0 rounded-3 shadow-none overflow-auto"
                             t-ref="textarea"
                             style="height:40px;"
                             t-on-keydown="onKeydown"
@@ -58,21 +60,23 @@
                              the textarea properly without flicker.
                         -->
                         <textarea
-                            class="o-mail-Composer-fake position-absolute border-0"
+                            class="o-mail-Composer-fake o-mail-Composer-inputStyle position-absolute border-0"
                             t-model="props.composer.text"
                             t-ref="fakeTextarea"
                             disabled="1"
                         />
                     </div>
-                    <div class="o-mail-Composer-actions d-flex bg-view rounded"
+                    <div class="o-mail-Composer-actions d-flex bg-view"
                         t-att-class="{
                             'ms-1': compact and ui.isSmall,
                             'mx-1': compact and !ui.isSmall,
                             'ms-3': normal,
                             'mx-3 border-top p-1': extended,
+                            'border-top': extended or props.composer.message,
+                            'rounded': !props.composer.message,
                         }"
                     >
-                        <div class="d-flex flex-grow-1 align-items-baseline mt-1" t-ref="main-actions">
+                        <div class="d-flex flex-grow-1 align-items-baseline" t-att-class="{ 'mt-1': !props.composer.message }" t-ref="main-actions">
                             <button class="btn border-0 p-1 rounded-pill" t-att-class="{'bg-300': this.picker.state.picker === this.picker.PICKERS.EMOJI}" aria-label="Emojis" t-on-click="onClickAddEmoji" t-ref="emoji-button"><i class="fa fa-fw fa-smile-o"/></button>
                             <FileUploader t-if="allowUpload" multiUpload="true" onUploaded.bind="(data) => { attachmentUploader.uploadData(data) }">
                                 <t t-set-slot="toggler">
@@ -81,7 +85,7 @@
                             </FileUploader>
                             <t t-if="extended and ui.isSmall and props.composer.message" t-call="mail.Composer.sendButton"/>
                             <t t-if="!extended" t-call="mail.Composer.fullComposer"/>
-                            <t t-if="!extended" t-call="mail.Composer.sendButton"/>
+                            <t t-if="hasSendButtonNonEditing" t-call="mail.Composer.sendButton"/>
                         </div>
                         <t t-if="extended" t-call="mail.Composer.fullComposer"/>
                     </div>
@@ -100,7 +104,7 @@
                 <Picker t-props="picker"/>
             </div>
         </div>
-        <span t-if="props.composer.message" class="text-muted" t-out="CANCEL_OR_SAVE_EDIT_TEXT" t-on-click="onClickCancelOrSaveEditText"/>
+        <span t-if="props.composer.message" class="text-muted px-1" t-out="CANCEL_OR_SAVE_EDIT_TEXT" t-on-click="onClickCancelOrSaveEditText"/>
     </div>
     <NavigableList t-if="suggestion" class="'o-mail-Composer-suggestionList'" t-props="navigableListProps"/>
 </t>

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -204,6 +204,7 @@ export class Message extends Component {
                 this.props.thread,
                 this.props.message
             ),
+            "o-editing": this.state.isEditing,
         };
     }
 

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -51,6 +51,11 @@
     &:not(.o-note) {
         padding-left: (map-get($spacers, 2) + map-get($spacers, 3)) / 2;
         padding-right: (map-get($spacers, 2) + map-get($spacers, 3)) / 2;
+
+        .o-mail-Message.o-editing & {
+            padding-left: map-get($spacers, 1);
+            padding-right: map-get($spacers, 1);
+        }
     }
 
     & > p {

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -88,7 +88,7 @@
                                                             'mb-0 py-2': !message.is_note,
                                                             'o-note': message.is_note,
                                                             'align-self-start rounded-end-3 rounded-bottom-3': !state.isEditing and !message.is_note,
-                                                            'o-mail-Message-editable flex-grow-1': state.isEditing,
+                                                            'flex-grow-1': state.isEditing,
                                                             }" t-ref="body">
                                                     <Composer t-if="state.isEditing" autofocus="true" composer="message.composer" messageComponent="constructor" onDiscardCallback.bind="exitEditMode" onPostCallback.bind="exitEditMode" mode="env.inChatter ? 'extended' : 'compact'" sidebar="false"/>
                                                     <t t-else="">

--- a/addons/mail/static/src/core/common/picker.js
+++ b/addons/mail/static/src/core/common/picker.js
@@ -53,6 +53,7 @@ export class Picker extends Component {
         "pickers",
         "position?",
         "storeScroll",
+        "fixed?",
     ];
     static template = "mail.Picker";
 
@@ -85,7 +86,7 @@ export class Picker extends Component {
     get popoverSettings() {
         return {
             position: this.props.position,
-            fixedPosition: true,
+            fixedPosition: this.props.fixed,
             onClose: () => this.close(),
             closeOnClickAway: false,
             animation: false,

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -42,7 +42,7 @@ test("Start edition on click edit", async () => {
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message-moreMenu [title='Edit']");
-    await contains(".o-mail-Message-editable .o-mail-Composer-input", { value: "Hello world" });
+    await contains(".o-mail-Message.o-editing .o-mail-Composer-input", { value: "Hello world" });
 });
 
 test("Edit message (mobile)", async () => {
@@ -67,9 +67,9 @@ test("Edit message (mobile)", async () => {
     await contains(".o-mail-Message");
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message-moreMenu [title='Edit']");
-    await contains(".o-mail-Message-editable .o-mail-Composer-input", { value: "Hello world" });
+    await contains(".o-mail-Message.o-editing .o-mail-Composer-input", { value: "Hello world" });
     await click("button", { text: "Discard editing" });
-    await contains(".o-mail-Message-editable .o-mail-Composer", { count: 0 });
+    await contains(".o-mail-Message.o-editing .o-mail-Composer", { count: 0 });
     await contains(".o-mail-Message-content", { text: "Hello world" });
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message-moreMenu [title='Edit']");
@@ -96,9 +96,7 @@ test("Editing message keeps the mentioned channels", async () => {
     await contains(".o_channel_redirect", { count: 1, text: "#other" });
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message-moreMenu [title='Edit']");
-    await contains(".o-mail-Message-editable .o-mail-Composer-input", {
-        value: "#other",
-    });
+    await contains(".o-mail-Message .o-mail-Composer-input", { value: "#other" });
     await insertText(".o-mail-Message .o-mail-Composer-input", "#other bye", { replace: true });
     await click(".o-mail-Message a", { text: "save" });
     await contains(".o-mail-Message-content", { text: "#other bye" });
@@ -186,7 +184,7 @@ test("Stop edition on click cancel", async () => {
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message-moreMenu [title='Edit']");
     await click(".o-mail-Message a", { text: "cancel" });
-    await contains(".o-mail-Message-editable .o-mail-Composer", { count: 0 });
+    await contains(".o-mail-Message.o-editing .o-mail-Composer", { count: 0 });
 });
 
 test("Stop edition on press escape", async () => {
@@ -207,7 +205,7 @@ test("Stop edition on press escape", async () => {
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message-moreMenu [title='Edit']");
     triggerHotkey("Escape", false);
-    await contains(".o-mail-Message-editable .o-mail-Composer", { count: 0 });
+    await contains(".o-mail-Message.o-editing .o-mail-Composer", { count: 0 });
 });
 
 test("Stop edition on click save", async () => {
@@ -228,7 +226,7 @@ test("Stop edition on click save", async () => {
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message-moreMenu [title='Edit']");
     await click(".o-mail-Message a", { text: "save" });
-    await contains(".o-mail-Message-editable .o-mail-Composer", { count: 0 });
+    await contains(".o-mail-Message.o-editing .o-mail-Composer", { count: 0 });
 });
 
 test("Stop edition on press enter", async () => {
@@ -249,7 +247,7 @@ test("Stop edition on press enter", async () => {
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message-moreMenu [title='Edit']");
     triggerHotkey("Enter", false);
-    await contains(".o-mail-Message-editable .o-mail-Composer", { count: 0 });
+    await contains(".o-mail-Message.o-editing .o-mail-Composer", { count: 0 });
 });
 
 test("Do not stop edition on click away when clicking on emoji", async () => {
@@ -271,7 +269,7 @@ test("Do not stop edition on click away when clicking on emoji", async () => {
     await click(".o-mail-Message-moreMenu [title='Edit']");
     await click(".o-mail-Composer button[aria-label='Emojis']");
     await click(".o-EmojiPicker-content :nth-child(1 of .o-Emoji)");
-    await contains(".o-mail-Message-editable .o-mail-Composer");
+    await contains(".o-mail-Message.o-editing .o-mail-Composer");
 });
 
 test("Edit and click save", async () => {
@@ -1037,7 +1035,7 @@ test('Quick edit (edit from Composer with ArrowUp) ignores empty ("deleted") mes
     await openDiscuss(channelId);
     await contains(".o-mail-Message");
     triggerHotkey("ArrowUp");
-    await contains(".o-mail-Message .o-mail-Message-editable");
+    await contains(".o-mail-Message.o-editing");
     await contains(".o-mail-Message .o-mail-Composer-input", { value: "not empty" });
 });
 
@@ -1058,7 +1056,7 @@ test("Editing a message to clear its composer opens message delete dialog.", asy
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message-moreMenu [title='Edit']");
-    await insertText(".o-mail-Message-editable .o-mail-Composer-input", "", { replace: true });
+    await insertText(".o-mail-Message.o-editing .o-mail-Composer-input", "", { replace: true });
     triggerHotkey("Enter");
     await contains(".modal-body p", { text: "Are you sure you want to delete this message?" });
 });
@@ -1083,7 +1081,7 @@ test("Clear message body should not open message delete dialog if it has attachm
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message-moreMenu [title='Edit']");
-    await insertText(".o-mail-Message-editable .o-mail-Composer-input", "", { replace: true });
+    await insertText(".o-mail-Message.o-editing .o-mail-Composer-input", "", { replace: true });
     triggerHotkey("Enter");
     await contains(".o-mail-Message-textContent", { text: "" });
     // weak test, no guarantee that we waited long enough for the potential dialog to show
@@ -1740,7 +1738,7 @@ test("Can edit a message only containing an attachment", async () => {
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message-moreMenu [title='Edit']");
-    await contains(".o-mail-Message-editable .o-mail-Composer-input");
+    await contains(".o-mail-Message.o-editing .o-mail-Composer-input");
 });
 
 test("Click on view reactions shows the reactions on the message", async () => {

--- a/addons/web/tooling/_eslintignore
+++ b/addons/web/tooling/_eslintignore
@@ -192,6 +192,8 @@ addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet.js
 !approvals/**/*
 !test_discuss_full_enterprise
 !test_discuss_full_enterprise/**/*
+!whatsapp
+!whatsapp/**/*
 
 # Whitelist point_of_sale
 !addons/point_of_sale


### PR DESCRIPTION
In chat window, editing message composer is too narrow.

This commit fixes the issue as follow:
1. Reduce spacing in message and composer while editing a message
2. Move actions to bottom

Before / After
<img width="363" alt="004-before" src="https://github.com/user-attachments/assets/ef80af40-710c-4de2-a5ed-185a68580ffc"> ![Screenshot 2024-08-20 at 16 53 09](https://github.com/user-attachments/assets/7982ed75-ff9e-41e7-92a4-965432ebd0cb)

https://github.com/odoo/enterprise/pull/68573