### PR TITLE
[FIX] account: fix table alias in computed field

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -909,7 +909,7 @@ class AccountMove(models.Model):
                     JOIN account_move counterpart_move ON counterpart_move.id = counterpart_line.move_id
                     LEFT JOIN account_payment pay ON pay.id = counterpart_move.payment_id
                     WHERE source_line.move_id IN %s AND counterpart_line.move_id != source_line.move_id
-                    GROUP BY source_line_id, source_move_id, source_line_account_type
+                    GROUP BY source_line.id, source_line.move_id, account.account_type
                 ''')
 
             self._cr.execute(' UNION ALL '.join(queries), [stored_ids, stored_ids])


### PR DESCRIPTION
If the model `account.move.line` has custom field with name `source_line_id` or `source_move_id` or `source_line_account_type` then, when the computed field `payment_state` in model `account.move` is computed it causes `psycopg2.errors.AmbiguousColumn` during `GROUP BY` operation here[^1]. Because **account_move_line** is one of the joined tables in that query and it causes issue while grouping. Actually the issue can occur if any of the joined tables in that[^2] query has custom field with the names above, it will cause same issue.

To resolve this issue, I added a table alias
to the all 3 elements in GROUP BY clause.

Steps to reproduce:
1. Install module account in any version >= `saas~15.3`
2. Add custom field to the model `account.move.line` with name `source_move_id`.
3. Try to create invoice

You will face issue similar to this:

```
  File "/home/odoo/src/odoo/saas-15.3/addons/account/models/account_move.py", line 1430, in _compute_amount
    self._cr.execute(' UNION ALL '.join(queries), [stored_ids, stored_ids])
  File "/home/odoo/src/odoo/saas-15.3/odoo/sql_db.py", line 356, in execute
    res = self._obj.execute(query, params)
psycopg2.errors.AmbiguousColumn: column reference "source_move_id" is ambiguous
LINE 20:                     GROUP BY source_line_id, source_move_id,...
```
I targeted this PR to `16.0` because branch `saas-15.3` is disbaled

[^1]: https://github.com/odoo/odoo/blob/8346b2a7561c178fd7e9f9d1fbd7dac3e3843fd1/addons/account/models/account_move.py#L912

[^2]: https://github.com/odoo/odoo/blob/8346b2a7561c178fd7e9f9d1fbd7dac3e3843fd1/addons/account/models/account_move.py#L896-L912

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
