### PR TITLE
[FIX] base_import: empty cell in XLS files

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -465,7 +465,9 @@ class Import(models.TransientModel):
                         _("Invalid cell value at row %(row)s, column %(col)s: %(cell_value)s", row=rowx, col=colx, cell_value=cell.value)
                     )
 
-                if isinstance(cell.value, float):
+                if cell.value is None:
+                    values.append('')
+                elif isinstance(cell.value, float):
                     if cell.value % 1 == 0:
                         values.append(str(int(cell.value)))
                     else:


### PR DESCRIPTION
Steps to reproduce:
-------------------
- Have xlrd >= 2.0 and openpyxl 3.1.2
- Using the base_import module, import an XLSX file with empty cells
- You will notice that all empty cells are read as "None"
- Click on test, will give this error : "Column debit contains incorrect values (value: None)"

Cause:
-----
Since (#169245) openpyxl is used instead of xlrd for parsing xlsx files, the empty cells are parsed as None, not as empty string (as it was in xlrd). then this None is cast to the string "None", causing issues.

Fix:
-----
An additional check  added to check if the cell is empty (value is None) and set it as empty string.

opw-4132402