### PR TITLE
[FIX] point_of_sale: adjust date formatting for Arabic language support

### DIFF
--- a/addons/point_of_sale/static/src/utils.js
+++ b/addons/point_of_sale/static/src/utils.js
@@ -1,4 +1,4 @@
-import { formatDateTime, parseDateTime } from "@web/core/l10n/dates";
+import { serializeDateTime, parseDateTime } from "@web/core/l10n/dates";
 
 /*
  * comes from o_spreadsheet.js
@@ -122,10 +122,7 @@ export function loadAllImages(el) {
 }
 
 export function getUTCString(datetimeObj) {
-    return formatDateTime(datetimeObj, {
-        format: "yyyy-MM-dd HH:mm:ss",
-        tz: "utc",
-    });
+    return serializeDateTime(datetimeObj);
 }
 
 export function parseUTCString(utcStr) {


### PR DESCRIPTION
Before this commit, capturing an order in Arabic language encountered issues due to date_order and payment_date being formatted in ISO with Arabic numerals. This commit modifies the formatting to use UTC without Arabic numerals, ensuring compatibility and addressing the capture issues.

opw-4119401

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
