### PR TITLE
[FIX] spreadsheet: odoo chart legend labels color

### DIFF
--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_bar_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_bar_chart.js
@@ -56,13 +56,13 @@ function createOdooChartRuntime(chart, getters) {
 }
 
 function getBarConfiguration(chart, labels, locale) {
-    const fontColor = chartFontColor(chart.background);
-    const config = getDefaultChartJsRuntime(chart, labels, fontColor, { locale });
+    const color = chartFontColor(chart.background);
+    const config = getDefaultChartJsRuntime(chart, labels, color, { locale });
     config.type = chart.type.replace("odoo_", "");
     const legend = {
         ...config.options.legend,
         display: chart.legendPosition !== "none",
-        labels: { fontColor },
+        labels: { color },
     };
     legend.position = chart.legendPosition;
     config.options.plugins = config.options.plugins || {};
@@ -78,13 +78,13 @@ function getBarConfiguration(chart, labels, locale) {
                 minRotation: 15,
                 padding: 5,
                 labelOffset: 2,
-                color: fontColor,
+                color,
             },
         },
         y: {
             position: chart.verticalAxisPosition,
             ticks: {
-                color: fontColor,
+                color,
                 // y axis configuration
             },
             beginAtZero: true, // the origin of the y axis is always zero

--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_pie_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_pie_chart.js
@@ -39,13 +39,13 @@ function createOdooChartRuntime(chart, getters) {
 }
 
 function getPieConfiguration(chart, labels, locale) {
-    const fontColor = chartFontColor(chart.background);
-    const config = getDefaultChartJsRuntime(chart, labels, fontColor, { locale });
+    const color = chartFontColor(chart.background);
+    const config = getDefaultChartJsRuntime(chart, labels, color, { locale });
     config.type = chart.type.replace("odoo_", "");
     const legend = {
         ...config.options.legend,
         display: chart.legendPosition !== "none",
-        labels: { fontColor },
+        labels: { color },
     };
     legend.position = chart.legendPosition;
     config.options.plugins = config.options.plugins || {};

--- a/addons/spreadsheet/static/tests/charts/model/odoo_chart_plugin_test.js
+++ b/addons/spreadsheet/static/tests/charts/model/odoo_chart_plugin_test.js
@@ -591,4 +591,26 @@ QUnit.module("spreadsheet > odoo chart plugin", {}, () => {
         model.dispatch("DELETE_SHEET", { sheetId });
         assert.strictEqual(model.getters.getOdooChartIds().length, 0);
     });
+
+    QUnit.test("Odoo chart legend color changes with background color update", async (assert) => {
+        const { model } = await createSpreadsheetWithChart({ type: "odoo_bar" });
+        const sheetId = model.getters.getActiveSheetId();
+        const chartId = model.getters.getChartIds(sheetId)[0];
+        const definition = model.getters.getChartDefinition(chartId);
+        const runtime = model.getters.getChartRuntime(chartId);
+        assert.strictEqual(runtime.chartJsConfig.options.plugins.legend.labels.color, "#000000");
+        model.dispatch("UPDATE_CHART", {
+            definition: {
+                ...definition,
+                background: "#000000",
+            },
+            id: chartId,
+            sheetId,
+        });
+        assert.strictEqual(
+            model.getters.getChartRuntime(chartId).chartJsConfig.options.plugins.legend.labels
+                .color,
+            "#FFFFFF"
+        );
+    });
 });


### PR DESCRIPTION
# Description

With the upgrade to Chart.js version 4.3, the configuration for setting legend label colors has changed. The `fontColor` key is now deprecated, and the `color` key must be used instead. This update was previously overlooked in the Odoo chart plugin.

This commit resolves the issue by updating the Odoo chart plugin to correctly use the color key for setting legend label colors.

Task: [4111089](https://www.odoo.com/odoo/project/2328/tasks/4111089)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
