### PR TITLE
[FIX] purchase: reset the discount value when no seller found

### DIFF
--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -332,6 +332,7 @@ class PurchaseOrderLine(models.Model):
 
             # If not seller, use the standard price. It needs a proper currency conversion.
             if not seller:
+                line.discount = 0
                 unavailable_seller = line.product_id.seller_ids.filtered(
                     lambda s: s.partner_id == line.order_id.partner_id)
                 if not unavailable_seller and line.price_unit and line.product_uom == line._origin.product_uom:


### PR DESCRIPTION
Problem:
When a discount is based on quantity and we update the quantity to a value that does not have a discount, the stale discount value remains.

Steps to reproduce:

- Create a product with two vendor lines for the same vendor but different discounts based on quantity: - Vendor1: Quantity 10 - Discount 5% - Vendor1: Quantity 20 - Discount 10%
- Create a new quotation with the product and set the quantity to 10.
- Update the quantity to 20.
- Update the quantity to 1. The 10% discount still appears, even though it should have been removed.

opw-4123984

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
