### PR TITLE
[FIX] web: remove embedded actions animation flicker

### DIFF
--- a/addons/web/static/src/core/notifications/notification_container.js
+++ b/addons/web/static/src/core/notifications/notification_container.js
@@ -11,7 +11,7 @@ export class NotificationContainer extends Component {
     static template = xml`
         <div class="o_notification_manager">
             <t t-foreach="notifications" t-as="notification" t-key="notification">
-                <Transition leaveDuration="0" name="'o_notification_fade'" t-slot-scope="transition">
+                <Transition leaveDuration="0" immediate="true" name="'o_notification_fade'" t-slot-scope="transition">
                     <Notification t-props="notification_value.props" className="(notification_value.props.className || '') + ' ' + transition.className"/>
                 </Transition>
             </t>

--- a/addons/web/static/src/core/transition.js
+++ b/addons/web/static/src/core/transition.js
@@ -1,6 +1,14 @@
 import { browser } from "./browser/browser";
 
-import { Component, useState, useEffect, xml, onWillUpdateProps, useComponent } from "@odoo/owl";
+import {
+    Component,
+    onWillUpdateProps,
+    status,
+    useComponent,
+    useEffect,
+    useState,
+    xml,
+} from "@odoo/owl";
 
 // Allows to disable transitions globally, useful for testing (and maybe for
 // a reduced motion setting in the future?)
@@ -16,8 +24,11 @@ export const config = {
  *
  * @param {Object} options
  * @param {string} options.name the prefix to use for the transition classes
- * @param {boolean} [options.onOff] whether to start the transition in the on or
- *  off state
+ * @param {boolean} [options.initialVisibility=true] whether to start the
+ *  transition in the on or off state
+ * @param {number} [options.immediate=false] (only relevant when initialVisibility
+ *  is true) set to true to animate initially. By default, there's no animation
+ *  if the element is initially visible.
  * @param {number} [options.leaveDuration] the leaveDuration of the transition
  * @param {Function} [options.onLeave] a function that will be called when the
  *  element will be removed in the next render cycle
@@ -28,6 +39,7 @@ export const config = {
 export function useTransition({
     name,
     initialVisibility = true,
+    immediate = false,
     leaveDuration = 500,
     onLeave = () => {},
 }) {
@@ -79,13 +91,17 @@ export function useTransition({
             // when true - transition from enter to enter-active
             // when false - transition from enter-active to leave, unmount after leaveDuration
             if (newState) {
-                state.stage = "enter";
-                state.shouldMount = true;
-                // force a render here so that we get a patch even if the state didn't change
-                component.render();
-                onNextPatch = () => {
+                if (status(component) === "mounted" || immediate) {
+                    state.stage = "enter";
+                    // force a render here so that we get a patch even if the state didn't change
+                    component.render();
+                    onNextPatch = () => {
+                        state.stage = "enter-active";
+                    };
+                } else {
                     state.stage = "enter-active";
-                };
+                }
+                state.shouldMount = true;
             } else {
                 state.stage = "leave";
                 timer = browser.setTimeout(() => {
@@ -117,15 +133,17 @@ export class Transition extends Component {
     static props = {
         name: String,
         visible: { type: Boolean, optional: true },
+        immediate: { type: Boolean, optional: true },
         leaveDuration: { type: Number, optional: true },
         onLeave: { type: Function, optional: true },
         slots: Object,
     };
 
     setup() {
-        const { visible, leaveDuration, name, onLeave } = this.props;
+        const { immediate, visible, leaveDuration, name, onLeave } = this.props;
         this.transition = useTransition({
             initialVisibility: visible,
+            immediate,
             leaveDuration,
             name,
             onLeave,

--- a/addons/web/static/tests/core/transition.test.js
+++ b/addons/web/static/tests/core/transition.test.js
@@ -5,7 +5,7 @@ import { mountWithCleanup, patchWithCleanup } from "@web/../tests/web_test_helpe
 import { Component, xml, useState } from "@odoo/owl";
 import { animationFrame, runAllTimers } from "@odoo/hoot-mock";
 
-test("useTransition hook", async () => {
+test("useTransition hook (default params)", async () => {
     patchWithCleanup(transitionConfig, {
         disabled: false,
     });
@@ -15,6 +15,39 @@ test("useTransition hook", async () => {
         setup() {
             this.transition = useTransition({
                 name: "test",
+                onLeave: () => expect.step("leave"),
+            });
+        }
+    }
+
+    // noMainContainer, because the await for the mount of the main container
+    // will already change the transition
+    const parent = await mountWithCleanup(Parent, { noMainContainer: true });
+
+    expect(".test.test-enter-active:not(.test-enter)").toHaveCount(1);
+    parent.transition.shouldMount = false;
+    await animationFrame();
+
+    // Leaving: -leave but not -enter-active
+    expect(".test.test-leave:not(.test-enter-active)").toHaveCount(1);
+    expect.verifySteps([]);
+    await runAllTimers();
+    expect.verifySteps(["leave"]);
+    await animationFrame();
+    expect(".test").toHaveCount(0);
+});
+
+test("useTransition hook (initially visible and immediate=true)", async () => {
+    patchWithCleanup(transitionConfig, {
+        disabled: false,
+    });
+    class Parent extends Component {
+        static template = xml`<div t-if="transition.shouldMount" t-att-class="transition.className"/>`;
+        static props = ["*"];
+        setup() {
+            this.transition = useTransition({
+                name: "test",
+                immediate: true,
                 onLeave: () => expect.step("leave"),
             });
         }
@@ -41,13 +74,47 @@ test("useTransition hook", async () => {
     expect(".test").toHaveCount(0);
 });
 
+test("useTransition hook (initially not visible)", async () => {
+    patchWithCleanup(transitionConfig, {
+        disabled: false,
+    });
+    class Parent extends Component {
+        static template = xml`<div t-if="transition.shouldMount" t-att-class="transition.className"/>`;
+        static props = ["*"];
+        setup() {
+            this.transition = useTransition({
+                name: "test",
+                initialVisibility: false,
+                onLeave: () => expect.step("leave"),
+            });
+        }
+    }
+
+    // noMainContainer, because the await for the mount of the main container
+    // will already change the transition
+    const parent = await mountWithCleanup(Parent, { noMainContainer: true });
+    expect(".test").toHaveCount(0);
+
+    parent.transition.shouldMount = true;
+    await animationFrame();
+
+    // Leaving: -leave but not -enter-active
+    expect(".test.test-enter:not(.test-enter-active)").toHaveCount(1);
+    await animationFrame();
+    // No longer has -enter class but now has -enter-active
+    expect(".test.test-enter-active:not(.test-enter)").toHaveCount(1);
+    await runAllTimers();
+    expect.verifySteps([]);
+    await animationFrame();
+});
+
 test("Transition HOC", async () => {
     patchWithCleanup(transitionConfig, {
         disabled: false,
     });
     class Parent extends Component {
         static template = xml`
-            <Transition name="'test'" visible="state.show" t-slot-scope="transition" onLeave="onLeave">
+            <Transition name="'test'" visible="state.show" immediate="true" t-slot-scope="transition" onLeave="onLeave">
                 <div t-att-class="transition.className"/>
             </Transition>
         `;


### PR DESCRIPTION
In a view with embedded actions (e.g. kanban view of tasks in a project), toggle it on s.t. it is visible, and then click on the kanban view switcher (basically to reload the kanban view). Before this commit, the embedded actions animation was played at each reload, causing a weird flickering.

The reason is that when the view is reloaded, the ControlPanel is destroyed and a new one is created, with the embedded actions to be displayed by default (as they had been toggled beforehand). Before this commit, in such a situation, the Transition component (and the useTransition hook) played the animation.

This behavior is only useful (and relevant) for a single usecase: Notifications. The NotificationContain uses a t-foreach to iterate over the notifications it has to display, and wrap them inside a Transition component. That means that when a notification pops, it must animate directly (it is always visible). For the remaining usecases in Odoo, we don't want to animate initially, if the element is visible by default.

This commit introduces an option "immediate" (in the HOC and the hook), which is false by default. When set to true, if the element is initially visible, the animation is played.

task~4035839

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
