### PR TITLE
[FIX] l10n_in_withholding: add missing consider_amount in the form view

### DIFF
--- a/addons/l10n_in_withholding/views/l10n_in_section_alert_views.xml
+++ b/addons/l10n_in_withholding/views/l10n_in_section_alert_views.xml
@@ -27,6 +27,7 @@
                         </h1>
                     </div>
                     <group class="w-50" string="Threshold limits">
+                        <field name="consider_amount"/>
                         <label for="is_per_transaction_limit"/>
                         <div>
                             <field class="w-25" name="is_per_transaction_limit" widget="boolean_toggle"/>


### PR DESCRIPTION
This commits adds the missing consider_amount field for `l10n.in.section.alert` form view


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
