### PR TITLE
[FIX] account : auto-install account_bacs when company is in UK

### DIFF
--- a/addons/account/__init__.py
+++ b/addons/account/__init__.py
@@ -40,7 +40,7 @@ def _auto_install_l10n(env):
             #countries using OHADA Chart of Accounts
             module_list.append('l10n_syscohada')
         elif country_code == 'GB':
-            module_list.append('l10n_uk')
+            module_list.extend(('l10n_uk', 'account_bacs'))
         elif country_code == 'DE':
             module_list.append('l10n_de_skr03')
             module_list.append('l10n_de_skr04')
@@ -54,8 +54,6 @@ def _auto_install_l10n(env):
             'PL', 'PT', 'RO', 'SI', 'TR', 'GB', 'VE', 'VN'
             ]:
             module_list.append('base_vat')
-        if country_code == 'uk':
-            module_list.append('account_bacs')
 
         module_ids = env['ir.module.module'].search([('name', 'in', module_list), ('state', '=', 'uninstalled')])
         if module_ids:


### PR DESCRIPTION
### Steps to reproduce:
- Change the main company's country to 'United Kingdom'
- Install the Accounting module
- The module "account_bacs" is not installed, but it should

### Cause:
In account, it checks if `country_code == 'uk'` instead of 'GB'

### Solution:
Move `module_list.append('account_bacs')` to the already existing `country_code == 'GB'`.

opw-4122475