### PR TITLE
[FIX] website: avoid to check for duplicative modal

### DIFF
--- a/addons/website/static/tests/tours/automatic_editor.js
+++ b/addons/website/static/tests/tours/automatic_editor.js
@@ -32,6 +32,7 @@ wTourUtils.registerWebsitePreviewTour('automatic_editor_on_new_website', {
     },
     {
         trigger: '.modal div[name="lang_ids"] .rounded-pill .o_tag_badge_text:contains(Parseltongue)',
+        in_modal: false,
     },
     {
         content: "load parseltongue",


### PR DESCRIPTION
[FIX] website: avoid to check for duplicated modal

Since [1], the `extra_trigger` key has been removed from the tests. Due
to it, the `automatic_editor_on_new_website` test fails as the
`.modal div[name="lang_ids"]...` selector is used in a `trigger` element
and not in `extra_trigger` anymore. Indeed, at the contrary of
`extra_trigger`, the `trigger` element directly searches in the main
modal, leading the `.modal` in the selector to be duplicated. To solve
the problem, `in_modal: false` is added to indicate to the system that
the search does not have to be done in the main modal.

[1]: https://github.com/odoo/odoo/commit/68a92cb0dd2ea06102df7cb44ae9121a61575ae1

runbot-69009