### PR TITLE
[IMP] account: Pricepocalypse follow-up

### DIFF
--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -183,7 +183,7 @@
                                 <group name="advanced_booleans">
                                     <field name="price_include" invisible="1"/>
                                     <field name="price_include_override"
-                                           invisible="amount_type == 'group' or type_tax_use == 'purchase'"
+                                           invisible="amount_type == 'group'"
                                            placeholder="Default"
                                     />
                                     <field name="include_base_amount" invisible="amount_type == 'group'"/>

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -42,7 +42,7 @@
                             </setting>
                         </block>
                         <block title="Taxes" name="default_taxes_setting_container">
-                            <setting id="default_taxes" string="Default Taxes" company_dependent="1" help="Default taxes applied when creating new products." title="These taxes are set in any new product created."
+                            <setting id="default_taxes" string="Default Taxes" company_dependent="1" help="Default taxes applied when creating new products."
                                 documentation="/applications/finance/accounting/taxation/taxes/default_taxes.html">
                                 <div class="content-group">
                                     <div class="row mt16">
@@ -54,7 +54,10 @@
                                         <field name="purchase_tax_id" domain="[('type_tax_use', 'in', ('purchase', 'all'))]"/>
                                     </div>
                                     <div class="row">
-                                        <label string="Prices" for="account_price_include" class="col-lg-3 o_light_label"/>
+                                        <div class="col-lg-3">
+                                            <label string="Prices" for="account_price_include" class="o_light_label"/>
+                                            <div class="fa fa-question-circle" title="This setting cannot be changed after an invoice is created."/>
+                                        </div>
                                         <field name="account_price_include" readonly="has_accounting_entries"/>
                                     </div>
                                 </div>


### PR DESCRIPTION
Some cleanup after the Pricepocalypse merge:
1. Added a tooltip for the new company setting on Tax included.
2. Made the "Included In price" setting visible for Purchase taxes.

task-4131136




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
