### PR TITLE
[FIX] hr_work_entry_contract: separate overlapping work entries by type

### DIFF
--- a/addons/hr_work_entry_contract/models/hr_contract.py
+++ b/addons/hr_work_entry_contract/models/hr_contract.py
@@ -4,6 +4,7 @@
 import itertools
 from collections import defaultdict
 from datetime import datetime, date, time
+from math import floor
 import pytz
 
 from dateutil.relativedelta import relativedelta
@@ -100,6 +101,34 @@ class HrContract(models.Model):
             ))
         return result
 
+    def _postprocess_attendance_intervals(self, intervals):
+        # _attendance_intervals_batch combines the attendances regardless of work entry type if their date and time overlap.
+        # This makes a single attendance block with the work entry type of the first attendance only. This function undoes those
+        # undesirable merges
+        try:
+            multi_type_intervals = [interval for interval in intervals if len(interval[2].work_entry_type_id) > 1]
+        except AttributeError:
+            return intervals
+        for interval in multi_type_intervals:
+            attendances = interval[2]
+            current_work_entry_type = attendances[0].work_entry_type_id
+            attendances_of_type = self.env["resource.calendar.attendance"]
+            start_date = interval[0]
+            for attendance in attendances:
+                if attendance.work_entry_type_id == current_work_entry_type:
+                    end_date = interval[0].replace(hour=floor(attendance.hour_to), minute=int((attendance.hour_to % 1) * 60))
+                    attendances_of_type |= attendance
+                else:
+                    intervals._items.append((start_date, end_date, attendances_of_type))
+                    start_date = interval[0].replace(hour=floor(attendance.hour_from), minute=int((attendance.hour_from % 1) * 60))
+                    end_date = interval[0].replace(hour=floor(attendance.hour_to), minute=int((attendance.hour_to % 1) * 60))
+                    current_work_entry_type = attendance.work_entry_type_id
+                    attendances_of_type = attendance
+            intervals._items.append((start_date, end_date, attendances_of_type))
+            intervals._items.remove(interval)
+        intervals._items.sort()
+        return intervals
+
     def _get_lunch_intervals(self, start_dt, end_dt):
         # {resource: intervals}
         employees_by_calendar = defaultdict(lambda: self.env['hr.employee'])
@@ -180,7 +209,7 @@ class HrContract(models.Model):
             mapped_leaves = {r.id: Intervals(result[r.id]) for r in resources_list}
             leaves = mapped_leaves[resource.id]
 
-            real_attendances = attendances - leaves
+            real_attendances = self._postprocess_attendance_intervals(attendances - leaves)
             if contract.has_static_work_entries() or not leaves:
                 # Empty leaves means empty real_leaves
                 real_leaves = attendances - real_attendances

--- a/addons/hr_work_entry_contract/tests/test_work_entry.py
+++ b/addons/hr_work_entry_contract/tests/test_work_entry.py
@@ -259,3 +259,68 @@ class TestWorkEntry(TestWorkEntryBase):
             work_entry.save()
         self.assertEqual(work_entry.employee_id.id, new_employee.id)
         self.assertEqual(work_entry.duration, 0.0)
+
+    def test_separate_overlapping_work_entries_by_type(self):
+        employee = self.env['hr.employee'].create({'name': 'Test'})
+        calendar = self.env['resource.calendar'].create({'name': 'Calendar', 'tz': 'Europe/Brussels'})
+        calendar.attendance_ids -= calendar.attendance_ids.filtered(lambda attendance: attendance.dayofweek == '0')
+
+        self.env['hr.contract'].create({
+            'employee_id': employee.id,
+            'resource_calendar_id': calendar.id,
+            'date_start': datetime(2024, 9, 1),
+            'date_end': datetime(2024, 9, 30),
+            'name': 'Contract',
+            'wage': 5000.0,
+            'state': 'open',
+        })
+
+        entry_type_1, entry_type_2 = self.env['hr.work.entry.type'].create([
+            {'name': 'Work type 1', 'is_leave': False, 'code': 'ENTRY_TYPE1'},
+            {'name': 'Work type 2', 'is_leave': False, 'code': 'ENTRY_TYPE2'},
+        ])
+
+        self.env['resource.calendar.attendance'].create([
+            {
+                'calendar_id': calendar.id,
+                'dayofweek': '0',
+                'name': 'Same type 1',
+                'hour_from': 8,
+                'hour_to': 11,
+                'day_period': 'morning',
+                'work_entry_type_id': entry_type_1.id,
+            },
+            {
+                'calendar_id': calendar.id,
+                'dayofweek': '0',
+                'name': 'Same type 2',
+                'hour_from': 11,
+                'hour_to': 12,
+                'day_period': 'morning',
+                'work_entry_type_id': entry_type_1.id,
+            },
+            {
+                'calendar_id': calendar.id,
+                'dayofweek': '0',
+                'name': 'Different types 1',
+                'hour_from': 13,
+                'hour_to': 16,
+                'day_period': 'afternoon',
+                'work_entry_type_id': entry_type_1.id,
+            },
+            {
+                'calendar_id': calendar.id,
+                'dayofweek': '0',
+                'name': 'Different types 2',
+                'hour_from': 16,
+                'hour_to': 17,
+                'day_period': 'afternoon',
+                'work_entry_type_id': entry_type_2.id,
+            },
+        ])
+
+        employee.generate_work_entries(datetime(2024, 9, 2), datetime(2024, 9, 2))
+        result_entries = self.env['hr.work.entry'].search([('employee_id', '=', employee.id)])
+        work_entry_types = [entry.work_entry_type_id for entry in result_entries]
+        self.assertEqual(len(result_entries), 3, 'Afternoon attendances should be split by work entry type')
+        self.assertEqual(work_entry_types, [entry_type_1, entry_type_1, entry_type_2])


### PR DESCRIPTION
Steps to reproduce:
- Payroll > Contracts > Contracts
- Pick a running contract
- Add a new line to the working schedule such that: -- It starts exactly when the previous entry ends
-- Both it and the previous entry have a work entry type -- They both have different types
- Work Entries > Work entries
- Regenerate work entries for the employee whose contract you editted
- It appears as a singular block of the first entry's type

For example Monday afernoon has an entry from 13:00 to 17:00, give it type attendance then create a new line from 17:00 to 18:00 with type ovetime hours. This is interpreted as a singular work entry of type attendance spanning from 13:00 to 18:00.

Work entries of different type should be kept separate or at least show all encompassed wok entry types. Preventing the merge is difficult as other modules likely want this behavior in resource.calendar hence the post processing method used here.

opw-4053366

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
