### PR TITLE
[FIX] base: Austrian vat label

### DIFF
--- a/odoo/addons/base/data/res_country_data.xml
+++ b/odoo/addons/base/data/res_country_data.xml
@@ -78,7 +78,7 @@
             <field eval="'%(street)s\n%(street2)s\n%(zip)s %(city)s\n%(country_name)s'" name="address_format" />
             <field name="currency_id" ref="EUR" />
             <field eval="43" name="phone_code" />
-            <field name="vat_label">USt</field>
+            <field name="vat_label">UID</field>
         </record>
         <record id="au" model="res.country">
             <field name="name">Australia</field>


### PR DESCRIPTION
The VAT label for Austria is set to
Ust while the official VAT Identification Number
webpage calls it UID.

This will update the country data to set it to UID by default.

See https://www.usp.gv.at/en/steuern-finanzen/umsatzsteuer-ueberblick/weitere-informationen-zur-umsatzsteuer/umsatzsteuer-identifikationsnummer.html

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
