### PR TITLE
[FIX] l10n_jp_ubl_pint: party_tax_scheme_vals

### DIFF
--- a/addons/l10n_jp_ubl_pint/models/account_edi_xml_pint_jp.py
+++ b/addons/l10n_jp_ubl_pint/models/account_edi_xml_pint_jp.py
@@ -1,4 +1,4 @@
-from odoo import models
+from odoo import fields, models
 
 
 class AccountEdiXmlUBLPINTJP(models.AbstractModel):
@@ -91,4 +91,13 @@ class AccountEdiXmlUBLPINTJP(models.AbstractModel):
         if invoice.currency_id != invoice.company_id.currency_id:
             # see https://docs.peppol.eu/poac/jp/pint-jp/bis/#_tax_in_accounting_currency
             vals['vals']['tax_currency_code'] = invoice.company_id.currency_id.name  # accounting currency
+
+        # aligned-ibr-jp-01 If the invoice is dated after 2023-10-01,
+        # the tax ID must be the new "Registration Number for Qualified Invoice purpose in Japan" which shouldn't have JP added at the start.
+        # Checked here as the partner methods don't have reference to the invoice.
+        if invoice.invoice_date > fields.Date.from_string('2023-10-01'):
+            for party_vals in [vals['vals']['accounting_supplier_party_vals'], vals['vals']['accounting_customer_party_vals']]:
+                partner = party_vals['party_vals']['partner']
+                if partner.country_id.code == "JP" and partner.vat:
+                    party_vals['party_vals']['party_tax_scheme_vals'][0]['company_id'] = partner.vat
         return vals


### PR DESCRIPTION
At the moment, JP is added at the start of the tax scheme vals. In Japan and after 2023-10-01, the expected value in the company_id is the "Registration Number for Qualified Invoice purpose in Japan" which starts with a T and does not want JP prepended to it.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
