### PR TITLE
[FIX] web: fix cropping issue in x2many fields pager

### DIFF
--- a/addons/web/static/src/views/fields/x2many/x2many_field.xml
+++ b/addons/web/static/src/views/fields/x2many/x2many_field.xml
@@ -3,7 +3,7 @@
 
     <t t-name="web.X2ManyField">
         <div t-att-class="className">
-            <div class="o_x2m_control_panel d-empty-none mt-1">
+            <div class="o_x2m_control_panel d-empty-none mt-1 mb-4">
                 <t t-if="displayControlPanelButtons">
                     <div class="o_cp_buttons gap-1" role="toolbar" aria-label="Control panel buttons" t-ref="buttons">
                         <t t-foreach="creates" t-as="create" t-key="create_index">


### PR DESCRIPTION
**Version:** Master

**Steps to Reproduce:**

1. Go to the models.
2. Open any model with more than 40 fields.
3. [See the issue here.](https://media.discordapp.net/attachments/1253578221186973736/1277558371007987803/image.png?ex=66ce4333&is=66ccf1b3&hm=ac6100acbb93ac03d88c10214042a6eed4f4dfb6e0945bdd00e8af0a6d9daa91&=&format=webp&quality=lossless&width=926&height=605)

**Issue:**
The page in x2many fields looks cropped.

**Cause:**
The `mb-4` margin-bottom property introduced in [this PR](https://github.com/odoo/odoo/pull/174856).

**Solution:**
Reapply the `mb-4` property.