### PR TITLE
[FIX] mrp.workcenter xml view wrong field name

### DIFF
--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -499,7 +499,7 @@
         <field name="model">mrp.workcenter.productivity</field>
         <field name="arch" type="xml">
             <search string="Operations">
-                <field name="workcenter_id"/>
+                <field name="production_id"/>
                 <field name="workcenter_id"/>
                 <field name="loss_id"/>
                 <separator/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: mrp.workcenter xml view wrong field name

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
