### PR TITLE
[FIX] pos_loyalty: dont count refund lines points

### DIFF
--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -855,7 +855,7 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
      */
     pointsForPrograms(programs) {
         pointsForProgramsCountedRules = {};
-        const orderLines = this.get_orderlines();
+        const orderLines = this.get_orderlines().filter((line) => !line.refunded_orderline_id);
         const linesPerRule = {};
         for (const line of orderLines) {
             const reward = line.reward_id


### PR DESCRIPTION
Steps to reproduce (from empty runbot):
1. Install pos_loyalty
2. Edit the existing active program named "Loyalty Program"
2a. Set "Program Type" to "Buy X Get Y"
2b. Change the existing reward to "[CONS_0002] Simple Pen"
![image](https://github.com/user-attachments/assets/6d7cdc98-fa11-4857-92bb-edc0fb29b04c)
3. Start a new POS session with the "Shop" POS.
4. Add two Whiteboard Pens, and claim the reward.
5. Pay for the order with bank payment, and start a new order.
6. Start a refund of the last order, refund the 2 Whiteboard Pens and the 1 Simple Pen.
![image](https://github.com/user-attachments/assets/6d54ccf6-3eea-4889-b9d6-856bda7b4fc7)
7. Continue the refund, and back at the main POS screen, now add two more Whiteboard Pens.
8. Notice that no reward is claimable
8a. It becomes claimable if you add two more Whiteboard Pens, for a total of 4.
![image](https://github.com/user-attachments/assets/769f470b-e162-4480-86b1-e37b3cd78401)


Before this commit, `pointsForPrograms` would calculate based on every order line present in the POS. However, this could lead to situations where lines that shouldn't be counted do get counted. For instance, a refund line should not be counted, as it would add a negative amount to the total amount.

After this commit, only non refund lines are used in `pointsForPrograms`, which are defined as lines that do not have a `refunded_orderline_id` set.

opw-4080144


