### PR TITLE
[FIX] l10n_in_pos: don't force update records

### DIFF
--- a/addons/l10n_in_pos/data/pos_bill_data.xml
+++ b/addons/l10n_in_pos/data/pos_bill_data.xml
@@ -5,23 +5,23 @@
             <field name="value">500.00</field>
         </record>
 
-        <record model="pos.bill" id="point_of_sale.0_05">
+        <record model="pos.bill" id="point_of_sale.0_05" forcecreate="0">
             <field name="for_all_config">False</field>
         </record>
 
-        <record model="pos.bill" id="point_of_sale.0_10">
+        <record model="pos.bill" id="point_of_sale.0_10" forcecreate="0">
             <field name="for_all_config">False</field>
         </record>
 
-        <record model="pos.bill" id="point_of_sale.0_20">
+        <record model="pos.bill" id="point_of_sale.0_20" forcecreate="0">
             <field name="for_all_config">False</field>
         </record>
 
-        <record model="pos.bill" id="point_of_sale.0_25">
+        <record model="pos.bill" id="point_of_sale.0_25" forcecreate="0">
             <field name="for_all_config">False</field>
         </record>
 
-        <record model="pos.bill" id="point_of_sale.0_50">
+        <record model="pos.bill" id="point_of_sale.0_50" forcecreate="0">
             <field name="for_all_config">False</field>
         </record>
     </data>


### PR DESCRIPTION
To reproduce the issue:
1) Start a database with flag `-i l10n_in_pos`
2) Go to point of sale>configuration>coins/bills.
3) Delete Records of Coins/bills.
4) Start the database again with flag `-u all`.

The records of pos.bill can be deleted, in point of sale module, these records are created at initialization but they can be deleted. They are not created later on as forcecreate="0". But in l10n_in_pos, these records are forcecreated/forceupdated. so setting the forcreate="0". Ensures that the records are created/updated only on initialization.

```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/saas-17.4/odoo/tools/convert.py", line 559, in _tag_root
    f(rec)
  File "/home/odoo/src/odoo/saas-17.4/odoo/tools/convert.py", line 387, in _tag_record
    raise Exception("Cannot update missing record %r" % xid)
Exception: Cannot update missing record 'point_of_sale.0_05'
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
