### PR TITLE
[FIX] website: make some mega menu templates more responsive in mobile

### DIFF
--- a/addons/website/static/src/snippets/s_mega_menu_images_subtitles/000.scss
+++ b/addons/website/static/src/snippets/s_mega_menu_images_subtitles/000.scss
@@ -9,4 +9,12 @@
             background: rgba(0, 0, 0, .05);
         }
     }
+
+    @include media-breakpoint-only(sm) {
+        .row > div.col-sm-6 {
+            flex-basis: 0;
+            flex-grow: 1;
+            max-width: 100%;
+        }
+    }
 }

--- a/addons/website/static/src/snippets/s_mega_menu_thumbnails/000.scss
+++ b/addons/website/static/src/snippets/s_mega_menu_thumbnails/000.scss
@@ -10,4 +10,11 @@
             height: auto;
         }
     }
+
+    @include media-breakpoint-down(xs) {
+        .row > div.col-6 {
+            flex-grow: 1;
+            max-width: 100%;
+        }
+    }
 }


### PR DESCRIPTION
The "Images Subtitles" and the "Thumbnails" mega menu templates do not look good in mobile view, depending on the size of the text written in them. Indeed, under some breakpoints, the classes force the elements to be next to each to other, to have two elements by line. So if a big word is contained in the left one, which is not rare in the German language for example, the text may overflow to the right one and overlap with it.

This commit fixes this issue by adding more freedom to these mega menu templates at the problematic breakpoints, so they can be more responsive with their content, while still looking good.

Step to reproduce:
- In the menu editor, add a mega menu.
- In edit mode, click on the mega menu.
- Select the "Images Subtitles" or the "Thumbnails" template.
- As a first element, write the following title: "Foto- und Fine Art Großformatdrucker".
- Save and resize down the screen until it toggles the mobile view.
- Open the mega menu and continue to resize down. => At some point, near the "SM" breakpoint, you will notice that the text becomes too big and overlaps the right element.

opw-4096112