### PR TITLE
[FIX] pos_self_order: always create an order now button

### DIFF
--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -94,33 +94,44 @@ class PosConfig(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
+        self._prepare_self_order_splash_screen(vals_list)
         pos_config_ids = super().create(vals_list)
-        pos_config_ids._configure_pos_config()
+        pos_config_ids._prepare_self_order_custom_btn()
         return pos_config_ids
 
-    def _configure_pos_config(self):
-        for pos_config_id in self:
-            for image_name in ['landing_01.jpg', 'landing_02.jpg', 'landing_03.jpg']:
-                image_path = opj("pos_self_order/static/img", image_name)
-                attachment = self.env['ir.attachment'].create({
+    @api.model
+    def _prepare_self_order_splash_screen(self, vals_list):
+        for vals in vals_list:
+            if not vals.get('self_ordering_mode'):
+                return True
+
+            if not vals.get('self_ordering_image_home_ids'):
+                vals['self_ordering_image_home_ids'] = [(0, 0, {
                     'name': image_name,
-                    'datas': base64.b64encode(file_open(image_path, "rb").read()),
+                    'datas': base64.b64encode(file_open(opj("pos_self_order/static/img", image_name), "rb").read()),
                     'res_model': 'pos.config',
-                    'res_id': pos_config_id.id,
                     'type': 'binary',
+                }) for image_name in ['landing_01.jpg', 'landing_02.jpg', 'landing_03.jpg']]
+
+        return True
+
+    def _prepare_self_order_custom_btn(self):
+        for record in self:
+            exists = record.env['pos_self_order.custom_link'].search_count([
+                ('pos_config_ids', 'in', record.id),
+                ('url', '=', f'/pos-self/{record.id}/products')
+            ])
+
+            if not exists:
+                record.env['pos_self_order.custom_link'].create({
+                    'name': _('Order Now'),
+                    'url': f'/pos-self/{record.id}/products',
+                    'pos_config_ids': [(4, record.id)],
                 })
-                pos_config_id.self_ordering_image_home_ids = [(4, attachment.id)]
-
-            self.env['pos_self_order.custom_link'].create({
-                'name': _('Order Now'),
-                'url': f'/pos-self/{pos_config_id.id}/products',
-                'pos_config_ids': [(4, pos_config_id.id)],
-            })
-
-            if pos_config_id.module_pos_restaurant:
-                pos_config_id.self_ordering_mode = 'mobile'
 
     def write(self, vals):
+        self._prepare_self_order_splash_screen([vals])
+
         for record in self:
             if vals.get('self_ordering_mode') == 'kiosk' or (vals.get('pos_self_ordering_mode') == 'mobile' and vals.get('pos_self_ordering_service_mode') == 'counter'):
                 vals['self_ordering_pay_after'] = 'each'
@@ -133,7 +144,10 @@ class PosConfig(models.Model):
 
             if vals.get('self_ordering_mode') == 'mobile' and vals.get('self_ordering_pay_after') == 'meal':
                 vals['self_ordering_service_mode'] = 'table'
-        return super().write(vals)
+
+        res = super().write(vals)
+        self._prepare_self_order_custom_btn()
+        return res
 
     @api.depends("module_pos_restaurant")
     def _compute_self_order(self):
@@ -205,7 +219,7 @@ class PosConfig(models.Model):
         table_route = ""
 
         if self.self_ordering_mode == 'consultation':
-            return f"{base_route}/products"
+            return base_route
 
         if self.self_ordering_mode == 'mobile':
             table = self.env["restaurant.table"].search(
@@ -325,7 +339,6 @@ class PosConfig(models.Model):
     def _modify_pos_restaurant_config(self):
         pos_config = self.env.ref('pos_restaurant.pos_config_main_restaurant', raise_if_not_found=False)
         if pos_config:
-            pos_config._configure_pos_config()
             pos_config.write({
                 'self_ordering_service_mode': 'table',
                 'self_ordering_pay_after': 'meal'

--- a/addons/pos_self_order/static/tests/tours/self_order_common_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_common_tour.js
@@ -16,6 +16,7 @@ registry.category("web_tour.tours").add("self_order_is_close", {
 registry.category("web_tour.tours").add("self_order_is_open_consultation", {
     test: true,
     steps: () => [
+        Utils.clickBtn("Order Now"),
         LandingPage.isOpened(),
         ProductPage.clickProduct("Coca-Cola"),
         Utils.checkIsNoBtn("Order"),

--- a/addons/pos_self_order/tests/test_self_order_common.py
+++ b/addons/pos_self_order/tests/test_self_order_common.py
@@ -47,10 +47,10 @@ class TestSelfOrderCommon(SelfOrderCommonTest):
             "combo_id": self.desk_accessories_combo.id,
         })
 
-        self_route = self.pos_config._get_self_order_route()
-
         for mode in ("mobile", "consultation", "kiosk"):
             self.pos_config.write({"self_ordering_mode": mode})
+            # The returned route depend of the pos_config mode
+            self_route = self.pos_config._get_self_order_route()
             self.start_tour(self_route, "self_order_pos_closed")
 
     def test_self_order_config_default_user(self):


### PR DESCRIPTION
Before, when changing `pos_config` configuration to kiosk mode, no order button was displayed on the self interface.

Now new methods are added to the `pos_config` model to always create an order now button on the self interface.

taskId 4119578

