### PR TITLE
[FIX] website_event: deterministic event ordering

### DIFF
--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -62,7 +62,7 @@ class WebsiteEventController(http.Controller):
         order = 'date_begin'
         if searches.get('date', 'all') == 'old':
             order = 'date_begin desc'
-        order = 'is_published desc, ' + order
+        order = 'is_published desc, ' + order + ', id desc'
         search = searches.get('search')
         event_count, details, fuzzy_search_term = website._search_with_fuzzy("events", search,
             limit=page * step, order=order, options=options)


### PR DESCRIPTION
Before this commit we had (rare) situation where events would have
matching dates, and then Postgres wouldn't guarantee their order,
causing issue with pagination.

[Reproduce]
- have events with the same dates
- query the events with and without limit

opw-4061191
