### PR TITLE
[FIX] mail, test_mail: make order of inbox notify deterministic

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1216,7 +1216,7 @@ class Message(models.Model):
     def _cleanup_side_records(self):
         """ Clean related data: notifications, stars, ... to avoid lingering
         notifications / unreachable counters with void messages notably. """
-        outdated_starred_partners = self.starred_partner_ids
+        outdated_starred_partners = self.starred_partner_ids.sorted("id")
         self.write({
             'starred_partner_ids': [(5, 0, 0)],
             'notification_ids': [(5, 0, 0)],

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3169,7 +3169,9 @@ class MailThread(models.AbstractModel):
           skip message usage and spare some queries;
         """
         bus_notifications = []
-        inbox_pids_uids = [(r["id"], r["uid"]) for r in recipients_data if r["notif"] == "inbox"]
+        inbox_pids_uids = sorted(
+            [(r["id"], r["uid"]) for r in recipients_data if r["notif"] == "inbox"]
+        )
         if inbox_pids_uids:
             notif_create_values = [
                 {

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -1191,8 +1191,8 @@ class MailCase(MockEmail):
         bus_notifs = self.env['bus.bus'].sudo().search([('channel', 'in', [json_dump(channel) for channel in channels])])
         new_line = "\n"
         self.assertEqual(
-            sorted(bus_notifs.mapped("channel")),
-            sorted([json_dump(channel) for channel in channels]),
+            bus_notifs.mapped("channel"),
+            [json_dump(channel) for channel in channels],
             f"\nExpected:\n{new_line.join([json_dump(channel) for channel in channels])}"
             f"\nReturned:\n{new_line.join(bus_notifs.mapped('channel'))}"
         )

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -381,8 +381,8 @@ class TestDiscuss(MailCommon, TestRecipients):
         self.assertFalse(msg.starred)
         self.assertBusNotifications(
             [
-                (self.cr.dbname, "res.partner", self.partner_employee.id),
                 (self.cr.dbname, "res.partner", self.partner_admin.id),
+                (self.cr.dbname, "res.partner", self.partner_employee.id),
             ],
             [
                 {

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1,9 +1,7 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from markupsafe import Markup
 from unittest.mock import patch
-from unittest import skip
 
 from odoo import fields
 from odoo.addons.base.tests.common import TransactionCaseWithUserDemo
@@ -1330,7 +1328,6 @@ class TestMessageToStorePerformance(BaseMailPerformance):
             self.assertEqual(len(res["Message"]), 6)
 
     @warmup
-    @skip("Ordering of notification randomly crash")
     def test_message_to_store_multi_followers_inbox(self):
         """Test query count as well as bus notifcations from sending a message to multiple followers
         with inbox."""


### PR DESCRIPTION
Adding sort to always process the partners in the same order. Confirmed to resolve the issue as adding reverse=True makes the test crash systematically instead.

runbot-70612
runbot-74125