### PR TITLE
[FIX] mail: no correspondent author prefix in messaging menu of chat

### DIFF
--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -38,11 +38,8 @@
         <t t-if="message.isSelfAuthored">
             <i class="fa fa-mail-reply me-1"/>You:
         </t>
-        <t t-elif="message.author and !message.author?.eq(thread.correspondent?.persona)">
-            <t t-esc="message.author.name"/>:
-        </t>
-        <t t-elif="message.email_from">
-            <t t-esc="message.email_from"/>:
+        <t t-elif="!message.author?.eq(thread.correspondent?.persona)">
+            <t t-esc="message.author?.name ?? message.email_from"/>:
         </t>
     </t>
 

--- a/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
+++ b/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
@@ -34,6 +34,7 @@ import { browser } from "@web/core/browser/browser";
 import { deserializeDateTime } from "@web/core/l10n/dates";
 import { rpc } from "@web/core/network/rpc";
 import { getOrigin } from "@web/core/utils/urls";
+import { queryOne } from "@odoo/hoot-dom";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -723,6 +724,38 @@ test("channel preview: basic rendering", async () => {
     await contains(".o-mail-NotificationItem img");
     await contains(".o-mail-NotificationItem-name", { text: "General" });
     await contains(".o-mail-NotificationItem-text", { text: "Demo: test" });
+});
+
+test("chat preview should not display correspondent name in body", async () => {
+    // DM chat with demo, the conversation is named "Demo" and body is simply message content
+    // not prefix like "Demo:"
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({ name: "Demo", email: "demo@odoo.com" });
+    const userId = pyEnv["res.users"].create({ partner_id: partnerId });
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_type: "chat",
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: partnerId }),
+        ],
+    });
+    await start();
+    await click(".o_menu_systray .dropdown-toggle:has(i[aria-label='Messages'])");
+    await withUser(userId, () =>
+        rpc("/mail/message/post", {
+            post_data: {
+                body: "<p>test</p>",
+                message_type: "comment",
+            },
+            thread_id: channelId,
+            thread_model: "discuss.channel",
+        })
+    );
+    await contains(".o-mail-NotificationItem");
+    await contains(".o-mail-NotificationItem img");
+    await contains(".o-mail-NotificationItem-name", { text: "Demo" });
+    await contains(".o-mail-NotificationItem-text", { text: "test" });
+    expect(queryOne(".o-mail-NotificationItem-text").textContent).toBe("test"); // exactly
 });
 
 test("filtered previews", async () => {


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/176485

PR above fixes an issue where messages without any author were not working in both messaging menu and chat bubble preview.

This commit made the unintentional change to display `email_from` of message preview in chat. This is because `email_from` is provided even though it could be unused. The `mail.message_preview_prefix` wanted to intentionally do nothing when message author is the correspondent (of chat).

This commit fixes this issue.

![before](https://github.com/user-attachments/assets/160bb7e5-525b-4024-8f8f-49f5434d4051) ![after](https://github.com/user-attachments/assets/7c6b68f0-6d79-4479-affd-42b7a6bc5732)
