### PR TITLE
[FIX] {sale_}stock: update move date on SO delivery date change

### DIFF
--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -65,6 +65,12 @@ class StockMove(models.Model):
     def _get_all_related_sm(self, product):
         return super()._get_all_related_sm(product) | self.filtered(lambda m: m.sale_line_id.product_id == product)
 
+    @api.depends('sale_line_id.scheduled_date')
+    def _compute_date(self):
+        for move in self:
+            date = move.sale_line_id and move.sale_line_id.scheduled_date
+            if date:
+                move.date = date
 
 class StockMoveLine(models.Model):
     _inherit = "stock.move.line"

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -33,7 +33,8 @@ class StockMove(models.Model):
         PROCUREMENT_PRIORITIES, 'Priority', default='0',
         compute="_compute_priority", store=True)
     date = fields.Datetime(
-        'Date Scheduled', default=fields.Datetime.now, index=True, required=True,
+        'Date Scheduled', store=True, compute = '_compute_date',
+        default=fields.Datetime.now, index=True, required=True,
         help="Scheduled date until move is done, then date of actual move processing")
     date_deadline = fields.Datetime(
         "Deadline", readonly=True, copy=False,
@@ -187,6 +188,11 @@ class StockMove(models.Model):
     show_quant = fields.Boolean("Show Quant", compute="_compute_show_info")
     show_lots_m2o = fields.Boolean("Show lot_id", compute="_compute_show_info")
     show_lots_text = fields.Boolean("Show lot_name", compute="_compute_show_info")
+
+    @api.depends()
+    def _compute_date(self):
+        # for overloading in descendant models
+        pass
 
     @api.depends('product_id')
     def _compute_product_uom(self):


### PR DESCRIPTION
Steps
---
* install stock,sale_management
* create a product P: Storable, *Manufacturing* Route
* create a bom and a 0,0 reordering rule for it
* make an SO for 1 P: delivery date = tomorrow (*Other Info* tab)
* save => the rr's forecast is 0 and nothing should be replenished
* change the so delivery date to today > save * => nothing changes

Fix
---
make moves date depend on the so delivery date when relevant

opw-4116911
