### PR TITLE
[REM] mail: remove message actions from mobile long press

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -38,7 +38,6 @@ import { messageActionsRegistry, useMessageActions } from "./message_actions";
 import { cookie } from "@web/core/browser/cookie";
 import { rpc } from "@web/core/network/rpc";
 import { escape } from "@web/core/utils/strings";
-import { useLongTouchPress } from "@mail/utils/common/hooks";
 import { MessageActionMenuMobile } from "./message_action_menu_mobile";
 import { discussComponentRegistry } from "./discuss_component_registry";
 
@@ -110,7 +109,6 @@ export class Message extends Component {
             emailHeaderOpen: false,
             showTranslation: false,
             actionMenuMobileOpen: false,
-            longTouching: false,
         });
         /** @type {ShadowRoot} */
         this.shadowRoot;
@@ -130,7 +128,6 @@ export class Message extends Component {
         this.ui = useState(useService("ui"));
         this.openReactionMenu = this.openReactionMenu.bind(this);
         this.optionsDropdown = useDropdownState();
-        useLongTouchPress("root", () => this.openMobileActions());
         useChildSubEnv({
             message: this.props.message,
             alignedRight: this.isAlignedRight,
@@ -216,7 +213,6 @@ export class Message extends Component {
                 this.props.thread,
                 this.props.message
             ),
-            "o-longTouching": this.state.longTouching,
             "o-actionMenuMobileOpen": this.state.actionMenuMobileOpen,
         };
     }
@@ -434,16 +430,6 @@ export class Message extends Component {
                 mail_message_to_resend: message.id,
             },
         });
-    }
-
-    onTouchstart() {
-        clearTimeout(this.longTouchingTimeoutId);
-        this.longTouchingTimeoutId = setTimeout(() => (this.state.longTouching = true), 150);
-    }
-
-    onTouchend() {
-        clearTimeout(this.longTouchingTimeoutId);
-        this.state.longTouching = false;
     }
 
     /** @param {MouseEvent} [ev] */

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -9,11 +9,6 @@
     &.o-highlighted {
         transform: translateY(-#{map-get($spacers, 3)});
     }
-    &.o-longTouching {
-        background-color: rgba($o-action, .075);
-        outline: 1px solid rgba($o-action, .1);
-        outline-offset: -1px;
-    }
 
     &.o-actionMenuMobileOpen {
         background-color: rgba($o-action, .1);

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -14,8 +14,6 @@
                 t-on-click="onClick"
                 t-on-mouseenter="onMouseenter"
                 t-on-mouseleave="onMouseleave"
-                t-on-touchstart.capture="onTouchstart"
-                t-on-touchend.capture="onTouchend"
                 t-ref="root"
                 t-if="message.exists()"
             >

--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -70,69 +70,6 @@ export function onExternalClick(refName, cb) {
     });
 }
 
-const LONG_TOUCH_PRESS_STATE = {
-    NEUTRAL: 0, // no prior touch start
-    ONGOING: 1, // ongoing, non-reached touch start long-press
-    REACHED: 2, // long touchstart that has reached trigger time but hasn't touchend yet
-};
-
-/**
- * @param {string} refName
- * @param {() => {}} fn
- */
-export function useLongTouchPress(refName, fn, delay = 500) {
-    const ref = useRef(refName);
-    let timeoutId;
-    let current = LONG_TOUCH_PRESS_STATE.NEUTRAL;
-    function onTouchend() {
-        if (current === LONG_TOUCH_PRESS_STATE.REACHED) {
-            return;
-        }
-        if (current === LONG_TOUCH_PRESS_STATE.ONGOING) {
-            clearTimeout(timeoutId);
-            current = LONG_TOUCH_PRESS_STATE.NEUTRAL;
-        }
-    }
-    // prevent iOS text-selection from long press
-    useLazyExternalListener(
-        () => ref.el,
-        "webkitmouseforcewillbegin",
-        (ev) => ev.preventDefault()
-    );
-    useLazyExternalListener(
-        () => ref.el,
-        "webkitmouseforcedown",
-        (ev) => ev.preventDefault()
-    );
-    useLazyExternalListener(
-        () => ref.el,
-        "webkitmouseforcechanged",
-        (ev) => ev.preventDefault()
-    );
-    onMounted(() => {
-        document.body.addEventListener("touchend", onTouchend, true);
-    });
-    onWillUnmount(() => {
-        document.body.removeEventListener("touchend", onTouchend, true);
-        clearTimeout(timeoutId);
-    });
-    useLazyExternalListener(
-        () => ref.el,
-        "touchstart",
-        () => {
-            if (current !== LONG_TOUCH_PRESS_STATE.NEUTRAL) {
-                return;
-            }
-            current = LONG_TOUCH_PRESS_STATE.ONGOING;
-            timeoutId = setTimeout(() => {
-                current = LONG_TOUCH_PRESS_STATE.REACHED;
-                fn();
-                current = LONG_TOUCH_PRESS_STATE.NEUTRAL;
-            }, delay);
-        }
-    );
-}
-
 /**
  * @param {string | string[]} refNames
  * @param {(boolean) => void} callback


### PR DESCRIPTION
Before this commit, long pressing on message in mobile would display action list.

If this was natively supported in web app by the mobile OS, then this would lead to better end-user experience. But since there's no support, the current implementation to simulate it is too prone to accidental triggering of message actions by just scroll message list.

It's better to remove the simulated long press on message and only keep the simple click on "..." that's far more reliable.