### PR TITLE
[FIX] mail: handle traceback after leaving discuss channel

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1106,15 +1106,18 @@ class Channel(models.Model):
         """
         for channel in self:
             if not channel.message_ids.ids:
-                return
+                continue
             # a bit not-modular but helps understanding code
             if channel.channel_type not in {'chat', 'whatsapp'}:
-                return
+                continue
             last_message_id = channel.message_ids.ids[0] # zero is the index of the last message
             member = self.env['discuss.channel.member'].search([('channel_id', '=', channel.id), ('partner_id', '=', self.env.user.partner_id.id)], limit=1)
+            if not member:
+                # member not a part of the channel
+                continue
             if member.fetched_message_id.id == last_message_id:
                 # last message fetched by user is already up-to-date
-                return
+                continue
             # Avoid serialization error when multiple tabs are opened.
             query = """
                 UPDATE discuss_channel_member


### PR DESCRIPTION
Issue -->

Traceback appears after a user leaves a discuss channel of type `chat` or `whatsapp`.

Cause -->

`action_unfollow` unlinks the channel member from the `discuss.channel.member` table. When handling new message notification to show "_ has left the channel", method `channel_fetched` attempts to execute a query with an empty `discuss.channel.member` record, which raises a Postgres type mismatch error (`integer` vs ` boolean`) when setting
`fetched_message_id`.

Solution -->

Check if the channel member exists, if not, then exit the method `channel_fetched`.

opw-4069813

