### PR TITLE
[IMP] *: Allow three way fiscal positions

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2195,7 +2195,7 @@ class AccountMove(models.Model):
             amls = record.line_ids
             impacted_countries = amls.tax_ids.country_id | amls.tax_line_id.country_id
             if impacted_countries and impacted_countries != record.tax_country_id:
-                if record.fiscal_position_id and impacted_countries != record.fiscal_position_id.country_id:
+                if record.fiscal_position_id and impacted_countries != record.fiscal_position_id.fiscal_country_id:
                     raise ValidationError(_("This entry contains taxes that are not compatible with your fiscal position. Check the country set in fiscal position and in your tax configuration."))
                 raise ValidationError(_("This entry contains one or more taxes that are incompatible with your fiscal country. Check company fiscal country in the settings and tax country in taxes configuration."))
 

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -40,15 +40,14 @@
                             <field name="auto_apply"/>
                             <field name="vat_required" invisible="not auto_apply"/>
                             <field name="foreign_vat"/>
-                            <field name="country_group_id" invisible="not auto_apply and not foreign_vat" required="foreign_vat and not country_id"/>
-                            <field name="country_id"
-                                required="foreign_vat and not country_group_id"
-                                options="{'no_open': True, 'no_create': True}"/>
-                            <field name="state_ids" widget="many2many_tags" domain="[('country_id', '=', country_id)]"
-                                invisible="(not auto_apply and not foreign_vat) or not country_id or states_count == 0"/>
+                            <field name="fiscal_country_id" string="Fiscal Country" required="foreign_vat"/>
+                            <field name="country_group_id" string="Delivery Country Group" invisible="not auto_apply" required="foreign_vat and not fiscal_country_id" options="{'no_open': True, 'no_create': True}"/>
+                            <field name="country_id" invisible="not auto_apply" options="{'no_open': True, 'no_create': True}"/>
+                            <field name="state_ids" widget="many2many_tags" domain="[('country_id', '=', fiscal_country_id)]"
+                                invisible="(not auto_apply and not foreign_vat) or not fiscal_country_id or states_count == 0"/>
                             <label for="zip_from" string="Zip Range"
-                                invisible="not auto_apply or not country_id"/>
-                            <div invisible="not auto_apply or not country_id">
+                                invisible="not auto_apply or not fiscal_country_id"/>
+                            <div invisible="not auto_apply or not fiscal_country_id">
                                 <span> From </span>
                                 <field name="zip_from" class="oe_inline"/>
                                 <div class="oe_edit_only"/>
@@ -75,7 +74,7 @@
                                         domain="[
                                             ('type_tax_use', '!=', 'none'),
                                             ('country_id', '=', parent.country_id if parent.foreign_vat else parent.company_country_id),
-                                            '|', ('company_id', '=', False), ('company_id', 'parent_of', parent.company_id)]"
+                                            '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]"
                                         context="{'append_type_to_tax_name': True}"
                                     />
                                 </tree>

--- a/addons/base_vat/models/account_fiscal_position.py
+++ b/addons/base_vat/models/account_fiscal_position.py
@@ -7,55 +7,24 @@ from odoo.exceptions import ValidationError
 class AccountFiscalPosition(models.Model):
     _inherit = 'account.fiscal.position'
 
-    @api.model_create_multi
-    def create(self, vals_list):
-        new_vals = []
-        for vals in vals_list:
-            new_vals.append(self.adjust_vals_country_id(vals))
-        return super().create(new_vals)
-
-    def write(self, vals):
-        vals = self.adjust_vals_country_id(vals)
-        return super().write(vals)
-
-    def adjust_vals_country_id(self, vals):
-        foreign_vat = vals.get('foreign_vat')
-        country_group_id = vals.get('country_group_id')
-        if foreign_vat and country_group_id and not (self.country_id or vals.get('country_id')):
-            vals['country_id'] = self.env['res.country.group'].browse(country_group_id).country_ids.filtered(lambda c: c.code == foreign_vat[:2].upper()).id or False
-        return vals
-
     @api.constrains('country_id', 'foreign_vat')
     def _validate_foreign_vat(self):
         for record in self:
             if not record.foreign_vat:
                 continue
 
-            if record.country_group_id:
-                # Checks the foreign vat is a VAT Number linked to a country of the country group
-                foreign_vat_country = self.country_group_id.country_ids.filtered(lambda c: c.code == record.foreign_vat[:2].upper())
-                if not foreign_vat_country:
-                    raise ValidationError(_("The country detected for this foreign VAT number does not match any of the countries composing the country group set on this fiscal position."))
-                if record.country_id:
-                    checked_country_code = self.env['res.partner']._run_vat_test(record.foreign_vat, record.country_id) or self.env['res.partner']._run_vat_test(record.foreign_vat, foreign_vat_country)
-                    if not checked_country_code:
-                        record.raise_vat_error_message(foreign_vat_country)
-                else:
-                    checked_country_code = self.env['res.partner']._run_vat_test(record.foreign_vat, foreign_vat_country)
-                    if not checked_country_code:
-                        record.raise_vat_error_message(record.country_id)
-            elif record.country_id:
+            elif record.fiscal_country_id:
                 foreign_vat_country = self.env['res.country'].search([('code', '=', record.foreign_vat[:2].upper())], limit=1)
-                checked_country_code = self.env['res.partner']._run_vat_test(record.foreign_vat, foreign_vat_country or record.country_id)
+                checked_country_code = self.env['res.partner']._run_vat_test(record.foreign_vat, foreign_vat_country or record.fiscal_country_id)
                 if not checked_country_code:
                     record.raise_vat_error_message()
 
-            if record.foreign_vat and not record.country_id and not record.country_group_id:
+            if record.foreign_vat and not record.fiscal_country_id and not record.country_group_id:
                 raise ValidationError(_("The country of the foreign VAT number could not be detected. Please assign a country to the fiscal position or set a country group"))
 
     def raise_vat_error_message(self, country=False):
         fp_label = _("fiscal position [%s]", self.name)
-        country_code = country.code.lower() if country else self.country_id.code.lower()
+        country_code = country.code.lower() if country else self.fiscal_country_id.code.lower()
         error_message = self.env['res.partner']._build_vat_error_message(country_code, self.foreign_vat, fp_label)
         raise ValidationError(error_message)
 


### PR DESCRIPTION
*: account, fiscal_position_three_way

---

Description of the issue this commit addresses:

Some companies export goods from warehouses outside of their fiscal country. It is currently not possible to use the "Detect Automatically" feature of the fiscal positions for them as the country they need to set to get the right tax mapping is not the country that needs to be detected for the auto apply.

---

Desired behavior after this commit is merged:

This commit allows users upon the installation of the new module to split the country of the tax mapping and the country of the auto apply. They are named "Fiscal Country" and "Delivery Country" and it grants companies the ability to have a working flow without starting from scratch if they need such a behavior.

---

Enterprise PR: https://github.com/odoo/enterprise/pull/68828
task-4066525

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
