### PR TITLE
[FIX] account: fix error in days_sales_outstanding compute function

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -477,7 +477,7 @@ class ResPartner(models.Model):
         }
         for partner in self:
             oldest_invoice_date, total_invoiced_tax_included = commercial_partners.get(partner, (fields.Date.context_today(self), 0))
-            days_since_oldest_invoice = (fields.Date.context_today(self) - oldest_invoice_date).days
+            days_since_oldest_invoice = (fields.Date.context_today(self) - oldest_invoice_date).days if oldest_invoice_date else 0
             partner.days_sales_outstanding = ((partner.credit / total_invoiced_tax_included) * days_since_oldest_invoice) if total_invoiced_tax_included else 0
 
     def _compute_journal_item_count(self):

--- a/doc/cla/individual/britoederr.md
+++ b/doc/cla/individual/britoederr.md
@@ -1,0 +1,11 @@
+Brazil, 8/21/2024
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Eder Brito britoederr@gmail.com https://github.com/britoederr


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This MR fix the error raised when a partner have related invoices without invoice_date field defined. In my case it happened after a migration.

This is the error trace:

```python
RPC_ERROR
Odoo Server Error
Traceback (most recent call last):
  File "/mnt/odoo/odoo/odoo/http.py", line 1764, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/odoo/odoo/odoo/service/model.py", line 133, in retrying
    result = func()
             ^^^^^^
  File "/mnt/odoo/odoo/odoo/http.py", line 1791, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/odoo/odoo/odoo/http.py", line 1995, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/odoo/odoo/addons/website/models/ir_http.py", line 235, in _dispatch
    response = super()._dispatch(endpoint)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/odoo/odoo/odoo/addons/base/models/ir_http.py", line 222, in _dispatch
    result = endpoint(**request.params)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/odoo/odoo/odoo/http.py", line 741, in route_wrapper
    result = endpoint(self, *args, **params_ok)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/odoo/odoo/addons/web/controllers/dataset.py", line 24, in call_kw
    return self._call_kw(model, method, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/odoo/odoo/addons/web/controllers/dataset.py", line 20, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/odoo/odoo/odoo/api.py", line 468, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/odoo/odoo/odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/odoo/odoo/addons/web/models/models.py", line 86, in web_read
    values_list: List[Dict] = self.read(fields_to_read, load=None)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/odoo/odoo/odoo/models.py", line 3545, in read
    return self._read_format(fnames=fields, load=load)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/odoo/odoo/odoo/models.py", line 3756, in _read_format
    vals[name] = convert(record[name], record, use_display_name)
                         ~~~~~~^^^^^^
  File "/mnt/odoo/odoo/odoo/models.py", line 6636, in _getitem_
    return self.fields[key].get_(self, self.env.registry[self._name])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/odoo/odoo/odoo/fields.py", line 1207, in _get_
    self.compute_value(recs)
  File "/mnt/odoo/odoo/odoo/fields.py", line 1389, in compute_value
    records._compute_field_value(self)
  File "/mnt/odoo/odoo/addons/mail/models/mail_thread.py", line 424, in _compute_field_value
    return super()._compute_field_value(field)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/odoo/odoo/odoo/models.py", line 4880, in _compute_field_value
    fields.determine(field.compute, self)
  File "/mnt/odoo/odoo/odoo/fields.py", line 102, in determine
    return needle(*args)
           ^^^^^^^^^^^^^
  File "/mnt/odoo/odoo/addons/account/models/partner.py", line 480, in _compute_days_sales_outstanding
    days_since_oldest_invoice = (fields.Date.context_today(self) - oldest_invoice_date).days
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for -: 'datetime.date' and 'bool'

The above server error caused the following client error:
OwlError: An error occured in the owl lifecycle (see this Error's "cause" property)
    Error: An error occured in the owl lifecycle (see this Error's "cause" property)
        at handleError (http://localhost:8069/web/assets/8c6578d/web.assets_web.min.js:916:101)
        at App.handleError (http://localhost:8069/web/assets/8c6578d/web.assets_web.min.js:1545:29)
        at ComponentNode.initiateRender (http://localhost:8069/web/assets/8c6578d/web.assets_web.min.js:1006:19)

Caused by: RPC_ERROR: Odoo Server Error
    RPC_ERROR
        at makeErrorFromResponse (http://localhost:8069/web/assets/8c6578d/web.assets_web.min.js:2886:163)
        at XMLHttpRequest.<anonymous> (http://localhost:8069/web/assets/8c6578d/web.assets_web.min.js:2890:13)
``` 



Current behavior before PR:
This error is issued when trying access a partner that have related invoices without invoice_date field defined.

Desired behavior after PR is merged:
The error is no longer issued by the Odoo

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
