### PR TITLE
[FIX] website: fix website backend menu tour

### DIFF
--- a/addons/website/static/tests/tours/website_backend_menus_redirect.js
+++ b/addons/website/static/tests/tours/website_backend_menus_redirect.js
@@ -26,7 +26,9 @@ registry.category("web_tour.tours").add('website_backend_menus_redirect', {
 }, {
     isActive: ["community"],
     content: 'Check that we landed on the apps page (Apps), and not the Home Action page (Settings)',
-    trigger: '.oe_module_vignette',
-    run: "click",
+    // It cannot be the name of the menu here, as that would still be displayed
+    // even when the default home action would be loaded. So instead, use a
+    // class used by the Apps Kanban.
+    trigger: '.oe_module_flag:not(:visible)',
 }
 ]});


### PR DESCRIPTION
Commit [1] introduced a test that checks if, when a Home Action is set,
clicking on the menu element of the "backend" menu in the website
frontend will properly redirect to the menu's child action, and not to
the Home Action.

It did so by checking whether we land on the "Apps" action instead of
the settings action and it checked it using a CSS class used inside that
kanban view.

However, commit [2] changed that Kanban view, removing that class.

This commit fixes this by changing the class back to something that is
used inside that kanban view.

[1]: https://github.com/odoo/odoo/commit/3fec4bb44829f22ed8466772613b44b1a3e57f76
[2]: https://github.com/odoo/odoo/commit/8ec9db10321b924c0154a5015bacb9b63c5740c1

runbot-74690