### PR TITLE
[FIX] hw_drivers: no refresh in kiosk mode

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
@@ -71,7 +71,7 @@ class DisplayDriver(Driver):
     def run(self):
         while self.device_identifier != 'distant_display' and not self._stopped.is_set() and "pos_customer_display" not in self.url:
             time.sleep(60)
-            if self.url != 'http://localhost:8069/point_of_sale/display/' + self.device_identifier:
+            if self.url != 'http://localhost:8069/point_of_sale/display/' + self.device_identifier and self.browser.chromium_additional_args != self.browser.kiosk_args:
                 # Refresh the page every minute
                 self.browser.refresh()
 


### PR DESCRIPTION
Currently in kiosk mode every minute we would refresh the browser which isn't at all necessary for kiosks. THis PR avoid refreshing browser if it's in kiosk mode


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
