### PR TITLE
[FIX] hr_holidays: fall back on company calendar

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -598,6 +598,10 @@ class HrEmployeePrivate(models.Model):
             target_date = fields.Date.context_today(self.env.user)
         return relativedelta(target_date, self.birthday).years if self.birthday else 0
 
+    def _get_current_calendar(self):
+        self.ensure_one()
+        return self.resource_calendar_id
+
     # ---------------------------------------------------------
     # Messaging
     # ---------------------------------------------------------

--- a/addons/hr_contract/models/hr_employee.py
+++ b/addons/hr_contract/models/hr_employee.py
@@ -132,6 +132,10 @@ class Employee(models.Model):
             return res
         return contracts[0].resource_calendar_id.sudo(False)
 
+    def _get_current_calendar(self):
+        self.ensure_one()
+        return self.sudo().contract_id.resource_calendar_id or super()._get_current_calendar()
+
     @api.model
     def _get_all_contracts(self, date_from, date_to, states=['open']):
         """


### PR DESCRIPTION
Steps to reproduce:
1. create an accrual plan based on worked time
2. create an accrual rule, with the source being calendar
3. create an employee that does not have a working schedule
4. create an accrual allocation for the employee with the plan
5. upon changing the date of the allocation, an error message pops up

Error:
```
  File "/data/build/odoo/addons/resource/models/resource_mixin.py", line 149, in _get_leave_days_data_batch
    attendances = calendar._attendance_intervals_batch(from_datetime, to_datetime, calendar_resources)
  File "/data/build/odoo/addons/resource/models/resource_calendar.py", line 278, in _attendance_intervals_batch
    self.ensure_one()
  File "/data/build/odoo/odoo/models.py", line 5867, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: resource.calendar()
```

This commit makes a fallback to avoid the error.

task-4100439


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
