### PR TITLE
[FIX] odoo, tools: fix float_round rounding issue

### DIFF
--- a/addons/stock/tests/test_packing.py
+++ b/addons/stock/tests/test_packing.py
@@ -333,13 +333,14 @@ class TestPacking(TestPackingCommon):
 
     def test_move_picking_with_package(self):
         """
-        355.4 rounded with 0.01 precision is 355.40000000000003.
-        check that nonetheless, moving a picking is accepted
+        Ensure that a quantity of 355.40000000000003 is properly handled,
+        rounded, and does not raise any exceptions during the
+        picking process.
         """
         self.assertEqual(self.productA.uom_id.rounding, 0.01)
         self.assertEqual(
             float_round(355.4, precision_rounding=self.productA.uom_id.rounding),
-            355.40000000000003,
+            355.4,
         )
         location_dict = {
             'location_id': self.stock_location.id,

--- a/odoo/addons/base/tests/test_float.py
+++ b/odoo/addons/base/tests/test_float.py
@@ -177,6 +177,8 @@ class TestFloatPrecision(TransactionCase):
         # res.currency.rate no more uses 6 digits of precision by default, it now uses whatever precision it gets
         try_roundtrip(10000.999999, 10000.999999, '2000-01-03')
 
+        assert float_round(0.0153, precision_digits=4) == 0.0153
+
         #TODO re-enable those tests when tests are made on dedicated models
         # (res.currency.rate don't accept negative value anymore)
         #try_roundtrip(-2.6748955, -2.674896, '2000-01-02')

--- a/odoo/tools/float_utils.py
+++ b/odoo/tools/float_utils.py
@@ -70,6 +70,12 @@ def float_round(value, precision_digits=None, precision_rounding=None, rounding_
     # Credit: discussion with OpenERP community members on bug 882036
 
     normalized_value = value / rounding_factor # normalize
+
+    # If the normalized value is already an integer, we don't need to apply any rounding
+    # because the value is already at the desired precision.
+    if normalized_value.is_integer():
+        return value
+
     sign = math.copysign(1.0, normalized_value)
     epsilon_magnitude = math.log(abs(normalized_value), 2)
     epsilon = 2**(epsilon_magnitude-52)


### PR DESCRIPTION
Fix an issue in the float_round function that resulted in inaccurate rounding when targeting a specific number of decimal places.

Example:
float_round(0.0153, precision_digits=4) should return 0.0153, but was incorrectly returning 0.015300000000000001.

To resolve this, the proposed fix involves returning the value directly if the normalized value is an integer, indicating that no further rounding is necessary.

In the example, the normalized value is 153.0, allowing us to return the original value without additional rounding.

opw-4110401
