### PR TITLE
[FIX] pos_restaurant: show FloorScreen after order cancelation

### DIFF
--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -38,7 +38,7 @@ patch(PosStore.prototype, {
     afterOrderDeletion() {
         if (
             this.config.module_pos_restaurant &&
-            !this.mainScreen.component.name === "TicketScreen"
+            this.mainScreen.component.name !== "TicketScreen"
         ) {
             return this.showScreen("FloorScreen");
         }


### PR DESCRIPTION
In `pos_restaurant`, when using the "Cancel Order" control button, the user is supposed to be shown the floor screen after the order is canceled. Instead, they are now shown simply a different order from a different table, which is wrong.

In this commit we fix the issue.

Task: 4126929




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
