### PR TITLE
[FIX] point_of_sale: handle inaccessible paid orders

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -13,7 +13,7 @@ import re
 
 from odoo import api, fields, models, tools, _
 from odoo.tools import float_is_zero, float_round, float_repr, float_compare
-from odoo.exceptions import ValidationError, UserError
+from odoo.exceptions import ValidationError, UserError, AccessError
 from odoo.osv.expression import AND
 import base64
 
@@ -1143,7 +1143,14 @@ class PosOrder(models.Model):
             `export_as_JSON` of models.Order. This is useful for back-and-forth communication
             between the pos frontend and backend.
         """
-        return self.mapped(self._export_for_ui) if self else []
+        results = []
+        for order in self:
+            try:
+                results.append(self._export_for_ui(order))
+            except AccessError:
+                # Skip the order in case of AccessError
+                continue
+        return results
 
 
 class PosOrderLine(models.Model):

--- a/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
@@ -634,7 +634,7 @@ odoo.define('point_of_sale.TicketScreen', function (require) {
             const domain = this._computeSyncedOrdersDomain();
             const limit = this._state.syncedOrders.nPerPage;
             const offset = (this._state.syncedOrders.currentPage - 1) * this._state.syncedOrders.nPerPage;
-            const { ids, totalCount } = await this.rpc({
+            let { ids, totalCount } = await this.rpc({
                 model: 'pos.order',
                 method: 'search_paid_order_ids',
                 kwargs: { config_id: this.env.pos.config.id, domain, limit, offset },
@@ -648,6 +648,11 @@ odoo.define('point_of_sale.TicketScreen', function (require) {
                     args: [idsNotInCache],
                     context: this.env.session.user_context,
                 });
+                // Remove not loaded Order IDs
+                const fetchedOrderIdsSet = new Set(fetchedOrders.map(order => order.id));
+                const notLoadedIds = idsNotInCache.filter(id => !fetchedOrderIdsSet.has(id));
+                ids = ids.filter(id => !notLoadedIds.includes(id));
+
                 // Check for missing products and partners and load them in the PoS
                 await this.env.pos._loadMissingProducts(fetchedOrders);
                 await this.env.pos._loadMissingPartners(fetchedOrders);


### PR DESCRIPTION
Before this commit, when a user without access to certain orders attempted to load paid orders, the process would fail and result in an error. This was particularly problematic if a POS order was linked to a sale order that the user did not have permission to access, causing the entire loading process to halt.

This commit addresses the issue by filtering out paid orders that the user cannot access.

opw-4108044

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
