### PR TITLE
[MERGE] event_*: improve scheduler scalability

### DIFF
--- a/addons/event/data/mail_template_data.xml
+++ b/addons/event/data/mail_template_data.xml
@@ -6,7 +6,7 @@
             <field name="name">Event: Registration Badge</field>
             <field name="model_id" ref="event.model_event_registration"/>
             <field name="subject">Your badge for {{ object.event_id.name }}</field>
-            <field name="email_from">{{ (object.event_id.organizer_id.email_formatted or object.event_id.user_id.email_formatted or '') }}</field>
+            <field name="email_from">{{ (object.event_id.organizer_id.email_formatted or object.event_id.company_id.email_formatted or user.email_formatted or '') }}</field>
             <field name="email_to">{{ (object.email and '"%s" &lt;%s&gt;' % (object.name, object.email) or object.partner_id.email_formatted or '') }}</field>
             <field name="description">Sent automatically to someone after they registered to an event</field>
             <field name="body_html" type="html">
@@ -246,7 +246,7 @@
             <field name="name">Event: Registration Confirmation</field>
             <field name="model_id" ref="event.model_event_registration"/>
             <field name="subject">Your registration at {{ object.event_id.name }}</field>
-            <field name="email_from">{{ (object.event_id.organizer_id.email_formatted or object.event_id.user_id.email_formatted or '') }}</field>
+            <field name="email_from">{{ (object.event_id.organizer_id.email_formatted or object.event_id.company_id.email_formatted or user.email_formatted or '') }}</field>
             <field name="email_to">{{ (object.email and '"%s" &lt;%s&gt;' % (object.name, object.email) or object.partner_id.email_formatted or '') }}</field>
             <field name="description">Sent to attendees after registering to an event</field>
             <field name="body_html" type="html">
@@ -504,7 +504,7 @@
             <field name="name">Event: Reminder</field>
             <field name="model_id" ref="event.model_event_registration"/>
             <field name="subject">{{ object.event_id.name }}: {{ object.event_date_range }}</field>
-            <field name="email_from">{{ (object.event_id.organizer_id.email_formatted or object.event_id.user_id.email_formatted or '') }}</field>
+            <field name="email_from">{{ (object.event_id.organizer_id.email_formatted or object.event_id.company_id.email_formatted or user.email_formatted or '') }}</field>
             <field name="email_to">{{ (object.email and '"%s" &lt;%s&gt;' % (object.name, object.email) or object.partner_id.email_formatted or '') }}</field>
             <field name="description">Sent automatically to attendees if there is a reminder defined on the event</field>
             <field name="body_html" type="html">

--- a/addons/event/models/event_mail.py
+++ b/addons/event/models/event_mail.py
@@ -176,6 +176,8 @@ class EventMailScheduler(models.Model):
             self._refresh_mail_count_done()
             if auto_commit:
                 self.env.cr.commit()
+                # invalidate cache, no need to keep previous content in memory
+                self.env.invalidate_all()
 
     def _execute_event_based_for_registrations(self, registrations):
         """ Method doing notification and recipients specific implementation
@@ -262,6 +264,8 @@ class EventMailScheduler(models.Model):
             self._refresh_mail_count_done()
             if auto_commit:
                 self.env.cr.commit()
+                # invalidate cache, no need to keep previous content in memory
+                self.env.invalidate_all()
 
     def _create_missing_mail_registrations(self, registrations):
         new = self.env["event.mail.registration"]

--- a/addons/event/models/event_mail_registration.py
+++ b/addons/event/models/event_mail_registration.py
@@ -19,13 +19,23 @@ class EventMailRegistration(models.Model):
     scheduled_date = fields.Datetime('Scheduled Time', compute='_compute_scheduled_date', store=True)
     mail_sent = fields.Boolean('Mail Sent')
 
+    @api.depends('registration_id', 'scheduler_id.interval_unit', 'scheduler_id.interval_type')
+    def _compute_scheduled_date(self):
+        for mail in self:
+            if mail.registration_id:
+                mail.scheduled_date = mail.registration_id.create_date.replace(microsecond=0) + _INTERVALS[mail.scheduler_id.interval_unit](mail.scheduler_id.interval_nbr)
+            else:
+                mail.scheduled_date = False
+
     def execute(self):
-        now = fields.Datetime.now()
-        todo = self.filtered(lambda reg_mail:
-            not reg_mail.mail_sent and \
-            reg_mail.registration_id.state in ['open', 'done'] and \
-            (reg_mail.scheduled_date and reg_mail.scheduled_date <= now) and \
-            reg_mail.scheduler_id.notification_type == 'mail'
+        self.filtered_domain(self._get_skip_domain())._execute_on_registrations()
+
+    def _execute_on_registrations(self):
+        """ Private mail registration execution. We consider input is already
+        filtered at this point, allowing to let caller do optimizations when
+        managing batches of registrations. """
+        todo = self.filtered(
+            lambda r: r.scheduler_id.notification_type == "mail"
         )
         done = self.browse()
         for reg_mail in todo:
@@ -55,13 +65,16 @@ class EventMailRegistration(models.Model):
             if not template.email_from:
                 email_values['email_from'] = author.email_formatted
             template.send_mail(reg_mail.registration_id.id, email_values=email_values)
-            done |= reg_mail
+            done += reg_mail
         done.write({'mail_sent': True})
+        return done
 
-    @api.depends('registration_id', 'scheduler_id.interval_unit', 'scheduler_id.interval_type')
-    def _compute_scheduled_date(self):
-        for mail in self:
-            if mail.registration_id:
-                mail.scheduled_date = mail.registration_id.create_date.replace(microsecond=0) + _INTERVALS[mail.scheduler_id.interval_unit](mail.scheduler_id.interval_nbr)
-            else:
-                mail.scheduled_date = False
+    def _get_skip_domain(self):
+        """ Domain of mail registrations ot skip: not already done, linked to
+        a valid registration, and scheduled in the past. """
+        return [
+            ("mail_sent", "=", False),
+            ("registration_id.state", "in", ("open", "done")),
+            ("scheduled_date", "!=", False),
+            ("scheduled_date", "<=", fields.Datetime.now()),
+        ]

--- a/addons/event/models/event_mail_registration.py
+++ b/addons/event/models/event_mail_registration.py
@@ -49,19 +49,10 @@ class EventMailRegistration(models.Model):
             elif self.env.user.email:
                 author = self.env.user.partner_id
 
+            template = reg_mail.scheduler_id.template_ref
             email_values = {
                 'author_id': author.id,
             }
-            template = None
-            try:
-                template = reg_mail.scheduler_id.template_ref.exists()
-            except MissingError:
-                pass
-
-            if not template:
-                _logger.warning("Cannot process ticket %s, because Mail Scheduler %s has reference to non-existent template", reg_mail.registration_id, reg_mail.scheduler_id)
-                continue
-
             if not template.email_from:
                 email_values['email_from'] = author.email_formatted
             template.send_mail(reg_mail.registration_id.id, email_values=email_values)

--- a/addons/event/models/event_mail_registration.py
+++ b/addons/event/models/event_mail_registration.py
@@ -12,7 +12,7 @@ class EventMailRegistration(models.Model):
     _name = 'event.mail.registration'
     _description = 'Registration Mail Scheduler'
     _rec_name = 'scheduler_id'
-    _order = 'scheduled_date DESC'
+    _order = 'scheduled_date DESC, id ASC'
 
     scheduler_id = fields.Many2one('event.mail', 'Mail Scheduler', required=True, ondelete='cascade')
     registration_id = fields.Many2one('event.registration', 'Attendee', required=True, ondelete='cascade')
@@ -28,7 +28,9 @@ class EventMailRegistration(models.Model):
                 mail.scheduled_date = False
 
     def execute(self):
-        self.filtered_domain(self._get_skip_domain())._execute_on_registrations()
+        # Deprecated, to be called only from parent scheduler
+        skip_domain = self._get_skip_domain() + [("registration_id.state", "in", ("open", "done"))]
+        self.filtered_domain(skip_domain)._execute_on_registrations()
 
     def _execute_on_registrations(self):
         """ Private mail registration execution. We consider input is already
@@ -47,7 +49,6 @@ class EventMailRegistration(models.Model):
         a valid registration, and scheduled in the past. """
         return [
             ("mail_sent", "=", False),
-            ("registration_id.state", "in", ("open", "done")),
             ("scheduled_date", "!=", False),
-            ("scheduled_date", "<=", fields.Datetime.now()),
+            ("scheduled_date", "<=", self.env.cr.now()),
         ]

--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -313,7 +313,6 @@ class EventRegistration(models.Model):
         if not onsubscribe_schedulers:
             return
 
-        onsubscribe_schedulers.update({'mail_done': False})
         # either trigger the cron, either run schedulers immediately (scaling choice)
         async_scheduler = self.env['ir.config_parameter'].sudo().get_param('event.event_mail_async')
         if async_scheduler:

--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -76,6 +76,10 @@ class EventRegistration(models.Model):
     registration_answer_ids = fields.One2many('event.registration.answer', 'registration_id', string='Attendee Answers')
     registration_answer_choice_ids = fields.One2many('event.registration.answer', 'registration_id', string='Attendee Selection Answers',
         domain=[('question_type', '=', 'simple_choice')])
+    # scheduled mails
+    mail_registration_ids = fields.One2many(
+        'event.mail.registration', 'registration_id',
+        string="Scheduler Emails", readonly=True)
     # properties
     registration_properties = fields.Properties(
         'Properties', definition='event_id.registration_properties_definition', copy=True)

--- a/addons/event/tests/common.py
+++ b/addons/event/tests/common.py
@@ -202,3 +202,9 @@ class EventCase(common.TransactionCase):
             "subject": "Reminder for {{ object.event_id.name }}: {{ object.event_date_range }}",
             "report_template_ids": [(4, cls.test_report_action.id)],
         })
+
+    def assertSchedulerCronTriggers(self, capture, call_at_list):
+        self.assertEqual(len(capture.records), len(call_at_list))
+        for record, call_at in zip(capture.records, call_at_list):
+            self.assertEqual(record.call_at, call_at.replace(microsecond=0))
+            self.assertEqual(record.cron_id, self.env.ref('event.event_mail_scheduler'))

--- a/addons/event/tests/test_event_flow.py
+++ b/addons/event/tests/test_event_flow.py
@@ -7,10 +7,11 @@ from dateutil.relativedelta import relativedelta
 from freezegun import freeze_time
 
 from odoo.addons.event.tests.common import EventCase
-from odoo.tests.common import users
+from odoo.tests.common import tagged, users
 from odoo.tools import mute_logger
 
 
+@tagged("event_mail")
 class TestEventFlow(EventCase):
 
     @users('user_eventmanager')
@@ -39,7 +40,7 @@ class TestEventFlow(EventCase):
         self.assertEqual(event.date_begin, specific_datetimes['date_begin'])
         self.assertEqual(event.date_end, specific_datetimes['date_end'])
 
-    @mute_logger('odoo.addons.event.models.event_mail_registration')
+    @mute_logger('odoo.addons.event.models.event_mail')
     def test_event_missed_mail_template(self):
         """ Check that error on mail sending is ignored if corresponding mail template was deleted """
         test_event = self.env['event.event'].with_user(self.user_eventmanager).create({

--- a/addons/event/tests/test_event_mail_schedule.py
+++ b/addons/event/tests/test_event_mail_schedule.py
@@ -328,6 +328,14 @@ class TestMailSchedule(EventCase, MockEmail, CronMixinCase):
                 'subject': f"Reminder for {test_event.name}: today",
             })
 
+    @users('user_eventmanager')
+    def test_event_mail_schedule_fail_registration_template_removed(self):
+        """ Test flow where scheduler fails due to template being removed. """
+        after_sub_scheduler = self.test_event.event_mail_ids.filtered(lambda s: s.interval_type == 'after_sub')
+        self.assertTrue(after_sub_scheduler)
+        self.template_subscription.sudo().unlink()
+        self.assertFalse(after_sub_scheduler.exists(), "When removing template, scheduler should be removed")
+
     @mute_logger('odoo.addons.base.models.ir_model', 'odoo.models')
     @users('user_eventmanager')
     @warmup

--- a/addons/event/tests/test_event_mail_schedule.py
+++ b/addons/event/tests/test_event_mail_schedule.py
@@ -388,8 +388,8 @@ class TestMailSchedule(EventCase, MockEmail, CronMixinCase):
             ])
         self.assertEqual(len(self._new_mails), 2,
                          'EventMail: should be limited to new registrations')
-        self.assertEqual(self.mail_mail_create_mocked.call_count, 2,
-                         'EventMail: should create one mail / new registration')
+        self.assertEqual(self.mail_mail_create_mocked.call_count, 1,
+                         'EventMail: should create mails in batch for new registrations')
 
     @mute_logger('odoo.addons.base.models.ir_model', 'odoo.models')
     @users('user_eventmanager')

--- a/addons/event_crm/tests/common.py
+++ b/addons/event_crm/tests/common.py
@@ -102,7 +102,11 @@ class EventCrmCase(TestCrmCommon, EventCase):
         self.assertEqual(lead.partner_name, expected_partner_name)
         self.assertEqual(lead.email_from, partner.email if partner and partner.email else registrations._find_first_notnull('email'))
         self.assertEqual(lead.phone, partner.phone if partner and partner.phone else registration_phone)
-        self.assertEqual(lead.mobile, partner.mobile if partner and partner.mobile else ((registration_phone != lead.phone) and registration_phone))
+        exp_mobile = partner.mobile if partner and partner.mobile else ((registration_phone != lead.phone) and registration_phone)
+        self.assertEqual(
+            lead.mobile, exp_mobile,
+            f"Expected {exp_mobile} (partner {partner.id} / {partner.mobile}) (registration phone {registration_phone} / lead phone {lead.phone})",
+        )
 
         # description: to improve
         self.assertNotIn('False', lead.description)  # avoid a "Dear False" like construct ^^ (this assert is serious and intended)

--- a/addons/event_sms/models/event_mail.py
+++ b/addons/event_sms/models/event_mail.py
@@ -27,24 +27,10 @@ class EventMailScheduler(models.Model):
         sms_schedulers = self.filtered(lambda scheduler: scheduler.template_ref and scheduler.template_ref._name == 'sms.template')
         sms_schedulers.notification_type = 'sms'
 
-    def execute(self):
-        for scheduler in self:
-            now = fields.Datetime.now()
-            if scheduler.interval_type != 'after_sub' and scheduler.notification_type == 'sms':
-                # before or after event -> one shot email
-                if scheduler.mail_done:
-                    continue
-                # Do not send SMS if the communication was scheduled before the event but the event is over
-                if scheduler.scheduled_date <= now and (scheduler.interval_type != 'before_event' or scheduler.event_id.date_end > now):
-                    scheduler.event_id.registration_ids.filtered(
-                        lambda registration: registration.state not in ('cancel', 'draft')
-                    )._message_sms_schedule_mass(
-                        template=scheduler.template_ref,
-                        mass_keep_log=True
-                    )
-                    scheduler.update({
-                        'mail_done': True,
-                        'mail_count_done': scheduler.event_id.seats_taken,
-                    })
-
-        return super(EventMailScheduler, self).execute()
+    def _execute_event_based_for_registrations(self, registrations):
+        if self.notification_type == "sms":
+            registrations._message_sms_schedule_mass(
+                template=self.template_ref,
+                mass_keep_log=True
+            )
+        return super()._execute_event_based_for_registrations(registrations)

--- a/addons/event_sms/models/event_mail.py
+++ b/addons/event_sms/models/event_mail.py
@@ -29,11 +29,15 @@ class EventMailScheduler(models.Model):
 
     def _execute_event_based_for_registrations(self, registrations):
         if self.notification_type == "sms":
-            registrations._message_sms_schedule_mass(
-                template=self.template_ref,
-                mass_keep_log=True
-            )
+            self._send_sms(registrations)
         return super()._execute_event_based_for_registrations(registrations)
+
+    def _send_sms(self, registrations):
+        """ SMS action: send SMS to attendees """
+        registrations._message_sms_schedule_mass(
+            template=self.template_ref,
+            mass_keep_log=True
+        )
 
     def _template_model_by_notification_type(self):
         info = super()._template_model_by_notification_type()

--- a/addons/event_sms/models/event_mail.py
+++ b/addons/event_sms/models/event_mail.py
@@ -34,3 +34,8 @@ class EventMailScheduler(models.Model):
                 mass_keep_log=True
             )
         return super()._execute_event_based_for_registrations(registrations)
+
+    def _template_model_by_notification_type(self):
+        info = super()._template_model_by_notification_type()
+        info["sms"] = "sms.template"
+        return info

--- a/addons/event_sms/models/event_mail_registration.py
+++ b/addons/event_sms/models/event_mail_registration.py
@@ -4,13 +4,9 @@ from odoo import fields, models
 class EventMailRegistration(models.Model):
     _inherit = 'event.mail.registration'
 
-    def execute(self):
-        now = fields.Datetime.now()
-        todo = self.filtered(lambda reg_mail:
-            not reg_mail.mail_sent and \
-            reg_mail.registration_id.state in ['open', 'done'] and \
-            (reg_mail.scheduled_date and reg_mail.scheduled_date <= now) and \
-            reg_mail.scheduler_id.notification_type == 'sms'
+    def _execute_on_registrations(self):
+        todo = self.filtered(
+            lambda r: r.scheduler_id.notification_type == "sms"
         )
         for reg_mail in todo:
             reg_mail.registration_id._message_sms_schedule_mass(
@@ -19,4 +15,5 @@ class EventMailRegistration(models.Model):
             )
         todo.write({'mail_sent': True})
 
-        return super(EventMailRegistration, self).execute()
+        return super(EventMailRegistration, self - todo)._execute_on_registrations()
+

--- a/addons/event_sms/models/event_mail_registration.py
+++ b/addons/event_sms/models/event_mail_registration.py
@@ -8,12 +8,8 @@ class EventMailRegistration(models.Model):
         todo = self.filtered(
             lambda r: r.scheduler_id.notification_type == "sms"
         )
-        for reg_mail in todo:
-            reg_mail.registration_id._message_sms_schedule_mass(
-                template=reg_mail.scheduler_id.template_ref,
-                mass_keep_log=True
-            )
-        todo.write({'mail_sent': True})
+        for scheduler, reg_mails in todo.grouped('scheduler_id').items():
+            scheduler._send_sms(reg_mails.registration_id)
+        todo.mail_sent = True
 
         return super(EventMailRegistration, self - todo)._execute_on_registrations()
-

--- a/addons/event_sms/tests/test_sms_schedule.py
+++ b/addons/event_sms/tests/test_sms_schedule.py
@@ -81,7 +81,6 @@ class TestSMSSchedule(EventCase, SMSCase):
             self.assertSMSOutgoing(
                 self.env['res.partner'], reg_sanitized_number,
                 content='%s registration confirmation.' % test_event.organizer_id.name)
-        self.assertTrue(sub_scheduler.mail_done)
         self.assertEqual(sub_scheduler.mail_count_done, 3)
 
         # clear notification queue to avoid conflicts when checking next notifications

--- a/addons/event_sms/tests/test_sms_schedule.py
+++ b/addons/event_sms/tests/test_sms_schedule.py
@@ -3,14 +3,13 @@
 
 from datetime import datetime, timedelta
 
-from odoo import fields
 from odoo.addons.event.tests.common import EventCase
 from odoo.addons.phone_validation.tools import phone_validation
 from odoo.addons.sms.tests.common import SMSCase
 from odoo.tests import tagged, users
 
 
-@tagged('event_mail')
+@tagged('event_mail', 'post_install', '-at_install')
 class TestSMSSchedule(EventCase, SMSCase):
 
     @classmethod
@@ -33,30 +32,36 @@ class TestSMSSchedule(EventCase, SMSCase):
             'lang': '{{ object.partner_id.lang }}'
         })
 
-        cls.test_event = cls.env['event.event'].create({
-            'date_begin': fields.Datetime.to_string(datetime.today() + timedelta(days=1)),
-            'date_end': fields.Datetime.to_string(datetime.today() + timedelta(days=15)),
-            'date_tz': 'Europe/Brussels',
-            'event_mail_ids': [
-                (5, 0),
-                (0, 0, {  # right at subscription
-                    'interval_unit': 'now',
-                    'interval_type': 'after_sub',
-                    'template_ref': 'sms.template,%i' % cls.sms_template_sub.id}),
-                (0, 0, {  # 3 days before event
-                    'interval_nbr': 3,
-                    'interval_unit': 'days',
-                    'interval_type': 'before_event',
-                    'template_ref': 'sms.template,%i' % cls.sms_template_rem.id}),
-            ],
-            'name': 'TestEvent',
-        })
+        cls.reference_now = datetime(2021, 3, 20, 14, 30, 15, 123456)
+        cls.event_date_begin = datetime(2021, 3, 25, 8, 0, 0)
+        cls.event_date_end = datetime(2021, 3, 27, 18, 0, 0)
+        with cls.mock_datetime_and_now(cls, cls.reference_now):
+            cls.test_event = cls.env['event.event'].create({
+                'date_begin': cls.event_date_begin,
+                'date_end': cls.event_date_end,
+                'date_tz': 'Europe/Brussels',
+                'event_mail_ids': [
+                    (5, 0),
+                    (0, 0, {  # right at subscription
+                        'interval_unit': 'now',
+                        'interval_type': 'after_sub',
+                        'notification_type': 'sms',
+                        'template_ref': 'sms.template,%i' % cls.sms_template_sub.id}),
+                    (0, 0, {  # 3 days before event
+                        'interval_nbr': 3,
+                        'interval_unit': 'days',
+                        'interval_type': 'before_event',
+                        'notification_type': 'sms',
+                        'template_ref': 'sms.template,%i' % cls.sms_template_rem.id}),
+                ],
+                'name': 'TestEvent',
+            })
 
     @users('user_eventmanager')
     def test_sms_schedule(self):
         test_event = self.env['event.event'].browse(self.test_event.ids)
 
-        with self.mockSMSGateway():
+        with self.mock_datetime_and_now(self.reference_now), self.mockSMSGateway():
             self._create_registrations(test_event, 3)
 
         # check subscription scheduler
@@ -89,7 +94,7 @@ class TestSMSSchedule(EventCase, SMSCase):
         self.assertEqual(before_scheduler.scheduled_date, test_event.date_begin + timedelta(days=-3))
 
         # execute event reminder scheduler explicitly
-        with self.mockSMSGateway():
+        with self.mock_datetime_and_now(self.reference_now + timedelta(days=3)), self.mockSMSGateway():
             before_scheduler.execute()
 
         # verify that subscription scheduler was auto-executed after each registration

--- a/addons/event_sms/tests/test_sms_schedule.py
+++ b/addons/event_sms/tests/test_sms_schedule.py
@@ -105,3 +105,10 @@ class TestSMSSchedule(EventCase, SMSCase):
                 content='%s reminder' % test_event.organizer_id.name)
         self.assertTrue(before_scheduler.mail_done)
         self.assertEqual(before_scheduler.mail_count_done, 3)
+
+    @users('user_eventmanager')
+    def test_sms_schedule_fail_registration_template_removed(self):
+        """ Test flow where scheduler fails due to template being removed. """
+        self.sms_template_sub.sudo().unlink()
+        after_sub_scheduler = self.test_event.event_mail_ids.filtered(lambda s: s.interval_type == 'after_sub')
+        self.assertFalse(after_sub_scheduler, "When removing template, scheduler should be removed")

--- a/addons/mail/models/ir_config_parameter.py
+++ b/addons/mail/models/ir_config_parameter.py
@@ -29,7 +29,12 @@ class IrConfigParameter(models.Model):
     #   - MailComposer._action_send_mail_mass_mail(): mails generation based on records
     #   - MailThread._notify_thread_by_email(): mails generation for notification emails
     #   - MailTemplate.send_mail_batch(): mails generation done directly from templates
-    #   to split mail generation in batches. 50 by default;
+    #   to split mail generation in batches;
+    #   - EventMail._execute_attendee_based() and EventMail._execute_event_based():
+    #    mails (+ sms, whatsapp) generation for each attendee of en event;
+    #    50 by default;
+    # * 'mail.render.cron.limit': used in cron involving rendering of content
+    #   and/or templates, like event mail scheduler cron. Defaults to 1000;
 
     # Mail Gateway
     #   * 'mail.gateway.loop.minutes' and 'mail.gateway.loop.threshold': block

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -41,7 +41,7 @@ class MailComposer(models.TransientModel):
     _inherit = 'mail.composer.mixin'
     _description = 'Email composition wizard'
     _log_access = True
-    _batch_size = 500
+    _batch_size = 50
 
     @api.model
     def default_get(self, fields_list):
@@ -394,7 +394,7 @@ class MailComposer(models.TransientModel):
             else:
                 active_res_ids = parse_res_ids(self.env.context.get('active_ids'), self.env)
                 # beware, field is limited in storage, usage of active_ids in context still required
-                if active_res_ids and len(active_res_ids) <= self._batch_size:
+                if active_res_ids and len(active_res_ids) <= 500:
                     composer.res_ids = f"{self.env.context['active_ids']}"
                 elif not active_res_ids and self.env.context.get('active_id'):
                     composer.res_ids = f"{[self.env.context['active_id']]}"
@@ -751,7 +751,7 @@ class MailComposer(models.TransientModel):
 
         batch_size = int(
             self.env['ir.config_parameter'].sudo().get_param('mail.batch_size')
-        ) or self._batch_size  # be sure to not have 0, as otherwise no iteration is done
+        ) or self._batch_size or 50  # be sure to not have 0, as otherwise no iteration is done
         for res_ids_iter in tools.split_every(batch_size, res_ids):
             res_ids_values = list(self._prepare_mail_values(res_ids_iter).values())
 

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -1031,7 +1031,8 @@ class MailComposer(models.TransientModel):
                  'partner_ids',
                  'report_template_ids',
                  'scheduled_date',
-                ]
+                ],
+                find_or_create_partners=self.env.context.get("mail_composer_force_partners", True),
             )
             for res_id in res_ids:
                 # remove attachments from template values as they should not be rendered

--- a/addons/sms/tests/common.py
+++ b/addons/sms/tests/common.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from contextlib import contextmanager
+from freezegun import freeze_time
 from unittest.mock import patch
 
 from odoo import exceptions, tools
@@ -15,6 +16,19 @@ class MockSMS(common.TransactionCase):
     def tearDown(self):
         super(MockSMS, self).tearDown()
         self._clear_sms_sent()
+
+    # ------------------------------------------------------------
+    # UTILITY MOCKS
+    # ------------------------------------------------------------
+
+    @contextmanager
+    def mock_datetime_and_now(self, mock_dt):
+        """ Used when synchronization date (using env.cr.now()) is important
+        in addition to standard datetime mocks. Used mainly to detect sync
+        issues. """
+        with freeze_time(mock_dt), \
+             patch.object(self.env.cr, 'now', lambda: mock_dt):
+            yield
 
     @contextmanager
     def mockSMSGateway(self, sms_allow_unlink=False, sim_error=None, nbr_t_error=None, moderated=False, force_delivered=False):

--- a/addons/sms/tests/common.py
+++ b/addons/sms/tests/common.py
@@ -30,6 +30,10 @@ class MockSMS(common.TransactionCase):
              patch.object(self.env.cr, 'now', lambda: mock_dt):
             yield
 
+    # ------------------------------------------------------------
+    # GATEWAY MOCK
+    # ------------------------------------------------------------
+
     @contextmanager
     def mockSMSGateway(self, sms_allow_unlink=False, sim_error=None, nbr_t_error=None, moderated=False, force_delivered=False):
         self._clear_sms_sent()

--- a/addons/test_event_full/tests/test_event_crm.py
+++ b/addons/test_event_full/tests/test_event_crm.py
@@ -2,9 +2,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.test_event_full.tests.common import TestEventFullCommon
-from odoo.tests import users
+from odoo.tests import tagged, users
 
 
+@tagged("event_crm")
 class TestEventCrm(TestEventFullCommon):
 
     @classmethod

--- a/addons/test_event_full/tests/test_event_mail.py
+++ b/addons/test_event_full/tests/test_event_mail.py
@@ -2,17 +2,14 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import datetime, timedelta
-from freezegun import freeze_time
 
-from odoo.addons.mail.tests.common import MockEmail
-from odoo.addons.sms.tests.common import SMSCase
-from odoo.addons.test_event_full.tests.common import TestWEventCommon, TestEventFullCommon
-from odoo.tests import tagged
+from odoo.addons.test_event_full.tests.common import TestEventFullCommon, TestEventMailCommon
+from odoo.tests import tagged, users
 from odoo.tools import formataddr
 
 
-@tagged('event_mail')
-class TestTemplateRefModel(TestWEventCommon):
+@tagged('event_mail', 'post_install', '-at_install')
+class TestEventMailInternals(TestEventMailCommon):
 
     def test_template_ref_delete_lines(self):
         """ When deleting a template, related lines should be deleted too """
@@ -54,51 +51,16 @@ class TestTemplateRefModel(TestWEventCommon):
         self.assertEqual(len(event.event_mail_ids.exists()), 0)
 
 
-class TestEventSmsMailSchedule(TestWEventCommon, MockEmail, SMSCase):
+@tagged('event_mail', 'post_install', '-at_install')
+class TestEventMailSchedule(TestEventMailCommon):
 
-    @freeze_time('2020-07-06 12:00:00')
     def test_event_mail_before_trigger_sent_count(self):
-        """ Emails are only sent to confirmed attendees.
-        This test checks that the count of sent emails does not include the emails sent to unconfirmed ones.
-
-        Time in the test is frozen to simulate the following state:
-
-                   NOW     Event Start    Event End
-                  12:00       13:00        14:00
-                    |           |            |
-            ──────────────────────────────────────►
-            |                   |                time
-            ◄─────────────────►
-                  3 hours
-              Trigger before event
-        """
-        self.sms_template_rem = self.env['sms.template'].create({
-            'name': 'Test reminder',
-            'model_id': self.env.ref('event.model_event_registration').id,
-            'body': '{{ object.event_id.organizer_id.name }} reminder',
-            'lang': '{{ object.partner_id.lang }}'
-        })
-        test_event = self.env['event.event'].create({
-            'name': 'TestEventMail',
-            # 'user_id': self.env.ref('base.user_admin').id,
-            'date_begin': datetime.now() + timedelta(hours=1),
-            'date_end': datetime.now() + timedelta(hours=2),
-            'event_mail_ids': [
-                (0, 0, {  # email 3 hours before event
-                    'interval_nbr': 3,
-                    'interval_unit': 'hours',
-                    'interval_type': 'before_event',
-                    'template_ref': 'mail.template,%i' % self.env['ir.model.data']._xmlid_to_res_id('event.event_reminder')}),
-                (0, 0, {  # sms 3 hours before event
-                    'interval_nbr': 3,
-                    'interval_unit': 'hours',
-                    'interval_type': 'before_event',
-                    'notification_type': 'sms',
-                    'template_ref': 'sms.template,%i' % self.sms_template_rem.id}),
-            ]
-        })
-        mail_scheduler = test_event.event_mail_ids
-        self.assertEqual(len(mail_scheduler), 2, 'There should be two mail schedulers. One for mail one for sms. Cannot perform test')
+        """ Emails are only sent to confirmed attendees. """
+        test_event = self.test_event
+        mail_schedulers = test_event.event_mail_ids
+        self.assertEqual(len(mail_schedulers), 6)
+        before = mail_schedulers.filtered(lambda m: m.interval_type == "before_event" and m.interval_unit == "days")
+        self.assertEqual(len(before), 2)
 
         # Add registrations
         _dummy, _dummy, open_reg, done_reg = self.env['event.registration'].create([{
@@ -127,8 +89,10 @@ class TestEventSmsMailSchedule(TestWEventCommon, MockEmail, SMSCase):
             'state': 'done',
         }])
 
-        with self.mock_mail_gateway(), self.mockSMSGateway():
-            mail_scheduler.execute()
+        with self.mock_datetime_and_now(self.event_date_begin - timedelta(days=2)), \
+             self.mock_mail_gateway(), \
+             self.mockSMSGateway():
+            before.execute()
 
         for registration in open_reg, done_reg:
             with self.subTest(registration_state=registration.state, medium='mail'):
@@ -136,7 +100,7 @@ class TestEventSmsMailSchedule(TestWEventCommon, MockEmail, SMSCase):
                     [formataddr((registration.name, registration.email))],
                     'outgoing',
                 )
-            with self.subTest(registration_state=registration.state, medium='mail'):
+            with self.subTest(registration_state=registration.state, medium='sms'):
                 self.assertSMS(
                     self.env['res.partner'],
                     registration.phone,
@@ -147,18 +111,104 @@ class TestEventSmsMailSchedule(TestWEventCommon, MockEmail, SMSCase):
 
         self.assertEqual(test_event.seats_taken, 2, 'Wrong number of seats_taken')
 
-        self.assertEqual(mail_scheduler.filtered(lambda r: r.notification_type == 'mail').mail_count_done, 2,
-            'Wrong Emails Sent Count! Probably emails sent to unconfirmed attendees were not included into the Sent Count')
-        self.assertEqual(mail_scheduler.filtered(lambda r: r.notification_type == 'sms').mail_count_done, 2,
-            'Wrong SMS Sent Count! Probably SMS sent to unconfirmed attendees were not included into the Sent Count')
+        for scheduler in before:
+            self.assertEqual(
+                scheduler.mail_count_done, 2,
+                'Wrong Emails Sent Count! Probably emails sent to unconfirmed attendees were not included into the Sent Count'
+            )
+
+    @users('user_eventmanager')
+    def test_schedule_event_scalability(self):
+        """ Test scalability / iterative work on event-based schedulers """
+        test_event = self.env['event.event'].browse(self.test_event.ids)
+        self._create_registrations(test_event, 30)
+
+        # check event-based schedulers
+        after_mail = test_event.event_mail_ids.filtered(lambda s: s.interval_type == "after_event" and s.notification_type == "mail")
+        self.assertEqual(len(after_mail), 1)
+        self.assertEqual(after_mail.mail_count_done, 0)
+        self.assertFalse(after_mail.mail_done)
+        after_sms = test_event.event_mail_ids.filtered(lambda s: s.interval_type == "after_event" and s.notification_type == "sms")
+        self.assertEqual(len(after_sms), 1)
+        self.assertEqual(after_sms.mail_count_done, 0)
+        self.assertFalse(after_sms.mail_done)
+        before_mail = test_event.event_mail_ids.filtered(lambda s: s.interval_type == "before_event" and s.notification_type == "mail")
+        self.assertEqual(len(before_mail), 1)
+        self.assertEqual(before_mail.mail_count_done, 0)
+        self.assertFalse(before_mail.mail_done)
+        before_sms = test_event.event_mail_ids.filtered(lambda s: s.interval_type == "before_event" and s.notification_type == "sms")
+        self.assertEqual(len(before_sms), 1)
+        self.assertEqual(before_sms.mail_count_done, 0)
+        self.assertFalse(before_sms.mail_done)
+
+        # launch before event schedulers -> all communications are sent
+        current_now = self.event_date_begin - timedelta(days=1)
+        with self.mock_datetime_and_now(current_now), \
+             self.mockSMSGateway(), \
+             self.mock_mail_gateway(), \
+             self.capture_triggers('event.event_mail_scheduler') as capture:
+            self.event_cron_id.method_direct_trigger()
+
+        self.assertEqual(after_mail.mail_count_done, 0)
+        self.assertFalse(after_mail.mail_done)
+        self.assertEqual(after_sms.mail_count_done, 0)
+        self.assertFalse(after_sms.mail_done)
+        self.assertEqual(before_mail.mail_count_done, 30)
+        self.assertTrue(before_mail.mail_done)
+        self.assertEqual(before_sms.mail_count_done, 30)
+        self.assertTrue(before_sms.mail_done)
+        self.assertFalse(capture.records)
+
+        # launch after event schedulers -> all communications are sent
+        current_now = self.event_date_end + timedelta(hours=1)
+        with self.mock_datetime_and_now(current_now), \
+             self.mockSMSGateway(), \
+             self.mock_mail_gateway(), \
+             self.capture_triggers('event.event_mail_scheduler') as capture:
+            self.event_cron_id.method_direct_trigger()
+
+        self.assertEqual(after_mail.mail_count_done, 30)
+        self.assertTrue(after_mail.mail_done)
+        self.assertEqual(after_sms.mail_count_done, 30)
+        self.assertTrue(after_sms.mail_done)
+        self.assertEqual(before_mail.mail_count_done, 30)
+        self.assertTrue(before_mail.mail_done)
+        self.assertEqual(before_sms.mail_count_done, 30)
+        self.assertTrue(before_sms.mail_done)
+        self.assertFalse(capture.records)
+
+    @users('user_eventmanager')
+    def test_schedule_subscription_scalability(self):
+        """ Test scalability / iterative work on subscription-based schedulers """
+        test_event = self.env['event.event'].browse(self.test_event.ids)
+
+        sub_mail = test_event.event_mail_ids.filtered(lambda s: s.interval_type == "after_sub" and s.interval_unit == "now" and s.notification_type == "mail")
+        self.assertEqual(len(sub_mail), 1)
+        self.assertEqual(sub_mail.mail_count_done, 0)
+        self.assertFalse(sub_mail.mail_done)
+        sub_sms = test_event.event_mail_ids.filtered(lambda s: s.interval_type == "after_sub" and s.interval_unit == "now" and s.notification_type == "sms")
+        self.assertEqual(len(sub_sms), 1)
+        self.assertEqual(sub_sms.mail_count_done, 0)
+        self.assertFalse(sub_sms.mail_done)
+
+        # create registrations -> each one receives its on subscribe communication
+        with self.mock_datetime_and_now(self.reference_now + timedelta(hours=1)), \
+             self.mockSMSGateway(), \
+             self.mock_mail_gateway(), \
+             self.capture_triggers('event.event_mail_scheduler') as capture:
+            self._create_registrations(test_event, 30)
+        self.assertEqual(sub_mail.mail_count_done, 30)
+        self.assertEqual(sub_sms.mail_count_done, 30)
+        self.assertFalse(capture.records)
 
 
-@tagged('event_mail')
-class TestEventSaleMailSchedule(TestEventFullCommon):
+@tagged('event_mail', 'post_install', '-at_install')
+class TestEventSaleMail(TestEventFullCommon):
 
     def test_event_mail_on_sale_confirmation(self):
         """Test that a mail is sent to the customer when a sale order is confirmed."""
         ticket = self.test_event.event_ticket_ids[0]
+        self.test_event.env.company.partner_id.email = 'test.email@test.example.com'
         order_line_vals = {
             "event_id": self.test_event.id,
             "event_ticket_id": ticket.id,
@@ -166,6 +216,14 @@ class TestEventSaleMailSchedule(TestEventFullCommon):
             "product_uom_qty": 1,
         }
         self.customer_so.write({"order_line": [(0, 0, order_line_vals)]})
+
+        # check sale mail configuration
+        aftersub = self.test_event.event_mail_ids.filtered(
+            lambda m: m.interval_type == "after_sub"
+        )
+        self.assertTrue(aftersub)
+        aftersub.template_ref.email_from = "{{ (object.event_id.organizer_id.email_formatted or object.event_id.user_id.email_formatted or '') }}"
+        self.assertEqual(self.test_event.organizer_id, self.test_event.env.company.partner_id)
 
         registration = self.env["event.registration"].create(
             {
@@ -188,5 +246,8 @@ class TestEventSaleMailSchedule(TestEventFullCommon):
             registration,
             [self.event_customer.id],
             "outgoing",
-            author=self.env.user.company_id.partner_id,
+            author=self.test_event.organizer_id,
+            fields_values={
+                "email_from": self.test_event.organizer_id.email_formatted,
+            },
         )

--- a/addons/test_event_full/tests/test_event_mail.py
+++ b/addons/test_event_full/tests/test_event_mail.py
@@ -233,11 +233,9 @@ class TestEventMailSchedule(TestEventMailCommon):
         sub_mail = test_event.event_mail_ids.filtered(lambda s: s.interval_type == "after_sub" and s.interval_unit == "now" and s.notification_type == "mail")
         self.assertEqual(len(sub_mail), 1)
         self.assertEqual(sub_mail.mail_count_done, 0)
-        self.assertFalse(sub_mail.mail_done)
         sub_sms = test_event.event_mail_ids.filtered(lambda s: s.interval_type == "after_sub" and s.interval_unit == "now" and s.notification_type == "sms")
         self.assertEqual(len(sub_sms), 1)
         self.assertEqual(sub_sms.mail_count_done, 0)
-        self.assertFalse(sub_sms.mail_done)
 
         # setup batch and cron limit sizes to check iterative behavior
         batch_size, cron_limit = 5, 20
@@ -275,9 +273,7 @@ class TestEventMailSchedule(TestEventMailCommon):
 
         # finished sending communications
         self.assertEqual(sub_mail.mail_count_done, 30)
-        self.assertTrue(sub_mail.mail_done)
         self.assertEqual(sub_sms.mail_count_done, 30)
-        self.assertTrue(sub_sms.mail_done)
         self.assertFalse(capture.records)
         self.assertEqual(mock_exec.call_count, 4, "Batch of 5 to make 10 remaining registrations: 2 calls / scheduler")
 

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -3028,7 +3028,7 @@ class TestComposerResultsMass(TestMailComposer):
             composer = composer_form.save()
             self.assertTrue(composer.composition_batch)
             self.assertEqual(composer.composition_mode, 'mass_mail')
-            self.assertFalse(composer.res_ids)
+            self.assertEqual(sorted(literal_eval(composer.res_ids)), sorted(self.test_records.ids))
 
             with self.mock_mail_gateway(mail_unlink_sent=True):
                 composer._action_send_mail()

--- a/addons/website_event_crm/tests/test_visitor_propagation.py
+++ b/addons/website_event_crm/tests/test_visitor_propagation.py
@@ -39,6 +39,6 @@ class TestWebsiteEventCrmFlow(TestEventCrmCommon):
                 'email': 'test2@test.example.com',
             },
         ])
-        leads = test_lang_registration1.lead_ids | test_lang_registration2.lead_ids
+        leads = test_lang_registration1.sudo().lead_ids | test_lang_registration2.sudo().lead_ids
         self.assertEqual(leads.visitor_ids, test_lang_visitor)
         self.assertEqual(leads.lang_id, test_lang_visitor.lang_id)

--- a/addons/website_event_track/data/mail_template_data.xml
+++ b/addons/website_event_track/data/mail_template_data.xml
@@ -4,6 +4,7 @@
         <field name="name">Event: Track Confirmation</field>
         <field name="model_id" ref="website_event_track.model_event_track"/>
         <field name="subject">Confirmation of {{ object.name }}</field>
+        <field name="email_from">{{ (object.event_id.organizer_id.email_formatted or object.event_id.company_id.email_formatted or user.email_formatted or '') }}</field>
         <field name="use_default_to" eval="True"/>
         <field name="description">Sent to speakers whose track proposal is accepted (set the template on the right stage)</field>
         <field name="body_html" type="html">


### PR DESCRIPTION
RATIONALE

When invoked through cron, event schedulers currently run on all available
registrations. This can lead to Memory or Time errors when dealing with
big events. We should instead move towards an interactive sending, committing
after each batch, to gradually send communications without errors and without
sending multiple times mails, sms, whatsapp messages, ...

SPECIFICATIONS

Global approach for this PR

  * rewrite schedulers execution code, notably to have more control on
    input / output of each type: event-based or attendee-based schedulers,
    give registrations to contact as input, ... ;
  * introduce more performance oriented code: avoid filters on all attendees,
    search for batches instead; find once attendees to contact then;
    delegate the sending only to sub modules;
  * make communications iterative

    * event-based: use recently introduced "last_registration_id" field to know
      at which point process was stopped, and resume communication sending;
    * attendee-based: contact by batches;

  * make code more defensive against ill defined templates and issues during
    communication sending;
  * add / improve tests;

See sub commits for more details.

Task-3814592: Event: Limit scheduler in cron mode
Task-3084943: Event: Improve communication scheduler scalability