### PR TITLE
[IMP] website_sale: filmstrip navigation design

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -797,7 +797,6 @@
         <div t-if="entries" class="o_wsale_filmstip_container d-flex align-items-stretch mb-2 overflow-hidden">
             <div class="o_wsale_filmstip_wrapper pb-1 overflow-auto">
                 <ul class="o_wsale_filmstip d-flex align-items-stretch mb-0 list-unstyled overflow-visible">
-                    <t t-foreach="entries" t-as="c" t-if="c.image_128" t-set="atLeastOneImage" t-value="True"/>
                     <t t-if="category.parent_id" t-set="backUrl" t-value="keep('/shop/category/' + slug(category.parent_id), category=0)"/>
                     <t t-else="" t-set="backUrl" t-value="'/shop'"/>
 
@@ -809,6 +808,7 @@
                         <a
                             t-att-href="keep('/shop/category/' + slug(c), category=0)"
                             class="text-decoration-none"
+                            draggable="false"
                         >
                             <input
                                 type="radio"
@@ -818,9 +818,10 @@
                                 t-att-value="c.id"
                                 t-att-checked="'true' if c.id == category.id else None"/>
                             <div
-                                t-attf-class="d-flex align-items-center fs-6 fw-normal
-                                    btn btn-{{navClass}} {{'ps-2 pe-3' if c.image_128 else 'px-4'}}
-                                    {{ 'border-primary' if c.id == category.id else '' }}"
+                                t-att-class="'d-flex align-items-center h-100 btn btn-'
+                                    + navClass
+                                    + (c.image_128 and ' ps-2 pe-3' or ' px-4')
+                                    + (c.id == category.id and ' border-primary' or '')"
                             >
                                 <div
                                     t-if="c.image_128"


### PR DESCRIPTION
Improve the existing top categories styling and behavior. Now if there is a category with an image next to one without it will visually grow to match it's neighbours.

Additionnaly grabbing the link would take priority making the drag event on the filmstrip extremely difficult and frustrating. Adding the grabbable attribute on the link prevent the accidental grab of the `<a>` element while wanting to navigate.

| Master | In this PR |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/e346f259-26b5-4af4-90f5-53cf365cb470) |<img width="560" alt="image" src="https://github.com/user-attachments/assets/6e4a688b-1a42-4379-b0a5-5eb10e6b3153"> | 

**TODO DEV**
- Hide categories when user is in last nested level (don't show sibling) -> Will be handled after 18

**Note** 
This PR would benefit from https://github.com/odoo/odoo/pull/178545 forwardport

task-4099024
part of task-3986921

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
