### PR TITLE
[FIX] html_editor: arrow key movements next to icon

### DIFF
--- a/addons/html_editor/static/src/utils/selection.js
+++ b/addons/html_editor/static/src/utils/selection.js
@@ -241,5 +241,12 @@ export function getAdjacentCharacter(selection, side, editable) {
             adjacentCharacter = focusNode && focusNode.textContent[characterIndex];
         }
     }
-    return closestBlock(focusNode) === originalBlock ? adjacentCharacter : undefined;
+    if (
+        !focusNode ||
+        !closestElement(focusNode).isContentEditable ||
+        closestBlock(focusNode) !== originalBlock
+    ) {
+        return undefined;
+    }
+    return adjacentCharacter;
 }

--- a/addons/html_editor/static/tests/keyboard/arrow.test.js
+++ b/addons/html_editor/static/tests/keyboard/arrow.test.js
@@ -350,6 +350,27 @@ describe("Around links", () => {
     });
 });
 
+describe("Around icons", () => {
+    test("should move past the icon (ArrowRight)", async () => {
+        await testEditor({
+            contentBefore: `<p>abc[]<span class="fa fa-music"></span>def</p>`,
+            contentBeforeEdit: `<p>abc[]<span class="fa fa-music" contenteditable="false">\u200b</span>def</p>`,
+            stepFunction: keyPress("ArrowRight"),
+            contentAfterEdit: `<p>abc<span class="fa fa-music" contenteditable="false">\u200b</span>[]def</p>`,
+            contentAfter: `<p>abc<span class="fa fa-music"></span>[]def</p>`,
+        });
+    });
+    test("should move past the icon (ArrowLeft)", async () => {
+        await testEditor({
+            contentBefore: `<p>abc<span class="fa fa-music"></span>[]def</p>`,
+            contentBeforeEdit: `<p>abc<span class="fa fa-music" contenteditable="false">\u200b</span>[]def</p>`,
+            stepFunction: keyPress("ArrowLeft"),
+            contentAfterEdit: `<p>abc[]<span class="fa fa-music" contenteditable="false">\u200b</span>def</p>`,
+            contentAfter: `<p>abc[]<span class="fa fa-music"></span>def</p>`,
+        });
+    });
+});
+
 describe("Selection correction when it lands at the editable root", () => {
     test("should place cursor in the table below", async () => {
         await testEditor({


### PR DESCRIPTION
Before this commit, pressing arrowRight with a collapsed selection before an icon would move the cursor past the icon and one character after it. Likewise, pressing arrowLeft with the cursor after an icon would move it to before the character before the icon.

This happened because to mechanism to anticipate an arrow movement next to an invisible character did not account for an invisible character inside a non-editable element, which is skipped as whole by the browser's default behavior and needs no intervention from the editor.
