### PR TITLE
[FIX] account: prevent error when we click on try our sample

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -9528,6 +9528,7 @@ msgstr ""
 #. module: account
 #. odoo-python
 #: code:addons/account/models/account_move.py:0
+#: code:addons/account/models/account_journal_dashboard.py:0
 msgid ""
 "No journal could be found in company %(company_name)s for any of those "
 "types: %(journal_types)s"

--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -888,7 +888,7 @@ class AccountJournal(models.Model):
             raise UserError(_("No attachment was provided"))
 
         if not self:
-            raise UserError(_("No journal found"))
+            raise UserError(self.env['account.journal']._build_no_journal_error_msg(self.env.company.display_name, [journal_type]))
 
         # As we are coming from the journal, we assume that each attachments
         # will create an invoice with a tentative to enhance with EDI / OCR..

--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -848,12 +848,21 @@ class account_journal(models.Model):
             'context': self._get_move_action_context(),
         }
 
+    def _build_no_journal_error_msg(self, company_name, journal_types):
+        return _(
+                "No journal could be found in company %(company_name)s for any of those types: %(journal_types)s",
+                company_name=company_name,
+                journal_types=', '.join(journal_types),
+            )
+
     def action_create_vendor_bill(self):
         """ This function is called by the "try our sample" button of Vendor Bills,
         visible on dashboard if no bill has been created yet.
         """
         context = dict(self._context)
-        purchase_journal = self.browse(context.get('default_journal_id'))
+        purchase_journal = self.browse(context.get('default_journal_id')) or self.search([('type', '=', 'purchase')], limit=1)
+        if not purchase_journal:
+            raise UserError(self._build_no_journal_error_msg(self.env.company.display_name, ['purchase']))
         context['default_move_type'] = 'in_invoice'
         invoice_date = fields.Date.today() - timedelta(days=12)
         partner = self.env['res.partner'].search([('name', '=', 'Deco Addict')], limit=1)

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -774,11 +774,7 @@ class AccountMove(models.Model):
             journal = self.env['account.journal'].search(domain, limit=1)
 
         if not journal:
-            error_msg = _(
-                "No journal could be found in company %(company_name)s for any of those types: %(journal_types)s",
-                company_name=company.display_name,
-                journal_types=', '.join(journal_types),
-            )
+            error_msg = self.env['account.journal']._build_no_journal_error_msg(company.display_name, journal_types)
             raise UserError(error_msg)
 
         return journal


### PR DESCRIPTION
The error occurs when we click on the button ``try our sample`` by creating a new company.

Steps to reproduce:
- Install the ``account`` module(without demo data)
- Create a new ``Company``
- Go to a newly created company
- Invoicing > Vendors > Bills
- Click on ``try our sample``

Traceback: 
``AttributeError: 'bool' object has no attribute 'id'``

This error occurs at [1], where we are receiving ``default_expense_account`` as False.

This commit will resolve the above error by raising an error if no journal exists in that particular company.

[1]- https://github.com/odoo/odoo/blob/f80f1a27152c5fc38253fa59d7a24206d5774a6b/addons/account/models/account_journal_dashboard.py#L878

sentry-5722721931

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
