### PR TITLE
[IMP] stock: forbid quant duplication

### DIFF
--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -10261,6 +10261,13 @@ msgstr ""
 #. odoo-python
 #: code:addons/stock/models/stock_quant.py:0
 #, python-format
+msgid "You cannot duplicate stock quants."
+msgstr ""
+
+#. module: stock
+#. odoo-python
+#: code:addons/stock/models/stock_quant.py:0
+#, python-format
 msgid "You cannot modify inventory loss quantity"
 msgstr ""
 

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -245,6 +245,9 @@ class StockQuant(models.Model):
             domain_operator = 'in'
         return [('id', domain_operator, quant_query)]
 
+    def copy(self, default=None):
+        raise UserError(_('You cannot duplicate stock quants.'))
+
     @api.model_create_multi
     def create(self, vals_list):
         """ Override to handle the "inventory mode" and create a quant as

--- a/addons/stock/tests/test_quant.py
+++ b/addons/stock/tests/test_quant.py
@@ -70,6 +70,18 @@ class StockQuant(TransactionCase):
         quants = self.env['stock.quant']._gather(product_id, location_id, lot_id=lot_id, package_id=package_id, owner_id=owner_id, strict=strict)
         return quants.filtered(lambda q: not (q.quantity == 0 and q.reserved_quantity == 0))
 
+    def test_copy_quant(self):
+        """
+        You should not be allowed to duplicate quants.
+        """
+        quant = self.env['stock.quant'].create([{
+            'location_id': self.stock_location.id,
+            'product_id': self.product.id,
+            'inventory_quantity': 10,
+        }])
+        with self.assertRaises(UserError):
+            quant.copy()
+
     def test_get_available_quantity_1(self):
         """ Quantity availability with only one quant in a location.
         """


### PR DESCRIPTION
Stock quants are not meant to be duplicated. This commit ensures that it is not possible to copy such records.

opw-4035690

(cherry picked from commit 044210f6c7c4e539b8ebd41082c737e8bc91fd4e)

---

In PR https://github.com/odoo/odoo/pull/172376 it was decided to not completely forbid quant duplication due to potential third party modules that could potentially use this feature.

However, we see an increment of customer with an incorrect quantity in past history, or a discrepancy in valuation and accounting because of this error.
Unfortunately, it is incredibly easy to duplicate the quants by mistake, for example by miss-clicking when trying to export or update the inventory qty to 0 ...

![image](https://github.com/user-attachments/assets/ef74c5fa-16f4-4532-a5ac-686c32056f29)

Hence, even if it breaks some third party modules, it is imperative to prevent further quants duplication.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
