### PR TITLE
[FIX] website_event: Use valid value for query selector

### DIFF
--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -92,7 +92,7 @@
                                         type="button"
                                         data-bs-toggle="collapse"
                                         t-attf-aria-controls="o_wevent_offcanvas_cat_#{category.id}"
-                                        t-att-data-bs-target="'.o_wevent_offcanvas_cat_%s' % category.id"
+                                        t-attf-data-bs-target=".o_wevent_offcanvas_cat_#{category.id}"
                                         aria-expanded="false">
                                         <t t-out="category.name"/>
                                     </button>


### PR DESCRIPTION
Steps:
- Open "Event Tags Categories"
- Rename one with invalid character for HTML class/ID (like "/")
- Open Website
- Open Events Page
- Switch to Mobile view
- Open Filter
- Open any category

Actual result:
- Traceback due to an invalid selector

Expected result:
- No traceback
- Filter category is opened as expected

opw-4126379
Caused by https://github.com/odoo/odoo/pull/145064

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
