### PR TITLE
[IMP] stock: two-phase procurement group

### DIFF
--- a/addons/mrp_subcontracting/models/stock_rule.py
+++ b/addons/mrp_subcontracting/models/stock_rule.py
@@ -11,3 +11,10 @@ class StockRule(models.Model):
         new_move_vals = super(StockRule, self)._push_prepare_move_copy_values(move_to_copy, new_date)
         new_move_vals["is_subcontract"] = False
         return new_move_vals
+
+    def _prepare_procurement_values(self, move_vals, product, old_values):
+        res = super()._prepare_procurement_values(move_vals, product, old_values)
+        production = self.env['mrp.production'].browse(move_vals.get('raw_material_production_id', False))
+        if production and production.subcontractor_id:
+            res['warehouse_id'] = self.env['stock.picking.type'].browse(move_vals['picking_type_id']).warehouse_id.id
+        return res

--- a/addons/mrp_subcontracting_dropshipping/models/stock_rule.py
+++ b/addons/mrp_subcontracting_dropshipping/models/stock_rule.py
@@ -7,6 +7,13 @@ from odoo import models
 class StockRule(models.Model):
     _inherit = 'stock.rule'
 
+    def _prepare_procurement_values(self, move_vals, product, old_values):
+        vals = super()._prepare_procurement_values(move_vals, product, old_values)
+        partner = self.env['procurement.group'].browse(move_vals['group_id']).partner_id
+        if not vals.get('partner_id') and partner and self.location_src_id.is_subcontracting_location:
+            vals['partner_id'] = partner.id
+        return vals
+
     def _prepare_purchase_order(self, company_id, origins, values):
         if 'partner_id' not in values[0] \
             and (company_id.subcontracting_location_id.parent_path in self.location_dest_id.parent_path

--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -267,7 +267,7 @@ class PurchaseOrderLine(models.Model):
     def _check_orderpoint_picking_type(self):
         warehouse_loc = self.order_id.picking_type_id.warehouse_id.view_location_id
         dest_loc = self.move_dest_ids.location_id or self.orderpoint_id.location_id
-        if warehouse_loc and dest_loc and dest_loc.warehouse_id and not warehouse_loc.parent_path in dest_loc[0].parent_path:
+        if warehouse_loc and dest_loc and dest_loc.warehouse_id and warehouse_loc.parent_path not in dest_loc[0].parent_path:
             raise UserError(_('The warehouse of operation type (%(operation_type)s) is inconsistent with location (%(location)s) of reordering rule (%(reordering_rule)s) for product %(product)s. Change the operation type or cancel the request for quotation.',
                               product=self.product_id.display_name, operation_type=self.order_id.picking_type_id.display_name, location=self.orderpoint_id.location_id.display_name, reordering_rule=self.orderpoint_id.display_name))
 
@@ -322,7 +322,7 @@ class PurchaseOrderLine(models.Model):
         if line_description and product_id.name != line_description:
             res['name'] += '\n' + line_description
         res['date_planned'] = values.get('date_planned')
-        res['move_dest_ids'] = [(4, x.id) for x in values.get('move_dest_ids', [])]
+        res['move_dest_ids'] = values.get('move_dest_ids', [])
         res['location_final_id'] = location_dest_id.id
         res['orderpoint_id'] = values.get('orderpoint_id', False) and values.get('orderpoint_id').id
         res['propagate_cancel'] = values.get('propagate_cancel')
@@ -348,7 +348,7 @@ class PurchaseOrderLine(models.Model):
             description_picking = values['product_description_variants']
         lines = self.filtered(
             lambda l: l.propagate_cancel == values['propagate_cancel']
-            and (l.orderpoint_id == values['orderpoint_id'] if values['orderpoint_id'] and not values['move_dest_ids'] else True)
+            and (l.orderpoint_id == values['orderpoint_id'] if values.get('orderpoint_id', False) and not values.get('move_dest_ids') else True)
         )
 
         # In case 'product_description_variants' is in the values, we also filter on the PO line

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from collections import defaultdict
 from datetime import datetime
+
 from dateutil.relativedelta import relativedelta
 from odoo.tools import float_compare
 
-from odoo import api, fields, models, SUPERUSER_ID, _
+from odoo import api, fields, models, SUPERUSER_ID, _, Command
 from odoo.addons.stock.models.stock_rule import ProcurementException
 from odoo.tools import groupby
 
@@ -44,115 +44,110 @@ class StockRule(models.Model):
         if self.action == 'buy':
             self.location_src_id = False
 
+    def _prepare_buy(self, procurement, taken_qties):
+        # Get the schedule date in order to find a valid seller
+        procurement_date_planned = fields.Datetime.from_string(procurement.values['date_planned'])
+
+        if procurement.values.get('supplierinfo_id'):
+            supplier = procurement.values['supplierinfo_id']
+        elif procurement.values.get('orderpoint_id') and procurement.values['orderpoint_id'].supplier_id:
+            supplier = procurement.values['orderpoint_id'].supplier_id
+        else:
+            supplier = procurement.product_id.with_company(procurement.company_id.id)._select_seller(
+                partner_id=procurement.values.get("supplierinfo_name") or (
+                            procurement.values.get("group_id") and procurement.values.get("group_id").partner_id),
+                quantity=procurement.product_qty,
+                date=max(procurement_date_planned.date(), fields.Date.today()),
+                uom_id=procurement.product_uom)
+
+        # Fall back on a supplier for which no price may be defined. Not ideal, but better than blocking the user.
+        supplier = supplier or procurement.product_id._prepare_sellers(False).filtered(
+            lambda s: not s.company_id or s.company_id == procurement.company_id
+        )[:1]
+
+        if not supplier:
+            msg = _(
+                'There is no matching vendor price to generate the purchase order for product %s (no vendor defined, minimum quantity not reached, dates not valid, ...). Go on the product form and complete the list of vendors.',
+                procurement.product_id.display_name)
+            raise ProcurementException([(procurement, msg)])
+
+        partner = supplier.partner_id
+        # we put `supplier_info` in values for extensibility purposes
+        procurement.values['supplier'] = supplier
+        procurement.values['propagate_cancel'] = self.propagate_cancel
+        domain = self._make_po_get_domain(procurement.company_id, procurement.values, partner)
+
+        # Check if a PO exists for the current domain.
+        po = self.env['purchase.order'].sudo().search(list(domain), limit=1)
+        if not po:
+            if float_compare(procurement.product_qty, 0.0, precision_rounding=procurement.product_uom.rounding) >= 0:
+                # We need a rule to generate the PO. However the rule generated
+                # the same domain for PO and the _prepare_purchase_order method
+                # should only uses the common rules's fields.
+                po_vals = self._prepare_purchase_order(procurement.company_id, [procurement.origin], [procurement.values])
+            else:
+                return 'buy', {}
+        else:
+            po_vals = {'po_id': po.id}
+            # If a purchase order is found, adapt its `origin` field.
+            if po.origin:
+                if procurement.origin not in po.origin.split(', '):
+                    po_vals['origin'] = po.origin + ', ' + procurement.origin
+            else:
+                po_vals['origin'] = procurement.origin
+
+        po_lines_by_product = {}
+        grouped_po_lines = groupby(
+            po.order_line.filtered(lambda l: not l.display_type and l.product_uom == l.product_id.uom_po_id),
+            key=lambda l: l.product_id.id)
+        for product, po_lines in grouped_po_lines:
+            po_lines_by_product[product] = self.env['purchase.order.line'].concat(*po_lines)
+        po_lines = po_lines_by_product.get(procurement.product_id.id, self.env['purchase.order.line'])
+        po_line = po_lines._find_candidate(*procurement)
+        if po_line:
+            # If the procurement can be merge in an existing line. Directly write the new values on it
+            po_vals['update_line'] = self._update_purchase_order_line(
+                procurement.product_id, procurement.product_qty, procurement.product_uom, procurement.company_id, procurement.values, po_line
+            )
+            po_vals['update_line']['pol_id'] = po_line.id
+        else:
+            if float_compare(procurement.product_qty, 0, precision_rounding=procurement.product_uom.rounding) <= 0:
+                # If procurement contains negative quantity, don't create a new line that would contain negative qty
+                return 'buy', {}
+            # If it does not exist a PO line for current procurement.
+            # Generate the create values for it and add it to a list in order to create it in batch.
+            po_vals['order_line'] = [Command.create(
+                self.env['purchase.order.line']._prepare_purchase_order_line_from_procurement(*procurement, po or po_vals)
+            )]
+            # Check if we need to advance the order date for the new line
+            order_date_planned = procurement.values['date_planned'] - relativedelta(days=procurement.values['supplier'].delay)
+            po_date_order = po.date_order if po else po_vals.get('date_order', fields.Datetime.now)
+            if fields.Date.to_date(order_date_planned) < fields.Date.to_date(po_date_order):
+                if po:
+                    po.date_planned = order_date_planned
+                else:
+                    po_vals['date_order'] = order_date_planned
+        return 'buy', po_vals
+
     @api.model
-    def _run_buy(self, procurements):
-        procurements_by_po_domain = defaultdict(list)
-        errors = []
-        for procurement, rule in procurements:
-
-            # Get the schedule date in order to find a valid seller
-            procurement_date_planned = fields.Datetime.from_string(procurement.values['date_planned'])
-
-            supplier = False
-            if procurement.values.get('supplierinfo_id'):
-                supplier = procurement.values['supplierinfo_id']
-            elif procurement.values.get('orderpoint_id') and procurement.values['orderpoint_id'].supplier_id:
-                supplier = procurement.values['orderpoint_id'].supplier_id
+    def _run_buy(self, po_vals, procurements):
+        for po in po_vals:
+            if 'po_id' in po:
+                po_to_edit = self.env['purchase.order'].browse(po['po_id'])
+                del po['po_id']
+                update_line = False
+                if po.get('update_line', False):
+                    update_line = po['update_line']
+                    del po['update_line']
+                po_to_edit.sudo().write(po)
+                if update_line:
+                    po_line = self.env['purchase.order.line'].browse(update_line['pol_id'])
+                    del update_line['pol_id']
+                    po_line.sudo().write(update_line)
+                self._confirm_new_moves(po_to_edit.order_line.move_dest_ids, procurements)
             else:
-                supplier = procurement.product_id.with_company(procurement.company_id.id)._select_seller(
-                    partner_id=procurement.values.get("supplierinfo_name") or (procurement.values.get("group_id") and procurement.values.get("group_id").partner_id),
-                    quantity=procurement.product_qty,
-                    date=max(procurement_date_planned.date(), fields.Date.today()),
-                    uom_id=procurement.product_uom)
-
-            # Fall back on a supplier for which no price may be defined. Not ideal, but better than
-            # blocking the user.
-            supplier = supplier or procurement.product_id._prepare_sellers(False).filtered(
-                lambda s: not s.company_id or s.company_id == procurement.company_id
-            )[:1]
-
-            if not supplier:
-                msg = _('There is no matching vendor price to generate the purchase order for product %s (no vendor defined, minimum quantity not reached, dates not valid, ...). Go on the product form and complete the list of vendors.', procurement.product_id.display_name)
-                errors.append((procurement, msg))
-
-            partner = supplier.partner_id
-            # we put `supplier_info` in values for extensibility purposes
-            procurement.values['supplier'] = supplier
-            procurement.values['propagate_cancel'] = rule.propagate_cancel
-
-            domain = rule._make_po_get_domain(procurement.company_id, procurement.values, partner)
-            procurements_by_po_domain[domain].append((procurement, rule))
-
-        if errors:
-            raise ProcurementException(errors)
-
-        for domain, procurements_rules in procurements_by_po_domain.items():
-            # Get the procurements for the current domain.
-            # Get the rules for the current domain. Their only use is to create
-            # the PO if it does not exist.
-            procurements, rules = zip(*procurements_rules)
-
-            # Get the set of procurement origin for the current domain.
-            origins = set([p.origin for p in procurements])
-            # Check if a PO exists for the current domain.
-            po = self.env['purchase.order'].sudo().search([dom for dom in domain], limit=1)
-            company_id = procurements[0].company_id
-            if not po:
-                positive_values = [p.values for p in procurements if float_compare(p.product_qty, 0.0, precision_rounding=p.product_uom.rounding) >= 0]
-                if positive_values:
-                    # We need a rule to generate the PO. However the rule generated
-                    # the same domain for PO and the _prepare_purchase_order method
-                    # should only uses the common rules's fields.
-                    vals = rules[0]._prepare_purchase_order(company_id, origins, positive_values)
-                    # The company_id is the same for all procurements since
-                    # _make_po_get_domain add the company in the domain.
-                    # We use SUPERUSER_ID since we don't want the current user to be follower of the PO.
-                    # Indeed, the current user may be a user without access to Purchase, or even be a portal user.
-                    po = self.env['purchase.order'].with_company(company_id).with_user(SUPERUSER_ID).create(vals)
-            else:
-                # If a purchase order is found, adapt its `origin` field.
-                if po.origin:
-                    missing_origins = origins - set(po.origin.split(', '))
-                    if missing_origins:
-                        po.write({'origin': po.origin + ', ' + ', '.join(missing_origins)})
-                else:
-                    po.write({'origin': ', '.join(origins)})
-
-            procurements_to_merge = self._get_procurements_to_merge(procurements)
-            procurements = self._merge_procurements(procurements_to_merge)
-
-            po_lines_by_product = {}
-            grouped_po_lines = groupby(po.order_line.filtered(lambda l: not l.display_type and l.product_uom == l.product_id.uom_po_id), key=lambda l: l.product_id.id)
-            for product, po_lines in grouped_po_lines:
-                po_lines_by_product[product] = self.env['purchase.order.line'].concat(*po_lines)
-            po_line_values = []
-            for procurement in procurements:
-                po_lines = po_lines_by_product.get(procurement.product_id.id, self.env['purchase.order.line'])
-                po_line = po_lines._find_candidate(*procurement)
-
-                if po_line:
-                    # If the procurement can be merge in an existing line. Directly
-                    # write the new values on it.
-                    vals = self._update_purchase_order_line(procurement.product_id,
-                        procurement.product_qty, procurement.product_uom, company_id,
-                        procurement.values, po_line)
-                    po_line.sudo().write(vals)
-                else:
-                    if float_compare(procurement.product_qty, 0, precision_rounding=procurement.product_uom.rounding) <= 0:
-                        # If procurement contains negative quantity, don't create a new line that would contain negative qty
-                        continue
-                    # If it does not exist a PO line for current procurement.
-                    # Generate the create values for it and add it to a list in
-                    # order to create it in batch.
-                    partner = procurement.values['supplier'].partner_id
-                    po_line_values.append(self.env['purchase.order.line']._prepare_purchase_order_line_from_procurement(
-                        *procurement, po))
-                    # Check if we need to advance the order date for the new line
-                    order_date_planned = procurement.values['date_planned'] - relativedelta(
-                        days=procurement.values['supplier'].delay)
-                    if fields.Date.to_date(order_date_planned) < fields.Date.to_date(po.date_order):
-                        po.date_order = order_date_planned
-            self.env['purchase.order.line'].sudo().create(po_line_values)
+                created_po = self.env['purchase.order'].with_company(po['company_id']).with_user(SUPERUSER_ID).create(po)
+                self._confirm_new_moves(created_po.order_line.move_dest_ids, procurements)
 
     def _get_lead_days(self, product, **values):
         """Add the company security lead time and the supplier delay to the cumulative delay
@@ -257,7 +252,7 @@ class StockRule(models.Model):
         res = {
             'product_qty': line.product_qty + procurement_uom_po_qty,
             'price_unit': price_unit,
-            'move_dest_ids': [(4, x.id) for x in values.get('move_dest_ids', [])]
+            'move_dest_ids': values.get('move_dest_ids', [])
         }
         orderpoint_id = values.get('orderpoint_id')
         if orderpoint_id:

--- a/addons/sale_mrp/models/stock_rule.py
+++ b/addons/sale_mrp/models/stock_rule.py
@@ -9,3 +9,12 @@ class StockRule(models.Model):
         if values.get('sale_line_id'):
             res['sale_line_id'] = values['sale_line_id']
         return res
+
+    def _prepare_procurement_values(self, move_vals, product, old_values):
+        res = super()._prepare_procurement_values(move_vals, product, old_values)
+        if move_vals.get('sale_line_id'):
+            so = self.env['sale.order.line'].browse(move_vals['sale_line_id']).order_id
+            res['analytic_account_id'] = so.analytic_account_id
+            if so.analytic_account_id:
+                res['analytic_distribution'] = {so.analytic_account_id.id: 100}
+        return res

--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -1356,13 +1356,13 @@ class TestSaleStock(TestSaleStockCommon, ValuationReconciliationTestCommon):
                 line.product_uom_qty = 3
 
         moves = so.picking_ids.move_ids.sorted('id')
-        ship_sm, pack_sm, pick_sm, ret_pack_sm, ret_pick_sm = moves
+        pick_sm, pack_sm, ship_sm, ret_pick_sm, ret_pack_sm = moves
         self.assertRecordValues(moves, [
-            {'location_id': out_location.id, 'location_dest_id': custo_location.id, 'move_orig_ids': pack_sm.ids, 'move_dest_ids': []},
-            {'location_id': pack_location.id, 'location_dest_id': out_location.id, 'move_orig_ids': pick_sm.ids, 'move_dest_ids': ship_sm.ids},
             {'location_id': stock_location.id, 'location_dest_id': pack_location.id, 'move_orig_ids': [], 'move_dest_ids': pack_sm.ids},
-            {'location_id': out_location.id, 'location_dest_id': pack_location.id, 'move_orig_ids': [], 'move_dest_ids': ret_pick_sm.ids},
+            {'location_id': pack_location.id, 'location_dest_id': out_location.id, 'move_orig_ids': pick_sm.ids, 'move_dest_ids': ship_sm.ids},
+            {'location_id': out_location.id, 'location_dest_id': custo_location.id, 'move_orig_ids': pack_sm.ids, 'move_dest_ids': []},
             {'location_id': pack_location.id, 'location_dest_id': stock_location.id, 'move_orig_ids': ret_pack_sm.ids, 'move_dest_ids': []},
+            {'location_id': out_location.id, 'location_dest_id': pack_location.id, 'move_orig_ids': [], 'move_dest_ids': ret_pick_sm.ids},
         ])
 
         ret_pack_sm.picking_id.action_assign()

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1450,15 +1450,16 @@ Please change the quantity done or the rounding precision of your unit of measur
         move_create_proc, move_to_confirm, move_waiting = self.browse(move_create_proc), self.browse(move_to_confirm), self.browse(move_waiting)
 
         # create procurements for make to order moves
-        procurement_requests = []
-        for move in move_create_proc:
-            values = move._prepare_procurement_values()
-            origin = move._prepare_procurement_origin()
-            procurement_requests.append(self.env['procurement.group'].Procurement(
-                move.product_id, move.product_uom_qty, move.product_uom,
-                move.location_id, move.rule_id and move.rule_id.name or "/",
-                origin, move.company_id, values))
-        self.env['procurement.group'].run(procurement_requests, raise_user_error=not self.env.context.get('from_orderpoint'))
+        if not self.env.context.get('do_not_procure'):
+            procurement_requests = []
+            for move in move_create_proc:
+                values = move._prepare_procurement_values()
+                origin = move._prepare_procurement_origin()
+                procurement_requests.append(self.env['procurement.group'].Procurement(
+                    move.product_id, move.product_uom_qty, move.product_uom,
+                    move.location_id, move.rule_id and move.rule_id.name or "/",
+                    origin, move.company_id, values))
+            self.env['procurement.group'].run(procurement_requests, raise_user_error=not self.env.context.get('from_orderpoint'))
 
         move_to_confirm.write({'state': 'confirmed'})
         (move_waiting | move_create_proc).write({'state': 'waiting'})

--- a/addons/stock/tests/test_old_rules.py
+++ b/addons/stock/tests/test_old_rules.py
@@ -67,7 +67,7 @@ class TestOldRules(TestStockCommon):
                 }
             ),
         ])
-        ship, pack, pick = self.env['stock.move'].search([('product_id', '=', self.productA.id)])
+        pick, pack, ship = self.env['stock.move'].search([('product_id', '=', self.productA.id)])
 
         # by default they all the same `date`
         self.assertEqual(set((ship + pack + pick).mapped('date')), {pick.date})


### PR DESCRIPTION
A new implementation of ProcurementGroup's `run` method and the `_run_pull`, `_run_manufacture` and `_run_buy` helpers to generate documents (move/MO/PO) based on the demand described in the provided procurements.

# Currently
This process is done layer by layer in a breadth first fashion:
- A rule is fetched for each procurement
- Move values are generated based on the (rule, procurement) tuples
- The moves are created and `_action_confirm`'ed
- The action confirm on the move generates new procurements based on the values of the move, and ProcurementGroup's run gets called again for the demand in the next layer.

# New proposed method
We split the `_run_[action]` methods in a `prepare_[action]` part and a `run_[action]` part. The 'prepare' part prepares a dict with all the values of the objects to be created in a recursive, depth-first fashion. The run part will then take these prepared values and actually create all the objects.

# Benefits of this new approach
More flexibility as the tree of documents to create is completely generated before saving any new entries in the database. This makes it possible to introduce conditional rules with conditions on the generation results of child moves.

Possible performance improvements as we only need one large create call instead of one for every layer of the tree. (to check...)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
