### PR TITLE
[FIX] base: enable partial matching for contact reference search

### DIFF
--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -406,7 +406,7 @@
             <field name="arch" type="xml">
                 <search string="Search Partner">
                     <field name="name"
-                        filter_domain="['|', '|', ('display_name', 'ilike', self), ('ref', '=', self), ('email', 'ilike', self)]"/>
+                        filter_domain="['|', '|', ('display_name', 'ilike', self), ('ref', 'ilike', self), ('email', 'ilike', self)]"/>
                     <field name="parent_id" domain="[('is_company', '=', True)]" operator="child_of"/>
                     <field name="email" filter_domain="[('email', 'ilike', self)]"/>
                     <field name="phone" filter_domain="['|', ('phone', 'ilike', self), ('mobile', 'ilike', self)]"/>


### PR DESCRIPTION
Problem: When searching for a reference in contacts, the search checks for an exact match. However, the expected behavior is to use `ilike` to allow partial matches.

Steps to reproduce:

- Add a reference to any contact (e.g., crutest).
- In the list of contacts, search for cru.
- No contact will appear.

opw-4133302

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
