### PR TITLE
[FIX] sale_timesheet: disambiguate analytic items

### DIFF
--- a/addons/sale_timesheet/i18n/sale_timesheet.pot
+++ b/addons/sale_timesheet/i18n/sale_timesheet.pot
@@ -682,11 +682,16 @@ msgstr ""
 #. odoo-python
 #: code:addons/sale_timesheet/models/project.py:0
 #: model:ir.model.fields.selection,name:sale_timesheet.selection__account_analytic_line__timesheet_invoice_type__other_costs
-#: model:ir.model.fields.selection,name:sale_timesheet.selection__account_analytic_line__timesheet_invoice_type__other_revenues
 #: model:ir.model.fields.selection,name:sale_timesheet.selection__timesheets_analysis_report__timesheet_invoice_type__other_costs
+msgid "Other costs"
+msgstr ""
+
+#. module: sale_timesheet
+#. odoo-python
+#: code:addons/sale_timesheet/models/project.py:0
+#: model:ir.model.fields.selection,name:sale_timesheet.selection__account_analytic_line__timesheet_invoice_type__other_revenues
 #: model:ir.model.fields.selection,name:sale_timesheet.selection__timesheets_analysis_report__timesheet_invoice_type__other_revenues
-#, python-format
-msgid "Materials"
+msgid "Other revenues"
 msgstr ""
 
 #. module: sale_timesheet

--- a/addons/sale_timesheet/models/account.py
+++ b/addons/sale_timesheet/models/account.py
@@ -14,8 +14,8 @@ TIMESHEET_INVOICE_TYPES = [
     ('non_billable', 'Non Billable Tasks'),
     ('timesheet_revenues', 'Timesheet Revenues'),
     ('service_revenues', 'Service Revenues'),
-    ('other_revenues', 'Materials'),
-    ('other_costs', 'Materials'),
+    ('other_revenues', 'Other revenues'),
+    ('other_costs', 'Other costs'),
 ]
 
 class AccountAnalyticLine(models.Model):


### PR DESCRIPTION
Steps to reproduce:
- Install timesheets, project and accounting
- Enable "Analytic accounting" in accounting settings
- Accounting > Accounting > Analytic items
- Goup by Billing type
- 2 different 'Materials'

Change was made in 3d3f4109a06445b6ce9606770085c763ea206b35. This is ambiguous and clashes with the previously used items in 15.0. https://github.com/odoo/odoo/blob/ec106bfaaede527857a028bf1956b309aad3dc51/addons/sale_timesheet/models/account.py#L17

opw-4080234

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
