### PR TITLE
[IMP] pos_self_order: shorten url

### DIFF
--- a/addons/pos_self_order/controllers/self_entry.py
+++ b/addons/pos_self_order/controllers/self_entry.py
@@ -7,7 +7,9 @@ from odoo.http import request
 
 class PosSelfKiosk(http.Controller):
     @http.route(["/pos-self/<config_id>", "/pos-self/<config_id>/<path:subpath>"], auth="public", website=True, sitemap=True)
-    def start_self_ordering(self, config_id=None, access_token=None, table_identifier=None):
+    def start_self_ordering(self, config_id=None, access_token=None, table_identifier=None, a=None, t=None):
+        access_token = access_token or a
+        table_identifier = table_identifier or t
         pos_config, _, config_access_token = self._verify_entry_access(config_id, access_token, table_identifier)
         return request.render(
                 'pos_self_order.index',

--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -213,9 +213,9 @@ class PosConfig(models.Model):
             )
 
             if table:
-                table_route = f"&table_identifier={table.identifier}"
+                table_route = f"&t={table.identifier}"
 
-        return f"{base_route}?access_token={self.access_token}{table_route}"
+        return f"{base_route}?a={self.access_token}{table_route}"
 
     def _get_self_order_url(self, table_id: Optional[int] = None) -> str:
         self.ensure_one()


### PR DESCRIPTION
The long length of the  url for self order is too long to be able to have qr codes with high redundancy.

In this commit we add the optional parameters `a` and `t` to the self order entry route to be used as an option to the existing `access_token` and `table_identifier`.

This means that new qr codes will be shorter, while keeping backward compatibility with existing ones.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
