### PR TITLE
[IMP] website: introduce `s_freegrid` snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -107,6 +107,7 @@
         'views/snippets/s_website_form.xml',
         'views/snippets/s_searchbar.xml',
         'views/snippets/s_button.xml',
+        'views/snippets/s_freegrid.xml',
         'views/snippets/s_image.xml',
         'views/snippets/s_video.xml',
         'views/snippets/s_cta_badge.xml',

--- a/addons/website/views/snippets/s_freegrid.xml
+++ b/addons/website/views/snippets/s_freegrid.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_freegrid" name="Free grid">
+    <section class="s_freegrid o_cc o_cc1 pt64 pb64">
+        <div class="container-fluid">
+            <div class="row o_grid_mode" data-row-count="16">
+                <div class="o_grid_item o_grid_item_image g-col-lg-1 g-height-8 col-lg-1 d-lg-block d-none o_snippet_mobile_invisible" style="z-index: 1; grid-area: 2 / 1 / 10 / 2; --grid-item-padding-y: 0px; --grid-item-padding-x: 0px;">
+                    <img class="img img-fluid mx-auto" src="/web/image/website.library_image_03" alt=""/>
+                </div>
+                <div class="o_grid_item o_grid_item_image g-col-lg-3 g-height-5 col-lg-3 d-lg-block d-none o_snippet_mobile_invisible" style="z-index: 2; grid-area: 1 / 2 / 6 / 5; --grid-item-padding-y: 8px; --grid-item-padding-x: 16px;">
+                    <img class="img img-fluid mx-auto" src="/web/image/website.library_image_13" alt=""/>
+                </div>
+                <div class="o_grid_item o_grid_item_image g-col-lg-3 g-height-5 col-lg-3 d-lg-block d-none o_snippet_mobile_invisible" style="z-index: 3; grid-area: 6 / 2 / 11 / 5; --grid-item-padding-y: 8px; --grid-item-padding-x: 16px;">
+                    <img class="img img-fluid mx-auto" src="/web/image/website.library_image_10" alt=""/>
+                </div>
+                <div class="o_grid_item o_grid_item_image g-col-lg-3 g-height-8 col-lg-3 d-lg-block d-none o_snippet_mobile_invisible" style="z-index: 4; grid-area: 2 / 5 / 10 / 8; --grid-item-padding-y: 0px; --grid-item-padding-x: 0px;">
+                    <img class="img img-fluid mx-auto" src="/web/image/website.library_image_05" alt=""/>
+                </div>
+                <div class="o_grid_item o_grid_item_image g-col-lg-3 g-height-10 col-lg-3" style="z-index: 5; grid-area: 1 / 8 / 11 / 11; --grid-item-padding-y: 8px; --grid-item-padding-x: 16px;">
+                    <img class="img img-fluid mx-auto" src="/web/image/website.library_image_14" alt=""/>
+                </div>
+                <div class="o_grid_item o_grid_item_image g-col-lg-2 g-height-8 col-lg-2 d-lg-block d-none o_snippet_mobile_invisible" style="z-index: 6; grid-area: 2 / 11 / 10 / 13; --grid-item-padding-y: 0px; --grid-item-padding-x: 0px;">
+                    <img class="img img-fluid mx-auto" src="/web/image/website.library_image_16" alt=""/>
+                </div>
+                <div class="o_grid_item g-height-5 g-col-lg-7 col-lg-7" style="z-index: 7; grid-area: 12 / 2 / 17 / 9; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
+                    <h2 style="text-align: left;">A deep dive into what makes our products innovative</h2>
+                    <p class="lead" style="text-align: left;">Write one or two paragraphs describing your product or services. To be successful your content needs to be useful to your readers. Start with the customer – find out what they want and give it to them.</p>
+                </div>
+                <div class="o_grid_item g-height-2 g-col-lg-3 col-lg-3" style="z-index: 8; grid-area: 12 / 9 / 14 / 12; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px;">
+                    <p style="text-align: right;">
+                        <a href="#" class="btn btn-primary btn-lg">Learn more</a>
+                    </p>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -65,6 +65,9 @@
                 <t t-snippet="website.s_key_benefits" string="Key benefits" group="columns">
                     <keywords>promotion, characteristic, quality, highlights, specs, advantages, functionalities, features, exhibit, details, capabilities, attributes, promotion, headline, content, overiew, spotlight</keywords>
                 </t>
+                <t t-snippet="website.s_freegrid" string="Free grid" group="columns">
+                    <keywords>description, containers, layouts, structures, multi-columns, modules, boxes, content, picture, photo, illustration, media, visual, article, story, combination, showcase, announcement, reveal, trendy, design, shape, geometric, engage, call to action, cta, button</keywords>
+                </t>
 
                 <!-- Content group -->
                 <t t-snippet="website.s_text_image" string="Text - Image" group="content">


### PR DESCRIPTION
This commit adds the new `s_freegrid` snippet.

task-4104931
Part-of: task-4077427

requires: https://github.com/odoo/design-themes/pull/881

| New snippet |
|--------|
| ![image](https://github.com/user-attachments/assets/af85b4e5-3652-4d17-a47d-90288bb6f687) | 


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
