### PR TITLE
[IMP] core: warn and avoid passing NewId to domains

### DIFF
--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -128,7 +128,7 @@ class HrEmployee(models.Model):
             start_naive = start_tz.astimezone(pytz.utc).replace(tzinfo=None)
 
             attendances = self.env['hr.attendance'].search([
-                ('employee_id', '=', employee.id),
+                ('employee_id', 'in', employee.ids),
                 ('check_in', '<=', now),
                 '|', ('check_out', '>=', start_naive), ('check_out', '=', False),
             ], order='check_in asc')
@@ -149,7 +149,7 @@ class HrEmployee(models.Model):
     def _compute_last_attendance_id(self):
         for employee in self:
             employee.last_attendance_id = self.env['hr.attendance'].search([
-                ('employee_id', '=', employee.id),
+                ('employee_id', 'in', employee.ids),
             ], order="check_in desc", limit=1)
 
     @api.depends('last_attendance_id.check_in', 'last_attendance_id.check_out', 'last_attendance_id')

--- a/addons/hr_gamification/models/hr_employee.py
+++ b/addons/hr_gamification/models/hr_employee.py
@@ -30,9 +30,9 @@ class HrEmployeeBase(models.AbstractModel):
     def _compute_employee_badges(self):
         for employee in self:
             badge_ids = self.env['gamification.badge.user'].search([
-                '|', ('employee_id', '=', employee.id),
+                '|', ('employee_id', 'in', employee.ids),
                      '&', ('employee_id', '=', False),
-                          ('user_id', '=', employee.user_id.id)
+                          ('user_id', 'in', employee.user_id.ids)
             ])
             employee.has_badges = bool(badge_ids)
             employee.badge_ids = badge_ids

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3509,7 +3509,7 @@ class MailThread(models.AbstractModel):
         tracking = []
         if check_tracking:
             tracking_values = self.env['mail.tracking.value'].sudo().search(
-                [('mail_message_id', '=', message.id)]
+                [('mail_message_id', 'in', message.ids)]
             )._filter_has_field_access(self.env)
             if tracking_values and hasattr(record_wlang, '_track_filter_for_display'):
                 tracking_values = record_wlang._track_filter_for_display(tracking_values)

--- a/addons/membership/models/partner.py
+++ b/addons/membership/models/partner.py
@@ -48,13 +48,13 @@ class Partner(models.Model):
         today = fields.Date.today()
         for partner in self:
             partner.membership_start = self.env['membership.membership_line'].search([
-                ('partner', '=', partner.associate_member.id or partner.id), ('date_cancel', '=', False)
+                ('partner', 'in', (partner.associate_member or partner).ids), ('date_cancel', '=', False)
             ], limit=1, order='date_from').date_from
             partner.membership_stop = self.env['membership.membership_line'].search([
-                ('partner', '=', partner.associate_member.id or partner.id), ('date_cancel', '=', False)
+                ('partner', 'in', (partner.associate_member or partner).ids), ('date_cancel', '=', False)
             ], limit=1, order='date_to desc').date_to
             partner.membership_cancel = self.env['membership.membership_line'].search([
-                ('partner', '=', partner.id)
+                ('partner', 'in', partner.ids)
             ], limit=1, order='date_cancel').date_cancel
 
             if partner.associate_member:

--- a/addons/mrp/models/mrp_routing.py
+++ b/addons/mrp/models/mrp_routing.py
@@ -74,7 +74,7 @@ class MrpRoutingWorkcenter(models.Model):
             operation.time_cycle = operation.time_cycle_manual
         for operation in self - manual_ops:
             data = self.env['mrp.workorder'].search([
-                ('operation_id', '=', operation.id),
+                ('operation_id', 'in', operation.ids),
                 ('qty_produced', '>', 0),
                 ('state', '=', 'done')],
                 limit=operation.time_mode_batch,

--- a/addons/sms/models/mail_thread.py
+++ b/addons/sms/models/mail_thread.py
@@ -294,7 +294,7 @@ class MailThread(models.AbstractModel):
                     '|', ('res_partner_id', 'in', partner_ids),
                     '&', ('res_partner_id', '=', False), ('sms_number', 'in', sms_numbers),
                     ('notification_type', '=', 'sms'),
-                    ('mail_message_id', '=', message.id)
+                    ('mail_message_id', 'in', message.ids),
                 ])
                 for n in existing:
                     if n.res_partner_id.id in partner_ids and n.mail_message_id == message:

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3070,6 +3070,7 @@ class BaseModel(metaclass=MetaModel):
                 return SQL("(%s IS NULL OR %s = FALSE)", sql_field, sql_field)
 
         if (field.relational or field.name == 'id') and operator in ('=', '!=') and isinstance(value, NewId):
+            _logger.warning("_condition_to_sql: ignored (%r, %r, NewId), did you mean (%r, 'in', recs.ids)?", fname, operator, fname)
             return SQL("TRUE") if operator in expression.NEGATIVE_TERM_OPERATORS else SQL("FALSE")
 
         # comparison with null


### PR DESCRIPTION
NewId is not an accepted value, so a warning should be raised. In a compute function, the value given to a domain may be `('some_id', '=', record.id)` which can result in a NewId given to the domain. Probably an 'in' condition was wanted.

odoo/enterprise#68657

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
