### PR TITLE
[FIX] base_import: import XLSX files without dimension tag

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -450,6 +450,8 @@ class Import(models.TransientModel):
         sheets = options['sheets'] = book.sheetnames
         sheet_name = options['sheet'] = options.get('sheet') or sheets[0]
         sheet = book[sheet_name]
+        if sheet.max_row is None:
+            sheet.calculate_dimension(True)
         rows = []
         for rowx, row in enumerate(sheet.rows, 1):
             values = []


### PR DESCRIPTION
After this https://github.com/odoo/odoo/commit/9b5ae3b38bef70151a1148d760340b35569c454a, the problem arises with some XLSX files (e.g., from Google Sheets). When the library openpyxl tries to parse these files, it fetches dimensions from the dimension tag {http://schemas.openxmlformats.org/spreadsheetml/2006/main}dimension. As a workaround, we can use the calculate_dimension method on the sheet to get the dimensions, which returns the same result.

Steps to reproduce:

- Import Vendor Pricelists.
- Import the same file into Google Sheets.
- Export it from Google Sheets.
- Import it back into Vendor Pricelists.
- An error will occur.

opw-4127978

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
