### PR TITLE
[IMP] mail: add channel/group owner

### DIFF
--- a/addons/hr_holidays/static/src/avatar_card_popover_patch.xml
+++ b/addons/hr_holidays/static/src/avatar_card_popover_patch.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-inherit="mail.AvatarCardPopover" t-inherit-mode="extension">
-        <xpath expr="//span[hasclass('o-mail-avatar-card-name')]" position="after">
+        <xpath expr="//div[hasclass('o-mail-avatar-card-name-actions')]" position="after">
             <span t-if="partner?.outOfOfficeDateEndText" class="text-warning me-1 smaller fw-bold opacity-75" t-esc="partner.outOfOfficeDateEndText"/>
         </xpath>
     </t>

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -158,6 +158,7 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
             lambda m: m.partner_id == self.chatbot_script.operator_partner_id
         )
         member_bot_data = {
+            "channel_role": False,
             "create_date": fields.Datetime.to_string(member_bot.create_date),
             "fetched_message_id": False,
             "id": member_bot.id,
@@ -284,6 +285,7 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
                             "discuss.channel": [{"id": discuss_channel.id, "member_count": 3}],
                             "discuss.channel.member": [
                                 {
+                                    "channel_role": False,
                                     "create_date": fields.Datetime.to_string(
                                         member_emp.create_date
                                     ),
@@ -326,11 +328,16 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
                         "payload": {
                             "discuss.channel": [
                                 {
-                                    "channel_member_ids": [["DELETE", [member_bot.id]]],
                                     "id": discuss_channel.id,
                                     "member_count": 2,
                                 }
-                            ]
+                            ],
+                            "discuss.channel.member": [
+                                {
+                                    "_DELETE": True,
+                                    "id": member_bot.id,
+                                }
+                            ],
                         },
                     },
                     {

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -184,6 +184,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                     "partner_id": operator.partner_id.id,
                     "seen_message_id": False,
                     "channel_id": {"id": channel_info["id"], "model": "discuss.channel"},
+                    "channel_role": False,
                 },
                 {
                     "create_date": fields.Datetime.to_string(visitor_member.create_date),
@@ -203,6 +204,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                     "seen_message_id": False,
                     "unpin_dt": False,
                     "channel_id": {"id": channel_info["id"], "model": "discuss.channel"},
+                    "channel_role": False,
                 },
             ],
         )
@@ -276,6 +278,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                     "seen_message_id": False,
                     "unpin_dt": fields.Datetime.to_string(operator_member.unpin_dt),
                     "channel_id": {"id": channel_info["id"], "model": "discuss.channel"},
+                    "channel_role": False,
                 },
             ],
         )

--- a/addons/mail/data/discuss_channel_data.xml
+++ b/addons/mail/data/discuss_channel_data.xml
@@ -27,6 +27,7 @@
         <record model="discuss.channel.member" id="channel_member_general_channel_for_admin">
             <field name="partner_id" ref="base.partner_admin"/>
             <field name="channel_id" ref="mail.channel_all_employees"/>
+            <field name="channel_role" eval="'owner'"/>
             <field name="fetched_message_id" ref="mail.module_install_notification"/>
             <field name="is_favorite" eval="True"/>
             <field name="seen_message_id" ref="mail.module_install_notification"/>

--- a/addons/mail/demo/discuss/public_channel_demo.xml
+++ b/addons/mail/demo/discuss/public_channel_demo.xml
@@ -64,6 +64,7 @@
         <record model="discuss.channel.member" id="mail.channel_public_community_member_partner_admin_demo">
             <field name="partner_id" ref="base.partner_admin"/>
             <field name="channel_id" ref="mail.channel_public_community_demo"/>
+            <field name="channel_role" eval="'owner'"/>
             <field name="fetched_message_id" ref="mail.channel_public_community_message_0_demo"/>
             <field name="seen_message_id" ref="mail.channel_public_community_message_0_demo"/>
             <field name="new_message_separator" eval="ref('mail.channel_public_community_message_0_demo') + 1"/>
@@ -71,6 +72,7 @@
         <record model="discuss.channel.member" id="mail.channel_public_community_member_partner_demo_demo">
             <field name="partner_id" ref="base.partner_demo"/>
             <field name="channel_id" ref="mail.channel_public_community_demo"/>
+            <field name="channel_role" eval="'owner'"/>
             <field name="fetched_message_id" ref="mail.channel_public_community_message_2_demo"/>
             <field name="is_favorite" eval="True"/>
             <field name="seen_message_id" ref="mail.channel_public_community_message_2_demo"/>

--- a/addons/mail/demo/discuss_channel_demo.xml
+++ b/addons/mail/demo/discuss_channel_demo.xml
@@ -222,6 +222,7 @@
         <record model="discuss.channel.member" id="mail.admin_member_troubleshooting">
             <field name="partner_id" ref="base.partner_admin"/>
             <field name="channel_id" ref="mail.troubleshooting_sub"/>
+            <field name="channel_role" eval="'owner'"/>
             <field name="fetched_message_id" ref="mail.troubleshooting_message_2"/>
             <field name="seen_message_id" ref="mail.troubleshooting_message_2"/>
             <field name="new_message_separator" eval="ref('mail.troubleshooting_message_2') + 1"/>

--- a/addons/mail/models/discuss/bus_sync_mixin.py
+++ b/addons/mail/models/discuss/bus_sync_mixin.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import defaultdict
-from odoo import models, api
+from odoo import models
 from odoo.addons.web.models.models import lazymapping
 from odoo.addons.mail.tools.discuss import Store
 
@@ -10,15 +10,13 @@ class BusSyncMixin(models.AbstractModel):
     _name = "bus.sync.mixin"
     _description = "Mixin for Bus Sync"
 
-    @api.model
     def _sync_field_names(self):
         """
         Return the field names to sync. Override in specific models.
-        Keys are bus subchannel names, values are lists of field names to sync.
+        Keys are bus subchannel or (main channel_id, subchannel) names, values are lists of field names to sync.
         """
         return defaultdict(list)
 
-    @api.model
     def _sync_extra_field_names(self, target: Store.Target, fields):
         """
         Return the extra field names to sync. Override in specific models.
@@ -46,31 +44,38 @@ class BusSyncMixin(models.AbstractModel):
 
         def get_vals(record):
             """Get the current values of the fields to sync."""
-            return {
-                subchannel: {
+            result = defaultdict(dict)
+            for bus_target, field_descriptions in fields_to_sync.items():
+                target = (
+                    (record[bus_target[0]], bus_target[1])
+                    if isinstance(bus_target, tuple)
+                    else (record._bus_channel(), bus_target)
+                )
+                result[target] = {
                     get_field_name(field_description): (
                         get_field_value(record, field_description),
                         field_description,
                     )
                     for field_description in field_descriptions
                 }
-                for subchannel, field_descriptions in self._sync_field_names().items()
-            }
+            return result
 
+        fields_to_sync = self._sync_field_names()
         old_vals = {record: get_vals(record) for record in self}
         result = super().write(vals)
         stores = lazymapping(lambda param: Store(bus_channel=param[0], bus_subchannel=param[1]))
         for record in self:
-            for subchannel, values in get_vals(record).items():
-                diff = []
+            for (channels, subchannel), values in get_vals(record).items():
+                diff = defaultdict(list)
                 for field_name, (value, field_description) in values.items():
-                    if value != old_vals[record][subchannel][field_name][0]:
-                        diff.append(field_description)
+                    if value != old_vals[record][channels, subchannel][field_name][0]:
+                        diff[channels, subchannel].append(field_description)
                 if diff:
-                    for channel in record._bus_channel():
-                        stores[channel, subchannel].add(record, diff)
-                        if extra_fields := record._sync_extra_field_names(stores[channel, subchannel].target, diff):
-                            stores[channel, subchannel].add(record, extra_fields)
+                    for (channels, subchannel), diff_fields in diff.items():
+                        for channel in channels:
+                            stores[channel, subchannel].add(record, diff_fields)
+                            if extra_fields := record._sync_extra_field_names(stores[channel, subchannel].target, diff_fields):
+                                stores[channel, subchannel].add(record, extra_fields)
         for store in stores.values():
             store.bus_send()
         return result

--- a/addons/mail/security/mail_security.xml
+++ b/addons/mail/security/mail_security.xml
@@ -96,6 +96,52 @@
             <field name="perm_unlink" eval="False"/>
         </record>
 
+        <record id="ir_rule_discuss_channel_member_is_channel_owner_unlink" model="ir.rule">
+            <field name="name">discuss.channel.member: channel owner can remove members except owners</field>
+            <field name="model_id" ref="mail.model_discuss_channel_member"/>
+            <field name="groups"
+                eval="[
+                    Command.link(ref('base.group_user')),
+                    Command.link(ref('base.group_portal')),
+                    Command.link(ref('base.group_public')),
+                ]"
+            />
+            <field name="domain_force">
+                [
+                    ("channel_id.self_member_id.channel_role", "=", "owner"),
+                    ("channel_role", "!=", "owner"),
+                    "|",
+                        ("channel_id.channel_type", "=", "channel"),
+                        ("channel_id.channel_type", "=", "group"),
+                ]
+            </field>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_read" eval="False"/>
+            <field name="perm_write" eval="False"/>
+        </record>
+        <record id="ir_rule_discuss_channel_member_is_channel_admin_unlink" model="ir.rule">
+            <field name="name">discuss.channel.member: channel admin can remove members except admins and owners</field>
+            <field name="model_id" ref="mail.model_discuss_channel_member"/>
+            <field name="groups"
+                eval="[
+                    Command.link(ref('base.group_user')),
+                    Command.link(ref('base.group_portal')),
+                    Command.link(ref('base.group_public')),
+                ]"
+            />
+            <field name="domain_force">
+                [
+                    ("channel_id.self_member_id.channel_role", "=", "admin"),
+                    ("channel_role", "=", False),
+                    "|",
+                        ("channel_id.channel_type", "=", "channel"),
+                        ("channel_id.channel_type", "=", "group"),
+                ]
+            </field>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_read" eval="False"/>
+            <field name="perm_write" eval="False"/>
+        </record>
         <record id="ir_rule_discuss_channel_member_create_is_group_matching_all" model="ir.rule">
             <field name="name">discuss.channel.member: can join group restricted channels when group is matching</field>
             <field name="model_id" ref="mail.model_discuss_channel_member"/>

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -43,6 +43,8 @@
             <div t-ref="displayName" class="d-flex overflow-hidden flex-column lh-sm">
                 <span class="ms-2 text-truncate text-muted fw-bold" t-esc="member.name" t-att-title="member.name"/>
             </div>
+            <i t-if="member.channel_role === 'owner'" class="ms-2 fa fa-star text-warning" role="img" title="Channel Owner" aria-label="Channel Owner"/>
+            <i t-if="member.channel_role === 'admin'" class="ms-2 fa fa-star text-primary" role="img" title="Channel Admin" aria-label="Channel Admin"/>
             <span class="ms-auto">
                 <span t-if="member.in(props.thread.invited_member_ids)" class="p-1 oi oi-user-plus opacity-75"/>
                 <span t-if="member.rtcSession?.is_muted and !member.rtcSession?.is_deaf" class="p-1 fa fa-microphone-slash opacity-75"/>

--- a/addons/mail/static/src/discuss/core/common/channel_member_model.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_model.js
@@ -4,6 +4,7 @@ import { fields, Record } from "@mail/model/export";
 import { browser } from "@web/core/browser/browser";
 import { deserializeDateTime } from "@web/core/l10n/dates";
 import { user } from "@web/core/user";
+import { rpc } from "@web/core/network/rpc";
 
 const { DateTime } = luxon;
 
@@ -47,6 +48,10 @@ export class ChannelMember extends Record {
         return this.partner_id || this.guest_id;
     }
     channel_id = fields.One("discuss.channel", { inverse: "channel_member_ids" });
+    /**
+     * @type {false|"owner"|"admin"}
+     */
+    channel_role;
     threadAsSelf = fields.One("mail.thread", {
         compute() {
             if (this.store.self?.eq(this.persona)) {
@@ -152,6 +157,13 @@ export class ChannelMember extends Record {
                   locale: user.lang,
               })
             : undefined;
+    }
+
+    async setChannelRole(channel_role) {
+        await rpc("/discuss/channel/member/set_role", {
+            member_id: this.id,
+            channel_role,
+        });
     }
 }
 

--- a/addons/mail/static/src/discuss/core/common/message_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/message_model_patch.js
@@ -52,6 +52,15 @@ const messagePatch = {
         });
         this.threadAsFirstUnread = fields.One("mail.thread", { inverse: "firstUnreadMessage" });
     },
+    /**
+     * @override
+     */
+    get allowsEdition() {
+        return (
+            super.allowsEdition ||
+            ["owner", "admin"].includes(this.channel_id?.self_member_id?.channel_role)
+        );
+    },
     /** @returns {import("models").ChannelMember[]} */
     get channelMemberHaveSeen() {
         return this.thread.membersThatCanSeen.filter(

--- a/addons/mail/static/src/discuss/core/web/channel_member_list_patch.js
+++ b/addons/mail/static/src/discuss/core/web/channel_member_list_patch.js
@@ -18,6 +18,7 @@ patch(ChannelMemberList.prototype, {
         if (!this.avatarCard.isOpen) {
             this.avatarCard.open(ev.currentTarget, {
                 id: member.partner_id.main_user_id?.id,
+                channelMember: member,
             });
         }
     },

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.js
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.js
@@ -1,13 +1,19 @@
 import { useService } from "@web/core/utils/hooks";
+import { _t } from "@web/core/l10n/translation";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { rpc } from "@web/core/network/rpc";
 import { Component } from "@odoo/owl";
 import { useOpenChat } from "@mail/core/web/open_chat_hook";
 import { ImStatus } from "@mail/core/common/im_status";
 
 export class AvatarCardPopover extends Component {
     static template = "mail.AvatarCardPopover";
-    static components = { ImStatus };
+    static components = { Dropdown, DropdownItem, ImStatus };
     static props = {
         id: { type: Number, required: true },
+        channelMember: { type: Object, optional: true },
         close: { type: Function, required: true },
         model: {
             type: String,
@@ -22,11 +28,67 @@ export class AvatarCardPopover extends Component {
     setup() {
         this.actionService = useService("action");
         this.store = useService("mail.store");
+        this.dialog = useService("dialog");
         this.openChat = useOpenChat(this.props.model);
         this.store.fetchStoreData("avatar_card", {
             id: this.props.id,
             model: this.props.model,
         });
+    }
+
+    get canOpenSettingMenu() {
+        return (
+            this.canSetAdmin ||
+            this.canRemoveAdmin ||
+            this.canSetOwner ||
+            this.canRemoveOwner ||
+            this.canRemoveMember
+        );
+    }
+
+    get selfChannelRole() {
+        return this.props.channelMember?.channel_id?.self_member_id?.channel_role;
+    }
+
+    get currentChannelRole() {
+        return this.props.channelMember?.channel_role;
+    }
+
+    get canSetAdmin() {
+        return (
+            this.currentChannelRole !== "admin" &&
+            (this.store.self_user?.is_admin ||
+                (this.selfChannelRole === "owner" && this.currentChannelRole !== "owner") ||
+                (this.selfChannelRole === "owner" && this.props.channelMember?.threadAsSelf))
+        );
+    }
+
+    get canRemoveAdmin() {
+        return (
+            this.currentChannelRole === "admin" &&
+            (this.store.self_user?.is_admin || this.selfChannelRole === "owner")
+        );
+    }
+
+    get canSetOwner() {
+        return (
+            this.currentChannelRole !== "owner" &&
+            (this.store.self_user?.is_admin || this.selfChannelRole === "owner")
+        );
+    }
+
+    get canRemoveOwner() {
+        return (
+            this.currentChannelRole === "owner" &&
+            (this.store.self_user?.is_admin || this.props.channelMember?.threadAsSelf)
+        );
+    }
+
+    get canRemoveMember() {
+        return (
+            this.store.self_user?.is_admin ||
+            (this.selfChannelRole && this.currentChannelRole !== "owner")
+        );
     }
 
     get user() {
@@ -75,6 +137,43 @@ export class AvatarCardPopover extends Component {
     onSendClick() {
         this.openChat(this.props.id);
         this.props.close();
+    }
+
+    onClickRemove() {
+        this.dialog.add(ConfirmationDialog, {
+            body: _t('Do you want to remove "%(member_name)s" from this channel?', {
+                member_name: this.props.channelMember.name,
+            }),
+            cancel: () => {},
+            confirm: () => {
+                rpc("/discuss/channel/remove_member", {
+                    member_id: this.props.channelMember.id,
+                });
+                this.props.close();
+            },
+        });
+    }
+
+    setChannelRole(role) {
+        if (
+            !this.store.self_user?.is_admin &&
+            (this.props.channelMember.threadAsSelf || role === "owner")
+        ) {
+            this.dialog.add(ConfirmationDialog, {
+                body: this.props.channelMember.threadAsSelf
+                    ? _t(
+                          "Do you want to remove owner from yourself? You will no longer have full control over the channel and its settings."
+                      )
+                    : _t(
+                          'Do you want to set "%(member_name)s" as the owner? This means that the member will have full control over the channel and its settings.\n\nThis action cannot be reverted.',
+                          { member_name: this.props.channelMember.name }
+                      ),
+                cancel: () => {},
+                confirm: () => this.props.channelMember.setChannelRole(role),
+            });
+        } else {
+            this.props.channelMember.setChannelRole(role);
+        }
     }
 
     async onClickViewProfile(newWindow) {

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
@@ -14,7 +14,30 @@
                         </span>
                     </span>
                     <div class="d-flex flex-column o_card_user_infos overflow-hidden">
-                        <span class="o-mail-avatar-card-name fw-bold" t-if="name" t-esc="name"/>
+                        <div class="o-mail-avatar-card-name-actions d-flex align-items-center justify-content-center">
+                            <span class="o-mail-avatar-card-name fw-bold" t-if="name" t-esc="name"/>
+                            <div class="flex-grow-1"/>
+                            <Dropdown t-if="canOpenSettingMenu" position="'right-start'">
+                                <button class="btn btn-sm">
+                                    <i class="oi oi-ellipsis-v"/>
+                                </button>
+                                <t t-set-slot="content">
+                                    <DropdownItem t-if="canSetAdmin" onSelected="() => this.setChannelRole('admin')">
+                                        Set Channel Admin
+                                    </DropdownItem>
+                                    <DropdownItem t-if="canRemoveAdmin or canRemoveOwner" onSelected="() => this.setChannelRole(false)">
+                                        <t t-if="canRemoveOwner">Remove Channel Owner</t>
+                                        <t t-if="canRemoveAdmin">Remove Channel Admin</t>
+                                    </DropdownItem>
+                                    <DropdownItem t-if="canSetOwner" onSelected="() => this.setChannelRole('owner')">
+                                        Set Channel Owner
+                                    </DropdownItem>
+                                    <DropdownItem t-if="canRemoveMember" onSelected.bind="onClickRemove">
+                                        <span class="text-danger">Remove from Channel</span>
+                                    </DropdownItem>
+                                </t>
+                            </Dropdown>
+                        </div>
                         <t t-if="userInfoTemplate" t-call="{{userInfoTemplate}}"/>
                         <a t-if="email" t-att-href="'mailto:'+email" t-att-title="email" class="text-truncate">
                             <i class="fa fa-fw fa-envelope me-1"/><t t-esc="email"/>

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -151,6 +151,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                             "discuss.channel.member": [
                                 {
                                     "channel_id": {"id": test_group.id, "model": "discuss.channel"},
+                                    "channel_role": False,
                                     "create_date": fields.Datetime.to_string(member.create_date),
                                     "fetched_message_id": False,
                                     "id": member.id,
@@ -197,6 +198,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                             "discuss.channel": [{"id": test_group.id, "member_count": 2}],
                             "discuss.channel.member": [
                                 {
+                                    "channel_role": False,
                                     "create_date": fields.Datetime.to_string(member.create_date),
                                     "fetched_message_id": False,
                                     "id": member.id,

--- a/addons/resource_mail/static/src/components/avatar_card_resource/avatar_card_resource_popover.js
+++ b/addons/resource_mail/static/src/components/avatar_card_resource/avatar_card_resource_popover.js
@@ -22,6 +22,7 @@ export class AvatarCardResourcePopover extends AvatarCardPopover {
 
     setup() {
         this.orm = useService("orm");
+        this.store = useService("mail.store");
         this.actionService = useService("action");
         this.openChat = useOpenChat("res.users");
         onWillStart(this.onWillStart);

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -921,6 +921,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         bus_last_id = self.env["bus.bus"].sudo()._bus_last_id()
         if channel == self.channel_general and partner == self.users[0].partner_id:
             return {
+                "channel_role": False,
                 "create_date": member_0_create_date,
                 "custom_channel_name": False,
                 "custom_notifications": False,
@@ -941,6 +942,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_channel_public_1 and partner == self.users[0].partner_id:
             return {
+                "channel_role": "owner",
                 "create_date": member_0_create_date,
                 "custom_channel_name": False,
                 "custom_notifications": False,
@@ -961,6 +963,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_channel_public_2 and partner == self.users[0].partner_id:
             return {
+                "channel_role": "owner",
                 "create_date": member_0_create_date,
                 "custom_channel_name": False,
                 "custom_notifications": False,
@@ -981,6 +984,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_channel_group_1 and partner == self.users[0].partner_id:
             return {
+                "channel_role": "owner",
                 "create_date": member_0_create_date,
                 "custom_channel_name": False,
                 "custom_notifications": False,
@@ -1007,6 +1011,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_channel_group_2 and partner == self.users[0].partner_id:
             return {
+                "channel_role": "owner",
                 "create_date": member_0_create_date,
                 "custom_channel_name": False,
                 "custom_notifications": False,
@@ -1027,6 +1032,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_group_1 and partner == self.users[0].partner_id:
             return {
+                "channel_role": "owner",
                 "create_date": member_0_create_date,
                 "custom_channel_name": False,
                 "custom_notifications": False,
@@ -1047,6 +1053,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_group_1 and partner == self.users[12].partner_id:
             return {
+                "channel_role": False,
                 "create_date": fields.Datetime.to_string(member_12.create_date),
                 "last_seen_dt": False,
                 "fetched_message_id": False,
@@ -1057,6 +1064,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_chat_1 and partner == self.users[0].partner_id:
             return {
+                "channel_role": False,
                 "create_date": member_0_create_date,
                 "custom_channel_name": False,
                 "custom_notifications": False,
@@ -1077,6 +1085,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_chat_1 and partner == self.users[14].partner_id:
             return {
+                "channel_role": False,
                 "create_date": fields.Datetime.to_string(member_14.create_date),
                 "last_seen_dt": False,
                 "fetched_message_id": False,
@@ -1087,6 +1096,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_chat_2 and partner == self.users[0].partner_id:
             return {
+                "channel_role": False,
                 "create_date": member_0_create_date,
                 "custom_channel_name": False,
                 "custom_notifications": False,
@@ -1107,6 +1117,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_chat_2 and partner == self.users[15].partner_id:
             return {
+                "channel_role": False,
                 "create_date": fields.Datetime.to_string(member_15.create_date),
                 "last_seen_dt": False,
                 "fetched_message_id": False,
@@ -1117,6 +1128,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_chat_3 and partner == self.users[0].partner_id:
             return {
+                "channel_role": False,
                 "create_date": member_0_create_date,
                 "custom_channel_name": False,
                 "custom_notifications": False,
@@ -1137,6 +1149,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_chat_3 and partner == self.users[2].partner_id:
             return {
+                "channel_role": False,
                 "create_date": fields.Datetime.to_string(member_2.create_date),
                 "last_seen_dt": False,
                 "fetched_message_id": False,
@@ -1147,6 +1160,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_chat_4 and partner == self.users[0].partner_id:
             return {
+                "channel_role": False,
                 "create_date": member_0_create_date,
                 "custom_channel_name": False,
                 "custom_notifications": False,
@@ -1167,6 +1181,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_chat_4 and partner == self.users[3].partner_id:
             return {
+                "channel_role": False,
                 "create_date": fields.Datetime.to_string(member_3.create_date),
                 "last_seen_dt": False,
                 "fetched_message_id": False,
@@ -1177,6 +1192,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_livechat_1 and partner == self.users[0].partner_id:
             return {
+                "channel_role": False,
                 "create_date": member_0_create_date,
                 "custom_channel_name": False,
                 "custom_notifications": False,
@@ -1198,6 +1214,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_livechat_1 and partner == self.users[1].partner_id:
             return {
+                "channel_role": False,
                 "create_date": fields.Datetime.to_string(member_1.create_date),
                 "last_seen_dt": fields.Datetime.to_string(member_1.last_seen_dt),
                 "fetched_message_id": last_message.id,
@@ -1209,6 +1226,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_livechat_2 and partner == self.users[0].partner_id:
             return {
+                "channel_role": False,
                 "create_date": member_0_create_date,
                 "custom_channel_name": False,
                 "custom_notifications": False,
@@ -1230,6 +1248,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_livechat_2 and guest:
             return {
+                "channel_role": False,
                 "create_date": fields.Datetime.to_string(member_g.create_date),
                 "last_seen_dt": fields.Datetime.to_string(member_g.last_seen_dt),
                 "fetched_message_id": last_message.id,

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -234,6 +234,7 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                 ),
                 "discuss.channel.member": [
                     {
+                        "channel_role": False,
                         "create_date": fields.Datetime.to_string(operator_member.create_date),
                         "fetched_message_id": False,
                         "id": operator_member.id,
@@ -244,6 +245,7 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                         "channel_id": {"id": channel.id, "model": "discuss.channel"},
                     },
                     {
+                        "channel_role": False,
                         "create_date": fields.Datetime.to_string(guest_member.create_date),
                         "fetched_message_id": False,
                         "id": guest_member.id,
@@ -350,6 +352,7 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
             [
                 {
                     "channel_id": {"id": channel.id, "model": "discuss.channel"},
+                    "channel_role": False,
                     "create_date": fields.Datetime.to_string(guest_member.create_date),
                     "custom_channel_name": False,
                     "custom_notifications": False,


### PR DESCRIPTION
1. Add a new selection field to store the ownership of a channel.
Owners are set by DB admin or another owner. Owners can assign admin to
channel members.
2. Owners, Admins and DB admin can remove members from the channel.
3. Owner/admin should have a special icon in the member list.

Task-4107790
https://github.com/odoo/upgrade/pull/6462



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
