### PR TITLE
[FIX] point_of_sale: display quantity for single-variant products

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.js
@@ -26,8 +26,10 @@ export class ProductInfoPopup extends Component {
         this.props.close();
     }
     get isVariant() {
-        return this.pos.models["product.product"].filter(
-            (p) => p.raw.product_tmpl_id === this.props.product.raw.product_tmpl_id
+        return (
+            this.pos.models["product.product"].filter(
+                (p) => p.raw.product_tmpl_id === this.props.product.raw.product_tmpl_id
+            ).length > 1
         );
     }
 }


### PR DESCRIPTION
Before this commit, the on-hand quantity of products was not displayed in the product info popup. Given that a product can have multiple variants, displaying on-hand quantity directly in the popup was deemed irrelevant. However, this commit introduces a change to display the on-hand quantity in the product info popup for products without variants, enhancing clarity and usability for single-variant products.

opw-4133522

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
