### PR TITLE
[FIX] event, test_mail: fix some performance tests / counters

### DIFF
--- a/addons/event/tests/test_event_mail_schedule.py
+++ b/addons/event/tests/test_event_mail_schedule.py
@@ -9,7 +9,7 @@ from odoo import Command
 from odoo.addons.base.tests.test_ir_cron import CronMixinCase
 from odoo.addons.event.tests.common import EventCase
 from odoo.addons.mail.tests.common import MockEmail
-from odoo.tests import tagged, users
+from odoo.tests import tagged, users, warmup
 from odoo.tools import formataddr, mute_logger
 
 
@@ -319,6 +319,7 @@ class TestMailSchedule(EventCase, MockEmail, CronMixinCase):
 
     @mute_logger('odoo.addons.base.models.ir_model', 'odoo.models')
     @users('user_eventmanager')
+    @warmup
     def test_event_mail_schedule_on_subscription(self):
         """ Test emails sent on subscription, notably to avoid bottlenecks """
         test_event = self.test_event.with_env(self.env)
@@ -332,8 +333,8 @@ class TestMailSchedule(EventCase, MockEmail, CronMixinCase):
         # consider having hanging registrations, still not processed (e.g. adding
         # a new scheduler after)
         self.env.invalidate_all()
-        # com 59, event 37
-        with self.assertQueryCount(62), self.mock_datetime_and_now(reference_now), \
+        # event 19
+        with self.assertQueryCount(32), self.mock_datetime_and_now(reference_now), \
              self.mock_mail_gateway():
             _existing = self.env['event.registration'].create([
                 {
@@ -356,8 +357,8 @@ class TestMailSchedule(EventCase, MockEmail, CronMixinCase):
             }),
         ]})
         self.env.invalidate_all()
-        # com 148, event 99
-        with self.assertQueryCount(153), \
+        # event 50
+        with self.assertQueryCount(62), \
              self.mock_datetime_and_now(reference_now + relativedelta(minutes=10)), \
              self.mock_mail_gateway():
             _new = self.env['event.registration'].create([

--- a/addons/test_mail/tests/test_mail_template.py
+++ b/addons/test_mail/tests/test_mail_template.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.addons.test_mail.tests.common import TestRecipients
-from odoo.tests import tagged, users
+from odoo.tests import tagged, users, warmup
 from odoo.tools import mute_logger, safe_eval
 
 
@@ -132,7 +132,7 @@ class TestMailTemplate(TestMailTemplateCommon):
         self.assertEqual(mail.body, body_result)
 
 
-@tagged('mail_template', 'multi_lang', 'post_install', '-at_install')
+@tagged('mail_template', 'multi_lang', 'mail_performance', 'post_install', '-at_install')
 class TestMailTemplateLanguages(TestMailTemplateCommon):
 
     @classmethod
@@ -183,11 +183,12 @@ class TestMailTemplateLanguages(TestMailTemplateCommon):
         cls.env.flush_all()
 
     @mute_logger('odoo.addons.mail.models.mail_mail')
+    @warmup
     def test_template_send_email(self):
         """ Test 'send_email' on template on a given record, used notably as
         contextual action. """
         self.env.invalidate_all()
-        with self.with_user(self.user_employee.login), self.assertQueryCount(28):  # test_mail: 28
+        with self.with_user(self.user_employee.login), self.assertQueryCount(13):
             mail_id = self.test_template.with_env(self.env).send_mail(self.test_record.id)
             mail = self.env['mail.mail'].sudo().browse(mail_id)
 
@@ -200,11 +201,12 @@ class TestMailTemplateLanguages(TestMailTemplateCommon):
         self.assertEqual(mail.subject, f'EnglishSubject for {self.test_record.name}')
 
     @mute_logger('odoo.addons.mail.models.mail_mail')
+    @warmup
     def test_template_send_email_nolayout(self):
         """ Test without layout, just to check impact """
         self.test_template.email_layout_xmlid = False
         self.env.invalidate_all()
-        with self.with_user(self.user_employee.login), self.assertQueryCount(21):  # test_mail: 21
+        with self.with_user(self.user_employee.login), self.assertQueryCount(12):
             mail_id = self.test_template.with_env(self.env).send_mail(self.test_record.id)
             mail = self.env['mail.mail'].sudo().browse(mail_id)
 
@@ -217,11 +219,12 @@ class TestMailTemplateLanguages(TestMailTemplateCommon):
         self.assertEqual(mail.subject, f'EnglishSubject for {self.test_record.name}')
 
     @mute_logger('odoo.addons.mail.models.mail_mail')
+    @warmup
     def test_template_send_email_batch(self):
         """ Test 'send_email' on template in batch """
         self.env.invalidate_all()
         mails = self.env['mail.mail'].sudo()
-        with self.with_user(self.user_employee.login), self.assertQueryCount(935):  # test_mail: 935
+        with self.with_user(self.user_employee.login), self.assertQueryCount(908):
             template = self.test_template.with_env(self.env)
             for record in self.test_records_batch:
                 mails += mails.browse(template.send_mail(record.id))
@@ -238,11 +241,12 @@ class TestMailTemplateLanguages(TestMailTemplateCommon):
                 self.assertEqual(mail.subject, f'SpanishSubject for {record.name}')
 
     @mute_logger('odoo.addons.mail.models.mail_mail')
+    @warmup
     def test_template_send_email_wreport(self):
         """ Test 'send_email' on template on a given record, used notably as
         contextual action, with dynamic reports involved """
         self.env.invalidate_all()
-        with self.with_user(self.user_employee.login), self.assertQueryCount(109):  # test_mail: 106
+        with self.with_user(self.user_employee.login), self.assertQueryCount(28):
             mail_id = self.test_template_wreports.with_env(self.env).send_mail(self.test_record.id)
             mail = self.env['mail.mail'].sudo().browse(mail_id)
 
@@ -254,11 +258,12 @@ class TestMailTemplateLanguages(TestMailTemplateCommon):
         self.assertEqual(mail.subject, f'EnglishSubject for {self.test_record.name}')
 
     @mute_logger('odoo.addons.mail.models.mail_mail')
+    @warmup
     def test_template_send_email_wreport_batch(self):
         """ Test 'send_email' on template in batch with dynamic reports """
         self.env.invalidate_all()
         mails = self.env['mail.mail'].sudo()
-        with self.with_user(self.user_employee.login), self.assertQueryCount(1645):  # test_mail: 1645
+        with self.with_user(self.user_employee.login), self.assertQueryCount(1519):
             template = self.test_template_wreports.with_env(self.env)
             for record in self.test_records_batch:
                 mails += mails.browse(template.send_mail(record.id))
@@ -297,6 +302,7 @@ class TestMailTemplateLanguages(TestMailTemplateCommon):
         self.assertEqual(mail.subject, f'SpanishSubject for {self.test_record.name}')
 
     @mute_logger('odoo.addons.mail.models.mail_mail')
+    @warmup
     def test_template_translation_partner_lang(self):
         """ Test template rendering using lang defined on a sub-record aka
         'partner_id.lang' """
@@ -317,7 +323,7 @@ class TestMailTemplateLanguages(TestMailTemplateCommon):
 
         self.env.invalidate_all()
         mails = self.env['mail.mail'].sudo()
-        with self.with_user(self.user_employee.login), self.assertQueryCount(53):
+        with self.with_user(self.user_employee.login), self.assertQueryCount(26):
             template = self.test_template.with_env(self.env)
             for record in self.test_records:
                 mails += mails.browse(


### PR DESCRIPTION
Fix query counters for event mail schedulers and mail template performance tests.

Use warmup decorator to remove queries linked to cold state, in order to have results closer to real life scenario.

Prepares Task-3084943: Event: Improve communication scheduler scalability
