### PR TITLE
[PERF] mail: hundreds of chat bubbles load faster

### DIFF
--- a/addons/mail/static/src/core/common/chat_hub.js
+++ b/addons/mail/static/src/core/common/chat_hub.js
@@ -33,10 +33,7 @@ export class ChatHub extends Component {
         this.onResize();
         useExternalListener(browser, "resize", this.onResize);
         useEffect(() => {
-            if (
-                this.chatHub.actuallyFolded.length &&
-                this.store.channels?.status === "not_fetched"
-            ) {
+            if (this.chatHub.folded.length && this.store.channels?.status === "not_fetched") {
                 this.store.channels.fetch();
             }
         });
@@ -64,7 +61,7 @@ export class ChatHub extends Component {
 
     get hiddenCounter() {
         let counter = 0;
-        for (const chatWindow of this.chatHub.actuallyHidden) {
+        for (const chatWindow of this.chatHub.folded.slice(this.chatHub.maxFolded)) {
             counter += chatWindow.thread.importantCounter > 0 ? 1 : 0;
         }
         return counter;
@@ -73,7 +70,7 @@ export class ChatHub extends Component {
     expand() {
         this.chatHub.compact = false;
         Object.assign(this.compactPosition, { left: "auto", top: "auto" });
-        this.more.isOpen = this.chatHub.actuallyHidden.length !== 0;
+        this.more.isOpen = this.chatHub.folded.length > this.chatHub.maxFolded;
     }
 }
 

--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -4,8 +4,8 @@
 <t t-name="mail.ChatHub">
     <div class="o-mail-ChatHub" t-if="(!store.discuss.isActive or ui.isSmall)">
         <t t-if="!store.chatHub.compact">
-            <t t-foreach="chatHub.actuallyOpened" t-as="cw" t-key="cw.localId">
-                <ChatWindow chatWindow="cw" right="env.embedLivechat ? chatHub.WINDOW_GAP : (chatHub.BUBBLE_START + chatHub.BUBBLE + (chatHub.BUBBLE_OUTER*2) + (chatHub.actuallyOpened.length - cw_index - 1) * (chatHub.WINDOW + chatHub.WINDOW_INBETWEEN * 2))"/>
+            <t t-foreach="chatHub.opened" t-as="cw" t-key="cw.localId">
+                <ChatWindow chatWindow="cw" right="env.embedLivechat ? chatHub.WINDOW_GAP : (chatHub.BUBBLE_START + chatHub.BUBBLE + (chatHub.BUBBLE_OUTER*2) + (chatHub.opened.length - cw_index - 1) * (chatHub.WINDOW + chatHub.WINDOW_INBETWEEN * 2))"/>
             </t>
         </t>
         <div t-if="!store.discuss.isActive and !ui.isSmall" class="o-mail-ChatHub-bubbles position-fixed end-0 d-flex flex-column align-content-start justify-content-end align-items-center" t-att-class="{ 'bottom-0': !store.chatHub.compact or compactPosition.top === 'auto' }" t-ref="bubbles" t-att-style="store.chatHub.compact ? `top: ${ compactPosition.top }; left: ${ compactPosition.left };` : ''">
@@ -14,17 +14,17 @@
                     <t t-call="mail.ChatHub.compactButton"/>
                 </t>
                 <t t-else="">
-                    <Dropdown t-if="chatHub.actuallyFolded.length gt 1" state="options" position="'top-end'" menuClass="'o-mail-ChatHub-optionsMenu o-mail-ChatHub-menu d-flex flex-column bg-view shadow-sm m-0 p-0 mb-1'">
-                        <button class="o-mail-ChatHub-bubbleBtn btn o-mail-ChatHub-optionsBtn fa fa-ellipsis-h bg-view mt-1" t-att-class="{ 'opacity-0': !chatHub.actuallyFolded.length or !bubblesHover.isHover and !options.isOpen, 'o-active': bubblesHover.isHover or options.isOpen }" aria-label="Chat Hub Options"/>
+                    <Dropdown t-if="chatHub.folded.length gt 1" state="options" position="'top-end'" menuClass="'o-mail-ChatHub-optionsMenu o-mail-ChatHub-menu d-flex flex-column bg-view shadow-sm m-0 p-0 mb-1'">
+                        <button class="o-mail-ChatHub-bubbleBtn btn o-mail-ChatHub-optionsBtn fa fa-ellipsis-h bg-view mt-1" t-att-class="{ 'opacity-0': !chatHub.folded.length or !bubblesHover.isHover and !options.isOpen, 'o-active': bubblesHover.isHover or options.isOpen }" aria-label="Chat Hub Options"/>
                         <t t-set-slot="content">
                             <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.closeAll()"><i class="oi fa-fw oi-close"></i>Close all conversations</button>
                             <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.compact = true"><i class="fa fa-fw fa-eye-slash"></i>Hide all conversations</button>
                         </t>
                     </Dropdown>
-                    <t t-foreach="chatHub.actuallyFolded" t-as="cw" t-key="cw.localId">
+                    <t t-foreach="chatHub.folded.slice(0, chatHub.maxFolded)" t-as="cw" t-key="cw.localId">
                         <ChatBubble chatWindow="cw"/>
                     </t>
-                    <t t-if="chatHub.actuallyHidden.length > 0" t-call="mail.ChatHub.hiddenButton"/>
+                    <t t-if="chatHub.folded.length > chatHub.maxFolded" t-call="mail.ChatHub.hiddenButton"/>
                 </t>
             </div>
         </div>
@@ -46,18 +46,18 @@
 </t>
 
 <t t-name="mail.ChatHub.hiddenButton">
-    <Dropdown t-if="chatHub.actuallyHidden.length > 0" state="more" position="'left-middle'" menuClass="'o-mail-ChatHub-hiddenMenu o-mail-ChatHub-menu bg-view shadow-sm p-0 m-0'" manual="true">
+    <Dropdown t-if="chatHub.folded.length > chatHub.maxFolded" state="more" position="'left-middle'" menuClass="'o-mail-ChatHub-hiddenMenu o-mail-ChatHub-menu bg-view shadow-sm p-0 m-0'" manual="true">
         <div class="o-mail-ChatBubble o-mail-ChatHub-hiddenBtn justify-content-center" t-att-class="{ 'o-active': more.isOpen }" t-on-click="() => store.chatHub.compact = true" t-ref="more-button">
             <div t-if="hiddenCounter > 0" class="o-mail-ChatHub-hiddenBtnCounter position-absolute badge rounded-pill fw-bold o-discuss-badge shadow">
                 <t t-out="hiddenCounter"/>
             </div>
             <button class="o-mail-ChatHub-bubbleBtn btn outline-0">
-                <i class="o-mail-ChatHub-hiddenBtnIcon d-flex justify-content-center align-items-center btn rounded-circle shadow-sm fs-2" t-att-class="{ 'o-active': more.isOpen }">+<t t-esc="chatHub.actuallyHidden.length"/></i>
+                <i class="o-mail-ChatHub-hiddenBtnIcon d-flex justify-content-center align-items-center btn rounded-circle shadow-sm fs-2" t-att-class="{ 'o-active': more.isOpen }">+<t t-esc="chatHub.folded.slice(chatHub.maxFolded).length"/></i>
             </button>
         </div>
         <t t-set-slot="content">
             <ul class="m-0 p-0 overflow-auto" role="menu" t-ref="more-menu">
-                <t t-foreach="chatHub.actuallyHidden" t-as="cw" t-key="cw.localId">
+                <t t-foreach="chatHub.folded.slice(chatHub.maxFolded)" t-as="cw" t-key="cw.localId">
                     <li class="o-mail-ChatHub-hiddenItem gap-2 px-2 py-1" role="menuitem" t-att-name="cw.displayName" t-on-click="() => cw.open()">
                         <img class="o-mail-ChatHub-hiddenAvatar rounded-circle" t-att-src="cw.thread?.avatarUrl" alt="Thread image" draggable="false"/>
                         <p class="text-truncate fw-bold mb-0" t-esc="cw.displayName"/>

--- a/addons/mail/static/src/core/common/chat_hub_model.js
+++ b/addons/mail/static/src/core/common/chat_hub_model.js
@@ -25,7 +25,6 @@ export class ChatHub extends Record {
         inverse: "hubAsOpened",
         /** @this {import("models").ChatHub} */
         onAdd(r) {
-            this.folded.delete(r);
             this.onRecompute();
         },
         /** @this {import("models").ChatHub} */
@@ -38,7 +37,6 @@ export class ChatHub extends Record {
         inverse: "hubAsFolded",
         /** @this {import("models").ChatHub} */
         onAdd(r) {
-            this.opened.delete(r);
             this.onRecompute();
         },
         /** @this {import("models").ChatHub} */
@@ -46,9 +44,6 @@ export class ChatHub extends Record {
             this.onRecompute();
         },
     });
-    actuallyOpened = Record.many("ChatWindow", { inverse: "hubAsActuallyOpened" });
-    actuallyFolded = Record.many("ChatWindow");
-    actuallyHidden = Record.many("ChatWindow");
 
     closeAll() {
         [...this.opened, ...this.folded].forEach((cw) => cw.close());
@@ -58,13 +53,6 @@ export class ChatHub extends Record {
         while (this.opened.length > this.maxOpened) {
             const cw = this.opened.pop();
             this.folded.unshift(cw);
-        }
-        this.actuallyOpened = this.opened;
-        this.actuallyFolded = this.folded;
-        this.actuallyHidden.clear();
-        while (this.actuallyFolded.length > this.maxFolded) {
-            const cw = this.actuallyFolded.pop();
-            this.actuallyHidden.unshift(cw);
         }
     }
 

--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -103,13 +103,11 @@ export class ChatWindow extends Component {
                 this.close({ escape: true });
                 break;
             case "Tab": {
-                const index = this.store.chatHub.actuallyOpened.findIndex((cw) =>
-                    cw.eq(chatWindow)
-                );
-                if (index === this.store.chatHub.actuallyOpened.length - 1) {
-                    this.store.chatHub.actuallyOpened[0].focus();
+                const index = this.store.chatHub.opened.findIndex((cw) => cw.eq(chatWindow));
+                if (index === this.store.chatHub.opened.length - 1) {
+                    this.store.chatHub.opened[0].focus();
                 } else {
-                    this.store.chatHub.actuallyOpened[index + 1].focus();
+                    this.store.chatHub.opened[index + 1].focus();
                 }
                 break;
             }

--- a/addons/mail/static/src/core/common/chat_window_model.js
+++ b/addons/mail/static/src/core/common/chat_window_model.js
@@ -23,37 +23,45 @@ export class ChatWindow extends Record {
     hidden = false;
     /** Whether the chat window was created from the messaging menu */
     fromMessagingMenu = false;
-    hubAsActuallyOpened = Record.one("ChatHub", {
+    hubAsOpened = Record.one("ChatHub", {
+        /** @this {import("models").ChatWindow} */
+        onAdd() {
+            this.hubAsFolded = undefined;
+        },
         /** @this {import("models").ChatWindow} */
         onDelete() {
-            if (!this.thread && !this.hubAsActuallyOpened) {
+            if (!this.thread && !this.hubAsOpened) {
                 this.delete();
             }
         },
     });
-    hubAsOpened = Record.one("ChatHub");
-    hubAsFolded = Record.one("ChatHub");
+    hubAsFolded = Record.one("ChatHub", {
+        /** @this {import("models").ChatWindow} */
+        onAdd() {
+            this.hubAsOpened = undefined;
+        },
+    });
 
     get displayName() {
         return this.thread?.displayName ?? _t("New message");
     }
 
     get isOpen() {
-        return Boolean(this.hubAsActuallyOpened);
+        return Boolean(this.hubAsOpened);
     }
 
     async close(options = {}) {
         const { escape = false } = options;
         const chatHub = this.store.chatHub;
-        const indexAsOpened = chatHub.actuallyOpened.findIndex((w) => w.eq(this));
+        const indexAsOpened = chatHub.opened.findIndex((w) => w.eq(this));
         const thread = this.thread;
         if (thread) {
             thread.state = "closed";
         }
         await this._onClose(options);
         this.delete();
-        if (escape && indexAsOpened !== -1 && chatHub.actuallyOpened.length > 0) {
-            chatHub.actuallyOpened[indexAsOpened === 0 ? 0 : indexAsOpened - 1].focus();
+        if (escape && indexAsOpened !== -1 && chatHub.opened.length > 0) {
+            chatHub.opened[indexAsOpened === 0 ? 0 : indexAsOpened - 1].focus();
         }
     }
 


### PR DESCRIPTION
Before this commit, when user had more about hundreds of chat bubbles, it was very slow to render them.

With 100 chat bubbles, it took 2.5seconds.

This happens because when there are lots of chat bubbles, most of them are actually hidden. The computation of hidden chat bubbles was very inefficient: it was recomputing the list each time a new chat bubble was opened or folded.

There's no need for this extra list: it can be deduced with a slice on folded chat windows. This is the core change of this commit that improves drastically performance to 400ms.

This commit scraps also `actually` fields in chatHub, which are actually useless as they are exactly the same as the non-actually fields. This reduces the load on the recomputing even further to loads 100 chat bubbles initially in 300ms.

With 100 chat bubbles:
- Before this commit: 2.5 seconds.
- After this commit: 300ms.

opw-4127973
