### PR TITLE
[FIX] website_payment: prevent crash when amount < min amount

### DIFF
--- a/addons/website_payment/static/src/snippets/s_donation/000.js
+++ b/addons/website_payment/static/src/snippets/s_donation/000.js
@@ -132,10 +132,10 @@ publicWidget.registry.DonationSnippet = publicWidget.Widget.extend({
             } else if ($buttons.length) {
                 amount = parseFloat(this.$('#s_donation_amount_input').val());
                 let errorMessage = '';
-                const minAmount = this.el.dataset.minimumAmount;
+                const minAmount = parseFloat(this.el.dataset.minimumAmount);
                 if (!amount) {
                     errorMessage = _t("Please select or enter an amount");
-                } else if (amount < parseFloat(minAmount)) {
+                } else if (amount < minAmount) {
                     errorMessage = _t(
                         "The minimum donation amount is %(amount)s",
                         {


### PR DESCRIPTION
Starting from version 17.4, setting a minimum donation amount causes the app to crash if the selected amount is below this minimum. The issue arises due to the use of `formatCurrency`, introduced in commit 41464b5896c00679a8f8ac4faba6bd6f1b11876d, which requires a number as its parameter. However, `minAmount` was being passed as a string, leading to the crash.

This commit ensures that `minAmount` is correctly parsed as a number before being used in `formatCurrency`.

Steps to Reproduce:
1. Set a minimum donation amount.
2. Attempt to donate an amount below the minimum.
3. Observe the app crash due to a TypeError.

task-4134736