### PR TITLE
[FIX] html_editor: padding of code section hint

### DIFF
--- a/addons/html_editor/static/src/main/font/code_section.scss
+++ b/addons/html_editor/static/src/main/font/code_section.scss
@@ -1,0 +1,13 @@
+$padding-value: map-get($spacers, 2) map-get($spacers, 3);
+
+pre {    
+    padding: $padding-value;
+    border: $border-width solid $border-color;
+    border-radius: $border-radius;
+    background-color: $gray-100;
+    color: $gray-900;
+
+    &.o-we-hint::before {
+        padding: $padding-value;
+    }
+}

--- a/addons/html_editor/static/tests/hint.test.js
+++ b/addons/html_editor/static/tests/hint.test.js
@@ -8,6 +8,7 @@ import {
     setContent,
     setSelection,
 } from "./_helpers/selection";
+import { insertText } from "./_helpers/user_actions";
 
 test("hints are removed when editor is destroyed", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>", {});
@@ -103,4 +104,14 @@ test("temporary hint should not be displayed where there's a permanent one", asy
             <p><br></p>
         `)
     );
+});
+
+test("hint for code section should have the same padding as its text content", async () => {
+    const { el, editor } = await setupEditor("<pre>[]</pre>", {});
+    expect(getContent(el)).toBe(`<pre placeholder="Code" class="o-we-hint">[]</pre>`);
+    const pre = el.firstElementChild;
+    const paddingHint = getComputedStyle(pre, "::before").padding;
+    insertText(editor, "abc");
+    const paddingContent = getComputedStyle(pre).padding;
+    expect(paddingHint).toBe(paddingContent);
 });


### PR DESCRIPTION
This commit adds the styling rules for the code section (present in the web_editor module), and fixes the padding for the hint that is displayed when the code section is empty.

Before this commit, the hint would be displayed on the top left corner of the code section without any padding, which, other than looking bad, does not match the position in which the text is inserted after typing.

Before: 
![image](https://github.com/user-attachments/assets/55ffcb4d-6937-46fc-943a-7fa2425e7036)


After: 
![image](https://github.com/user-attachments/assets/ceeb6e8a-5816-4efa-a24f-cfca73efb24e)

For the reference, this is how it looks like when non-empty: 
![image](https://github.com/user-attachments/assets/b972cb3d-0bfc-4f71-a43b-e064e8958e30)

