### PR TITLE
[FIX] purchase, sale: missing product name in journal items

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -3293,6 +3293,9 @@ class AccountMoveLine(models.Model):
         }
         return res
 
+    def _get_journal_items_full_name(self, name, display_name):
+        return name if not display_name or display_name in name else f"{display_name} {name}"
+
     # -------------------------------------------------------------------------
     # PUBLIC ACTIONS
     # -------------------------------------------------------------------------

--- a/addons/l10n_it_stock_ddt/tests/expected_xmls/deferred_invoice.xml
+++ b/addons/l10n_it_stock_ddt/tests/expected_xmls/deferred_invoice.xml
@@ -80,7 +80,7 @@
                     <CodiceTipo>INTERNAL</CodiceTipo>
                     <CodiceValore>PRE-PAID</CodiceValore>
                 </CodiceArticolo>
-                <Descrizione>product_service_order</Descrizione>
+                <Descrizione>[PRE-PAID] product_service_order product_service_order</Descrizione>
                 <Quantita>5.00</Quantita>
                 <UnitaMisura>Hours</UnitaMisura>
                 <PrezzoUnitario>90.000000</PrezzoUnitario>
@@ -93,7 +93,7 @@
                     <CodiceTipo>INTERNAL</CodiceTipo>
                     <CodiceValore>FURN_9999</CodiceValore>
                 </CodiceArticolo>
-                <Descrizione>product_order_no</Descrizione>
+                <Descrizione>[FURN_9999] product_order_no product_order_no</Descrizione>
                 <Quantita>5.00</Quantita>
                 <PrezzoUnitario>280.000000</PrezzoUnitario>
                 <PrezzoTotale>1400.00</PrezzoTotale>
@@ -105,7 +105,7 @@
                     <CodiceTipo>INTERNAL</CodiceTipo>
                     <CodiceValore>FURN_7777</CodiceValore>
                 </CodiceArticolo>
-                <Descrizione>product_delivery_no</Descrizione>
+                <Descrizione>[FURN_7777] product_delivery_no product_delivery_no</Descrizione>
                 <Quantita>2.00</Quantita>
                 <PrezzoUnitario>70.000000</PrezzoUnitario>
                 <PrezzoTotale>140.00</PrezzoTotale>

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -558,7 +558,7 @@ class PurchaseOrderLine(models.Model):
 
         res = {
             'display_type': self.display_type or 'product',
-            'name': self.name,
+            'name': self.env['account.move.line']._get_journal_items_full_name(self.name, self.product_id.display_name),
             'product_id': self.product_id.id,
             'product_uom_id': self.product_uom.id,
             'quantity': self.qty_to_invoice,

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1175,7 +1175,7 @@ class SaleOrderLine(models.Model):
         res = {
             'display_type': self.display_type or 'product',
             'sequence': self.sequence,
-            'name': self.name,
+            'name': self.env['account.move.line']._get_journal_items_full_name(self.name, self.product_id.display_name),
             'product_id': self.product_id.id,
             'product_uom_id': self.product_uom.id,
             'quantity': self.qty_to_invoice,

--- a/addons/sale/tests/test_sale_to_invoice.py
+++ b/addons/sale/tests/test_sale_to_invoice.py
@@ -1101,3 +1101,27 @@ class TestSaleToInvoice(TestSaleCommon):
 
         self.assertEqual(sale_order_1.amount_to_invoice, -700.0)
         self.assertEqual(sale_order_2.amount_to_invoice, 0.0)
+
+    def test_invoice_line_name_has_product_name(self):
+        """ Testing that when invoicing a sales order, the invoice line name ALWAYS contains the product name. """
+        so = self.sale_order
+
+        # Use only invoicable on order products
+        so.order_line[1].product_id = so.order_line[0].product_id
+        so.order_line[3].product_id = so.order_line[2].product_id
+
+        # Adapt the SOL names to test the different cases
+        so.order_line[0].name = "just a description"
+        so.order_line[1].name = so.order_line[1].product_id.display_name
+        so.order_line[2].name = f"{so.order_line[2].product_id.display_name} with more description"
+        so.order_line[3].name = "product"
+
+        # Invoice the sale order
+        so.action_confirm()
+        inv = self.sale_order._create_invoices()
+
+        # Check the invoice line names
+        self.assertEqual(inv.invoice_line_ids[0].name, f"{so.order_line[0].product_id.display_name} {so.order_line[0].name}", "When the description doesn't contain the product name, it should be added to the invoice line name")
+        self.assertEqual(inv.invoice_line_ids[1].name, f"{so.order_line[1].name}", "When the description is the product name, the invoice line name should only be the description")
+        self.assertEqual(inv.invoice_line_ids[2].name, f"{so.order_line[2].name}", "When description contains the product name, the invoice line name should only be the description")
+        self.assertEqual(inv.invoice_line_ids[3].name, f"{so.order_line[3].product_id.display_name} {so.order_line[3].name}", "When the product name contains the description, the invoice line name should contain the product name and the description")


### PR DESCRIPTION
Description of the issue this commit addresses:

When creating an invoice from the sales or the purchase app, the product names are not picked and put in the name (label) of the invoice lines linked to it. This causes several issues among which the act that the pdf of the invoice only gives the description of the product but not its name.

---

Example steps to reproduce:

1. Install sale_subscription
2. Go to sales app and create a new quotation
3. Put any partner and chose the "Monthly Cleaning" quotation template
4. Confirm the quotation
5. Create Invoice for quotation as "Regular Invoice"
6. Confirm the invoice
7. Check the invoice's PDF (Preview / Send & Print)
8. The name of the subscription product is missing

---

Desired behavior after this commit is merged:

This commit makes sure the product's display_name is always shown in the invoice line's name so that it is rendered on the pdf.

---

Enterprise PR: https://github.com/odoo/enterprise/pull/68620
opw-4119507

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
