### PR TITLE
[FIX] sale: avoid unreliable environment changes

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -816,13 +816,11 @@ class SaleOrder(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:
-            if 'company_id' in vals:
-                self = self.with_company(vals['company_id'])
             if vals.get('name', _("New")) == _("New"):
                 seq_date = fields.Datetime.context_timestamp(
                     self, fields.Datetime.to_datetime(vals['date_order'])
                 ) if 'date_order' in vals else None
-                vals['name'] = self.env['ir.sequence'].next_by_code(
+                vals['name'] = self.env['ir.sequence'].with_company(vals.get('company_id')).next_by_code(
                     'sale.order', sequence_date=seq_date) or _("New")
 
         return super().create(vals_list)


### PR DESCRIPTION
**Steps to reproduce:**

```
>>> print(self.env.company)
res.company(1)
```

```
>>> company1, company2, company3 = self.env['res.company'].browse([1,2,3])
>>> orders = self.env['sale.order'].create(
    [
        {'partner_id': partner.id, 'company_id': company1.id},
        {'partner_id': partner.id, 'company_id': company2.id},
        {'partner_id': partner.id, 'company_id': company3.id},
    ]
)
```

```
>>> print(orders.env.company)
res.company(3)
```

**Expected result:**

The company in the environment returned should be the same than the company in the environment that created the order.

Useful information:
This code was introduced by 0c1fcfb0e1ee7481518403bfe0dfd01200d7c060, before the adaptation of the `create` method to support multi-records creation (f503e69d3bc56bfad1d9405ee0b76dbd975c4872).  Now that most fields are now handled in compute methods, the `with_company` call can be safely moved to target only the `ir.sequence` logic.
