### PR TITLE
[FIX] stock: don’t show lot_name when use & create lot is True

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -583,6 +583,7 @@ Please change the quantity done or the rounding precision of your unit of measur
                 and (move.picking_type_id.use_existing_lots or move.state == 'done' or move.origin_returned_move_id.id)
             move.show_lots_text = move.has_tracking != 'none'\
                 and move.picking_type_id.use_create_lots\
+                and not move.picking_type_id.use_existing_lots\
                 and move.state != 'done' \
                 and not move.origin_returned_move_id.id
 

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -6722,3 +6722,25 @@ class StockMove(TransactionCase):
         # Since both moves have the same date, ensure that the reservation is changed on the latest created
         self.assertEqual(move_1.state, 'assigned')
         self.assertEqual(move_2.state, 'partially_available')
+
+    def test_compute_show_info(self):
+        """
+        Test that `lot_name` and `lot_id` are hidden in the view and that
+        `quant` is displayed when the picking type has `use_create_lots`
+        and `use_existing_lots` set to True.
+        """
+        picking_type_in = self.env.ref('stock.picking_type_in')
+        picking_type_in.use_create_lots = True
+        picking_type_in.use_existing_lots = True
+        move1 = self.env['stock.move'].create({
+            'name': 'test_in_1',
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'product_id': self.product_lot.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 5.0,
+            'picking_type_id': picking_type_in.id,
+        })
+        self.assertFalse(move1.show_lots_text)
+        self.assertFalse(move1.show_lots_m2o)
+        self.assertTrue(move1.show_quant)


### PR DESCRIPTION
Steps to reproduce the bug:
- Go to the delivery operation type:
    - set to True "use_existing_lots" and "use_create_lots"
- Create a storable product “P1” tracked by SN
- Create a delivery with one unit of P1
- Confirm it
- Click on the detailed operation to select the serial number

Problem:
The 'Lot_name' field is displayed, but since the operation type
has both `use_existing_lots` and `use_create_lots` set to True,
the 'Lot_name' field should not be displayed.

https://github.com/odoo/odoo/blob/4da8c6ebca024b31278a946aef55cc37f0210b33/addons/stock/models/stock_move.py#L606-L610

https://github.com/odoo/odoo/blob/4da8c6ebca024b31278a946aef55cc37f0210b33/addons/stock/views/stock_move_views.xml#L294-L297
|
|
|
|
|
FYI: https://github.com/odoo/odoo/commit/b771eadf8f6a70cbbb01481f362c89b41796d671#diff-55c6314416a6a400da6acd5018d161a55eeeb0e3008fec8828121e3dd12be0ebL550

opw-[4113887](https://www.odoo.com/web#id=4113887&view_type=form&model=project.task)
