### PR TITLE
[IMP] test_main_flows: simplify kanban archs

### DIFF
--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -1233,11 +1233,11 @@ stepUtils.autoExpandMoreButtons(true),
     run: "click",
 }, {
     isActive: ["enterprise", "desktop"],
-    trigger: "div.o_bank_rec_st_line_kanban_card span:contains('the_flow.customer')",
+    trigger: ".o_kanban_record span:contains('the_flow.customer')",
 },
 {
     isActive: ["enterprise", "desktop"],
-    trigger: "div.o_bank_rec_st_line_kanban_card span:contains('the_flow.customer')",
+    trigger: ".o_kanban_record span:contains('the_flow.customer')",
     content: _t("Select the newly created bank transaction"),
     run: "click",
 }, {


### PR DESCRIPTION
In this commit we have simplified the kanban arch for the account_accountant and
related modules. The goal is to simplify them, make them easier to read, and use
bootstrap utility
classnames.
- Previously, we used `kanban-box`, but now we are using `kanban-card` instead.
- Deprecated `oe_kanban_global_click` and `oe_kanban_global_click_edit`.
- More use of `<field/>` tags
- Removed the `oe_kanban_colorpicker` class and replaced it with the
  `kanban_color_picker` widget.
- Changed type='edit' to type='open' to open records. since version 16, records
  always open in edit mode by default.
- `kanban_image` from rendering context, is deprecated so we use
  `<field name="..." widget="image"/>` instead

Enterprise pr: https://github.com/odoo/enterprise/pull/68609

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
