### PR TITLE
[FIX] pos_sale: preserve sale order line link on order reload

### DIFF
--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -159,9 +159,9 @@ class PosOrderLine(models.Model):
 
     def _export_for_ui(self, orderline):
         result = super()._export_for_ui(orderline)
-        # NOTE We are not exporting 'sale_order_line_id' because it is being used in any views in the POS App.
         result['down_payment_details'] = bool(orderline.down_payment_details) and orderline.down_payment_details
         result['sale_order_origin_id'] = bool(orderline.sale_order_origin_id) and orderline.sale_order_origin_id.read(fields=['name'])[0]
+        result['sale_order_line_id'] = bool(orderline.sale_order_line_id) and orderline.sale_order_line_id.read(fields=['name'])[0]
         return result
 
     def _order_line_fields(self, line, session_id=None):


### PR DESCRIPTION
Before this commit, reloading a sale order imported into the POS would result in the loss of the link between the POS order line and the sale order line.

opw-4120046

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
