### PR TITLE
[FIX] mass_mailing_sms: use column_invisible instead of invisible in tree

### DIFF
--- a/addons/mass_mailing_sms/report/mailing_trace_report_views.xml
+++ b/addons/mass_mailing_sms/report/mailing_trace_report_views.xml
@@ -8,10 +8,10 @@
         <field name="mode">primary</field>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='opened']" position="attributes">
-                <attribute name="invisible">1</attribute>
+                <attribute name="column_invisible">1</attribute>
             </xpath>
             <xpath expr="//field[@name='replied']" position="attributes">
-                <attribute name="invisible">1</attribute>
+                <attribute name="column_invisible">1</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION

-Probably miss by script since
https://github.com/odoo/odoo/commit/332c117f60a36f723c450f61ce2e0e7181d66c21

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
