### PR TITLE
[FIX] account : permit invoice generation from POS with l10n_mx

### DIFF
--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -433,7 +433,7 @@ class AccountMoveSend(models.TransientModel):
         :param invoice_data:    The collected data for the invoice so far.
         """
         pdf_report = self.env['ir.actions.report'].browse(invoice_data['pdf_report_id'])
-        content, _report_format = self.env['ir.actions.report'].with_company(invoice.company_id)._render(pdf_report.report_name, invoice.ids, data={'proforma': True})
+        content, _report_format = self.env['ir.actions.report'].with_company(invoice.company_id)._pre_render_qweb_pdf(pdf_report.report_name, invoice.ids, data={'proforma': True})
 
         invoice_data['proforma_pdf_attachment_values'] = {
             'raw': content[invoice.id],


### PR DESCRIPTION
### Steps to reproduce:
- Install 'l10n_mx' and switch to a Mexican company
- Go to POS and make a sale
- Select a customer and the option to generate an invoice
- Validate
- An error shows up

### Cause:
In the method `_prepare_invoice_proforma_pdf_report` content is interpreted as an array (`'raw': content[invoice.id]`) but is actually the binary. This change was made in this [performance commit](https://github.com/odoo/odoo/commit/0e73d3f1751495786eb2b18384ea39f4da18e3fb) 
But this change considers `content` is a dictionary like returned by the method `_pre_render_qweb_pdf`, it is not.

### Solution:
Call `_pre_render_qweb_pdf` instead of `_render`

opw-4121014