### PR TITLE
 [FIX] stock: detailed ops: hide quant related fields

### DIFF
--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -212,7 +212,7 @@
                         column_invisible="not parent.show_quant"
                         options="{'no_create': True, 'no_open': True}"/>
                     <field name="lot_id" groups="stock.group_production_lot"
-                        column_invisible="parent.has_tracking == 'none' or not parent.show_lots_m2o"
+                        column_invisible="parent.show_quant or parent.has_tracking == 'none' or not parent.show_lots_m2o"
                         readonly="package_level_id and parent.picking_type_entire_packs"
                         domain="[('product_id', '=', parent.product_id), ('company_id', '=', company_id)]"
                         context="{
@@ -229,7 +229,7 @@
                         readonly="package_level_id and parent.picking_type_entire_packs"
                         domain="[('id', 'child_of', parent.location_dest_id), '|', ('company_id', '=', False), ('company_id', '=', company_id), ('usage', '!=', 'view')]"
                         groups="stock.group_stock_multi_locations"/>
-                    <field name="package_id" column_invisible="not parent.show_quant" readonly="package_level_id and parent.picking_type_entire_packs" groups="stock.group_tracking_lot"/>
+                    <field name="package_id" column_invisible="1" readonly="package_level_id and parent.picking_type_entire_packs" groups="stock.group_tracking_lot"/>
                     <field name="result_package_id" readonly="package_level_id and parent.picking_type_entire_packs" groups="stock.group_tracking_lot" context="{'picking_id': picking_id}"/>
                     <field name="owner_id" column_invisible="parent.show_quant" readonly="package_level_id and parent.picking_type_entire_packs" groups="stock.group_tracking_owner"/>
                     <field name="state" column_invisible="True"/>


### PR DESCRIPTION
Steps
---
* install `stock`
* from *Settings* > *Stock* activate packages
* create a product P and put 2 packages (pk1, pk2) of 10 units each
  in stock (inventory adjustment)
* create a delivery order for 10 P > *Mark as Todo*
* go to the detailed ops for the move
        * => it auto suggest the sml: pk1, qty = 10
* set the qty on the generated sml to 3
* *add a line* > pick from *WHStock - pk2*:
        * => this creates the sml: pk2, qty = 7
* set the new sml's package to pk1
        * => the *Pick From* field doesn't change
* *save*, the second sml's package has been reset to pk2

Cause
---
In the detailed ops we use a dummy `quant_id` field on sml to allow
selecting a quant and carrying some fields values from it to the sml.

But, when the quant was selected, setting the values of the carried
field, will not affect back the quant. And later, because the quant is
set, we use its values instead of the ones the user specified.

Fix
---
Hide the affected fields in the view, so the user cannot attempt to set
them, which would not work. i.e if they want to set the package id they should
do it via the quant dropdown.

opw-4089523

