### PR TITLE
[FIX] discuss: welcome page

### DIFF
--- a/addons/mail/static/src/discuss/call/public/discuss_public_patch.js
+++ b/addons/mail/static/src/discuss/call/public/discuss_public_patch.js
@@ -14,8 +14,8 @@ patch(DiscussPublic.prototype, {
     },
     async displayChannel() {
         super.displayChannel();
-        const video = browser.localStorage.getItem("discuss_call_preview_join_video");
-        const mute = browser.localStorage.getItem("discuss_call_preview_join_mute");
+        const video = browser.localStorage.getItem("discuss_call_preview_join_video") === "true";
+        const mute = browser.localStorage.getItem("discuss_call_preview_join_mute") === "true";
         if (this.thread.defaultDisplayMode === "video_full_screen") {
             this.rtc.toggleCall(this.thread, { video }).then(() => {
                 if (mute) {

--- a/addons/mail/static/src/discuss/core/public/welcome_page.js
+++ b/addons/mail/static/src/discuss/core/public/welcome_page.js
@@ -1,6 +1,6 @@
 /* @odoo-module */
 
-import { Component, useRef, useState } from "@odoo/owl";
+import { Component, useRef, useState, onMounted } from "@odoo/owl";
 
 import { browser } from "@web/core/browser/browser";
 import { useService } from "@web/core/utils/hooks";
@@ -12,6 +12,7 @@ export class WelcomePage extends Component {
     static template = "mail.WelcomePage";
 
     setup() {
+        this.isClosed = false;
         this.store = useState(useService("mail.store"));
         this.rpc = useService("rpc");
         this.personaService = useService("mail.persona");
@@ -22,6 +23,12 @@ export class WelcomePage extends Component {
         });
         this.audioRef = useRef("audio");
         this.videoRef = useRef("video");
+        onMounted(() => {
+            if (this.props.data.channelData.defaultDisplayMode === "video_full_screen") {
+                this.enableMicrophone();
+                this.enableVideo();
+            }
+        });
     }
 
     onKeydownInput(ev) {
@@ -30,10 +37,18 @@ export class WelcomePage extends Component {
         }
     }
 
-    async joinChannel() {
+    joinChannel() {
         if (this.store.guest) {
-            await this.personaService.updateGuestName(this.store.self, this.state.userName.trim());
+            this.personaService.updateGuestName(this.store.self, this.state.userName.trim());
         }
+        browser.localStorage.setItem("discuss_call_preview_join_mute", !this.state.audioStream);
+        browser.localStorage.setItem(
+            "discuss_call_preview_join_video",
+            Boolean(this.state.videoStream)
+        );
+        this.stopTracksOnMediaStream(this.state.audioStream);
+        this.stopTracksOnMediaStream(this.state.videoStream);
+        this.isClosed = true;
         this.props.proceed?.();
     }
 
@@ -49,17 +64,17 @@ export class WelcomePage extends Component {
         }
         try {
             this.state.audioStream = await navigator.mediaDevices.getUserMedia({ audio: true });
-            this.audioRef.el.srcObject = this.audioStream;
+            this.audioRef.el.srcObject = this.state.audioStream;
         } catch {
             // TODO: display popup asking the user to re-enable their mic
+        }
+        if (this.isClosed) {
+            this.stopTracksOnMediaStream(this.state.audioStream);
         }
     }
 
     disableMicrophone() {
         this.audioRef.el.srcObject = null;
-        if (!this.state.audioStream) {
-            return;
-        }
         this.stopTracksOnMediaStream(this.state.audioStream);
         this.state.audioStream = null;
     }
@@ -74,13 +89,13 @@ export class WelcomePage extends Component {
         } catch {
             // TODO: display popup asking the user to re-enable their camera
         }
+        if (this.isClosed) {
+            this.stopTracksOnMediaStream(this.state.videoStream);
+        }
     }
 
     disableVideo() {
         this.videoRef.el.srcObject = null;
-        if (!this.state.videoStream) {
-            return;
-        }
         this.stopTracksOnMediaStream(this.state.videoStream);
         this.state.videoStream = null;
     }
@@ -89,6 +104,9 @@ export class WelcomePage extends Component {
      * @param {MediaStream} mediaStream
      */
     stopTracksOnMediaStream(mediaStream) {
+        if (!mediaStream) {
+            return;
+        }
         for (const track of mediaStream.getTracks()) {
             track.stop();
         }
@@ -100,10 +118,6 @@ export class WelcomePage extends Component {
         } else {
             this.disableMicrophone();
         }
-        browser.localStorage.setItem(
-            "discuss_call_preview_join_mute",
-            Boolean(!this.state.audioStream)
-        );
     }
 
     async onClickVideo() {
@@ -112,10 +126,6 @@ export class WelcomePage extends Component {
         } else {
             this.disableVideo();
         }
-        browser.localStorage.setItem(
-            "discuss_call_preview_join_video",
-            Boolean(this.state.videoStream)
-        );
     }
     getLoggedInAsText() {
         return sprintf(_t("Logged in as %s"), this.store.user.name);

--- a/addons/mail/static/src/discuss/core/public/welcome_page.xml
+++ b/addons/mail/static/src/discuss/core/public/welcome_page.xml
@@ -19,7 +19,7 @@
                 </p>
                 <div class="position-absolute bottom-0">
                     <button class="btn fa-stack align-self-end p-0 m-3 rounded-circle fs-1 shadow" t-attf-class="{{ state.audioStream ? 'btn-dark' : 'btn-danger' }}" t-on-click="onClickMic">
-                        <i class="fa fa-stack" t-attf-class="{{ state.audioStream ? 'fa-microphone-slash' : 'fa-microphone' }}"/>
+                        <i class="fa fa-stack" t-attf-class="{{ state.audioStream ? 'fa-microphone' : 'fa-microphone-slash' }}"/>
                     </button>
                     <button class="btn fa-stack align-self-end p-0 m-3 rounded-circle fs-1 shadow" t-attf-class="{{ state.videoStream ? 'btn-dark' : 'btn-danger' }}" t-on-click="onClickVideo">
                         <i class="fa fa-camera fa-stack"/>


### PR DESCRIPTION
Since the refactor https://github.com/odoo/odoo/pull/110188, the welcome page had several bugs:

1) The `fa-microphone-slash` icon was displayed when the microphone was on instead of when the microphone was mute.

2) The localStorage keys `discuss_call_preview_join_mute` and `discuss_call_preview_join_video` were set with booleans, while the localStorage stores as strings, which made them always truthy as soon as they were set.

3) The microphone preview was not working as the `srcObject` of the audio element was `undefined` because we were using `this.audioStream` instead of `this.state.audioStream`.

4) Before the refactor, the preview was automatically started when opening the welcome page, this commit restores this behavior: https://github.com/odoo/odoo/blob/16.0/addons/mail/static/src/models/discuss_public_view.js#L46-L49

5) Streams (tracks) were not closed after leaving the welcome view, nor was it checked whether they were still needed after the `getUserMedia` promise.
