### PR TITLE
[FIX] spreadsheet: omit pivot context when loading a pivot

### DIFF
--- a/addons/spreadsheet/static/src/pivot/pivot_data_source.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_data_source.js
@@ -3,6 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { OdooViewsDataSource } from "../data_sources/odoo_views_data_source";
 import { SpreadsheetPivotModel } from "./pivot_model";
+import { omit } from "@web/core/utils/objects";
 
 export default class PivotDataSource extends OdooViewsDataSource {
     /**
@@ -14,7 +15,19 @@ export default class PivotDataSource extends OdooViewsDataSource {
      * @param {import("./pivot_model").PivotSearchParams} params.searchParams
      */
     constructor(services, params) {
-        super(services, params);
+        const filteredParams = {
+            ...params,
+            searchParams: {
+                ...params.searchParams,
+                context: omit(
+                    params.searchParams.context,
+                    "pivot_measures",
+                    "pivot_row_groupby",
+                    "pivot_column_groupby"
+                ),
+            },
+        };
+        super(services, filteredParams);
     }
 
     async _load() {

--- a/addons/spreadsheet/static/tests/pivots/model/pivot_plugin_test.js
+++ b/addons/spreadsheet/static/tests/pivots/model/pivot_plugin_test.js
@@ -301,6 +301,52 @@ QUnit.module("spreadsheet > pivot plugin", {}, () => {
         }
     );
 
+    QUnit.test("Context is purged from PivotView related keys", async function (assert) {
+        const spreadsheetData = {
+            sheets: [
+                {
+                    id: "sheet1",
+                    cells: {
+                        A1: { content: `=ODOO.PIVOT(1, "probability")` },
+                    },
+                },
+            ],
+            pivots: {
+                1: {
+                    id: 1,
+                    colGroupBys: ["foo"],
+                    rowGroupBys: ["bar"],
+                    domain: [],
+                    measures: [{ field: "probability", operator: "avg" }],
+                    model: "partner",
+                    context: {
+                        pivot_measures: ["__count"],
+                        // inverse row and col group bys
+                        pivot_row_groupby: ["test"],
+                        pivot_column_groupby: ["check"],
+                        dummyKey: "true",
+                    },
+                },
+            },
+        };
+        const model = await createModelWithDataSource({
+            spreadsheetData,
+            mockRPC: function (route, { model, method, kwargs }) {
+                if (model === "partner" && method === "read_group") {
+                    assert.step(`pop`);
+                    assert.notOk(
+                        ["pivot_measures", "pivot_row_groupby", "pivot_column_groupby"].some(
+                            (val) => val in (kwargs.context || {})
+                        ),
+                        "The context should not contain pivot related keys"
+                    );
+                }
+            },
+        });
+        await waitForDataSourcesLoaded(model);
+        assert.verifySteps(["pop", "pop", "pop", "pop"]);
+    });
+
     QUnit.test("fetch metadata only once per model", async function (assert) {
         const spreadsheetData = {
             sheets: [


### PR DESCRIPTION
Similar issue than the one fixed here [^1], if a spreadsheet already contained a pivot with some pivot-view related context, it would be used to load the pivot model inside spreadsheet.

This becomes a bigger issue in later versions where we added extented granularity.

[^1]: https://github.com/odoo/enterprise/issues/44075

Task: 4129333

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
