### PR TITLE
[16.0][FIX] web_editor: Tabs of web editor are not translatables

### DIFF
--- a/addons/web_editor/static/src/components/media_dialog/media_dialog.js
+++ b/addons/web_editor/static/src/components/media_dialog/media_dialog.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import {_lt} from "@web/core/l10n/translation";
 import { useService } from '@web/core/utils/hooks';
 import { Mutex } from "@web/core/utils/concurrency";
 import { useWowlService } from '@web/legacy/utils';
@@ -15,22 +16,22 @@ import { Component, useState, onRendered, xml } from "@odoo/owl";
 export const TABS = {
     IMAGES: {
         id: 'IMAGES',
-        title: "Images",
+        title: _lt("Images"),
         Component: ImageSelector,
     },
     DOCUMENTS: {
         id: 'DOCUMENTS',
-        title: "Documents",
+        title: _lt("Documents"),
         Component: DocumentSelector,
     },
     ICONS: {
         id: 'ICONS',
-        title: "Icons",
+        title: _lt("Icons"),
         Component: IconSelector,
     },
     VIDEOS: {
         id: 'VIDEOS',
-        title: "Videos",
+        title: _lt("Videos"),
         Component: VideoSelector,
     },
 };


### PR DESCRIPTION
It is necessary to wrap the tab names in _lt to make them translatable into the various languages offered by Odoo.

Before these changes, the tab names are always in English.

After these changes, when translations are added to the terms, they will appear translated into the selected language.

cc @Tecnativa

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
