### PR TITLE
[REF] core: refactor search for translated fields

### DIFF
--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1265,7 +1265,7 @@ class TestQueries(TransactionCase):
             WHERE (
                 (
                     ("res_partner"."active" = %s) AND
-                    ("res_partner"."name"::text LIKE %s)
+                    ("res_partner"."name" LIKE %s)
                 ) AND (
                     ("res_partner"."title" = %s) OR (
                         ("res_partner"."ref" != %s) OR
@@ -1284,7 +1284,7 @@ class TestQueries(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner"."id"
             FROM "res_partner"
-            WHERE (("res_partner"."active" = %s) AND ("res_partner"."name"::text LIKE %s))
+            WHERE (("res_partner"."active" = %s) AND ("res_partner"."name" LIKE %s))
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             Model.search([('name', 'like', 'foo')])
@@ -1292,7 +1292,7 @@ class TestQueries(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner"."id"
             FROM "res_partner"
-            WHERE (("res_partner"."active" = %s) AND ("res_partner"."name"::text LIKE %s))
+            WHERE (("res_partner"."active" = %s) AND ("res_partner"."name" LIKE %s))
             ORDER BY "res_partner"."id"
         ''']):
             Model.search([('name', 'like', 'foo')], order='id')
@@ -1304,7 +1304,7 @@ class TestQueries(TransactionCase):
         with self.assertQueries(['''
             SELECT COUNT(*)
             FROM "res_partner"
-            WHERE (("res_partner"."active" = %s) AND ("res_partner"."name"::text LIKE %s))
+            WHERE (("res_partner"."active" = %s) AND ("res_partner"."name" LIKE %s))
         ''']):
             Model.search_count([('name', 'like', 'foo')])
 
@@ -1315,7 +1315,7 @@ class TestQueries(TransactionCase):
         with self.assertQueries(['''
             SELECT COUNT(*) FROM (
                 SELECT FROM "res_partner"
-                WHERE (("res_partner"."active" = %s) AND ("res_partner"."name"::text LIKE %s))
+                WHERE (("res_partner"."active" = %s) AND ("res_partner"."name" LIKE %s))
                 LIMIT %s
             ) t
         ''']):
@@ -1329,7 +1329,7 @@ class TestQueries(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner_title"."id"
             FROM "res_partner_title"
-            WHERE (COALESCE("res_partner_title"."name"->>%s, "res_partner_title"."name"->>%s) like %s)
+            WHERE (COALESCE("res_partner_title"."name"->>%s, "res_partner_title"."name"->>%s) LIKE %s)
             ORDER BY COALESCE("res_partner_title"."name"->>%s, "res_partner_title"."name"->>%s)
         ''']):
             Model.search([('name', 'like', 'foo')])
@@ -1378,7 +1378,7 @@ class TestQueries(TransactionCase):
             FROM "ir_model"
             WHERE (
                 ("ir_model"."name"->>%s ILIKE %s)
-                OR ("ir_model"."model"::text ILIKE %s)
+                OR ("ir_model"."model" ILIKE %s)
             )
             ORDER BY "ir_model"."model"
             LIMIT %s
@@ -1389,8 +1389,8 @@ class TestQueries(TransactionCase):
             SELECT "ir_model"."id", "ir_model"."name"->>%s
             FROM "ir_model"
             WHERE (
-                ("ir_model"."name" is NULL OR "ir_model"."name"->>%s not ilike %s)
-                AND (("ir_model"."model"::text NOT ILIKE %s) OR "ir_model"."model" IS NULL)
+                (("ir_model"."name"->>%s NOT ILIKE %s) OR "ir_model"."name"->>%s IS NULL)
+                AND (("ir_model"."model" NOT ILIKE %s) OR "ir_model"."model" IS NULL)
             )
             ORDER BY "ir_model"."model"
             LIMIT %s
@@ -1411,7 +1411,7 @@ class TestMany2one(TransactionCase):
             FROM "res_users"
             LEFT JOIN "res_partner" AS "res_users__partner_id" ON
                 ("res_users"."partner_id" = "res_users__partner_id"."id")
-            WHERE ("res_users__partner_id"."name"::text LIKE %s)
+            WHERE ("res_users__partner_id"."name" LIKE %s)
             ORDER BY "res_users__partner_id"."name", "res_users"."login"
         ''']):
             self.User.search([('name', 'like', 'foo')])
@@ -1423,7 +1423,7 @@ class TestMany2one(TransactionCase):
             FROM "res_users"
             LEFT JOIN "res_partner" AS "res_users__partner_id" ON
                 ("res_users"."partner_id" = "res_users__partner_id"."id")
-            WHERE ("res_users__partner_id"."name"::text LIKE %s)
+            WHERE ("res_users__partner_id"."name" LIKE %s)
             ORDER BY "res_users__partner_id"."name", "res_users"."login"
         ''']):
             self.User.search([('partner_id.name', 'like', 'foo')])
@@ -1446,7 +1446,7 @@ class TestMany2one(TransactionCase):
             WHERE ("res_partner"."company_id" IN (
                 SELECT "res_company"."id"
                 FROM "res_company"
-                WHERE ("res_company"."name"::text LIKE %s)
+                WHERE ("res_company"."name" LIKE %s)
             ))
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
@@ -1461,7 +1461,7 @@ class TestMany2one(TransactionCase):
                 WHERE ("res_company"."partner_id" IN (
                     SELECT "res_partner"."id"
                     FROM "res_partner"
-                    WHERE ("res_partner"."name"::text LIKE %s)
+                    WHERE ("res_partner"."name" LIKE %s)
                 ))
             ))
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
@@ -1474,11 +1474,11 @@ class TestMany2one(TransactionCase):
             WHERE (("res_partner"."company_id" IN (
                 SELECT "res_company"."id"
                 FROM "res_company"
-                WHERE ("res_company"."name"::text LIKE %s)
+                WHERE ("res_company"."name" LIKE %s)
             )) OR ("res_partner"."country_id" IN (
                 SELECT "res_country"."id"
                 FROM "res_country"
-                WHERE ("res_country"."code"::text LIKE %s)
+                WHERE ("res_country"."code" LIKE %s)
             )))
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
@@ -1496,7 +1496,7 @@ class TestMany2one(TransactionCase):
             WHERE (("res_partner"."company_id" NOT IN (
                 SELECT "res_company"."id"
                 FROM "res_company"
-                WHERE ("res_company"."name"::text LIKE %s)
+                WHERE ("res_company"."name" LIKE %s)
             )) OR "res_partner"."company_id" IS NULL)
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
@@ -1511,7 +1511,7 @@ class TestMany2one(TransactionCase):
             WHERE ("res_partner"."company_id" IN (
                 SELECT "res_company"."id"
                 FROM "res_company"
-                WHERE (("res_company"."active" = %s) AND ("res_company"."name"::text LIKE %s))
+                WHERE (("res_company"."active" = %s) AND ("res_company"."name" LIKE %s))
             ))
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
@@ -1525,7 +1525,7 @@ class TestMany2one(TransactionCase):
             WHERE ("res_partner"."company_id" IN (
                 SELECT "res_company"."id"
                 FROM "res_company"
-                WHERE (("res_company"."active" = %s) AND ("res_company"."name"::text LIKE %s))
+                WHERE (("res_company"."active" = %s) AND ("res_company"."name" LIKE %s))
                 ORDER BY "res_company"."id"
                 LIMIT %s
             ))
@@ -1538,7 +1538,7 @@ class TestMany2one(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_company"."id"
             FROM "res_company"
-            WHERE (("res_company"."active" = %s) AND ("res_company"."name"::text LIKE %s))
+            WHERE (("res_company"."active" = %s) AND ("res_company"."name" LIKE %s))
             ORDER BY "res_company"."id"
         ''', '''
             SELECT "res_partner"."id"
@@ -1554,7 +1554,7 @@ class TestMany2one(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_company"."id"
             FROM "res_company"
-            WHERE (("res_company"."active" = %s) AND ("res_company"."name"::text LIKE %s))
+            WHERE (("res_company"."active" = %s) AND ("res_company"."name" LIKE %s))
             ORDER BY "res_company"."id"
         ''', '''
             SELECT "res_partner"."id"
@@ -1573,7 +1573,7 @@ class TestMany2one(TransactionCase):
             WHERE ("res_partner"."company_id" IN (
                 SELECT "res_company"."id"
                 FROM "res_company"
-                WHERE (("res_company"."active" = %s) AND ("res_company"."name"::text LIKE %s))
+                WHERE (("res_company"."active" = %s) AND ("res_company"."name" LIKE %s))
             ))
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
@@ -1591,7 +1591,7 @@ class TestMany2one(TransactionCase):
             FROM "res_partner"
             LEFT JOIN "res_company" AS "res_partner__company_id" ON
                 ("res_partner"."company_id" = "res_partner__company_id"."id")
-            WHERE ("res_partner__company_id"."name"::text LIKE %s)
+            WHERE ("res_partner__company_id"."name" LIKE %s)
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('company_id.name', 'like', self.company.name)])
@@ -1604,7 +1604,7 @@ class TestMany2one(TransactionCase):
             WHERE ("res_partner__company_id"."partner_id" IN (
                 SELECT "res_partner"."id"
                 FROM "res_partner"
-                WHERE ("res_partner"."name"::text LIKE %s)
+                WHERE ("res_partner"."name" LIKE %s)
             ))
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
@@ -1623,7 +1623,7 @@ class TestMany2one(TransactionCase):
                 FROM "res_company"
                 LEFT JOIN "res_partner" AS "res_company__partner_id" ON
                     ("res_company"."partner_id" = "res_company__partner_id"."id")
-                WHERE ("res_company__partner_id"."name"::text LIKE %s)
+                WHERE ("res_company__partner_id"."name" LIKE %s)
             ))
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
@@ -1641,7 +1641,7 @@ class TestMany2one(TransactionCase):
                 ("res_partner"."company_id" = "res_partner__company_id"."id")
             LEFT JOIN "res_partner" AS "res_partner__company_id__partner_id" ON
                 ("res_partner__company_id"."partner_id" = "res_partner__company_id__partner_id"."id")
-            WHERE ("res_partner__company_id__partner_id"."name"::text LIKE %s)
+            WHERE ("res_partner__company_id__partner_id"."name" LIKE %s)
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('company_id.partner_id.name', 'like', self.company.name)])
@@ -1662,8 +1662,8 @@ class TestMany2one(TransactionCase):
                 ("res_partner"."country_id" = "res_partner__country_id"."id")
             LEFT JOIN "res_company" AS "res_partner__company_id" ON
                 ("res_partner"."company_id" = "res_partner__company_id"."id")
-            WHERE (("res_partner__company_id"."name"::text LIKE %s)
-                OR ("res_partner__country_id"."code"::text LIKE %s))
+            WHERE (("res_partner__company_id"."name" LIKE %s)
+                OR ("res_partner__country_id"."code" LIKE %s))
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([
@@ -1681,7 +1681,7 @@ class TestMany2one(TransactionCase):
             WHERE ("res_partner"."company_id" IN (
                 SELECT "res_company"."id"
                 FROM "res_company"
-                WHERE ("res_company"."name"::text LIKE %s)
+                WHERE ("res_company"."name" LIKE %s)
             ))
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
@@ -1693,7 +1693,7 @@ class TestMany2one(TransactionCase):
             WHERE (("res_partner"."company_id" NOT IN (
                 SELECT "res_company"."id"
                 FROM "res_company"
-                WHERE ("res_company"."name"::text LIKE %s)
+                WHERE ("res_company"."name" LIKE %s)
             )) OR "res_partner"."company_id" IS NULL)
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
@@ -1736,7 +1736,7 @@ class TestOne2many(TransactionCase):
             WHERE ("res_partner"."id" IN (
                 SELECT "res_partner_bank"."partner_id"
                 FROM "res_partner_bank"
-                WHERE ("res_partner_bank"."sanitized_acc_number"::text LIKE %s)
+                WHERE ("res_partner_bank"."sanitized_acc_number" LIKE %s)
             ))
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
@@ -1753,7 +1753,7 @@ class TestOne2many(TransactionCase):
                     AND ("res_partner"."id" IN (
                         SELECT "res_partner_bank"."partner_id"
                         FROM "res_partner_bank"
-                        WHERE ("res_partner_bank"."sanitized_acc_number"::text LIKE %s)
+                        WHERE ("res_partner_bank"."sanitized_acc_number" LIKE %s)
                     ))
                 ) AND "res_partner"."parent_id" IS NOT NULL
             ))
@@ -1786,7 +1786,7 @@ class TestOne2many(TransactionCase):
             WHERE ("res_partner"."id" IN (
                 SELECT "res_partner_bank"."partner_id"
                 FROM "res_partner_bank"
-                WHERE ("res_partner_bank"."sanitized_acc_number"::text LIKE %s)
+                WHERE ("res_partner_bank"."sanitized_acc_number" LIKE %s)
             ))
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
@@ -1798,11 +1798,11 @@ class TestOne2many(TransactionCase):
             WHERE (("res_partner"."id" IN (
                 SELECT "res_partner_bank"."partner_id"
                 FROM "res_partner_bank"
-                WHERE ("res_partner_bank"."sanitized_acc_number"::text LIKE %s)
+                WHERE ("res_partner_bank"."sanitized_acc_number" LIKE %s)
             )) AND ("res_partner"."id" IN (
                 SELECT "res_partner_bank"."partner_id"
                 FROM "res_partner_bank"
-                WHERE ("res_partner_bank"."sanitized_acc_number"::text LIKE %s)
+                WHERE ("res_partner_bank"."sanitized_acc_number" LIKE %s)
             )))
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
@@ -1820,7 +1820,7 @@ class TestOne2many(TransactionCase):
                       WHERE (("res_partner"."active" = TRUE) AND ("res_partner"."id" IN
                                 (SELECT "res_partner_bank"."partner_id"
                                  FROM "res_partner_bank"
-                                 WHERE ("res_partner_bank"."sanitized_acc_number"::text LIKE %s)))
+                                 WHERE ("res_partner_bank"."sanitized_acc_number" LIKE %s)))
                              )))
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
@@ -1847,7 +1847,7 @@ class TestOne2many(TransactionCase):
                         WHERE ((
                             "res_partner_bank"."id" IN %s
                         ) AND (
-                            "res_partner_bank"."sanitized_acc_number"::text LIKE %s
+                            "res_partner_bank"."sanitized_acc_number" LIKE %s
                         ))
                     )
                 ))
@@ -1875,7 +1875,7 @@ class TestOne2many(TransactionCase):
                 WHERE ((
                     "res_partner"."active" = TRUE
                 ) AND (
-                    "res_partner__state_id__country_id"."code"::text LIKE %s
+                    "res_partner__state_id__country_id"."code" LIKE %s
                 ))
             ))
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
@@ -1891,7 +1891,7 @@ class TestOne2many(TransactionCase):
             WHERE ("res_partner"."id" IN (
                 SELECT "res_partner_bank"."partner_id"
                 FROM "res_partner_bank"
-                WHERE ("res_partner_bank"."sanitized_acc_number"::text LIKE %s)
+                WHERE ("res_partner_bank"."sanitized_acc_number" LIKE %s)
             ))
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
@@ -1995,7 +1995,7 @@ class TestMany2many(TransactionCase):
                         AND "res_groups__rule_groups"."rule_group_id" IN (
                             SELECT "ir_rule"."id"
                             FROM "ir_rule"
-                            WHERE ("ir_rule"."name"::text LIKE %s)
+                            WHERE ("ir_rule"."name" LIKE %s)
                         )
                     )
                 )
@@ -2021,7 +2021,7 @@ class TestMany2many(TransactionCase):
                 AND "res_users__company_ids"."cid" IN (
                     SELECT "res_company"."id"
                     FROM "res_company"
-                    WHERE ("res_company"."name"::text LIKE %s)
+                    WHERE ("res_company"."name" LIKE %s)
                 )
             )
             ORDER BY "res_users"."id"

--- a/odoo/addons/test_new_api/tests/test_indexed_translation.py
+++ b/odoo/addons/test_new_api/tests/test_indexed_translation.py
@@ -46,13 +46,13 @@ class TestIndexedTranslation(odoo.tests.TransactionCase):
             SELECT "test_new_api_indexed_translation"."id"
             FROM "test_new_api_indexed_translation"
             WHERE (jsonb_path_query_array("test_new_api_indexed_translation"."name", '$.*')::text ILIKE %s
-            AND "test_new_api_indexed_translation"."name"->>%s ILIKE %s)
+            AND ("test_new_api_indexed_translation"."name"->>%s ILIKE %s))
             ORDER BY "test_new_api_indexed_translation"."id"
         """, """
             SELECT "test_new_api_indexed_translation"."id"
             FROM "test_new_api_indexed_translation"
             WHERE (jsonb_path_query_array("test_new_api_indexed_translation"."name", '$.*')::text ILIKE %s
-            AND COALESCE("test_new_api_indexed_translation"."name"->>%s, "test_new_api_indexed_translation"."name"->>%s) ILIKE %s)
+            AND (COALESCE("test_new_api_indexed_translation"."name"->>%s, "test_new_api_indexed_translation"."name"->>%s) ILIKE %s))
             ORDER BY "test_new_api_indexed_translation"."id"
         """, """
             SELECT "test_new_api_indexed_translation"."id"

--- a/odoo/addons/test_new_api/tests/test_search.py
+++ b/odoo/addons/test_new_api/tests/test_search.py
@@ -15,8 +15,8 @@ class TestSubqueries(TransactionCase):
             WHERE ("test_new_api_multi"."partner" IN (
                 SELECT "res_partner"."id"
                 FROM "res_partner"
-                WHERE (("res_partner"."name"::text LIKE %s)
-                   AND ("res_partner"."phone"::text LIKE %s)
+                WHERE (("res_partner"."name" LIKE %s)
+                   AND ("res_partner"."phone" LIKE %s)
                 )
             ))
             ORDER BY "test_new_api_multi"."id"
@@ -33,8 +33,8 @@ class TestSubqueries(TransactionCase):
             WHERE ("test_new_api_multi"."partner" IN (
                 SELECT "res_partner"."id"
                 FROM "res_partner"
-                WHERE (("res_partner"."name"::text LIKE %s)
-                    OR ("res_partner"."phone"::text LIKE %s)
+                WHERE (("res_partner"."name" LIKE %s)
+                    OR ("res_partner"."phone" LIKE %s)
                 )
             ))
             ORDER BY "test_new_api_multi"."id"
@@ -52,8 +52,8 @@ class TestSubqueries(TransactionCase):
             WHERE (("test_new_api_multi"."partner" NOT IN (
                 SELECT "res_partner"."id"
                 FROM "res_partner"
-                WHERE (("res_partner"."name"::text LIKE %s)
-                    AND ("res_partner"."phone"::text LIKE %s)
+                WHERE (("res_partner"."name" LIKE %s)
+                    AND ("res_partner"."phone" LIKE %s)
                 )
             )) OR "test_new_api_multi"."partner" IS NULL)
             ORDER BY "test_new_api_multi"."id"
@@ -71,8 +71,8 @@ class TestSubqueries(TransactionCase):
             WHERE (("test_new_api_multi"."partner" NOT IN (
                 SELECT "res_partner"."id"
                 FROM "res_partner"
-                WHERE (("res_partner"."name"::text LIKE %s)
-                    OR ("res_partner"."phone"::text LIKE %s)
+                WHERE (("res_partner"."name" LIKE %s)
+                    OR ("res_partner"."phone" LIKE %s)
                 )
             )) OR "test_new_api_multi"."partner" IS NULL)
             ORDER BY "test_new_api_multi"."id"
@@ -91,8 +91,8 @@ class TestSubqueries(TransactionCase):
             LEFT JOIN "res_partner" AS "test_new_api_multi__partner"
                 ON ("test_new_api_multi"."partner" = "test_new_api_multi__partner"."id")
             WHERE (
-                ("test_new_api_multi__partner"."name"::text LIKE %s)
-                OR ("test_new_api_multi__partner"."phone"::text LIKE %s)
+                ("test_new_api_multi__partner"."name" LIKE %s)
+                OR ("test_new_api_multi__partner"."phone" LIKE %s)
             )
             ORDER BY "test_new_api_multi"."id"
         """]):
@@ -112,8 +112,8 @@ class TestSubqueries(TransactionCase):
             WHERE (
                 "test_new_api_multi__partner"."id" IS NULL OR (
                     NOT ((
-                        ("test_new_api_multi__partner"."name"::text LIKE %s)
-                        OR ("test_new_api_multi__partner"."phone"::text LIKE %s)
+                        ("test_new_api_multi__partner"."name" LIKE %s)
+                        OR ("test_new_api_multi__partner"."phone" LIKE %s)
                     ))
                 )
             )
@@ -133,9 +133,9 @@ class TestSubqueries(TransactionCase):
                 SELECT "res_partner"."id"
                 FROM "res_partner"
                 WHERE (
-                    ("res_partner"."email"::text LIKE %s)
-                    AND (("res_partner"."name"::text LIKE %s)
-                      OR ("res_partner"."phone"::text LIKE %s)
+                    ("res_partner"."email" LIKE %s)
+                    AND (("res_partner"."name" LIKE %s)
+                      OR ("res_partner"."phone" LIKE %s)
                     )
                 )
             ))
@@ -156,22 +156,22 @@ class TestSubqueries(TransactionCase):
                 (
                     (
                         ({many2one} IN (
-                            {subselect} WHERE ("res_partner"."function"::text LIKE %s)
+                            {subselect} WHERE ("res_partner"."function" LIKE %s)
                         )) OR (({many2one} NOT IN (
                             {subselect} WHERE (
-                                ("res_partner"."phone"::text LIKE %s)
-                                AND ("res_partner"."mobile"::text LIKE %s)
+                                ("res_partner"."phone" LIKE %s)
+                                AND ("res_partner"."mobile" LIKE %s)
                             )))
                             OR "test_new_api_multi"."partner" IS NULL
                         )
                     ) AND ({many2one} IN (
                         {subselect} WHERE (
-                            ("res_partner"."name"::text LIKE %s)
-                            OR ("res_partner"."email"::text LIKE %s)
+                            ("res_partner"."name" LIKE %s)
+                            OR ("res_partner"."email" LIKE %s)
                         )
                     ))
                 ) AND (({many2one} NOT IN (
-                    {subselect} WHERE ("res_partner"."website"::text LIKE %s)
+                    {subselect} WHERE ("res_partner"."website" LIKE %s)
                     ))
                     OR "test_new_api_multi"."partner" IS NULL
                 )
@@ -202,12 +202,12 @@ class TestSubqueries(TransactionCase):
             WHERE (("test_new_api_multi"."id" IN (
                 SELECT "test_new_api_multi_line"."multi"
                 FROM "test_new_api_multi_line"
-                WHERE ("test_new_api_multi_line"."name"::text LIKE %s)
+                WHERE ("test_new_api_multi_line"."name" LIKE %s)
                       AND "test_new_api_multi_line"."multi" IS NOT NULL
             )) AND ("test_new_api_multi"."id" IN (
                 SELECT "test_new_api_multi_line"."multi"
                 FROM "test_new_api_multi_line"
-                WHERE ("test_new_api_multi_line"."name"::text LIKE %s)
+                WHERE ("test_new_api_multi_line"."name" LIKE %s)
                       AND "test_new_api_multi_line"."multi" IS NOT NULL
             )))
             ORDER BY "test_new_api_multi"."id"
@@ -224,8 +224,8 @@ class TestSubqueries(TransactionCase):
             WHERE ("test_new_api_multi"."id" IN (
                 SELECT "test_new_api_multi_line"."multi"
                 FROM "test_new_api_multi_line"
-                WHERE (("test_new_api_multi_line"."name"::text LIKE %s)
-                    OR ("test_new_api_multi_line"."name"::text LIKE %s)
+                WHERE (("test_new_api_multi_line"."name" LIKE %s)
+                    OR ("test_new_api_multi_line"."name" LIKE %s)
                 ) AND "test_new_api_multi_line"."multi" IS NOT NULL
             ))
             ORDER BY "test_new_api_multi"."id"
@@ -243,13 +243,13 @@ class TestSubqueries(TransactionCase):
             WHERE (("test_new_api_multi"."id" IN (
                 SELECT "test_new_api_multi_line"."multi"
                 FROM "test_new_api_multi_line"
-                WHERE ("test_new_api_multi_line"."name"::text LIKE %s)
+                WHERE ("test_new_api_multi_line"."name" LIKE %s)
                    AND "test_new_api_multi_line"."multi" IS NOT NULL)
             ) AND ("test_new_api_multi"."id" IN (
                 SELECT "test_new_api_multi_line"."multi"
                 FROM "test_new_api_multi_line"
-                WHERE (("test_new_api_multi_line"."name"::text LIKE %s)
-                    OR ("test_new_api_multi_line"."name"::text LIKE %s)
+                WHERE (("test_new_api_multi_line"."name" LIKE %s)
+                    OR ("test_new_api_multi_line"."name" LIKE %s)
                 ) AND "test_new_api_multi_line"."multi" IS NOT NULL
             )))
             ORDER BY "test_new_api_multi"."id"
@@ -273,8 +273,8 @@ class TestSubqueries(TransactionCase):
                     SELECT "test_new_api_multi_tag"."id"
                     FROM "test_new_api_multi_tag"
                     WHERE (
-                        ("test_new_api_multi_tag"."name"::text ILIKE %s)
-                        AND ("test_new_api_multi_tag"."name"::text LIKE %s)
+                        ("test_new_api_multi_tag"."name" ILIKE %s)
+                        AND ("test_new_api_multi_tag"."name" LIKE %s)
                     )
                 )
             ) AND EXISTS (
@@ -285,8 +285,8 @@ class TestSubqueries(TransactionCase):
                     SELECT "test_new_api_multi_tag"."id"
                     FROM "test_new_api_multi_tag"
                     WHERE (
-                        ("test_new_api_multi_tag"."name"::text ILIKE %s)
-                        AND ("test_new_api_multi_tag"."name"::text LIKE %s)
+                        ("test_new_api_multi_tag"."name" ILIKE %s)
+                        AND ("test_new_api_multi_tag"."name" LIKE %s)
                     )
                 )
             ))
@@ -309,10 +309,10 @@ class TestSubqueries(TransactionCase):
                     SELECT "test_new_api_multi_tag"."id"
                     FROM "test_new_api_multi_tag"
                     WHERE (
-                        ("test_new_api_multi_tag"."name"::text ILIKE %s)
+                        ("test_new_api_multi_tag"."name" ILIKE %s)
                         AND (
-                            ("test_new_api_multi_tag"."name"::text LIKE %s)
-                            OR ("test_new_api_multi_tag"."name"::text LIKE %s)
+                            ("test_new_api_multi_tag"."name" LIKE %s)
+                            OR ("test_new_api_multi_tag"."name" LIKE %s)
                         )
                     )
                 )
@@ -338,8 +338,8 @@ class TestSubqueries(TransactionCase):
                         SELECT "test_new_api_multi_tag"."id"
                         FROM "test_new_api_multi_tag"
                         WHERE (
-                            ("test_new_api_multi_tag"."name"::text ILIKE %s)
-                            AND ("test_new_api_multi_tag"."name"::text LIKE %s)
+                            ("test_new_api_multi_tag"."name" ILIKE %s)
+                            AND ("test_new_api_multi_tag"."name" LIKE %s)
                         )
                     )
                 ) AND EXISTS (
@@ -350,10 +350,10 @@ class TestSubqueries(TransactionCase):
                         SELECT "test_new_api_multi_tag"."id"
                         FROM "test_new_api_multi_tag"
                         WHERE (
-                            ("test_new_api_multi_tag"."name"::text ILIKE %s)
+                            ("test_new_api_multi_tag"."name" ILIKE %s)
                             AND (
-                                ("test_new_api_multi_tag"."name"::text LIKE %s)
-                                OR ("test_new_api_multi_tag"."name"::text LIKE %s)
+                                ("test_new_api_multi_tag"."name" LIKE %s)
+                                OR ("test_new_api_multi_tag"."name" LIKE %s)
                             )
                         )
                     )
@@ -821,7 +821,7 @@ class TestFlushSearch(TransactionCase):
         ''', '''
             SELECT "test_new_api_city"."id"
             FROM "test_new_api_city"
-            WHERE ("test_new_api_city"."name"::text LIKE %s)
+            WHERE ("test_new_api_city"."name" LIKE %s)
             ORDER BY "test_new_api_city"."id"
         ''']):
             self.brussels.name = "Bruxelles"
@@ -841,7 +841,7 @@ class TestFlushSearch(TransactionCase):
             WHERE ("test_new_api_city"."country_id" IN (
                 SELECT "test_new_api_country"."id"
                 FROM "test_new_api_country"
-                WHERE ("test_new_api_country"."name"::text LIKE %s)
+                WHERE ("test_new_api_country"."name" LIKE %s)
             ))
             ORDER BY "test_new_api_city"."id"
         ''']):
@@ -861,7 +861,7 @@ class TestFlushSearch(TransactionCase):
             WHERE ("test_new_api_city"."country_id" IN (
                 SELECT "test_new_api_country"."id"
                 FROM "test_new_api_country"
-                WHERE ("test_new_api_country"."name"::text LIKE %s)
+                WHERE ("test_new_api_country"."name" LIKE %s)
             ))
             ORDER BY "test_new_api_city"."id"
         ''']):
@@ -883,7 +883,7 @@ class TestFlushSearch(TransactionCase):
             FROM "test_new_api_city"
             LEFT JOIN "test_new_api_country" AS "test_new_api_city__country_id"
                 ON ("test_new_api_city"."country_id" = "test_new_api_city__country_id"."id")
-            WHERE ("test_new_api_city__country_id"."name"::text LIKE %s)
+            WHERE ("test_new_api_city__country_id"."name" LIKE %s)
             ORDER BY "test_new_api_city"."id"
         ''']):
             self.brussels.country_id = self.france
@@ -948,7 +948,7 @@ class TestFlushSearch(TransactionCase):
         ''', '''
             SELECT "test_new_api_city"."id"
             FROM "test_new_api_city"
-            WHERE ("test_new_api_city"."id" = %s) AND ("test_new_api_city"."name"::text LIKE %s)
+            WHERE ("test_new_api_city"."id" = %s) AND ("test_new_api_city"."name" LIKE %s)
             ORDER BY "test_new_api_city"."id"
         ''']):
             self.brussels.name = "Bruxelles"
@@ -1033,7 +1033,7 @@ class TestFlushSearch(TransactionCase):
         ''', '''
             SELECT "test_new_api_city"."id", "test_new_api_city"."name"
             FROM "test_new_api_city"
-            WHERE ("test_new_api_city"."name"::text LIKE %s)
+            WHERE ("test_new_api_city"."name" LIKE %s)
             ORDER BY "test_new_api_city"."id"
         '''], flush=False):
             self.brussels.name = "Brussel"

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2892,7 +2892,7 @@ class BaseModel(metaclass=MetaModel):
         field_to_flush = field if flush and fname != 'id' else None
         sql_field = SQL.identifier(alias, fname, to_flush=field_to_flush)
 
-        if field.translate and not self.env.context.get('prefetch_langs'):
+        if field.translate:
             langs = field.get_translation_fallback_langs(self.env)
             sql_field_langs = [SQL("%s->>%s", sql_field, lang) for lang in langs]
             if len(sql_field_langs) == 1:
@@ -3073,6 +3073,9 @@ class BaseModel(metaclass=MetaModel):
                 if params:
                     if fname != 'id':
                         params = [field.convert_to_column(p, self, validate=False) for p in params]
+                        if field.translate:
+                            # unwrap actual values from the Json values returned by convert_to_column()
+                            params = [p.adapted['en_US'] for p in params]
                     sql = SQL("(%s %s %s)", sql_field, sql_operator, tuple(params))
                 else:
                     # The case for (fname, 'in', []) or (fname, 'not in', []).
@@ -3120,12 +3123,16 @@ class BaseModel(metaclass=MetaModel):
             sql_value = value
         elif need_wildcard:
             sql_value = SQL("%s", f"%{value}%")
+        elif field.translate:
+            # convert_to_column returns psycopg2.extras.Json({'en_US': text_value})
+            # only take the text_value to compare with the result of field_to_sql
+            sql_value = SQL("%s", field.convert_to_column(value, self, validate=False).adapted['en_US'])
         else:
             sql_value = SQL("%s", field.convert_to_column(value, self, validate=False))
 
         sql_left = sql_field
-        if operator.endswith('like'):
-            sql_left = SQL("%s::text", sql_field)
+        if operator.endswith('like') and field.type not in ('char', 'text', 'html'):
+            sql_left = SQL("(%s)::text", sql_field)
         if operator.endswith('ilike'):
             sql_left = self.env.registry.unaccent(sql_left)
             sql_value = self.env.registry.unaccent(sql_value)
@@ -4095,6 +4102,8 @@ class BaseModel(metaclass=MetaModel):
                     # PG 9.2 introduces conflicting pg_size_pretty(numeric) -> need ::cast
                     sql = self._field_to_sql(self._table, field.name, query)
                     sql = SQL("pg_size_pretty(length(%s)::bigint)", sql)
+                elif field.translate and self.env.context.get('prefetch_langs'):
+                    sql = SQL.identifier(self._table, field.name, to_flush=field)
                 else:
                     # flushing is necessary to retrieve the en_US value of fields without a translation
                     sql = self._field_to_sql(self._table, field.name, query, flush=field.translate)

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -1382,88 +1382,34 @@ class expression(object):
                     else:
                         push_result(model._condition_to_sql(alias, left, operator, right, self.query))
 
-                elif field.translate and (isinstance(right, str) or right is False) and left == field.name:
+                elif field.translate and (isinstance(right, str) or right is False) and left == field.name and \
+                    self._has_trigram and field.index == 'trigram' and operator in ('=', 'like', 'ilike', '=like', '=ilike'):
                     right = right or ''
-                    model_raw_trans = model.with_context(prefetch_langs=True)
-                    sql_field = model_raw_trans._field_to_sql(alias, field.name, self.query)
                     sql_operator = SQL_OPERATORS[operator]
-                    sql_exprs = []
-
                     need_wildcard = operator in WILDCARD_OPERATORS
 
                     if need_wildcard and not right:
                         push_result(SQL("FALSE") if operator in NEGATIVE_TERM_OPERATORS else SQL("TRUE"))
                         continue
+                    push_result(model._condition_to_sql(alias, left, operator, right, self.query))
 
                     if not need_wildcard:
                         right = field.convert_to_column(right, model, validate=False).adapted['en_US']
 
-                    if (
-                        (need_wildcard and not right)
-                        or (right and operator in NEGATIVE_TERM_OPERATORS)
-                        or (operator == '=' and right == '')  # noqa: PLC1901
-                    ):
-                        sql_exprs.append(SQL("%s IS NULL OR", sql_field))
-
-                    if self._has_trigram and field.index == 'trigram' and operator in ('=', 'like', 'ilike', '=like', '=ilike'):
-                        # a prefilter using trigram index to speed up '=', 'like', 'ilike'
-                        # '!=', '<=', '<', '>', '>=', 'in', 'not in', 'not like', 'not ilike' cannot use this trick
-                        if operator == '=':
-                            _right = value_to_translated_trigram_pattern(right)
-                        else:
-                            _right = pattern_to_translated_trigram_pattern(right)
-
-                        if _right != '%':
-                            _left = SQL("jsonb_path_query_array(%s, '$.*')::text", sql_field)
-                            _sql_operator = SQL('LIKE') if operator == '=' else sql_operator
-                            sql_exprs.append(SQL(
-                                "%s %s %s AND",
-                                self._unaccent(_left),
-                                _sql_operator,
-                                self._unaccent(SQL("%s", _right))
-                            ))
-
-                    unaccent = self._unaccent if operator.endswith('ilike') else lambda x: x
-                    sql_left = model._field_to_sql(alias, field.name, self.query)
-
-                    if need_wildcard:
-                        right = f'%{right}%'
-
-                    sql_exprs.append(SQL(
-                        "%s %s %s",
-                        unaccent(sql_left),
-                        sql_operator,
-                        unaccent(SQL("%s", right)),
-                    ))
-                    push_result(SQL("(%s)", SQL(" ").join(sql_exprs)))
-
-                elif field.translate and operator in ['in', 'not in'] and isinstance(right, (list, tuple)) and left == field.name:
-                    model_raw_trans = model.with_context(prefetch_langs=True)
-                    sql_field = model_raw_trans._field_to_sql(alias, field.name, self.query)
-                    sql_operator = SQL_OPERATORS[operator]
-                    params = [it for it in right if it is not False and it is not None]
-                    check_null = len(params) < len(right)
-                    if check_null and '' not in params:
-                        params.append('')
-                    check_null = check_null or ('' in params)
-                    if params:
-                        params = [field.convert_to_column(p, model, validate=False).adapted['en_US'] for p in params]
-                        langs = field.get_translation_fallback_langs(model.env)
-                        sql_left_langs = [SQL("%s->>%s", sql_field, lang) for lang in langs]
-                        if len(sql_left_langs) == 1:
-                            sql_left = sql_left_langs[0]
-                        else:
-                            sql_left = SQL('COALESCE(%s)', SQL(', ').join(sql_left_langs))
-                        sql = SQL("%s %s %s", sql_left, sql_operator, tuple(params))
+                    # a prefilter using trigram index to speed up '=', 'like', 'ilike'
+                    # '!=', '<=', '<', '>', '>=', 'in', 'not in', 'not like', 'not ilike' cannot use this trick
+                    if operator == '=':
+                        _right = value_to_translated_trigram_pattern(right)
                     else:
-                        # The case for (left, 'in', []) or (left, 'not in', []).
-                        sql = SQL("FALSE") if operator == 'in' else SQL("TRUE")
-                    if (operator == 'in' and check_null) or (operator == 'not in' and not check_null):
-                        sql = SQL("(%s OR %s IS NULL)", sql, sql_field)
-                    elif operator == 'not in' and check_null:
-                        sql = SQL("(%s AND %s IS NOT NULL)", sql, sql_field)  # needed only for TRUE.
-                    push_result(sql)
+                        _right = pattern_to_translated_trigram_pattern(right)
 
+                    if _right != '%':
+                        # combine both generated SQL expressions (above and below) with an AND
+                        push('&', model, alias)
+                        sql_column = SQL('%s.%s', SQL.identifier(alias), SQL.identifier(field.name))
+                        indexed_value = self._unaccent(SQL("jsonb_path_query_array(%s, '$.*')::text", sql_column))
+                        _sql_operator = SQL('LIKE') if operator == '=' else sql_operator
+                        push_result(SQL("%s %s %s", indexed_value, _sql_operator, self._unaccent(SQL("%s", _right))))
                 else:
                     push_result(model._condition_to_sql(alias, left, operator, right, self.query))
 


### PR DESCRIPTION
1. before this commit: 
the _field_to_sql of a translated field for en_US is 
`"table_name"."field_name"->>'en_US'`
it might be type converted to `::text` in `condition_to_sql`
`"table_name"."field_name"->>'en_US'::text`
it is always correct but in an unexpected way. The `::text` converts `'en_US'` but not the result of `_field_to_sql`.
after this commit: 
(_field_to_sql)::text is only for non char,text,html fields

3. before this commit: 
for translated fields, `_field_to_sql` returns 
`"table_name"."field_name"` when `prefetch_langs` in the context
`"table_name"."field_name"->>'en_US'` for `'en_US'` without `prefetch_langs`
after this commit: 
for translated fields, `_field_to_sql` always returns 
`"table_name"."field_name"->>'en_US'` for 'en_US'
which represents the business value of the fname to be used in condition check for domain or selected as a result to generate report. Benefiting from this, the special logic branch for translated fields in expression.py can be simplified or removed

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
