### PR TITLE
[FIX] test_discuss_full: fix query counter determinism

### DIFF
--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -21,7 +21,7 @@ class TestDiscussFullPerformance(HttpCase):
     #     4: settings
     #     1: has_access_livechat
     _query_count_init_store = 17
-    _query_count = 50 + 1  # +1 is necessary to fix nondeterministic issue on runbot
+    _query_count = 50 + 2  # +2 is necessary to fix nondeterministic issue on runbot
     # Queries for _query_count_discuss_channels:
     #     1: bus last id
     _query_count_discuss_channels = 70


### PR DESCRIPTION
Method was refactored in master to get more consistent results. Stable can just get a temporary extra query.

runbot-70182