### PR TITLE
[FIX] base: force the use of user index

### DIFF
--- a/odoo/addons/base/models/res_device.py
+++ b/odoo/addons/base/models/res_device.py
@@ -153,7 +153,7 @@ class ResDevice(models.Model):
 
     @api.model
     def _select(self):
-        return "SELECT DISTINCT ON (D.session_identifier, D.platform, D.browser) D.*"
+        return "SELECT DISTINCT ON (D.user_id, D.session_identifier, D.platform, D.browser) D.*"
 
     @api.model
     def _from(self):
@@ -165,7 +165,7 @@ class ResDevice(models.Model):
 
     @api.model
     def _order_by(self):
-        return "ORDER BY D.session_identifier, D.platform, D.browser, D.last_activity DESC"
+        return "ORDER BY D.user_id, D.session_identifier, D.platform, D.browser, D.last_activity DESC"
 
     @property
     def _query(self):


### PR DESCRIPTION
Explanation:
------------
To retrieve the last log from a device, keys (session_identifier, platform, browser)
are sufficient. But in order to encourage postgresql (when it optimises costs)
to use the index placed on `user_id`, it is a good idea to add it as a key
in the `DISTINCT ON` and `ORDER BY`.

In theory, adding `user_id` does not change the result of the view, due to the fact
that a `session_identifier` should match only a unique ``user_id``. This cannot be
guaranteed in practice (and it will depend on the order) but the risk of collision
is very low, i.e. several `user_id` who match a `session identifier`.

It makes sense to add this constraint in order to optimise performance when loading
the user profile view during which a `WHERE` clause on the user is added.

Analyze:
--------

`res_device`: before commit
`res_device_2`: after commit

```
explain analyze select * from res_device where user_id=<ID>;

Subquery Scan on res_device  (cost=67659.10..74221.39 rows=504 width=153) (actual time=484.820..671.743 rows=8 loops=1)
Filter: (res_device.user_id = 13)
Rows Removed by Filter: 279564
->  Unique  (cost=67659.10..72962.57 rows=100705 width=153) (actual time=483.679..653.555 rows=279572 loops=1)
    ->  Sort  (cost=67659.10..68984.97 rows=530347 width=153) (actual time=483.677..565.894 rows=530442 loops=1)
        Sort Key: d.session_identifier, d.platform, d.browser, d.last_activity DESC
        Sort Method: quicksort  Memory: 165461kB
        ->  Seq Scan on res_device_log d  (cost=0.00..17232.18 rows=530347 width=153) (actual time=0.009..84.712 rows=530442 loops=1)
            Filter: (NOT revoked)
            Rows Removed by Filter: 75
Planning Time: 0.107 ms
Execution Time: 686.165 ms
(12 rows)
```

```
explain analyze select * from res_device_2 where user_id=<ID>;

Unique  (cost=10.72..10.81 rows=9 width=153) (actual time=1.333..1.338 rows=8 loops=1)
	->  Sort  (cost=10.72..10.74 rows=9 width=153) (actual time=1.332..1.333 rows=12 loops=1)
		Sort Key: d.session_identifier, d.platform, d.browser, d.last_activity DESC
        Sort Method: quicksort  Memory: 28kB
	->  Index Scan using res_device_log__user_id_index on res_device_log d  (cost=0.42..10.57 rows=9 width=153) (actual time=1.299..1.320 rows=12 loops=1)
               Index Cond: (user_id = 13)
               Filter: (NOT revoked)
Planning Time: 0.117 ms
Execution Time: 1.358 ms
(9 rows)
```