### PR TITLE
[FIX] mail: disable screen-sharing in mobile OS

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_action_list.js
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.js
@@ -29,7 +29,7 @@ export class CallActionList extends Component {
             icon: "fa fa-fw fa-hand-paper-o",
             onSelect: (ev) => this.onClickRaiseHand(ev),
         });
-        if (isMobileOS) {
+        if (!isMobileOS()) {
             acts.push({
                 id: "shareScreen",
                 name: !this.rtc.state.sendScreen ? _t("Share Screen") : _t("Stop Sharing Screen"),


### PR DESCRIPTION
This feature is not available in mobile OS at the time of this commit [1]:

- Safari on iOS 17.5
- Chrome for Android 127
- Firefox for Android 127

Therefore the button should not be shown, otherwise it mistakenly gives the impression that user could make it work by enabling screen-sharing permission which is not possible on mobile OS.

opw-4108833

[1]: https://caniuse.com/mdn-api_mediadevices_getdisplaymedia

<img width="333" alt="Screenshot 2024-08-21 at 13 26 13" src="https://github.com/user-attachments/assets/ead3281d-2ef4-412e-8d4f-edab4a85b1e9">
