### PR TITLE
[IMP] hr: time off type filter and display color

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -480,10 +480,17 @@ class HolidaysRequest(models.Model):
         for leave in self:
             duration = leave.number_of_days
             unit = _('days')
-            if leave.leave_type_request_unit == 'hour':
-                duration = leave.number_of_hours
-                unit = _('hours')
-            leave.duration_display = '%g %s' % (float_round(duration, precision_digits=2), unit)
+            display = "%g %s" % (float_round(duration, precision_digits=2), unit)
+            if leave.leave_type_request_unit == "hour":
+                hours, minutes = divmod(abs(leave.number_of_hours) * 60, 60)
+                minutes = round(minutes)
+                if minutes == 60:
+                    minutes = 0
+                    hours += 1
+                duration = '%d:%02d' % (hours, minutes)
+                unit = _("hours")
+                display = f"{duration} {unit}"
+            leave.duration_display = display
 
     @api.depends('state', 'employee_id', 'department_id')
     def _compute_can_reset(self):

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -36,9 +36,12 @@ class HolidaysAllocation(models.Model):
         return [('employee_requests', '=', 'yes')]
 
     def _domain_employee_id(self):
-        if self.env.user.has_group('hr_holidays.group_hr_holidays_user'):
-            return []
-        return [('leave_manager_id', '=', self.env.user.id)]
+        domain = [('company_id', 'in', self.env.companies.ids)]
+        if not self.env.user.has_group('hr_holidays.group_hr_holidays_user'):
+            domain += [
+                ('leave_manager_id', '=', self.env.user.id)
+            ]
+        return domain
 
     name = fields.Char(
         string='Description',

--- a/addons/hr_holidays/report/hr_leave_report_calendar.py
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.py
@@ -28,6 +28,7 @@ class LeaveReportCalendar(models.Model):
         ('validate', 'Approved')
     ], readonly=True)
     description = fields.Char("Description", readonly=True, groups='hr_holidays.group_hr_holidays_user')
+    holiday_status_id = fields.Many2one('hr.leave.type', readonly=True, string="Time Off Type")
 
     is_hatched = fields.Boolean('Hatched', readonly=True)
     is_striked = fields.Boolean('Striked', readonly=True)
@@ -51,6 +52,7 @@ class LeaveReportCalendar(models.Model):
             hl.department_id AS department_id,
             hl.number_of_days as duration,
             hl.private_name AS description,
+            hl.holiday_status_id AS holiday_status_id,
             em.company_id AS company_id,
             em.job_id AS job_id,
             COALESCE(

--- a/addons/hr_holidays/report/hr_leave_report_calendar.xml
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.xml
@@ -69,6 +69,7 @@
                 <filter name="refused_leaves" string="Refused" domain="[('state', '=', 'refuse')]"/>
                 <filter string="Waiting for Approval" name="approve" domain="[('state','in',('confirm','validate1'))]"/>
                 <filter name="groupby_job_id" string="Job Position" context="{'group_by': 'job_id'}"/>
+                <filter name="groupby_time_off_type" string="Time Off Type" context="{'group_by': 'holiday_status_id'}"/>
                 <filter name="groupby_company_id" string="Company" context="{'group_by': 'company_id'}" groups="base.group_multi_company"/>
                 <filter name="groupby_department_id" context="{'group_by': 'department_id'}"/>
             </search>

--- a/addons/hr_holidays/static/src/components/float_time_selection/float_time_selection.js
+++ b/addons/hr_holidays/static/src/components/float_time_selection/float_time_selection.js
@@ -1,15 +1,14 @@
 import { onWillStart, useState } from "@odoo/owl";
 import { registry } from "@web/core/registry";
 import { usePopover } from "@web/core/popover/popover_hook";
-import { FolatTimeSelectionPopover } from "./float_time_selection_popover";
+import { FloatTimeSelectionPopover } from "./float_time_selection_popover";
 
 import { FloatTimeField, floatTimeField } from "@web/views/fields/float_time/float_time_field";
-import { standardFieldProps } from "@web/views/fields/standard_field_props";
 
 function floatToHoursMinutes(floatValue) {
     const hours = Math.floor(floatValue);
     const minutes = Math.round((floatValue - hours) * 60);
-    return { hours: String(hours).padStart(2, '0'), minutes: String(minutes).padStart(2, '0') };
+    return { hours: String(hours).padStart(2, "0"), minutes: String(minutes).padStart(2, "0") };
 }
 
 function hoursMinutesToFloat(hours, minutes) {
@@ -19,17 +18,17 @@ function hoursMinutesToFloat(hours, minutes) {
 export class FloatTimeSelectionField extends FloatTimeField {
     static template = "hr_holidays.FloatTimeSelectionField";
     static props = {
-        ...standardFieldProps,
+        ...FloatTimeField.props,
     };
 
     setup() {
         super.setup();
-        this.popover = usePopover(FolatTimeSelectionPopover, {
+        this.popover = usePopover(FloatTimeSelectionPopover, {
             onClose: this.onClose.bind(this),
         });
         this.timeValues = useState({
-            hours: '00',
-            minutes: '00',
+            hours: "00",
+            minutes: "00",
             floatValue: 0,
         });
 
@@ -62,10 +61,10 @@ export class FloatTimeSelectionField extends FloatTimeField {
     handleInputChange() {
         this.popover.close();
         const inputValue = this.inputFloatTimeRef.el.value;
-        const [hours, minutes] = inputValue.split(':').map(Number);
+        const [hours, minutes] = inputValue.split(":").map(Number);
         if (!isNaN(hours) && !isNaN(minutes)) {
-            this.timeValues.hours = String(hours).padStart(2, '0');
-            this.timeValues.minutes = String(minutes).padStart(2, '0');
+            this.timeValues.hours = String(hours).padStart(2, "0");
+            this.timeValues.minutes = String(minutes).padStart(2, "0");
             this.timeValues.floatValue = hoursMinutesToFloat(hours, minutes);
         } else {
             const { hours, minutes } = floatToHoursMinutes(parseFloat(inputValue));
@@ -85,4 +84,4 @@ export const charHours = {
     component: FloatTimeSelectionField,
 };
 
-registry.category("fields").add('float_time_selection', charHours);
+registry.category("fields").add("float_time_selection", charHours);

--- a/addons/hr_holidays/static/src/components/float_time_selection/float_time_selection_popover.js
+++ b/addons/hr_holidays/static/src/components/float_time_selection/float_time_selection_popover.js
@@ -5,13 +5,21 @@ const numberRange = (min, max) => [...Array(max - min)].map((_, i) => i + min);
 const HOURS = numberRange(0, 24).map((hour) => [hour, String(hour)]);
 const MINUTES = numberRange(0, 60).map((minute) => [minute, String(minute || 0).padStart(2, "0")]);
 
-export class FolatTimeSelectionPopover extends Component {
+export class FloatTimeSelectionPopover extends Component {
     static props = {
         close: { type: Function },
         onTimeChange: { type: Function },
+        timeValues: {
+            type: Object,
+            shape: {
+                hours: "00",
+                minutes: "00",
+                floatValue: 0,
+            },
+        },
     };
 
-    static template = "hr_holidays.FolatTimeSelectionPopover";
+    static template = "hr_holidays.FloatTimeSelectionPopover";
 
     setup() {
         this.availableHours = HOURS;

--- a/addons/hr_holidays/static/src/components/float_time_selection/float_time_selection_popover.xml
+++ b/addons/hr_holidays/static/src/components/float_time_selection/float_time_selection_popover.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-name="hr_holidays.FolatTimeSelectionPopover">
+    <t t-name="hr_holidays.FloatTimeSelectionPopover">
         <div class="position-relative d-flex align-items-center flex-sm-row gap-1 gap-md-1 p-2">
             <select class="o_hour_selection form-control form-control-sm w-auto" t-on-change="onTimeChange" t-model="state.selectedHours">
                 <t t-foreach="availableHours" t-as="unit" t-key="unit[0]">

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -1084,7 +1084,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         })
 
         self.assertEqual(sick_leave.duration_display, '3 days')
-        self.assertEqual(comp_leave.duration_display, '4 hours')
+        self.assertEqual(comp_leave.duration_display, '4:00 hours')
 
         calendar.global_leave_ids = [(0, 0, {
             'name': 'Winter Holidays',
@@ -1095,7 +1095,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
 
         msg = "hr_holidays: duration_display should update after adding an overlapping holiday"
         self.assertEqual(sick_leave.duration_display, '2 days', msg)
-        self.assertEqual(comp_leave.duration_display, '0 hours', msg)
+        self.assertEqual(comp_leave.duration_display, '0:00 hours', msg)
 
     def test_duration_display_public_leave_include(self):
         """

--- a/addons/hr_holidays/views/hr_leave_type_views.xml
+++ b/addons/hr_holidays/views/hr_leave_type_views.xml
@@ -135,6 +135,7 @@
                 <field name="requires_allocation" optional="hide"/>
                 <field name="allocation_validation_type" string="Allocation Approval"/>
                 <field name="employee_requests" optional="hide"/>
+                <field name="color" widget="color_picker" optional="hide"/>
                 <field name="company_id" groups="base.group_multi_company" optional="hide"/>
             </tree>
         </field>


### PR DESCRIPTION
The "Time Off Types" list view now allows you to optionally
display the color associated with each leave type.
In the Gantt view for the "Overview" action for time off,
you can now group by leave type. A company domain was added
on the Employee field in the new allocation form view,
to prevent cross-company allocations.
Additionally, The "Requested (Days/Hours)" field in the
time off request form now displays hours in the HH:MM format
instead of a decimal/float.

task-4119241

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
