### PR TITLE
[FIX] web, web_editor: use /link in mass_mailing

### DIFF
--- a/addons/web/static/src/core/ensure_jquery.js
+++ b/addons/web/static/src/core/ensure_jquery.js
@@ -4,7 +4,7 @@ export async function ensureJQuery() {
     if (!window.jQuery) {
         await loadBundle("web._assets_jquery");
         // allow to instantiate Bootstrap classes via jQuery: e.g. $(...).dropdown
-        const BTS_CLASSES = ["Carousel", "Dropdown", "Modal", "Popover", "Tooltip"];
+        const BTS_CLASSES = ["Carousel", "Dropdown", "Modal", "Popover", "Tooltip", "Collapse"];
         const $ = window.jQuery;
         for (const CLS of BTS_CLASSES) {
             const plugin = window[CLS];


### PR DESCRIPTION
Before this commit, in the massmailing editor, when you enter ‘/link’ a crash occurs.

Why:
====
Since the PR odoo/odoo#174213, we lazy load jquery in the massmailing editor using the ensureJQuery function. This loads jquery and binds all jQueryInterfaces. The Collapse plugin is used in the web_editor's LinkDialog.

Solution:
========
Added the ‘Collapse’ plugin to the list of plugins that ensureJQuery must bind.

How to reproduce:
=================
- Go to the massmailing editor
- Type '/link'
- Select the ‘Link’ command

Before this commit:
    A crash is displayed

After this commit:
    The link configuration dialog opens correctly

No test is added because this functional flow may change in v18 and certainly v19. It depends on when the new editor (html_editor) is used in massmailing.

Task-ID: 4134135

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
