### PR TITLE
[FIX] event*: use column_invisible instead of invisible in tree

### DIFF
--- a/addons/event_crm_sale/views/event_lead_rule_views.xml
+++ b/addons/event_crm_sale/views/event_lead_rule_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="event_crm.event_lead_rule_view_tree"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='lead_creation_basis']" position="attributes">
-                <attribute name="invisible">0</attribute>
+                <attribute name="column_invisible">False</attribute>
             </xpath>
         </field>
     </record>

--- a/addons/website_event_crm/views/event_lead_rule_views.xml
+++ b/addons/website_event_crm/views/event_lead_rule_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="event_crm.event_lead_rule_view_tree"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='lead_creation_basis']" position="attributes">
-                <attribute name="invisible">0</attribute>
+                <attribute name="column_invisible">False</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
*= event_crm_sale, website_event_crm

*  -Probably miss by script since
https://github.com/odoo/odoo/pull/104741/commits/332c117f60a36f723c450f61ce2e0e7181d66c21

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
