### PR TITLE
[FIX] base_import: empty cell in XLS files

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -483,6 +483,8 @@ class Import(models.TransientModel):
                     values.append(cell.value.strftime(DEFAULT_SERVER_DATETIME_FORMAT))
                 elif isinstance(cell.value, datetime.date):
                     values.append(cell.value.strftime(DEFAULT_SERVER_DATE_FORMAT))
+                elif cell.value is None:
+                    values.append('')
                 else:
                     values.append(str(cell.value))
 


### PR DESCRIPTION
Steps to reproduce:
-------------------
- Have xlrd >= 2.0 and openpyxl 3.1.2
- Using the base_import module, import an XLSX file with empty Cells
- You will notice that all empty cells are read as "None"
- Click on test, will give this error : "Column debit contains incorrect values (value: None)

 Cause
-----

Since using openpyxl instead of xlrd for parsing xlsx files, the empty cells are parsed as None, not as empty string (as it was in xlrd). then this None is cast to the string "None", causing issues.

 Fix
-----
An additional check needs to be added to check if the cell is empty (value is None) and set it as empty string.

opw-id 4132402