### PR TITLE
[IMP] sale_project: remove unused domain

### DIFF
--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -368,11 +368,11 @@ class ProjectProject(models.Model):
             'sale_items': self._get_sale_items() if self.allow_billable else {},
         }
 
-    def get_sale_items_data(self, domain=None, offset=0, limit=None, with_action=True):
+    def get_sale_items_data(self, offset=0, limit=None, with_action=True):
         if not self.env.user.has_group('project.group_project_user'):
             return {}
         sols = self.env['sale.order.line'].sudo().search(
-            domain or self._get_sale_items_domain(),
+            self._get_sale_items_domain(),
             offset=offset,
             limit=limit,
         )
@@ -410,7 +410,7 @@ class ProjectProject(models.Model):
         domain = self._get_sale_items_domain()
         return {
             'total': self.env['sale.order.line'].sudo().search_count(domain),
-            'data': self.get_sale_items_data(domain, limit=5, with_action=with_action),
+            'data': self.get_sale_items_data(limit=5, with_action=with_action),
         }
 
     def _show_profitability(self):

--- a/addons/sale_project/static/src/components/project_right_side_panel/project_right_side_panel.js
+++ b/addons/sale_project/static/src/components/project_right_side_panel/project_right_side_panel.js
@@ -12,7 +12,7 @@ patch(ProjectRightSidePanel.prototype, {
         const saleOrderItems = await this.orm.call(
             'project.project',
             'get_sale_items_data',
-            [this.projectId, undefined, offset, limit],
+            [this.projectId, offset, limit],
             {
                 context: this.context,
             },


### PR DESCRIPTION
get_sale_items_data has the ability to search by domain. This function was added in commit:
08501fa130007e3b43fe394c6221328be0d75f25

However this feature isn't used anywhere in our code it's best to remove this domain parameter in master.

Task-4017318