### PR TITLE
[FIX] mrp: Show apply button after SN generation

### DIFF
--- a/addons/mrp/wizard/stock_assign_serial_numbers.py
+++ b/addons/mrp/wizard/stock_assign_serial_numbers.py
@@ -5,6 +5,7 @@ from collections import Counter
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
+from odoo.tools.float_utils import float_compare
 
 
 class StockAssignSerialNumbers(models.TransientModel):
@@ -57,7 +58,8 @@ class StockAssignSerialNumbers(models.TransientModel):
             self.produced_qty = 0
             raise UserError(_('There are more Serial Numbers than the Quantity to Produce'))
         self.produced_qty = len(serial_numbers)
-        self.show_apply = self.produced_qty == self.expected_qty
+        precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
+        self.show_apply = float_compare(self.produced_qty, self.expected_qty, precision_digits=precision) == 0
         self.show_backorders = 0 < self.produced_qty < self.expected_qty
 
     def _assign_serial_numbers(self, cancel_remaining_quantity=False):


### PR DESCRIPTION
### Current behavior:
- If `mass produce` is activated on the manufacturing order, the `Apply` button does not appear after the customer clicks `Generate` to create serial numbers, preventing them from applying the changes. The issue is due to a mismatch in the precision between `produced_qty` and `expected_qty`.

### Expected behavior:
- Allow customers to apply SNs after they generate them.

### Fix:
- We use `float_compare` to avoid precision issues.

### Affected versions:
- 17.0

opw-4126574