### PR TITLE
[FIX] bus: fix non-deterministic bus test

### DIFF
--- a/addons/bus/static/tests/helpers/websocket_event_deferred.js
+++ b/addons/bus/static/tests/helpers/websocket_event_deferred.js
@@ -9,7 +9,7 @@ import { makeDeferred } from "@web/../tests/helpers/utils";
 
 // should be enough to decide whether or not notifications/channel
 // subscriptions... are received.
-const TIMEOUT = 500;
+const TIMEOUT = 2000;
 const callbackRegistry = registry.category("mock_server_websocket_callbacks");
 
 /**


### PR DESCRIPTION
Before this PR, the `receive notifications from a channel` test was sometimes failing. This test waits for the channel to be registered before sending the notification. This flow has many async points:
- bus service to worker to start it
- bus service to worker to initialize it
- worker to bus service to acknowledge the initialization
- bus service to worker to add the channel

The `waitUntilSubscribe` helper waits up to 500ms, but when runbot is heavily used, it can take a bit longer. This PR increases the delay to ensure the flow can complete within the given time.

runbot-75076