### PR TITLE
[FIX] website_payment: prevent TypeError when editing custom amount

### DIFF
--- a/addons/website_payment/static/src/js/payment_form.js
+++ b/addons/website_payment/static/src/js/payment_form.js
@@ -34,15 +34,16 @@ PaymentForm.include({
     _updateAmount(ev) {
         if (ev.target.value >= 0) {
             this.paymentContext.amount = ev.target.value;
-            if (ev.target.name === "o_donation_amount" && ev.target.type === "number") {
-                this.el.querySelector("#other_amount").value = ev.target.value;
+            const otherAmountEl = this.el.querySelector("#other_amount");
+            if (ev.target.name === "o_donation_amount" && ev.target.type === "number" && otherAmountEl) {
+                otherAmountEl.value = ev.target.value;
             }
             if (ev.target.id === "other_amount" || (ev.target.name === "o_donation_amount" && ev.target.type === "number")) {
                 this.el.querySelectorAll('input[name="o_donation_amount"][type="radio"]').forEach((radioEl) => {
                     radioEl.checked = false;
                 });
-            } else if (ev.target.name === "o_donation_amount") {
-                this.el.querySelector("#other_amount").checked = false;
+            } else if (ev.target.name === "o_donation_amount" && otherAmountEl) {
+                otherAmountEl.checked = false;
             }
         }
     },


### PR DESCRIPTION
In the `/donation/pay` route, a TypeError occurs when trying to edit the custom amount if no predefined amounts are set. This happens because the script attempts to set the 'value' property of a null element.
Issue introduced in commit: d7e49acf0df0f8043ade969ffea6decfe111690f

Steps to Reproduce:
1. Go to `/donation/pay` without any predefined amounts.
2. Click on the custom amount field.

This commit fixes the issue by ensuring the element exists before attempting to set its value.

task-4103208