### PR TITLE
[FIX] web_editor: apply image optimization on /image command

### DIFF
--- a/addons/web_editor/static/src/components/media_dialog/media_dialog.js
+++ b/addons/web_editor/static/src/components/media_dialog/media_dialog.js
@@ -238,9 +238,9 @@ export class MediaDialog extends Component {
                 element.classList.add(...TABS[this.state.activeTab].Component.mediaSpecificClasses);
             });
             if (this.props.multiImages) {
-                this.props.save(elements);
+                await this.props.save(elements);
             } else {
-                this.props.save(elements[0]);
+                await this.props.save(elements[0]);
             }
         }
         this.props.close();

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -6526,6 +6526,9 @@ registry.ImageTools = ImageHandlerOption.extend({
         this.trigger_up('snippet_edition_request', {exec: async () => {
             await this._autoOptimizeImage();
             this.trigger_up('cover_update');
+            if (ev._complete) {
+                ev._complete();
+            }
         }});
     },
     /**


### PR DESCRIPTION
When an image is added in a website page by using the `/image` command
of the Powerbox, it is not optimized like when the media dialog is
used to replace an image.
Also, when an image is replaced, the auto-optimization is not always
included in the last history step - which makes operations like
inserting a new paragraph remove the optimization.

This commit makes sure that the `image_changed` event is:
- triggered after the new image is inside the DOM
- completed before considering we are done
- included in the same history step that applied the media dialog's
  change.

It also avoids recomputing the auto-optimization several times for a
single trigger of the event.

Steps to reproduce:

Scenario 1:
- Drop a three columns snippet
- Put your cursor after "Feature 1"
- Press ENTER
- Use the "/image" Powerbox command to add an image that should be
resized by the auto-optimization

=> Image was the original uploaded image.

Scenario 2:
- Drop a three columns snippet
- Double click on an image
- Upload/select an image that will be resized by the auto-optimization
- Put your cursor after "Feature 1"
- Press ENTER

=> Image's optimization was lost because it happened after the history
step was completed.

task-4129429