### PR TITLE
[FIX] mass_mailing: revert backgorund filter in cover template change

### DIFF
--- a/addons/mass_mailing/static/src/js/snippets.editor.js
+++ b/addons/mass_mailing/static/src/js/snippets.editor.js
@@ -55,6 +55,19 @@ export const MassMailingSnippetsMenu = snippetsEditor.SnippetsMenu.extend({
     /**
      * @override
      */
+    _patchForComputeSnippetTemplates: function ($html) {
+        // TODO: Remove in master and remove the background filter from the snippet
+        const cover_snippet = $html.find("[data-oe-type='snippet'] [data-snippet='s_cover']");
+        if (cover_snippet.length) {
+            cover_snippet[0].querySelector('.o_we_bg_filter.bg-black-50').remove();
+            cover_snippet[0].querySelector('h1').classList.remove("text-white");
+            cover_snippet[0].querySelector('p').classList.remove("text-white");
+        }
+        return this._super($html);
+    },
+    /**
+     * @override
+     */
     _onClick: function (ev) {
         this._super(...arguments);
         var srcElement = ev.target || (ev.originalEvent && (ev.originalEvent.target || ev.originalEvent.originalTarget)) || ev.srcElement;


### PR DESCRIPTION
Commit that introduced the issue https://github.com/odoo/odoo/pull/128108/commits/33a04876cad58f413455bdc406c1ad4c70d73e1b

Steps to reproduce the issue:
=============================
- Create a new mass mailing
- Add cover snippet
- Test the email
- Background image doesn't appear

Origin of the issue:
====================
After the chnage of the mentioned commit, we add a div with a black background filter. It displays correclty in mass_mailing view since it has opacity 0.5 but after the `inline` process of the template we convert rgba colors to hex color with `rgbToHex` because some email engines doesn't support rgba. As a result, we will have a black div that covers the background image in the sent email.

Solution:
=========
Rever the change.

task-4070400