### PR TITLE
[FIX] purchase_stock: use the last purchase date for the supplier info

### DIFF
--- a/addons/purchase_stock/models/product.py
+++ b/addons/purchase_stock/models/product.py
@@ -89,7 +89,7 @@ class SupplierInfo(models.Model):
             ('order_line.product_id', 'in',
              self.product_tmpl_id.product_variant_ids.ids),
             ('partner_id', 'in', self.name.ids),
-        ], order='date_order')
+        ], order='date_order desc')
         for supplier in self:
             products = supplier.product_tmpl_id.product_variant_ids
             for purchase in purchases:

--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -1008,3 +1008,49 @@ class TestReorderingRule(TransactionCase):
         self.assertEqual(orderpoint.supplier_id, product.seller_ids, 'The supplier should be set in the orderpoint')
         self.assertEqual(orderpoint.product_uom, product.uom_id, 'The orderpoint uom should be the same as the product uom')
         self.assertEqual(orderpoint.qty_to_order, 6000)
+
+    def test_supplierinfo_last_purchase_date(self):
+        """
+        Test that the last_purchase_date on the replenishment information is correctly computed
+        A user creates two purchase orders
+        The last_purchase_date on the supplier info should be computed as the most recent date_order from the purchase orders
+        """
+        res_partner = self.env['res.partner'].create({
+            'name': 'Test Partner',
+        })
+        product = self.env['product.product'].create({
+            'name': 'Storable Product',
+            'type': 'product',
+        })
+        orderpoint = self.env['stock.warehouse.orderpoint'].create({
+            'product_id': product.id,
+            'product_min_qty': 0,
+            'product_max_qty': 0,
+        })
+        po1_vals = {
+            'partner_id': res_partner.id,
+            'date_order': dt.today() - td(days=15),
+            'order_line': [
+                (0, 0, {
+                    'name': product.name,
+                    'product_id': product.id,
+                    'product_qty': 1.0,
+                })],
+        }
+        po2_vals = {
+            'partner_id': res_partner.id,
+            'date_order': dt.today(),
+            'order_line': [
+                (0, 0, {
+                    'name': product.name,
+                    'product_id': product.id,
+                    'product_qty': 1.0,
+                })],
+        }
+        po1 = self.env['purchase.order'].create(po1_vals)
+        po1.button_confirm()
+        po2 = self.env['purchase.order'].create(po2_vals)
+        po2.button_confirm()
+        replenishment_info = self.env['stock.replenishment.info'].create({'orderpoint_id': orderpoint.id})
+        supplier_info = replenishment_info.supplierinfo_ids
+        self.assertEqual(supplier_info.last_purchase_date, dt.today().date(), "The last_purhchase_date should be set to the most recent date_order from the purchase orders")


### PR DESCRIPTION
Problem: When viewing the replenishment information for a product, the last purchase date is set to the date from the oldest purchase order. The last_purchase_date field is set using the purchase order with the oldest date_order field. The last_purchase_date field should be set using the purchase order with the most recent date_order field.

Purpose: By ordering the purchase orders by date_order desc we will get the purchase order with the most recent date_order field. This will cause the supplier’s last purchase date to be the most recent one instead of the oldest one.

Steps to Reproduce on Runbot:

1. Create a storable product and create a reordering rule for this product
2. Create a purchase order for this product and set the Order Deadline to a date in the past and then confirm it
3. Create a purchase order for this product and set the Order Deadline to the current date and the confirm it
4. Navigate to this product’s replenishment information
5. Observe that the Last Purchase date is the earlier of the two dates from the purchase orders

opw-4113810

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
