### PR TITLE
[FIX] hr_holidays: fix security on multi-company leaves

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -535,7 +535,7 @@ class HolidaysRequest(models.Model):
     def _compute_from_employee_id(self):
         for holiday in self:
             holiday.manager_id = holiday.employee_id.parent_id.id
-            if holiday.employee_id.user_id != self.env.user and self._origin.employee_id != holiday.employee_id:
+            if holiday.employee_id.user_id != self.env.user and holiday._origin.employee_id != holiday.employee_id:
                 holiday.holiday_status_id = False
 
     @api.depends('employee_id', 'holiday_type')

--- a/addons/hr_holidays/security/hr_holidays_security.xml
+++ b/addons/hr_holidays/security/hr_holidays_security.xml
@@ -135,7 +135,7 @@
     <record id="hr_leave_rule_multicompany" model="ir.rule">
         <field name="name">Time Off: multi company global rule</field>
         <field name="model_id" ref="model_hr_leave"/>
-        <field name="domain_force">[('holiday_status_id.company_id', 'in', company_ids + [False])]</field>
+        <field name="domain_force">['|', ('holiday_status_id', '=', False), ('holiday_status_id.company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record id="hr_leave_allocation_rule_multicompany" model="ir.rule">


### PR DESCRIPTION
Before this commit, the multi-company security rule was only checking the company of the holiday status,
sometimes giving an error in the case where that field was set as empty upon the creation of a new leave.

This commit adds an additional condition in the rule to ensure that a holiday status is set before checking for that field's company.
