### PR TITLE
[FIX] html_editor: press 'ctrl+a' should select sub content

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -8,15 +8,15 @@ import {
     previousLeaf,
 } from "@html_editor/utils/dom_info";
 import { closestElement, descendants } from "@html_editor/utils/dom_traversal";
+import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
 import { Plugin } from "../plugin";
-import { DIRECTIONS, endPos, leftPos, nodeSize, rightPos } from "../utils/position";
+import { DIRECTIONS, boundariesIn, endPos, leftPos, nodeSize, rightPos } from "../utils/position";
 import {
     getAdjacentCharacter,
     normalizeCursorPosition,
     normalizeDeepCursorPosition,
     normalizeFakeBR,
 } from "../utils/selection";
-import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
 
 /**
  * @typedef { Object } EditorSelection
@@ -111,6 +111,9 @@ export class SelectionPlugin extends Plugin {
         "rectifySelection",
         // "collapseIfZWS",
     ];
+    static resources = (p) => ({
+        shortcuts: [{ hotkey: "control+a", command: "SELECT_ALL" }],
+    });
 
     setup() {
         this.resetSelection();
@@ -134,6 +137,22 @@ export class SelectionPlugin extends Plugin {
             this.isPointerDown = false;
             this.preventNextMousedownFix = false;
         });
+    }
+
+    handleCommand(command, payload) {
+        switch (command) {
+            case "SELECT_ALL":
+                {
+                    const selection = this.getEditableSelection();
+                    const containerSelector = "#wrap > *, .oe_structure > *, [contenteditable]";
+                    const container =
+                        selection && closestElement(selection.anchorNode, containerSelector);
+                    const [anchorNode, anchorOffset, focusNode, focusOffset] =
+                        boundariesIn(container);
+                    this.setSelection({ anchorNode, anchorOffset, focusNode, focusOffset });
+                }
+                break;
+        }
     }
 
     resetSelection() {

--- a/addons/html_editor/static/tests/selection.test.js
+++ b/addons/html_editor/static/tests/selection.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "@odoo/hoot";
-import { queryFirst } from "@odoo/hoot-dom";
+import { press, queryFirst } from "@odoo/hoot-dom";
 import { animationFrame, tick } from "@odoo/hoot-mock";
 import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { Plugin } from "../src/plugin";
@@ -141,4 +141,20 @@ test("setSelection should not set the selection outside the editable", async () 
     await tick();
     const selection = editor.shared.setSelection(editor.shared.getEditableSelection());
     expect(el.contains(selection.anchorNode)).toBe(true);
+});
+
+test("press 'ctrl+a' in 'oe_structure' child should only select his content", async () => {
+    const { el } = await setupEditor(`<div class="oe_structure"><p>a[]b</p><p>cd</p></div>`);
+    press(["ctrl", "a"]);
+    expect(getContent(el)).toBe(`<div class="oe_structure"><p>[ab]</p><p>cd</p></div>`);
+});
+
+test("press 'ctrl+a' in 'contenteditable' should only select his content", async () => {
+    const { el } = await setupEditor(
+        `<div contenteditable="false"><p contenteditable="true">a[]b</p><p contenteditable="true">cd</p></div>`
+    );
+    press(["ctrl", "a"]);
+    expect(getContent(el)).toBe(
+        `<div contenteditable="false"><p contenteditable="true">[ab]</p><p contenteditable="true">cd</p></div>`
+    );
 });


### PR DESCRIPTION
The goal of this commit is to reintroduce an old editor behavior: pressing 'ctrl+a' in the child of an 'oe_structure' element or in a 'contenteditable' must only select the entire content of this element.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
