### PR TITLE
[FIX] project: correct filter name

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -712,7 +712,7 @@ class Project(models.Model):
         action['display_name'] = _("%(name)s's Rating", name=self.name)
         action_context = ast.literal_eval(action['context']) if action['context'] else {}
         action_context.update(self._context)
-        action_context['search_default_filter_write_date'] = 'custom_create_date_last_30_days'
+        action_context['search_default_filter_write_date'] = 'custom_write_date_last_30_days'
         action_context.pop('group_by', None)
         action['domain'] = [('consumed', '=', True), ('parent_res_model', '=', 'project.project'), ('parent_res_id', '=', self.id)]
         if self.rating_count == 1:


### PR DESCRIPTION
Issue
-----
[project, sale_timesheet]
1. Activate "Customer ratings" in Project settings.
2. On Project kanban view > Open dropdown of a project > Customer Ratings > Traceback.

Change
-----
Small correction of 72f98a5925512a19fc084f1fc207f221e47e856e, the correct filter is the one defined here:
https://github.com/odoo/odoo/blob/72f98a5925512a19fc084f1fc207f221e47e856e/addons/project/views/rating_rating_views.xml#L141

opw-4111790