### PR TITLE
[FIX] web_editor: fix removal of ".o_default_text_snippet" class

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2034,7 +2034,7 @@ var SnippetsMenu = Widget.extend({
             // Note: we cannot listen to keyup in .o_default_snippet_text
             // elements via delegation because keyup only bubbles from focusable
             // elements which contenteditable are not.
-            const selection = this.ownerDocument.getSelection();
+            const selection = this.$body[0].ownerDocument.getSelection();
             if (!selection.rangeCount) {
                 return;
             }


### PR DESCRIPTION
Since [1], the ".o_default_text_snippet" class has not been correctly
removed when text is modified within a content-editable element. This
commit resolves the issue.

Steps to reproduce:

- Drag and drop the "Pricelist block" into the page.
- Click on the snippet newly inserted to display the options on the
  right panel.
- Enable the "Descriptions" option under the Pricelist block options to
  display descriptions.
- Edit some descriptions directly in the snippet.
- Disable and re-enable the "Descriptions" option.
- Bug: The edited descriptions are replaced by the default text.

[1]: https://github.com/odoo/odoo/commit/03c552690b15cbf2e7d6b7812386ac64042219af#diff-52a4f9d2c217548e69e6b7fd097f286f1754a6389734eea254b87255e501cbef

task-4084956
task-4147162 (first part)