### PR TITLE
[FIX] base_import: date parsing in XLSX files

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -452,6 +452,7 @@ class Import(models.TransientModel):
             return self._read_xls(options)
 
         import openpyxl.cell.cell as types
+        import openpyxl.styles.numbers as styles  # noqa: PLC0415
         book = load_workbook(io.BytesIO(self.file or b''), data_only=True)
         sheets = options['sheets'] = book.sheetnames
         sheet_name = options['sheet'] = options.get('sheet') or sheets[0]
@@ -470,10 +471,16 @@ class Import(models.TransientModel):
                         values.append(str(int(cell.value)))
                     else:
                         values.append(str(cell.value))
-                elif isinstance(cell.value, datetime.datetime):
-                    values.append(cell.value.strftime(DEFAULT_SERVER_DATETIME_FORMAT))
-                elif isinstance(cell.value, datetime.date):
-                    values.append(cell.value.strftime(DEFAULT_SERVER_DATE_FORMAT))
+                elif cell.is_date:
+                    d_fmt = styles.is_datetime(cell.number_format)
+                    if d_fmt == "datetime":
+                        values.append(cell.value.strftime(DEFAULT_SERVER_DATETIME_FORMAT))
+                    elif d_fmt == "date":
+                        values.append(cell.value.strftime(DEFAULT_SERVER_DATE_FORMAT))
+                    else:
+                        raise ValueError(
+                        _("Invalid cell format at row %(row)s, column %(col)s: %(cell_value)s, with format: %(cell_format)s, as (%(format_type)s) formats are not supported.", row=rowx, col=colx, cell_value=cell.value, cell_format=cell.number_format, format_type=d_fmt)
+                        )
                 else:
                     values.append(str(cell.value))
 


### PR DESCRIPTION
Steps to reproduce:
-------------------
- Have xlrd >= 2.0 and openpyxl 3.1.2
- Using the `base_import` module, import an XLSX file with dates
- Test -> ValueError unconverted data remains: 00:00:00

Cause:
-----
Since xlrd 2.0.0 in (#169245), if we have a date in an XLSX file, we nonetheless
always get a datetime with a time value of 00:00:00 instead of a
date object. This datetime later fails to be converted to a date
because of an "unconverted data remains: 00:00:00" error.

Fix:
---
Use is_datetime() from openpyxl.styles.numbers to check cell.number_format instead of depending on object type.