### PR TITLE
Fix Employee's Name Appears Twice in Calendar View in Time Off App

### DIFF
--- a/addons/hr_holidays/static/src/views/calendar/calendar_model.js
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_model.js
@@ -25,7 +25,10 @@ export class TimeOffCalendarModel extends CalendarModel {
         let result = super.normalizeRecord(...arguments);
         if (rawRecord.employee_id) {
             const employee = rawRecord.employee_id[1];
-            result.title = [employee, result.title].join(' ');
+            // If the employee's name isn't already included at the start of the title
+            if (!result.title.startsWith(employee)){
+                result.title = [employee, result.title].join(' ');
+            }
         }
         return result;
     }


### PR DESCRIPTION
Steps to reproduce:
 1. Open time off app.
 2. Go to overview
 3. select calendar view.
 4. Employees' names are repeated twice on records.

Fix:
 * Replace the repated employee's name with the name of the time off
   type. For example, Mitchell Mitchell 3 days would be replaced with
   Mitchell Paid Time Off 3 days.

task-4128789