### PR TITLE
[FIX] html_editor: apply custom hex color

### DIFF
--- a/addons/html_editor/static/src/main/font/color_selector.xml
+++ b/addons/html_editor/static/src/main/font/color_selector.xml
@@ -10,7 +10,7 @@
                 </t>
             </button>
             <t t-set-slot="content">
-                <div class="o_font_color_selector user-select-none">
+                <div class="o_font_color_selector user-select-none" data-prevent-closing-overlay="true">
                     <div class="mb-1 d-flex">
                         <button class="btn btn-sm btn-light ms-1"
                             t-att-class="{active: state.activeTab === 'solid'}"

--- a/addons/html_editor/static/src/main/font/gradient_picker.xml
+++ b/addons/html_editor/static/src/main/font/gradient_picker.xml
@@ -12,7 +12,7 @@
 
             <div t-if="this.state.type === 'linear'" class="d-flex align-items-center justify-content-between">
                 Angle
-                <span class="d-flex justify-content-between" data-prevent-closing-overlay="true">
+                <span class="d-flex justify-content-between">
                     <input name="angle" type="text" t-att-value="this.state.angle" t-on-change="onAngleChange" style="width: 5ch" />
                     <span class="input-group-text">deg</span>
                 </span>
@@ -20,13 +20,13 @@
             <div t-else="">
                 <div class="d-flex align-items-center justify-content-between">
                     Position X
-                    <span class="d-flex justify-content-between" data-prevent-closing-overlay="true">
+                    <span class="d-flex justify-content-between">
                         <input name="positionX" t-att-value="this.positions['x']" t-on-change="(ev) => this.onPositionChange('x', ev)" class="input" type="text" style="width: 5ch"/>
                     </span>
                 </div>
                 <div class="d-flex align-items-center justify-content-between">
                     Position Y
-                    <span class="d-flex justify-content-between" data-prevent-closing-overlay="true">
+                    <span class="d-flex justify-content-between">
                         <input name="positionY" t-att-value="this.positions['y']" t-on-change="(ev) => this.onPositionChange('y', ev)" class="input" type="text" style="width: 5ch" />
                     </span>
                 </div>
@@ -77,11 +77,11 @@
 
             <div>
                 First color %
-                <span class="d-flex justify-content-between" data-prevent-closing-overlay="true">
+                <span class="d-flex justify-content-between">
                     <input name="firstColorPercentage" t-att-value="this.colors[0].percentage" t-on-click="() => this.state.currentColorIndex = 0" t-on-change="(ev) => this.onColorPercentageChange(0, ev)" class="w-100 form-range" type="range" min="0" max="100"/>
                 </span>
                 Second color %
-                <span class="d-flex justify-content-between" data-prevent-closing-overlay="true">
+                <span class="d-flex justify-content-between">
                     <input name="secondColorPercentage" t-att-value="this.colors[1].percentage" t-on-click="() => this.state.currentColorIndex = 1 " t-on-change="(ev) => this.onColorPercentageChange(1, ev)" class="w-100 form-range" type="range" min="0" max="100"/>
                 </span>
             </div>

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "@odoo/hoot";
-import { click, waitFor, queryOne, hover, press, waitUntil } from "@odoo/hoot-dom";
+import { click, waitFor, queryOne, hover, press, waitUntil, edit } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { setupEditor } from "./_helpers/editor";
 import { getContent, setSelection } from "./_helpers/selection";
@@ -106,6 +106,35 @@ test("custom colors used in the editor are shown in the colorpicker", async () =
     expect(queryOne("button[data-color='rgb(0, 255, 0)']").style.backgroundColor).toBe(
         "rgb(0, 255, 0)"
     );
+});
+
+test("select hex color and apply it", async () => {
+    const { el } = await setupEditor(`<p><font style="color: rgb(255, 0, 0);">[test]</font></p>`);
+    await waitFor(".o-we-toolbar");
+    expect(".o_font_color_selector").toHaveCount(0);
+
+    click(".o-select-color-foreground");
+    await animationFrame();
+    expect(".o_font_color_selector").toHaveCount(1);
+
+    click(".btn:contains('Custom')");
+    await animationFrame();
+    click(".o_hex_input");
+    await animationFrame();
+    expect(".o_font_color_selector").toHaveCount(1);
+
+    edit("#017E84"); // === rgb(1, 126, 132)
+    await animationFrame();
+    expect("button[data-color='rgb(1, 126, 132)']").toHaveCount(1);
+    expect(queryOne("button[data-color='rgb(1, 126, 132)']").style.backgroundColor).toBe(
+        "rgb(1, 126, 132)"
+    );
+    expect(getContent(el)).toBe(`<p><font style="color: rgb(1, 126, 132);">[test]</font></p>`);
+
+    click(".odoo-editor-editable");
+    await animationFrame();
+    expect(".o_font_color_selector").toHaveCount(0);
+    expect(getContent(el)).toBe(`<p><font style="color: rgb(1, 126, 132);">[test]</font></p>`);
 });
 
 test("Can reset a color", async () => {


### PR DESCRIPTION
Before this commit, cannot select a hex custom color in the colorpicker as the toolbar closes instantly when clicking in the hex color input.

Solution:

Added ‘data-prevent-closing-overlay=true’ to the root of the color selector. This ensures that changing the selection does not close the toolbar.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
