### PR TITLE
[IMP] mail: Include success, info, warning & danger type color schemes in simple notification handler

### DIFF
--- a/addons/mail/static/src/models/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler.js
@@ -437,13 +437,19 @@ registerModel({
          * @param {boolean} param1.sticky
          * @param {string} param1.title
          * @param {boolean} param1.warning
+         * @param {string} param1.type
          */
-        _handleNotificationSimpleNotification({ message, message_is_html, sticky, title, warning }) {
+        _handleNotificationSimpleNotification({ message, message_is_html, sticky, title, warning, type }) {
+            type = warning
+               ? "warning"
+               : ["info", "success", "warning", "danger"].includes(type)
+               ? type
+               : "danger";
             this.messaging.notify({
                 message: message_is_html ? Markup(message) : message,
                 sticky,
                 title,
-                type: warning ? 'warning' : 'danger',
+                type,
             });
         },
         /**


### PR DESCRIPTION
Before this PR, simple notifications did not have options for 'success' or 'info' type border color themes.

This PR allows users to send simple notifications with 'success', 'info', 'warning', and 'danger' border color schemes. If the warning or type parameter is not provided, it will default to the 'danger' type, as it did before this PR, so it will not affect any previously written bus notification call.

Desired behavior after PR is merged:
This PR enables simple notifications to use 'success', 'info', 'warning', and 'danger' type border color schemes.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
