### PR TITLE
[FIX] mrp: avoid mixing workorder dependency when adding steps

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1470,7 +1470,7 @@ class MrpProduction(models.Model):
         self.allow_workorder_dependencies = self.bom_id.allow_operation_dependencies
 
         def workorder_order(wo):
-            return (wo.operation_id.bom_id, wo.operation_id.sequence)
+            return (wo.operation_id.bom_id, wo.operation_id.sequence, wo.id)
 
         if self.allow_workorder_dependencies:
             for workorder in self.workorder_ids.sorted(workorder_order):

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -4119,6 +4119,38 @@ class TestMrpOrder(TestMrpCommon):
         self.assertTrue(all(sml.lot_id == producing_lot for sml in mo.move_finished_ids.move_line_ids))
         self.assertEqual(sum(sml.quantity for sml in mo.move_finished_ids.move_line_ids), 3.0)
 
+    def test_mrp_link_new_operations(self):
+        """
+        Checks that newly created operations are linked with the correct dependencies.
+            - Create and confirm an MO with 2 operations: op1 > op2
+            - Start op2 and create a new operation op3
+            > The new dependency should be op1 > op2 > op3
+        """
+        mo = self.env['mrp.production'].create({
+            'product_id': self.product_1.id,
+            'product_qty': 1.0,
+        })
+        with Form(mo) as mo_form:
+            with mo_form.workorder_ids.new() as line_op_1:
+                line_op_1.name = "op1"
+                line_op_1.workcenter_id = self.workcenter_1
+            with mo_form.workorder_ids.new() as line_op_2:
+                line_op_2.name = "op2"
+                line_op_2.workcenter_id = self.workcenter_1
+        op_1, op_2 = mo.workorder_ids
+        mo.action_confirm()
+        self.assertFalse(op_1.blocked_by_workorder_ids)
+        self.assertEqual(op_2.blocked_by_workorder_ids, op_1)
+        op_2.button_start()
+        with Form(mo) as mo_form:
+            with mo_form.workorder_ids.new() as line_op_3:
+                line_op_3.name = "op3"
+                line_op_3.workcenter_id = self.workcenter_1
+        op_3 = mo.workorder_ids - (op_1 | op_2)
+        self.assertFalse(op_1.blocked_by_workorder_ids)
+        self.assertEqual(op_2.blocked_by_workorder_ids, op_1)
+        self.assertEqual(op_3.blocked_by_workorder_ids, op_2)
+
 
 @tagged('post_install', '-at_install')
 class TestMrpSynchronization(HttpCase):


### PR DESCRIPTION
### Steps to reproduce:

- Create a MO for a product without BOM (no need of components)
- Go to the "Work Orders" tab and create 2 operations: op1 and op2
- Confirm the MO
- Start the operation waiting for an other WO (op2)
- Create a third operation: op3
- Save
#### > Validation Error: You cannot create a cyclic dependency.

### Cause of the Issue:

During the creation of op3, all the workorders of our MO will be confirmed to ensures that the links of the 3 operations are correctly made:
https://github.com/odoo/odoo/blob/d2ce6622f2d6f1917dc319112a688e35a73c2088/addons/mrp/models/mrp_workorder.py#L469-L474 This will trigger a call of the `_link_workorders_and_moves` to re-link them all. However, during this call since op2 has been started the order of the workorders will be op2 > op1 rather than op1 > op2 and since the MO has no bom nor `operation_id` the records will not be reordered correctly before being linked:
https://github.com/odoo/odoo/blob/d2ce6622f2d6f1917dc319112a688e35a73c2088/addons/mrp/models/mrp_production.py#L1472-L1473 https://github.com/odoo/odoo/blob/d2ce6622f2d6f1917dc319112a688e35a73c2088/addons/mrp/models/mrp_production.py#L1485-L1487 This will create a loop on the m2m dependency since op1 will be blocked by op2 and op2 is already blocked by op1. This is detected by the framework which raises the error.

opw-4105603
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
