### PR TITLE
[FIX] point_of_sale: correct handling of cash rounding in payment

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -179,9 +179,6 @@ export class PaymentScreen extends Component {
         } else {
             this.selectedPaymentLine.set_amount(amount);
         }
-        if (!this.pos.get_order().check_paymentlines_rounding()) {
-            this._display_popup_error_paymentlines_rounding();
-        }
     }
     toggleIsToInvoice() {
         this.currentOrder.set_to_invoice(!this.currentOrder.is_to_invoice());

--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -2720,7 +2720,7 @@ export class Order extends PosModel {
         return false;
     }
     is_paid() {
-        return this.get_due() <= 0 && this.check_paymentlines_rounding();
+        return this.get_due() <= 0;
     }
     is_paid_with_cash() {
         return !!this.paymentlines.find(function (pl) {

--- a/addons/point_of_sale/static/tests/tours/PaymentScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/PaymentScreen.tour.js
@@ -290,13 +290,10 @@ registry.category("web_tour.tours").add("CashRoundingPayment", {
             PaymentScreen.totalIs("1.90"),
             PaymentScreen.clickPaymentMethod("Cash"),
             PaymentScreen.pressNumpad("1 ."),
-            PaymentScreen.pressNumpad("2 4"),
-            PaymentScreen.fillPaymentLineAmountMobile("Cash", "1.24"),
-            PaymentScreen.selectedPaymentlineHas("Cash", "1.24"),
+            PaymentScreen.pressNumpad("9 4"),
+            PaymentScreen.fillPaymentLineAmountMobile("Cash", "1.94"),
+            PaymentScreen.selectedPaymentlineHas("Cash", "1.94"),
+            PaymentScreen.clickValidate(),
             ErrorPopup.isShown(),
-            ErrorPopup.messageBodyContains(
-                // Verify the value displayed are as expected
-                "The rounding precision is 0.10 so you should set 1.20 or 1.30 as payment amount instead of 1.24."
-            ),
         ].flat(),
 });


### PR DESCRIPTION
Before this commit, entering a payment amount with cash rounding higher than one (e.g., 10) incorrectly triggered an error popup every time.

opw-4124332

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
