### PR TITLE
[FIX] mrp: prevent error when clicking on overview in mo

### DIFF
--- a/addons/mrp/i18n/mrp.pot
+++ b/addons/mrp/i18n/mrp.pot
@@ -3864,6 +3864,12 @@ msgstr ""
 
 #. module: mrp
 #. odoo-python
+#: code:addons/mrp/models/stock_move.py:0
+msgid "Please enter a positive quantity."
+msgstr ""
+
+#. module: mrp
+#. odoo-python
 #: code:addons/mrp/models/mrp_production.py:0
 msgid "Please set the first Serial Number or a default sequence"
 msgstr ""

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -3,9 +3,10 @@
 
 from collections import defaultdict
 from dateutil.relativedelta import relativedelta
-from odoo import api, Command, fields, models
+from odoo import _, api, Command, fields, models
 from odoo.osv import expression
 from odoo.tools import float_compare, float_round, float_is_zero, OrderedSet
+from odoo.exceptions import ValidationError
 
 
 class StockMoveLine(models.Model):
@@ -321,6 +322,12 @@ class StockMove(models.Model):
         if self.raw_material_production_id and not self.manual_consumption and self.picked and self.product_uom and \
            float_compare(self.product_uom_qty, self.quantity, precision_rounding=self.product_uom.rounding) != 0:
             self.manual_consumption = True
+
+    @api.constrains('quantity', 'raw_material_production_id')
+    def _check_negative_quantity(self):
+        for move in self:
+            if move.raw_material_production_id and float_compare(move.quantity, 0, precision_rounding=move.product_uom.rounding) < 0:
+                raise ValidationError(_("Please enter a positive quantity."))
 
     @api.model
     def default_get(self, fields_list):

--- a/addons/mrp/report/mrp_report_mo_overview.py
+++ b/addons/mrp/report/mrp_report_mo_overview.py
@@ -768,7 +768,7 @@ class ReportMoOverview(models.AbstractModel):
                     line['quantity'] -= used_quantity
 
                     move_out_qty -= used_quantity
-                    if float_compare(move_out_qty, 0, line['move_out'].product_uom.rounding) <= 0:
+                    if float_compare(move_out_qty, 0, precision_rounding=line['move_out'].product_uom.rounding) <= 0:
                         break
         return new_lines + forecast_lines
 


### PR DESCRIPTION
When the quantity of components is negative in mo and user clicks on
the overview button.
a traceback will appear.

Steps to reproduce the error:
- Install ```mrp``` and ```purchase```
- Create product A > In Purchase, add vendor > In Inventory, Select Buy and
  Replenish on Order (MTO) in Routes > Save
- Create one MO > Select any product > In components, Select product A >
  In To consume, Set 10 for ex. > Confirm
- Click on Purchases smart button > Confirm Order > Receive Products > Validate
- Go back to MO > Set negative value in Quantity (ex. -1) > Save
- Click on Overview

Traceback:
```
AssertionError: precision_digits must be a non-negative integer, got 0.01
  File "odoo/http.py", line 2373, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1903, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1966, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1933, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2177, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 223, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 754, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 35, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 459, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/mrp/report/mrp_report_mo_overview.py", line 19, in get_report_values
    'data': self._get_report_data(production_id),
  File "addons/mrp/report/mrp_report_mo_overview.py", line 77, in _get_report_data
    components = self._get_components_data(production, level=1, current_index='')
  File "addons/mrp/report/mrp_report_mo_overview.py", line 416, in _get_components_data
    replenish_data = self._get_replenishments_from_forecast(production, replenish_data)
  File "addons/mrp/report/mrp_report_mo_overview.py", line 694, in _get_replenishments_from_forecast
    forecast_lines = self._add_origins_to_forecast(forecast_lines)
  File "addons/mrp/report/mrp_report_mo_overview.py", line 771, in _add_origins_to_forecast
    if float_compare(move_out_qty, 0, line['move_out'].product_uom.rounding) <= 0:
  File "odoo/tools/float_utils.py", line 181, in float_compare
    rounding_factor = _float_check_precision(precision_digits=precision_digits,
  File "odoo/tools/float_utils.py", line 39, in _float_check_precision
    assert float(precision_digits).is_integer() and precision_digits >= 0,\
```

https://github.com/odoo/odoo/blob/2c89fae7bc3e026425a4f02c4a70e4a87083560d/addons/mrp/report/mrp_report_mo_overview.py#L771
Here, In the above line ```precision_rounding``` is missing.
So, it will lead to the above traceback.

This commit will prevent the negative quantity of component product.

Sentry-5729142241

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
