### PR TITLE
[FIX] web: form: ´.btn´ nodes should be in .o_statusbar_buttons

### DIFF
--- a/addons/web/static/src/views/form/form_compiler.js
+++ b/addons/web/static/src/views/form/form_compiler.js
@@ -442,7 +442,7 @@ export class FormCompiler extends ViewCompiler {
             if (!compiled || isTextNode(compiled)) {
                 continue;
             }
-            if (getTag(child, true) === "field") {
+            if (getTag(child, true) === "field" && !child.classList.contains("btn"))  {
                 compiled.setAttribute("showTooltip", true);
                 others.push(compiled);
             } else {

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -320,7 +320,7 @@
             }
         }
 
-        > .o_field_widget {
+        .o_field_widget {
             --fieldWidget-margin-bottom: 0;
 
             align-self: flex-start;

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -3129,30 +3129,6 @@ test.tags("desktop")(`buttons classes in form view`, async () => {
     expect(`button[name="15"]`).toHaveClass("btn o_this_is_a_button");
 });
 
-test.tags("desktop")(`nested buttons in form view header`, async () => {
-    await mountView({
-        resModel: "partner",
-        type: "form",
-        arch: `
-            <form>
-                <header>
-                    <button name="0"/>
-                    <button name="1"/>
-                    <div>
-                        <button name="2"/>
-                        <button name="3"/>
-                    </div>
-                </header>
-            </form>
-        `,
-        resId: 2,
-    });
-    expect(`.o_form_statusbar button:eq(0)`).toHaveAttribute("name", "0");
-    expect(`.o_form_statusbar button:eq(1)`).toHaveAttribute("name", "1");
-    expect(`.o_form_statusbar button:eq(2)`).toHaveAttribute("name", "2");
-    expect(`.o_form_statusbar button:eq(3)`).toHaveAttribute("name", "3");
-});
-
 test.tags("desktop")(`buttons should be in .o_statusbar_buttons in form view header on desktop`, async () => {
     await mountView({
         resModel: "partner",

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -3153,6 +3153,44 @@ test.tags("desktop")(`nested buttons in form view header`, async () => {
     expect(`.o_form_statusbar button:eq(3)`).toHaveAttribute("name", "3");
 });
 
+test.tags("desktop")(`buttons should be in .o_statusbar_buttons in form view header on desktop`, async () => {
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        arch: `
+            <form>
+                <header>
+                    <button name="0"/>
+                    <field name="foo" widget="url" class="btn btn-secondary" text="My Button" readonly="1"/>
+                </header>
+            </form>
+        `,
+        resId: 2,
+    });
+    expect(`.o_statusbar_buttons > button:eq(0)`).toHaveAttribute("name", "0");
+    expect(`.o_statusbar_buttons > div:eq(0)`).toHaveAttribute("name", "foo");
+});
+
+test.tags("mobile")(`buttons should be in .o_statusbar_buttons in form view header on mobile`, async () => {
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        arch: `
+            <form>
+                <header>
+                    <button name="0"/>
+                    <field name="foo" widget="url" class="btn btn-secondary" text="My Button" readonly="1"/>
+                </header>
+            </form>
+        `,
+        resId: 2,
+    });
+
+    await contains(`.o_statusbar_buttons .dropdown-toggle`).click();
+    expect(`.o_statusbar_button_dropdown_item > button`).toHaveAttribute("name", "0");
+    expect(`.o_statusbar_button_dropdown_item > div`).toHaveAttribute("name", "foo");
+});
+
 test(`button in form view and long willStart`, async () => {
     mockService("action", {
         doActionButton(params) {


### PR DESCRIPTION
The ´.o_form_statusbar´ is divided in two parts:
- ´.o_statusbar_buttons´
- Fields representing Stages

Before this commit, only ´<button/>´ was grouped in ´.o_statusbar_buttons´. Now, we also take into account others tags who as ´btn´ as class.

This fix alignement issues in case of you want to use a field as a button. Eg: ´<field name="my_field" widget="url" class="btn btn-secondary" text="My Button"/>´

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
