### PR TITLE
[IMP] mail: general setting should mute a channel

### DIFF
--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -353,6 +353,10 @@ export class Thread extends Record {
         return this.selfMember?.message_unread_counter > 0 || this.needactionMessages.length > 0;
     }
 
+    get isMuted() {
+        return this.mute_until_dt || this.store.settings.mute_until_dt;
+    }
+
     get typesAllowingCalls() {
         return ["chat", "channel", "group"];
     }

--- a/addons/mail/static/src/discuss/core/common/notification_settings.js
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.js
@@ -1,8 +1,20 @@
-import { Component, useState } from "@odoo/owl";
+import { Component, useState, xml } from "@odoo/owl";
 import { ActionPanel } from "@mail/discuss/core/common/action_panel";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { useService } from "@web/core/utils/hooks";
+import { DiscussNotificationSettingsClientAction } from "./discuss_notification_settings_client_action";
+import { Dialog } from "@web/core/dialog/dialog";
+
+class NotificationDialog extends Component {
+    static props = ["close?"];
+    static components = { Dialog, DiscussNotificationSettingsClientAction };
+    static template = xml`
+        <Dialog size="'md'" footer="false">
+            <DiscussNotificationSettingsClientAction/>
+        </Dialog>
+    `;
+}
 
 export class NotificationSettings extends Component {
     static components = { ActionPanel, Dropdown, DropdownItem };
@@ -11,10 +23,15 @@ export class NotificationSettings extends Component {
 
     setup() {
         this.store = useState(useService("mail.store"));
+        this.dialog = useService("dialog");
     }
 
     setMute(minutes) {
         this.store.settings.setMuteDuration(minutes, this.props.thread);
         this.props.close?.();
+    }
+
+    onClickServerMuted() {
+        this.dialog.add(NotificationDialog);
     }
 }

--- a/addons/mail/static/src/discuss/core/common/notification_settings.xml
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.xml
@@ -4,6 +4,9 @@
     <t t-name="discuss.NotificationSettings">
         <ActionPanel title.translate="Notification Settings">
             <div class="o-discuss-NotificationSettings">
+                <div t-if="store.settings.mute_until_dt" class="d-flex flex-column alert alert-warning">
+                    <span><i class="fa fa-exclamation-triangle"/> <a href="#" t-on-click="onClickServerMuted">Server is muted</a></span>
+                </div>
                 <t t-if="props.thread.mute_until_dt">
                     <button class="btn w-100 d-flex p-1 opacity-75 opacity-100-hover" t-on-click="()=>this.setMute(false)">
                         <div class="d-flex flex-column flex-grow-1 px-2 py-1 w-100 rounded">

--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -40,12 +40,12 @@ threadActionsRegistry
         },
         component: NotificationSettings,
         icon(component) {
-            return component.thread.mute_until_dt
+            return component.thread.isMuted
                 ? "fa fa-fw text-danger fa-bell-slash"
                 : "fa fa-fw fa-bell";
         },
         iconLarge(component) {
-            return component.thread.mute_until_dt
+            return component.thread.isMuted
                 ? "fa fa-fw fa-lg text-danger fa-bell-slash"
                 : "fa fa-fw fa-lg fa-bell";
         },

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
@@ -39,7 +39,7 @@ export class DiscussSidebarChannel extends Component {
             "bg-inherit": this.thread.notEq(this.store.discuss.thread),
             "o-active": this.thread.eq(this.store.discuss.thread),
             "o-unread":
-                this.thread.selfMember?.message_unread_counter > 0 && !this.thread.mute_until_dt,
+                this.thread.selfMember?.message_unread_counter > 0 && !this.thread.isMuted,
             "opacity-50": this.thread.mute_until_dt,
             "position-relative justify-content-center mx-2 o-compact":
                 this.store.discuss.isSidebarCompact,

--- a/addons/mail/static/src/discuss/core/web/messaging_menu_patch.js
+++ b/addons/mail/static/src/discuss/core/web/messaging_menu_patch.js
@@ -26,8 +26,7 @@ patch(MessagingMenu.prototype, {
                 : Object.values(this.store.Thread.records).filter(
                       (thread) =>
                           thread.displayToSelf &&
-                          !thread.mute_until_dt &&
-                          !this.store.settings.mute_until_dt &&
+                          !thread.isMuted &&
                           (thread.selfMember?.message_unread_counter ||
                               thread.message_needaction_counter)
                   ).length;


### PR DESCRIPTION
Before this PR, the general mute server setting was not properly accounted for when determining if a thread was muted or not.
This PR introduces a `isMuted` property that solves this issue.


