### PR TITLE
[IMP] website: add support for Google Consent mode V2

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -2016,3 +2016,17 @@ class Website(models.Model):
                         if isinstance(value, str):
                             value = value.lower()
                             yield from re.findall(match_pattern, value)
+
+    def _allConsentsGranted(self):
+        """
+        Checks if all (cookies) consents have been granted. Note that in the
+        case no cookies bar has been enabled, this considers that full consent
+        has been immediately given. Indeed, in that case, we suppose that the
+        user implemented his own consent behavior through custom code / app.
+        That custom code / app is able to override this function as desired and
+        xpath the `tracking_code_config` script in `website.layout`.
+
+        :return: True if all consents have been granted, False otherwise
+        """
+        self.ensure_one()
+        return not self.cookies_bar or self.env['ir.http']._is_allowed_cookie('optional')

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -197,11 +197,35 @@
     <xpath expr="//div[@id='wrapwrap']" position="after">
         <t t-if="website.google_analytics_key and not editable">
             <script id="tracking_code" t-attf-src="https://www.googletagmanager.com/gtag/js?id={{ website.google_analytics_key }}" async="async"/>
-            <script>
+            <script id="tracking_code_config">
                 window.dataLayer = window.dataLayer || [];
                 function gtag(){dataLayer.push(arguments);}
+                gtag('consent', 'default', {
+                    'ad_storage': 'denied',
+                    'ad_user_data': 'denied',
+                    'ad_personalization': 'denied',
+                    'analytics_storage': 'denied',
+                });
                 gtag('js', new Date());
                 gtag('config', '<t t-esc="website.google_analytics_key"/>');
+                function allConsentsGranted() {
+                    gtag('consent', 'update', {
+                        'ad_storage': 'granted',
+                        'ad_user_data': 'granted',
+                        'ad_personalization': 'granted',
+                        'analytics_storage': 'granted',
+                    });
+                }
+                <t t-if="website._allConsentsGranted()">
+                    allConsentsGranted();
+                </t>
+                <t t-else="">
+                    document.addEventListener(
+                        "optionalCookiesAccepted",
+                        allConsentsGranted,
+                        {once: true}
+                    );
+                </t>
             </script>
         </t>
         <t t-if="website.plausible_shared_key and not editable">


### PR DESCRIPTION
To abide by EU laws, Google set up their Consent mode V2, which is a way to let them know, when using Analytics, when a user has granted their consent. This also impacts websites outside of the EU, as they could be accessed by EU citizens / from the EU.
This commit makes sure the Consent mode is properly implemented when a Google Analytics key is added in the settings.

task-3880544