### PR TITLE
[FIX] pos_self_order: properly print receipt in kiosk

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
@@ -19,7 +19,7 @@
                 <div t-if="props.data.header" style="white-space:pre-line" t-esc="props.data.header" />
                 <div t-if="props.data.cashier" class="cashier">
                     <div>--------------------------------</div>
-                    <div>Served by <t t-esc="props.data.cashier" /></div>
+                    <div t-esc="props.data.cashier" />
                 </div>
                 <div t-if="props.data.trackingNumber and !props.data.bigTrackingNumber">
                     <span class="fs-2" t-esc="props.data.trackingNumber" />

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1631,7 +1631,7 @@ export class PosStore extends Reactive {
     getReceiptHeaderData(order) {
         return {
             company: this.company,
-            cashier: this.get_cashier()?.name,
+            cashier: _t("Served by %s", this.get_cashier()?.name),
             header: this.config.receipt_header,
         };
     }

--- a/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.js
+++ b/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.js
@@ -70,7 +70,7 @@ export class ConfirmationPage extends Component {
             access_token: this.selfOrder.access_token,
             order_access_tokens: [this.props.orderAccessToken],
         });
-        this.selfOrder.models.replaceDataByKey("uuid", data);
+        this.selfOrder.models.loadData(data);
         const order = this.selfOrder.models["pos.order"].find(
             (o) => o.access_token === this.props.orderAccessToken
         );

--- a/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.js
+++ b/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.js
@@ -31,7 +31,7 @@ export class PaymentPage extends Component {
     get showFooterBtn() {
         return this.selfOrder.paymentError || this.state.selection;
     }
-    rpc;
+
     selectMethod(methodId) {
         this.state.selection = false;
         this.state.paymentMethodId = methodId;

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -148,7 +148,7 @@ export class SelfOrder extends Reactive {
 
         const handleMessage = (data) => {
             let message = "";
-            this.models.replaceDataByKey("uuid", data);
+            this.models.loadData(data);
             const oUpdated = data["pos.order"].find((o) => o.uuid === this.selectedOrderUuid);
 
             if (["paid", "invoiced", "done"].includes(oUpdated?.state)) {
@@ -793,12 +793,17 @@ export class SelfOrder extends Reactive {
     showDownloadButton(order) {
         return this.config.self_ordering_mode === "mobile" && order.state === "paid";
     }
-    getReceiptHeaderData() {
+    getReceiptHeaderData(order) {
         // FIXME - We should extract this methods from PoS to be allowed to use it here.
         return {
             company: this.company,
-            cashier: "Self-Order",
+            cashier: _t("Self-Order"),
+            selfOrderingMode: this.config.self_ordering_mode,
             header: this.config.receipt_header,
+            trackingNumber: order.trackingNumber,
+            bigTrackingNumber: true,
+            pickingService: this.config.self_ordering_service_mode,
+            tableTracker: order.table_stand_number,
         };
     }
     orderExportForPrinting(order) {


### PR DESCRIPTION
Steps to reproduce:

1. Install pos_self_order and pos_iot in demo mode to have a "Kiosk" config.
2. Configure an epson printer in the "Kiosk" config.
3. Open a Kiosk session.
4. Make an order with order items.
5. Reach the confirmation page.

Issues:

1. Printed receipt don't have the order items.
2. The tracking number is not properly displayed (very small) and there are
   missing header information.
3. The header data lists: "Served by Self-Order".

Proposed solution:

1. Make sure the items are listed.
2. Show all the necessary header data and make the tracking number should be
   bigger.
3. Replace "Served by Self-Order" with "Self-Order".

How the changes worked:

1. `replaceDataByKey` should be replaced by `loadData` because at this point, we
   need to update the record saved in `models`.

TASK-ID: 4127287