### PR TITLE
[FIX] project_hr_expense: The Project Admin can't access the Project Update

### DIFF
--- a/addons/project/tests/test_project_profitability.py
+++ b/addons/project/tests/test_project_profitability.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import TransactionCase, users, tagged
+from odoo.addons.mail.tests.common import mail_new_test_user
 
 
 class TestProjectProfitabilityCommon(TransactionCase):
@@ -51,3 +52,23 @@ class TestProfitability(TestProjectProfitabilityCommon):
             self.project_profitability_items_empty,
             'The profitability data of the project should be return no data and so 0 for each total amount.'
         )
+
+
+@tagged('-at_install', 'post_install')
+class TestProjectProfitabilityAccess(TestProjectProfitabilityCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.project_user = mail_new_test_user(cls.env, 'Project User', groups='project.group_project_user')
+        cls.project_manager = mail_new_test_user(cls.env, 'Project Admin', groups='project.group_project_manager')
+
+    @users('Project User', 'Project Admin')
+    def test_project_profitability_read(self):
+        """ Test the project profitability read access rights
+
+            In other modules, project profitability may contain some data.
+            The project user and project admin should have read access rights to project profitability.
+        """
+        self.project.with_user(self.env.user)._get_profitability_items(False)

--- a/addons/project_hr_expense/models/project.py
+++ b/addons/project_hr_expense/models/project.py
@@ -72,7 +72,7 @@ class Project(models.Model):
         # As both purchase orders and expenses (paid by employee) create vendor bills,
         # we need to make sure they are exclusive in the profitability report.
         move_line_ids = super()._get_already_included_profitability_invoice_line_ids()
-        query = self.env['account.move.line']._search([
+        query = self.env['account.move.line'].sudo()._search([
             ('move_id.expense_sheet_id', '!=', False),
             ('id', 'not in', move_line_ids),
         ])


### PR DESCRIPTION
* PROPBLEM: The error is raised when user has access to Project Update, but not to Journal Item.
* SOLUTION: Add `sudo` when searching `account.move.line` in the method `_get_already_included_profitability_invoice_line_ids`.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
