### PR TITLE
[FIX] website: active old s_blockquote CSS for old s_quote_carousel

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1634,6 +1634,14 @@ class Website(models.Model):
             is_snippet_used = snippet_used[key]
             if is_snippet_used != snippet_asset.active:
                 snippet_asset.active = is_snippet_used
+                # Handle missing data-snippet attributes
+                if snippet_id == 's_quotes_carousel' and asset_type == 'css' and asset_version in ['000', '001']:
+                    old_blockquote_key = ('s_blockquote', '000', 'css')
+                    if not snippet_used.get(old_blockquote_key):
+                        snippet_used[old_blockquote_key] = True
+                        old_blockquote_asset = snippet_assets.filtered(lambda asset: asset.path == 'website/static/src/snippets/s_blockquote/000.scss')
+                        if old_blockquote_asset and not old_blockquote_asset.active:
+                            old_blockquote_asset.active = True
         self.env['ir.asset'].flush_model()
 
     def _search_build_domain(self, domain, search, fields, extra=None):


### PR DESCRIPTION
When assets are reactivated, `s_blockquote` blocks that are nested inside `s_quote_carousel` blocks are not detected. Because of this their old CSS remains inactive after an upgrade.

This commit reactivates the of `s_blockquote` CSS when an old `s_quote_carousel` CSS is reactivated.

Steps to reproduce:
- In saas-17.4, drop a Quotes carousel block.
- Make sure there is no other Blockquote block.
- Upgrade to master.
- Run the "Disable unused snippets assets" cron.

=> The blockquote's 000.scss was not reactivated.

task-4137572
