### PR TITLE
[DRAFT][FIX] account: Remove depends chain account.code -> account.reconcile

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4833,7 +4833,7 @@ class BaseModel(metaclass=MetaModel):
                 # If a field is not stored, its inverse method will probably
                 # write on its dependencies, which will invalidate the field on
                 # all records. We therefore inverse the field record by record.
-                if all(field.store or field.company_dependent for field in fields):
+                if all(field.store or not field._depends for field in fields):
                     batches = [rec_vals]
                 else:
                     batches = [[rec_data] for rec_data in rec_vals]


### PR DESCRIPTION
To reproduce:
1. Open the 'Outstanding Receipts' account in any DB
2. Change its code
3. Notice how the 'Reconcile' checkbox is unchecked.

Analysis:
Since #94171 (merged in 15.5), there is a dependency chain `code` -> `account_type` -> `reconcile`.

As such, changing the code will cause `reconcile` to be recomputed even if the account type was not changed.

Because the Outstanding Receipts has account type `asset_current`, which by default is not reconcilable, it's changed back to not-reconcilable any time the code is changed.

The solution in master, since we now have an inverse method for `code`, is to remove the dependency and compute the account type in the inverse.

We will see, depending on the complexity, whether we do a similar fix in earlier versions.

taskid: none