### PR TITLE
[IMP] barcodes_gs1_nomenclature: convert URI/GS1

### DIFF
--- a/addons/barcodes/tests/test_barcode_nomenclature.py
+++ b/addons/barcodes/tests/test_barcode_nomenclature.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from odoo.exceptions import ValidationError
 from odoo.tests import common
 
@@ -253,3 +252,39 @@ class TestBarcodeNomenclature(common.TransactionCase):
         self.assertEqual(res['encoding'], 'ean13')
         self.assertEqual(res['base_code'], '2212300000002')
         self.assertEqual(res['value'], 456.1025)
+
+    def test_barcode_uri_conversion(self):
+        """ This test ensures URIs are correctly converted into barcode data."""
+
+        uri = 'urn:epc:class:lgtin : 4012345.012345.998877'
+        barcode_data = self.nomenclature.parse_barcode(uri)
+        self.assertEqual(len(barcode_data), 2)
+        product_part, lot_part = barcode_data
+        self.assertEqual(product_part['type'], 'product')
+        self.assertEqual(product_part['value'], '04012345123456')
+        self.assertEqual(lot_part['type'], 'lot')
+        self.assertEqual(lot_part['value'], '998877')
+
+        uri = 'urn:epc:id:sgtin:9521141.012345.4711'
+        barcode_data = self.nomenclature.parse_barcode(uri)
+        self.assertEqual(len(barcode_data), 2)
+        product_part, serial_part = barcode_data
+        self.assertEqual(product_part['type'], 'product')
+        self.assertEqual(product_part['value'], '09521141123454')
+        self.assertEqual(serial_part['type'], 'lot')
+        self.assertEqual(serial_part['value'], '4711')
+
+        uri = 'urn:epc:tag:sgtin-96 : 1.358378.0728089.620776'
+        barcode_data = self.nomenclature.parse_barcode(uri)
+        self.assertEqual(len(barcode_data), 2)
+        product_part, serial_part = barcode_data
+        self.assertEqual(product_part['type'], 'product')
+        self.assertEqual(product_part['value'], '03583787280898')
+        self.assertEqual(serial_part['type'], 'lot')
+        self.assertEqual(serial_part['value'], '620776')
+
+        uri = 'urn:epc:id:sscc:952656789012.03456'
+        barcode_data = self.nomenclature.parse_barcode(uri)
+        self.assertEqual(len(barcode_data), 1)
+        self.assertEqual(barcode_data[0]['type'], 'package')
+        self.assertEqual(barcode_data[0]['value'], '095265678901234568')

--- a/addons/barcodes_gs1_nomenclature/models/barcode_nomenclature.py
+++ b/addons/barcodes_gs1_nomenclature/models/barcode_nomenclature.py
@@ -57,6 +57,7 @@ class BarcodeNomenclature(models.Model):
     def parse_gs1_rule_pattern(self, match, rule):
         result = {
             'rule': rule,
+            'type': rule.type,
             'ai': match.group(1),
             'string_value': match.group(2),
         }
@@ -126,10 +127,10 @@ class BarcodeNomenclature(models.Model):
 
         return results
 
-    def parse_barcode(self, barcode):
+    def parse_nomenclature_barcode(self, barcode):
         if self.is_gs1_nomenclature:
             return self.gs1_decompose_extanded(barcode)
-        return super().parse_barcode(barcode)
+        return super().parse_nomenclature_barcode(barcode)
 
     @api.model
     def _preprocess_gs1_search_args(self, args, barcode_types, field='barcode'):
@@ -155,7 +156,7 @@ class BarcodeNomenclature(models.Model):
 
                 replacing_operator = 'ilike' if operator in ['ilike', '='] else 'not ilike'
                 for data in parsed_data:
-                    data_type = data['rule'].type
+                    data_type = data['type']
                     value = data['value']
                     if data_type in barcode_types:
                         if data_type == 'lot':

--- a/addons/barcodes_gs1_nomenclature/static/src/js/barcode_parser.js
+++ b/addons/barcodes_gs1_nomenclature/static/src/js/barcode_parser.js
@@ -145,11 +145,11 @@ patch(BarcodeParser.prototype, {
      * @override
      * @returns {Object|Array|null} If nomenclature is GS1, returns an array or null
      */
-    parse_barcode(barcode) {
+    parseBarcodeNomenclature(barcode) {
         if (this.nomenclature && this.nomenclature.is_gs1_nomenclature) {
             return this.gs1_decompose_extanded(barcode);
         }
-        return super.parse_barcode(...arguments);
+        return super.parseBarcodeNomenclature(...arguments);
     },
 
     /**


### PR DESCRIPTION
When data is received as barcode while using GS1 nomenclature, if these data are an URI, the barcode parser will convert them into a GS1 barcode before doing the actual parsing.

task-4089638

Enterprise PR: odoo/enterprise#68825