### PR TITLE
[PERF] mail: generate mails in smaller batchs by default

### DIFF
--- a/addons/mail/models/ir_config_parameter.py
+++ b/addons/mail/models/ir_config_parameter.py
@@ -29,7 +29,7 @@ class IrConfigParameter(models.Model):
     #   - MailComposer._action_send_mail_mass_mail(): mails generation based on records
     #   - MailThread._notify_thread_by_email(): mails generation for notification emails
     #   - MailTemplate.send_mail_batch(): mails generation done directly from templates
-    #   to split mail generation in batches. 500 by default;
+    #   to split mail generation in batches. 50 by default;
 
     # Mail Gateway
     #   * 'mail.gateway.loop.minutes' and 'mail.gateway.loop.threshold': block

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -617,7 +617,7 @@ class MailTemplate(models.Model):
         mails_sudo = self.env['mail.mail'].sudo()
         batch_size = int(
             self.env['ir.config_parameter'].sudo().get_param('mail.batch_size')
-        ) or 500  # be sure to not have 0, as otherwise no iteration is done
+        ) or 50  # be sure to not have 0, as otherwise no iteration is done
         RecordModel = self.env[self.model].with_prefetch(res_ids)
         record_ir_model = self.env['ir.model']._get(self.model)
 

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3228,7 +3228,7 @@ class MailThread(models.AbstractModel):
         # loop on groups (customer, portal, user,  ... + model specific like group_sale_salesman)
         gen_batch_size = int(
             self.env['ir.config_parameter'].sudo().get_param('mail.batch_size')
-        ) or 500  # be sure to not have 0, as otherwise no iteration is done
+        ) or 50  # be sure to not have 0, as otherwise no iteration is done
         notif_create_values = []
         for _lang, render_values, recipients_group in self._notify_get_classified_recipients_iterator(
             message,

--- a/addons/test_mail/tests/test_mail_template.py
+++ b/addons/test_mail/tests/test_mail_template.py
@@ -235,7 +235,7 @@ class TestMailTemplateLanguages(TestMailTemplateCommon):
     def test_template_send_email_batch(self):
         """ Test 'send_email' on template in batch """
         self.env.invalidate_all()
-        with self.with_user(self.user_employee.login), self.assertQueryCount(18):
+        with self.with_user(self.user_employee.login), self.assertQueryCount(25):
             template = self.test_template.with_env(self.env)
             mails_sudo = template.send_mail_batch(self.test_records_batch.ids)
 
@@ -275,7 +275,7 @@ class TestMailTemplateLanguages(TestMailTemplateCommon):
         """ Test 'send_email' on template in batch with dynamic reports """
         self.env.invalidate_all()
 
-        with self.with_user(self.user_employee.login), self.assertQueryCount(229):
+        with self.with_user(self.user_employee.login), self.assertQueryCount(236):
             template = self.test_template_wreports.with_env(self.env)
             mails_sudo = template.send_mail_batch(self.test_records_batch.ids)
 
@@ -312,8 +312,8 @@ class TestMailTemplateLanguages(TestMailTemplateCommon):
         """ Test 'send_email' on template in batch, using configuration parameter
         for batch rendering. """
         for batch_size, exp_mail_create_count in [
-            (False, 1),  # unset, default is 500
-            (0, 1),  # 0: fallbacks on default
+            (False, 2),  # unset, default is 50
+            (0, 2),  # 0: fallbacks on default
             (30, 4),  # 100 / 30 -> 4 iterations
         ]:
             with self.subTest(batch_size=batch_size):


### PR DESCRIPTION
When generating mails in batch, defaults to 50 mails to generate instead of 500 when no configuration parameter is defined. As mails are generated based on templates which may contain calls to wkhtml smaller batches ensure shorter iterations in loop, allowing to commit more often notably.

Task-3764891: Mail: Batch-ize MailTemplate send_mail
