### PR TITLE
[FIX] repair: validate repair with reserved product

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -244,13 +244,13 @@ class Repair(models.Model):
             ('location_id', '=', self.location_id.id),
             ('lot_id', '=', self.lot_id.id),
             ('owner_id', '=', self.partner_id.id),
-        ]).mapped('quantity'))
+        ]).mapped('available_quantity'))
         available_qty_noown = sum(self.env['stock.quant'].search([
             ('product_id', '=', self.product_id.id),
             ('location_id', '=', self.location_id.id),
             ('lot_id', '=', self.lot_id.id),
             ('owner_id', '=', False),
-        ]).mapped('quantity'))
+        ]).mapped('available_quantity'))
         repair_qty = self.product_uom._compute_quantity(self.product_qty, self.product_id.uom_id)
         for available_qty in [available_qty_owner, available_qty_noown]:
             if float_compare(available_qty, repair_qty, precision_digits=precision) >= 0:


### PR DESCRIPTION
* PROPBLEM: Product A (storable, no tracking) have 1 qty available, create a SO then make a delivery (not validate yet) -> Product A is already reserved for that SO. Then create a repair for it and validate -> user can do it normally, nothing happen. Instead, we should warning about insufficient quantiy
* SOLUTION: compare value using 'available_quantity' instead of 'quantity' in stock.quant

Same PR: https://github.com/odoo/odoo/pull/174480

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
