### PR TITLE
[FIX] l10n_es_edi_sii: avoid traceback when same bill reference

### DIFF
--- a/addons/l10n_es_edi_sii/models/account_edi_format.py
+++ b/addons/l10n_es_edi_sii/models/account_edi_format.py
@@ -549,8 +549,11 @@ class AccountEdiFormat(models.Model):
                         if partner_info.get('NIF') and partner_info['NIF'] == respl_partner_info.NIF:
                             inv = candidate
                             break
-                        if partner_info.get('IDOtro') and all(getattr(respl_partner_info.IDOtro, k) == v
-                                                              for k, v in partner_info['IDOtro'].items()):
+                        if (
+                            partner_info.get('IDOtro')
+                            and respl_partner_info['IDOtro']
+                            and all(respl_partner_info['IDOtro'][k] == v for k, v in partner_info['IDOtro'].items())
+                        ):
                             inv = candidate
                             break
 


### PR DESCRIPTION
If we have two bills with the same bill ref and two different partner, one with NIF and the other without it, the schedule action to process SII response might fail since the code expect a NIF in the SII response when there is not (bill with partner without NIF).

Technical example:
```py
>>> partner_info # Candidate invoice in odoo
{'IDOtro': {'ID': 'NO_DISPONIBLE', 'IDType': '06', 'CodigoPais': 'ES'}}
>>> respl_partner_info # SII response
{'NIF': '12345678K', 'IDOtro': None}
```
This causes a rollback and no bills at all are processed in Odoo's side.

Steps to reproduce:
1/ Create a l10n_es company with l10n_es_edi_sii in test mode
2/ Create a bill with a bill reference 10001, some lines (ex: negative lines)
     that will trigger an error from SII and a partner with a NIF
3/ Copy the partner and remove the NIF
4/ Copy the first bill, keep the same bill reference and change the partner to
     copied one
5/ Post both bills
6/ Trigger the schedule action "EDI : Perform web services operations" => Traceback with
ValueError: <class 'AttributeError'>: "'NoneType' object has no attribute 'ID'" while evaluating

Now, a default value is set when the key is not found in respl_partner_info.IDOtro .

opw-4102638
