### PR TITLE
[IMP] mail: add regexp compatible ignore list to link previews

### DIFF
--- a/addons/mail/data/ir_config_parameter_data.xml
+++ b/addons/mail/data/ir_config_parameter_data.xml
@@ -5,5 +5,6 @@
             <field name="key">mail.activity.gc.delete_overdue_years</field>
             <field name="value">3</field>
         </record>
+        <function model="mail.link.preview" name="_init_ignore_list"/>
     </data>
 </odoo>


### PR DESCRIPTION
This PR is going to limit the generation of link preview inside the chatter and
discuss for internal link (/web|/odoo) and add and regexp compatible
`ir.config_parameter` called `mail.mail_link_preview_ignore_list` that accepts a
list of links or regexp to be ignored when creating link previews.

task-4102866
