### PR TITLE
[FIX] point_of_sale: avoid archive journal used in payment methods

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -7402,6 +7402,14 @@ msgstr ""
 #: code:addons/point_of_sale/models/account_journal.py:0
 #, python-format
 msgid ""
+"This journal is associated with a payment method. You cannot archive it"
+msgstr ""
+
+#. module: point_of_sale
+#. odoo-python
+#: code:addons/point_of_sale/models/account_journal.py:0
+#, python-format
+msgid ""
 "This journal is associated with a payment method. You cannot modify its type"
 msgstr ""
 

--- a/addons/point_of_sale/models/account_journal.py
+++ b/addons/point_of_sale/models/account_journal.py
@@ -9,6 +9,11 @@ class AccountJournal(models.Model):
 
     pos_payment_method_ids = fields.One2many('pos.payment.method', 'journal_id', string='Point of Sale Payment Methods')
 
+    def action_archive(self):
+        if self.pos_payment_method_ids:
+            raise ValidationError(_("This journal is associated with a payment method. You cannot archive it"))
+        return super().action_archive()
+
     @api.constrains('type')
     def _check_type(self):
         methods = self.env['pos.payment.method'].sudo().search([("journal_id", "in", self.ids)])

--- a/addons/point_of_sale/tests/test_pos_setup.py
+++ b/addons/point_of_sale/tests/test_pos_setup.py
@@ -4,6 +4,7 @@
 from odoo import tools
 import odoo
 from odoo.addons.point_of_sale.tests.common import TestPoSCommon
+from odoo.exceptions import ValidationError
 
 @odoo.tests.tagged('post_install', '-at_install')
 class TestPoSSetup(TestPoSCommon):
@@ -74,3 +75,8 @@ class TestPoSSetup(TestPoSCommon):
         self.assertEqual(tax_group_7_10.name, 'Tax 7+10%')
         self.assertEqual(tax_group_7_10.amount_type, 'group')
         self.assertEqual(sorted(tax_group_7_10.children_tax_ids.ids), sorted((tax7 | tax10).ids))
+
+    def test_archive_used_journal(self):
+        journal = self.cash_pm1.journal_id
+        with self.assertRaises(ValidationError):
+            journal.action_archive()


### PR DESCRIPTION
You shouldn't be able to archive a journal that is used in a payment method.

Steps to reproduce:
-------------------
* Open a payment method and archive the journal used in it
* Open PoS and make an order using this payment method
> Observation: Close the PoS session, you will have an error saying you
cannot close the session.

Why the fix:
------------
We override the `action_archive` function to make sure no payment method is using the journal being archived.

opw-4070620
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
