### PR TITLE
[IMP] website_sale: use default snippet s_share

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1195,8 +1195,10 @@
                                     </div>
                                 </t>
                             </div>
-                            <div id="o_product_terms_and_share" class="d-flex justify-content-between flex-column flex-md-row align-items-md-end mb-3">
-                            </div>
+                            <div
+                                id="o_product_terms_and_share"
+                                class="d-flex justify-content-between flex-column flex-md-row align-items-md-end gap-3 mb-3"
+                            />
                         </div>
                     </div>
                 </section>
@@ -1263,12 +1265,59 @@
 
     <template id="product_share_buttons" inherit_id="website_sale.product" active="True" name="Share Buttons" priority="22">
         <xpath expr="//div[@id='o_product_terms_and_share']" position="inside">
-            <div class="h4 mt-3 mb-0 d-flex justify-content-md-end flex-shrink-0" contenteditable="false">
-                <t t-snippet-call="website.s_share">
-                    <t t-set="_no_title" t-value="True"/>
-                    <t t-set="_classes" t-valuef="text-lg-end"/>
-                    <t t-set="_link_classes" t-valuef="mx-1 my-0"/>
-                </t>
+            <div
+                data-snippet="s_share"
+                data-name="Share"
+                class="s_share text-start o_no_link_popover"
+            >
+                <h4 class="s_share_title d-none o_default_snippet_text">Share</h4>
+                <a
+                    href="https://www.facebook.com/sharer/sharer.php?u={url}"
+                    target="_blank"
+                    aria-label="Facebook"
+                    class="s_share_facebook"
+                >
+                    <i class="fa fa-facebook rounded shadow-sm"/>
+                </a>
+                <a
+                    href="https://twitter.com/intent/tweet?text={title}&amp;url={url}"
+                    target="_blank"
+                    aria-label="X"
+                    class="s_share_twitter"
+                >
+                    <i class="fa fa-twitter rounded shadow-sm"/>
+                </a>
+                <a
+                    href="https://www.linkedin.com/sharing/share-offsite/?url={url}"
+                    target="_blank"
+                    aria-label="LinkedIn"
+                    class="s_share_linkedin"
+                >
+                    <i class="fa fa-linkedin rounded shadow-sm"/>
+                </a>
+                <a
+                    href="https://wa.me/?text={title}"
+                    target="_blank"
+                    aria-label="WhatsApp"
+                    class="s_share_whatsapp"
+                >
+                    <i class="fa fa-whatsapp rounded shadow-sm"/>
+                </a>
+                <a
+                    href="https://pinterest.com/pin/create/button/?url={url}&amp;media={media}&amp;description={title}"
+                    target="_blank"
+                    aria-label="Pinterest"
+                    class="s_share_pinterest"
+                >
+                    <i class="fa fa-pinterest rounded shadow-sm"/>
+                </a>
+                <a
+                    href="mailto:?body={url}&amp;subject={title}"
+                    aria-label="Email"
+                    class="s_share_email"
+                >
+                    <i class="fa fa-envelope rounded shadow-sm"/>
+                </a>
             </div>
         </xpath>
     </template>


### PR DESCRIPTION
The `s_share` on the product page was customized and not editable. This commit makes it default and let the user customize it like the default snippet.

task-3986983
part-of task-3986921

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
