### PR TITLE
[FIX] website: click on the primary button inside the modal

### DIFF
--- a/addons/website/static/tests/tours/automatic_editor.js
+++ b/addons/website/static/tests/tours/automatic_editor.js
@@ -70,7 +70,7 @@ wTourUtils.registerWebsitePreviewTour('automatic_editor_on_new_website', {
     },
     {
         content: "validate the website creation modal",
-        trigger: 'button.btn-primary',
+        trigger: '.modal button.btn-primary',
         run: "click",
     },
     {


### PR DESCRIPTION
[FIX] website: click on the primary button inside the modal

Since [1], the `in_modal` key has been removed from the structure of a
step. Due to it, the system is not searching in the main modal by
default anymore leading to the `automatic_editor_on_new_website` test to
not click on the correct button at the `validate the website creation
modal` step. To solve the problem `.modal` is added in the selector in
order to force the click on the primary button inside the modal.

[1]: https://github.com/odoo/odoo/commit/cdd1d521e0c9c831b5914f08ba5451810618c29f

runbot-72542