### PR TITLE
[IMP] pos_self_order: png qr codes

### DIFF
--- a/addons/pos_self_order/models/res_config_settings.py
+++ b/addons/pos_self_order/models/res_config_settings.py
@@ -94,7 +94,7 @@ class ResConfigSettings(models.TransientModel):
         )
         qr.add_data(url)
         qr.make(fit=True)
-        return qr.make_image(fill_color="black", back_color="white")
+        return qr.make_image(fill_color="black", back_color="transparent")
 
     def generate_qr_codes_zip(self):
         if not self.pos_self_ordering_mode in ['mobile', 'consultation']:


### PR DESCRIPTION
Previously, the qr codes for `pos_self_order` were created with a white bg. We now change this such that they are of type `png` and have a transparent bg.






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
