### PR TITLE
[FIX] account: fix JSON-RPC error in account move line

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1401,7 +1401,7 @@ class AccountMoveLine(models.Model):
     # -------------------------------------------------------------------------
     def check_field_access_rights(self, operation, field_names):
         result = super().check_field_access_rights(operation, field_names)
-        if not fields:
+        if not field_names:
             weirdos = ['term_key', 'tax_key', 'compute_all_tax', 'epd_key', 'epd_needed', 'discount_allocation_key', 'discount_allocation_needed']
             result = [fname for fname in result if fname not in weirdos]
         return result


### PR DESCRIPTION
An issue was introduced due to an error in a forward-port.

Original commit:
https://github.com/odoo/odoo/commit/69c19f3caf1c5fa776e23a17290fea293b84a18e

Problematic forward-port commit:
https://github.com/odoo/odoo/commit/602b3f3d39db29fbcd90e3f734bdcc73e67f175d

Steps to reproduce:
In versions 17.0 to 17.4, execute the following
request (adjust the parameters accordingly):
```
curl -X POST <DB_URL>/jsonrpc \
     -H "Content-Type: application/json" \
     -d '{
           "jsonrpc": "2.0",
           "method": "call",
           "params": {
               "service": "object",
               "method": "execute",
               "args": [
                   <DB NAME>,
                   <UID>,
                   <PASSWORD>,
                   "account.move.line",
                   "search_read",
                   [],
                   {}
               ]
           },
           "id": 2
         }
```

The error "keys must be str, int, float, bool or None, not frozendict" will occur.

Solution:
The fix involves renaming the field to align with the approach used in the original commit.
