### PR TITLE
[FIX] point_of_sale: correctly map account from fiscal position

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -802,8 +802,9 @@ class PosSession(models.Model):
                         .filtered(lambda m: not bool(m.origin_returned_move_id and sum(m.stock_valuation_layer_ids.mapped('quantity')) >= 0))\
                         .mapped('stock_valuation_layer_ids')
                     for move in stock_moves_batch.with_context(candidates_prefetch_ids=candidates._prefetch_ids):
-                        exp_key = move.product_id._get_product_accounts()['expense']
-                        out_key = move.product_id.categ_id.property_stock_account_output_categ_id
+                        fpos = order_line.order_id.fiscal_position_id
+                        exp_key = fpos.map_account(move.product_id._get_product_accounts()['expense'])
+                        out_key = fpos.map_account(move.product_id.categ_id.property_stock_account_output_categ_id)
                         signed_product_qty = move.product_qty
                         if move._is_in():
                             signed_product_qty *= -1

--- a/addons/point_of_sale/tests/test_pos_stock_account.py
+++ b/addons/point_of_sale/tests/test_pos_stock_account.py
@@ -262,3 +262,39 @@ class TestPoSStock(TestPoSCommon):
         self.pos_session.action_pos_session_validate()
         expense_account_move_line = self.env['account.move.line'].search([('account_id', '=', self.expense_account.id)])
         self.assertEqual(expense_account_move_line.balance, 0.0, "Expense account should be 0.0")
+
+    def test_fiscal_position_account_mapping_stock_valuation(self):
+        self.categ4 = self.env['product.category'].create({
+            'name': 'Category 4',
+            'property_cost_method': 'fifo',
+            'property_valuation': 'real_time',
+        })
+        income_account_id = self.categ4.property_account_income_categ_id.id
+        expense_account_id = self.categ4.property_account_expense_categ_id.id
+        dest_account = self.env['account.account'].search([], limit=1)[0]
+        fiscal_position = self.env['account.fiscal.position'].create({
+            'name': 'test fp',
+            'account_ids': [
+                (0, None, {
+                    'account_src_id': income_account_id,
+                    'account_dest_id': dest_account.id,
+                }),
+                (0, None, {
+                    'account_src_id': expense_account_id,
+                    'account_dest_id': dest_account.id,
+                }),
+            ],
+        })
+
+        self.product4 = self.create_product('Product 4', self.categ4, 30.0)
+
+        self.open_new_session()
+        orders = []
+        orders.append(self.create_ui_order_data([(self.product4, 1)]))
+        orders[0]['data']['fiscal_position_id'] = fiscal_position.id
+        self.env['pos.order'].create_from_ui(orders)
+
+        self.pos_session.action_pos_session_validate()
+        session_move_accounts = self.pos_session.move_id.invoice_line_ids.mapped("account_id.id")
+        self.assertTrue(income_account_id not in session_move_accounts)
+        self.assertTrue(expense_account_id not in session_move_accounts)


### PR DESCRIPTION
When using a fiscal position that map account. If you use automatic stock valuation and make an order in the PoS, the account used where not mapped correctly for all the account move lines.

Steps to reproduce:
-------------------
* Turn on automatic stock valuation for the category `All`
* The category use account A and account B for expense and income
* Create a fiscal position that matches account A and B to any other account
* Open PoS and make an order
> Observation: Go back to the order and look at the move lines linked to
  the order. One of the lines still use an account that hasn't been mapped

Why the fix:
------------
We make sure that when creating the stock valuation lines the account are correctly mapped using `order_id.fiscal_position_id.map_account`

opw-4086609
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
