### PR TITLE
[FIX] stock: trigger scheduler reservation 'at_confirm'

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -549,8 +549,6 @@ Please change the quantity done or the rounding precision of your unit of measur
                 if move.priority == '1':
                     days = move.picking_type_id.reservation_days_before_priority
                 move.reservation_date = fields.Date.to_date(move.date) - timedelta(days=days)
-            else:
-                move.reservation_date = False
 
     @api.depends('has_tracking', 'picking_type_id.use_create_lots', 'picking_type_id.use_existing_lots', 'state', 'origin_returned_move_id', 'product_id.detailed_type', 'picking_code')
     def _compute_show_info(self):

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -550,7 +550,9 @@ class ProcurementGroup(models.Model):
         moves_domain = [
             ('state', 'in', ['confirmed', 'partially_available']),
             ('product_uom_qty', '!=', 0.0),
-            ('reservation_date', '<=', fields.Date.today())
+            '|',
+                ('reservation_date', '<=', fields.Date.today()),
+                ('picking_type_id.reservation_method', '=', 'at_confirm'),
         ]
         if company_id:
             moves_domain = expression.AND([[('company_id', '=', company_id)], moves_domain])


### PR DESCRIPTION
### Steps to reproduce:

- Create a storable product A
- Create and confirm a delivery order for 1 unit of A
- Add one unit of A in stock
- Inventory > Operations > Run Scheduler

#### > The reservation of the delivery order is not performed

### Cause of the issue:

The "reservation_date" of moves whose "picking_type" does not have a reservation method 'At Date' is removed each time it is computed because of these lines:
https://github.com/odoo/odoo/blob/17a18f9d065d25095f80e6982b6dc0673e5c382e/addons/stock/models/stock_move.py#L547-L553 However, during the `_run_scheduler_tasks` only the moves whose `reservation_date` is set will be reserved:
https://github.com/odoo/odoo/blob/17a18f9d065d25095f80e6982b6dc0673e5c382e/addons/stock/models/stock_rule.py#L549-L554 https://github.com/odoo/odoo/blob/17a18f9d065d25095f80e6982b6dc0673e5c382e/addons/stock/models/stock_rule.py#L572-L574

opw-4105299
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
