### PR TITLE
[FIX] project: fix traceback when the user deleted the project menu

### DIFF
--- a/addons/project/models/ir_ui_menu.py
+++ b/addons/project/models/ir_ui_menu.py
@@ -10,7 +10,9 @@ class IrUiMenu(models.Model):
     def _load_menus_blacklist(self):
         res = super()._load_menus_blacklist()
         if not self.env.user.has_group('project.group_project_manager'):
-            res.append(self.env.ref('project.rating_rating_menu_project').id)
+            rating = self.env.ref('project.rating_rating_menu_project', raise_if_not_found=False)
+            if rating:
+                res.append(rating.id)
         if self.env.user.has_group('project.group_project_stages'):
             res.append(self.env.ref('project.menu_projects').id)
             res.append(self.env.ref('project.menu_projects_config').id)


### PR DESCRIPTION
Currently, a traceback occurs when the user deletes the rating menu from the settings.

To reproduce this issue:

1) Install `project`
2) Delete the menu (`Customer Rating`) from `Settings/technical/menuitems`
3) Now log in with a user who has no  manager rights in the project 
4) An error will be encountered

Error:
```
ValueError: External ID not found in the system: project.rating_rating_menu_project
```

As we can see the "rating_rating_menu_project" is only used in one place. We can make the code more robust by prechecking the menu, before accessing its id.

Also, a user with no admin rights in the project is not able to log in because of the above traceback.

https://github.com/odoo/odoo/blob/65cec4c3cda49cf06bbb2aa9e6779be84b3f8e73/addons/project/models/ir_ui_menu.py#L13

By applying this commit, we can resolve this issue. 

sentry-5718768459

