### PR TITLE
[FIX] website: fix progress in _cron_unlink_old_visitors

### DIFF
--- a/addons/website/models/website_visitor.py
+++ b/addons/website/models/website_visitor.py
@@ -338,19 +338,19 @@ class WebsiteVisitor(models.Model):
         reason. """
         auto_commit = not getattr(threading.current_thread(), 'testing', False)
         visitor_model = self.env['website.visitor']
-        visitor_count = visitor_model.sudo().search_count(self._inactive_visitors_domain(), limit=50000)
+        visitor_ids = visitor_model.sudo().search(self._inactive_visitors_domain(), limit=limit).ids
         visitor_done = 0
         for inactive_visitors_batch in split_every(
             batch_size,
-            visitor_model.sudo().search(self._inactive_visitors_domain(), limit=limit).ids,
+            visitor_ids,
             visitor_model.browse,
         ):
             inactive_visitors_batch.unlink()
             visitor_done += len(inactive_visitors_batch)
             if auto_commit:
-                self.env['ir.cron']._notify_progress(done=visitor_done, remaining=visitor_count - visitor_done)
+                self.env['ir.cron']._notify_progress(done=visitor_done, remaining=len(visitor_ids) - visitor_done)
                 self.env.cr.commit()
-        self.env['ir.cron']._notify_progress(done=visitor_done, remaining=visitor_count - visitor_done)
+        self.env['ir.cron']._notify_progress(done=visitor_done, remaining=len(visitor_ids) - visitor_done)
 
     def _inactive_visitors_domain(self):
         """ This method defines the domain of visitors that can be cleaned. By


### PR DESCRIPTION
Since commit 9d78a326, we attempt to send the progress, but because we count before the loop, by the time we make the request again a few milliseconds later, new records have already been added. As a result, the remaining count becomes negative, since done < remaining.


```
ValueError: <class 'ValueError'>: "`done` and `remaining` must be positive integers." while evaluating
'model._cron_unlink_old_visitors()
```


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
