### PR TITLE
[FIX] im_livechat: trigger step data wrongly inserted

### DIFF
--- a/addons/im_livechat/models/chatbot_script_answer.py
+++ b/addons/im_livechat/models/chatbot_script_answer.py
@@ -3,6 +3,7 @@
 
 from odoo import api, models, fields
 from odoo.osv import expression
+from odoo.addons.mail.tools.discuss import Store
 
 import textwrap
 
@@ -56,3 +57,14 @@ class ChatbotScriptAnswer(models.Model):
             domain = expression.AND([domain, [('chatbot_script_id', '=', force_domain_chatbot_script_id)]])
 
         return self._search(domain, limit=limit, order=order)
+
+    def _to_store(self, store: Store, /, *, fields=None):
+        if fields is None:
+            fields = ["label", "redirectLink"]
+        for answer in self:
+            data = {"id": answer.id}
+            if "label" in fields:
+                data["label"] = answer.name
+            if "redirectLink" in fields:
+                data["redirectLink"] = answer.redirect_link
+            store.add("ChatbotScriptAnswer", data)

--- a/addons/im_livechat/static/src/embed/common/chat_window_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/chat_window_model_patch.js
@@ -16,6 +16,8 @@ patch(ChatWindow.prototype, {
             this.open({ notifyState: this.thread?.state !== "open" });
         } else {
             await super.close(...arguments);
+            this.thread.messages.forEach((message) => message.delete());
+            this.thread.delete();
         }
         this.store.env.services["im_livechat.livechat"].leave();
         this.store.env.services["im_livechat.chatbot"].stop();

--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_step_model.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_step_model.js
@@ -17,11 +17,7 @@ export class ChatbotStep extends Record {
             return this.scriptStep?.type;
         },
     });
-    isLast = Record.attr(false, {
-        compute() {
-            return this.scriptStep.isLast;
-        },
-    });
+    isLast = false;
 
     get expectAnswer() {
         return [

--- a/addons/mail/static/src/core/common/attachment_model.js
+++ b/addons/mail/static/src/core/common/attachment_model.js
@@ -16,9 +16,9 @@ export class Attachment extends FileModelMixin(Record) {
     static insert(data) {
         return super.insert(...arguments);
     }
-    static new(data) {
+    static new() {
         /** @type {import("models").Attachment} */
-        const attachment = super.new(data);
+        const attachment = super.new(...arguments);
         Record.onChange(attachment, ["extension", "filename"], () => {
             if (!attachment.extension && attachment.filename) {
                 attachment.extension = attachment.filename.split(".").pop();

--- a/addons/mail/static/src/core/common/discuss_app_model.js
+++ b/addons/mail/static/src/core/common/discuss_app_model.js
@@ -2,9 +2,9 @@ import { _t } from "@web/core/l10n/translation";
 import { Record } from "./record";
 
 export class DiscussApp extends Record {
-    static new(data) {
+    static new() {
         /** @type {import("models").DiscussApp} */
-        const res = super.new(data);
+        const res = super.new(...arguments);
         Object.assign(res, {
             channels: {
                 extraClass: "o-mail-DiscussSidebarCategory-channel",

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -42,8 +42,8 @@ export class Thread extends Record {
     static insert(data) {
         return super.insert(...arguments);
     }
-    static new(data) {
-        const thread = super.new(data);
+    static new() {
+        const thread = super.new(...arguments);
         Record.onChange(thread, ["state"], () => {
             if (thread.state === "open" && !this.store.env.services.ui.isSmall) {
                 const cw = this.store.ChatWindow?.insert({ thread });

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -27,17 +27,6 @@ export class DiscussCoreCommon {
                 }),
             { once: true }
         );
-        this.busService.subscribe("discuss.channel/joined", async (payload) => {
-            const { channel, invited_by_user_id: invitedByUserId } = payload;
-            const thread = this.store.Thread.insert(channel);
-            await thread.fetchChannelInfo();
-            if (invitedByUserId && invitedByUserId !== this.store.self.userId) {
-                this.notificationService.add(
-                    _t("You have been invited to #%s", thread.displayName),
-                    { type: "info" }
-                );
-            }
-        });
         this.busService.subscribe("discuss.channel/leave", (payload) => {
             const { Thread } = this.store.insert(payload);
             const [thread] = Thread;

--- a/addons/mail/static/src/discuss/core/web/discuss_core_web_service.js
+++ b/addons/mail/static/src/discuss/core/web/discuss_core_web_service.js
@@ -32,6 +32,17 @@ export class DiscussCoreWeb {
                 category.open = open;
             }
         });
+        this.busService.subscribe("discuss.channel/joined", async (payload) => {
+            const { channel, invited_by_user_id: invitedByUserId } = payload;
+            const thread = this.store.Thread.insert(channel);
+            await thread.fetchChannelInfo();
+            if (invitedByUserId && invitedByUserId !== this.store.self.userId) {
+                this.notificationService.add(
+                    _t("You have been invited to #%s", thread.displayName),
+                    { type: "info" }
+                );
+            }
+        });
         this.busService.subscribe("res.users/connection", async ({ partnerId, username }) => {
             // If the current user invited a new user, and the new user is
             // connecting for the first time while the current user is present

--- a/addons/mail/static/src/model/record.js
+++ b/addons/mail/static/src/model/record.js
@@ -81,7 +81,11 @@ export class Record {
                     }
                 }
                 // relational field (note: optional when OR)
-                return `(${data[expr]?.localId})`;
+                if (isRecord(data[expr])) {
+                    return `(${data[expr]?.localId})`;
+                }
+                const TargetModelName = Model._.fieldsTargetModel.get(expr);
+                return `(${Model.store[TargetModelName].get(data[expr])?.localId})`;
             }
             return data[expr];
         }
@@ -172,27 +176,12 @@ export class Record {
      *
      * @returns {Record}
      */
-    static new(data) {
+    static new(data, ids) {
         const Model = toRaw(this);
         const store = Model._rawStore;
         return store.MAKE_UPDATE(function RecordNew() {
             const recordProxy = new Model.Class();
             const record = toRaw(recordProxy)._raw;
-            const ids = Model._retrieveIdFromData(data);
-            for (const name in ids) {
-                if (
-                    ids[name] &&
-                    !isRecord(ids[name]) &&
-                    !isCommand(ids[name]) &&
-                    isRelation(Model, name)
-                ) {
-                    // preinsert that record in relational field,
-                    // as it is required to make current local id
-                    ids[name] = Model._rawStore[Model._.fieldsTargetModel.get(name)].preinsert(
-                        ids[name]
-                    );
-                }
-            }
             Object.assign(record._, { localId: Model.localId(ids) });
             Object.assign(recordProxy, { ...ids });
             Model.records[record.localId] = recordProxy;
@@ -316,13 +305,26 @@ export class Record {
         record.update.call(record._proxy, data);
         return recordFullProxy;
     }
-    /**
-     * @returns {Record}
-     */
+    /** @returns {Record} */
     static preinsert(data) {
         const ModelFullProxy = this;
         const Model = toRaw(ModelFullProxy);
-        return Model.get.call(ModelFullProxy, data) ?? Model.new(data);
+        const ids = Model._retrieveIdFromData(data);
+        for (const name in ids) {
+            if (
+                ids[name] &&
+                !isRecord(ids[name]) &&
+                !isCommand(ids[name]) &&
+                isRelation(Model, name)
+            ) {
+                // preinsert that record in relational field,
+                // as it is required to make current local id
+                ids[name] = Model._rawStore[Model._.fieldsTargetModel.get(name)].preinsert(
+                    ids[name]
+                );
+            }
+        }
+        return Model.get.call(ModelFullProxy, data) ?? Model.new(data, ids);
     }
 
     /** @returns {import("models").Store} */

--- a/addons/mail/static/tests/core/record.test.js
+++ b/addons/mail/static/tests/core/record.test.js
@@ -9,7 +9,7 @@ import { reactive, toRaw } from "@odoo/owl";
 import { mockService } from "@web/../tests/web_test_helpers";
 
 import { Record, Store, makeStore } from "@mail/core/common/record";
-import { Markup } from "@mail/model/misc";
+import { AND, Markup } from "@mail/model/misc";
 import { registry } from "@web/core/registry";
 
 describe.current.tags("desktop");
@@ -883,4 +883,41 @@ test("setup() has precedence over instance class field definition", async () => 
     const store = await start();
     const test = store.Test2.insert();
     expect(test.x).toBe(true);
+});
+
+test("insert with id relation keeps existing field values", async () => {
+    class User extends Record {
+        static id = "id";
+        id;
+    }
+    User.register(localRegistry);
+    class Thread extends Record {
+        static id = "id";
+        id;
+    }
+    Thread.register(localRegistry);
+    class ChannelMember extends Record {
+        static id = AND("channel", "user");
+        is_internal = Record.attr(false);
+        channel = Record.one("Thread");
+        user = Record.one("User");
+    }
+    ChannelMember.register(localRegistry);
+    const store = await start();
+    const member1 = store.ChannelMember.insert({
+        is_internal: true,
+        user: { id: 1 },
+        channel: { id: 2 },
+    });
+    const user1 = member1.user;
+    const channel1 = member1.channel;
+    expect(member1.is_internal).toBe(true);
+    const member2 = store.ChannelMember.insert({
+        user: { id: 1 },
+        channel: { id: 2 },
+    });
+    expect(member2.eq(member1)).toBe(true);
+    expect(member2.user.eq(user1)).toBe(true);
+    expect(member2.channel.eq(channel1)).toBe(true);
+    expect(member2.is_internal).toBe(true);
 });

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_trigger_selection_tour.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_trigger_selection_tour.js
@@ -1,0 +1,39 @@
+import { registry } from "@web/core/registry";
+
+const answerBothQuestions = [
+    {
+        trigger:
+            ".o-livechat-root:shadow .o-mail-Message:contains(Hello, here is a first question?)",
+    },
+    {
+        trigger: ".o-livechat-root:shadow li:contains(Yes to first question)",
+        run: "click",
+    },
+    {
+        trigger:
+            ".o-livechat-root:shadow .o-mail-Message:contains(Hello, here is a second question?)",
+    },
+    {
+        trigger: ".o-livechat-root:shadow li:contains(No to second question)",
+        run: "click",
+    },
+];
+registry.category("web_tour.tours").add("website_livechat.chatbot_trigger_selection", {
+    test: true,
+    url: "/contactus",
+    steps: () => [
+        {
+            trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",
+            run: "click",
+        },
+        ...answerBothQuestions,
+        {
+            trigger: ".o-livechat-root:shadow button[title='Restart Conversation']",
+            run: "click",
+        },
+        ...answerBothQuestions,
+        {
+            trigger: ".o-livechat-root:shadow button[title='Restart Conversation']",
+        },
+    ],
+});

--- a/addons/website_livechat/tests/test_chatbot_ui.py
+++ b/addons/website_livechat/tests/test_chatbot_ui.py
@@ -162,3 +162,43 @@ class TestLivechatChatbotUI(TestLivechatCommon, ChatbotCase):
         default_website.channel_id = livechat_channel.id
         self.env.ref("website.default_website").channel_id = livechat_channel.id
         self.start_tour("/contactus", "website_livechat.chatbot_redirect")
+
+    def test_chatbot_trigger_selection(self):
+        chatbot_trigger_selection = self.env["chatbot.script"].create(
+            {"title": "Trigger question selection bot"}
+        )
+        question_1, question_2 = tuple(
+            self.env["chatbot.script.step"].create([
+                {
+                    "chatbot_script_id": chatbot_trigger_selection.id,
+                    "message": "Hello, here is a first question?",
+                    "step_type": "question_selection",
+                },
+                {
+                    "chatbot_script_id": chatbot_trigger_selection.id,
+                    "message": "Hello, here is a second question?",
+                    "step_type": "question_selection",
+                },
+            ])
+        )
+        self.env["chatbot.script.answer"].create([
+            {
+                "name": "Yes to first question",
+                "script_step_id": question_1.id,
+            },
+            {
+                "name": "No to second question",
+                "script_step_id": question_2.id,
+            },
+        ])
+        livechat_channel = self.env["im_livechat.channel"].create({
+            'name': 'Redirection Channel',
+            'rule_ids': [Command.create({
+                'regex_url': '/contactus',
+                'chatbot_script_id': chatbot_trigger_selection.id,
+            })]
+        })
+        default_website = self.env.ref("website.default_website")
+        default_website.channel_id = livechat_channel.id
+        self.env.ref("website.default_website").channel_id = livechat_channel.id
+        self.start_tour("/contactus", "website_livechat.chatbot_trigger_selection")


### PR DESCRIPTION
Since [1], the return type of the `/chatbot/trigger/step` route
has changed. However the call site was not adapted. As a result,
the chat bot fails when triggering a question selection step.

Steps to reproduce:
- Create a chat bot script with two question selections
- Enable it on the website
- Follow the steps, the second one results in a crash

This PR adapts the chat bot code to properly use the new mail
store syntax.

[1]: https://github.com/odoo/odoo/pull/171585

enterprise: https://github.com/odoo/enterprise/pull/68605