### PR TITLE
[FIX] base: check for invalid company_id in partner_id

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -447,6 +447,19 @@ class Partner(models.Model):
         if self._has_cycle():
             raise ValidationError(_('You cannot create recursive Partner hierarchies.'))
 
+    @api.constrains('company_id')
+    def _check_partner_company(self):
+        for partner in self:
+            if partner.is_company and partner.company_id:
+                related_company = self.env['res.company'].search([
+                    ('partner_id', '=', partner.id)
+                ], limit=1)
+
+                if related_company and partner.company_id != related_company.id:
+                    raise ValidationError(
+                        "The company assigned to this partner does not match the company this partner represents."
+                    )
+
     def copy_data(self, default=None):
         default = dict(default or {})
         vals_list = super().copy_data(default=default)


### PR DESCRIPTION
This PR introduces a constraint on res_partner to enforce consistency between a company's partner and that partner's associated company. If a partner represents a company, it makes no sense for it's company_id to be another one as It would cause access errors and issues in other models (`recordx.partner_id.company_id != recordx.company_id`)

Starting from saas-17.3 because many test DBs are failing to upgrade beyond it because of this issue.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
