### PR TITLE
[FIX] base: missing content-type on /web/image

### DIFF
--- a/odoo/addons/base/models/ir_binary.py
+++ b/odoo/addons/base/models/ir_binary.py
@@ -73,21 +73,18 @@ class IrBinary(models.AbstractModel):
             return Stream.from_attachment(record)
 
         record.check_field_access_rights('read', [field_name])
-        field_def = record._fields[field_name]
 
-        # fields.Binary(attachment=False) or compute/related
-        if not field_def.attachment or field_def.compute or field_def.related:
-            return Stream.from_binary_field(record, field_name)
+        if record._fields[field_name].attachment:
+            field_attachment = self.env['ir.attachment'].sudo().search(
+                domain=[('res_model', '=', record._name),
+                        ('res_id', '=', record.id),
+                        ('res_field', '=', field_name)],
+                limit=1)
+            if not field_attachment:
+                raise MissingError("The related attachment does not exist.")
+            return Stream.from_attachment(field_attachment)
 
-        # fields.Binary(attachment=True)
-        field_attachment = self.env['ir.attachment'].sudo().search(
-            domain=[('res_model', '=', record._name),
-                    ('res_id', '=', record.id),
-                    ('res_field', '=', field_name)],
-            limit=1)
-        if not field_attachment:
-            raise MissingError("The related attachment does not exist.")
-        return Stream.from_attachment(field_attachment)
+        return Stream.from_binary_field(record, field_name)
 
     def _get_stream_from(
         self, record, field_name='raw', filename=None, filename_field='name',

--- a/odoo/addons/test_http/models.py
+++ b/odoo/addons/test_http/models.py
@@ -18,7 +18,7 @@ class Stargate(models.Model):
     has_galaxy_crystal = fields.Boolean(store=True, compute='_compute_has_galaxy_crystal', readonly=False)
     glyph_attach = fields.Image(attachment=True)
     glyph_inline = fields.Image(attachment=False)
-    glyph_related = fields.Image('Glyph 128', related='glyph_attach', max_width=128, max_height=128)
+    glyph_related = fields.Image('Glyph 128', related='glyph_attach', max_width=128, max_height=128, store=True)
     glyph_compute = fields.Image(compute='_compute_glyph_compute')
 
     _sql_constraints = [

--- a/odoo/addons/test_http/tests/test_common.py
+++ b/odoo/addons/test_http/tests/test_common.py
@@ -1,12 +1,18 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import datetime, timezone
 from unittest.mock import patch
+
+from werkzeug.datastructures import ResponseCacheControl
+from werkzeug.http import parse_cache_control_header
 
 import odoo
 from odoo.http import Session
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 from odoo.tools.func import lazy_property
 from odoo.addons.test_http.utils import MemoryGeoipResolver, MemorySessionStore
+
+HTTP_DATETIME_FORMAT = '%a, %d %b %Y %H:%M:%S GMT'
 
 
 class TestHttpBase(HttpCaseWithUserDemo):
@@ -43,3 +49,15 @@ class TestHttpBase(HttpCaseWithUserDemo):
             db_filter.side_effect = lambda dbs, host=None: [db for db in dbs if db in dblist]
             Registry.return_value = self.registry
             return self.url_open(url, *args, allow_redirects=allow_redirects, **kwargs)
+
+    def parse_http_cache_control(self, cache_control):
+        return parse_cache_control_header(cache_control, None, ResponseCacheControl)
+
+    def assertCacheControl(self, response, cache_control):
+        self.assertEqual(
+           self.parse_http_cache_control(response.headers['Cache-Control']),
+           self.parse_http_cache_control(cache_control),
+        )
+
+    def parse_http_expires(self, expires):
+        return datetime.strptime(expires, HTTP_DATETIME_FORMAT).replace(tzinfo=timezone.utc)

--- a/odoo/addons/test_http/tests/test_static.py
+++ b/odoo/addons/test_http/tests/test_static.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import base64
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from os.path import basename, join as opj
 from unittest.mock import patch
 from freezegun import freeze_time
@@ -10,8 +10,9 @@ from urllib3.util import parse_url
 import odoo
 from odoo.tests import new_test_user, tagged
 from odoo.tools import config, file_open, image_process
+from odoo.tools.misc import submap
 
-from .test_common import TestHttpBase
+from .test_common import TestHttpBase, HTTP_DATETIME_FORMAT
 
 
 class TestHttpStaticCommon(TestHttpBase):
@@ -32,8 +33,7 @@ class TestHttpStaticCommon(TestHttpBase):
         res = self.db_url_open(url, headers=headers)
         res.raise_for_status()
         self.assertEqual(res.status_code, assert_status_code)
-        for header_name, header_value in assert_headers.items():
-            self.assertEqual(res.headers.get(header_name), header_value)
+        self.assertEqual(submap(res.headers, assert_headers), assert_headers)
         if assert_content:
             self.assertEqual(res.content, assert_content)
         return res
@@ -67,20 +67,20 @@ class TestHttpStatic(TestHttpStaticCommon):
     def test_static00_static(self):
         with self.subTest(x_sendfile=False):
             res = self.assertDownloadGizeh('/test_http/static/src/img/gizeh.png')
-            self.assertEqual(res.headers.get('Cache-Control', ''), 'public, max-age=604800')
+            self.assertCacheControl(res, 'public, max-age=604800')
 
         with self.subTest(x_sendfile=True), \
              patch.object(config, 'options', {**config.options, 'x_sendfile': True}):
             # The file is outside of the filestore, X-Sendfile disabled
             res = self.assertDownloadGizeh('/test_http/static/src/img/gizeh.png', x_sendfile=False)
-            self.assertEqual(res.headers.get('Cache-Control', ''), 'public, max-age=604800')
+            self.assertCacheControl(res, 'public, max-age=604800')
 
     def test_static01_debug_assets(self):
         session = self.authenticate(None, None)
         session.debug = 'assets'
 
         res = self.assertDownloadGizeh('/test_http/static/src/img/gizeh.png')
-        self.assertEqual(res.headers.get('Cache-Control', ''), 'no-cache, max-age=0')
+        self.assertCacheControl(res, 'no-cache, max-age=0')
 
     def test_static02_not_found(self):
         res = self.nodb_url_open("/test_http/static/i-dont-exist")
@@ -490,67 +490,63 @@ class TestHttpStaticLogo(TestHttpStaticCommon):
 
 class TestHttpStaticCache(TestHttpStaticCommon):
     @freeze_time(datetime.utcnow())
-    def test_static_cache0_standard(self, domain=''):
-        # Wed, 21 Oct 2015 07:28:00 GMT
-        # The timezone should be %Z (instead of 'GMT' hardcoded) but
-        # somehow strftime doesn't set it.
-        http_date_format = '%a, %d %b %Y %H:%M:%S GMT'
-        today = datetime.utcnow().strftime(http_date_format)
-        one_week_away = (datetime.utcnow() + timedelta(weeks=1)).strftime(http_date_format)
+    def test_static_cache0_standard(self):
+        one_week_away = int((datetime.now(timezone.utc) + timedelta(weeks=1)).timestamp())
 
-        res1 = self.nodb_url_open(f'{domain}/test_http/static/src/img/gizeh.png')
+        res1 = self.nodb_url_open('/test_http/static/src/img/gizeh.png')
         res1.raise_for_status()
         self.assertEqual(res1.status_code, 200)
-        self.assertEqual(res1.headers.get('Cache-Control'), 'public, max-age=604800')  # one week
-        self.assertEqual(res1.headers.get('Expires'), one_week_away)
+        self.assertCacheControl(res1, 'public, max-age=604800')  # one week
+        expires = self.parse_http_expires(res1.headers['Expires']).timestamp()
+        self.assertIn(expires, range(one_week_away, one_week_away + 60))  # + 60 for nginx
         self.assertIn('ETag', res1.headers)
 
-        res_etag = self.nodb_url_open(f'{domain}/test_http/static/src/img/gizeh.png', headers={
+        res_etag = self.nodb_url_open('/test_http/static/src/img/gizeh.png', headers={
             'If-None-Match': res1.headers['ETag']
         })
         res_etag.raise_for_status()
         self.assertEqual(res_etag.status_code, 304, "We should not download the file again.")
 
-        res_last_modified = self.nodb_url_open(f'{domain}/test_http/static/src/img/gizeh.png', headers={
-            'If-Modified-Since': today,
+        res_last_modified = self.nodb_url_open('/test_http/static/src/img/gizeh.png', headers={
+            'If-Modified-Since': datetime.now(timezone.utc).strftime(HTTP_DATETIME_FORMAT),
         })
         res_last_modified.raise_for_status()
         self.assertEqual(res_last_modified.status_code, 304, "We should not download the file again.")
 
     @freeze_time(datetime.utcnow())
-    def test_static_cache1_unique(self, domain=''):
+    def test_static_cache1_unique(self):
         # Wed, 21 Oct 2015 07:28:00 GMT
         # The timezone should be %Z (instead of 'GMT' hardcoded) but
         # somehow strftime doesn't set it.
-        http_date_format = '%a, %d %b %Y %H:%M:%S GMT'
-        today = datetime.utcnow().strftime(http_date_format)
-        one_year_away = (datetime.utcnow() + timedelta(days=365)).strftime(http_date_format)
+        now = datetime.now(timezone.utc)
+        one_year_away = int((now + timedelta(days=365)).timestamp())
 
-        res1 = self.assertDownloadGizeh(f'{domain}/web/image/test_http.gizeh_png?unique=1')
-        self.assertEqual(res1.headers.get('Cache-Control'), 'public, max-age=31536000, immutable')  # one year
-        self.assertEqual(res1.headers.get('Expires'), one_year_away)
+        res1 = self.assertDownloadGizeh('/web/image/test_http.gizeh_png?unique=1')
+        self.assertCacheControl(res1, 'public, max-age=31536000, immutable')  # one year
+        expires = self.parse_http_expires(res1.headers['Expires']).timestamp()
+        self.assertIn(expires, range(one_year_away, one_year_away + 60))  # + 60 for nginx
         self.assertIn('ETag', res1.headers)
 
-        res_etag = self.db_url_open(f'{domain}/web/image/test_http.gizeh_png?unique=1', headers={
+        res_etag = self.db_url_open('/web/image/test_http.gizeh_png?unique=1', headers={
             'If-None-Match': res1.headers['ETag']
         })
         res_etag.raise_for_status()
         self.assertEqual(res_etag.status_code, 304, "We should not download the file again.")
 
-        res_last_modified = self.db_url_open(f'{domain}/web/image/test_http.gizeh_png?unique=1', headers={
-            'If-Modified-Since': today,
+        res_last_modified = self.db_url_open('/web/image/test_http.gizeh_png?unique=1', headers={
+            'If-Modified-Since': now.strftime(HTTP_DATETIME_FORMAT),
         })
         res_last_modified.raise_for_status()
         self.assertEqual(res_last_modified.status_code, 304, "We should not download the file again.")
 
     @freeze_time(datetime.utcnow())
-    def test_static_cache2_nocache(self, domain=''):
-        res1 = self.assertDownloadGizeh(f'{domain}/web/content/test_http.gizeh_png?nocache=1')
-        self.assertEqual(res1.headers.get('Cache-Control'), 'no-cache')
+    def test_static_cache2_nocache(self):
+        res1 = self.assertDownloadGizeh('/web/content/test_http.gizeh_png?nocache=1')
+        self.assertCacheControl(res1, 'no-cache')
         self.assertNotIn('Expires', res1.headers)
         self.assertIn('ETag', res1.headers)
 
-        res_etag = self.db_url_open(f'{domain}/web/content/test_http.gizeh_png?nocache=1', headers={
+        res_etag = self.db_url_open('/web/content/test_http.gizeh_png?nocache=1', headers={
             'If-None-Match': res1.headers['ETag']
         })
         res_etag.raise_for_status()
@@ -575,7 +571,7 @@ class TestHttpStaticCache(TestHttpStaticCommon):
         # Admin can get the actual image
         self.authenticate('admin', 'admin')
         res = self.assertDownloadGizeh(url)
-        self.assertEqual(res.headers.get('Cache-Control', ''), 'no-cache, private')
+        self.assertCacheControl(res, 'no-cache, private')
         res_etag = self.db_url_open(url, headers={'If-None-Match': res.headers['ETag']})
         res_etag.raise_for_status()
         self.assertEqual(res_etag.status_code, 304, "The admin should use its cache")

--- a/odoo/addons/test_http/tests/test_web_server.py
+++ b/odoo/addons/test_http/tests/test_web_server.py
@@ -26,6 +26,16 @@ class TestHttpStaticWebServer(test_static.TestHttpStatic, test_static.TestHttpSt
             assert_filename=assert_filename
         )
 
+    def assertDownload(
+        self, url, headers, assert_status_code, assert_headers, assert_content=None
+    ):
+        assert_headers.pop('Content-Length', None)  # nginx compresses on-the-fly
+        if assert_headers.pop('X-Sendfile', None):
+            assert_headers.pop('X-Accel-Redirect', None)
+            assert_content = None
+        return super().assertDownload(
+            url, headers, assert_status_code, assert_headers, assert_content)
+
     def test_static_cache3_private(self):
         super().test_static_cache3_private()
 


### PR DESCRIPTION
As the portal user, change your profile picture to a svg image, then show it via the normal /web/image URL. The downloaded picture lacks a valid content-type header.

Related stored attachment fields were served via the method `Stream.from_binary_field` instead of `Stream.from_attachment`, only the latter is capable of copying the attachment mimetype on the stream.

---

Also gave a shot at making the `odoo-bin --test-tags webserver:TestHttpStaticWebServer` test green again.