### PR TITLE
[IMP] html_editor: Enhance toolbar usability on mobile devices

### DIFF
--- a/addons/html_editor/static/src/main/chatgpt/chatgpt_plugin.js
+++ b/addons/html_editor/static/src/main/chatgpt/chatgpt_plugin.js
@@ -20,6 +20,9 @@ export class ChatGPTPlugin extends Plugin {
                 id: "translate",
                 category: "ai",
                 title: _t("Translate with AI"),
+                isAvailable: (selection) => {
+                    return !selection.isCollapsed;
+                },
                 Component: LanguageSelector,
             },
             {
@@ -120,6 +123,12 @@ export class ChatGPTPlugin extends Plugin {
                 { ...dialogParams, originalText, sanitize },
                 { onClose }
             );
+        }
+        if (this.services.ui.isSmall) {
+            // If the dialog is opened on a small screen, remove all selection
+            // because the selection can be seen through the dialog on some devices.
+            // TODO: Find a better way and avoid modifying range
+            this.document.getSelection()?.removeAllRanges();
         }
     }
 }

--- a/addons/html_editor/static/src/main/chatgpt/chatgpt_prompt_dialog.js
+++ b/addons/html_editor/static/src/main/chatgpt/chatgpt_prompt_dialog.js
@@ -37,7 +37,7 @@ export class ChatGPTPromptDialog extends ChatGPTDialog {
             messages: [],
         });
         this.promptInputRef = useRef("promptInput");
-        useAutofocus({ refName: "promptInput" });
+        useAutofocus({ refName: "promptInput", mobile: true });
         useEffect(
             () => {
                 // Resize the textarea to fit its content.

--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -41,6 +41,10 @@ export class LinkPopover extends Component {
         { style: "flat", label: _t("Flat") },
     ];
     setup() {
+        this.ui = useService("ui");
+        this.notificationService = useService("notification");
+        this.http = useService("http");
+
         this.state = useState({
             editing: this.props.linkEl.href ? false : true,
             url: this.props.linkEl.href || "",
@@ -60,9 +64,6 @@ export class LinkPopover extends Component {
             buttonStyle: this.initButtonStyle(this.props.linkEl.className),
             isImage: this.props.isImage,
         });
-        this.notificationService = useService("notification");
-
-        this.http = useService("http");
 
         this.editingWrapper = useRef("editing-wrapper");
         useAutofocus({

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -47,7 +47,7 @@
                         </div>
                     </div>
 
-                    <div class="col o_link_dialog_preview" style="max-width: 125px;border-left: 1px solid #DEE2E6;">
+                    <div t-if="!this.ui.isSmall" class="col o_link_dialog_preview" style="max-width: 125px;border-left: 1px solid #DEE2E6;">
                         <div class="text-center p-2">
                             <label>Preview</label>
                             <div style="max-width: 100px; max-height: 200px;" class="text-truncate">

--- a/addons/html_editor/static/src/main/media/media_dialog/search_media.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/search_media.js
@@ -11,7 +11,7 @@ export class SearchMedia extends Component {
         </div>`;
     static props = ["searchPlaceholder", "search", "needle"];
     setup() {
-        useAutofocus();
+        useAutofocus({ mobile: true });
         this.debouncedSearch = useDebounced(this.props.search, 1000);
 
         this.state = useState({

--- a/addons/html_editor/static/src/main/toolbar/mobile_toolbar.js
+++ b/addons/html_editor/static/src/main/toolbar/mobile_toolbar.js
@@ -1,0 +1,30 @@
+import { Component, onMounted, useExternalListener, useRef } from "@odoo/owl";
+import { Toolbar } from "./toolbar";
+
+export class ToolbarMobile extends Component {
+    static template = "html_editor.MobileToolbar";
+    static props = ["*"];
+    static components = {
+        Toolbar,
+    };
+
+    setup() {
+        this.toolbar = useRef("toolbarWrapper");
+        useExternalListener(window.visualViewport, "resize", this.fixToolbarPosition);
+        onMounted(() => {
+            this.fixToolbarPosition();
+        });
+    }
+
+    /**
+     * Fixes the position of the toolbar for the keyboard height.
+     */
+    fixToolbarPosition() {
+        const keyboardHeight = window.innerHeight - window.visualViewport.height;
+        if (keyboardHeight > 0) {
+            this.toolbar.el.style.bottom = `${keyboardHeight}px`;
+        } else {
+            this.toolbar.el.style.bottom = `0px`;
+        }
+    }
+}

--- a/addons/html_editor/static/src/main/toolbar/mobile_toolbar.xml
+++ b/addons/html_editor/static/src/main/toolbar/mobile_toolbar.xml
@@ -1,0 +1,7 @@
+<templates xml:space="preserve">
+    <t t-name="html_editor.MobileToolbar">
+        <div t-ref="toolbarWrapper" class="o-toolbar-above-keyboard">
+            <Toolbar t-props="this.props"/>
+        </div>
+    </t>
+</templates>

--- a/addons/html_editor/static/src/main/toolbar/toolbar.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar.js
@@ -33,6 +33,7 @@ export class Toolbar extends Component {
                                                 ...base,
                                                 Component: Function,
                                                 props: { type: Object, optional: true },
+                                                isAvailable: { type: Function, optional: true },
                                             });
                                         } else {
                                             validate(button, {

--- a/addons/html_editor/static/src/main/toolbar/toolbar.scss
+++ b/addons/html_editor/static/src/main/toolbar/toolbar.scss
@@ -1,3 +1,10 @@
+.o-toolbar-above-keyboard {
+    position: fixed;
+    width: 100%;
+    z-index: 2000;
+    bottom: 0;
+}
+
 .o-we-toolbar {
     height: 40px;
     padding: 0 2px;
@@ -34,4 +41,5 @@
         border-left: 1px solid lightgrey;
 
     }
+
 }

--- a/addons/html_editor/static/src/main/toolbar/toolbar.xml
+++ b/addons/html_editor/static/src/main/toolbar/toolbar.xml
@@ -1,6 +1,6 @@
 <templates xml:space="preserve">
     <t t-name="html_editor.Toolbar">
-        <div class="o-we-toolbar bg-white d-flex align-items-center m-0"  t-att-class="props.class">
+        <div class="o-we-toolbar bg-white d-flex align-items-center m-0" t-on-pointerdown.prevent="" style="overflow-x: auto; overflow-y:hidden"  t-att-class="props.class">
             <t t-foreach="this.getFilteredButtonGroups()" t-as="buttonGroup" t-key="buttonGroup.id">
                 <span class="o-we-toolbar-vertical-seperator"></span>
                 <div class="btn-group" t-att-name="buttonGroup.id">

--- a/addons/html_editor/static/src/plugin.js
+++ b/addons/html_editor/static/src/plugin.js
@@ -96,6 +96,7 @@ export class Plugin {
         this.dispatch = dispatch;
         this._cleanups = [];
         this.resources = null; // set before start
+        this.isDestroyed = false;
     }
 
     setup() {}
@@ -121,5 +122,6 @@ export class Plugin {
         for (const cleanup of this._cleanups) {
             cleanup();
         }
+        this.isDestroyed = true;
     }
 }

--- a/addons/html_editor/static/tests/format/font_size.test.js
+++ b/addons/html_editor/static/tests/format/font_size.test.js
@@ -1,10 +1,11 @@
-import { test } from "@odoo/hoot";
-import { testEditor } from "../_helpers/editor";
+import { test, expect } from "@odoo/hoot";
+import { setupEditor, testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { strong } from "../_helpers/tags";
 import { setFontSize } from "../_helpers/user_actions";
 import { Plugin } from "@html_editor/plugin";
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
+import { animationFrame } from "@odoo/hoot-mock";
 
 test("should change the font size of a few characters", async () => {
     await testEditor({
@@ -31,12 +32,11 @@ test("should change the font size of a whole heading after a triple click", asyn
 });
 
 test("should get ready to type with a different font size", async () => {
-    await testEditor({
-        contentBefore: "<p>ab[]cd</p>",
-        stepFunction: setFontSize("36px"),
-        contentAfterEdit: `<p>ab<span data-oe-zws-empty-inline="" style="font-size: 36px;">[]\u200B</span>cd</p>`,
-        contentAfter: "<p>ab[]cd</p>",
-    });
+    const { editor } = await setupEditor('<p class="p">ab[]cd</p>');
+    editor.dispatch("FORMAT_FONT_SIZE", { size: "36px" });
+    await animationFrame();
+    expect(".p span").toHaveStyle({ "font-size": "36px" });
+    expect(".p span").toHaveAttribute("data-oe-zws-empty-inline", "");
 });
 
 test("should change the font-size for a character in an inline that has a font-size", async () => {

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -652,7 +652,7 @@ test("isDirty should be false when the content is being transformed by the edito
     expect(`.o_form_button_save`).not.toBeVisible();
 });
 
-test("link preview in Link Popover", async () => {
+test.tags("desktop")("link preview in Link Popover", async () => {
     Partner._records = [
         {
             id: 1,

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -474,7 +474,7 @@ describe("Link creation", () => {
     });
 });
 
-describe("Link formatting in the popover", () => {
+describe.tags("desktop")("Link formatting in the popover", () => {
     test("click on link, the link popover should load the current format correctly", async () => {
         await setupEditor(
             '<p><a href="http://test.com/" class="btn btn-outline-primary rounded-circle btn-lg">link2[]</a></p>'
@@ -519,31 +519,28 @@ describe("Link formatting in the popover", () => {
         await animationFrame();
         expect(linkPreviewEl).toHaveClass(["btn", "btn-primary", "rounded-circle", "btn-lg"]);
     });
-    test.tags("desktop")(
-        "after applying the link format, the link's format should be updated",
-        async () => {
-            const { el } = await setupEditor('<p><a href="http://test.com/">link2[]</a></p>');
-            await waitFor(".o-we-linkpopover");
-            click(".o_we_edit_link");
-            await waitFor("#link-preview");
-            expect(queryOne('select[name="link_type"]').selectedIndex).toBe(0);
+    test("after applying the link format, the link's format should be updated", async () => {
+        const { el } = await setupEditor('<p><a href="http://test.com/">link2[]</a></p>');
+        await waitFor(".o-we-linkpopover");
+        click(".o_we_edit_link");
+        await waitFor("#link-preview");
+        expect(queryOne('select[name="link_type"]').selectedIndex).toBe(0);
 
-            click('select[name="link_type"');
-            select("secondary");
-            await animationFrame();
-            click('select[name="link_style_shape"');
-            select("flat");
-            await animationFrame();
+        click('select[name="link_type"');
+        select("secondary");
+        await animationFrame();
+        click('select[name="link_style_shape"');
+        select("flat");
+        await animationFrame();
 
-            const linkPreviewEl = queryOne("#link-preview");
-            expect(linkPreviewEl).toHaveClass(["btn", "btn-secondary", "flat"]);
+        const linkPreviewEl = queryOne("#link-preview");
+        expect(linkPreviewEl).toHaveClass(["btn", "btn-secondary", "flat"]);
 
-            click(".o_we_apply_link");
-            expect(cleanLinkArtifacts(getContent(el))).toBe(
-                '<p><a href="http://test.com/" class="btn btn-secondary flat">link2[]</a></p>'
-            );
-        }
-    );
+        click(".o_we_apply_link");
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p><a href="http://test.com/" class="btn btn-secondary flat">link2[]</a></p>'
+        );
+    });
     test("no preview of the link when the url is empty", async () => {
         await setupEditor("<p><a>link2[]</a></p>");
         await waitFor(".o-we-linkpopover");

--- a/addons/html_editor/static/tests/rating_star.test.js
+++ b/addons/html_editor/static/tests/rating_star.test.js
@@ -38,17 +38,20 @@ test("select star rating", async () => {
         `<p>\u200B<span contenteditable="false" class="o_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i></span>\u200B[]</p>`
     );
 
-    click("i.fa:first");
+    click("i.fa-star-o:first");
+    await animationFrame();
     expect(getContent(el)).toBe(
         `<p>\u200B<span contenteditable="false" class="o_stars"><i class="fa fa-star" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i></span>\u200B[]</p>`
     );
 
-    click("i.fa:last");
+    click("i.fa-star-o:last");
+    await animationFrame();
     expect(getContent(el)).toBe(
         `<p>\u200B<span contenteditable="false" class="o_stars"><i class="fa fa-star" contenteditable="false">\u200B</i><i class="o_stars fa fa-star" contenteditable="false">\u200B</i><i class="o_stars fa fa-star" contenteditable="false">\u200B</i></span>\u200B[]</p>`
     );
 
-    click("i.fa:last");
+    click("i.fa-star:last");
+    await animationFrame();
     expect(getContent(el)).toBe(
         `<p>\u200B<span contenteditable="false" class="o_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i></span>\u200B[]</p>`
     );

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -18,7 +18,25 @@ import { setupEditor } from "./_helpers/editor";
 import { unformat } from "./_helpers/format";
 import { getContent, moveSelectionOutsideEditor, setContent } from "./_helpers/selection";
 
-test("toolbar is only visible when selection is not collapsed", async () => {
+test.tags("desktop")(
+    "toolbar is only visible when selection is not collapsed in desktop",
+    async () => {
+        const { el } = await setupEditor("<p>test</p>");
+
+        // set a non-collapsed selection to open toolbar
+        expect(".o-we-toolbar").toHaveCount(0);
+        setContent(el, "<p>[test]</p>");
+        await waitFor(".o-we-toolbar");
+        expect(".o-we-toolbar").toHaveCount(1);
+
+        // set a collapsed selection to close toolbar
+        setContent(el, "<p>test[]</p>");
+        await waitUntil(() => !document.querySelector(".o-we-toolbar"));
+        expect(".o-we-toolbar").toHaveCount(0);
+    }
+);
+
+test.tags("mobile")("toolbar is also visible when selection is collapsed in mobile", async () => {
     const { el } = await setupEditor("<p>test</p>");
 
     // set a non-collapsed selection to open toolbar
@@ -27,14 +45,14 @@ test("toolbar is only visible when selection is not collapsed", async () => {
     await waitFor(".o-we-toolbar");
     expect(".o-we-toolbar").toHaveCount(1);
 
-    // set a collapsed selection to close toolbar
     setContent(el, "<p>test[]</p>");
-    await waitUntil(() => !document.querySelector(".o-we-toolbar"));
-    expect(".o-we-toolbar").toHaveCount(0);
+    await animationFrame();
+    expect(".o-we-toolbar").toHaveCount(1);
 });
 
 test("toolbar closes when selection leaves editor", async () => {
-    await setupEditor("<p>[test]</p>");
+    const { el } = await setupEditor("<p>test</p>");
+    setContent(el, "<p>[test]</p>");
     await waitFor(".o-we-toolbar");
 
     click(document.body);
@@ -218,7 +236,7 @@ test("toolbar works: can select font size", async () => {
     expect(".o-we-toolbar [name='font-size']").toHaveText(h1Size);
 });
 
-test("toolbar should not open on keypress tab inside table", async () => {
+test.tags("desktop")("toolbar should not open on keypress tab inside table", async () => {
     const contentBefore = unformat(`
         <table>
             <tbody>
@@ -247,7 +265,7 @@ test("toolbar should not open on keypress tab inside table", async () => {
     expect(".o-we-toolbar").toHaveCount(0);
 });
 
-test("toolbar should close on keypress tab inside table", async () => {
+test.tags("desktop")("toolbar should close on keypress tab inside table", async () => {
     const contentBefore = unformat(`
         <table>
             <tbody>
@@ -506,34 +524,40 @@ test("toolbar buttons should have title attribute with translated text", async (
     }
 });
 
-test("close the toolbar if the selection contains any nodes (traverseNode = [])", async () => {
-    const { el } = await setupEditor("<p>a</p><p>b</p>");
-    expect(".o-we-toolbar").toHaveCount(0);
+test.tags("desktop")(
+    "close the toolbar if the selection contains any nodes (traverseNode = [])",
+    async () => {
+        const { el } = await setupEditor("<p>a</p><p>b</p>");
+        expect(".o-we-toolbar").toHaveCount(0);
 
-    setContent(el, "<p>[a</p><p>]b</p>");
-    await tick(); // selectionChange
-    await animationFrame();
-    expect(".o-we-toolbar").toHaveCount(1);
+        setContent(el, "<p>[a</p><p>]b</p>");
+        await tick(); // selectionChange
+        await animationFrame();
+        expect(".o-we-toolbar").toHaveCount(1);
 
-    // This selection is possible when you double-click at the end of a line.
-    setContent(el, "<p>a[</p><p>]b</p>");
-    await tick(); // selectionChange
-    await animationFrame();
-    expect(".o-we-toolbar").toHaveCount(0);
-});
+        // This selection is possible when you double-click at the end of a line.
+        setContent(el, "<p>a[</p><p>]b</p>");
+        await tick(); // selectionChange
+        await animationFrame();
+        expect(".o-we-toolbar").toHaveCount(0);
+    }
+);
 
-test("close the toolbar if the selection contains any nodes (traverseNode = [], ignore whitespace)", async () => {
-    const { el } = await setupEditor("<p>a</p>\n<p>b</p>");
-    expect(".o-we-toolbar").toHaveCount(0);
+test.tags("desktop")(
+    "close the toolbar if the selection contains any nodes (traverseNode = [], ignore whitespace)",
+    async () => {
+        const { el } = await setupEditor("<p>a</p>\n<p>b</p>");
+        expect(".o-we-toolbar").toHaveCount(0);
 
-    setContent(el, "<p>[a</p>\n<p>]b</p>");
-    await tick(); // selectionChange
-    await animationFrame();
-    expect(".o-we-toolbar").toHaveCount(1);
+        setContent(el, "<p>[a</p>\n<p>]b</p>");
+        await tick(); // selectionChange
+        await animationFrame();
+        expect(".o-we-toolbar").toHaveCount(1);
 
-    // This selection is possible when you double-click at the end of a line.
-    setContent(el, "<p>a[</p>\n<p>]b</p>");
-    await tick(); // selectionChange
-    await animationFrame();
-    expect(".o-we-toolbar").toHaveCount(0);
-});
+        // This selection is possible when you double-click at the end of a line.
+        setContent(el, "<p>a[</p>\n<p>]b</p>");
+        await tick(); // selectionChange
+        await animationFrame();
+        expect(".o-we-toolbar").toHaveCount(0);
+    }
+);

--- a/addons/html_editor/static/tests/wysiwyg.test.js
+++ b/addons/html_editor/static/tests/wysiwyg.test.js
@@ -109,7 +109,7 @@ describe("Wysiwyg Component", () => {
         expect(":iframe .test.odoo-editor-editable").toHaveCount(1);
     });
 
-    test("wysiwyg in iframe: toolbar should be well positioned", async () => {
+    test.tags("desktop")("wysiwyg in iframe: toolbar should be well positioned", async () => {
         const CLOSE_ENOUGH = 10;
         const { el } = await setupWysiwyg({
             iframe: true,


### PR DESCRIPTION
Previously, the toolbar in the HTML editor was not optimized for mobile
use. Users had to manually select text to display the toolbar, which
often caused it to overflow beyond the screen boundaries,
leading to a frustrating experience.

This commit ensures that the toolbar is always visible when the editor
is active and by preventing overflow on mobile screens.
Additionally, the toolbar is now positioned above the keyboard for
easier access and a more seamless editing experience.

task-1695