### PR TITLE
[FIX] html_editor: press "esc" in new form view dialog

### DIFF
--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -4,7 +4,7 @@ import {
     DYNAMIC_PLACEHOLDER_PLUGINS,
 } from "@html_editor/plugin_sets";
 import { Wysiwyg } from "@html_editor/wysiwyg";
-import { Component, useRef, useState } from "@odoo/owl";
+import { Component, status, useRef, useState } from "@odoo/owl";
 import { localization } from "@web/core/l10n/localization";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
@@ -128,6 +128,9 @@ export class HtmlField extends Component {
     }
 
     async _commitChanges({ urgent }) {
+        if (status(this) === "destroyed") {
+            return;
+        }
         if (this.isDirty) {
             if (this.state.showCodeView) {
                 await this.updateValue(this.codeViewRef.el.value);


### PR DESCRIPTION
The goal of this commit is to prevent the crash that occurs when a form view dialog containing an edited html field is closed.

Why:
====
When a form view dialog containing a new record is opened, the focus will default to the first field that accepts it. Then, when we close the dialog, the useActiveElement hook has the effect of restoring the last focus (the focus on the first field). This has the effect of triggering a ‘blur’ event on the html field we edited. This will then call commitChanges, which uses a mutex. So the code contained in the mutex will be executed after the component is destroyed which causes our crash.

Solution:
========
The functions called in the mutex must be protected by checking that the component is not destroyed.

How to reproduce:
================
- Go to the form view dialog of a new record with a first field containing an input (char, int,...) and an html field. (the focus is on the first field)
- Edit the html field
- Press ‘escape

Before this commit:
    A crash occurs when the form view dialog closes.

After this commit:
    The form view dialog closes correctly.

Task-ID: 4087374


Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
