### PR TITLE
[FIX] account: no company inside compute_all

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -713,7 +713,7 @@ class AccountTax(models.Model):
         if not self:
             company = self.env.company
         else:
-            company = self[0].company_id._accessible_branches()[:1]
+            company = self[0].company_id._accessible_branches()[:1] or self[0].company_id
 
         # 1) Flatten the taxes.
         taxes, groups_map = self.flatten_taxes_hierarchy(create_map=True)


### PR DESCRIPTION
The aim of this commit is to ensure we always have a company from which to pull values.

Context:
On odoo.com, we have only one website but when users buy something on our website, we create the so, the payment and the invoice with the company which is in the country of the user.
This results in a situation in which the user initiating the payment transaction is the one used to create and post the invoice.
When reaching the line checking which branch are accessible, if there is a mismatched between the available branches and the current branch, we get an empty recordset.

Before this commit:
It was possible to not have a company there, leading to inconsistencies later on when relying on company to get some values like `tax_calculation_rounding_method`.
For odoo.com, it resulted in a 0.01€ discrepancie between the sale order and its invoice. As the payment transaction was made based on the sale order amount, the invoice remained unpaid forcing the accountants to manually write off the difference.

After this commit:
There is always a default company provided ensuring taxes gets computed correctly and thus having sale order and invoice having the same amount.

Special thanks to PMO for his HUGE help debugging this madness.

task-id: None (issue spotted on odoo.com)
