### PR TITLE
[IMP] web: datetime field: add condensed format

### DIFF
--- a/addons/web/static/src/core/datetime/datetimepicker_service.js
+++ b/addons/web/static/src/core/datetime/datetimepicker_service.js
@@ -271,15 +271,13 @@ export const datetimePickerService = {
                 const safeConvert = (operation, value) => {
                     const { type } = pickerProps;
                     const convertFn = (operation === "format" ? formatters : parsers)[type];
+                    const options = { tz: pickerProps.tz, format: hookParams.format };
+                    if (operation === "format") {
+                        options.showSeconds = hookParams.showSeconds ?? true;
+                        options.condensed = hookParams.condensed || false;
+                    }
                     try {
-                        return [
-                            convertFn(value, {
-                                format: hookParams.format,
-                                tz: pickerProps.tz,
-                                showSeconds: hookParams.showSeconds ?? true,
-                            }),
-                            null,
-                        ];
+                        return [convertFn(value, options), null];
                     } catch (error) {
                         if (error?.name === "ConversionError") {
                             return [null, error];

--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -61,6 +61,7 @@ export class DateTimeField extends Component {
             optional: true,
             validate: (props) => ["days", "months", "years", "decades"].includes(props),
         },
+        condensed: { type: Boolean, optional: true },
     };
     static defaultProps = {
         showSeconds: true,
@@ -129,6 +130,7 @@ export class DateTimeField extends Component {
         const dateTimePicker = useDateTimePicker({
             target: "root",
             showSeconds: this.props.showSeconds,
+            condensed: this.props.condensed,
             get pickerProps() {
                 return getPickerProps();
             },
@@ -188,10 +190,11 @@ export class DateTimeField extends Component {
      */
     getFormattedValue(valueIndex) {
         const value = this.values[valueIndex];
+        const { condensed, showSeconds } = this.props;
         return value
             ? this.field.type === "date" || !this.props.showTime
-                ? formatDate(value)
-                : formatDateTime(value, { showSeconds: this.props.showSeconds })
+                ? formatDate(value, { condensed })
+                : formatDateTime(value, { showSeconds, condensed })
             : "";
     }
 
@@ -338,6 +341,12 @@ export const dateField = {
                 { label: _t("Decades"), value: "decades" },
             ],
         },
+        {
+            label: _t("Condensed display"),
+            name: "condensed",
+            type: "boolean",
+            help: _t(`Set to true to display days, months (and hours) with unpadded numbers`),
+        },
     ],
     supportedTypes: ["date"],
     extractProps: ({ attrs, options }, dynamicInfo) => ({
@@ -352,6 +361,7 @@ export const dateField = {
         warnFuture: exprToBoolean(options.warn_future),
         minPrecision: options.min_precision,
         maxPrecision: options.max_precision,
+        condensed: options.condensed,
     }),
     fieldDependencies: ({ type, attrs, options }) => {
         const deps = [];

--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -190,11 +190,11 @@ export class DateTimeField extends Component {
      */
     getFormattedValue(valueIndex) {
         const value = this.values[valueIndex];
-        const { condensed, showSeconds } = this.props;
+        const { condensed, showSeconds, showTime } = this.props;
         return value
-            ? this.field.type === "date" || !this.props.showTime
+            ? this.field.type === "date"
                 ? formatDate(value, { condensed })
-                : formatDateTime(value, { showSeconds, condensed })
+                : formatDateTime(value, { condensed, showSeconds, showTime })
             : "";
     }
 

--- a/addons/web/static/src/views/fields/float/float_field.js
+++ b/addons/web/static/src/views/fields/float/float_field.js
@@ -51,10 +51,6 @@ export class FloatField extends Component {
         return this.props.inputType === "number" ? Number(value) : parseFloat(value);
     }
 
-    get digits() {
-        const fieldDigits = this.props.record.fields[this.props.name].digits;
-        return !this.props.digits && Array.isArray(fieldDigits) ? fieldDigits : this.props.digits;
-    }
     get formattedValue() {
         if (
             !this.props.formatNumber ||
@@ -62,14 +58,18 @@ export class FloatField extends Component {
         ) {
             return this.value;
         }
+        const options = {
+            digits: this.props.digits,
+            field: this.props.record.fields[this.props.name],
+        };
         if (this.props.humanReadable && !this.state.hasFocus) {
             return formatFloat(this.value, {
-                digits: this.digits,
+                ...options,
                 humanReadable: true,
                 decimals: this.props.decimals,
             });
         } else {
-            return formatFloat(this.value, { digits: this.digits, humanReadable: false });
+            return formatFloat(this.value, { ...options, humanReadable: false });
         }
     }
 

--- a/addons/web/static/src/views/fields/float_toggle/float_toggle_field.js
+++ b/addons/web/static/src/views/fields/float_toggle/float_toggle_field.js
@@ -40,14 +40,11 @@ export class FloatToggleField extends Component {
         return this.props.factor;
     }
 
-    get digits() {
-        const fieldDigits = this.props.record.fields[this.props.name].digits;
-        return !this.props.digits && Array.isArray(fieldDigits) ? fieldDigits : this.props.digits;
-    }
     get formattedValue() {
         return formatFloatFactor(this.props.record.data[this.props.name], {
-            digits: this.digits,
+            digits: this.props.digits,
             factor: this.factor,
+            field: this.props.record.fields[this.props.name],
         });
     }
 }

--- a/addons/web/static/src/views/fields/percentage/percentage_field.js
+++ b/addons/web/static/src/views/fields/percentage/percentage_field.js
@@ -20,8 +20,9 @@ export class PercentageField extends Component {
         useInputField({
             getValue: () =>
                 formatPercentage(this.props.record.data[this.props.name], {
-                    digits: this.digits,
+                    digits: this.props.digits,
                     noSymbol: true,
+                    field: this.props.record.fields[this.props.name],
                 }),
             refName: "numpadDecimal",
             parse: (v) => parsePercentage(v),
@@ -29,13 +30,10 @@ export class PercentageField extends Component {
         useNumpadDecimal();
     }
 
-    get digits() {
-        const fieldDigits = this.props.record.fields[this.props.name].digits;
-        return !this.props.digits && Array.isArray(fieldDigits) ? fieldDigits : this.props.digits;
-    }
     get formattedValue() {
         return formatPercentage(this.props.record.data[this.props.name], {
-            digits: this.digits,
+            digits: this.props.digits,
+            field: this.props.record.fields[this.props.name],
         });
     }
 }

--- a/addons/web/static/src/views/fields/stat_info/stat_info_field.js
+++ b/addons/web/static/src/views/fields/stat_info/stat_info_field.js
@@ -16,13 +16,13 @@ export class StatInfoField extends Component {
         string: { type: String, optional: true },
     };
 
-    get digits() {
-        const fieldDigits = this.props.record.fields[this.props.name].digits;
-        return !this.props.digits && Array.isArray(fieldDigits) ? fieldDigits : this.props.digits;
-    }
     get formattedValue() {
-        const formatter = formatters.get(this.props.record.fields[this.props.name].type);
-        return formatter(this.props.record.data[this.props.name] || 0, { digits: this.digits });
+        const field = this.props.record.fields[this.props.name];
+        const formatter = formatters.get(field.type);
+        return formatter(this.props.record.data[this.props.name] || 0, {
+            digits: this.props.digits,
+            field,
+        });
     }
     get label() {
         return this.props.labelField

--- a/addons/web/static/src/views/kanban/kanban_record.js
+++ b/addons/web/static/src/views/kanban/kanban_record.js
@@ -227,8 +227,8 @@ export class KanbanRecord extends Component {
 
     getFormattedValue(fieldId) {
         const { archInfo, record } = this.props;
-        const { attrs, name } = archInfo.fieldNodes[fieldId];
-        return getFormattedValue(record, name, attrs);
+        const { name } = archInfo.fieldNodes[fieldId];
+        return getFormattedValue(record, name, archInfo.fieldNodes[fieldId]);
     }
 
     /**

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -828,7 +828,7 @@ export class ListRenderer extends Component {
         if (column.options.enable_formatting === false) {
             return record.data[fieldName];
         }
-        return getFormattedValue(record, fieldName, column.attrs);
+        return getFormattedValue(record, fieldName, column);
     }
 
     evalInvisible(invisible, record) {

--- a/addons/web/static/src/views/utils.js
+++ b/addons/web/static/src/views/utils.js
@@ -128,21 +128,20 @@ export const computeReportMeasures = (
 };
 
 /**
- * @param {String} fieldName
- * @param {Object} rawAttrs
  * @param {Record} record
+ * @param {String} fieldName
+ * @param {Object} [fieldInfo]
  * @returns {String}
  */
-export function getFormattedValue(record, fieldName, attrs) {
+export function getFormattedValue(record, fieldName, fieldInfo = null) {
     const field = record.fields[fieldName];
     const formatter = registry.category("formatters").get(field.type, (val) => val);
-    const formatOptions = {
-        escape: false,
-        data: record.data,
-        isPassword: "password" in attrs,
-        digits: attrs.digits ? JSON.parse(attrs.digits) : field.digits,
-        field: record.fields[fieldName],
-    };
+    const formatOptions = {};
+    if (fieldInfo && formatter.extractOptions) {
+        Object.assign(formatOptions, formatter.extractOptions(fieldInfo));
+    }
+    formatOptions.data = record.data;
+    formatOptions.field = field;
     return record.data[fieldName] !== undefined
         ? formatter(record.data[fieldName], formatOptions)
         : "";

--- a/addons/web/static/tests/core/l10n/dates.test.js
+++ b/addons/web/static/tests/core/l10n/dates.test.js
@@ -77,6 +77,25 @@ test("formatDate/formatDateTime specs, at midnight", async () => {
     expect(formatDateTime(minus13FromLocalTZ)).toBe("05/04/2009 00:00:00");
 });
 
+test("formatDate/formatDateTime with condensed option", async () => {
+    mockDate("2009-05-03 08:00:00");
+    mockTimeZone(0);
+    const now = DateTime.now();
+
+    patchWithCleanup(localization, {
+        dateFormat: "MM/dd/yyyy",
+        dateTimeFormat: "MM/dd/yyyy HH:mm:ss",
+    });
+    expect(formatDate(now, { condensed: true })).toBe("5/3/2009");
+    expect(formatDateTime(now, { condensed: true })).toBe("5/3/2009 8:00:00");
+
+    patchWithCleanup(localization, { dateFormat: "yyyy-MM-dd" });
+    expect(formatDate(now, { condensed: true })).toBe("2009-5-3");
+
+    patchWithCleanup(localization, { dateFormat: "dd MMM yy" });
+    expect(formatDate(now, { condensed: true })).toBe("3 May 09");
+});
+
 test("formatDateTime in different timezone", async () => {
     patchWithCleanup(localization, {
         dateFormat: "MM/dd/yyyy",

--- a/addons/web/static/tests/views/fields/datetime_field.test.js
+++ b/addons/web/static/tests/views/fields/datetime_field.test.js
@@ -556,8 +556,8 @@ test("datetime field in list with show_time option", async () => {
         resModel: "partner",
         arch: `
             <tree editable="bottom">
-                <field name="datetime" widget="datetime" options="{'show_time': false}"/>
-                <field name="datetime" widget="datetime" />
+                <field name="datetime" options="{'show_time': false}"/>
+                <field name="datetime" />
             </tree>
         `,
     });
@@ -606,12 +606,12 @@ test("datetime field in kanban view with condensed option", async () => {
             <kanban>
                 <templates>
                     <t t-name="kanban-card">
-                        <field name="datetime" options="{'condensed': true}" widget="datetime"/>
+                        <field name="datetime" options="{'condensed': true}"/>
                     </t>
                 </templates>
             </kanban>`,
     });
 
     const expectedDateString = "2/8/2017 8:00:00"; // 10:00:00 without timezone
-    expect(".o_field_datetime:first").toHaveText(expectedDateString);
+    expect(".o_kanban_record:first").toHaveText(expectedDateString);
 });

--- a/addons/web/static/tests/views/fields/datetime_field.test.js
+++ b/addons/web/static/tests/views/fields/datetime_field.test.js
@@ -547,7 +547,7 @@ test("edit a datetime field in form view with show_seconds option", async () => 
     });
 });
 
-test("list datetime with date widget test", async () => {
+test("datetime field in list with show_time option", async () => {
     mockTimeZone(+2);
     onRpc("has_group", () => true);
 
@@ -575,4 +575,43 @@ test("list datetime with date widget test", async () => {
     expect(queryFirst(".o_field_datetime input").value).toBe("02/08/2017 12:00:00", {
         message: "for datetime field both date and time should be visible with datetime widget",
     });
+});
+
+test("datetime field in form view with condensed option", async () => {
+    mockTimeZone(-2); // UTC-2
+
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: `
+            <form>
+                <field name="datetime" options="{'condensed': true}"/>
+                <field name="datetime" options="{'condensed': true}" readonly="1"/>
+            </form>`,
+    });
+
+    const expectedDateString = "2/8/2017 8:00:00"; // 10:00:00 without timezone
+    expect(".o_field_datetime input").toHaveValue(expectedDateString);
+    expect(".o_field_datetime.o_readonly_modifier").toHaveText(expectedDateString);
+});
+
+test("datetime field in kanban view with condensed option", async () => {
+    mockTimeZone(-2); // UTC-2
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="kanban-card">
+                        <field name="datetime" options="{'condensed': true}" widget="datetime"/>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    const expectedDateString = "2/8/2017 8:00:00"; // 10:00:00 without timezone
+    expect(".o_field_datetime:first").toHaveText(expectedDateString);
 });

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -388,6 +388,25 @@ test("field with widget and attributes in kanban", async () => {
     });
 });
 
+test("kanban with integer field with human_readable option", async () => {
+    Partner._records[0].int_field = 5 * 1000 * 1000;
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="kanban-card">
+                        <field name="int_field" options="{'human_readable': true}"/>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    expect(queryAllTexts(".o_kanban_record:not(.o_kanban_ghost)")).toEqual(["5M", "9", "17", "-4"]);
+    expect(".o_field_widget").toHaveCount(0);
+});
+
 test.tags("desktop")("Hide tooltip when user click inside a kanban headers item", async () => {
     await mountView({
         type: "kanban",

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -376,6 +376,21 @@ test(`list with class and style attributes`, async () => {
     });
 });
 
+test(`list with integer field with human_readable option`, async () => {
+    Foo._records[0].int_field = 5 * 1000 * 1000;
+    await mountView({
+        type: "list",
+        resModel: "foo",
+        arch: `
+            <list>
+                <field name="int_field" options="{'human_readable': true}"/>
+            </list>`,
+    });
+
+    expect(queryAllTexts(".o_data_cell")).toEqual(["5M", "9", "17", "-4"]);
+    expect(".o_field_widget").toHaveCount(0);
+});
+
 test(`list with create="0"`, async () => {
     await mountView({
         resModel: "foo",


### PR DESCRIPTION
This commit adds the "condensed" option to date and datetime fields and formatters. If set to true, months, days and hours are displayed without leading 0.

e.g. 03/05/2024 08:00:00 => 3/5/2024 8:00:00

Task~4126988

