### PR TITLE
[FIX] im_livechat: prevent window from closing on mobile

### DIFF
--- a/addons/im_livechat/static/src/embed/common/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_service.js
@@ -123,7 +123,7 @@ export class LivechatService {
         if (temporaryThread) {
             const chatWindow = this.store.ChatWindow.get({ thread: temporaryThread });
             temporaryThread.delete();
-            chatWindow.close();
+            await chatWindow.close();
         }
         if (!this.thread) {
             return;


### PR DESCRIPTION
Current behaviour:
---
On mobile (or small screen), after opening a chat window, if you interact with it, it will close.

Steps to reproduce:
---
1. Open odoo on a small screen
2. Click on the chat button
3. Click on an option or write something
4. The chat window will close

Cause of the issue:
---
Caused by: https://github.com/odoo/odoo/commit/82e3295d43f7809661a40d1b21ffbcbce23c700b 
When calling `persist`, `this.store.chatHub.opened.add` is called before `chatWindow.close` can finish, 
so when `onRecompute` is called, `this.opened.length` is 2, and because `this.maxOpened` is 1 on mobile, 
`this.opened.pop()` closes the current chat.

Fix:
---
Added `await` to `chatWindow.close` to make sure that chat is closed and deleted before calling `onRecompute`.

opw-4088730

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
