### PR TITLE
[IMP] web_tour: error reporting

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_step_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_step_automatic.js
@@ -141,7 +141,7 @@ export class TourStepAutomatic extends TourStep {
         } else if (this.isBlocked) {
             return "Element has been found but DOM is blocked by UI.";
         } else if (!this.hasRun) {
-            return `Element has been found. The error seems to be with step.run`;
+            return `Element has been found. The error seems to be with step.run.`;
         }
         return "";
     }
@@ -202,19 +202,21 @@ export class TourStepAutomatic extends TourStep {
     }
 
     /**
-     * @param {Array<string>} [errors]
+     * @param {string} [error]
      */
     throwError(error = "") {
         tourState.set(this.tour.name, "stepState", "errored");
         const debugMode = tourState.get(this.tour.name, "debug");
+        // console.error notifies the test runner that the tour failed.
+        const errors = [
+            `FAILED: ${this.describeMe}.`,
+            this.describeWhyIFailed,
+            error,
+        ]
+        console.error(errors.filter(Boolean).join("\n"));
         // The logged text shows the relative position of the failed step.
         // Useful for finding the failed step.
-        console.warn(this.describeWhyIFailedDetailed);
-        // console.error notifies the test runner that the tour failed.
-        console.error(`FAILED: ${this.describeMe}. ${this.describeWhyIFailed}`);
-        if (error.length) {
-            console.error(error);
-        }
+        console.dir(this.describeWhyIFailedDetailed);
         if (debugMode !== false) {
             // eslint-disable-next-line no-debugger
             debugger;

--- a/addons/web_tour/static/tests/tour_service.test.js
+++ b/addons/web_tour/static/tests/tour_service.test.js
@@ -290,8 +290,11 @@ test("a failing tour logs the step that failed in run", async () => {
     const expectedError = [
         "log: [1/2] Tour tour2 → Step .button0",
         `log: [2/2] Tour tour2 → Step .button1`,
-        "error: FAILED: [2/2] Tour tour2 → Step .button1. Element has been found. The error seems to be with step.run",
-        "error: Cannot read properties of null (reading 'click')",
+        [
+            "error: FAILED: [2/2] Tour tour2 → Step .button1.",
+            "Element has been found. The error seems to be with step.run.",
+            "Cannot read properties of null (reading 'click')",
+        ].join("\n"),
         "error: tour not succeeded",
     ];
     expect.verifySteps(expectedError);
@@ -339,10 +342,13 @@ test("a failing tour with disabled element", async () => {
     await advanceTime(750);
     await advanceTime(750);
     const expectedError = [
-        `error: FAILED: [2/3] Tour tour3 → Step .button1. Element has been found. The error seems to be with step.run`,
-        `error: Element can't be disabled when you want to click on it.
-Tip: You can add the ":enabled" pseudo selector to your selector to wait for the element is enabled.`,
-        `error: FAILED: [3/3] Tour tour3 → Step .button2. The cause is that trigger (.button2) element cannot be found in DOM. TIP: You can use :not(:visible) to force the search for an invisible element.`,
+        [
+            `error: FAILED: [2/3] Tour tour3 → Step .button1.`,
+            `Element has been found. The error seems to be with step.run.`,
+            `Element can't be disabled when you want to click on it.`,
+            `Tip: You can add the ":enabled" pseudo selector to your selector to wait for the element is enabled.`,
+        ].join('\n'),
+        `error: FAILED: [3/3] Tour tour3 → Step .button2.\nThe cause is that trigger (.button2) element cannot be found in DOM. TIP: You can use :not(:visible) to force the search for an invisible element.`,
         `error: tour not succeeded`,
     ];
     await advanceTime(10000);
@@ -351,8 +357,9 @@ Tip: You can add the ":enabled" pseudo selector to your selector to wait for the
 
 test("a failing tour logs the step that failed", async () => {
     patchWithCleanup(browser.console, {
+        dir: (s) => expect.step(`runbot: ${s.replace(/[\s-]*/g, '')}`),
         log: (s) => expect.step(`log: ${s}`),
-        warn: (s) => expect.step(`warn: ${s.replace(/[ \n\-/\r\t]/gi, "")}`),
+        warn: (s) => expect.step(`warn: ${s.replace(/[\s-]*/gi, "")}`),
         error: (s) => expect.step(`error: ${s}`),
     });
 
@@ -438,8 +445,8 @@ test("a failing tour logs the step that failed", async () => {
     expect.verifySteps(["log: [5/9] Tour tour1 → Step content (trigger: .wrong_selector)"]);
     await advanceTime(10000);
     expect.verifySteps([
-        `warn: {"content":"content","trigger":".button1","run":"click"},{"content":"content","trigger":".button2","run":"click"},{"content":"content","trigger":".button3","run":"click"},FAILED:[59]Tourtour1→Stepcontent(trigger:.wrong_selector){"content":"content","trigger":".wrong_selector","run":"click"},{"content":"content","trigger":".button4","run":"click"},{"content":"content","trigger":".button5","run":"click"},{"content":"content","trigger":".button6","run":"click"},`,
-        "error: FAILED: [5/9] Tour tour1 → Step content (trigger: .wrong_selector). The cause is that trigger (.wrong_selector) element cannot be found in DOM. TIP: You can use :not(:visible) to force the search for an invisible element.",
+        "error: FAILED: [5/9] Tour tour1 → Step content (trigger: .wrong_selector).\nThe cause is that trigger (.wrong_selector) element cannot be found in DOM. TIP: You can use :not(:visible) to force the search for an invisible element.",
+        `runbot: {"content":"content","trigger":".button1","run":"click"},{"content":"content","trigger":".button2","run":"click"},{"content":"content","trigger":".button3","run":"click"},FAILED:[5/9]Tourtour1→Stepcontent(trigger:.wrong_selector){"content":"content","trigger":".wrong_selector","run":"click"},{"content":"content","trigger":".button4","run":"click"},{"content":"content","trigger":".button5","run":"click"},{"content":"content","trigger":".button6","run":"click"},`,
     ]);
 });
 
@@ -913,7 +920,7 @@ test("automatic tour with invisible element", async () => {
     await advanceTime(750);
     await advanceTime(10000);
     expect.verifySteps([
-        "error: FAILED: [2/3] Tour tour_de_wallonie → Step .button1. The cause is that trigger (.button1) element cannot be found in DOM. TIP: You can use :not(:visible) to force the search for an invisible element.",
+        "error: FAILED: [2/3] Tour tour_de_wallonie → Step .button1.\nThe cause is that trigger (.button1) element cannot be found in DOM. TIP: You can use :not(:visible) to force the search for an invisible element.",
     ]);
 });
 


### PR DESCRIPTION
Before this change, on many tour failures (e.g. exception raised) the tour manager generates two `console.error` calls, which translate to two `logging.error` calls, which leads to the runbot creating two different errors, which creates more errors to sort than necessary and furthermore creates less specialised error messages which are harder to track and match.

Compose the error message upfront then emit it at once.

Also move the warning providing the failure location information below the main error message, as it's basically a sub-error, and convert it to a `console.dir`: it's a bit of a misuse but the runbot treats `console.dir` as a `logging.runbot` meaning it's stored in the DB and shown but it's not considered an error in and of itself. That keeps it as useful as it was before but more secondary.
