### PR TITLE
[FIX] web: Add company_currency_id to session

### DIFF
--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -111,6 +111,7 @@ class Http(models.AbstractModel):
                 ) if session_uid else None,
             },
             "currencies": self.sudo().get_currencies(),
+            "company_currency_id": user.company_id.currency_id.id if session_uid else None,
             'bundle_params': {
                 'lang': request.session.context['lang'],
             },


### PR DESCRIPTION
There are several points where trying to access to company_currency_id on session object, but it is never filled. And it can produce that in some views the currency is not displayed.

Example: On kanban of CRM, the values of the cards is totalized on the top, but the currency is not shown.
![image](https://github.com/user-attachments/assets/7f527367-fd3d-4a19-88c3-a0f6652826e8)

With this changes the company_currency_id is filled, so it will be available when trying to access to it.
![image](https://github.com/user-attachments/assets/579b1782-4e0c-4983-9a02-10e5b5063dd7)

This PR tries to solve the issue https://github.com/odoo/odoo/issues/174408

cc @Tecnativa TT50299

ping @pedrobaeza @victoralmau 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
