### PR TITLE
[IMP] web_editor, website: allow to create a link to a document

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
@@ -292,12 +292,23 @@ export class Link extends Component {
             (type && size ? (' btn-' + size) : '');
         var isNewWindow = this._isNewWindow(url);
         var doStripDomain = this._doStripDomain();
-        if (this.state.url.indexOf(location.origin) === 0 && doStripDomain) {
-            this.state.url = this.state.url.slice(location.origin.length);
+        let urlWithoutDomain = this.state.url;
+        if (this.state.url.indexOf(location.origin) === 0) {
+            urlWithoutDomain = this.state.url.slice(location.origin.length);
+            if (doStripDomain) {
+                this.state.url = urlWithoutDomain;
+            }
         }
         var allWhitespace = /\s+/gi;
         var allStartAndEndSpace = /^\s+|\s+$/gi;
         const isImage = this.props.link && this.props.link.querySelector('img');
+        let isDocument = false;
+        let directDownload = true;
+        if (urlWithoutDomain && urlWithoutDomain.startsWith("/web/content/")) {
+            isDocument = true;
+            directDownload = urlWithoutDomain.includes("&download=true");
+        } 
+        
         return {
             content: content,
             url: this._correctLink(this.state.url),
@@ -311,6 +322,8 @@ export class Link extends Component {
             isNewWindow: isNewWindow,
             doStripDomain: doStripDomain,
             isImage,
+            isDocument,
+            directDownload,
         };
     }
     /**

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
@@ -49,6 +49,8 @@ export class LinkTools extends Link {
         showLinkSizeRow: true,
         showLinkCustomColor: true,
         showLinkShapeRow: true,
+        isDocument: false,
+        directDownload: true,
     });
 
     setup() {
@@ -119,6 +121,7 @@ export class LinkTools extends Link {
             // Link URL was deduced from label. Apply changes to DOM.
             this.__onURLInput();
         }
+        this._checkDocumentState();
 
         return ret;
     }
@@ -143,6 +146,20 @@ export class LinkTools extends Link {
         super.focusUrl(...arguments);
     }
 
+    openDocumentDialog() {
+        this.props.wysiwyg.openMediaDialog({
+            resModel: "ir.ui.view",
+            useMediaLibrary: true,
+            noImages: true,
+            noIcons: true,
+            noVideos: true,
+            save: (link) => {
+                const relativeUrl = link.href.substr(window.location.origin.length);
+                this.$el[0].querySelector("#o_link_dialog_url_input").value = relativeUrl;
+                this.__onURLInput();
+            },
+        });
+    }
     //--------------------------------------------------------------------------
     // Private
     //--------------------------------------------------------------------------
@@ -425,6 +442,20 @@ export class LinkTools extends Link {
     _onClickCheckbox(ev) {
         const $target = $(ev.target);
         $target.closest('we-button.o_we_checkbox_wrapper').toggleClass('active');
+        if (ev.target.getAttribute("name") === "direct_download") {
+            const el = ev.target.closest("we-button.o_we_checkbox_wrapper");
+            const urlInputEl = this.$el[0].querySelector("#o_link_dialog_url_input");
+            let href = urlInputEl.value.replace("&download=true", "");
+            if (el.classList.contains("active")) {
+                href += "&download=true";
+                this.state.directDownload = true;
+            }
+            else {
+                this.state.directDownload = false;
+            }
+            urlInputEl.value = href;
+            this.state.url = href;
+        } 
         this._adaptPreview();
     }
     _onPickSelectOption(ev) {
@@ -481,12 +512,22 @@ export class LinkTools extends Link {
             this.props.wysiwyg.odooEditor.historyStep();
         }
     }
+    _checkDocumentState() {
+        this.state.isDocument = false;
+        this.state.directDownload = true;
+        const url = this.state.url;
+        if (url && url.startsWith("/web/content/")) {
+            this.state.isDocument = true;
+            this.state.directDownload = url.includes("&download=true");
+        } 
+    }
     /**
      * @override
      */
     __onURLInput() {
         super.__onURLInput(...arguments);
         this.props.wysiwyg.odooEditor.historyPauseSteps('_onURLInput');
+        this._checkDocumentState();
         this._syncContent();
         this._adaptPreview();
         this.props.wysiwyg.odooEditor.historyUnpauseSteps('_onURLInput');

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1454,6 +1454,7 @@ export class Wysiwyg extends Component {
                 this._onClick = ev => {
                     if (
                         !ev.target.closest('#create-link') &&
+                        !ev.target.closest(".o_technical_modal") &&
                         (!ev.target.closest('.oe-toolbar') || !ev.target.closest('we-customizeblock-option')) &&
                         !ev.target.closest('.ui-autocomplete') &&
                         (!this.state.linkToolProps || ![ev.target, ...wysiwygUtils.ancestors(ev.target)].includes(this.linkToolsInfos.link))

--- a/addons/web_editor/static/src/xml/wysiwyg.xml
+++ b/addons/web_editor/static/src/xml/wysiwyg.xml
@@ -130,6 +130,7 @@
                     <we-title class="o_short_title"></we-title>
                     <div class="o_url_input">
                         <input name="url" id="o_link_dialog_url_input" type="text" placeholder="Your URL"/>
+                        <we-button class="o_we_user_value_widget fa fa-file" t-on-click="this.openDocumentDialog" data-tooltip="Link to an uploaded document"></we-button>
                     </div>
                 </we-input>
             </we-row>
@@ -309,6 +310,14 @@
                         <div class="o_switch">
                             <we-checkbox name="is_new_window" t-att-checked="this.initialNewWindow ? 'checked' : undefined"/>
                         </div>
+                </we-button>
+            </we-row>
+            <we-row  t-if="!state.isButton and state.isDocument">
+                <we-button t-attf-class="o_we_user_value_widget o_we_checkbox_wrapper o_we_sublevel_1 #{state.directDownload ? 'active' : ''}">
+                    <we-title class="o_long_title">Direct Download</we-title>
+                    <div class="o_switch">
+                        <we-checkbox name="direct_download" t-att-checked="state.directDownload ? 'checked' : undefined"/>
+                    </div>
                 </we-button>
             </we-row>
         </div>

--- a/addons/website/static/src/components/autocomplete_with_pages/autocomplete_with_pages.js
+++ b/addons/website/static/src/components/autocomplete_with_pages/autocomplete_with_pages.js
@@ -150,14 +150,4 @@ export class AutoCompleteWithPages extends AutoComplete {
         this.targetDropdown.setSelectionRange(0, this.targetDropdown.value.length);
         this.props.onFocus(ev);
     }
-
-    /**
-     * @override
-     */
-    close() {
-        this.props.onInput({
-            inputValue: this.inputRef.el.value,
-        });
-        super.close();
-    }
 }

--- a/addons/website/static/src/js/editor/widget_link.js
+++ b/addons/website/static/src/js/editor/widget_link.js
@@ -53,7 +53,7 @@ patch(LinkTools.prototype, {
     _adaptPageAnchor() {
         const urlInputValue = this.$el.find('input[name="url"]').val();
         const $pageAnchor = this.$el.find('.o_link_dialog_page_anchor');
-        const showAnchorSelector = urlInputValue[0] === '/';
+        const showAnchorSelector = (urlInputValue[0] === '/') && (!urlInputValue.startsWith("/web/content/"));
         const $selectMenu = this.$el.find('we-selection-items[name="link_anchor"]');
 
         if ($selectMenu.data("anchor-for") !== urlInputValue) { // avoid useless query

--- a/addons/website/static/src/xml/web_editor.xml
+++ b/addons/website/static/src/xml/web_editor.xml
@@ -14,7 +14,7 @@
                     '<span class="highlighted-text">#</span>' to link to an anchor.
                 </small>
             </div>
-            <we-row class="o_link_dialog_page_anchor d-none" t-attf-class="#{state.isButton ? ' d-none' : ''}">
+            <we-row class="o_link_dialog_page_anchor d-none" t-attf-class="#{state.isButton || state.isDocument ? ' d-none' : ''}">
                 <we-select class="o_we_user_value_widget o_we_sublevel_1">
                     <we-title>Page Anchor</we-title>
                     <div>

--- a/addons/website/static/tests/tours/link_to_document.js
+++ b/addons/website/static/tests/tours/link_to_document.js
@@ -1,0 +1,53 @@
+import { dragNDrop, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
+/**
+ * The purpose of this tour is to check the Linktools to create a link to an
+ * uploaded document.
+ */
+registerWebsitePreviewTour(
+    "test_link_to_document",
+    {
+        url: "/",
+        test: true,
+        edition: true,
+    },
+    () => [
+        ...dragNDrop({
+            name: "Banner",
+            id: "s_banner",
+            groupName: "Intro",
+        }),
+        {
+            content: "Click on button Start Now",
+            trigger: ":iframe #wrap .s_banner a:nth-child(1)",
+            run: "click",
+        },
+        {
+            content: "Click on link to an uploaded document",
+            trigger: ".o_url_input .o_we_user_value_widget.fa.fa-file",
+            run: "click",
+        },
+        {
+            content: "Click on the first file uploaded",
+            trigger:
+                ".o_select_media_dialog .o_we_documents .o_existing_attachment_cell:nth-child(1)",
+            run: "click",
+        },
+        {
+            content: "Check if a document link is created",
+            trigger: ":iframe #wrap .s_banner .oe_edited_link[href^='/web/content']",
+        },
+        {
+            content: "Check if by default the option auto-download is enabled",
+            trigger: ":iframe #wrap .s_banner .oe_edited_link[href$='download=true']",
+        },
+        {
+            content: "Deactivate direct download",
+            trigger: ".o_switch > we-checkbox[name='direct_download']",
+            run: "click",
+        },
+        {
+            content: "Check if auto-download is disabled",
+            trigger: ":iframe #wrap .s_banner .oe_edited_link:not([href$='download=true'])",
+        },
+    ]
+);

--- a/addons/website/tests/test_attachment.py
+++ b/addons/website/tests/test_attachment.py
@@ -41,3 +41,13 @@ class TestWebsiteAttachment(odoo.tests.HttpCase):
 
     def test_02_image_quality(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'website_image_quality', login="admin")
+
+    def test_03_link_to_document(self):
+        text = b'Lorem Ipsum'
+        self.env['ir.attachment'].create({
+            'name': 'sample.txt',
+            'public': True,
+            'mimetype': 'text/plain',
+            'raw': text,
+        })
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'test_link_to_document', login="admin")


### PR DESCRIPTION
This commit provides a new button next to the URL input in the "link
tools" to easily create links to documents
It enhances user experience by allowing selection from the media library
instead of manually entering a URL.
A test has been made.

task-4100016
