### PR TITLE
[IMP] web: improve within operator management

### DIFF
--- a/addons/web/static/src/core/tree_editor/tree_editor_components.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_components.js
@@ -1,6 +1,5 @@
 import { Component } from "@odoo/owl";
 import { TagsList } from "@web/core/tags_list/tags_list";
-import { capitalize } from "@web/core/utils/strings";
 import { _t } from "@web/core/l10n/translation";
 
 export class Input extends Component {
@@ -33,7 +32,7 @@ export class Range extends Component {
 }
 
 export class Within extends Component {
-    static props = ["value", "update"];
+    static props = ["value", "update", "amountEditorInfo", "optionEditorInfo"];
     static template = "web.TreeEditor.Within";
     static components = { Input, Select };
     static options = [
@@ -42,11 +41,6 @@ export class Within extends Component {
         ["months", _t("months")],
         ["years", _t("years")],
     ];
-
-    get options() {
-        return Within.options.map((option) => [option[0], capitalize(option[1])]);
-    }
-
     update(index, newValue) {
         const result = [...this.props.value];
         result[index] = newValue;

--- a/addons/web/static/src/core/tree_editor/tree_editor_components.xml
+++ b/addons/web/static/src/core/tree_editor/tree_editor_components.xml
@@ -33,9 +33,19 @@
     </t>
 
     <t t-name="web.TreeEditor.Within">
-        <div class="d-flex align-items-center">
-            <Input value="props.value[0]" update="(val) => this.update(0, val)"/>
-            <Select value="props.value[1]" options="options" update="(val) => this.update(1, val)"/>
+        <div class="d-flex align-items-center gap-2">
+            <t t-call="web.TreeEditor.Editor">
+                <t t-set="_classes" t-value="'overflow-hidden flex-grow-1'"/>
+                <t t-set="info" t-value="props.amountEditorInfo" />
+                <t t-set="value" t-value="props.value[0]" />
+                <t t-set="update" t-value="(val) => this.update(0, val)" />
+            </t>
+            <t t-call="web.TreeEditor.Editor">
+                <t t-set="_classes" t-value="'overflow-hidden flex-grow-1'"/>
+                <t t-set="info" t-value="props.optionEditorInfo" />
+                <t t-set="value" t-value="props.value[1]" />
+                <t t-set="update" t-value="(val) => this.update(1, val)" />
+            </t>
         </div>
     </t>
 

--- a/addons/web/static/src/core/tree_editor/tree_editor_value_editors.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_value_editors.js
@@ -134,12 +134,13 @@ function getPartialValueEditorInfo(fieldDef, operator, params = {}) {
                 extractProps: ({ value, update }) => ({
                     value,
                     update,
+                    amountEditorInfo: getValueEditorInfo({ type: "integer" }, "="),
+                    optionEditorInfo: makeSelectEditor(Within.options),
                 }),
                 isSupported: (value) =>
                     Array.isArray(value) &&
                     value.length === 3 &&
-                    Number.isInteger(value[0]) &&
-                    Within.options.some((o) => o[0] === value[1]) &&
+                    typeof value[1] === "string" &&
                     value[2] === fieldDef.type,
                 defaultValue: () => {
                     return [-1, "months", fieldDef.type];

--- a/addons/web/static/tests/core/tree_editor/condition_tree.test.js
+++ b/addons/web/static/tests/core/tree_editor/condition_tree.test.js
@@ -63,6 +63,14 @@ test("domainFromTree", () => {
             tree: condition("foo", "within", [1, "weeks", "date"], true),
             result: `["!", "&", ("foo", ">=", context_today().strftime("%Y-%m-%d")), ("foo", "<=", (context_today() + relativedelta(weeks = 1)).strftime("%Y-%m-%d"))]`,
         },
+        {
+            tree: condition("foo", "within", [expression("a"), "weeks", "date"], true),
+            result: `["!", "&", ("foo", ">=", (context_today() + relativedelta(weeks = a)).strftime("%Y-%m-%d")), ("foo", "<=", context_today().strftime("%Y-%m-%d"))]`,
+        },
+        {
+            tree: condition("foo", "within", [1, "b", "date"], true),
+            result: `["!", "&", ("foo", ">=", context_today().strftime("%Y-%m-%d")), ("foo", "<=", (context_today() + relativedelta(b = 1)).strftime("%Y-%m-%d"))]`,
+        },
     ];
     for (const { tree, result } of toTest) {
         expect(domainFromTree(tree)).toBe(result);
@@ -326,6 +334,14 @@ test("expressionFromTree", () => {
         {
             expressionTree: condition("foo", "within", [-1, "months", "datetime"]),
             result: `foo >= datetime.datetime.combine(context_today() + relativedelta(months = -1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S") and foo <= datetime.datetime.combine(context_today(), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`,
+        },
+        {
+            expressionTree: condition("foo", "within", [expression("a"), "months", "datetime"]),
+            result: `foo >= datetime.datetime.combine(context_today() + relativedelta(months = a), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S") and foo <= datetime.datetime.combine(context_today(), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`,
+        },
+        {
+            expressionTree: condition("foo", "within", [-1, "b", "datetime"]),
+            result: `foo >= datetime.datetime.combine(context_today() + relativedelta(b = -1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S") and foo <= datetime.datetime.combine(context_today(), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`,
         },
         {
             expressionTree: complexCondition("uid"),


### PR DESCRIPTION
There were at least two problems with the within operator:
- enter 1% (for instance) in the editor for the amount would cause a crash
- enter something else that an integer would make the within operator
  be replaced by a between operator with long expressions (like
  'context_today() + relativedelta(weeks = ...').

Here we remove those problems and we also improve the support of
expressions/invalid values in the amount and period editors.

Task IDs: 4067794, 4086413
