### PR TITLE
[FIX] analytic, account: use column_invisible instead of invisible

### DIFF
--- a/addons/account/views/account_analytic_account_views.xml
+++ b/addons/account/views/account_analytic_account_views.xml
@@ -27,10 +27,10 @@
             <field name="inherit_id" ref="analytic.view_account_analytic_account_list"/>
             <field name="arch" type="xml">
                 <field name="debit" position="attributes">
-                    <attribute name="invisible">False</attribute>
+                    <attribute name="column_invisible">False</attribute>
                 </field>
                 <field name="credit" position="attributes">
-                    <attribute name="invisible">False</attribute>
+                    <attribute name="column_invisible">False</attribute>
                 </field>
             </field>
         </record>

--- a/addons/analytic/views/analytic_account_views.xml
+++ b/addons/analytic/views/analytic_account_views.xml
@@ -60,8 +60,8 @@
                     <field name="plan_id"/>
                     <field name="active" column_invisible="True"/>
                     <field name="company_id" groups="base.group_multi_company"/>
-                    <field name="debit" sum="Debit" invisible="1"/>
-                    <field name="credit" sum="Credit" invisible="1"/>
+                    <field name="debit" sum="Debit" column_invisible="True"/>
+                    <field name="credit" sum="Credit" column_invisible="True"/>
                     <field name="balance" sum="Balance"/>
                 </tree>
             </field>


### PR DESCRIPTION
* When fwd https://github.com/odoo/odoo/pull/156349 , we forgot to adapt with change in >=17.0

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
