### PR TITLE
[FIX] hr_expense: total label not showing in expense form

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -199,7 +199,7 @@
                             </div>
 
                             <!-- CASE: converter when currency is different than the company one -->
-                            <label for="total_amount" string="" invisible="not is_multiple_currency and not product_has_cost"/>
+                            <label for="total_amount" invisible="not is_multiple_currency and not product_has_cost"/>
                             <div class="o_row" invisible="not is_multiple_currency and not product_has_cost">
                                 <field name="total_amount" widget='monetary' options="{'currency_field': 'company_currency_id'}"
                                        force_save="1" readonly="not is_editable or product_has_cost" class="oe_inline"/>


### PR DESCRIPTION
In [1] an empty string for the `total_amount_company` field label was added causing to don't have any label, this commit fixes that.

[1]: https://github.com/odoo/odoo/commit/3cdec23a

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
