### PR TITLE
[FIX] point_of_sale: disable double-tap zooming

### DIFF
--- a/addons/point_of_sale/static/src/app/pos_app.scss
+++ b/addons/point_of_sale/static/src/app/pos_app.scss
@@ -10,6 +10,7 @@
        -moz-user-select: none;
             user-select: none;
     text-shadow: none;
+    touch-action: manipulation;
 }
 /*  ********* Generic element styling  ********* */
 


### PR DESCRIPTION
Check: https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action#manipulation