### PR TITLE
[FIX] analytic,account: move sequence test

### DIFF
--- a/addons/account/tests/test_account_analytic.py
+++ b/addons/account/tests/test_account_analytic.py
@@ -277,3 +277,40 @@ class TestAccountAnalyticAccount(AccountTestInvoicingCommon, AnalyticCommon):
         self.assertEqual(score, 2)
         score = applicability_with_company._get_score(business_domain='invoice', product=self.product_a.id)
         self.assertEqual(score, 1)
+
+    def test_model_sequence(self):
+        plan_A, plan_B, plan_C = self.env['account.analytic.plan'].create([
+            {'name': "Plan A"},
+            {'name': "Plan B"},
+            {'name': "Plan C"},
+        ])
+        aa_A1, aa_A2, aa_B1, aa_B3, aa_C2 = self.env['account.analytic.account'].create([
+            {'name': "A1", 'plan_id': plan_A.id},
+            {'name': "A2", 'plan_id': plan_A.id},
+            {'name': "B1", 'plan_id': plan_B.id},
+            {'name': "B3", 'plan_id': plan_B.id},
+            {'name': "C2", 'plan_id': plan_C.id},
+        ])
+        m1, m2, m3 = self.env['account.analytic.distribution.model'].create([
+            {'account_prefix': '123', 'sequence': 10, 'analytic_distribution': {f'{aa_A1.id},{aa_B1.id}': 100}},
+            {'account_prefix': '123', 'sequence': 20, 'analytic_distribution': {f'{aa_A2.id},{aa_C2.id}': 100}},
+            {'account_prefix': '123', 'sequence': 30, 'analytic_distribution': {f'{aa_B3.id}': 100}},
+        ])
+        criteria = {
+            'account_prefix': '123456',
+            'company_id': self.env.company.id,
+        }
+
+        # Priority: m1 > m2 > m3 : A1, B1
+        distribution = self.env['account.analytic.distribution.model']._get_distribution(criteria)
+        self.assertEqual(distribution, m1.analytic_distribution, 'm1 fills A & B, ignore m1 & m2')
+
+        # Priority: m2 > m1 > m3 : A2, B3, C2
+        m1.sequence, m2.sequence, m3.sequence = 2, 1, 3
+        distribution = self.env['account.analytic.distribution.model']._get_distribution(criteria)
+        self.assertEqual(distribution, m2.analytic_distribution | m3.analytic_distribution, 'm2 fills A, ignore m1')
+
+        # Priority: m3 > m1 > m2 : A2, B3, C2
+        m1.sequence, m2.sequence, m3.sequence = 2, 3, 1
+        distribution = self.env['account.analytic.distribution.model']._get_distribution(criteria)
+        self.assertEqual(distribution, m2.analytic_distribution | m3.analytic_distribution, 'm3 fills B, ignore m1')


### PR DESCRIPTION
This test checks that multiple models are applied based on their sequence, however it also uses the `account_prefix` criterion, which is only available when `account` is installed.

To keep things simple, we just move the test.

runbot-75208
