### PR TITLE
[IMP] l10n_sa_edi: add branch ID on journal

### DIFF
--- a/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
+++ b/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
@@ -305,10 +305,23 @@ class AccountEdiXmlUBL21Zatca(models.AbstractModel):
             'due_date': None,
         })
 
+        vals['vals']['accounting_supplier_party_vals']['party_vals'].update(
+            self._l10n_sa_get_supplier_party_vals(invoice))
         vals['vals']['legal_monetary_total_vals'].update(self._l10n_sa_get_monetary_vals(invoice, vals))
         self._l10n_sa_postprocess_line_vals(vals)
 
         return vals
+
+    def _l10n_sa_get_supplier_party_vals(self, invoice):
+        if invoice.journal_id.l10n_sa_branch_id:
+            supplier = invoice.company_id.partner_id.commercial_partner_id
+            return {
+                'party_identification_vals': [{
+                    'id_attrs': {'schemeID': supplier.l10n_sa_additional_identification_scheme},
+                    'id': invoice.journal_id.l10n_sa_branch_id,
+                }]
+            }
+        return {}
 
     def _l10n_sa_postprocess_line_vals(self, vals):
         """

--- a/addons/l10n_sa_edi/models/account_journal.py
+++ b/addons/l10n_sa_edi/models/account_journal.py
@@ -91,6 +91,10 @@ class AccountJournal(models.Model):
     l10n_sa_latest_submission_hash = fields.Char("Latest Submission Hash", copy=False,
                                                  help="Hash of the latest submitted invoice to be used as the Previous Invoice Hash (KSA-13)")
 
+    l10n_sa_branch_id = fields.Char("Branch ID", copy=False,
+                                    help="Can be used in the case where the company has multiple branches that share"
+                                         " the same VAT number, but have different registry numbers.")
+
     # ====== Utility Functions =======
 
     def _l10n_sa_ready_to_submit_einvoices(self):

--- a/addons/l10n_sa_edi/views/account_journal_views.xml
+++ b/addons/l10n_sa_edi/views/account_journal_views.xml
@@ -16,6 +16,7 @@
                         <group>
                             <group>
                                 <field name="l10n_sa_serial_number"/>
+                                <field name="l10n_sa_branch_id" placeholder="e.g: 3999999999"/>
                             </group>
                         </group>
                         <p groups="base.group_system">


### PR DESCRIPTION
As per ZATCA rule BR-KSA-08: In the case where a company has multiple commercial registrations, such as different branches, the sheller should fill the commercial registration of the branch in respect of which the Tax Invoice is being issued. In the case of Odoo, the branch ID will be set on the Journal.

Description of the issue/feature this PR addresses:
Currently there is no option to link a Branch ID to a company, as the only option is to have multiple companies with the same VAT but different Additional Identification Number values.

Current behavior before PR:
Additional Identification Number submitted to ZATCA is set directly on the company and does not allow for multiple branches by company

Desired behavior after PR is merged:
Additional Identification Number submitted to ZATCA can be set on the Journal which allows to have different registration numbers per journal




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
