### PR TITLE
[IMP] core: sanitize request cookies

### DIFF
--- a/addons/auth_totp/controllers/home.py
+++ b/addons/auth_totp/controllers/home.py
@@ -27,7 +27,7 @@ class Home(web_home.Home):
 
         user = request.env['res.users'].browse(request.session.pre_uid)
         if user and request.httprequest.method == 'GET':
-            cookies = request.httprequest.cookies
+            cookies = request.cookies
             key = cookies.get(TRUSTED_DEVICE_COOKIE)
             if key:
                 user_match = request.env['auth_totp.device']._check_credentials_for_uid(

--- a/addons/auth_totp/models/res_users.py
+++ b/addons/auth_totp/models/res_users.py
@@ -49,7 +49,7 @@ class Users(models.Model):
         To be overriden if needs to be disabled for other 2FA providers
         """
         if request and self._mfa_type():
-            key = request.httprequest.cookies.get('td_id')
+            key = request.cookies.get('td_id')
             if key:
                 if request.env['auth_totp.device']._check_credentials_for_uid(
                     scope="browser", key=key, uid=self.id):

--- a/addons/bus/controllers/websocket.py
+++ b/addons/bus/controllers/websocket.py
@@ -51,7 +51,7 @@ class WebsocketController(Controller):
 
     @route("/websocket/on_closed", type="json", auth="public", cors="*")
     def on_websocket_closed(self):
-        request.env["ir.websocket"]._on_websocket_closed(request.httprequest.cookies)
+        request.env["ir.websocket"]._on_websocket_closed(request.cookies)
 
     @route('/bus/websocket_worker_bundle', type='http', auth='public', cors='*')
     def get_websocket_worker_bundle(self, v=None):  # pylint: disable=unused-argument

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -20,6 +20,7 @@ from urllib.parse import urlparse
 from weakref import WeakSet
 
 from werkzeug.local import LocalStack
+from werkzeug.datastructures import ImmutableMultiDict, MultiDict
 from werkzeug.exceptions import BadRequest, HTTPException, ServiceUnavailable
 
 import odoo
@@ -30,7 +31,7 @@ from odoo.modules.registry import Registry
 from odoo.service import model as service_model
 from odoo.service.server import CommonServer
 from odoo.service.security import check_session
-from odoo.tools import config
+from odoo.tools import config, lazy_property
 
 _logger = logging.getLogger(__name__)
 
@@ -867,6 +868,13 @@ class WebsocketRequest:
         use :meth:`~update_env` instead.
         """
         self.update_env(context=dict(self.env.context, **overrides))
+
+    @lazy_property
+    def cookies(self):
+        cookies = MultiDict(self.httprequest.cookies)
+        if self.registry:
+            self.registry['ir.http']._sanitize_cookies(cookies)
+        return ImmutableMultiDict(cookies)
 
 
 class WebsocketConnectionHandler:

--- a/addons/event/controllers/main.py
+++ b/addons/event/controllers/main.py
@@ -15,7 +15,7 @@ class EventController(Controller):
     def event_ics_file(self, event, **kwargs):
         lang = request.context.get('lang', request.env.user.lang)
         if request.env.user._is_public():
-            lang = request.httprequest.cookies.get('frontend_lang')
+            lang = request.cookies.get('frontend_lang')
         event = event.with_context(lang=lang)
         files = event._get_ics_file()
         if not event.id in files:

--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -484,7 +484,7 @@ class IrHttp(models.AbstractModel):
         try:
             request.registry['ir.http']._auth_method_public()  # it calls update_env
             nearest_url_lang = request.env['ir.http'].get_nearest_lang(request.env['res.lang']._get_data(url_code=url_lang_str).code or url_lang_str)
-            cookie_lang = request.env['ir.http'].get_nearest_lang(request.httprequest.cookies.get('frontend_lang'))
+            cookie_lang = request.env['ir.http'].get_nearest_lang(request.cookies.get('frontend_lang'))
             context_lang = request.env['ir.http'].get_nearest_lang(real_env.context.get('lang'))
             default_lang = cls._get_default_lang()
             request.lang = request.env['res.lang']._get_data(code=(
@@ -599,7 +599,7 @@ class IrHttp(models.AbstractModel):
     @classmethod
     def _frontend_pre_dispatch(cls):
         request.update_context(lang=request.lang.code)
-        if request.httprequest.cookies.get('frontend_lang') != request.lang.code:
+        if request.cookies.get('frontend_lang') != request.lang.code:
             request.future_response.set_cookie('frontend_lang', request.lang.code)
 
     @classmethod

--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -139,7 +139,7 @@ class LivechatController(http.Controller):
             chatbot_script=chatbot_script,
             user_id=user_id,
             country_id=country_id,
-            lang=request.httprequest.cookies.get('frontend_lang')
+            lang=request.cookies.get('frontend_lang')
         )
         if not channel_vals:
             return False

--- a/addons/im_livechat/models/chatbot_script.py
+++ b/addons/im_livechat/models/chatbot_script.py
@@ -217,5 +217,5 @@ class ChatbotScript(models.Model):
         }
 
     def _get_chatbot_language(self):
-        frontend_lang = request and request.httprequest.cookies.get('frontend_lang')
+        frontend_lang = request and request.cookies.get('frontend_lang')
         return frontend_lang or self.env.user.lang or get_lang(self.env).code

--- a/addons/im_livechat/tools/misc.py
+++ b/addons/im_livechat/tools/misc.py
@@ -8,7 +8,7 @@ def downgrade_to_public_user():
     in order to ensure that the no user-specific data is kept in the request."""
     public_user = request.env.ref("base.public_user")
     request.update_env(user=public_user)
-    request.httprequest.cookies = {}
+    request.cookies = {}
 
 
 def force_guest_env(guest_token, raise_if_not_found=True):

--- a/addons/mail/controllers/mail.py
+++ b/addons/mail/controllers/mail.py
@@ -71,7 +71,7 @@ class MailController(http.Controller):
                 # We need here to extend the "allowed_company_ids" to allow a redirection
                 # to any record that the user can access, regardless of currently visible
                 # records based on the "currently allowed companies".
-                cids_str = request.httprequest.cookies.get('cids', str(user.company_id.id))
+                cids_str = request.cookies.get('cids', str(user.company_id.id))
                 cids = [int(cid) for cid in cids_str.split('-')]
                 try:
                     record_sudo.with_user(uid).with_context(allowed_company_ids=cids).check_access_rule('read')

--- a/addons/mail/models/discuss/mail_guest.py
+++ b/addons/mail/models/discuss/mail_guest.py
@@ -25,7 +25,7 @@ def add_guest_to_context(func):
     def wrapper(self, *args, **kwargs):
         req = request or wsrequest
         token = (
-            req.httprequest.cookies.get(req.env["mail.guest"]._cookie_name, "")
+            req.cookies.get(req.env["mail.guest"]._cookie_name, "")
         )
         guest = req.env["mail.guest"]._get_guest_from_token(token)
         if guest and not guest.timezone and not req.env.cr.readonly:
@@ -88,7 +88,7 @@ class MailGuest(models.Model):
         return self.env['mail.guest']
 
     def _get_timezone_from_request(self, request):
-        timezone = request.httprequest.cookies.get('tz')
+        timezone = request.cookies.get('tz')
         return timezone if timezone in pytz.all_timezones else False
 
     def _update_name(self, name):

--- a/addons/mail/models/ir_http.py
+++ b/addons/mail/models/ir_http.py
@@ -14,7 +14,7 @@ class IrHttp(models.AbstractModel):
         result = super().session_info()
         store = Store()
         ResUsers = self.env["res.users"]
-        if cids := request.httprequest.cookies.get("cids", False):
+        if cids := request.cookies.get("cids", False):
             ResUsers = self.with_context(allowed_company_ids=[int(cid) for cid in cids.split("-")]).env["res.users"]
         ResUsers._init_store_data(store)
         result["storeData"] = store.get_result()

--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -221,7 +221,7 @@ class Survey(http.Controller):
         # Get the current answer token from cookie
         answer_from_cookie = False
         if not answer_token:
-            answer_token = request.httprequest.cookies.get('survey_%s' % survey_token)
+            answer_token = request.cookies.get('survey_%s' % survey_token)
             answer_from_cookie = bool(answer_token)
 
         access_data = self._get_access_data(survey_token, answer_token, ensure_token=False)

--- a/addons/utm/models/ir_http.py
+++ b/addons/utm/models/ir_http.py
@@ -17,7 +17,7 @@ class IrHttp(models.AbstractModel):
         response = Response.load(response)
         domain = cls.get_utm_domain_cookies()
         for url_parameter, __, cookie_name in request.env['utm.mixin'].tracking_fields():
-            if url_parameter in request.params and request.httprequest.cookies.get(cookie_name) != request.params[url_parameter]:
+            if url_parameter in request.params and request.cookies.get(cookie_name) != request.params[url_parameter]:
                 response.set_cookie(cookie_name, request.params[url_parameter], max_age=31 * 24 * 3600, domain=domain, cookie_type='optional')
 
     @classmethod

--- a/addons/utm/models/utm_mixin.py
+++ b/addons/utm/models/utm_mixin.py
@@ -36,7 +36,7 @@ class UtmMixin(models.AbstractModel):
                 value = False
                 if request:
                     # ir_http dispatch saves the url params in a cookie
-                    value = request.httprequest.cookies.get(cookie_name)
+                    value = request.cookies.get(cookie_name)
                 # if we receive a string for a many2one, we search/create the id
                 if field.type == 'many2one' and isinstance(value, str) and value:
                     record = self._find_or_create_record(field.comodel_name, value)

--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -40,6 +40,12 @@ class Http(models.AbstractModel):
         return any(bot in user_agent for bot in cls.bots)
 
     @classmethod
+    def _sanitize_cookies(cls, cookies):
+        super()._sanitize_cookies(cookies)
+        if cids := cookies.get('cids'):
+            cookies['cids'] = '-'.join(cids.split(','))
+
+    @classmethod
     def _handle_debug(cls):
         debug = request.httprequest.args.get('debug')
         if debug is not None:

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -296,7 +296,7 @@
                 </script>
                 <t t-call-assets="web.assets_web_print" media="print" t-js="false"/>
 
-                <t t-if="request.httprequest.cookies.get('color_scheme') == 'dark'">
+                <t t-if="request.cookies.get('color_scheme') == 'dark'">
                     <t t-call-assets="web.assets_web_dark" media="screen"/>
                 </t>
                 <t t-else="">

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -415,7 +415,7 @@ class Http(models.AbstractModel):
             if not request.env['website'].get_current_website().cookies_bar:
                 # Cookies bar is disabled on this website
                 return True
-            accepted_cookie_types = json_scriptsafe.loads(request.httprequest.cookies.get('website_cookies_bar', '{}'))
+            accepted_cookie_types = json_scriptsafe.loads(request.cookies.get('website_cookies_bar', '{}'))
 
             # pre-16.0 compatibility, `website_cookies_bar` was `"true"`.
             # In that case we delete that cookie and let the user choose again.

--- a/addons/website/models/website_visitor.py
+++ b/addons/website/models/website_visitor.py
@@ -392,7 +392,7 @@ class WebsiteVisitor(models.Model):
         self.env.cr.execute(query, (date_now, self.id), log_exceptions=False)
 
     def _get_visitor_timezone(self):
-        tz = request.httprequest.cookies.get('tz') if request else None
+        tz = request.cookies.get('tz') if request else None
         if tz in pytz.all_timezones:
             return tz
         elif not self.env.user._is_public():

--- a/addons/website/tools.py
+++ b/addons/website/tools.py
@@ -62,6 +62,7 @@ def MockRequest(
         cr=env.cr,
         uid=env.uid,
         context=env.context,
+        cookies=cookies,
         lang=env['res.lang']._get_data(code=lang_code),
         website=website,
         render=lambda *a, **kw: '<MockResponse>',

--- a/addons/website_crm_iap_reveal/models/ir_http.py
+++ b/addons/website_crm_iap_reveal/models/ir_http.py
@@ -29,7 +29,7 @@ class IrHttp(models.AbstractModel):
                         if not ip_address:
                             return response
                         website_id = request.website.id
-                        rules_excluded = (request.httprequest.cookies.get('rule_ids') or '').split(',')
+                        rules_excluded = (request.cookies.get('rule_ids') or '').split(',')
                         before = time.time()
                         new_rules_excluded = request.env['crm.reveal.view'].sudo()._create_reveal_view(website_id, url, ip_address, country_code, state_code, rules_excluded)
                         # even when we match, no view may have been created if this is a duplicate

--- a/addons/website_forum/controllers/website_forum.py
+++ b/addons/website_forum/controllers/website_forum.py
@@ -26,7 +26,7 @@ class WebsiteForum(WebsiteProfile):
 
     def _prepare_user_values(self, **kwargs):
         values = super(WebsiteForum, self)._prepare_user_values(**kwargs)
-        values['forum_welcome_message'] = request.httprequest.cookies.get('forum_welcome_message', False)
+        values['forum_welcome_message'] = request.cookies.get('forum_welcome_message', False)
         values.update({
             'header': kwargs.get('header', dict()),
             'searches': kwargs.get('searches', dict()),

--- a/addons/website_livechat/models/website_visitor.py
+++ b/addons/website_livechat/models/website_visitor.py
@@ -118,7 +118,7 @@ class WebsiteVisitor(models.Model):
         visitor_id, upsert = super()._upsert_visitor(access_token, force_track_values=force_track_values)
         if upsert == 'inserted':
             visitor_sudo = self.sudo().browse(visitor_id)
-            if discuss_channel_uuid := request.httprequest.cookies.get("im_livechat_uuid"):
+            if discuss_channel_uuid := request.cookies.get("im_livechat_uuid"):
                 discuss_channel = request.env["discuss.channel"].sudo().search([("uuid", "=", discuss_channel_uuid)])
                 discuss_channel.write({
                     'livechat_visitor_id': visitor_sudo.id,

--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -174,6 +174,10 @@ class IrHttp(models.AbstractModel):
         return request._geoip_resolve()
 
     @classmethod
+    def _sanitize_cookies(cls, cookies):
+        pass
+
+    @classmethod
     def _pre_dispatch(cls, rule, args):
         ICP = request.env['ir.config_parameter'].with_user(SUPERUSER_ID)
 

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -2349,7 +2349,7 @@ class ResetViewArchWizard(models.TransientModel):
                     (view_arch, get_table_name(view.view_id) if view.reset_mode == 'other_view' else _("Current Arch")),
                     (diff_to, diff_to_name),
                     custom_style=False,
-                    dark_color_scheme=request and request.httprequest.cookies.get('color_scheme') == 'dark',
+                    dark_color_scheme=request and request.cookies.get('color_scheme') == 'dark',
                 )
                 view.has_diff = view_arch != diff_to
 

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -918,7 +918,7 @@ class Users(models.Model):
                         raise AccessDenied()
                     user = user.with_user(user)
                     auth_info = user._check_credentials(credential, user_agent_env)
-                    tz = request.httprequest.cookies.get('tz') if request else None
+                    tz = request.cookies.get('tz') if request else None
                     if tz in pytz.all_timezones and (not user.tz or not user.login_date):
                         # first login or missing tz -> set tz to browser tz
                         user.tz = tz

--- a/odoo/addons/base/tests/test_xmlrpc.py
+++ b/odoo/addons/base/tests/test_xmlrpc.py
@@ -149,6 +149,7 @@ class TestAPIKeys(common.HttpCase):
                 'environ': {'REMOTE_ADDR': 'localhost'},
                 'cookies': {},
             }),
+            'cookies': {},
             # bypass check_identity flow
             'session': {'identity-check-last': time.time()},
             'geoip': {},

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1823,7 +1823,7 @@ class Request:
         elif sess.is_dirty:
             root.session_store.save(sess)
 
-        cookie_sid = self.httprequest.cookies.get('session_id')
+        cookie_sid = self.cookies.get('session_id')
         if sess.is_dirty or cookie_sid != sess.sid:
             self.future_response.set_cookie('session_id', sess.sid, max_age=get_session_max_inactivity(self.env), httponly=True)
 

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1576,6 +1576,13 @@ class Request:
         except (ValueError, KeyError):
             return None
 
+    @lazy_property
+    def cookies(self):
+        cookies = werkzeug.datastructures.MultiDict(self.httprequest.cookies)
+        if self.registry:
+            self.registry['ir.http']._sanitize_cookies(cookies)
+        return werkzeug.datastructures.ImmutableMultiDict(cookies)
+
     # =====================================================
     # Helpers
     # =====================================================


### PR DESCRIPTION
Changing the format of a data stored inside a cookie makes is dangerous
as there always is a possibility that someone has a valid session with
that cookie but with the previous format. Ideally in all places where we
use that cookie, we should test for all formats.

In this work we propose a more definitive solution to this problem.
Whenever one is going to use `request.cookies` we run code to sanitize
the existing cookies to converge all possible data format to a single
one.

This way the applications can not bother about what format their data is
and always process a single unified format.

