### PR TITLE
[FIX] pos_sale: traceback when closing session

### DIFF
--- a/addons/pos_sale/__manifest__.py
+++ b/addons/pos_sale/__manifest__.py
@@ -12,7 +12,7 @@
 
 This module adds a custom Sales Team for the Point of Sale. This enables you to view and manage your point of sale sales with more ease.
 """,
-    'depends': ['point_of_sale', 'sale_management'],
+    'depends': ['point_of_sale', 'sale_management', 'sale_stock'],
     'data': [
         'data/pos_sale_data.xml',
         'security/pos_sale_security.xml',


### PR DESCRIPTION
* STEP TO REPRODUCE: install pos_sale and no sale_stock module install -> make an pos order -> validate -> close session -> error
* REASON: this module use 'move_ids' of sale.order.line which is in module sale_stock
* SOLUTION: add dependency in manifest

Close https://github.com/odoo/odoo/issues/177317

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
