### PR TITLE
[FIX] l10n_sa_edi: update allowance charge vals dict

### DIFF
--- a/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
+++ b/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
@@ -274,7 +274,7 @@ class AccountEdiXmlUBL21Zatca(models.AbstractModel):
                 'tax_category_vals': [{
                     'id': tax['id'],
                     'percent': tax['percent'],
-                    'tax_scheme_id': 'VAT',
+                    'tax_scheme_vals': {'id': 'VAT'},
                 } for tax in self._get_tax_category_list(line.move_id, taxes)],
             })
         return res


### PR DESCRIPTION
This commit fixes an issue regarding global discount lines on invoices that should be represented as allowance charge elements on the UBL file sent to ZATCA. In V17 the structure of the dictionary passed to the XML template in charge of rendering AllowanceCharge changed and expects the value of the tax_scheme_id to be passed inside a dict called tax_scheme_vals, which was not the case previously.

Description of the issue/feature this PR addresses:
When trying to submit an invoice containing global discounts to ZATCA, the server throws an error since it expects a Tax Scheme ID on the Allowance Charge element linked to the global discount. This only happens on V17 as the structure of the data passed to the AllowanceCharge XML template changed

Current behavior before PR:
ZATCA servers return an error when submitting invoices containing a global discount line

Desired behavior after PR is merged:
ZATCA servers correctly process invoices containing global discount lines



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
