### PR TITLE
[FIX] account: Fix reconcile changes when code changes

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -438,7 +438,11 @@ class AccountAccount(models.Model):
     @api.depends('account_type')
     def _compute_reconcile(self):
         for account in self:
-            account.reconcile = account.account_type in ('asset_receivable', 'liability_payable')
+            if account.internal_group in ('income', 'expense', 'equity'):
+                account.reconcile = False
+            elif account.account_type in ('asset_receivable', 'liability_payable'):
+                account.reconcile = True
+            # For other asset/liability accounts, don't do any change to account.reconcile.
 
     def _set_opening_debit(self):
         for record in self:

--- a/addons/account/tests/test_account_account.py
+++ b/addons/account/tests/test_account_account.py
@@ -175,7 +175,7 @@ class TestAccountAccount(AccountTestInvoicingCommon):
         self.assertEqual(account.name, "Existing Account")
 
     def test_compute_account_type(self):
-        existing_account = self.env['account.account'].search([], limit=1)
+        existing_account = self.company_data['default_account_revenue']
         # account_type should be computed
         new_account_code = self.env['account.account']._search_new_account_code(
             company=existing_account.company_id,


### PR DESCRIPTION
Steps to reproduce:
- Open the 'Outstanding Receipts' account on any DB
- Change its code
- Notice how `reconcile` changes to False.

Analysis:
- Since #94171 (merged in 15.5), there is a dependency chain `code` -> `account_type` -> `reconcile`.
- As such, changing the code will cause `reconcile` to be recomputed even if the account type was not changed.
- Because the Outstanding Receipts has account type `asset_current`, it's changed back to `reconcile=False` any time `code` is changed.

Solution:
- We don't change `reconcile` if the account_type is an asset or liability type different from `asset_receivable` or `liability_payable`.

taskid: 4137941