### PR TITLE
[FIX] mail: fix chat window header too thin 

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -105,7 +105,11 @@
 </t>
 
 <t t-name="mail.ChatWindow.headerContent">
-    <div t-if="thread" class="o-mail-ChatWindow-threadAvatar my-0" t-attf-class="{{ threadActions.actions.length > 4 ? 'ms-1' : 'ms-3' }} me-1">
+    <div t-if="thread" class="o-mail-ChatWindow-threadAvatar my-0 me-1" t-att-class="{
+        'py-2': threadActions.actions.length lte 3,
+        'ms-1': threadActions.actions.length > 4,
+        'ms-3': threadActions.actions.length lte 4,
+    }">
         <img class="rounded" t-att-src="thread.avatarUrl" alt="Thread Image"/>
     </div>
     <ThreadIcon t-if="thread and thread.channel_type === 'chat' and thread.correspondent" thread="thread"/>


### PR DESCRIPTION
Since [1], chat window headers is too thin when the thread has
less than 3 actions. It occurs because when a thread has more
than 3 action, they are grouped in a dropdown which increases
the height of the header. When this is not the case, the header
is too small. This PR fixes this issue.

[1]: https://github.com/odoo/odoo/pull/176802

Before:
![image](https://github.com/user-attachments/assets/7e5016eb-7712-473c-80d3-d0e54a98bad8)

After:
![image](https://github.com/user-attachments/assets/b2b25f9a-5443-48c9-9be8-14ab3ff53171)
