### PR TITLE
[IMP] website: add new `s_features_wall` snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -45,6 +45,7 @@
         'views/snippets/s_snippet_group.xml',
         'views/snippets/s_text_block.xml',
         'views/snippets/s_features.xml',
+        'views/snippets/s_features_wall.xml',
         'views/snippets/s_three_columns.xml',
         'views/snippets/s_key_benefits.xml',
         'views/snippets/s_picture.xml',

--- a/addons/website/views/snippets/s_features_wall.xml
+++ b/addons/website/views/snippets/s_features_wall.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_features_wall" name="Features Wall">
+    <section class="s_features_wall pt56 pb56" data-oe-shape-data="{'shape':'web_editor/Airy/04_001','colors':{'c1':'o-color-3'},'flip':['x'],'showOnMobile':false,'shapeAnimationSpeed':'0','animated':'true'}">
+        <div class="o_we_shape o_web_editor_Airy_04_001 o_we_animated" style="background-image: url('/web_editor/shape/web_editor%2FAiry%2F04_001.svg?c1=%23E5EDF2&amp;flip=x'); background-position: 50% 50%;"/>
+        <div class="container">
+            <div class="row o_grid_mode" data-row-count="21">
+                <div class="o_grid_item g-height-21 g-col-lg-5 col-lg-5" style="z-index: 1; grid-area: 1 / 1 / 22 / 6; --grid-item-padding-y: 0px; --grid-item-padding-x: 16px;">
+                    <h2 class="display-3-fs">Unveil Our Exclusive Collections</h2>
+                    <p class="lead">Write one or two paragraphs describing your product or services. To be successful your content needs to be useful to your readers.</p>
+                </div>
+                <div class="o_grid_item o_grid_item_image g-height-6 g-col-lg-3 col-lg-3" style="z-index: 2; grid-area: 1 / 7 / 7 / 10; --grid-item-padding-y: 0px; --grid-item-padding-x: 16px;">
+                    <img class="img img-fluid" src="/web/image/website.library_image_16"/>
+                </div>
+                <div class="o_grid_item g-height-4 g-col-lg-3 col-lg-3 s_col_no_bgcolor" style="z-index: 3; grid-area: 7 / 7 / 11 / 10; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
+                    <h3 class="h5-fs">Expertise and Knowledge</h3>
+                    <p>We offer cutting-edge products and services to tackle modern challenges. Leveraging the latest technology, we help you achieve your goals.</p>
+                </div>
+                <div class="o_grid_item o_grid_item_image g-height-6 g-col-lg-3 col-lg-3" style="z-index: 4; grid-area: 12 / 7 / 18 / 10; --grid-item-padding-y: 0px; --grid-item-padding-x: 16px;">
+                    <img class="img img-fluid" src="/web/image/website.library_image_03"/>
+                </div>
+                <div class="o_grid_item g-height-4 g-col-lg-3 col-lg-3 s_col_no_bgcolor" style="z-index: 5; grid-area: 18 / 7 / 22 / 10; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
+                    <h3 class="h5-fs">Tailored Solutions</h3>
+                    <p>Customer satisfaction is our priority. Our support team is always ready to assist, ensuring you have a smooth and successful experience.</p>
+                </div>
+                <div class="o_grid_item o_grid_item_image g-height-6 g-col-lg-3 col-lg-3" style="z-index: 6; grid-area: 6 / 10 / 12 / 13; --grid-item-padding-y: 0px; --grid-item-padding-x: 16px;">
+                    <img class="img img-fluid" src="/web/image/website.library_image_13"/>
+                </div>
+                <div class="o_grid_item g-height-4 g-col-lg-3 col-lg-3 s_col_no_bgcolor" style="z-index: 7; grid-area: 12 / 10 / 16 / 13; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
+                    <h3 class="h5-fs">Quality and Excellence</h3>
+                    <p>With extensive experience and deep industry knowledge, we provide insights and solutions that keep you ahead of the curve.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -62,6 +62,9 @@
                 <t t-snippet="website.s_three_columns" string="Columns" group="columns">
                     <keywords>columns, description</keywords>
                 </t>
+                <t t-snippet="website.s_features_wall" string="Features Wall" group="columns">
+                    <keywords>reveal, showcase, launch, presentation, announcement, content, picture, photo, illustration, media, visual, combination</keywords>
+                </t>
                 <t t-snippet="website.s_key_benefits" string="Key benefits" group="columns">
                     <keywords>promotion, characteristic, quality, highlights, specs, advantages, functionalities, features, exhibit, details, capabilities, attributes, promotion, headline, content, overiew, spotlight</keywords>
                 </t>


### PR DESCRIPTION
This commit introduces the new `s_features_wall` columns snippet.

Part of task-4077427
task-4105231

requires: https://github.com/odoo/design-themes/pull/880

<img width="1700" alt="Screenshot 2024-08-22 at 11 46 37" src="https://github.com/user-attachments/assets/ebf165b9-39fc-4fa2-8adc-95258dfb59d4">


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
