### PR TITLE
[IMP] core: stop importing odoo.tests when running

### DIFF
--- a/addons/account_update_tax_tags/__init__.py
+++ b/addons/account_update_tax_tags/__init__.py
@@ -1,2 +1,1 @@
-from . import tests
 from . import wizard

--- a/addons/auth_totp_mail_enforce/__init__.py
+++ b/addons/auth_totp_mail_enforce/__init__.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import controllers
 from . import models
-from . import tests

--- a/addons/l10n_es_pos/__init__.py
+++ b/addons/l10n_es_pos/__init__.py
@@ -1,6 +1,5 @@
 from odoo import _
 from . import models
-from . import tests
 
 
 def _l10n_es_pos_post_init_hook(env):

--- a/addons/l10n_gcc_invoice/__init__.py
+++ b/addons/l10n_gcc_invoice/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import models
-from . import tests

--- a/addons/marketing_card/__init__.py
+++ b/addons/marketing_card/__init__.py
@@ -1,4 +1,3 @@
 from . import controllers
 from . import models
-from . import tests
 from . import wizards

--- a/addons/pos_event/__init__.py
+++ b/addons/pos_event/__init__.py
@@ -1,3 +1,2 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import models
-from . import tests

--- a/addons/pos_loyalty/__init__.py
+++ b/addons/pos_loyalty/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import models
-from . import tests

--- a/addons/pos_self_order/__init__.py
+++ b/addons/pos_self_order/__init__.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
-
 from . import controllers
 from . import models
-from . import tests
+
 
 def _post_self_order_post_init(env):
     env['pos.config']._modify_pos_restaurant_config()

--- a/addons/test_mail_full/__init__.py
+++ b/addons/test_mail_full/__init__.py
@@ -1,5 +1,2 @@
-# -*- coding: utf-8 -*-
-
 from . import controllers
 from . import models
-from . import tests

--- a/addons/test_marketing_card/__init__.py
+++ b/addons/test_marketing_card/__init__.py
@@ -1,2 +1,1 @@
 from . import models
-from . import tests

--- a/addons/website/tools.py
+++ b/addons/website/tools.py
@@ -8,10 +8,11 @@ from unittest.mock import Mock, MagicMock, patch
 from werkzeug.exceptions import NotFound
 from werkzeug.test import EnvironBuilder
 
-import odoo
-from odoo.tests.common import HttpCase, HOST
+import odoo.http
 from odoo.tools.misc import hmac, DotDict, frozendict
 from odoo.tools import config
+
+HOST = '127.0.0.1'
 
 
 @contextlib.contextmanager
@@ -22,7 +23,8 @@ def MockRequest(
         # website_sale
         sale_order_id=None, website_sale_current_pl=None,
 ):
-
+    # TODO move MockRequest to a package in tests
+    from odoo.tests.common import HttpCase  # noqa: PLC0415
     lang_code = context.get('lang', env.context.get('lang', 'en_US'))
     env = env(context=dict(context, lang=lang_code))
     request = Mock(

--- a/addons/website_event_crm/__init__.py
+++ b/addons/website_event_crm/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import models
-from . import tests

--- a/odoo/addons/test_read_group/__init__.py
+++ b/odoo/addons/test_read_group/__init__.py
@@ -1,4 +1,1 @@
-# -*- coding: utf-8 -*-
-
 from . import models
-from . import tests

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -20,7 +20,6 @@ from .. import SUPERUSER_ID, api, tools
 from .module import adapt_version, initialize_sys_path, load_openerp_module
 
 _logger = logging.getLogger(__name__)
-_test_logger = logging.getLogger('odoo.tests')
 
 
 def load_data(env, idref, mode, kind, package):
@@ -273,7 +272,7 @@ def load_module_graph(env, graph, status=None, perform_checks=True,
         test_time = test_queries = 0
         test_results = None
         if tools.config.options['test_enable'] and (needs_update or not updating):
-            loader = odoo.tests.loader
+            from odoo.tests import loader  # noqa: PLC0415
             suite = loader.make_suite([module_name], 'at_install')
             if suite.countTestCases():
                 if not needs_update:
@@ -588,7 +587,7 @@ def load_modules(registry, force_demo=False, status=None, update_module=False):
                 except Exception as e:
                     _logger.warning('invalid custom view(s) for model %s: %s', model, e)
 
-        if report.wasSuccessful():
+        if not registry._assertion_report or registry._assertion_report.wasSuccessful():
             _logger.info('Modules loaded.')
         else:
             _logger.error('At least one test failed when loading the modules.')

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -62,6 +62,7 @@ _CACHES_BY_KEY = {
     'groups': ('groups', 'templates', 'templates.cached_values'),  # The processing of groups is saved in the view
 }
 
+
 def _unaccent(x):
     if isinstance(x, SQL):
         return SQL("unaccent(%s)", x)
@@ -154,7 +155,11 @@ class Registry(Mapping):
         self._sql_constraints = set()
         self._init = True
         self._database_translated_fields = ()  # names of translated fields in database
-        self._assertion_report = odoo.tests.result.OdooTestResult()
+        if config['test_enable'] or config['test_file']:
+            from odoo.tests.result import OdooTestResult  # noqa: PLC0415
+            self._assertion_report = OdooTestResult()
+        else:
+            self._assertion_report = None
         self._fields_by_model = None
         self._ordinary_tables = None
         self._constraint_queue = deque()

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -58,7 +58,7 @@ from odoo.fields import Command
 from odoo.modules.registry import Registry
 from odoo.service import security
 from odoo.sql_db import BaseCursor, Cursor
-from odoo.tools import mute_logger, profiler, SQL, DotDict, float_compare
+from odoo.tools import config, float_compare, mute_logger, profiler, SQL, DotDict
 from odoo.tools.mail import single_email_re
 from odoo.tools.misc import find_in_path, lower_logging
 from odoo.tools.xml_utils import _validate_xml
@@ -89,6 +89,15 @@ except ImportError:
     freezegun = None
 
 _logger = logging.getLogger(__name__)
+if config['test_enable'] or config['test_file']:
+    _logger.info("Importing test framework", stack_info=_logger.isEnabledFor(logging.DEBUG))
+else:
+    _logger.error(
+        "Importing test framework"
+        ", avoid importing from business modules and when not running in test mode",
+        stack_info=True,
+    )
+
 
 # backward compatibility: Form was defined in this file
 def __getattr__(name):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Stop importing `odoo.tests` when not running in test-mode.

Current behavior before PR:
Testing framework imported even if not running any tests.

Desired behavior after PR is merged:
`odoo.tests` is not imported.


Related to https://github.com/odoo/odoo/pull/175940


odoo/enterprise#68964
odoo/upgrade#6424

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
