### PR TITLE
[FIX] web: missing spaces in error_dialog messages

### DIFF
--- a/addons/web/static/src/core/errors/error_dialogs.js
+++ b/addons/web/static/src/core/errors/error_dialogs.js
@@ -57,13 +57,16 @@ export class ErrorDialog extends Component {
         });
         this.copyButtonRef = useRef("copyButton");
         this.popover = usePopover(Tooltip);
-        this.contextDetails = `Occured ${
-            this.props.serverHost ? `on ${this.props.serverHost} ` : ""
-        }${
-            this.props.model && this.props.id
-                ? `on model ${this.props.model} and id ${this.props.id} `
-                : ""
-        }on ${DateTime.now().setZone("UTC").toFormat("yyyy-MM-dd HH:mm:ss")} GMT`;
+        this.contextDetails = "Occured ";
+        if (this.props.serverHost) {
+            this.contextDetails += `on ${this.props.serverHost} `;
+        }
+        if (this.props.model && this.props.id) {
+            this.contextDetails += `on model ${this.props.model} and id ${this.props.id} `;
+        }
+        this.contextDetails += `on ${DateTime.now()
+            .setZone("UTC")
+            .toFormat("yyyy-MM-dd HH:mm:ss")} GMT`;
     }
 
     showTooltip() {


### PR DESCRIPTION
This commit fixes an issue where some white spaces were missing inside of error dialogs context messages while not in debug mode. This is happening due to a known issue on nested template strings with the rjsmin library (https://github.com/ndparker/rjsmin/issues/22). We therefore circumvent the problem by rewriting the code without using nested template strings.
