### PR TITLE
[IMP] website: improve media icons

### DIFF
--- a/addons/website/static/src/snippets/s_social_media/000.scss
+++ b/addons/website/static/src/snippets/s_social_media/000.scss
@@ -1,5 +1,6 @@
 
 .s_social_media {
+    $-size: map-get($spacers, 5);
     > * {
         display: inline-block;
         vertical-align: middle;
@@ -12,8 +13,17 @@
             display: flex;
             justify-content: center;
             align-items: center;
+            &:not(.fa-2x, .fa-3x, .fa-4x, .fa-5x) {
+                &.rounded-circle,
+                &.rounded {
+                    width: $-size - .5rem;
+                    height: $-size - .5rem;
+                }
+            }
         }
-        margin: .2rem;
+        &:has(i:not(.fa-stack)) {
+            margin: .2rem;
+        }
     }
     &:not(.no_icon_color) {
         .s_social_media_facebook {


### PR DESCRIPTION
This commit enhances the social media icons by reducing their width and height when the layout is set to disk or square with a small size. Additionally, it removes the left and right margins of the icons when the layout is set to none and the size is small.

task-4107178