### PR TITLE
[FIX] pos_mercado_pago: Use unique identifier for payment intents.

### DIFF
--- a/addons/pos_mercado_pago/controllers/main.py
+++ b/addons/pos_mercado_pago/controllers/main.py
@@ -46,14 +46,15 @@ class PosMercadoPagoWebhook(http.Controller):
 
         # If and only if this webhook is related with a payment intend (see payment_mercado_pago.js)
         # then the field data['additional_info']['external_reference'] contains a string
-        # formated like "XXX_YYY" where "XXX" is the session_id and "YYY" is the payment_method_id
+        # formated like "XXX_YYY_ZZZ" where "XXX" is the session_id, "YYY" is the payment_method_id,
+        # and ZZZ is the pos_reference/uid for customer identification (Format ZZZZ-ZZZZ-ZZZZ)
         external_reference = data.get('additional_info', {}).get('external_reference')
 
-        if not external_reference or not re.fullmatch(r'\d+_\d+', external_reference):
+        if not external_reference or not re.fullmatch(r'\d+_\d+[_\d-]*', external_reference):
             _logger.debug('POST message received with no or malformed "external_reference" key')
             return http.Response(status=400)
 
-        session_id, payment_method_id = external_reference.split('_')
+        session_id, payment_method_id, _ = external_reference.split('_')
 
         pos_session_sudo = request.env['pos.session'].sudo().browse(int(session_id))
         if not pos_session_sudo or pos_session_sudo.state != 'opened':

--- a/addons/pos_mercado_pago/models/mercado_pago_pos_request.py
+++ b/addons/pos_mercado_pago/models/mercado_pago_pos_request.py
@@ -19,9 +19,15 @@ class MercadoPagoPosRequest:
         :param endpoint: The endpoint to be reached by the request.
         :param payload: The payload of the request.
         :return The JSON-formatted content of the response.
+
+        Note: The platform id below is not secret, and is just used to
+        quantify the amount of Odoo users on Mercado's backend.
         """
         endpoint = MERCADO_PAGO_API_ENDPOINT + endpoint
-        header = {'Authorization': f"Bearer {self.mercado_pago_bearer_token}"}
+        header = {
+            'Authorization': f"Bearer {self.mercado_pago_bearer_token}",
+            'X-platform-id': "dev_cdf1cfac242111ef9fdebe8d845d0987"
+        }
         try:
             response = requests.request(method, endpoint, headers=header, json=payload, timeout=REQUEST_TIMEOUT)
             return response.json()

--- a/addons/pos_mercado_pago/static/src/app/payment_mercado_pago.js
+++ b/addons/pos_mercado_pago/static/src/app/payment_mercado_pago.js
@@ -5,13 +5,14 @@ import { ErrorPopup } from "@point_of_sale/app/errors/popups/error_popup";
 
 export class PaymentMercadoPago extends PaymentInterface {
     async create_payment_intent() {
-        const line = this.pos.get_order().selected_paymentline;
+        const order = this.pos.get_order();
+        const line = order.selected_paymentline;
         // Build informations for creating a payment intend on Mercado Pago.
         // Data in "external_reference" are send back with the webhook notification
         const infos = {
             amount: parseInt(line.amount * 100, 10),
             additional_info: {
-                external_reference: `${this.pos.pos_session.id}_${line.payment_method.id}`,
+                external_reference: `${this.pos.pos_session.id}_${line.payment_method.id}_${order.uid}`,
                 print_on_terminal: true,
             },
         };


### PR DESCRIPTION
For Mercado Pago to recommend odoo to customers they needed two changes: 
1) Send a unique external reference to identify payments 
2) Send the platform-id header to identify how many people use the integration.

This PR addresses both:
1) Utilize the pos_reference field (uid) to identify records 
2) Use a system parameter to store the platform id special value we needed to send for identification.

task-4075847
