### PR TITLE
[FIX] mail: disable screen-sharing in mobile OS

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_actions.js
+++ b/addons/mail/static/src/discuss/call/common/call_actions.js
@@ -1,4 +1,5 @@
 import { useComponent, useState } from "@odoo/owl";
+import { isMobileOS } from "@web/core/browser/feature_detection";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
@@ -57,7 +58,7 @@ callActionsRegistry
         sequence: 40,
     })
     .add("share-screen", {
-        condition: (component) => component.rtc,
+        condition: (component) => component.rtc && !isMobileOS(),
         name: (component) =>
             component.rtc.selfSession.isScreenSharingOn
                 ? _t("Stop Sharing Screen")
@@ -119,13 +120,15 @@ function transformAction(component, id, action) {
 
 export function useCallActions() {
     const component = useComponent();
-    const transformedActions = callActionsRegistry
+    const state = useState({ actions: [] });
+    state.actions = callActionsRegistry
         .getEntries()
         .map(([id, action]) => transformAction(component, id, action));
-    const state = useState({
-        actions: transformedActions
-            .filter((action) => action.condition)
-            .sort((a1, a2) => a1.sequence - a2.sequence),
-    });
-    return state;
+    return {
+        get actions() {
+            return state.actions
+                .filter((action) => action.condition)
+                .sort((a1, a2) => a1.sequence - a2.sequence);
+        },
+    };
 }

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -15,9 +15,9 @@ import {
 } from "@mail/../tests/mail_test_helpers";
 import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
 
-import { describe, test } from "@odoo/hoot";
+import { describe, expect, test } from "@odoo/hoot";
 import { hover, queryFirst } from "@odoo/hoot-dom";
-import { animationFrame } from "@odoo/hoot-mock";
+import { animationFrame, mockUserAgent } from "@odoo/hoot-mock";
 import {
     Command,
     mockService,
@@ -26,6 +26,7 @@ import {
 } from "@web/../tests/web_test_helpers";
 
 import { browser } from "@web/core/browser/browser";
+import { isMobileOS } from "@web/core/browser/feature_detection";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -51,6 +52,10 @@ test("basic rendering", async () => {
     await contains("[title='Raise Hand']");
     await contains("[title='Share Screen']");
     await contains("[title='Enter Full Screen']");
+    // screen sharing not available in mobile OS
+    mockUserAgent("Chrome/0.0.0 Android (OdooMobile; Linux; Android 13; Odoo TestSuite)");
+    expect(isMobileOS()).toBe(true);
+    await contains("[title='Share Screen']", { count: 0 });
 });
 
 test("keep the `more` popover active when hovering it", async () => {


### PR DESCRIPTION
This feature is not available in mobile OS at the time of this commit [1]:

- Safari on iOS 17.5
- Chrome for Android 127
- Firefox for Android 127

Therefore the button should not be shown, otherwise it mistakenly gives the impression that user could make it work by enabling screen-sharing permission which is not possible on mobile OS.

opw-4108833

[1]: https://caniuse.com/mdn-api_mediadevices_getdisplaymedia

<img width="333" alt="Screenshot 2024-08-21 at 13 26 13" src="https://github.com/user-attachments/assets/ead3281d-2ef4-412e-8d4f-edab4a85b1e9">