### PR TITLE
[FIX] portal, point_of_sale: return new instance of fields list

### DIFF
--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -182,7 +182,7 @@ class PosController(PortalAccount):
                 # Check that the billing information of the user are filled.
                 error, error_message = {}, []
                 partner = request.env.user.partner_id
-                for field in self.MANDATORY_BILLING_FIELDS:
+                for field in self._get_mandatory_fields():
                     if not partner[field]:
                         error[field] = 'error'
                         error_message.append(_('The %s must be filled in your details.', request.env['ir.model.fields']._get('res.partner', field).field_description))
@@ -235,8 +235,8 @@ class PosController(PortalAccount):
         # If the user is not connected, then we will simply create a new partner with the form values.
         # Matching with existing partner was tried, but we then can't update the values, and it would force the user to use the ones from the first invoicing.
         if request.env.user._is_public() and not pos_order.partner_id.id:
-            partner_values.update({key: kwargs[key] for key in self.MANDATORY_BILLING_FIELDS})
-            partner_values.update({key: kwargs[key] for key in self.OPTIONAL_BILLING_FIELDS if key in kwargs})
+            partner_values.update({key: kwargs[key] for key in self._get_mandatory_fields()})
+            partner_values.update({key: kwargs[key] for key in self._get_optional_fields() if key in kwargs})
             for field in {'country_id', 'state_id'} & set(partner_values.keys()):
                 try:
                     partner_values[field] = int(partner_values[field])

--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -133,8 +133,8 @@ def _build_url_w_params(url_string, query_params, remove_duplicates=True):
 
 class CustomerPortal(Controller):
 
-    MANDATORY_BILLING_FIELDS = ["name", "phone", "email", "street", "city", "country_id"]
-    OPTIONAL_BILLING_FIELDS = ["zipcode", "state_id", "vat", "company_name"]
+    MANDATORY_BILLING_FIELDS = ["name", "phone", "email", "street", "city", "country_id"]   # TODO master: delete
+    OPTIONAL_BILLING_FIELDS = ["zipcode", "state_id", "vat", "company_name"]    # TODO master: delete
 
     _items_per_page = 80
 
@@ -420,11 +420,11 @@ class CustomerPortal(Controller):
 
     def _get_mandatory_fields(self):
         """ This method is there so that we can override the mandatory fields """
-        return self.MANDATORY_BILLING_FIELDS
+        return list(self.MANDATORY_BILLING_FIELDS)
 
     def _get_optional_fields(self):
         """ This method is there so that we can override the optional fields """
-        return self.OPTIONAL_BILLING_FIELDS
+        return list(self.OPTIONAL_BILLING_FIELDS)
 
     def _document_check_access(self, model_name, document_id, access_token=None):
         """Check if current user is allowed to access the specified record.


### PR DESCRIPTION
Since [1], the `MANDATORY_BILLING_FIELDS` are now returned through
the method `/portal._get_mandatory_fields`:
https://github.com/odoo/odoo/blob/b454a060a41961b7e0c9cc1ee6ec77b5cca1ec75/addons/portal/controllers/portal.py#L421-L423
Where `MANDATORY_BILLING_FIELDS` is a list defined on the class:
https://github.com/odoo/odoo/blob/b454a060a41961b7e0c9cc1ee6ec77b5cca1ec75/addons/portal/controllers/portal.py#L134-L136
This is a problem: the value is an object, so if the list is modified
during a call, the method will then return that modified list
instead of the initial one.

For instance, in `l10n_ec_website_sale`, we add some values to that
list:
https://github.com/odoo/odoo/blob/10b7c27a4fc873c6220d63a0686f484e92ae906b/addons/l10n_ec_website_sale/controllers/portal.py#L14-L17
Then, if we call again `_get_mandatory_fields` with a company that
is not EC, we will still have `l10n_latam_identification_type_id`
and `vat` in the list of mandatory fields. That is incorrect.

Looking at builds on runbot, some of them failed because of that error.
This is the case with the FW of [2] on 17.4 which is blocked because
of the above issue. Indeed, this commit contains a tour that
checkouts a cart with an EC company. And, in 17.4, this flow leads
to a call of `_get_mandatory_fields`. As explained, we will therefore
add the EC mandatory fields. So, if [2] is part of the code, and if we
try to run this:
`--test-tags=.test_checkout_address_ec,.test_qr_code_receipt_mx`
Where the first test comes from [2] and the second one is an
existing test in the code, it will fail: the first test will add
some values in `MANDATORY_BILLING_FIELDS`. Then, during the second
test, at some point we also check the mandatory fields: the method
will return the modified list (i.e., with the EC fields), and we will
not have any value for these unexpected fields -> the test will fail

[1] 9b9b0ee4c2d8a8a66e5e0456acbb780e5d8d6456
[2] 732b4fbbf3009769708f9c9cba57609d22f2a570
