### PR TITLE
[FIX] account: no sequence number on automatic draft moves

### DIFF
--- a/addons/account/wizard/account_automatic_entry_wizard.py
+++ b/addons/account/wizard/account_automatic_entry_wizard.py
@@ -261,6 +261,7 @@ class AutomaticEntryWizard(models.TransientModel):
             'currency_id': self.journal_id.currency_id.id or self.journal_id.company_id.currency_id.id,
             'move_type': 'entry',
             'line_ids': [],
+            'name': '/',  # ensure to not provide a sequence number while the move stays in draft
             'ref': _('Adjusting Entry'),
             'date': fields.Date.to_string(self.date),
             'journal_id': self.journal_id.id,
@@ -273,6 +274,7 @@ class AutomaticEntryWizard(models.TransientModel):
                 'currency_id': self.journal_id.currency_id.id or self.journal_id.company_id.currency_id.id,
                 'move_type': 'entry',
                 'line_ids': [],
+                'name': '/',  # ensure to not provide a sequence number while the move stays in draft
                 'ref': self._format_strings(_('Adjusting Entry of {date} ({percent:.2f}% recognized on {new_date})'), grouped_lines[0].move_id, amount),
                 'date': fields.Date.to_string(date),
                 'journal_id': self.journal_id.id,

--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -212,6 +212,7 @@ class AccruedExpenseRevenue(models.TransientModel):
 
         move_type = _('Expense') if is_purchase else _('Revenue')
         move_vals = {
+            'name': '/',  # ensure to not provide a sequence number while the move stays in draft
             'ref': _('Accrued %s entry as of %s', move_type, format_date(self.env, self.date)),
             'journal_id': self.journal_id.id,
             'date': self.date,
@@ -229,6 +230,7 @@ class AccruedExpenseRevenue(models.TransientModel):
         move = self.env['account.move'].create(move_vals)
         move._post()
         reverse_move = move._reverse_moves(default_values_list=[{
+            'name': '/',
             'ref': _('Reversal of: %s', move.ref),
             'date': self.reversal_date,
         }])


### PR DESCRIPTION
When automatic entries are generated, a sequence number should not be assigned on them as long as they are on draft state. This commit ensures that the name of the entries is 'Draft' (or '/') when the move is generated. A sequence number will be assigned once the move is posted

This commit specifically targets the automatic entry wizard using the cut-off button on move lines and the accrued orders.

task-4069862

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
