### PR TITLE
[FIX] website: delete children of parent menu first

### DIFF
--- a/addons/website/static/src/components/dialog/edit_menu.js
+++ b/addons/website/static/src/components/dialog/edit_menu.js
@@ -218,6 +218,12 @@ export class EditMenuDialog extends Component {
 
     deleteMenu(id) {
         const menuToDelete = this.map.get(id);
+
+        // Delete children first
+        for (const child of menuToDelete.children) {
+            this.deleteMenu(child.fields.id);
+        }
+
         const parentId = menuToDelete.fields['parent_id'] || this.state.rootMenu.fields['id'];
         const parent = this.map.get(parentId);
         parent.children = parent.children.filter(menu => menu.fields['id'] !== id);

--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -295,3 +295,31 @@ wTourUtils.registerWebsitePreviewTour('edit_menus', {
         },
     },
 ]);
+
+wTourUtils.registerWebsitePreviewTour(
+    "edit_menus_delete_parent",
+    {
+        test: true,
+        url: "/",
+    },
+    () => [
+        {
+            content: "Open site menu",
+            extra_trigger: "iframe #wrapwrap",
+            trigger: 'button[data-menu-xmlid="website.menu_site"]',
+        },
+        {
+            content: "Click on Edit Menu",
+            trigger: 'a[data-menu-xmlid="website.menu_edit_menu"]',
+        },
+        {
+            content: "Delete Home menu",
+            trigger: ".modal-body ul li:nth-child(1) button.js_delete_menu",
+        },
+        {
+            content: "Save",
+            trigger: ".modal-footer button:first-child",
+            run: "click",
+        },
+    ]
+);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -629,3 +629,14 @@ class TestUi(odoo.tests.HttpCase):
             self.env['website'].with_context(website_id=website.id).viewref(key).active = active
 
         self.start_tour('/', 'website_no_dirty_lazy_image', login='admin')
+
+    def test_website_edit_menus_delete_parent(self):
+        website = self.env['website'].browse(1)
+        menu_tree = self.env['website.menu'].get_tree(website.id)
+
+        parent_menu = menu_tree['children'][0]['fields']
+        child_menu = menu_tree['children'][1]['fields']
+        child_menu['parent_id'] = parent_menu['id']
+
+        self.env['website.menu'].save(website.id, {'data': [parent_menu, child_menu]})
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'edit_menus_delete_parent', login='admin')


### PR DESCRIPTION
Steps to reproduce:
- Open website menu editor
- Add a child menu to a menu
- Delete the parent menu
- Save

Old behavior: a traceback appears
New behavior: no traceback, parent and children menus are correctly deleted.

This commit fixes the issue by properly deleting children menus recursively before deleting the parent.

opw-4119441
