### PR TITLE
[FIX] web: x2many discard on a new record

### DIFF
--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -764,7 +764,7 @@ export class Record extends DataPoint {
                     staticList = this._createStaticListDatapoint(data, fieldName);
                 }
                 if (valueIsCommandList) {
-                    staticList._applyCommands(value);
+                    staticList._applyInitialCommands(value);
                 }
                 parsedValues[fieldName] = staticList;
             } else {


### PR DESCRIPTION
- Have an one2may or a many2many on a setting (with some data in them);
- Edit/toggle any setting;
- Click on an action button or navigate to another view;
- On the "Unsaved changes" dialog, select "Discard".

Before this commit, the `discard` function of the relational model,
didn't take into account the initial commands, and replace the x2many
with an empty list of commands.
The issue is that the settings need to be saved (after discarding the
changes) when leaving, throws an action's button. This is done, to
create a res_id, that is most of the time mandatory to perform the
action (see [1])
 So if the `discard` function, empty the x2many, the setting will be
 modified, and the x2many will be emptied.

Now, the `discard` function of the relational model take into account
the x2many initial commands, therefore the x2many setting will stay
unchanged.

[1] : https://github.com/odoo/odoo/commit/9b81ddb993e4d56aba5aae637d160522d3af1d30

opw-4050990
opw-4092267
opw-4100926

Co-authored-by: Aaron Bohy <aab@odoo.com>