### PR TITLE
Revert "[IMP] website{_event}_sale: propagate attendee value"

### DIFF
--- a/addons/website_event_sale/controllers/main.py
+++ b/addons/website_event_sale/controllers/main.py
@@ -2,8 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import defaultdict
-
-from odoo import tools
 from odoo.http import request, route
 
 from odoo.addons.website_event.controllers.main import WebsiteEventController
@@ -64,14 +62,6 @@ class WebsiteEventSaleController(WebsiteEventController):
         if any(info['event_ticket_id'] for info in registrations):
             order_sudo = request.website.sale_get_order()
             if order_sudo.amount_total:
-                if order_sudo.partner_id.is_public:
-                    first_registration = registrations[0]
-                    if first_registration.get('name') and first_registration.get('email'):
-                        formatted_address = tools.formataddr((first_registration['name'], first_registration['email']))
-                        partner = request.env['res.partner'].sudo().find_or_create(formatted_address)
-                        if not partner.phone and first_registration.get('phone'):
-                            partner.phone = first_registration['phone']
-                        order_sudo.partner_id = partner
                 request.session['sale_last_order_id'] = order_sudo.id
                 return request.redirect("/shop/checkout")
             # free tickets -> order with amount = 0: auto-confirm, no checkout

--- a/addons/website_event_sale/static/tests/tours/website_event_sale_last_ticket.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale_last_ticket.js
@@ -61,7 +61,7 @@ registry.category("web_tour.tours").add('event_buy_last_ticket', {
     },
     {
         content: "Validate address",
-        trigger: 'a.a-submit.btn-primary',
+        trigger: '.btn-primary:contains("Continue checkout")',
     },
     ...wsTourUtils.payWithTransfer(true),
 ]});


### PR DESCRIPTION
This reverts commit 31ba553f283af73b9a84ba299ad9b7240e3ab779.

After careful consideration, we deemed it overkill and not necessary. It adds extra overhead as most of the time you will be logged anyway and everything will be pre-filled for you.

It also creates a lot of unnecessary partner records in case users decide to drop out of the checkout flow and not complete it.
