### PR TITLE
[FIX] html_editor: toolbar namespace resolution for image and icon

### DIFF
--- a/addons/html_editor/static/src/main/media/icon_plugin.js
+++ b/addons/html_editor/static/src/main/media/icon_plugin.js
@@ -11,9 +11,13 @@ export class IconPlugin extends Plugin {
                 {
                     id: "icon",
                     isApplied: (traversedNodes) =>
-                        // Last traversed nodes are an icon and its ZWS child.
-                        traversedNodes.at(-1)?.textContent === "\u200b" &&
-                        traversedNodes.at(-2)?.classList?.contains("fa"),
+                        traversedNodes.every(
+                            (node) =>
+                                // All nodes should be icons, its ZWS child or its ancestors
+                                node.classList?.contains("fa") ||
+                                node.parentElement.classList.contains("fa") ||
+                                node.querySelector?.(".fa")
+                        ),
                 },
             ],
             toolbarCategory: [

--- a/addons/html_editor/static/src/main/media/image_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_plugin.js
@@ -21,9 +21,11 @@ export class ImagePlugin extends Plugin {
             toolbarNamespace: [
                 {
                     id: "image",
-                    isApplied: (traversedNodes) => {
-                        return traversedNodes.at(-1)?.tagName === "IMG";
-                    },
+                    isApplied: (traversedNodes) =>
+                        traversedNodes.every(
+                            // All nodes should be images or its ancestors
+                            (node) => node.nodeName === "IMG" || node.querySelector?.("img")
+                        ),
                 },
             ],
             toolbarCategory: [

--- a/addons/html_editor/static/tests/icon.test.js
+++ b/addons/html_editor/static/tests/icon.test.js
@@ -15,6 +15,24 @@ test("icon toolbar is displayed (2)", async () => {
     expect(".btn-group[name='icon_size']").toHaveCount(1);
 });
 
+test("icon toolbar is displayed (3)", async () => {
+    await setupEditor(`<p>abc[<span class="fa fa-glass"></span>]def</p>`);
+    await waitFor(".o-we-toolbar");
+    expect(".btn-group[name='icon_size']").toHaveCount(1);
+});
+
+test("toolbar should not be namespaced for icon", async () => {
+    await setupEditor(`<p>a[bc<span class="fa fa-glass"></span>]def</p>`);
+    await waitFor(".o-we-toolbar");
+    expect(".btn-group[name='icon_size']").toHaveCount(0);
+});
+
+test("toolbar should not be namespaced for icon (2)", async () => {
+    await setupEditor(`<p>abc[<span class="fa fa-glass"></span>de]f</p>`);
+    await waitFor(".o-we-toolbar");
+    expect(".btn-group[name='icon_size']").toHaveCount(0);
+});
+
 test("Can resize an icon", async () => {
     await setupEditor(`<p><span class="fa fa-glass">[]</span></p>`);
     await waitFor(".o-we-toolbar");

--- a/addons/html_editor/static/tests/image.test.js
+++ b/addons/html_editor/static/tests/image.test.js
@@ -354,3 +354,11 @@ test("Toolbar detects image namespace when there is text next to it", async () =
     await waitFor(".o-we-toolbar");
     expect("button[name='image_delete']").toHaveCount(1);
 });
+
+test("Toolbar should not be namespaced for image", async () => {
+    await setupEditor(`
+        <p>a[bc<img class="img-fluid test-image" src="${base64Img}">]def</p>
+    `);
+    await waitFor(".o-we-toolbar");
+    expect("button[name='image_delete']").toHaveCount(0);
+});


### PR DESCRIPTION
Steps:
- insert an image after some text
- with the keyboard (shift + arrows) select part of the text and the image, e.g. `<p>te[xt<img>]</p>` The displayed toolbar should be the "regular" one, that is, not the one specific for images.

The same steps apply for an icon, i.e., the selection below results in the toolbar with buttons specific for icon maninulation, while it should be the regular one.
	`<p>te[xt<span class="fa"></span>]</p>`
