### PR TITLE
[FIX] account, l10n_*: fix installation issue for many localizations

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -190,7 +190,7 @@ class AccountChartTemplate(models.AbstractModel):
             delay_account_group_sync=True,
             lang='en_US',
         )
-        company = company.with_env(self.env)
+        company = self.env['res.company'].browse(company.id)  # also update company.pool
 
         reload_template = template_code == company.chart_template
         company.chart_template = template_code

--- a/addons/l10n_bd/__manifest__.py
+++ b/addons/l10n_bd/__manifest__.py
@@ -10,6 +10,7 @@
     'depends': [
         'account',
     ],
+    'auto_install': ['account'],
     'data': [
         'data/account.account.tag.csv',
         'data/res.country.state.csv',

--- a/addons/l10n_bf/__manifest__.py
+++ b/addons/l10n_bf/__manifest__.py
@@ -12,6 +12,7 @@ The Chart of Accounts is from SYSCOHADA.
     'depends': [
         'l10n_syscohada',
     ],
+    'auto_install': ['l10n_syscohada'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_bj/__manifest__.py
+++ b/addons/l10n_bj/__manifest__.py
@@ -12,6 +12,7 @@ The Chart of Accounts is from SYSCOHADA.
     'depends': [
         'l10n_syscohada',
     ],
+    'auto_install': ['l10n_syscohada'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_cd/__manifest__.py
+++ b/addons/l10n_cd/__manifest__.py
@@ -12,6 +12,7 @@ The Chart of Accounts is from SYSCOHADA.
     'depends': [
         'l10n_syscohada',
     ],
+    'auto_install': ['l10n_syscohada'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_cf/__manifest__.py
+++ b/addons/l10n_cf/__manifest__.py
@@ -12,6 +12,7 @@ The Chart of Accounts is from SYSCOHADA.
     'depends': [
         'l10n_syscohada',
     ],
+    'auto_install': ['l10n_syscohada'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_cg/__manifest__.py
+++ b/addons/l10n_cg/__manifest__.py
@@ -12,6 +12,7 @@ The Chart of Accounts is from SYSCOHADA.
     'depends': [
         'l10n_syscohada',
     ],
+    'auto_install': ['l10n_syscohada'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_ci/__manifest__.py
+++ b/addons/l10n_ci/__manifest__.py
@@ -12,6 +12,7 @@ The Chart of Accounts is from SYSCOHADA.
     'depends': [
         'l10n_syscohada',
     ],
+    'auto_install': ['l10n_syscohada'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_cm/__manifest__.py
+++ b/addons/l10n_cm/__manifest__.py
@@ -12,6 +12,7 @@ The Chart of Accounts is from SYSCOHADA.
     'depends': [
         'l10n_syscohada',
     ],
+    'auto_install': ['l10n_syscohada'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_cy/__manifest__.py
+++ b/addons/l10n_cy/__manifest__.py
@@ -12,6 +12,7 @@ Basic package for Cyprus that contains the chart of accounts, taxes, tax reports
         'account',
         'base_vat',
     ],
+    'auto_install': ['account'],
     'data': [
         'data/menuitem_data.xml',
         'data/account_tax_report_data.xml',

--- a/addons/l10n_ga/__manifest__.py
+++ b/addons/l10n_ga/__manifest__.py
@@ -12,6 +12,7 @@ The Chart of Accounts is from SYSCOHADA.
     'depends': [
         'l10n_syscohada',
     ],
+    'auto_install': ['l10n_syscohada'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_gn/__manifest__.py
+++ b/addons/l10n_gn/__manifest__.py
@@ -12,6 +12,7 @@ The Chart of Accounts is from SYSCOHADA.
     'depends': [
         'l10n_syscohada',
     ],
+    'auto_install': ['l10n_syscohada'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_gq/__manifest__.py
+++ b/addons/l10n_gq/__manifest__.py
@@ -12,6 +12,7 @@ The Chart of Accounts is from SYSCOHADA.
     'depends': [
         'l10n_syscohada',
     ],
+    'auto_install': ['l10n_syscohada'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_gw/__manifest__.py
+++ b/addons/l10n_gw/__manifest__.py
@@ -12,6 +12,7 @@ The Chart of Accounts is from SYSCOHADA.
     'depends': [
         'l10n_syscohada',
     ],
+    'auto_install': ['l10n_syscohada'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_km/__manifest__.py
+++ b/addons/l10n_km/__manifest__.py
@@ -12,6 +12,7 @@ The Chart of Accounts is from SYSCOHADA.
     'depends': [
         'l10n_syscohada',
     ],
+    'auto_install': ['l10n_syscohada'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_ml/__manifest__.py
+++ b/addons/l10n_ml/__manifest__.py
@@ -12,6 +12,7 @@ The Chart of Accounts is from SYSCOHADA.
     'depends': [
         'l10n_syscohada',
     ],
+    'auto_install': ['l10n_syscohada'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_mt/__manifest__.py
+++ b/addons/l10n_mt/__manifest__.py
@@ -13,6 +13,7 @@ Malta basic package that contains the chart of accounts, the taxes, tax reports,
         'account',
         'base_vat',
     ],
+    'auto_install': ['account'],
     'data': [
         'data/menuitem_data.xml',
         'data/account_tax_report_data.xml',

--- a/addons/l10n_ne/__manifest__.py
+++ b/addons/l10n_ne/__manifest__.py
@@ -12,6 +12,7 @@ The Chart of Accounts is from SYSCOHADA.
     'depends': [
         'l10n_syscohada',
     ],
+    'auto_install': ['l10n_syscohada'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_rw/__manifest__.py
+++ b/addons/l10n_rw/__manifest__.py
@@ -8,6 +8,7 @@
     'depends': [
         'account',
     ],
+    'auto_install': ['account'],
     'description': """
     Rwandan localisation containing:
     - COA

--- a/addons/l10n_sn/__manifest__.py
+++ b/addons/l10n_sn/__manifest__.py
@@ -12,6 +12,7 @@ The Chart of Accounts is from SYSCOHADA.
     'depends': [
         'l10n_syscohada',
     ],
+    'auto_install': ['l10n_syscohada'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_td/__manifest__.py
+++ b/addons/l10n_td/__manifest__.py
@@ -12,6 +12,7 @@ The Chart of Accounts is from SYSCOHADA.
     'depends': [
         'l10n_syscohada',
     ],
+    'auto_install': ['l10n_syscohada'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_tg/__manifest__.py
+++ b/addons/l10n_tg/__manifest__.py
@@ -12,6 +12,7 @@ The Chart of Accounts is from SYSCOHADA.
     'depends': [
         'l10n_syscohada',
     ],
+    'auto_install': ['l10n_syscohada'],
     'data': [
         'data/account_tax_report_data.xml'
     ],

--- a/addons/l10n_ug/__manifest__.py
+++ b/addons/l10n_ug/__manifest__.py
@@ -18,6 +18,7 @@ This is the basic Ugandian localisation necessary to run Odoo in UG:
     "depends": [
         "account",
     ],
+    'auto_install': ['account'],
     "data": [
         "data/account_tax_report_data.xml",
     ],


### PR DESCRIPTION
**Steps to reproduce:**
- Create an empty db
- Go to the configuration of the company
- Set the country of the company to Bangladesh
- Install Accounting

**1st issue:**
The localization module (i.e. l10n_bd) has not been installed.
[Same issue with:
l10n_bd, l10n_bf, l10n_bj, l10n_cd, l10n_cf, l10n_cg, l10n_ci, l10n_cm, l10n_cy, l10n_ga, l10n_gn, l10n_gq, l10n_gw, l10n_km, l10n_ml, l10n_mt, l10n_ne, l10n_rw, l10n_sn, l10n_td, l10n_tg, l10n_ug]

- Go to Accounting settings
- Select "Bangladesh" as Fiscal Localization
- Save the settings

**2nd issue:**
A KeyError is raised:
File "/home/odoo/src/17_1/odoo/odoo/fields.py", line 1362, in compute_value
    fields = records.pool.field_computed[self]
KeyError: 'account.asset.currency_id'

**Cause:**
**1st issue:**
"auto_install" is not present in the manifest file.

**2nd issue:**
When loading the chart template in "_load" method, "pool" attribute of "company" and "self" is not the same after the creation of a new registry. And [company = company.with_env(self.env)] does not update company.pool Therefore, when executing [self._pre_reload_data(company, template_data, data)], "self" and "company" are not on the same registry.

**Solution:**
**1st issue:**
Add 'auto_install': ['account'] in the manifest as it is done in others localization modules.

**2nd issue:**
Browse the company instead of using "with_env(self.env)" to update "company.pool".

opw-4119423




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
