### PR TITLE
[FIX] point_of_sale: handle an error when process a pos order

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -134,8 +134,10 @@ class PosOrder(models.Model):
             except psycopg2.DatabaseError:
                 # do not hide transactional errors, the order(s) won't be saved!
                 raise
+            except UserError as e:
+                _logger.warning('Could not fully process the POS Order: %s', tools.exception_to_unicode(e))
             except Exception as e:
-                _logger.error('Could not fully process the POS Order: %s', tools.exception_to_unicode(e))
+                _logger.error('Could not fully process the POS Order: %s', tools.exception_to_unicode(e), exc_info=True)
             self._create_order_picking()
             self._compute_total_cost_in_real_time()
 


### PR DESCRIPTION
Currently, the error occurs when the system cannot fully process the POS Order

This error occurs during the process of the POS Order, So replace a logger error a message with a logger warning message at [1] to prevent more error logs in a terminal.

link [1]:https://github.com/odoo/odoo/blob/3be513d5cc89ad4fefb84fabd8c9089f9ef95aa2/addons/point_of_sale/models/pos_order.py#L147

Sentry-5315326414

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
