### PR TITLE
[FIX] point_of_sale: track order edit not triggering when change to 0

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1303,7 +1303,7 @@ class PosOrderLine(models.Model):
                 if pl[2].get('server_id'):
                     pl[2]['id'] = pl[2]['server_id']
                     del pl[2]['server_id']
-        if self.order_id.config_id.order_edit_tracking and values.get('qty') and values.get('qty') < self.qty:
+        if self.order_id.config_id.order_edit_tracking and values.get('qty') is not None and values.get('qty') < self.qty:
             self.is_edited = True
             body = _("%(product_name)s: Ordered quantity: %(old_qty)s", product_name=self.full_product_name, old_qty=self.qty)
             body += Markup("&rarr;") + str(values.get('qty'))

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -290,6 +290,7 @@
                 <field name="user_id" widget="many2one_avatar_user" readonly="state in ['done', 'invoiced']"/>
                 <field name="amount_total" sum="Amount total" widget="monetary" decoration-bf="1"/>
                 <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-success="state not in ('draft','cancel')"/>
+                <field name="is_edited" readonly="1" optional="hide"/>
             </tree>
         </field>
     </record>

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -256,3 +256,23 @@ registry.category("web_tour.tours").add("BillScreenTour", {
             billScreenQRCode,
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("OrderTrackingTour", {
+    test: true,
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola", true, "2.0"),
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("5"),
+            ProductScreen.selectedOrderlineHas("Coca-Cola", "2.0"),
+            ProductScreen.clickNumpad("⌫"),
+            ProductScreen.clickNumpad("1"),
+            ProductScreen.selectedOrderlineHas("Coca-Cola", "1.0"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+        ].flat(),
+});

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -285,3 +285,10 @@ class TestFrontend(TestPointOfSaleHttpCommon):
         self.pos_config.company_id.point_of_sale_use_ticket_qr_code = True
         self.pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('BillScreenTour')
+
+    def test_12_order_tracking(self):
+        self.pos_config.write({'order_edit_tracking': True})
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('OrderTrackingTour')
+        order1 = self.env['pos.order'].search([('pos_reference', 'ilike', '%-0001')], limit=1, order='id desc')
+        self.assertTrue(order1.is_edited)


### PR DESCRIPTION
Before this commit, when changing a quantity of a line to 0 without deleting the line, the order edit tracking was not triggered due to a wrong condition evaluating to false instead of true because we did not take into account the fact that the qty can be 0. We know check if the quantity is not None instead of checking if it is not a falsy value.

We also add the column is_edited to the pos_order tree view.

task-id: 4137831

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
