### PR TITLE
[FIX] mail: fix _filter_threads_fields rating mixin

### DIFF
--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -1547,8 +1547,8 @@ class MailCommon(common.TransactionCase, MailCase):
         """ Remove store thread data dependant on other modules if they are not not installed.
         Not written in a modular way to avoid complex override for a simple test tool.
         """
-        if "rating.rating" not in self.env:
-            for data in threads_data:
+        for data in threads_data:
+            if not issubclass(self.env.registry[data["model"]], self.env.registry["rating.mixin"]):
                 data.pop("rating_avg", None)
                 data.pop("rating_count", None)
         return list(threads_data)


### PR DESCRIPTION
Checking existence of the rating model was not enough to guarantee the mixin was present on the thread.

In particular, rating module can be installed but if im_livechat is not installed, discuss channel will not have the rating mixin.

runbot-75205