### PR TITLE
[FIX] website_forum: limit the number of pages displayed in the pager

### DIFF
--- a/addons/website_forum/controllers/main.py
+++ b/addons/website_forum/controllers/main.py
@@ -138,7 +138,7 @@ class WebsiteForum(WebsiteProfile):
         if my:
             url_args['my'] = my
         pager = request.website.pager(url=url, total=question_count, page=page,
-                                      step=self._post_per_page, scope=self._post_per_page,
+                                      step=self._post_per_page, scope=5,
                                       url_args=url_args)
 
         values = self._prepare_user_values(forum=forum, searches=post, header={'ask_hide': not forum.active})


### PR DESCRIPTION
When having a lot of forum posts, the pager can display up to 10 pages, because the specified scope is the set to the same value as the number of posts per page, which is 10. This causes layout issues in mobile view in that case, because the pager overflows from the page.

This commit fixes that by setting the scope to 5 instead (like the Event pager), which is just enough to not overflow.

opw-4050389