### PR TITLE
[REF] web: kanban: use standard mecanism to force m2m_tags

### DIFF
--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
@@ -169,7 +169,7 @@ export class Many2ManyTagsField extends Component {
             resId: record.resId,
             context: this.props.context,
             title: _t("Edit: %s", record.data.display_name),
-        })
+        });
     }
 
     get tags() {
@@ -264,7 +264,7 @@ export const many2ManyTagsField = {
         const noCreate = Boolean(options.no_create);
         const canCreate = noCreate ? false : hasCreatePermission;
         const hasEditPermission = attrs.can_write ? evaluateBooleanExpr(attrs.can_write) : true;
-        const canEditTags = Boolean(options.edit_tags) ? hasEditPermission : false;
+        const canEditTags = options.edit_tags ? hasEditPermission : false;
         const noQuickCreate = Boolean(options.no_quick_create);
         const noCreateEdit = Boolean(options.no_create_edit);
         return {
@@ -286,6 +286,7 @@ export const many2ManyTagsField = {
 registry.category("fields").add("many2many_tags", many2ManyTagsField);
 registry.category("fields").add("calendar.one2many", many2ManyTagsField);
 registry.category("fields").add("calendar.many2many", many2ManyTagsField);
+registry.category("fields").add("kanban.many2many", many2ManyTagsField);
 
 /**
  * A specialization that allows to edit the color with the colorpicker.

--- a/addons/web/static/src/views/kanban/kanban_arch_parser.js
+++ b/addons/web/static/src/views/kanban/kanban_arch_parser.js
@@ -95,14 +95,6 @@ export class KanbanArchParser {
             }
             // Case: field node
             if (node.tagName === "field") {
-                // In kanban, we display many2many fields as tags by default
-                const widget = node.getAttribute("widget");
-                if (
-                    !widget &&
-                    models[modelName].fields[node.getAttribute("name")].type === "many2many"
-                ) {
-                    node.setAttribute("widget", "many2many_tags");
-                }
                 const fieldInfo = Field.parseFieldNode(node, models, modelName, "kanban", jsClass);
                 const name = fieldInfo.name;
                 if (!(fieldInfo.name in fieldNextIds)) {


### PR DESCRIPTION
In kanban views, we want many2many fields to be displayed as tags by default (unless stated otherwise, with a  `widget="..."`). There's an API to enforce this, which is to register a key `kanban.many2many` in the "fields" registry. Before this commit, we didn't use it. We instead manually added the attribute `widget` on the field nodes in the kanban arch parser. This commit removes that, and uses the standard mecanism.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
