### PR TITLE
[FIX] stock: disallow multi-edit for `lot_id` and `quant_id`

### DIFF
--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -1508,6 +1508,15 @@ msgstr ""
 
 #. module: stock
 #. odoo-python
+#: code:addons/stock/models/stock_move_line.py:0
+#, python-format
+msgid ""
+"Changing the Lot/Serial number for move lines with different products is not"
+" allowed."
+msgstr ""
+
+#. module: stock
+#. odoo-python
 #: code:addons/stock/models/product_strategy.py:0
 #: code:addons/stock/models/stock_location.py:0
 #: code:addons/stock/models/stock_lot.py:0

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -381,6 +381,9 @@ class StockMoveLine(models.Model):
         if 'product_id' in vals and any(vals.get('state', ml.state) != 'draft' and vals['product_id'] != ml.product_id.id for ml in self):
             raise UserError(_("Changing the product is only allowed in 'Draft' state."))
 
+        if ('lot_id' in vals or 'quant_id' in vals) and len(self.product_id) > 1:
+            raise UserError(_("Changing the Lot/Serial number for move lines with different products is not allowed."))
+
         moves_to_recompute_state = self.env['stock.move']
         triggers = [
             ('location_id', 'stock.location'),


### PR DESCRIPTION
Steps to reproduce the bug:
- Create two products tracked by Serial Number (SN): “P1” and “P2”.
- Update their quantities.
- Create a delivery with one unit of each.
- Mark it as "To Do".
- Go to the detailed operation.
- Attempt to edit the "pick from" (`quant_id`) or the serial number of P1.
- Save.

Problem:
The product “P2” is incorrectly updated to “P1”.

opw-3995450
