### PR TITLE
[FIX] base: propagate changes on implied groups update

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -31,6 +31,7 @@ from odoo.http import request, DEFAULT_LANG
 from odoo.osv import expression
 from odoo.service.db import check_super
 from odoo.tools import is_html_empty, partition, collections, frozendict, lazy_property
+from odoo.tools.misc import OrderedSet
 
 _logger = logging.getLogger(__name__)
 
@@ -1319,6 +1320,8 @@ class GroupsImplied(models.Model):
         res = super(GroupsImplied, self).write(values)
         if values.get('users') or values.get('implied_ids'):
             # add all implied groups (to all users of each group)
+            updated_group_ids = OrderedSet()
+            updated_user_ids = OrderedSet()
             for group in self:
                 self._cr.execute("""
                     WITH RECURSIVE group_imply(gid, hid) AS (
@@ -1339,8 +1342,22 @@ class GroupsImplied(models.Model):
                            FROM res_groups_users_rel r
                            JOIN group_imply i ON (r.gid = i.hid)
                           WHERE i.gid = %(gid)s
+                    RETURNING gid, uid
                 """, dict(gid=group.id))
-            self._check_one_user_type()
+                updated = self.env.cr.fetchall()
+                gids, uids = zip(*updated) if updated else ([], [])
+                updated_group_ids.update(gids)
+                updated_user_ids.update(uids)
+            # notify the ORM about the updated users and groups
+            updated_groups = self.env['res.groups'].browse(updated_group_ids)
+            updated_groups.invalidate_recordset(['users'])
+            updated_groups.modified(['users'])
+            updated_users = self.env['res.users'].browse(updated_user_ids)
+            updated_users.invalidate_recordset(['groups_id'])
+            updated_users.modified(['groups_id'])
+            # explicitly check constraints
+            updated_groups._validate_fields(['users'])
+            updated_users._validate_fields(['groups_id'])
         return res
 
     def _apply_group(self, implied_group):


### PR DESCRIPTION
Steps to reproduce:

1. Add a stored computed field on `res.users` that depends on `groups_id`
2. Add a constraint on `res.users` that depends on `groups_id`
3. Give the user a group
4. Modify the given group and add an implied group

Result:

- The computed field is not recomputed
- The constraint is not checked

The reason for this is that the users groups are updated with a raw SQL query, and the ORM is not aware of the changes.

This is a regression since 5f12e244. This issue was partially detected and fixed in 459e6dc1, but only for a single constraint.

This commit makes sure that the ORM properly propagates the changes to computed fields and all constraints, not just the one that was explicitly checked.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
