### PR TITLE
[FIX] point_of_sale: prioritize config warehouse in quantity display

### DIFF
--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -204,11 +204,19 @@ class ProductProduct(models.Model):
 
         # Warehouses
         warehouse_list = [
-            {'name': w.name,
+            {'id': w.id,
+            'name': w.name,
             'available_quantity': self.with_context({'warehouse_id': w.id}).qty_available,
             'forecasted_quantity': self.with_context({'warehouse_id': w.id}).virtual_available,
             'uom': self.uom_name}
             for w in self.env['stock.warehouse'].search([])]
+
+        if config.picking_type_id.warehouse_id:
+            # Sort the warehouse_list, prioritizing config.picking_type_id.warehouse_id
+            warehouse_list = sorted(
+                warehouse_list,
+                key=lambda w: w['id'] != config.picking_type_id.warehouse_id.id
+            )
 
         # Suppliers
         key = itemgetter('partner_id')


### PR DESCRIPTION
Before this commit, when multiple warehouses were available, the product info popup could display the product quantity from a warehouse different from the config warehouse.

opw-4102838

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
