### PR TITLE
[FIX] mail: disable screen-sharing in mobile OS

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_action_list.js
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.js
@@ -27,7 +27,7 @@ export class CallActionList extends Component {
             icon: "fa fa-fw fa-hand-paper-o",
             onSelect: (ev) => this.onClickRaiseHand(ev),
         });
-        if (isMobileOS) {
+        if (!isMobileOS()) {
             acts.push({
                 id: "shareScreen",
                 name: !this.rtc.state.sendScreen ? _t("Share Screen") : _t("Stop Sharing Screen"),

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -13,9 +13,9 @@ import {
     step,
     triggerEvents,
 } from "@mail/../tests/mail_test_helpers";
-import { describe, test } from "@odoo/hoot";
+import { describe, expect, test } from "@odoo/hoot";
 import { hover, queryFirst } from "@odoo/hoot-dom";
-import { animationFrame } from "@odoo/hoot-mock";
+import { animationFrame, mockUserAgent } from "@odoo/hoot-mock";
 import {
     Command,
     mockService,
@@ -24,6 +24,7 @@ import {
 } from "@web/../tests/web_test_helpers";
 
 import { browser } from "@web/core/browser/browser";
+import { isMobileOS } from "@web/core/browser/feature_detection";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -49,6 +50,10 @@ test("basic rendering", async () => {
     await contains("[title='Raise Hand']");
     await contains("[title='Share Screen']");
     await contains("[title='Enter Full Screen']");
+    // screen sharing not available in mobile OS
+    mockUserAgent("Chrome/0.0.0 Android (OdooMobile; Linux; Android 13; Odoo TestSuite)");
+    expect(isMobileOS()).toBe(true);
+    await contains("[title='Share Screen']", { count: 0 });
 });
 
 test("keep the `more` popover active when hovering it", async () => {


### PR DESCRIPTION
This feature is not available in mobile OS at the time of this commit [1]:

- Safari on iOS 17.5
- Chrome for Android 127
- Firefox for Android 127

Therefore the button should not be shown, otherwise it mistakenly gives the impression that user could make it work by enabling screen-sharing permission which is not possible on mobile OS.

opw-4108833

[1]: https://caniuse.com/mdn-api_mediadevices_getdisplaymedia

<img width="333" alt="Screenshot 2024-08-21 at 13 26 13" src="https://github.com/user-attachments/assets/ead3281d-2ef4-412e-8d4f-edab4a85b1e9">