### PR TITLE
[FIX] account: fix default_account_id for misc journal

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -355,6 +355,8 @@ class AccountJournal(models.Model):
     @api.onchange('type')
     def _onchange_type(self):
         self.refund_sequence = self.type in ('sale', 'purchase')
+        if self.type == 'general':
+            self.default_account_id = False
 
     def _get_alias_values(self, type, alias_name=None):
         """ This function verifies that the user-given mail alias (or its fallback) doesn't contain non-ascii chars.


### PR DESCRIPTION
**Steps to reproduce:**
- Install account_accountant.
- Create a journal with a type other than miscellaneous. 
- For the created journal, select a default account
- Now change the journal type to Miscellaneous.

**Issue :**
- When changing the journal type to Miscellaneous from any other type, the default_account_id remains unchanged in the database. Functionally, the default_account_id should be removed for Miscellaneous journals, as this field isn't visible in the front-end, so customers aren't aware if it still contains data.
- I have faced one issue where customer changed journal type to miscellaneous and after upgrade he faced some issue related to cash flow statement which is accuring because there is default_account_id set for it.
- Before fix : https://drive.google.com/file/d/1YXL-JesJeUppdVPvJSYHmAMLGfWsUFif/view?usp=sharing
- After fix : https://drive.google.com/file/d/1c9elB9qB1lHfmJ0R_a8oposeN4OZ5cjl/view?usp=sharing
opw-4072696
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
