### PR TITLE
[FIX] l10n_gcc_invoice: translate tax group name

### DIFF
--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -349,23 +349,24 @@
                                     <!-- copy-pasted template "account.tax_groups_totals" with reversed columns order -->
                                     <t t-foreach="tax_totals['groups_by_subtotal'][subtotal_to_show]" t-as="amount_by_group">
                                         <tr>
-                                            <t t-if="tax_totals['display_tax_base']">
-                                                <td class="text-end o_price_total">
-                                                    <span class="text-nowrap" t-esc="amount_by_group['formatted_tax_group_amount']"/>
-                                                </td>
-                                                <td class="text-end">
+                                            <td class="text-end o_price_total">
+                                                <span class="text-nowrap" t-esc="amount_by_group['formatted_tax_group_amount']"/>
+                                            </td>
+                                            <td class="text-end">
+                                                <strong>
                                                     <span t-esc="amount_by_group['tax_group_name']"/>
-                                                    <span class="text-nowrap"> on
-                                                        <t t-esc="amount_by_group['formatted_tax_group_base_amount']"/>
+                                                    <t t-if="tax_totals['display_tax_base']">
+                                                        <span class="text-nowrap"> on
+                                                            <t t-esc="amount_by_group['formatted_tax_group_base_amount']"/>
+                                                        </span>
+                                                    </t>
+                                                    <!-- Arabic translation of tax group -->
+                                                    <t t-set="arabic_tax_group_name" t-value="o_sec.tax_totals['groups_by_subtotal'][o_sec.tax_totals['subtotals'][subtotal_index]['name']][amount_by_group_index]['tax_group_name']"/>
+                                                    <span t-if="arabic_tax_group_name != amount_by_group['tax_group_name']" class="text-nowrap">/
+                                                        <t t-esc="arabic_tax_group_name"/>
                                                     </span>
-                                                </td>
-                                            </t>
-                                            <t t-else="">
-                                                <td class="text-end o_price_total">
-                                                    <span class="text-nowrap" t-esc="amount_by_group['formatted_tax_group_amount']" />
-                                                </td>
-                                                <td class="text-end"><span class="text-nowrap" t-esc="amount_by_group['tax_group_name']"/></td>
-                                            </t>
+                                                </strong>
+                                            </td>
                                         </tr>
                                     </t>
 


### PR DESCRIPTION
Problem: The tax group name is not translated to
Arabic.

Purpose: Display the Arabic translation of the
tax group name as well to stay consistent with
the report.

Steps to Reproduce:
1. Install l10n_sa
2. Switch to SA company
3. Add Arabic as a language
4. Add an Arabic translation for a tax group name
5. Change a contact's language to Arabic
6. Create an invoice with the Arabic contact and a tax from the same tax group
7. Preview or Print and observe that the tax group name is not translated to Arabic

opw-4094196
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
