### PR TITLE
[FIX] point_of_sale: use default pricelist when contact is deselected

### DIFF
--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -2476,7 +2476,7 @@ export class Order extends PosModel {
                 ) || this.pos.config.pricelist_id;
         } else {
             newPartnerFiscalPositionId = defaultFiscalPositionId;
-            newPartnerPricelist = this.pos.default_pricelist;
+            newPartnerPricelist = this.pos.config.pricelist_id;
         }
         const fiscalPosition = this.pos.models["account.fiscal.position"].find(
             (fp) => fp.id === newPartnerFiscalPositionId


### PR DESCRIPTION
Before this commit, deselecting a contact in the POS would not revert to using the default pricelist for price computation. This issue was due to incorrect pricelist assignment when a contact was removed.

opw-4068014

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
