### PR TITLE
[FIX] website_payment: enhance test coverage for donation amounts

### DIFF
--- a/addons/website_payment/__manifest__.py
+++ b/addons/website_payment/__manifest__.py
@@ -29,6 +29,9 @@ This is a bridge module that adds multi-website support for payment acquirers.
             'website_payment/static/src/js/website_payment_donation.js',
             'website_payment/static/src/js/website_payment_form.js',
         ],
+        'web.assets_tests': [
+            'website_payment/static/tests/tours/donation.js',
+        ],
     },
     'license': 'LGPL-3',
 }

--- a/addons/website_payment/static/tests/tours/donation.js
+++ b/addons/website_payment/static/tests/tours/donation.js
@@ -1,0 +1,84 @@
+odoo.define("website_payment.tour.donation_snippet_edition", function (require) {
+    "use strict";
+
+    const tour = require("web_tour.tour");
+    const wTourUtils = require("website.tour_utils");
+
+    tour.register("donation_snippet_edition", {
+        test: true,
+        url: "/?enable_editor=1",
+    }, [
+        wTourUtils.dragNDrop({
+            id: "s_donation",
+            name: "Donation"
+        }),
+        ...wTourUtils.clickOnSave(),
+        // -- Testing the minimum amount --
+        {
+            content: "Enter a negative custom amount, testing the minimum amount",
+            trigger: "#s_donation_amount_input",
+            run: "text -5",
+        },
+        {
+            content: "Donate with custom amount set",
+            trigger: ".s_donation_donate_btn",
+        },
+        {
+            content: "Check if alert-danger element exists",
+            trigger: "p.alert-danger",
+        },
+        // -- End of testing the minimum amount --
+        {
+            content: "Enter a custom amount",
+            trigger: "#s_donation_amount_input",
+            run: "text 55",
+        },
+        {
+            content: "Donate with custom amount set",
+            trigger: ".s_donation_donate_btn",
+        },
+        {
+            content: "Check if custom amount radio input is selected",
+            trigger: "input#other_amount:checked",
+            run: () => {}, // This is a check
+        },
+        {
+            content: "Check if custom amount radio input has value 55",
+            trigger: 'input#other_amount[value="55.0"]',
+            run: () => {}, // This is a check
+        },
+        {
+            content: "Select the amount of 25",
+            trigger: "input#amount_1",
+        },
+        {
+            content: "Verify that amount_1 is checked",
+            trigger: "input#amount_1:checked",
+            run: () => {}, // This is a check
+        },
+        {
+            content: "Verify that other_amount is not checked",
+            trigger: "input#other_amount:not(:checked)",
+            run: () => {}, // This is a check
+        },
+        {
+            content: "Change custom amount to 67",
+            trigger: "input#other_amount_value",
+            run: "text 67",
+        },
+        {
+            content: "Select the custom amount radio button",
+            trigger: "input#other_amount",
+        },
+        {
+            content: "Submit the donation form",
+            trigger: "button[name='o_payment_submit_button']",
+        },
+        {
+            content: "Verify that the amount displayed is 67",
+            trigger: 'span.oe_currency_value:contains("67.00")',
+            run: () => {}, // This is a check
+            timeout: 10000  // Make sure the payment process animation is finished
+        },
+    ]);
+});

--- a/addons/website_payment/tests/__init__.py
+++ b/addons/website_payment/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_snippets

--- a/addons/website_payment/tests/test_snippets.py
+++ b/addons/website_payment/tests/test_snippets.py
@@ -1,0 +1,9 @@
+import odoo
+import odoo.tests
+
+
+@odoo.tests.common.tagged('post_install', '-at_install')
+class TestSnippets(odoo.tests.HttpCase):
+
+    def test_01_donation(self):
+        self.start_tour("/?enable_editor=1", "donation_snippet_edition", login='admin')


### PR DESCRIPTION
This commit improves test coverage for the `website_payment` module by addressing recent updates and scenarios:

- **Minimum Amount**: Verifies that donations below the minimum
  amount are properly handled (PR: [177766](https://github.com/odoo/odoo/pull/177766)).
- **Multiple Amounts**: Ensures that multiple donation amounts cannot
  be selected at once (PR: [176722](https://github.com/odoo/odoo/pull/176722)).
- **Last Amount Selection**: Checks that the last selected amount is
  correctly applied (PR: [176722](https://github.com/odoo/odoo/pull/176722)).

These enhancements ensure that the module's behavior is thoroughly tested and functioning as expected.

During FW to 16.0 we will take in consideration the iframe

task-4138385