### PR TITLE
[FIX] point_of_sale: use right numberingSystem 

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_payment.js
+++ b/addons/point_of_sale/static/src/app/models/pos_payment.js
@@ -1,7 +1,8 @@
 import { registry } from "@web/core/registry";
 import { Base } from "./related_models";
+import { serializeDateTime } from "@web/core/l10n/dates";
 import { roundDecimals } from "@web/core/utils/numbers";
-import { getUTCString, uuidv4 } from "@point_of_sale/utils";
+import { uuidv4 } from "@point_of_sale/utils";
 
 const { DateTime } = luxon;
 
@@ -10,7 +11,7 @@ export class PosPayment extends Base {
 
     setup(vals) {
         super.setup(...arguments);
-        this.payment_date = getUTCString(DateTime.now());
+        this.payment_date = serializeDateTime(DateTime.now());
         this.uuid = vals.uuid ? vals.uuid : uuidv4();
         this.amount = vals.amount || 0;
         this.ticket = vals.ticket || "";

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -13,11 +13,11 @@ import { PaymentScreenStatus } from "@point_of_sale/app/screens/payment_screen/p
 import { usePos } from "@point_of_sale/app/store/pos_hook";
 import { Component, useState, onMounted } from "@odoo/owl";
 import { Numpad, enhancedButtons } from "@point_of_sale/app/generic_components/numpad/numpad";
+import { serializeDateTime } from "@web/core/l10n/dates";
 import { floatIsZero } from "@web/core/utils/numbers";
 import { OrderReceipt } from "@point_of_sale/app/screens/receipt_screen/receipt/order_receipt";
 import { ask } from "@point_of_sale/app/store/make_awaitable_dialog";
 import { handleRPCError } from "@point_of_sale/app/errors/error_handlers";
-import { getUTCString } from "@point_of_sale/utils";
 
 export class PaymentScreen extends Component {
     static template = "point_of_sale.PaymentScreen";
@@ -246,7 +246,7 @@ export class PaymentScreen extends Component {
             this.hardwareProxy.openCashbox();
         }
 
-        this.currentOrder.date_order = getUTCString(luxon.DateTime.now());
+        this.currentOrder.date_order = serializeDateTime(luxon.DateTime.now());
         for (const line of this.paymentLines) {
             if (!line.amount === 0) {
                 this.currentOrder.remove_paymentline(line);


### PR DESCRIPTION
Problem:
In POS, when we start an order, the date is created on the client side. If the client's language is set to Arabic, the date will be in Arabic numerals, which causes a crash when adding it to the database.

Steps to reproduce:

- Install the Arabic language.
- Open POS.
- Create an order with any product, select "Card," and Pay.
- A traceback occurs.

opw-4109126

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
