### PR TITLE
[FIX] mrp: fix the timezone issue for start_date wo test

### DIFF
--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -3947,6 +3947,7 @@ class TestMrpOrder(TestMrpCommon):
         will be set too. As if the finish date is not set the planned workorder will not
         be shown in planning gantt view
         """
+        self.env.company.resource_calendar_id.tz = 'Europe/Brussels'
         mo = self.env['mrp.production'].create({
             'product_id': self.product.id,
             'product_uom_id': self.bom_1.product_uom_id.id,


### PR DESCRIPTION
The issue:
While running the test test_multi_edit_start_date_wo, the calendar is set to the Europe/Brussels timezone when demo data is loaded. However, when demo data is not loaded, the calendar defaults to the UTC timezone.

The fix:
Adapt the timezone

runbot-56562