### PR TITLE
[FIX] account, account_payment, portal: improve installments portal view

### DIFF
--- a/addons/account/controllers/portal.py
+++ b/addons/account/controllers/portal.py
@@ -37,9 +37,12 @@ class PortalAccount(CustomerPortal):
         return overdue_invoice_count
 
     def _invoice_get_page_view_values(self, invoice, access_token, **kwargs):
+        custom_amount = None
+        if kwargs.get('amount'):
+            custom_amount = float(kwargs['amount'])
         values = {
             'page_name': 'invoice',
-            **invoice._get_invoice_portal_extra_values(),
+            **invoice._get_invoice_portal_extra_values(custom_amount=custom_amount),
         }
         return self._get_page_view_values(invoice, access_token, values, 'my_invoices_history', False, **kwargs)
 

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5094,42 +5094,95 @@ class AccountMove(models.Model):
         term_lines = self.line_ids.filtered(lambda l: l.display_type == 'payment_term')
         return term_lines._get_installments_data()
 
-    def get_next_installment_due(self):
+    def _get_invoice_next_payment_values(self, custom_amount=None):
         self.ensure_one()
-        return next((x for x in self._get_installments_data() if not x['reconciled']), None)
+        if self.currency_id.is_zero(self.amount_residual):
+            payment_state = 'fully_paid'
+        elif self.currency_id.is_zero(self.amount_total - self.amount_residual):
+            payment_state = 'not_paid'
+        else:
+            payment_state = 'partially_paid'
 
-    def get_amount_overdue(self):
-        self.ensure_one()
-        return sum(
-            x['amount_residual_currency_unsigned']
-            for x in self._get_installments_data()
-            if x['type'] == 'overdue'
-        )
+        term_lines = self.line_ids.filtered(lambda line: line.display_type == 'payment_term')
+        installments = term_lines._get_installments_data()
+        not_reconciled_installments = [x for x in installments if not x['reconciled']]
+        overdue_installments = [x for x in not_reconciled_installments if x['type'] == 'overdue']
+        # Early payment discounts can only have one installment at most
+        epd_installment = next((installment for installment in installments if installment['type'] == 'early_payment_discount'), {})
+        show_installments = len(installments) > 1
+        additional_info = {}
 
-    def _get_invoice_portal_extra_values(self):
+        if show_installments and overdue_installments:
+            installment_state = 'overdue'
+            amount_due = self.amount_residual
+            next_amount_to_pay = sum(x['amount_residual_currency_unsigned'] for x in overdue_installments)
+            next_payment_reference = f"{self.name}-{overdue_installments[0]['number']}"
+            next_due_date = overdue_installments[0]['date_maturity']
+        elif show_installments and not_reconciled_installments:
+            installment_state = 'next'
+            amount_due = self.amount_residual
+            next_amount_to_pay = not_reconciled_installments[0]['amount_residual_currency_unsigned']
+            next_payment_reference = f"{self.name}-{not_reconciled_installments[0]['number']}"
+            next_due_date = not_reconciled_installments[0]['date_maturity']
+        elif epd_installment:
+            installment_state = 'epd'
+            amount_due = epd_installment['amount_residual_currency_unsigned']
+            next_amount_to_pay = self.amount_residual
+            next_payment_reference = self.name
+            next_due_date = epd_installment['date_maturity']
+            discount_date = epd_installment['line'].discount_date
+            discount_amount_currency = epd_installment['discount_amount_currency']
+            days_left = (discount_date - fields.Date.context_today(self)).days  # should never be lower than 0 since epd is valid
+            discount_msg = _(
+                "Discount of %(amount)s if paid %(when)s",
+                amount=self.currency_id.format(discount_amount_currency),
+                when=_("within %(days)s days", days=days_left) if days_left > 0 else _("today"),
+            )
+
+            additional_info.update({
+                'epd_discount_amount_currency': discount_amount_currency,
+                'epd_discount_amount': epd_installment['discount_amount'],
+                'discount_date': fields.Date.to_string(discount_date),
+                'epd_days_left': days_left,
+                'epd_line': epd_installment['line'],
+                'epd_discount_msg': discount_msg,
+            })
+        else:
+            installment_state = None
+            amount_due = self.amount_residual
+            next_amount_to_pay = self.amount_residual
+            next_payment_reference = self.name
+            next_due_date = self.invoice_date_due
+
+        if custom_amount is not None:
+            is_custom_amount_same_as_next_amount = self.currency_id.is_zero(custom_amount - next_amount_to_pay)
+            is_custom_amount_same_as_epd_discounted_amount = installment_state == 'epd' and self.currency_id.is_zero(custom_amount - amount_due)
+            if not is_custom_amount_same_as_next_amount and not is_custom_amount_same_as_epd_discounted_amount:
+                installment_state = 'next'
+                next_amount_to_pay = custom_amount
+                next_payment_reference = self.name
+                next_due_date = installments[0]['date_maturity']
+
+        return {
+            'payment_state': payment_state,
+            'installment_state': installment_state,
+            'next_amount_to_pay': next_amount_to_pay,
+            'next_payment_reference': next_payment_reference,
+            'amount_paid': self.amount_total - self.amount_residual,
+            'amount_due': amount_due,
+            'next_due_date': next_due_date,
+            'due_date': self.invoice_date_due,
+            'not_reconciled_installments': not_reconciled_installments,
+            'is_last_installment': len(not_reconciled_installments) == 1,
+            **additional_info,
+        }
+
+    def _get_invoice_portal_extra_values(self, custom_amount=None):
         self.ensure_one()
-        installment = self.get_next_installment_due()
-        amount_overdue = self.get_amount_overdue()
-        show_payment_info = (
-            self.payment_state not in ('paid', 'in_payment', 'reversed') and self.move_type == 'out_invoice'
-        )
-        show_amount_overdue = show_payment_info and amount_overdue and amount_overdue != self.amount_residual
-        show_installment = (
-            show_payment_info
-            and installment
-            and installment['type'] != 'early_payment_discount'
-            and installment['amount_residual_currency_unsigned'] != self.amount_residual
-        )
         return {
             'invoice': self,
-            'amount_paid': self.amount_total - self.amount_residual,
-            'amount_due': self.amount_residual,
-            'show_installment': show_installment or show_amount_overdue,
-            'show_payment_info': show_payment_info,
-            'amount_next_installment': installment['amount_residual_currency_unsigned'] if show_installment else 0.0,
-            'date_next_installment': installment['date_maturity'] if show_installment else None,
-            'name_next_installment': f"{self.name}-{installment['number']}" if show_installment else "",
-            'amount_overdue': amount_overdue if show_amount_overdue else 0.0,
+            'currency': self.currency_id,
+            **self._get_invoice_next_payment_values(custom_amount=custom_amount),
         }
 
     def _get_accounting_date(self, invoice_date, has_tax, lock_dates=None):

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -3185,6 +3185,8 @@ class AccountMoveLine(models.Model):
                     'amount_residual': line.discount_balance,
                     'amount_residual_currency_unsigned': -sign * line.discount_amount_currency,
                     'amount_residual_unsigned': -sign * line.discount_balance,
+                    'discount_amount_currency': line.amount_currency - line.discount_amount_currency,
+                    'discount_amount': line.balance - line.discount_balance,
                     'type': 'early_payment_discount',
                 })
                 continue

--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -1644,7 +1644,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             'payment_difference': 1036.0,
             'installments_mode': 'full',
             'installments_switch_amount': 115.0,
-            'communication': Like(f'BATCH/{self.current_year}/...'),
+            'communication': invoice.name,
         }])
 
         # Case when at date of the first installment.
@@ -1664,7 +1664,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             'payment_difference': 1034.0,
             'installments_mode': 'full',
             'installments_switch_amount': 115.0,
-            'communication': Like(f'BATCH/{self.current_year}/...'),
+            'communication': invoice.name,
         }])
 
         # First installment is overdue.
@@ -1684,7 +1684,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             'payment_difference': 0.0,
             'installments_mode': 'overdue',
             'installments_switch_amount': 1150.0,
-            'communication': Like(f'BATCH/{self.current_year}/...'),
+            'communication': invoice.name,
         }])
 
         # Third installment is overdue.
@@ -1694,5 +1694,5 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             'payment_difference': 0.0,
             'installments_mode': 'full',
             'installments_switch_amount': 0.0,
-            'communication': Like(f'BATCH/{self.current_year}/...'),
+            'communication': invoice.name,
         }])

--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -117,32 +117,40 @@
                 <t t-call="portal.portal_record_sidebar">
                     <t t-set="classes" t-value="'col-lg-4 col-xxl-3 d-print-none'"/>
                     <t t-set="title">
-                        <h2 class="mb-0 text-break">
+                        <h2 class="mb-0 text-break mx-auto">
                             <span t-field="invoice.amount_total"/>
                         </h2>
-                        <div class="small" t-if="show_payment_info">
-                            <i class="fa fa-clock-o"/><span class="o_portal_sidebar_timeago ml4" t-att-datetime="invoice.invoice_date_due"/>
-                        </div>
-                        <div class="my-3 w-100">
-                            <div class="alert alert-success w-100 px-2 py-1 text-center" t-if="amount_paid">
-                                Amount Paid: <span t-out="amount_paid" t-options="{'widget': 'monetary', 'display_currency': invoice.currency_id}"/>
+                        <div class="my-1 w-100" t-if="payment_state in ('not_paid', 'partially_paid')">
+                            <div class="alert alert-success px-2 py-1 text-center mb-2" t-if="payment_state == 'partially_paid'">
+                                Already Paid: <span t-out="amount_paid" t-options="{'widget': 'monetary', 'display_currency': currency}"/>
                             </div>
-                            <div class="alert alert-warning w-100 px-2 py-1 text-center" t-if="amount_due">
-                                Amount Due: <span t-out="amount_due" t-options="{'widget': 'monetary', 'display_currency': invoice.currency_id}"/>
+                            <div t-if="payment_state == 'partially_paid'" class="alert alert-warning px-2 py-1 text-center mb-2">
+                                Left to pay:
+                                <span t-out="amount_due" t-options="{'widget': 'monetary', 'display_currency': currency}"/>
+                                <div t-if="installment_state and is_last_installment" class="w-100 mt-2">
+                                    <i class="fa fa-clock-o"/>
+                                    <span class="o_portal_sidebar_timeago" t-att-datetime="due_date"/>
+                                </div>
+                            </div>
+                            <div t-if="installment_state == 'epd' and epd_discount_amount_currency" class="alert alert-warning px-2 py-1 text-center mb-2">
+                                <t t-out="epd_discount_msg"/>
                             </div>
                         </div>
-                        <h4 name="installment_title" class="w-100" t-if="show_installment">
-                            Installment
-                        </h4>
-                        <h3
-                            name="installment_amount"
-                            class="mb-0 text-break"
-                            t-if="show_installment"
-                            t-out="amount_overdue or amount_next_installment"
-                            t-options="{'widget': 'monetary', 'display_currency': invoice.currency_id}"
-                        />
-                        <div name="installment_due_date" class="small" t-if="show_installment">
-                            <i class="fa fa-clock-o"/><span class="o_portal_sidebar_timeago ml4" t-att-datetime="date_next_installment or invoice.invoice_date_due"/>
+                        <t t-if="installment_state in ('next', 'overdue') and not is_last_installment and amount_due != 0.0">
+                            <h5 name="installment_title" class="w-100 text-center mb-0">
+                                <t t-if="installment_state == 'next'">Next Installment</t>
+                                <t t-elif="installment_state == 'overdue'">Overdue</t>
+                            </h5>
+                            <h4
+                                name="installment_amount"
+                                class="mb-0 text-break w-100 text-center"
+                                t-out="next_amount_to_pay"
+                                t-options="{'widget': 'monetary', 'display_currency': currency}"
+                            />
+                        </t>
+                        <div class="small w-100 text-center" t-if="payment_state in ('not_paid', 'partially_paid') and not (is_last_installment and installment_state)">
+                            <i class="fa fa-clock-o"/>
+                            <span class="o_portal_sidebar_timeago ml4" t-att-datetime="next_due_date"/>
                         </div>
                     </t>
 

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -174,9 +174,9 @@ class AccountPaymentRegister(models.TransientModel):
         :param lines:           A recordset of the `account.move.line`'s that will be reconciled.
         :return:                A string representing a communication to be set on payment.
         '''
-        if len(lines) == 1:
-            line = lines[0]
-            label = line.name or line.move_id.ref or line.move_id.name
+        if len(lines.move_id) == 1:
+            move = lines.move_id
+            label = (len(lines) == 1 and lines.name) or move.ref or move.name
         else:
             label = self.company_id.get_next_batch_payment_communication()
         return label

--- a/addons/account/wizard/account_payment_register_views.xml
+++ b/addons/account/wizard/account_payment_register_views.xml
@@ -39,7 +39,7 @@
                     <field name="missing_account_partners" invisible="1"/>
 
                     <div role="alert" class="alert alert-info" invisible="not hide_writeoff_section">
-                        <p><b>Early Payment Discount of <field name="payment_difference"/> has been applied.</b></p>
+                        <p class="m-0"><b>Early Payment Discount of <field name="payment_difference"/> has been applied.</b></p>
                     </div>
                     <div role="alert" class="alert alert-warning" invisible="untrusted_payments_count == 0">
                         <span class="fw-bold"><field name="untrusted_payments_count" class="oe_inline"/> out of <field name="total_payments_amount" class="oe_inline"/> payments will be skipped due to <button class="oe_link p-0 align-baseline" type="object" name="action_open_untrusted_bank_accounts">untrusted bank accounts</button>.</span>

--- a/addons/account_payment/controllers/portal.py
+++ b/addons/account_payment/controllers/portal.py
@@ -23,32 +23,30 @@ class PortalAccount(portal.PortalAccount, PaymentPortal):
                 'payment': payment,  # We want to show the dialog even when everything has been paid (with a custom message)
             }
 
+        epd = values.get('epd_discount_amount_currency', 0.0)
+        discounted_amount = invoice.amount_residual - epd
+
         common_view_values = self._get_common_page_view_values(
             invoices_data={
                 'partner': invoice.partner_id,
                 'company': invoice.company_id,
                 'total_amount': invoice.amount_total,
                 'currency': invoice.currency_id,
-                'amount_residual': invoice.amount_residual,
+                'amount_residual': discounted_amount,
                 'landing_route': invoice.get_portal_url(),
                 'transaction_route': f'/invoice/transaction/{invoice.id}',
             },
             access_token=access_token,
             **kwargs)
-        installment = invoice.get_next_installment_due()
-        next_installment = (
-            installment
-            and installment['type'] != 'early_payment_discount'
-            and installment['amount_residual_currency_unsigned'] != invoice.amount_residual
-        )
+
+        amount_custom = float(kwargs['amount']) if kwargs.get('amount') else 0.0
         values |= {
             **common_view_values,
-            'amount_custom': float(kwargs['amount']) if kwargs.get('amount') else 0.0,
-            'amount_next_installment': installment['amount_residual_currency_unsigned'] if next_installment else 0.0,
+            'amount_custom': amount_custom,
             'payment': payment,
             'invoice_id': invoice.id,
             'invoice_name': invoice.name,
-            'invoice_name_installment': f"{invoice.name}-{installment['number']}" if next_installment else "",
+            'show_epd': epd,
         }
         return values
 
@@ -149,7 +147,6 @@ class PortalAccount(portal.PortalAccount, PaymentPortal):
             ),
         }
         payment_context = {
-            'amount': invoices_data['amount_residual'],
             'currency': invoices_data['currency'],
             'partner_id': partner_sudo.id,
             'providers_sudo': providers_sudo,
@@ -172,4 +169,4 @@ class PortalAccount(portal.PortalAccount, PaymentPortal):
         # If we have a custom payment amount, make sure it hasn't been tampered with
         if amount and not payment_utils.check_access_token(payment_token, invoice_id, amount):
             return request.redirect('/my')
-        return super().portal_my_invoice_detail(invoice_id, **kw)
+        return super().portal_my_invoice_detail(invoice_id, amount=amount, **kw)

--- a/addons/account_payment/static/src/js/payment_form.js
+++ b/addons/account_payment/static/src/js/payment_form.js
@@ -19,40 +19,13 @@ PaymentForm.include({
         const chosenPaymentDetails = paymentDialog
             ? paymentDialog.querySelector(".o_btn_payment_tab.active")
             : null;
-        if (chosenPaymentDetails && chosenPaymentDetails.id === "o_payment_installments_tab") {
-            this.paymentContext.payNextInstallment = true;
-        }
-        await this._super(...arguments);
-    },
-
-    /**
-     * Add installment specific params for the RPC to the transaction route.
-     *
-     * @override method from payment.payment_form
-     * @private
-     * @returns {Object} The transaction route params.
-     */
-    _prepareTransactionRouteParams() {
-        const transactionRouteParams = this._super(...arguments);
-
-        const amountCustom =
-            this.paymentContext.amountCustom && parseFloat(this.paymentContext.amountCustom);
-        const amountOverdue =
-            this.paymentContext.amountOverdue && parseFloat(this.paymentContext.amountOverdue);
-        const amountNextInstallment =
-            this.paymentContext.amountNextInstallment &&
-            parseFloat(this.paymentContext.amountNextInstallment);
-
-        if (this.paymentContext.payNextInstallment) {
-            transactionRouteParams.amount = amountCustom || amountOverdue || amountNextInstallment;
-            if (!amountCustom && !amountOverdue) {
-                transactionRouteParams.name_next_installment =
-                    this.paymentContext.nameNextInstallment;
+        if (chosenPaymentDetails){
+            if (chosenPaymentDetails.id === "o_payment_installments_tab") {
+                this.paymentContext.amount = parseFloat(this.paymentContext.invoiceNextAmountToPay);
+            } else {
+                this.paymentContext.amount = parseFloat(this.paymentContext.invoiceAmountDue);
             }
         }
-
-        transactionRouteParams.payment_reference = this.paymentContext.paymentReference;
-
-        return transactionRouteParams;
+        await this._super(...arguments);
     },
 });

--- a/addons/account_payment/static/src/js/portal_my_invoices_payment.js
+++ b/addons/account_payment/static/src/js/portal_my_invoices_payment.js
@@ -18,7 +18,7 @@ publicWidget.registry.PortalMyInvoicesPaymentList = publicWidget.Widget.extend({
         const dueDateLabels = this.el.querySelectorAll(".o_portal_invoice_due_date");
         const today = DateTime.now().startOf("day");
         dueDateLabels.forEach((label) => {
-            const dateTime = deserializeDateTime(label.getAttribute("datetime"));
+            const dateTime = deserializeDateTime(label.getAttribute("datetime")).startOf('day');
             const diff = dateTime.diff(today).as("days");
 
             let dueDateLabel = "";

--- a/addons/account_payment/views/account_portal_templates.xml
+++ b/addons/account_payment/views/account_portal_templates.xml
@@ -82,17 +82,17 @@
         <xpath expr="//t[@t-foreach='invoices']/tr/td[last()]" position="after">
             <td class="d-none d-lg-table-cell text-center">
                 <span
-                    t-if="invoice_data['show_installment']"
-                    t-attf-class="{{'text-danger' if invoice_data['amount_overdue'] else ''}}"
-                    t-out="invoice_data['amount_overdue'] or invoice_data['amount_next_installment']"
+                    t-if="invoice_data['installment_state'] in ('next', 'overdue')"
+                    t-attf-class="{{'text-danger' if invoice_data['installment_state'] == 'overdue' else ''}}"
+                    t-out="invoice_data['next_amount_to_pay']"
                     t-options="{'widget': 'monetary', 'display_currency': invoice.currency_id}"
                 />
                 <small
-                    t-if="invoice_data['show_installment'] and not invoice_data['amount_overdue']"
+                    t-if="invoice_data['installment_state'] == 'next'"
                     class="o_portal_invoice_due_date"
-                    t-att-datetime="invoice_data['date_next_installment']"
+                    t-att-datetime="invoice_data['next_due_date']"
                 />
-                <small t-if="invoice_data['amount_overdue']" class="text-danger">
+                <small t-if="invoice_data['installment_state'] == 'overdue'" class="text-danger">
                     overdue
                 </small>
             </td>
@@ -141,7 +141,7 @@
                             <div t-if="company_mismatch">
                                 <t t-call="payment.company_mismatch_warning"/>
                             </div>
-                            <div t-elif="amount_custom or amount_overdue or amount_next_installment" id="o_payment_installments_modal">
+                            <div t-elif="installment_state in ('next', 'overdue') and amount_due != next_amount_to_pay" id="o_payment_installments_modal">
                                 <div class="btn-group w-100" id="o_payment_tabs" role="tablist">
                                     <button class="btn btn-outline-primary o_btn_payment_tab active"
                                         id="o_payment_installments_tab"
@@ -155,7 +155,7 @@
                                         <strong>Installment</strong>
                                         <br/>
                                         <t
-                                            t-out="amount_custom or amount_overdue or amount_next_installment"
+                                            t-out="next_amount_to_pay"
                                             t-options="{'widget': 'monetary', 'display_currency': currency}"
                                         />
                                     </button>
@@ -169,7 +169,7 @@
                                         aria-selected="false"
                                     >
                                         <strong>Full Amount</strong><br/>
-                                        <t t-out="amount" t-options="{'widget': 'monetary', 'display_currency': currency}"/>
+                                        <t t-out="amount_due" t-options="{'widget': 'monetary', 'display_currency': currency}"/>
                                     </button>
                                 </div>
                                 <div class="tab-content" id="o_payment_tabcontent">
@@ -184,7 +184,7 @@
                                             <t t-call="payment.summary_item">
                                                 <t t-set="name" t-value="'amount_installment'"/>
                                                 <t t-set="label">Amount</t>
-                                                <t t-set="value" t-value="amount_custom or amount_overdue or amount_next_installment"/>
+                                                <t t-set="value" t-value="next_amount_to_pay"/>
                                                 <t t-set="options"
                                                     t-value="{'widget': 'monetary', 'display_currency': currency}"
                                                 />
@@ -192,7 +192,7 @@
                                             <t t-call="payment.summary_item">
                                                 <t t-set="name" t-value="'reference_installment'"/>
                                                 <t t-set="label">Reference</t>
-                                                <t t-set="value" t-value="invoice_name if amount_custom or amount_overdue else invoice_name_installment"/>
+                                                <t t-set="value" t-value="next_payment_reference"/>
                                                 <t t-set="include_separator" t-value="True"/>
                                             </t>
                                         </div>
@@ -203,11 +203,14 @@
                                         aria-labelledby="o_payment_full_tab"
                                         tabindex="0"
                                     >
+                                        <div t-if="show_epd" class="alert alert-success">
+                                            Early Payment Discount of <span t-out="epd_discount_amount_currency" t-options="{'widget': 'monetary', 'display_currency': currency}"/> has been applied.
+                                        </div>
                                         <div class="text-bg-light row row-cols-1 row-cols-md-2 mx-0 py-2 rounded">
                                             <t t-call="payment.summary_item">
                                                 <t t-set="name" t-value="'amount_full'"/>
                                                 <t t-set="label">Amount</t>
-                                                <t t-set="value" t-value="amount"/>
+                                                <t t-set="value" t-value="amount_due"/>
                                                 <t t-set="options"
                                                     t-value="{'widget': 'monetary', 'display_currency': currency}"
                                                 />
@@ -215,20 +218,24 @@
                                             <t t-call="payment.summary_item">
                                                 <t t-set="name" t-value="'reference_full'"/>
                                                 <t t-set="label">Reference</t>
-                                                <t t-set="value" t-value="invoice_name"/>
+                                                <t t-set="value" t-value="next_payment_reference"/>
                                                 <t t-set="include_separator" t-value="True"/>
                                             </t>
                                         </div>
                                     </div>
+                                    <!-- the 'amount' is set js-side depending the active tab -->
                                     <t t-call="account_payment.form"/>
                                 </div>
                             </div>
-                            <t t-elif="amount > 0">
+                            <t t-else="">
+                                <div t-if="show_epd" class="alert alert-success">
+                                    Early Payment Discount of <span t-out="epd_discount_amount_currency" t-options="{'widget': 'monetary', 'display_currency': currency}"/> has been applied.
+                                </div>
                                 <div class="text-bg-light row row-cols-1 row-cols-md-2 mx-0 mb-3 py-2 rounded">
                                     <t t-call="payment.summary_item">
                                         <t t-set="name" t-value="'amount_full'"/>
                                         <t t-set="label">Amount</t>
-                                        <t t-set="value" t-value="amount"/>
+                                        <t t-set="value" t-value="amount_due"/>
                                         <t t-set="options"
                                             t-value="{'widget': 'monetary', 'display_currency': currency}"
                                         />
@@ -236,11 +243,13 @@
                                     <t t-call="payment.summary_item">
                                         <t t-set="name" t-value="'reference_full'"/>
                                         <t t-set="label">Reference</t>
-                                        <t t-set="value" t-value="invoice_name"/>
+                                        <t t-set="value" t-value="next_payment_reference"/>
                                         <t t-set="include_separator" t-value="True"/>
                                     </t>
                                 </div>
-                                <t t-call="account_payment.form"/>
+                                <t t-call="account_payment.form">
+                                    <t t-set="amount" t-value="amount_due"/>
+                                </t>
                             </t>
                         </div>
                     </div>
@@ -299,10 +308,6 @@
             <div t-else="" id="portal_pay" t-att-data-payment="payment">
                 <t t-call="account_payment.portal_invoice_payment_paid"/>
             </div>
-        </xpath>
-        <xpath expr="//h3[@name='installment_amount']" position="attributes">
-            <attribute name="t-if" separator=" or " add="amount_custom"/>
-            <attribute name="t-out">amount_custom or amount_overdue or amount_next_installment</attribute>
         </xpath>
     </template>
 

--- a/addons/account_payment/views/payment_form_templates.xml
+++ b/addons/account_payment/views/payment_form_templates.xml
@@ -3,10 +3,8 @@
 
     <template id="account_payment.form" inherit_id="payment.form" name="Invoice Payment Form">
         <xpath expr="//form[@id='o_payment_form']" position="attributes">
-            <attribute name="t-att-data-amount-custom">amount_custom</attribute>
-            <attribute name="t-att-data-amount-overdue">amount_overdue</attribute>
-            <attribute name="t-att-data-amount-next-installment">amount_next_installment</attribute>
-            <attribute name="t-att-data-name-next-installment">name_next_installment</attribute>
+            <attribute name="t-att-data-invoice-next-amount-to-pay">next_amount_to_pay</attribute>
+            <attribute name="t-att-data-invoice-amount-due">amount_due</attribute>
             <attribute name="t-att-data-payment-reference">payment_reference</attribute>
         </xpath>
     </template>

--- a/addons/account_payment/wizards/payment_link_wizard_views.xml
+++ b/addons/account_payment/wizards/payment_link_wizard_views.xml
@@ -16,6 +16,14 @@
         <field name="model">payment.link.wizard</field>
         <field name="inherit_id" ref="payment.payment_link_wizard_view_form"/>
         <field name="arch" type="xml">
+
+            <div name="no_partner_email" position="before">
+                <field name="epd_info"
+                       class="alert alert-info fw-bold w-100 mb-3"
+                       role="alert"
+                       invisible="not epd_info"/>
+            </div>
+
             <field name="amount" position="after">
                 <field name="invoice_amount_due" invisible="res_model != 'account.move'"/>
             </field>
@@ -27,7 +35,7 @@
             <group name="payment_info" position="after">
                 <group name="next_installments"
                     string="Next Installments"
-                    invisible="not open_installments"
+                    invisible="not display_open_installments"
                     class="mt-n4"
                 >
                     <field name="open_installments_preview" nolabel="1"/>

--- a/addons/payment/wizards/payment_link_wizard.py
+++ b/addons/payment/wizards/payment_link_wizard.py
@@ -43,7 +43,7 @@ class PaymentLinkWizard(models.TransientModel):
             elif wizard.amount <= 0:
                 wizard.warning_message = _("Please set a positive amount.")
             elif wizard.amount > wizard.amount_max:
-                wizard.warning_message = _("Please set an amount lower than %s.", wizard.amount_max)
+                wizard.warning_message = _("Please set an amount lower than %s.", wizard.currency_id.format(wizard.amount_max))
 
     @api.depends('res_model', 'res_id')
     def _compute_company_id(self):

--- a/addons/payment/wizards/payment_link_wizard_views.xml
+++ b/addons/payment/wizards/payment_link_wizard_views.xml
@@ -6,11 +6,18 @@
         <field name="model">payment.link.wizard</field>
         <field name="arch" type="xml">
             <form string="Generate Payment Link">
-                <div class="alert alert-warning fw-bold"
+                <div name="no_partner_email"
+                     class="alert alert-warning fw-bold"
                      role="alert"
                      invisible="partner_email">
                      This partner has no email, which may cause issues with some payment providers.
                      Setting an email for this partner is advised.
+                </div>
+                <div name="payment_link_warning_information"
+                     class="alert alert-warning fw-bold"
+                     role="alert"
+                     invisible="warning_message == ''">
+                    <field name="warning_message"/>
                 </div>
                 <group>
                     <group name="payment_info" string="Payment Info" class="mt-n4">
@@ -24,12 +31,6 @@
                         <field name="currency_id" invisible="1"/>
                     </group>
                 </group>
-                <div name="payment_link_warning_information"
-                     class="alert alert-warning text-center fw-bold"
-                     role="alert"
-                     invisible="warning_message == ''">
-                    <field name="warning_message"/>
-                </div>
                 <footer>
                     <field name="link"
                            string="Generate and Copy Payment Link"

--- a/addons/portal/static/src/js/portal_sidebar.js
+++ b/addons/portal/static/src/js/portal_sidebar.js
@@ -28,7 +28,7 @@ var PortalSidebar = publicWidget.Widget.extend({
     _setDelayLabel: function () {
         var $sidebarTimeago = this.$el.find('.o_portal_sidebar_timeago').toArray();
         $sidebarTimeago.forEach((el) => {
-            var dateTime = deserializeDateTime($(el).attr('datetime')),
+            var dateTime = deserializeDateTime($(el).attr('datetime')).startOf('day'),
                 today = DateTime.now().startOf('day'),
                 diff = dateTime.diff(today).as("days"),
                 displayStr;


### PR DESCRIPTION
This commit introduces several visual and functional improvements
to the portal view for invoices, particularly focusing on early
payment discounts (EPD).

Key improvements:
- The portal view now clearly indicates when an EPD is available,
  informing users that a discount can be applied if the invoice
  is paid before the maximum discount date.
- The payment process is updated to handle write-offs automatically
  when the EPD is applied.
- The register payment wizard now shows an information message
  if the EPD has been applied, ensuring transparency during the
  payment process.
- Fixes the "memo" field when using installments in the payment
  register wizard, displaying the correct invoice name instead
  of a batch number.
- Payment links generated from invoices now display an information
  message about EPD eligibility, encouraging prompt payments.

These changes build upon recent updates related to installments
and the handling of invoice payments in the portal:
https://github.com/odoo/odoo/commit/3113e7eb6c27c616d2c5cce0d15fc3c1bea12346.

task-4128723


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
