### PR TITLE
[FIX] web: export is not a read-only

### DIFF
--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -509,7 +509,7 @@ class ExportFormat(object):
 
 class CSVExport(ExportFormat, http.Controller):
 
-    @http.route('/web/export/csv', type='http', auth='user', readonly=True)
+    @http.route('/web/export/csv', type='http', auth='user')
     def web_export_csv(self, data):
         try:
             return self.base(data)
@@ -553,7 +553,7 @@ class CSVExport(ExportFormat, http.Controller):
 
 class ExcelExport(ExportFormat, http.Controller):
 
-    @http.route('/web/export/xlsx', type='http', auth='user', readonly=True)
+    @http.route('/web/export/xlsx', type='http', auth='user')
     def web_export_xlsx(self, data):
         try:
             return self.base(data)


### PR DESCRIPTION
Export routes ('/web/export/csv' and '/web/export/xlsx') are marked as read-only, but the _export_rows() can actually create ir_model_data rows in the database. If import-compatible export is enabled and you export a row without an external ID, you will get a traceback if the readonly replica feature is enabled.

The fallback mechanism of the readonly transaction to retry the current request doesn't work because the `except Exception as exc` in export routes changes the exception type (=> traceback).

=> Remove the readonly flag from export routes.