### PR TITLE
[FIX] website: fix active icon size option within the editor

### DIFF
--- a/addons/website/views/snippets/s_badge.xml
+++ b/addons/website/views/snippets/s_badge.xml
@@ -3,7 +3,7 @@
 
 <template name="Badge" id="s_badge">
     <span class="s_badge badge text-bg-secondary o_animable" data-name="Badge" data-vxml="001">
-        <i class="fa fa-1x fa-fw fa-folder o_not-animable"/>Category
+        <i class="fa fa-fw fa-folder o_not-animable"/>Category
     </span>
 </template>
 

--- a/addons/website/views/snippets/s_cta_badge.xml
+++ b/addons/website/views/snippets/s_cta_badge.xml
@@ -3,7 +3,7 @@
 
 <template name="CTA Badge" id="s_cta_badge">
     <span class="s_cta_badge d-inline-block my-3 border rounded py-2 px-3 o_cc o_cc1 o_animable" data-name="CTA Badge" style="border-radius: 32px !important;">
-        <i class="fa fa-1x fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;What do you want to promote&amp;nbsp;? &#160;&#160;&#160;&#160;<a href="#">See more <i class="fa fa-long-arrow-right" role="img"/></a>
+        <i class="fa fa-fw fa-info-circle o_not-animable" role="img"/>&#160;&#160;What do you want to promote&amp;nbsp;? &#160;&#160;&#160;&#160;<a href="#">See more <i class="fa fa-long-arrow-right" role="img"/></a>
     </span>
 </template>
 


### PR DESCRIPTION
This PR fixes an issue about the size of icons not being shown as active within the web editor for the `s_badge` and `s_cta_badge`snippets.

Prior to this commit, a `fa-1x` class was used to set the size of the icon to `1x`. While this provides the right visual result, it prevents the editor from displaying this size as active, meaning that if a user clicks on the icon, it'll appear like no option is selected within the editor.

This commit fixes this issue by removing the 1x class from the icon within the `badge` and `s_cta_badge`, two snippets that are using an icon with this extra class.

| Master | This PR |
|--------|--------|
| <img alt="image" src="https://github.com/user-attachments/assets/ce3f9781-672d-4111-9c69-16a4a7d76f56"> | <img alt="image" src="https://github.com/user-attachments/assets/eeb89f34-7b33-4334-ba12-508739e12fe2"> | 

task-4131509

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
