### PR TITLE
[FIX] base_import_module: fix test_import_zip_ignore_unexpected_data_extension

### DIFF
--- a/addons/base_import_module/tests/test_import_module.py
+++ b/addons/base_import_module/tests/test_import_module.py
@@ -160,9 +160,8 @@ class TestImportModule(odoo.tests.TransactionCase):
         ]
         with self.assertLogs('odoo.addons.base_import_module.models.ir_module') as log_catcher:
             self.import_zipfile(files)
-            self.assertEqual(len(log_catcher.output), 2)
-            self.assertIn('module foo: skip unsupported file res.partner.xls', log_catcher.output[0])
-            self.assertIn("Successfully imported module 'foo'", log_catcher.output[1])
+            self.assertIn("INFO:odoo.addons.base_import_module.models.ir_module:module foo: skip unsupported file res.partner.xls", log_catcher.output)
+            self.assertIn("INFO:odoo.addons.base_import_module.models.ir_module:Successfully imported module 'foo'", log_catcher.output)
             self.assertFalse(self.env.ref('foo.foo', raise_if_not_found=False))
 
     def test_import_zip_extract_only_useful(self):


### PR DESCRIPTION
In some cases, like when another tests activates a language, the log output can include an extra line.
See an example here: https://runbot.odoo.com/runbot/build/66699073 After this commit, we only check for the logs we care about.

See also: https://github.com/odoo/odoo/pull/175344


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
