### PR TITLE
[FIX] point_of_sale: prevent error when a contact name is false

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
@@ -82,7 +82,9 @@ export class PartnerList extends Component {
             : partners
                   .slice(0, 1000)
                   .toSorted((a, b) =>
-                      this.props.partner?.id === a.id ? -1 : a.name.localeCompare(b.name)
+                      this.props.partner?.id === a.id
+                          ? -1
+                          : (a.name || "").localeCompare(b.name || "")
                   );
 
         return availablePartners;


### PR DESCRIPTION
Before this commit, encountering a contact with a false name (particularly contacts of type address with no name) would lead to a TypeError, `a.name.localeCompare` is not a function.

opw-4124243

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
