### PR TITLE
[FIX] sale_pdf_quote_builder: correct help note on attached_on

### DIFF
--- a/addons/sale_pdf_quote_builder/i18n/sale_pdf_quote_builder.pot
+++ b/addons/sale_pdf_quote_builder/i18n/sale_pdf_quote_builder.pot
@@ -37,7 +37,8 @@ msgid ""
 "e.g. this option can be useful to share Product description files.\n"
 "Confirmed order: the document will be sent to and accessible by customers.\n"
 "e.g. this option can be useful to share User Manual or digital content bought on ecommerce. \n"
-"Inside quote: The document will be included in the pdf of the quotation between the header pages and the quote table. "
+"Inside quote: The document will be included in the pdf of the quotation \n"
+"and sales order between the header pages and the quote table. "
 msgstr ""
 
 #. module: sale_pdf_quote_builder

--- a/addons/sale_pdf_quote_builder/models/product_document.py
+++ b/addons/sale_pdf_quote_builder/models/product_document.py
@@ -20,8 +20,8 @@ class ProductDocument(models.Model):
              "Confirmed order: the document will be sent to and accessible by customers.\n"
              "e.g. this option can be useful to share User Manual or digital content bought"
              " on ecommerce. \n"
-             "Inside quote: The document will be included in the pdf of the quotation between the "
-             "header pages and the quote table. ",
+             "Inside quote: The document will be included in the pdf of the quotation \n"
+             "and sale order between the header pages and the quote table. ",
     )
 
     @api.constrains('attached_on', 'datas', 'type')


### PR DESCRIPTION
Changed the note on the attached_on field to properly note that the Inside quote option will include the document on the pdf of the quotation and sale order instead of just the quotation. Previously only said that it would be on the quote and caused confusion for customers when it would also show on the sale order.

opw-4106894




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
