### PR TITLE
[FIX] bus: update presence missed when main tab is not responsive

### DIFF
--- a/addons/bus/static/src/im_status_service.js
+++ b/addons/bus/static/src/im_status_service.js
@@ -14,18 +14,15 @@ export const UPDATE_BUS_PRESENCE_DELAY = 60000;
  * im_status to be up to date.
  */
 export const imStatusService = {
-    dependencies: ["bus_service", "multi_tab", "presence"],
+    dependencies: ["bus_service", "presence"],
 
-    start(env, { bus_service, multi_tab, presence }) {
+    start(env, { bus_service, presence }) {
         let lastSentInactivity;
         let becomeAwayTimeout;
 
         const updateBusPresence = () => {
             lastSentInactivity = presence.getInactivityPeriod();
             startAwayTimeout();
-            if (!multi_tab.isOnMainTab()) {
-                return;
-            }
             bus_service.send("update_presence", {
                 inactivity_period: lastSentInactivity,
                 im_status_ids_by_model: {},

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -881,7 +881,7 @@ class WebsocketConnectionHandler:
     # Latest version of the websocket worker. This version should be incremented
     # every time `websocket_worker.js` is modified to force the browser to fetch
     # the new worker bundle.
-    _VERSION = "1.0.9"
+    _VERSION = "1.0.10"
 
     @classmethod
     def websocket_allowed(cls, request):


### PR DESCRIPTION
When the user disconnects from one of their devices, they're
considered offline until another device indicates otherwise. When such
a notification is received by a browser, the main tab notifies the
server that the user is still active.

However, the main tab is not always reliable. As a result, such a
notification can be missed, leading to an incorrect IM status for the
user.

This issue is not easily reproducible since it heavily depends on
external factors such as tab throttling or the `pagehide` event not
being received. Let's imagine the `pagehide` event (which is known to
be unreliable) isn't triggered when the main tab closes:
- Only one tab remains, and another tab is open in a different browser.
- The user closes the second browser.
- The "offline" notification is received, and we detect that we should
notify the server. However, the main tab isn't available: the presence
will never be updated.

To solve this issue, every tab will request an update from the
websocket shared worker. The worker will debounce the update calls to
ensure only one message is sent through the socket.