### PR TITLE
[FIX] website: prevent infinite stretch in Add new page dialog

### DIFF
--- a/addons/website/static/src/components/dialog/add_page_dialog.js
+++ b/addons/website/static/src/components/dialog/add_page_dialog.js
@@ -160,6 +160,7 @@ export class AddPageTemplatePreview extends Component {
                     overflow: hidden;
                     padding-right: 0px;
                     padding-left: 0px;
+                    --snippet-preview-height: 340px;
                 }
                 section {
                     /* Avoid the zoom's missing pixel. */


### PR DESCRIPTION
The "Add new page" dialog adds CSS inside the preview `iframe`s to fix heights that are expressed in percentage of the viewport. The redesigned "Image carousel" snippet introduces a CSS variable that makes it possible to specify the height, but turns to using 100% of the viewport if it is not defined.

This commit sets a value for that variable to avoid that the `iframe` gets resized to ever bigger sizes.

Steps to reproduce:
- Add a new page.
- Go to the "Team" sections.

=> One of the preview grew infinitely.

task-3654328
