### PR TITLE
[IMP] base_import_module: translate industry knowledge

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -218,6 +218,14 @@ class IrModule(models.Model):
                 _logger.info('module %s: no translation for language %s', module, lang)
         translation_importer.save(overwrite=True)
 
+        if ('knowledge.article' in self.env
+            and (article_record := self.env.ref(f"{module}.welcome_article", raise_if_not_found=False))
+            and article_record._name == 'knowledge.article'
+            and self.env.ref(f"{module}.welcome_article_body", raise_if_not_found=False)
+        ):
+            body = self.env['ir.qweb']._render(f"{module}.welcome_article_body", lang=self.env.user.lang)
+            article_record.write({'body': body})
+
         mod._update_from_terp(terp)
         _logger.info("Successfully imported module '%s'", module)
 


### PR DESCRIPTION
In industry modules, the knowledge article should be translated in the language of the user installing it. But the `body` of the article is not translatable.

This commit forces the rendering of the article in the user language.

task-4063061
