### PR TITLE
[FIX] website: show bootstrap Tab without using JQuery

### DIFF
--- a/addons/website/static/src/snippets/s_tabs/options.js
+++ b/addons/website/static/src/snippets/s_tabs/options.js
@@ -76,7 +76,7 @@ options.registry.NavTabs = options.registry.MultipleItems.extend({
             .find('.nav-link');
         this._findLinksAndPanes();
         this._generateUniqueIDs();
-        $navLink.tab('show');
+        new window.Tab($navLink[0]).show();
     },
     /**
      * @override
@@ -86,7 +86,7 @@ options.registry.NavTabs = options.registry.MultipleItems.extend({
         const $navLinkToShow = this.$navLinks.eq((this.$navLinks.index($targetNavLink) + 1) % this.$navLinks.length);
         $targetNavLink.parent().remove();
         this._findLinksAndPanes();
-        $navLinkToShow.tab('show');
+        new window.Tab($navLinkToShow[0]).show();
     },
 });
 options.registry.NavTabsStyle = options.Class.extend({


### PR DESCRIPTION
Since [1] when JQuery was removed from the backend assets, the `tab` bootstrap method is not availabe anymore on JQuery objects. Because of this, adding and removing tabs from a Tabs block fails.

This commit adapts the calls to use bootstrap directly.

Steps to reproduce:
- Drop a Tabs block.
- Select the Tabs block.
- Add a new tab or remove a tab.

=> An error dialog was displayed.

[1]: https://github.com/odoo/odoo/commit/b8fc93ea97b8870459063214d5cf468a6a3c6efe

task-4126163
