### PR TITLE
[FIX] pos_self_order: fix several issues in self order mode

### DIFF
--- a/addons/l10n_gcc_pos/static/src/overrides/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/l10n_gcc_pos/static/src/overrides/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -14,10 +14,10 @@
             </t>
         </xpath>
 
-        <xpath expr="//t[@t-esc='props.data.cashier']/.." position="attributes">
+        <xpath expr="//div[@t-esc='props.data.cashier']/.." position="attributes">
             <attribute name="t-if">!props.data.is_gcc_country</attribute>
         </xpath>
-        <xpath expr="//t[@t-esc='props.data.cashier']/.." position="after">
+        <xpath expr="//div[@t-esc='props.data.cashier']/.." position="after">
             <div t-if="props.data.is_gcc_country" t-translation="off">
                 <div>Served by / خدم بواسطة <t t-esc="props.data.cashier"/></div>
             </div>

--- a/addons/point_of_sale/models/pos_bus_mixin.py
+++ b/addons/point_of_sale/models/pos_bus_mixin.py
@@ -1,13 +1,20 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import uuid
-from odoo import fields, models
+from odoo import fields, models, api
 
 class PosBusMixin(models.AbstractModel):
     _name = "pos.bus.mixin"
     _description = "Bus Mixin"
 
     access_token = fields.Char('Security Token', copy=False)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        for record in records:
+            record._ensure_access_token()
+        return records
 
     def _ensure_access_token(self):
         if self.access_token:

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -960,6 +960,10 @@ class PosOrder(models.Model):
         # Sometime pos_orders_ids can be empty.
         pos_order_ids = self.env['pos.order'].browse(order_ids)
         config_id = pos_order_ids[0].config_id.id if pos_order_ids else False
+
+        for order in pos_order_ids:
+            order._ensure_access_token()
+
         return {
             'pos.order': pos_order_ids.read(pos_order_ids._load_pos_data_fields(config_id), load=False) if config_id else [],
             'pos.payment': pos_order_ids.payment_ids.read(pos_order_ids.payment_ids._load_pos_data_fields(config_id), load=False) if config_id else [],

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -961,9 +961,6 @@ class PosOrder(models.Model):
         pos_order_ids = self.env['pos.order'].browse(order_ids)
         config_id = pos_order_ids[0].config_id.id if pos_order_ids else False
 
-        for order in pos_order_ids:
-            order._ensure_access_token()
-
         return {
             'pos.order': pos_order_ids.read(pos_order_ids._load_pos_data_fields(config_id), load=False) if config_id else [],
             'pos.payment': pos_order_ids.payment_ids.read(pos_order_ids.payment_ids._load_pos_data_fields(config_id), load=False) if config_id else [],

--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -871,8 +871,13 @@ export function createRelatedModels(modelDefs, modelClasses = {}, indexes = {}) 
      */
     function loadData(rawData, load = [], fromSerialized = false) {
         const results = {};
+        const oldStates = {};
 
         for (const model in rawData) {
+            if (!oldStates[model]) {
+                oldStates[model] = {};
+            }
+
             if (!load.includes(model) && load.length !== 0) {
                 continue;
             } else if (!results[model]) {
@@ -896,6 +901,11 @@ export function createRelatedModels(modelDefs, modelClasses = {}, indexes = {}) 
                 }
 
                 baseData[model][record.id] = record;
+
+                if (records[model][record.id]) {
+                    oldStates[model][record.id] = records[model][record.id].serializeState();
+                }
+
                 const result = create(model, record, true, false, true);
 
                 if (!(model in results)) {
@@ -963,6 +973,10 @@ export function createRelatedModels(modelDefs, modelClasses = {}, indexes = {}) 
         // Setup all records when relations are linked
         for (const { raw, record } of modelToSetup) {
             record.setup(raw);
+
+            if (oldStates[record.model.modelName][record.id]) {
+                record.setupState(oldStates[record.model.modelName][record.id]);
+            }
         }
 
         makeRecordsAvailable(results, rawData);

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
@@ -19,7 +19,7 @@
                 <div t-if="props.data.header" style="white-space:pre-line" t-esc="props.data.header" />
                 <div t-if="props.data.cashier" class="cashier">
                     <div>--------------------------------</div>
-                    <div>Served by <t t-esc="props.data.cashier" /></div>
+                    <div t-esc="props.data.cashier" />
                 </div>
                 <div t-if="props.data.trackingNumber and !props.data.bigTrackingNumber">
                     <span class="fs-2" t-esc="props.data.trackingNumber" />

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1628,7 +1628,7 @@ export class PosStore extends Reactive {
     getReceiptHeaderData(order) {
         return {
             company: this.company,
-            cashier: this.get_cashier()?.name,
+            cashier: _t("Served by %s", this.get_cashier()?.name),
             header: this.config.receipt_header,
         };
     }

--- a/addons/pos_online_payment_self_order/static/src/self_order_service.js
+++ b/addons/pos_online_payment_self_order/static/src/self_order_service.js
@@ -28,13 +28,18 @@ patch(SelfOrder.prototype, {
         let exitRouteUrl = baseUrl;
 
         if (exitRoute) {
+            let table = "";
             exitRouteUrl += `/pos-self/${order_pos_config_id.id}`;
 
             if (this.config.self_ordering_pay_after === "each") {
                 exitRouteUrl += `/confirmation/${order.access_token}/order`;
             }
 
-            exitRouteUrl += `?access_token=${this.access_token}`;
+            if (this.currentTable) {
+                table = `&table_identifier=${this.currentTable.identifier}`;
+            }
+
+            exitRouteUrl += `?access_token=${this.access_token}${table}`;
         }
 
         const exit = encodeURIComponent(exitRouteUrl);

--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -33,7 +33,7 @@ class PosSelfOrderController(http.Controller):
         order['date_order'] = str(fields.Datetime.now())
         order['fiscal_position_id'] = fiscal_position.id if fiscal_position else False
 
-        results = pos_config.env['pos.order'].sudo().with_company(pos_config.company_id.id).sync_from_ui([order])
+        results = pos_config.env['pos.order'].sudo().with_context(from_self=True).with_company(pos_config.company_id.id).sync_from_ui([order])
         line_ids = pos_config.env['pos.order.line'].browse([line['id'] for line in results['pos.order.line']])
         order_ids = pos_config.env['pos.order'].browse([order['id'] for order in results['pos.order']])
 
@@ -77,7 +77,7 @@ class PosSelfOrderController(http.Controller):
             if len(line.combo_line_ids) > 0:
                 original_total = sum(line.combo_line_ids.mapped("combo_item_id").combo_id.mapped("base_price"))
                 remaining_total = lst_price
-                factor = lst_price / original_total
+                factor = lst_price / original_total if original_total > 0 else 1
 
                 for i, pos_order_line in enumerate(line.combo_line_ids):
                     child_product = pos_order_line.product_id

--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -70,7 +70,6 @@ class PosOrder(models.Model):
 
     def _send_notification(self, order_ids):
         for order in order_ids:
-            order._ensure_access_token()
             order._notify('ORDER_STATE_CHANGED', {
                 'pos.order': order.read(order._load_pos_self_data_fields(order.config_id.id), load=False),
                 'pos.order.line': order.lines.read(order._load_pos_self_data_fields(order.config_id.id), load=False),

--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -70,6 +70,7 @@ class PosOrder(models.Model):
 
     def _send_notification(self, order_ids):
         for order in order_ids:
+            order._ensure_access_token()
             order._notify('ORDER_STATE_CHANGED', {
                 'pos.order': order.read(order._load_pos_self_data_fields(order.config_id.id), load=False),
                 'pos.order.line': order.lines.read(order._load_pos_self_data_fields(order.config_id.id), load=False),

--- a/addons/pos_self_order/static/src/app/models/pos_order.js
+++ b/addons/pos_self_order/static/src/app/models/pos_order.js
@@ -12,7 +12,11 @@ patch(PosOrder.prototype, {
         };
     },
     get unsentLines() {
-        return this.lines.filter((l) => l.uiState.hasChange);
+        return this.lines.filter(
+            (l) =>
+                !Object.keys(this.uiState.lineChanges).includes(l.uuid) ||
+                this.uiState.lineChanges[l.uuid].qty !== l.qty
+        );
     },
     get changes() {
         return this.lines.reduce((acc, line) => {

--- a/addons/pos_self_order/static/src/app/models/pos_order_line.js
+++ b/addons/pos_self_order/static/src/app/models/pos_order_line.js
@@ -4,15 +4,6 @@ import { PosOrderline } from "@point_of_sale/app/models/pos_order_line";
 import { patch } from "@web/core/utils/patch";
 
 patch(PosOrderline.prototype, {
-    setup() {
-        super.setup(...arguments);
-
-        this.uiState = {
-            ...this.uiState,
-            sentQty: 0,
-            sentNote: "",
-        };
-    },
     get changes() {
         const change = this.order_id.uiState.lineChanges[this.uuid];
 

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
@@ -54,6 +54,17 @@ export class CartPage extends Component {
         }
 
         if (
+            this.selfOrder.currentTable &&
+            !this.selfOrder.currentOrder.table_id &&
+            type === "mobile" &&
+            orderingMode === "table"
+        ) {
+            this.selfOrder.currentOrder.update({
+                table_id: this.selfOrder.currentTable,
+            });
+        }
+
+        if (
             type === "mobile" &&
             orderingMode === "table" &&
             !takeAway &&
@@ -96,7 +107,7 @@ export class CartPage extends Component {
 
     canChangeQuantity(line) {
         const order = this.selfOrder.currentOrder;
-        const lastChange = order.lineChanges[line.uuid];
+        const lastChange = order.uiState.lineChanges[line.uuid];
 
         if (!lastChange) {
             return true;
@@ -119,6 +130,7 @@ export class CartPage extends Component {
 
         if (lastChange) {
             line.qty = lastChange.qty;
+            line.setDirty();
         } else {
             this.selfOrder.removeLine(line);
         }
@@ -137,8 +149,11 @@ export class CartPage extends Component {
         for (const cline of this.selfOrder.currentOrder.lines) {
             if (cline.combo_parent_uuid === line.uuid) {
                 this._changeQuantity(cline, increase);
+                cline.setDirty();
             }
         }
+
+        line.setDirty();
     }
 
     async changeQuantity(line, increase) {

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
@@ -54,24 +54,17 @@ export class CartPage extends Component {
         }
 
         if (
-            this.selfOrder.currentTable &&
-            !this.selfOrder.currentOrder.table_id &&
-            type === "mobile" &&
-            orderingMode === "table"
-        ) {
-            this.selfOrder.currentOrder.update({
-                table_id: this.selfOrder.currentTable,
-            });
-        }
-
-        if (
             type === "mobile" &&
             orderingMode === "table" &&
             !takeAway &&
-            !this.selfOrder.currentOrder.table_id
+            !this.selfOrder.currentTable
         ) {
             this.state.selectTable = true;
             return;
+        } else {
+            this.selfOrder.currentOrder.update({
+                table_id: this.selfOrder.currentTable,
+            });
         }
 
         this.selfOrder.rpcLoading = true;
@@ -81,10 +74,10 @@ export class CartPage extends Component {
 
     selectTable(table) {
         if (table) {
-            this.selfOrder.table = table;
             this.selfOrder.currentOrder.update({
                 table_id: table,
             });
+            this.selfOrder.currentTable = table;
             this.router.addTableIdentifier(table);
             this.pay();
         }

--- a/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.js
+++ b/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.js
@@ -70,7 +70,7 @@ export class ConfirmationPage extends Component {
             access_token: this.selfOrder.access_token,
             order_access_tokens: [this.props.orderAccessToken],
         });
-        this.selfOrder.models.replaceDataByKey("uuid", data);
+        this.selfOrder.models.loadData(data);
         const order = this.selfOrder.models["pos.order"].find(
             (o) => o.access_token === this.props.orderAccessToken
         );

--- a/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.js
+++ b/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.js
@@ -31,7 +31,7 @@ export class PaymentPage extends Component {
     get showFooterBtn() {
         return this.selfOrder.paymentError || this.state.selection;
     }
-    rpc;
+
     selectMethod(methodId) {
         this.state.selection = false;
         this.state.paymentMethodId = methodId;

--- a/addons/pos_self_order/static/src/app/self_order_router_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_router_service.js
@@ -26,6 +26,11 @@ export class SelfOrderRouter extends Reactive {
         history.replaceState({}, "", url);
     }
 
+    getTableIdentifier() {
+        const url = new URL(browser.location.href);
+        return url.searchParams.get("table_identifier");
+    }
+
     back() {
         if (!this.historyPage.length) {
             // We use the browser history, so if the user arrives on a page with a back button from a link,

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -156,8 +156,6 @@ export class SelfOrder extends Reactive {
                 message = _t("Your order has been paid");
             } else if (oUpdated?.state === "cancel") {
                 message = _t("Your order has been cancelled");
-            } else if (oUpdated) {
-                message = _t("Your order has been updated");
             }
 
             if (message) {
@@ -500,6 +498,10 @@ export class SelfOrder extends Reactive {
     }
 
     saveOrdersAccessTokens() {
+        if (this.self_ordering_mode === "kiosk") {
+            return new Set();
+        }
+
         const localStorageKey = `self_order_${this.access_token}`;
         const orderAccessToken = localStorage.getItem(localStorageKey);
         const orderAccessTokenSet = new Set();
@@ -664,7 +666,7 @@ export class SelfOrder extends Reactive {
                 access_token: this.access_token,
                 order_access_tokens: [...accessTokens, ...localAccessToken],
             });
-            this.models.replaceDataByKey("uuid", data);
+            this.models.loadData(data);
             this.selectedOrderUuid = null;
         } catch (error) {
             this.handleErrorNotification(
@@ -833,12 +835,16 @@ export class SelfOrder extends Reactive {
     showDownloadButton(order) {
         return this.config.self_ordering_mode === "mobile" && order.state === "paid";
     }
-    getReceiptHeaderData() {
+    getReceiptHeaderData(order) {
         // FIXME - We should extract this methods from PoS to be allowed to use it here.
         return {
             company: this.company,
-            cashier: "Self-Order",
+            cashier: _t("Self-Order"),
             header: this.config.receipt_header,
+            trackingNumber: order.trackingNumber,
+            bigTrackingNumber: true,
+            pickingService: this.config.self_ordering_service_mode,
+            tableTracker: order.table_stand_number,
         };
     }
     orderExportForPrinting(order) {


### PR DESCRIPTION
### Commit 1:
- Paid orders wasn't saved in localStorage so user cannot see his history
- User cannot reduce line on cart page, a traceback was raised.
- Paid order from kiosk was printing empty ticket.
- Table selector was always displayed, even with a table identifier in URL

### Commit 2 (@caburj):
Steps to reproduce:

1. Install pos_self_order and pos_iot in demo mode to have a "Kiosk" config.
2. Configure an epson printer in the "Kiosk" config.
3. Open a Kiosk session.
4. Make an order with order items.
5. Reach the confirmation page.

Issues:

1. Printed receipt don't have the order items.
2. The tracking number is not properly displayed (very small) and there are
   missing header information.
3. The header data lists: "Served by Self-Order".

Proposed solution:

1. Make sure the items are listed.
2. Show all the necessary header data and make the tracking number should be
   bigger.
3. Replace "Served by Self-Order" with "Self-Order".

How the changes worked:

1. `replaceDataByKey` should be replaced by `loadData` because at this point, we
   need to update the record saved in `models`.

TASK-ID: 4127287
