### PR TITLE
[FIX] account: group access

### DIFF
--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -81,8 +81,8 @@
                                                required="type in ('bank', 'cash')"
                                                options="{'no_quick_create': True}"
                                                groups="account.group_account_readonly"/>
-                                        <field name="profit_account_id" invisible="type not in ('cash', 'bank')"/>
-                                        <field name="loss_account_id" invisible="type not in ('cash', 'bank')"/>
+                                        <field name="profit_account_id" invisible="type not in ('cash', 'bank')" groups="account.group_account_readonly"/>
+                                        <field name="loss_account_id" invisible="type not in ('cash', 'bank')" groups="account.group_account_readonly"/>
                                         <field name="refund_sequence" invisible="type not in ['sale', 'purchase']"/>
                                         <field name="payment_sequence" invisible="type not in ('bank', 'cash')"/>
                                         <field name="code" placeholder="e.g. INV"/>

--- a/addons/account/views/account_menuitem.xml
+++ b/addons/account/views/account_menuitem.xml
@@ -38,9 +38,9 @@
             <menuitem id="account_reports_partners_reports_menu" name="Partner Reports" sequence="3"/>
             <menuitem id="account_reports_management_menu" name="Management" sequence="4">
                 <menuitem id="menu_action_account_invoice_report_all" name="Invoice Analysis" action="action_account_invoice_report_all" sequence="1"/>
-                <menuitem id="menu_action_analytic_reporting" name="Analytic Reporting" action="action_analytic_reporting" groups="analytic.group_analytic_accounting"/>
+                <menuitem id="menu_action_analytic_reporting" name="Analytic Reporting" action="action_analytic_reporting" groups="account.group_account_readonly"/>
             </menuitem>
-            <menuitem id="account_reports_legal_statements_menu" name="Statement Reports" sequence="1" groups="account.group_account_basic"/>
+            <menuitem id="account_reports_legal_statements_menu" name="Statement Reports" sequence="1" groups="account.group_account_readonly"/>
         </menuitem>
         <menuitem id="menu_finance_configuration" name="Configuration" sequence="35" groups="account.group_account_manager">
             <menuitem id="menu_account_config" name="Settings" action="action_account_config" groups="base.group_system" sequence="0"/>


### PR DESCRIPTION
The profit & loss accounts fields are visible on bank journals with only `account`/`account_accountant` installed.
add a groups attribute, to remove these fields

remove menus (Analytic Report & Tax Report) that should only be visible to accountants.

Task-4130326