### PR TITLE
[REF] mrp: function _get_move_raw_values add param line_data

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1153,11 +1153,12 @@ class MrpProduction(models.Model):
                     line_data['qty'],
                     bom_line.product_uom_id,
                     operation,
-                    bom_line
+                    bom_line,
+                    line_data
                 ))
         return moves
 
-    def _get_move_raw_values(self, product, product_uom_qty, product_uom, operation_id=False, bom_line=False):
+    def _get_move_raw_values(self, product, product_uom_qty, product_uom, operation_id=False, bom_line=False, line_data=False):
         """ Warning, any changes done to this method will need to be repeated for consistency in:
             - Manually added components, i.e. "default_" values in view
             - Moves from a copied MO, i.e. move.create


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
https://github.com/odoo/odoo/blob/71a423c427cf225c137f84be8e7621fdf94e2d15/addons/mrp/models/mrp_production.py#L1151

When  calling _get_move_raw_values, the line_data from bom explode is not passed.
It is better to pass it, so other developers can do some customize develop to change the  move raw values according to the line_data.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
