### PR TITLE
[FIX] analytic: save analytic_distribution in wizard views

### DIFF
--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
@@ -616,7 +616,7 @@ export class AnalyticDistribution extends Component {
 
         const selectors = [
             ".o_popover",
-            ".modal:not(.o_inactive_modal)",
+            ".modal:not(.o_inactive_modal):not(:has(.o_act_window))",
         ];
         if (this.isDropdownOpen
             && !this.widgetRef.el.contains(ev.target)


### PR DESCRIPTION
### Steps to reproduce the issue:

1. Make sure you have access to the Analytic Distribution fields
2. Create an expense
3. Open the Split Expense Wizard and add Analytic Distribution to the new Expenses
    - Click out of the Analytic Distribution widget to close it, don't use the close icon
4. Finish the splitting process
5. On the Tree view that follows, the Analytic Distribution fields are empty

### Explanation:

`onWindowClick` checks if the `analytic_distirbution` widget should close. If the conditions are met, `forceCloseEditor` is called and the data is saved.
In this case, one of the `selectors` is retrieved by `ev.target.closest`, namely `.modal:not(.o_inactive_modal)`, therefore not meeting the conditions to call `forceCloseEditor`, but the widget still closes.

### Fix reasoning:

We want `forceCloseEditor` to be called in this situation, since the user is not clicking on an element related to `analytic_distribution`. We can use  `o_act_window` to filter Search More modals from Wizards, as it is absent from the former.

opw-4001757