### PR TITLE
[IMP] web: customizable classes for the `remaining_days` field

### DIFF
--- a/addons/web/static/src/views/fields/remaining_days/remaining_days_field.js
+++ b/addons/web/static/src/views/fields/remaining_days/remaining_days_field.js
@@ -1,7 +1,9 @@
 /** @odoo-module **/
 
 import { DatePicker, DateTimePicker } from "@web/core/datepicker/datepicker";
+import { evaluateExpr } from "@web/core/py_js/py";
 import { formatDate, formatDateTime } from "@web/core/l10n/dates";
+import { getClassNameFromDecoration } from "@web/views/utils";
 import { localization } from "@web/core/l10n/localization";
 import { _lt, _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
@@ -54,6 +56,19 @@ export class RemainingDaysField extends Component {
             : formatDate(this.props.value);
     }
 
+    get classNames() {
+        if (!this.props.value) {
+            return false;
+        }
+        const classNames = {};
+        const evalContext = {days: this.diffDays, record: this.props.record.evalContext};
+        for (const decoration in this.props.classes) {
+            const value = evaluateExpr(this.props.classes[decoration], evalContext);
+            classNames[getClassNameFromDecoration(decoration)] = value;
+        }
+        return classNames;
+    }
+
     onDateTimeChanged(datetime) {
         this.props.update(datetime || false);
     }
@@ -62,6 +77,19 @@ export class RemainingDaysField extends Component {
 RemainingDaysField.template = "web.RemainingDaysField";
 RemainingDaysField.props = {
     ...standardFieldProps,
+    classes: { type: Object, optional: true },
+};
+RemainingDaysField.defaultProps = {
+    classes: {
+        'bf': 'days <= 0',
+        'danger': 'days < 0',
+        'warning': 'days == 0',
+    },
+};
+RemainingDaysField.extractProps = ({ attrs }) => {
+    return {
+        classes: attrs.options.classes,
+    };
 };
 
 RemainingDaysField.displayName = _lt("Remaining Days");

--- a/addons/web/static/src/views/fields/remaining_days/remaining_days_field.xml
+++ b/addons/web/static/src/views/fields/remaining_days/remaining_days_field.xml
@@ -3,15 +3,9 @@
 
     <t t-name="web.RemainingDaysField" owl="1">
         <t t-if="props.readonly">
-            <t t-set="days" t-value="diffDays" />
-            <t t-set="formatted" t-value="formattedValue" />
             <div
-                t-att-class="{
-                    'fw-bold': days !== null and days lte 0,
-                    'text-danger': days !== null and days lt 0,
-                    'text-warning': days !== null and days === 0,
-                }"
-                t-att-title="formatted"
+                t-att-class="classNames"
+                t-att-title="formattedValue"
             >
                 <t t-esc="diffString"/>
             </div>


### PR DESCRIPTION
This commit adds the ability to customize the classes of the `remaining_days` field through the `classes` option.

Usage:

```xml
<field
    name="fname"
    widget="remaining_days"
    options="{'classes': {'success': 'days &gt;= 10'}"
/>
```

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
