### PR TITLE
[FIX] account,l10n: remove useless invisible uncommented field

### DIFF
--- a/addons/account/wizard/account_move_reversal_view.xml
+++ b/addons/account/wizard/account_move_reversal_view.xml
@@ -6,11 +6,6 @@
             <field name="model">account.move.reversal</field>
             <field name="arch" type="xml">
                 <form string="Reverse Journal Entry">
-                    <field name="residual" invisible="1"/>
-                    <field name="company_id" invisible="1"/>
-                    <field name="move_ids" invisible="1"/>
-                    <field name="move_type" invisible="1"/>
-                    <field name="available_journal_ids" invisible="1"/>
                     <group>
                         <field name="reason" invisible="move_type == 'entry'"/>
                         <field name="journal_id" domain="[('id', 'in', available_journal_ids)]"/>

--- a/addons/l10n_latam_invoice_document/wizards/account_move_reversal_view.xml
+++ b/addons/l10n_latam_invoice_document/wizards/account_move_reversal_view.xml
@@ -6,12 +6,7 @@
         <field name="model">account.move.reversal</field>
         <field name="inherit_id" ref="account.view_account_move_reversal"/>
         <field name="arch" type="xml">
-            <form>
-                <field name="l10n_latam_use_documents" invisible="1"/>
-                <field name="l10n_latam_manual_document_number" invisible="1"/>
-            </form>
             <field name="date" position="before">
-                <field name="l10n_latam_available_document_type_ids" invisible="1"/>
                 <field name="l10n_latam_document_type_id" invisible="not l10n_latam_use_documents" required="l10n_latam_use_documents" options="{'no_open': True, 'no_create': True}"/>
                 <field name="l10n_latam_document_number" invisible="not l10n_latam_use_documents or not l10n_latam_manual_document_number" required="l10n_latam_manual_document_number and l10n_latam_use_documents"/>
             </field>

--- a/addons/l10n_pe/data/res_country_data.xml
+++ b/addons/l10n_pe/data/res_country_data.xml
@@ -7,9 +7,6 @@
         <field name="arch" type="xml">
             <form>
                 <div class="o_address_format">
-                    <field name="country_enforce_cities" invisible="1"/>
-                    <field name="parent_id" invisible="1"/>
-                    <field name="type" invisible="1"/>
                     <field name="street" placeholder="Street..." class="o_address_street"
                            readonly="type == 'contact' and parent_id"/>
                     <field name="street2" placeholder="Street 2..." class="o_address_street"


### PR DESCRIPTION
The error is detected by the `test_uncommented_invisible_field` test. Invisible fields are not commented and seem useless (fields are added automatically if they are used for modifiers)

runbot build error: 62493
