### PR TITLE
[FIX] mail: do not allow sending message while files are uploading

### DIFF
--- a/addons/mail/static/src/core/common/attachment_model.js
+++ b/addons/mail/static/src/core/common/attachment_model.js
@@ -44,6 +44,10 @@ export class Attachment extends FileModelMixin(Record) {
         return `${this.create_date.monthLong}, ${this.create_date.year}`;
     }
 
+    get uploading() {
+        return this.id < 0;
+    }
+
     /** Remove the given attachment globally. */
     delete() {
         if (this.tmpUrl) {

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -569,9 +569,13 @@ export class Composer extends Component {
     async processMessage(cb) {
         const el = this.ref.el;
         const attachments = this.props.composer.attachments;
-        if (
+        if (attachments.some(({ uploading }) => uploading)) {
+            this.env.services.notification.add(_t("Please wait while the file is uploading."), {
+                type: "warning",
+            });
+        } else if (
             this.props.composer.text.trim() ||
-            (attachments.length > 0 && attachments.every(({ uploading }) => !uploading)) ||
+            attachments.length > 0 ||
             (this.message && this.message.attachments.length > 0)
         ) {
             if (!this.state.active) {
@@ -585,10 +589,6 @@ export class Composer extends Component {
             this.clear();
             this.state.active = true;
             el.focus();
-        } else if (attachments.some(({ uploading }) => Boolean(uploading))) {
-            this.env.services.notification.add(_t("Please wait while the file is uploading."), {
-                type: "warning",
-            });
         }
     }
 

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -1563,10 +1563,7 @@ test("mark channel as seen if last message is visible when switching channels wh
 test("warning on send with shortcut when attempting to post message with still-uploading attachments", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "test" });
-    onRpcBefore("/mail/attachment/upload", async (args) => {
-        // simulates attachment is never finished uploading
-        await new Deferred();
-    });
+    onRpcBefore("/mail/attachment/upload", async () => await new Deferred()); // simulates attachment is never finished uploading
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Composer input[type=file]");
@@ -1575,15 +1572,14 @@ test("warning on send with shortcut when attempting to post message with still-u
         contentType: "text/plain",
         name: "text.txt",
     });
+    await insertText(".o-mail-Composer-input", "Dummy Message");
     await editInput(document.body, ".o-mail-Composer input[type=file]", [file]);
     await contains(".o-mail-AttachmentCard");
-    await contains(".o-mail-AttachmentCard.o-isUploading");
+    await contains(".o-mail-AttachmentCard .fa.fa-spinner");
     await contains(".o-mail-Composer-send:disabled");
     // Try to send message
     triggerHotkey("Enter");
-    await contains(".o_notification:has(.o_notification_bar.bg-warning)", {
-        text: "Please wait while the file is uploading.",
-    });
+    await contains(".o_notification", { text: "Please wait while the file is uploading." });
 });
 
 test("failure on loading messages should display error", async () => {


### PR DESCRIPTION
Before this commit, when attempting to post a message that contains text and had a file uploading, this fails to send the message.

Steps to reproduce:
- Use slow network (e.g. "Slow 4g")
- Type some text in composer
- Copy-paste a file with CTRL-V in input
- Send message with ENTER

=> The attachment is sent but the text failed to post.

Even though clicking on error can attempt to resend the textual message, it never works because it is linked to uploading attachment but it doesn't exist anymore, so the message is permanently lost.

There is in fact some code that should prevent posting a message while there are file that are still uploading. This was not working because typing some text was wrongfully a condition enough to not put alert.

This commit fixes the issue by properly preventing sending message while attachment is being uploaded.

![Aug-20-2024 19-00-35](https://github.com/user-attachments/assets/e621964b-e495-4af0-b18a-1d065ce64ce0)
