### PR TITLE
[FIX] hr_expense: add tags to caba taxes in company expenses

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -548,10 +548,11 @@ Or send your receipts at <a href="mailto:%(email)s?subject=Lunch%%20with%%20cust
             move_line_values = []
             unit_amount = expense.unit_amount or expense.total_amount
             quantity = expense.quantity if expense.unit_amount else 1
+            is_company_paying = expense.payment_mode == 'company_account'
             taxes = expense.tax_ids.with_context(
                 round=True,
-                caba_no_transition_account=expense.payment_mode == 'company_account',
-            ).compute_all(unit_amount, expense.currency_id, quantity, expense.product_id)
+                caba_no_transition_account=is_company_paying,
+            ).compute_all(unit_amount, expense.currency_id, quantity, expense.product_id, include_caba_tags=is_company_paying)
             total_amount = 0.0
             total_amount_currency = 0.0
             partner_id = expense.employee_id.sudo().address_home_id.commercial_partner_id.id

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -582,6 +582,10 @@ class TestExpenses(TestExpenseCommon):
     def test_expense_by_company_with_caba_tax(self):
         """When using cash basis tax in an expense paid by the company, the transition account should not be used."""
 
+        caba_tag = self.env['account.account.tag'].create({
+            'name': 'Cash Basis Tag Final Account',
+            'applicability': 'taxes',
+        })
         caba_transition_account = self.env['account.account'].create({
             'name': 'Cash Basis Tax Transition Account',
             'user_type_id': self.env.ref('account.data_account_type_current_assets').id,
@@ -592,6 +596,17 @@ class TestExpenses(TestExpenseCommon):
             'tax_exigibility': 'on_payment',
             'amount': 15,
             'cash_basis_transition_account_id': caba_transition_account.id,
+            'invoice_repartition_line_ids': [
+                Command.create({
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+                Command.create({
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'tag_ids': caba_tag.ids,
+                }),
+            ]
         })
 
         expense_sheet = self.env['hr.expense.sheet'].create({
@@ -612,3 +627,4 @@ class TestExpenses(TestExpenseCommon):
         moves = expense_sheet.action_sheet_move_create()
         tax_lines = moves[expense_sheet.id].line_ids.filtered(lambda line: line.tax_line_id == caba_tax)
         self.assertNotEqual(tax_lines.account_id, caba_transition_account, "The tax should not be on the transition account")
+        self.assertEqual(tax_lines.tax_tag_ids, caba_tag, "The tax should still retrieve its tags")


### PR DESCRIPTION
### Issue:

Previous fix: odoo/odoo@4c0f03c7a1d1ec1f99dbc8b2202454e4398e386b
In CH tax report, tax amounts from Payments of Expenses paid by company are not shown when using taxes with Cash Basis.

### Explanation:

The CH report uses tags to fetch taxes. With previous fix, those tags were still not passed through.

### Fix reasoning:

We will use the same condition for the `include_caba_tags` parameter as for the `caba_no_transition_account` context key for consistency.

opw-3946362