### PR TITLE
[FIX] website: fix s_hr data-name within s_key_benefits

### DIFF
--- a/addons/website/views/snippets/s_key_benefits.xml
+++ b/addons/website/views/snippets/s_key_benefits.xml
@@ -15,7 +15,7 @@
                 </div>
                 <div class="o_grid_item g-col-lg-4 g-height-7 col-lg-4 pt48 pb24" style="--grid-item-padding-x: 16px; grid-area: 6 / 1 / 12 / 5; z-index: 3;">
                     <span class="display-3 text-o-color-1">1</span>
-                    <div class="s_hr pt8 pb24" data-snippet="s_hr">
+                    <div class="s_hr pt8 pb24" data-snippet="s_hr" data-name="Separator">
                         <hr class="w-100 mx-auto"/>
                     </div>
                     <h3 class="h4-fs">Fair pricing</h3>
@@ -23,7 +23,7 @@
                 </div>
                 <div class="o_grid_item g-col-lg-4 g-height-7 col-lg-4 pt48 pb24" style="--grid-item-padding-x: 16px; grid-area: 6 / 5 / 12 / 9; z-index: 4;">
                     <span class="display-3 text-o-color-1">2</span>
-                    <div class="s_hr pt8 pb24" data-snippet="s_hr">
+                    <div class="s_hr pt8 pb24" data-snippet="s_hr" data-name="Separator">
                         <hr class="w-100 mx-auto"/>
                     </div>
                     <h3 class="h4-fs">24/7 Support</h3>
@@ -31,7 +31,7 @@
                 </div>
                 <div class="o_grid_item g-col-lg-4 g-height-7 col-lg-4 pt48 pb24" style="--grid-item-padding-x: 16px; grid-area: 6 / 9 / 12 / 13; z-index: 5;">
                     <span class="display-3 text-o-color-1">3</span>
-                    <div class="s_hr pt8 pb24" data-snippet="s_hr">
+                    <div class="s_hr pt8 pb24" data-snippet="s_hr" data-name="Separator">
                         <hr class="w-100 mx-auto"/>
                     </div>
                     <h3 class="h4-fs">Tax free</h3>


### PR DESCRIPTION
This commit aims to fix a misleading label on the `s_hr` occurrences within the `s_key_benefits` snippet.

Prior to this commit, the `s_hr` occurrences were labeled as `Block`. This was especially misleading as the parent element is named `Column`, making differentiation difficult.

To address this issue, we simply set a `data-name` that really illustrate the element users are clicking on.

task-4134877
follow-up of task-4104927

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
