### PR TITLE
[FIX] account_edi_ubl_cii: change payment code for DK

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -156,9 +156,15 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         return vals
 
     def _get_invoice_payment_means_vals_list(self, invoice):
+        # in Denmark payment code 30 is not allowed. we hardcode it to 1 ("unknown") for now
+        # as we cannot deduce this information from the invoice
+        payment_means_code, payment_means_name = 30, 'credit transfer'
+        if invoice.partner_id.country_code == 'DK':
+            payment_means_code, payment_means_name = 1, 'unknown'
+
         vals = {
-            'payment_means_code': 30,
-            'payment_means_code_attrs': {'name': 'credit transfer'},
+            'payment_means_code': payment_means_code,
+            'payment_means_code_attrs': {'name': payment_means_name},
             'payment_due_date': invoice.invoice_date_due or invoice.invoice_date,
             'instruction_id': invoice.payment_reference,
             'payment_id_vals': [invoice.payment_reference or invoice.name],


### PR DESCRIPTION
UBL rule DK-R-005 limits the options available for the payment means. Currently, we have a hard-coded value of 30 for every invoice, because it is not possible to deduce the right payment means code at the moment. In OIOUBL we hard-code this field to `unknown` as it has the same UBL rule.

With this commit we can use a different value for DK partners. In the future we could try to populate it dynamically.

See also:
https://docs.peppol.eu/poacc/billing/3.0/rules/ubl-peppol/DK-R-005/

opw-4080715





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
