### PR TITLE
[IMP] l10n_hu: improve name and translation of taxes

### DIFF
--- a/addons/l10n_hu/data/account_tax_template_data.xml
+++ b/addons/l10n_hu/data/account_tax_template_data.xml
@@ -3,8 +3,8 @@
     <!-- Sales -->
     <record id="F27" model="account.tax.template">
         <field name="sequence">10</field>
-        <field name="name">27% VAT</field>
-        <field name="description">27% VAT</field>
+        <field name="name">27%</field>
+        <field name="description">27%</field>
         <field name="price_include" eval="0"/>
         <field name="amount">27</field>
         <field name="amount_type">percent</field>
@@ -41,8 +41,8 @@
 
     <record id="F18" model="account.tax.template">
         <field name="sequence">20</field>
-        <field name="name">18% VAT</field>
-        <field name="description">18% VAT</field>
+        <field name="name">18%</field>
+        <field name="description">18%</field>
         <field name="price_include" eval="0"/>
         <field name="amount">18</field>
         <field name="amount_type">percent</field>
@@ -79,8 +79,8 @@
 
     <record id="F5" model="account.tax.template">
         <field name="sequence">30</field>
-        <field name="name">5% VAT</field>
-        <field name="description">5% VAT</field>
+        <field name="name">5%</field>
+        <field name="description">5%</field>
         <field name="price_include" eval="0"/>
         <field name="amount_type">percent</field>
         <field name="amount">5</field>
@@ -117,8 +117,8 @@
 
     <record id="FA" model="account.tax.template">
         <field name="sequence">40</field>
-        <field name="name">0% Subject</field>
-        <field name="description">0% Subject</field>
+        <field name="name">0% AAM</field>
+        <field name="description">0% AAM</field>
         <field name="price_include" eval="0"/>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
@@ -151,8 +151,8 @@
 
     <record id="FT" model="account.tax.template">
         <field name="sequence">50</field>
-        <field name="name">0% Material</field>
-        <field name="description">0% Material</field>
+        <field name="name">0% TAM</field>
+        <field name="description">0% TAM</field>
         <field name="price_include" eval="0"/>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
@@ -185,8 +185,8 @@
 
     <record id="FKKS" model="account.tax.template">
         <field name="sequence">60</field>
-        <field name="name">0% Services Exempt</field>
-        <field name="description">0% Services Exempt</field>
+        <field name="name">0% S EXEMPT</field>
+        <field name="description">0% S EXEMPT</field>
         <field name="price_include" eval="0"/>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
@@ -219,8 +219,8 @@
 
     <record id="FKKT" model="account.tax.template">
         <field name="sequence">61</field>
-        <field name="name">0% Goods Exempt</field>
-        <field name="description">0% Goods Exempt</field>
+        <field name="name">0% G EXEMPT</field>
+        <field name="description">0% G EXEMPT</field>
         <field name="price_include" eval="0"/>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
@@ -253,8 +253,8 @@
 
     <record id="FF" model="account.tax.template">
         <field name="sequence">70</field>
-        <field name="name">0% VAT (Reverse)</field>
-        <field name="description">0% VAT (Reverse)</field>
+        <field name="name">0% R</field>
+        <field name="description">0% R</field>
         <field name="price_include" eval="0"/>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
@@ -287,8 +287,8 @@
 
     <record id="FEUSZ" model="account.tax.template">
         <field name="sequence">80</field>
-        <field name="name">0% Services ICD</field>
-        <field name="description">0% Services Intra-community Deliveries</field>
+        <field name="name">0% EU S</field>
+        <field name="description">0% EU S</field>
         <field name="price_include" eval="0"/>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
@@ -321,8 +321,8 @@
 
     <record id="FEUT" model="account.tax.template">
         <field name="sequence">81</field>
-        <field name="name">0% Goods ICD</field>
-        <field name="description">0% Goods Intra-community Deliveries</field>
+        <field name="name">0% EU G</field>
+        <field name="description">0% EU G</field>
         <field name="price_include" eval="0"/>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
@@ -355,8 +355,8 @@
 
     <record id="FEXS" model="account.tax.template">
         <field name="sequence">90</field>
-        <field name="name">0% Services Export</field>
-        <field name="description">0% Services Export</field>
+        <field name="name">0% S EX</field>
+        <field name="description">0% S EX</field>
         <field name="price_include" eval="0"/>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
@@ -389,8 +389,8 @@
 
     <record id="FEXT" model="account.tax.template">
         <field name="sequence">91</field>
-        <field name="name">0% Goods Export</field>
-        <field name="description">0% Goods Export</field>
+        <field name="name">0% G EX</field>
+        <field name="description">0% G EX</field>
         <field name="price_include" eval="0"/>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
@@ -425,8 +425,8 @@
     <!-- Purchase -->
     <record id="V27" model="account.tax.template">
         <field name="sequence">100</field>
-        <field name="name">27% VAT</field>
-        <field name="description">27% VAT</field>
+        <field name="name">27%</field>
+        <field name="description">27%</field>
         <field name="price_include" eval="0"/>
         <field name="amount_type">percent</field>
         <field name="amount">27</field>
@@ -463,8 +463,8 @@
 
     <record id="V27TE" model="account.tax.template">
         <field name="sequence">110</field>
-        <field name="name">27% Property, plant and equipment</field>
-        <field name="description">27% Property, plant and equipment</field>
+        <field name="name">27% PPE</field>
+        <field name="description">27% PPE</field>
         <field name="price_include" eval="0"/>
         <field name="amount_type">percent</field>
         <field name="amount">27</field>
@@ -501,8 +501,8 @@
 
     <record id="V18" model="account.tax.template">
         <field name="sequence">120</field>
-        <field name="name">18% VAT</field>
-        <field name="description">18% VAT</field>
+        <field name="name">18%</field>
+        <field name="description">18%</field>
         <field name="price_include" eval="0"/>
         <field name="amount_type">percent</field>
         <field name="amount">18</field>
@@ -539,8 +539,8 @@
 
     <record id="V5" model="account.tax.template">
         <field name="sequence">130</field>
-        <field name="name">5% VAT</field>
-        <field name="description">5% VAT</field>
+        <field name="name">5%</field>
+        <field name="description">5%</field>
         <field name="price_include" eval="0"/>
         <field name="amount_type">percent</field>
         <field name="amount">5</field>
@@ -577,8 +577,8 @@
 
     <record id="VKOMP7" model="account.tax.template">
         <field name="sequence">140</field>
-        <field name="name">7% Comp.</field>
-        <field name="description">7% Compensation Surcharge</field>
+        <field name="name">7% CS</field>
+        <field name="description">7% CS</field>
         <field name="price_include" eval="0"/>
         <field name="amount_type">percent</field>
         <field name="amount">7</field>
@@ -615,8 +615,8 @@
 
     <record id="VKOMP12" model="account.tax.template">
         <field name="sequence">150</field>
-        <field name="name">12% Comp.</field>
-        <field name="description">12% Compensation Surcharge</field>
+        <field name="name">12% CS</field>
+        <field name="description">12% CS</field>
         <field name="price_include" eval="0"/>
         <field name="amount">12</field>
         <field name="amount_type">percent</field>
@@ -653,8 +653,8 @@
 
     <record id="VA" model="account.tax.template">
         <field name="sequence">160</field>
-        <field name="name">0% Subject</field>
-        <field name="description">0% Subject</field>
+        <field name="name">0% AAM</field>
+        <field name="description">0% AAM</field>
         <field name="price_include" eval="0"/>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -687,8 +687,8 @@
 
     <record id="VT" model="account.tax.template">
         <field name="sequence">170</field>
-        <field name="name">0% Material</field>
-        <field name="description">0% Material</field>
+        <field name="name">0% TAM</field>
+        <field name="description">0% TAM</field>
         <field name="price_include" eval="0"/>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -721,8 +721,8 @@
 
     <record id="VKKS" model="account.tax.template">
         <field name="sequence">180</field>
-        <field name="name">0% Services Exempt</field>
-        <field name="description">0% Services Exempt</field>
+        <field name="name">0% S EXEMPT</field>
+        <field name="description">0% S EXEMPT</field>
         <field name="price_include" eval="0"/>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -755,8 +755,8 @@
 
     <record id="VKKT" model="account.tax.template">
         <field name="sequence">181</field>
-        <field name="name">0% Goods Exempt</field>
-        <field name="description">0% Goods Exempt</field>
+        <field name="name">0% G EXEMPT</field>
+        <field name="description">0% G EXEMPT</field>
         <field name="price_include" eval="0"/>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -789,8 +789,8 @@
 
     <record id="VF" model="account.tax.template">
         <field name="sequence">190</field>
-        <field name="name">0% VAT (Reverse)</field>
-        <field name="description">0% VAT (Reverse)</field>
+        <field name="name">0% R</field>
+        <field name="description">0% R</field>
         <field name="price_include" eval="0"/>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -823,8 +823,8 @@
 
     <record id="VEU27S" model="account.tax.template">
         <field name="sequence">200</field>
-        <field name="name">27% Services ICA</field>
-        <field name="description">27% Services Intra-community Acquisition</field>
+        <field name="name">27% EU S</field>
+        <field name="description">27% EU S</field>
         <field name="price_include" eval="0"/>
         <field name="amount">27</field>
         <field name="amount_type">percent</field>
@@ -873,8 +873,8 @@
 
     <record id="VEU27T" model="account.tax.template">
         <field name="sequence">201</field>
-        <field name="name">27% Goods ICA</field>
-        <field name="description">27% Goods Intra-community Acquisition</field>
+        <field name="name">27% EU G</field>
+        <field name="description">27% EU G</field>
         <field name="price_include" eval="0"/>
         <field name="amount">27</field>
         <field name="amount_type">percent</field>
@@ -923,8 +923,8 @@
 
     <record id="VEU27TE" model="account.tax.template">
         <field name="sequence">210</field>
-        <field name="name">27% ICA (Property)</field>
-        <field name="description">27% ICA (Property)</field>
+        <field name="name">27% EU P</field>
+        <field name="description">27% EU P</field>
         <field name="price_include" eval="0"/>
         <field name="amount">27</field>
         <field name="amount_type">percent</field>
@@ -974,7 +974,7 @@
     <record id="VEUM" model="account.tax.template">
         <field name="sequence">220</field>
         <field name="name">0% ICA</field>
-        <field name="description">0% Intra-community Acquisition</field>
+        <field name="description">0% ICA</field>
         <field name="price_include" eval="0"/>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -1007,8 +1007,8 @@
 
     <record id="VIMS" model="account.tax.template">
         <field name="sequence">230</field>
-        <field name="name">27% Import</field>
-        <field name="description">27% Import</field>
+        <field name="name">27% EX</field>
+        <field name="description">27% EX</field>
         <field name="price_include" eval="0"/>
         <field name="amount">27</field>
         <field name="amount_type">percent</field>
@@ -1057,8 +1057,8 @@
 
     <record id="VIMK" model="account.tax.template">
         <field name="sequence">240</field>
-        <field name="name">27% Import (Sourcing)</field>
-        <field name="description">27% Import (Sourcing)</field>
+        <field name="name">27% EX S</field>
+        <field name="description">27% EX S</field>
         <field name="price_include" eval="0"/>
         <field name="amount">27</field>
         <field name="amount_type">percent</field>
@@ -1095,8 +1095,8 @@
 
     <record id="VIM" model="account.tax.template">
         <field name="sequence">250</field>
-        <field name="name">0% Import</field>
-        <field name="description">0% Import</field>
+        <field name="name">0% EX</field>
+        <field name="description">0% EX</field>
         <field name="price_include" eval="0"/>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>

--- a/addons/l10n_hu/i18n/hu.po
+++ b/addons/l10n_hu/i18n/hu.po
@@ -4,125 +4,16 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 15.0+e\n"
+"Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-04 13:33+0000\n"
-"PO-Revision-Date: 2022-08-04 13:33+0000\n"
+"POT-Creation-Date: 2024-08-26 11:09+0000\n"
+"PO-Revision-Date: 2024-08-26 11:09+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
-
-#. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_FKKT
-#: model:account.tax,description:l10n_hu.1_VKKT
-#: model:account.tax,description:l10n_hu.2_FKKT
-#: model:account.tax,description:l10n_hu.2_VKKT
-#: model:account.tax,name:l10n_hu.1_FKKT model:account.tax,name:l10n_hu.1_VKKT
-#: model:account.tax,name:l10n_hu.2_FKKT model:account.tax,name:l10n_hu.2_VKKT
-#: model:account.tax.template,description:l10n_hu.FKKT
-#: model:account.tax.template,description:l10n_hu.VKKT
-#: model:account.tax.template,name:l10n_hu.FKKT
-#: model:account.tax.template,name:l10n_hu.VKKT
-msgid "0% Goods Exempt"
-msgstr "0% árumentes"
-
-#. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_FEXT
-#: model:account.tax,description:l10n_hu.2_FEXT
-#: model:account.tax,name:l10n_hu.1_FEXT model:account.tax,name:l10n_hu.2_FEXT
-#: model:account.tax.template,description:l10n_hu.FEXT
-#: model:account.tax.template,name:l10n_hu.FEXT
-msgid "0% Goods Export"
-msgstr "0% áruexport"
-
-#. module: l10n_hu
-#: model:account.tax,name:l10n_hu.1_FEUT model:account.tax,name:l10n_hu.2_FEUT
-#: model:account.tax.template,name:l10n_hu.FEUT
-msgid "0% Goods ICD"
-msgstr "0% áruk ICD"
-
-#. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_FEUT
-#: model:account.tax,description:l10n_hu.2_FEUT
-#: model:account.tax.template,description:l10n_hu.FEUT
-msgid "0% Goods Intra-community Deliveries"
-msgstr "0% Áruk Közösségen belüli kiszállítás"
-
-#. module: l10n_hu
-#: model:account.tax,name:l10n_hu.1_VEUM model:account.tax,name:l10n_hu.2_VEUM
-#: model:account.tax.template,name:l10n_hu.VEUM
-msgid "0% ICA"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_VIM
-#: model:account.tax,description:l10n_hu.2_VIM
-#: model:account.tax,name:l10n_hu.1_VIM model:account.tax,name:l10n_hu.2_VIM
-#: model:account.tax.template,description:l10n_hu.VIM
-#: model:account.tax.template,name:l10n_hu.VIM
-msgid "0% Import"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_VEUM
-#: model:account.tax,description:l10n_hu.2_VEUM
-#: model:account.tax.template,description:l10n_hu.VEUM
-msgid "0% Intra-community Acquisition"
-msgstr "0% Közösségen belüli beszerzés"
-
-#. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_FT
-#: model:account.tax,description:l10n_hu.1_VT
-#: model:account.tax,description:l10n_hu.2_FT
-#: model:account.tax,description:l10n_hu.2_VT
-#: model:account.tax,name:l10n_hu.1_FT model:account.tax,name:l10n_hu.1_VT
-#: model:account.tax,name:l10n_hu.2_FT model:account.tax,name:l10n_hu.2_VT
-#: model:account.tax.template,description:l10n_hu.FT
-#: model:account.tax.template,description:l10n_hu.VT
-#: model:account.tax.template,name:l10n_hu.FT
-#: model:account.tax.template,name:l10n_hu.VT
-msgid "0% Material"
-msgstr "0% Anyag"
-
-#. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_FKKS
-#: model:account.tax,description:l10n_hu.1_VKKS
-#: model:account.tax,description:l10n_hu.2_FKKS
-#: model:account.tax,description:l10n_hu.2_VKKS
-#: model:account.tax,name:l10n_hu.1_FKKS model:account.tax,name:l10n_hu.1_VKKS
-#: model:account.tax,name:l10n_hu.2_FKKS model:account.tax,name:l10n_hu.2_VKKS
-#: model:account.tax.template,description:l10n_hu.FKKS
-#: model:account.tax.template,description:l10n_hu.VKKS
-#: model:account.tax.template,name:l10n_hu.FKKS
-#: model:account.tax.template,name:l10n_hu.VKKS
-msgid "0% Services Exempt"
-msgstr "0% Szolgáltatásmentes"
-
-#. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_FEXS
-#: model:account.tax,description:l10n_hu.2_FEXS
-#: model:account.tax,name:l10n_hu.1_FEXS model:account.tax,name:l10n_hu.2_FEXS
-#: model:account.tax.template,description:l10n_hu.FEXS
-#: model:account.tax.template,name:l10n_hu.FEXS
-msgid "0% Services Export"
-msgstr "0% Szolgáltatások exportálása"
-
-#. module: l10n_hu
-#: model:account.tax,name:l10n_hu.1_FEUSZ
-#: model:account.tax,name:l10n_hu.2_FEUSZ
-#: model:account.tax.template,name:l10n_hu.FEUSZ
-msgid "0% Services ICD"
-msgstr "0% Szolgáltatások ICD"
-
-#. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_FEUSZ
-#: model:account.tax,description:l10n_hu.2_FEUSZ
-#: model:account.tax.template,description:l10n_hu.FEUSZ
-msgid "0% Services Intra-community Deliveries"
-msgstr "0% Szolgáltatások Közösségen belüli szállítások"
 
 #. module: l10n_hu
 #: model:account.tax,description:l10n_hu.1_FA
@@ -135,13 +26,68 @@ msgstr "0% Szolgáltatások Közösségen belüli szállítások"
 #: model:account.tax.template,description:l10n_hu.VA
 #: model:account.tax.template,name:l10n_hu.FA
 #: model:account.tax.template,name:l10n_hu.VA
-msgid "0% Subject"
-msgstr "0% Tárgy"
+msgid "0% AAM"
+msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.group,name:l10n_hu.tax_group_afa_0
-msgid "0% VAT"
-msgstr "0% ÁFA"
+#: model:account.tax,description:l10n_hu.1_FEUT
+#: model:account.tax,description:l10n_hu.2_FEUT
+#: model:account.tax,name:l10n_hu.1_FEUT model:account.tax,name:l10n_hu.2_FEUT
+#: model:account.tax.template,description:l10n_hu.FEUT
+#: model:account.tax.template,name:l10n_hu.FEUT
+msgid "0% EU G"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.tax,description:l10n_hu.1_FEUSZ
+#: model:account.tax,description:l10n_hu.2_FEUSZ
+#: model:account.tax,name:l10n_hu.1_FEUSZ
+#: model:account.tax,name:l10n_hu.2_FEUSZ
+#: model:account.tax.template,description:l10n_hu.FEUSZ
+#: model:account.tax.template,name:l10n_hu.FEUSZ
+msgid "0% EU S"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.tax,description:l10n_hu.1_VIM
+#: model:account.tax,description:l10n_hu.2_VIM
+#: model:account.tax,name:l10n_hu.1_VIM model:account.tax,name:l10n_hu.2_VIM
+#: model:account.tax.template,description:l10n_hu.VIM
+#: model:account.tax.template,name:l10n_hu.VIM
+msgid "0% EX"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.tax,description:l10n_hu.1_FEXT
+#: model:account.tax,description:l10n_hu.2_FEXT
+#: model:account.tax,name:l10n_hu.1_FEXT model:account.tax,name:l10n_hu.2_FEXT
+#: model:account.tax.template,description:l10n_hu.FEXT
+#: model:account.tax.template,name:l10n_hu.FEXT
+msgid "0% G EX"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.tax,description:l10n_hu.1_FKKT
+#: model:account.tax,description:l10n_hu.1_VKKT
+#: model:account.tax,description:l10n_hu.2_FKKT
+#: model:account.tax,description:l10n_hu.2_VKKT
+#: model:account.tax,name:l10n_hu.1_FKKT model:account.tax,name:l10n_hu.1_VKKT
+#: model:account.tax,name:l10n_hu.2_FKKT model:account.tax,name:l10n_hu.2_VKKT
+#: model:account.tax.template,description:l10n_hu.FKKT
+#: model:account.tax.template,description:l10n_hu.VKKT
+#: model:account.tax.template,name:l10n_hu.FKKT
+#: model:account.tax.template,name:l10n_hu.VKKT
+msgid "0% G EXEMPT"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.tax,description:l10n_hu.1_VEUM
+#: model:account.tax,description:l10n_hu.2_VEUM
+#: model:account.tax,name:l10n_hu.1_VEUM model:account.tax,name:l10n_hu.2_VEUM
+#: model:account.tax.template,description:l10n_hu.VEUM
+#: model:account.tax.template,name:l10n_hu.VEUM
+msgid "0% ICA"
+msgstr ""
 
 #. module: l10n_hu
 #: model:account.tax,description:l10n_hu.1_FF
@@ -154,22 +100,60 @@ msgstr "0% ÁFA"
 #: model:account.tax.template,description:l10n_hu.VF
 #: model:account.tax.template,name:l10n_hu.FF
 #: model:account.tax.template,name:l10n_hu.VF
-msgid "0% VAT (Reverse)"
-msgstr "0% ÁFA (fordított)"
+msgid "0% R"
+msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax,name:l10n_hu.1_VKOMP12
-#: model:account.tax,name:l10n_hu.2_VKOMP12
-#: model:account.tax.template,name:l10n_hu.VKOMP12
-msgid "12% Comp."
-msgstr "12% Komp."
+#: model:account.tax,description:l10n_hu.1_FEXS
+#: model:account.tax,description:l10n_hu.2_FEXS
+#: model:account.tax,name:l10n_hu.1_FEXS model:account.tax,name:l10n_hu.2_FEXS
+#: model:account.tax.template,description:l10n_hu.FEXS
+#: model:account.tax.template,name:l10n_hu.FEXS
+msgid "0% S EX"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.tax,description:l10n_hu.1_FKKS
+#: model:account.tax,description:l10n_hu.1_VKKS
+#: model:account.tax,description:l10n_hu.2_FKKS
+#: model:account.tax,description:l10n_hu.2_VKKS
+#: model:account.tax,name:l10n_hu.1_FKKS model:account.tax,name:l10n_hu.1_VKKS
+#: model:account.tax,name:l10n_hu.2_FKKS model:account.tax,name:l10n_hu.2_VKKS
+#: model:account.tax.template,description:l10n_hu.FKKS
+#: model:account.tax.template,description:l10n_hu.VKKS
+#: model:account.tax.template,name:l10n_hu.FKKS
+#: model:account.tax.template,name:l10n_hu.VKKS
+msgid "0% S EXEMPT"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.tax,description:l10n_hu.1_FT
+#: model:account.tax,description:l10n_hu.1_VT
+#: model:account.tax,description:l10n_hu.2_FT
+#: model:account.tax,description:l10n_hu.2_VT
+#: model:account.tax,name:l10n_hu.1_FT model:account.tax,name:l10n_hu.1_VT
+#: model:account.tax,name:l10n_hu.2_FT model:account.tax,name:l10n_hu.2_VT
+#: model:account.tax.template,description:l10n_hu.FT
+#: model:account.tax.template,description:l10n_hu.VT
+#: model:account.tax.template,name:l10n_hu.FT
+#: model:account.tax.template,name:l10n_hu.VT
+msgid "0% TAM"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.tax.group,name:l10n_hu.tax_group_afa_0
+msgid "0% VAT"
+msgstr "0% ÁFA"
 
 #. module: l10n_hu
 #: model:account.tax,description:l10n_hu.1_VKOMP12
 #: model:account.tax,description:l10n_hu.2_VKOMP12
+#: model:account.tax,name:l10n_hu.1_VKOMP12
+#: model:account.tax,name:l10n_hu.2_VKOMP12
 #: model:account.tax.template,description:l10n_hu.VKOMP12
-msgid "12% Compensation Surcharge"
-msgstr "12% Kompenzációs felár"
+#: model:account.tax.template,name:l10n_hu.VKOMP12
+msgid "12% CS"
+msgstr "12% KF"
 
 #. module: l10n_hu
 #: model:account.tax,description:l10n_hu.1_F18
@@ -178,83 +162,21 @@ msgstr "12% Kompenzációs felár"
 #: model:account.tax,description:l10n_hu.2_V18
 #: model:account.tax,name:l10n_hu.1_F18 model:account.tax,name:l10n_hu.1_V18
 #: model:account.tax,name:l10n_hu.2_F18 model:account.tax,name:l10n_hu.2_V18
-#: model:account.tax.group,name:l10n_hu.tax_group_afa_18
-#: model:account.report.line,name:l10n_hu.tax_report_alap_fiz_afa_18
-#: model:account.report.line,name:l10n_hu.tax_report_alap_viss_18
-#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_18
-#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_viss_18
 #: model:account.tax.template,description:l10n_hu.F18
 #: model:account.tax.template,description:l10n_hu.V18
 #: model:account.tax.template,name:l10n_hu.F18
 #: model:account.tax.template,name:l10n_hu.V18
-msgid "18% VAT"
-msgstr "18% ÁFA"
-
-#. module: l10n_hu
-#: model:account.tax,name:l10n_hu.1_VEU27T
-#: model:account.tax,name:l10n_hu.2_VEU27T
-#: model:account.tax.template,name:l10n_hu.VEU27T
-msgid "27% Goods ICA"
-msgstr "27% áruk ICA"
-
-#. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_VEU27T
-#: model:account.tax,description:l10n_hu.2_VEU27T
-#: model:account.tax.template,description:l10n_hu.VEU27T
-msgid "27% Goods Intra-community Acquisition"
-msgstr "27% Áruk Közösségen belüli beszerzése"
-
-#. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_VEU27TE
-#: model:account.tax,description:l10n_hu.2_VEU27TE
-#: model:account.tax,name:l10n_hu.1_VEU27TE
-#: model:account.tax,name:l10n_hu.2_VEU27TE
-#: model:account.tax.template,description:l10n_hu.VEU27TE
-#: model:account.tax.template,name:l10n_hu.VEU27TE
-msgid "27% ICA (Property)"
-msgstr "27% KBB (tulajdon)"
-
-#. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_VIMS
-#: model:account.tax,description:l10n_hu.2_VIMS
-#: model:account.tax,name:l10n_hu.1_VIMS model:account.tax,name:l10n_hu.2_VIMS
-#: model:account.tax.template,description:l10n_hu.VIMS
-#: model:account.tax.template,name:l10n_hu.VIMS
-msgid "27% Import"
+msgid "18%"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_VIMK
-#: model:account.tax,description:l10n_hu.2_VIMK
-#: model:account.tax,name:l10n_hu.1_VIMK model:account.tax,name:l10n_hu.2_VIMK
-#: model:account.tax.template,description:l10n_hu.VIMK
-#: model:account.tax.template,name:l10n_hu.VIMK
-msgid "27% Import (Sourcing)"
-msgstr "27% Import (beszerzés)"
-
-#. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_V27TE
-#: model:account.tax,description:l10n_hu.2_V27TE
-#: model:account.tax,name:l10n_hu.1_V27TE
-#: model:account.tax,name:l10n_hu.2_V27TE
-#: model:account.tax.template,description:l10n_hu.V27TE
-#: model:account.tax.template,name:l10n_hu.V27TE
-msgid "27% Property, plant and equipment"
-msgstr "27% Ingatlanok, gépek és berendezések"
-
-#. module: l10n_hu
-#: model:account.tax,name:l10n_hu.1_VEU27S
-#: model:account.tax,name:l10n_hu.2_VEU27S
-#: model:account.tax.template,name:l10n_hu.VEU27S
-msgid "27% Services ICA"
-msgstr "27% Szolgáltatások ICA"
-
-#. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_VEU27S
-#: model:account.tax,description:l10n_hu.2_VEU27S
-#: model:account.tax.template,description:l10n_hu.VEU27S
-msgid "27% Services Intra-community Acquisition"
-msgstr "27% Szolgáltatások Közösségen belüli beszerzés"
+#: model:account.report.line,name:l10n_hu.tax_report_alap_fiz_afa_18
+#: model:account.report.line,name:l10n_hu.tax_report_alap_viss_18
+#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_18
+#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_viss_18
+#: model:account.tax.group,name:l10n_hu.tax_group_afa_18
+msgid "18% VAT"
+msgstr "18% ÁFA"
 
 #. module: l10n_hu
 #: model:account.tax,description:l10n_hu.1_F27
@@ -263,50 +185,98 @@ msgstr "27% Szolgáltatások Közösségen belüli beszerzés"
 #: model:account.tax,description:l10n_hu.2_V27
 #: model:account.tax,name:l10n_hu.1_F27 model:account.tax,name:l10n_hu.1_V27
 #: model:account.tax,name:l10n_hu.2_F27 model:account.tax,name:l10n_hu.2_V27
-#: model:account.tax.group,name:l10n_hu.tax_group_afa_27
-#: model:account.report.line,name:l10n_hu.tax_report_alap_fiz_afa_27
-#: model:account.report.line,name:l10n_hu.tax_report_alap_viss_27
-#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_27
-#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_viss_27
 #: model:account.tax.template,description:l10n_hu.F27
 #: model:account.tax.template,description:l10n_hu.V27
 #: model:account.tax.template,name:l10n_hu.F27
 #: model:account.tax.template,name:l10n_hu.V27
+msgid "27%"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.tax,description:l10n_hu.1_VEU27T
+#: model:account.tax,description:l10n_hu.2_VEU27T
+#: model:account.tax,name:l10n_hu.1_VEU27T
+#: model:account.tax,name:l10n_hu.2_VEU27T
+#: model:account.tax.template,description:l10n_hu.VEU27T
+#: model:account.tax.template,name:l10n_hu.VEU27T
+msgid "27% EU G"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.tax,description:l10n_hu.1_VEU27TE
+#: model:account.tax,description:l10n_hu.2_VEU27TE
+#: model:account.tax,name:l10n_hu.1_VEU27TE
+#: model:account.tax,name:l10n_hu.2_VEU27TE
+#: model:account.tax.template,description:l10n_hu.VEU27TE
+#: model:account.tax.template,name:l10n_hu.VEU27TE
+msgid "27% EU P"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.tax,description:l10n_hu.1_VEU27S
+#: model:account.tax,description:l10n_hu.2_VEU27S
+#: model:account.tax,name:l10n_hu.1_VEU27S
+#: model:account.tax,name:l10n_hu.2_VEU27S
+#: model:account.tax.template,description:l10n_hu.VEU27S
+#: model:account.tax.template,name:l10n_hu.VEU27S
+msgid "27% EU S"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.tax,description:l10n_hu.1_VIMS
+#: model:account.tax,description:l10n_hu.2_VIMS
+#: model:account.tax,name:l10n_hu.1_VIMS model:account.tax,name:l10n_hu.2_VIMS
+#: model:account.tax.template,description:l10n_hu.VIMS
+#: model:account.tax.template,name:l10n_hu.VIMS
+msgid "27% EX"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.tax,description:l10n_hu.1_VIMK
+#: model:account.tax,description:l10n_hu.2_VIMK
+#: model:account.tax,name:l10n_hu.1_VIMK model:account.tax,name:l10n_hu.2_VIMK
+#: model:account.tax.template,description:l10n_hu.VIMK
+#: model:account.tax.template,name:l10n_hu.VIMK
+msgid "27% EX S"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.tax,description:l10n_hu.1_V27TE
+#: model:account.tax,description:l10n_hu.2_V27TE
+#: model:account.tax,name:l10n_hu.1_V27TE
+#: model:account.tax,name:l10n_hu.2_V27TE
+#: model:account.tax.template,description:l10n_hu.V27TE
+#: model:account.tax.template,name:l10n_hu.V27TE
+msgid "27% PPE"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.report.line,name:l10n_hu.tax_report_alap_fiz_afa_27
+#: model:account.report.line,name:l10n_hu.tax_report_alap_viss_27
+#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_27
+#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_viss_27
+#: model:account.tax.group,name:l10n_hu.tax_group_afa_27
 msgid "27% VAT"
 msgstr "27% ÁFA"
 
 #. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_F5
-#: model:account.tax,description:l10n_hu.1_V5
-#: model:account.tax,description:l10n_hu.2_F5
-#: model:account.tax,description:l10n_hu.2_V5
-#: model:account.tax,name:l10n_hu.1_F5 model:account.tax,name:l10n_hu.1_V5
-#: model:account.tax,name:l10n_hu.2_F5 model:account.tax,name:l10n_hu.2_V5
-#: model:account.tax.group,name:l10n_hu.tax_group_afa_5
 #: model:account.report.line,name:l10n_hu.tax_report_alap_fiz_afa_5
 #: model:account.report.line,name:l10n_hu.tax_report_alap_viss_5
 #: model:account.report.line,name:l10n_hu.tax_report_fizetndo_5
 #: model:account.report.line,name:l10n_hu.tax_report_fizetndo_viss_5
-#: model:account.tax.template,description:l10n_hu.F5
-#: model:account.tax.template,description:l10n_hu.V5
-#: model:account.tax.template,name:l10n_hu.F5
-#: model:account.tax.template,name:l10n_hu.V5
+#: model:account.tax.group,name:l10n_hu.tax_group_afa_5
 msgid "5% VAT"
 msgstr "5% ÁFA"
 
 #. module: l10n_hu
-#: model:account.tax,name:l10n_hu.1_VKOMP7
-#: model:account.tax,name:l10n_hu.2_VKOMP7
-#: model:account.tax.template,name:l10n_hu.VKOMP7
-msgid "7% Comp."
-msgstr "7% Komp."
-
-#. module: l10n_hu
 #: model:account.tax,description:l10n_hu.1_VKOMP7
 #: model:account.tax,description:l10n_hu.2_VKOMP7
+#: model:account.tax,name:l10n_hu.1_VKOMP7
+#: model:account.tax,name:l10n_hu.2_VKOMP7
 #: model:account.tax.template,description:l10n_hu.VKOMP7
-msgid "7% Compensation Surcharge"
-msgstr "7% Kompenzációs felár"
+#: model:account.tax.template,name:l10n_hu.VKOMP7
+msgid "7% CS"
+msgstr "7% KF"
 
 #. module: l10n_hu
 #: model:account.account,name:l10n_hu.1_l10n_hu_5591
@@ -446,6 +416,7 @@ msgstr "Az ügyfelektől kapott előlegek"
 #: model:account.account.template,name:l10n_hu.l10n_hu_5295
 msgid "Advertising, publicity, propaganda costs"
 msgstr "Reklám, reklám, propaganda költségek"
+
 #. module: l10n_hu
 #: model:account.account,name:l10n_hu.1_l10n_hu_9763
 #: model:account.account,name:l10n_hu.2_l10n_hu_9763
@@ -526,11 +497,9 @@ msgid "Anniversary reward, object reward"
 msgstr "Jubileumi jutalom, tárgyi jutalom"
 
 #. module: l10n_hu
-#: model:account.account,name:l10n_hu.1_l10n_hu_418
-#: model:account.account,name:l10n_hu.2_l10n_hu_418
-#: model:account.account.template,name:l10n_hu.l10n_hu_418
-msgid "Balance sheet result from the correction of previous years"
-msgstr "Mérleg eredménye az előző évek korrekciójából"
+#: model:account.report.column,name:l10n_hu.tax_report_balance
+msgid "Balance"
+msgstr "Mérleg"
 
 #. module: l10n_hu
 #: model:account.account,name:l10n_hu.1_l10n_hu_5321
@@ -960,7 +929,7 @@ msgstr "Kötvénykibocsátásból származó adósság"
 #: model:account.group,name:l10n_hu.2_l10n_hu_group_18
 #: model:account.group.template,name:l10n_hu.l10n_hu_group_18
 msgid "Debt securities"
-msgstr "Hitelviszonyt megtestesítő értékpapírok
+msgstr "Hitelviszonyt megtestesítő értékpapírok"
 
 #. module: l10n_hu
 #: model:account.account,name:l10n_hu.1_l10n_hu_375
@@ -1252,12 +1221,12 @@ msgstr "Mentes"
 #. module: l10n_hu
 #: model:account.report.line,name:l10n_hu.tax_report_alap_viss_targyi
 msgid "Exempt from material tax"
-msgstr "Mentes az anyagi adó alól"
+msgstr "Tárgyi adómentes"
 
 #. module: l10n_hu
 #: model:account.report.line,name:l10n_hu.tax_report_alap_fiz_targyi
 msgid "Exempt from property tax"
-msgstr "Mentes az ingatlanadó alól"
+msgstr "Ingatlanadó mentesség"
 
 #. module: l10n_hu
 #: model:account.report.line,name:l10n_hu.tax_report_alap_fiz_alanyi
@@ -1663,11 +1632,6 @@ msgid "Housing subsidy, rent contribution"
 msgstr "Lakhatási támogatás, lakbér hozzájárulás"
 
 #. module: l10n_hu
-#: model:ir.ui.menu,name:l10n_hu.hu_reports_menu
-msgid "Hungary"
-msgstr "Magyarország"
-
-#. module: l10n_hu
 #: model:account.chart.template,name:l10n_hu.hungarian_chart_template
 msgid "Hungary - National Chart of Accounts"
 msgstr "Magyarország - Nemzeti Számlatábla"
@@ -1734,7 +1698,7 @@ msgstr "Külföldi követelések értékvesztése és visszaírása"
 #: model:account.account.template,name:l10n_hu.l10n_hu_3719
 msgid "Impairment and reversal of interests in associates"
 msgstr ""
-"A társult vállalkozásokban lévő érdekeltségek értékvesztése és visszavonása
+"A társult vállalkozásokban lévő érdekeltségek értékvesztése és visszavonása"
 
 #. module: l10n_hu
 #: model:account.account,name:l10n_hu.1_l10n_hu_279
@@ -1817,7 +1781,7 @@ msgstr "Értékpapírok értékvesztése és visszaírása"
 #: model:account.account,name:l10n_hu.2_l10n_hu_179
 #: model:account.account.template,name:l10n_hu.l10n_hu_179
 msgid "Impairment and reversal of shares"
-msgstr "Részvények értékvesztése és visszaírása
+msgstr "Részvények értékvesztése és visszaírása"
 
 #. module: l10n_hu
 #: model:account.account,name:l10n_hu.1_l10n_hu_3729
@@ -1871,7 +1835,7 @@ msgstr "Értékvesztés, nem tervezett értékcsökkenés"
 #. module: l10n_hu
 #: model:account.report.line,name:l10n_hu.tax_report_alap_import
 msgid "Import"
-msgstr "Importálás"
+msgstr "Import"
 
 #. module: l10n_hu
 #: model:account.group,name:l10n_hu.1_l10n_hu_group_85
@@ -1906,7 +1870,7 @@ msgstr "Immateriális javak"
 #: model:account.account,name:l10n_hu.2_l10n_hu_3688
 #: model:account.account.template,name:l10n_hu.l10n_hu_3688
 msgid "Intangible assets and tangible assets settlement account"
-msgstr "Immateriális javak és tárgyi eszközök elszámolási számla
+msgstr "Immateriális javak és tárgyi eszközök elszámolási számla"
 
 #. module: l10n_hu
 #: model:account.account,name:l10n_hu.1_l10n_hu_114
@@ -2122,7 +2086,7 @@ msgstr "Likviditási transzfer"
 #: model:account.account,name:l10n_hu.2_l10n_hu_469
 #: model:account.account.template,name:l10n_hu.l10n_hu_469
 msgid "Local taxes settlement account"
-msgstr "Helyi adók elszámolási számla
+msgstr "Helyi adók elszámolási számla"
 
 #. module: l10n_hu
 #: model:account.account,name:l10n_hu.1_l10n_hu_194
@@ -2600,7 +2564,7 @@ msgstr "A működési menedzsment összköltsége"
 #: model:account.account,name:l10n_hu.2_l10n_hu_281
 #: model:account.account.template,name:l10n_hu.l10n_hu_281
 msgid "Own containers"
-msgstr "Saját konténerek
+msgstr "Saját konténerek"
 
 #. module: l10n_hu
 #: model:account.account,name:l10n_hu.1_l10n_hu_374
@@ -2641,7 +2605,7 @@ msgstr "EU-n kívüli partner"
 #: model:account.report.line,name:l10n_hu.tax_report_base_pay
 #: model:account.report.line,name:l10n_hu.tax_report_vat_pay
 msgid "Payable"
-msgstr "Kifizetendő"
+msgstr "Fizetendő"
 
 #. module: l10n_hu
 #: model:account.account,name:l10n_hu.1_l10n_hu_474
@@ -2655,7 +2619,7 @@ msgstr "Az elkülönített alapokhoz kapcsolódó fizetési kötelezettségek"
 #: model:account.account,name:l10n_hu.2_l10n_hu_172
 #: model:account.account.template,name:l10n_hu.l10n_hu_172
 msgid "Permanent significant ownership interest"
-msgstr "Tartós jelentős tulajdoni részesedés
+msgstr "Tartós jelentős tulajdoni részesedés"
 
 #. module: l10n_hu
 #: model:account.account,name:l10n_hu.1_l10n_hu_462
@@ -2761,13 +2725,6 @@ msgstr "A központok előállítási költségei"
 #: model:account.account.template,name:l10n_hu.l10n_hu_131
 msgid "Production machines, equipment, tools, production tools"
 msgstr "Gyártógépek, berendezések, szerszámok, gyártóeszközök"
-
-#. module: l10n_hu
-#: model:account.account,name:l10n_hu.1_l10n_hu_419
-#: model:account.account,name:l10n_hu.2_l10n_hu_419
-#: model:account.account.template,name:l10n_hu.l10n_hu_419
-msgid "Profit after tax"
-msgstr "Adózott eredmény"
 
 #. module: l10n_hu
 #: model:account.account,name:l10n_hu.1_l10n_hu_413
@@ -2950,7 +2907,7 @@ msgstr "Eladott, engedményezett (engedményezett) követelések elismert érté
 #: model:account.report.line,name:l10n_hu.tax_report_base_rec
 #: model:account.report.line,name:l10n_hu.tax_report_vat_rec
 msgid "Recoverable"
-msgstr "Helyrehozható"
+msgstr "Visszaigényelhető"
 
 #. module: l10n_hu
 #: model:account.account,name:l10n_hu.1_l10n_hu_411
@@ -3077,7 +3034,7 @@ msgstr "Értékvesztés visszaírása, nem tervezett értékcsökkenés"
 #. module: l10n_hu
 #: model:account.report.line,name:l10n_hu.tax_report_alap_forditott
 msgid "Reverse"
-msgstr "Fordított"
+msgstr "Fordított ÁFA"
 
 #. module: l10n_hu
 #: model:account.account,name:l10n_hu.1_l10n_hu_851
@@ -3341,9 +3298,14 @@ msgid "Suppliers"
 msgstr "Szállítók"
 
 #. module: l10n_hu
+#: model:account.report,name:l10n_hu.tax_report
+msgid "Tax Report"
+msgstr "Adóbevallás"
+
+#. module: l10n_hu
 #: model:account.report.line,name:l10n_hu.tax_report_alap
 msgid "Tax base"
-msgstr "Adó alap"
+msgstr "Adóalap"
 
 #. module: l10n_hu
 #: model:account.group,name:l10n_hu.1_l10n_hu_group_89
@@ -3456,7 +3418,7 @@ msgid ""
 "Unscheduled depreciation and reversal of other plant, equipment and vehicles"
 msgstr ""
 "Egyéb berendezések, berendezések és járművek előre nem tervezett "
-"értékcsökkenése és visszaírása
+"értékcsökkenése és visszaírása"
 
 #. module: l10n_hu
 #: model:account.account,name:l10n_hu.1_l10n_hu_138
@@ -3467,7 +3429,7 @@ msgid ""
 "vehicles"
 msgstr ""
 "Műszaki berendezések, gépek és járművek előre nem tervezett "
-"értékcsökkenése, visszaírása
+"értékcsökkenése, visszaírása"
 
 #. module: l10n_hu
 #: model:account.account,name:l10n_hu.1_l10n_hu_9663
@@ -3720,128 +3682,3 @@ msgstr "Folyamatban lévő termelés és félkész termékek értékvesztése"
 #: model:account.group.template,name:l10n_hu.l10n_hu_group_23
 msgid "Work in progress and semi-finished products"
 msgstr "Befejezetlen termelés és félkész termékek"
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_afa_18
-msgid "base_pay_18"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_afa_27
-msgid "base_pay_27"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_afa_5
-msgid "base_pay_5"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_koron_kivuli
-msgid "base_pay_exempt"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_targyi
-msgid "base_pay_exempt_property"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_alanyi
-msgid "base_pay_exempt_tax"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_export
-msgid "base_pay_exports"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_eu
-msgid "base_pay_intra"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_viss_18
-msgid "base_rec_18"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_viss_27
-msgid "base_rec_27"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_viss_5
-msgid "base_rec_5"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_komp
-msgid "base_rec_compensation"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_viss_koron_kivuli
-msgid "base_rec_exempt"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_viss_targyi
-msgid "base_rec_exempt_material"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_viss_alanyi
-msgid "base_rec_exempt_tax"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_import
-msgid "base_rec_import"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_viss
-msgid "base_rec_intra"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_forditott
-msgid "base_rec_reverse"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_fizetndo_18
-msgid "vat_pay_18"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_fizetndo_27
-msgid "vat_pay_27"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_fizetndo_5
-msgid "vat_pay_5"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_fizetndo_viss_18
-msgid "vat_rec_18"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_fizetndo_viss_27
-msgid "vat_rec_27"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_fizetndo_viss_5
-msgid "vat_rec_5"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_fizetndo_viss_komp
-msgid "vat_rec_compensation"
-msgstr ""

--- a/addons/l10n_hu/i18n/l10n_hu.pot
+++ b/addons/l10n_hu/i18n/l10n_hu.pot
@@ -4,125 +4,16 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 15.0+e\n"
+"Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-04 13:34+0000\n"
-"PO-Revision-Date: 2022-08-04 13:34+0000\n"
+"POT-Creation-Date: 2024-08-26 11:07+0000\n"
+"PO-Revision-Date: 2024-08-26 11:07+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
-
-#. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_FKKT
-#: model:account.tax,description:l10n_hu.1_VKKT
-#: model:account.tax,description:l10n_hu.2_FKKT
-#: model:account.tax,description:l10n_hu.2_VKKT
-#: model:account.tax,name:l10n_hu.1_FKKT model:account.tax,name:l10n_hu.1_VKKT
-#: model:account.tax,name:l10n_hu.2_FKKT model:account.tax,name:l10n_hu.2_VKKT
-#: model:account.tax.template,description:l10n_hu.FKKT
-#: model:account.tax.template,description:l10n_hu.VKKT
-#: model:account.tax.template,name:l10n_hu.FKKT
-#: model:account.tax.template,name:l10n_hu.VKKT
-msgid "0% Goods Exempt"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_FEXT
-#: model:account.tax,description:l10n_hu.2_FEXT
-#: model:account.tax,name:l10n_hu.1_FEXT model:account.tax,name:l10n_hu.2_FEXT
-#: model:account.tax.template,description:l10n_hu.FEXT
-#: model:account.tax.template,name:l10n_hu.FEXT
-msgid "0% Goods Export"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.tax,name:l10n_hu.1_FEUT model:account.tax,name:l10n_hu.2_FEUT
-#: model:account.tax.template,name:l10n_hu.FEUT
-msgid "0% Goods ICD"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_FEUT
-#: model:account.tax,description:l10n_hu.2_FEUT
-#: model:account.tax.template,description:l10n_hu.FEUT
-msgid "0% Goods Intra-community Deliveries"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.tax,name:l10n_hu.1_VEUM model:account.tax,name:l10n_hu.2_VEUM
-#: model:account.tax.template,name:l10n_hu.VEUM
-msgid "0% ICA"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_VIM
-#: model:account.tax,description:l10n_hu.2_VIM
-#: model:account.tax,name:l10n_hu.1_VIM model:account.tax,name:l10n_hu.2_VIM
-#: model:account.tax.template,description:l10n_hu.VIM
-#: model:account.tax.template,name:l10n_hu.VIM
-msgid "0% Import"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_VEUM
-#: model:account.tax,description:l10n_hu.2_VEUM
-#: model:account.tax.template,description:l10n_hu.VEUM
-msgid "0% Intra-community Acquisition"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_FT
-#: model:account.tax,description:l10n_hu.1_VT
-#: model:account.tax,description:l10n_hu.2_FT
-#: model:account.tax,description:l10n_hu.2_VT
-#: model:account.tax,name:l10n_hu.1_FT model:account.tax,name:l10n_hu.1_VT
-#: model:account.tax,name:l10n_hu.2_FT model:account.tax,name:l10n_hu.2_VT
-#: model:account.tax.template,description:l10n_hu.FT
-#: model:account.tax.template,description:l10n_hu.VT
-#: model:account.tax.template,name:l10n_hu.FT
-#: model:account.tax.template,name:l10n_hu.VT
-msgid "0% Material"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_FKKS
-#: model:account.tax,description:l10n_hu.1_VKKS
-#: model:account.tax,description:l10n_hu.2_FKKS
-#: model:account.tax,description:l10n_hu.2_VKKS
-#: model:account.tax,name:l10n_hu.1_FKKS model:account.tax,name:l10n_hu.1_VKKS
-#: model:account.tax,name:l10n_hu.2_FKKS model:account.tax,name:l10n_hu.2_VKKS
-#: model:account.tax.template,description:l10n_hu.FKKS
-#: model:account.tax.template,description:l10n_hu.VKKS
-#: model:account.tax.template,name:l10n_hu.FKKS
-#: model:account.tax.template,name:l10n_hu.VKKS
-msgid "0% Services Exempt"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_FEXS
-#: model:account.tax,description:l10n_hu.2_FEXS
-#: model:account.tax,name:l10n_hu.1_FEXS model:account.tax,name:l10n_hu.2_FEXS
-#: model:account.tax.template,description:l10n_hu.FEXS
-#: model:account.tax.template,name:l10n_hu.FEXS
-msgid "0% Services Export"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.tax,name:l10n_hu.1_FEUSZ
-#: model:account.tax,name:l10n_hu.2_FEUSZ
-#: model:account.tax.template,name:l10n_hu.FEUSZ
-msgid "0% Services ICD"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_FEUSZ
-#: model:account.tax,description:l10n_hu.2_FEUSZ
-#: model:account.tax.template,description:l10n_hu.FEUSZ
-msgid "0% Services Intra-community Deliveries"
-msgstr ""
 
 #. module: l10n_hu
 #: model:account.tax,description:l10n_hu.1_FA
@@ -135,12 +26,67 @@ msgstr ""
 #: model:account.tax.template,description:l10n_hu.VA
 #: model:account.tax.template,name:l10n_hu.FA
 #: model:account.tax.template,name:l10n_hu.VA
-msgid "0% Subject"
+msgid "0% AAM"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.group,name:l10n_hu.tax_group_afa_0
-msgid "0% VAT"
+#: model:account.tax,description:l10n_hu.1_FEUT
+#: model:account.tax,description:l10n_hu.2_FEUT
+#: model:account.tax,name:l10n_hu.1_FEUT model:account.tax,name:l10n_hu.2_FEUT
+#: model:account.tax.template,description:l10n_hu.FEUT
+#: model:account.tax.template,name:l10n_hu.FEUT
+msgid "0% EU G"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.tax,description:l10n_hu.1_FEUSZ
+#: model:account.tax,description:l10n_hu.2_FEUSZ
+#: model:account.tax,name:l10n_hu.1_FEUSZ
+#: model:account.tax,name:l10n_hu.2_FEUSZ
+#: model:account.tax.template,description:l10n_hu.FEUSZ
+#: model:account.tax.template,name:l10n_hu.FEUSZ
+msgid "0% EU S"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.tax,description:l10n_hu.1_VIM
+#: model:account.tax,description:l10n_hu.2_VIM
+#: model:account.tax,name:l10n_hu.1_VIM model:account.tax,name:l10n_hu.2_VIM
+#: model:account.tax.template,description:l10n_hu.VIM
+#: model:account.tax.template,name:l10n_hu.VIM
+msgid "0% EX"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.tax,description:l10n_hu.1_FEXT
+#: model:account.tax,description:l10n_hu.2_FEXT
+#: model:account.tax,name:l10n_hu.1_FEXT model:account.tax,name:l10n_hu.2_FEXT
+#: model:account.tax.template,description:l10n_hu.FEXT
+#: model:account.tax.template,name:l10n_hu.FEXT
+msgid "0% G EX"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.tax,description:l10n_hu.1_FKKT
+#: model:account.tax,description:l10n_hu.1_VKKT
+#: model:account.tax,description:l10n_hu.2_FKKT
+#: model:account.tax,description:l10n_hu.2_VKKT
+#: model:account.tax,name:l10n_hu.1_FKKT model:account.tax,name:l10n_hu.1_VKKT
+#: model:account.tax,name:l10n_hu.2_FKKT model:account.tax,name:l10n_hu.2_VKKT
+#: model:account.tax.template,description:l10n_hu.FKKT
+#: model:account.tax.template,description:l10n_hu.VKKT
+#: model:account.tax.template,name:l10n_hu.FKKT
+#: model:account.tax.template,name:l10n_hu.VKKT
+msgid "0% G EXEMPT"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.tax,description:l10n_hu.1_VEUM
+#: model:account.tax,description:l10n_hu.2_VEUM
+#: model:account.tax,name:l10n_hu.1_VEUM model:account.tax,name:l10n_hu.2_VEUM
+#: model:account.tax.template,description:l10n_hu.VEUM
+#: model:account.tax.template,name:l10n_hu.VEUM
+msgid "0% ICA"
 msgstr ""
 
 #. module: l10n_hu
@@ -154,21 +100,59 @@ msgstr ""
 #: model:account.tax.template,description:l10n_hu.VF
 #: model:account.tax.template,name:l10n_hu.FF
 #: model:account.tax.template,name:l10n_hu.VF
-msgid "0% VAT (Reverse)"
+msgid "0% R"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax,name:l10n_hu.1_VKOMP12
-#: model:account.tax,name:l10n_hu.2_VKOMP12
-#: model:account.tax.template,name:l10n_hu.VKOMP12
-msgid "12% Comp."
+#: model:account.tax,description:l10n_hu.1_FEXS
+#: model:account.tax,description:l10n_hu.2_FEXS
+#: model:account.tax,name:l10n_hu.1_FEXS model:account.tax,name:l10n_hu.2_FEXS
+#: model:account.tax.template,description:l10n_hu.FEXS
+#: model:account.tax.template,name:l10n_hu.FEXS
+msgid "0% S EX"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.tax,description:l10n_hu.1_FKKS
+#: model:account.tax,description:l10n_hu.1_VKKS
+#: model:account.tax,description:l10n_hu.2_FKKS
+#: model:account.tax,description:l10n_hu.2_VKKS
+#: model:account.tax,name:l10n_hu.1_FKKS model:account.tax,name:l10n_hu.1_VKKS
+#: model:account.tax,name:l10n_hu.2_FKKS model:account.tax,name:l10n_hu.2_VKKS
+#: model:account.tax.template,description:l10n_hu.FKKS
+#: model:account.tax.template,description:l10n_hu.VKKS
+#: model:account.tax.template,name:l10n_hu.FKKS
+#: model:account.tax.template,name:l10n_hu.VKKS
+msgid "0% S EXEMPT"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.tax,description:l10n_hu.1_FT
+#: model:account.tax,description:l10n_hu.1_VT
+#: model:account.tax,description:l10n_hu.2_FT
+#: model:account.tax,description:l10n_hu.2_VT
+#: model:account.tax,name:l10n_hu.1_FT model:account.tax,name:l10n_hu.1_VT
+#: model:account.tax,name:l10n_hu.2_FT model:account.tax,name:l10n_hu.2_VT
+#: model:account.tax.template,description:l10n_hu.FT
+#: model:account.tax.template,description:l10n_hu.VT
+#: model:account.tax.template,name:l10n_hu.FT
+#: model:account.tax.template,name:l10n_hu.VT
+msgid "0% TAM"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.tax.group,name:l10n_hu.tax_group_afa_0
+msgid "0% VAT"
 msgstr ""
 
 #. module: l10n_hu
 #: model:account.tax,description:l10n_hu.1_VKOMP12
 #: model:account.tax,description:l10n_hu.2_VKOMP12
+#: model:account.tax,name:l10n_hu.1_VKOMP12
+#: model:account.tax,name:l10n_hu.2_VKOMP12
 #: model:account.tax.template,description:l10n_hu.VKOMP12
-msgid "12% Compensation Surcharge"
+#: model:account.tax.template,name:l10n_hu.VKOMP12
+msgid "12% CS"
 msgstr ""
 
 #. module: l10n_hu
@@ -178,82 +162,20 @@ msgstr ""
 #: model:account.tax,description:l10n_hu.2_V18
 #: model:account.tax,name:l10n_hu.1_F18 model:account.tax,name:l10n_hu.1_V18
 #: model:account.tax,name:l10n_hu.2_F18 model:account.tax,name:l10n_hu.2_V18
-#: model:account.tax.group,name:l10n_hu.tax_group_afa_18
-#: model:account.report.line,name:l10n_hu.tax_report_alap_fiz_afa_18
-#: model:account.report.line,name:l10n_hu.tax_report_alap_viss_18
-#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_18
-#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_viss_18
 #: model:account.tax.template,description:l10n_hu.F18
 #: model:account.tax.template,description:l10n_hu.V18
 #: model:account.tax.template,name:l10n_hu.F18
 #: model:account.tax.template,name:l10n_hu.V18
+msgid "18%"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.report.line,name:l10n_hu.tax_report_alap_fiz_afa_18
+#: model:account.report.line,name:l10n_hu.tax_report_alap_viss_18
+#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_18
+#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_viss_18
+#: model:account.tax.group,name:l10n_hu.tax_group_afa_18
 msgid "18% VAT"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.tax,name:l10n_hu.1_VEU27T
-#: model:account.tax,name:l10n_hu.2_VEU27T
-#: model:account.tax.template,name:l10n_hu.VEU27T
-msgid "27% Goods ICA"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_VEU27T
-#: model:account.tax,description:l10n_hu.2_VEU27T
-#: model:account.tax.template,description:l10n_hu.VEU27T
-msgid "27% Goods Intra-community Acquisition"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_VEU27TE
-#: model:account.tax,description:l10n_hu.2_VEU27TE
-#: model:account.tax,name:l10n_hu.1_VEU27TE
-#: model:account.tax,name:l10n_hu.2_VEU27TE
-#: model:account.tax.template,description:l10n_hu.VEU27TE
-#: model:account.tax.template,name:l10n_hu.VEU27TE
-msgid "27% ICA (Property)"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_VIMS
-#: model:account.tax,description:l10n_hu.2_VIMS
-#: model:account.tax,name:l10n_hu.1_VIMS model:account.tax,name:l10n_hu.2_VIMS
-#: model:account.tax.template,description:l10n_hu.VIMS
-#: model:account.tax.template,name:l10n_hu.VIMS
-msgid "27% Import"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_VIMK
-#: model:account.tax,description:l10n_hu.2_VIMK
-#: model:account.tax,name:l10n_hu.1_VIMK model:account.tax,name:l10n_hu.2_VIMK
-#: model:account.tax.template,description:l10n_hu.VIMK
-#: model:account.tax.template,name:l10n_hu.VIMK
-msgid "27% Import (Sourcing)"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_V27TE
-#: model:account.tax,description:l10n_hu.2_V27TE
-#: model:account.tax,name:l10n_hu.1_V27TE
-#: model:account.tax,name:l10n_hu.2_V27TE
-#: model:account.tax.template,description:l10n_hu.V27TE
-#: model:account.tax.template,name:l10n_hu.V27TE
-msgid "27% Property, plant and equipment"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.tax,name:l10n_hu.1_VEU27S
-#: model:account.tax,name:l10n_hu.2_VEU27S
-#: model:account.tax.template,name:l10n_hu.VEU27S
-msgid "27% Services ICA"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_VEU27S
-#: model:account.tax,description:l10n_hu.2_VEU27S
-#: model:account.tax.template,description:l10n_hu.VEU27S
-msgid "27% Services Intra-community Acquisition"
 msgstr ""
 
 #. module: l10n_hu
@@ -263,49 +185,97 @@ msgstr ""
 #: model:account.tax,description:l10n_hu.2_V27
 #: model:account.tax,name:l10n_hu.1_F27 model:account.tax,name:l10n_hu.1_V27
 #: model:account.tax,name:l10n_hu.2_F27 model:account.tax,name:l10n_hu.2_V27
-#: model:account.tax.group,name:l10n_hu.tax_group_afa_27
-#: model:account.report.line,name:l10n_hu.tax_report_alap_fiz_afa_27
-#: model:account.report.line,name:l10n_hu.tax_report_alap_viss_27
-#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_27
-#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_viss_27
 #: model:account.tax.template,description:l10n_hu.F27
 #: model:account.tax.template,description:l10n_hu.V27
 #: model:account.tax.template,name:l10n_hu.F27
 #: model:account.tax.template,name:l10n_hu.V27
+msgid "27%"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.tax,description:l10n_hu.1_VEU27T
+#: model:account.tax,description:l10n_hu.2_VEU27T
+#: model:account.tax,name:l10n_hu.1_VEU27T
+#: model:account.tax,name:l10n_hu.2_VEU27T
+#: model:account.tax.template,description:l10n_hu.VEU27T
+#: model:account.tax.template,name:l10n_hu.VEU27T
+msgid "27% EU G"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.tax,description:l10n_hu.1_VEU27TE
+#: model:account.tax,description:l10n_hu.2_VEU27TE
+#: model:account.tax,name:l10n_hu.1_VEU27TE
+#: model:account.tax,name:l10n_hu.2_VEU27TE
+#: model:account.tax.template,description:l10n_hu.VEU27TE
+#: model:account.tax.template,name:l10n_hu.VEU27TE
+msgid "27% EU P"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.tax,description:l10n_hu.1_VEU27S
+#: model:account.tax,description:l10n_hu.2_VEU27S
+#: model:account.tax,name:l10n_hu.1_VEU27S
+#: model:account.tax,name:l10n_hu.2_VEU27S
+#: model:account.tax.template,description:l10n_hu.VEU27S
+#: model:account.tax.template,name:l10n_hu.VEU27S
+msgid "27% EU S"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.tax,description:l10n_hu.1_VIMS
+#: model:account.tax,description:l10n_hu.2_VIMS
+#: model:account.tax,name:l10n_hu.1_VIMS model:account.tax,name:l10n_hu.2_VIMS
+#: model:account.tax.template,description:l10n_hu.VIMS
+#: model:account.tax.template,name:l10n_hu.VIMS
+msgid "27% EX"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.tax,description:l10n_hu.1_VIMK
+#: model:account.tax,description:l10n_hu.2_VIMK
+#: model:account.tax,name:l10n_hu.1_VIMK model:account.tax,name:l10n_hu.2_VIMK
+#: model:account.tax.template,description:l10n_hu.VIMK
+#: model:account.tax.template,name:l10n_hu.VIMK
+msgid "27% EX S"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.tax,description:l10n_hu.1_V27TE
+#: model:account.tax,description:l10n_hu.2_V27TE
+#: model:account.tax,name:l10n_hu.1_V27TE
+#: model:account.tax,name:l10n_hu.2_V27TE
+#: model:account.tax.template,description:l10n_hu.V27TE
+#: model:account.tax.template,name:l10n_hu.V27TE
+msgid "27% PPE"
+msgstr ""
+
+#. module: l10n_hu
+#: model:account.report.line,name:l10n_hu.tax_report_alap_fiz_afa_27
+#: model:account.report.line,name:l10n_hu.tax_report_alap_viss_27
+#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_27
+#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_viss_27
+#: model:account.tax.group,name:l10n_hu.tax_group_afa_27
 msgid "27% VAT"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax,description:l10n_hu.1_F5
-#: model:account.tax,description:l10n_hu.1_V5
-#: model:account.tax,description:l10n_hu.2_F5
-#: model:account.tax,description:l10n_hu.2_V5
-#: model:account.tax,name:l10n_hu.1_F5 model:account.tax,name:l10n_hu.1_V5
-#: model:account.tax,name:l10n_hu.2_F5 model:account.tax,name:l10n_hu.2_V5
-#: model:account.tax.group,name:l10n_hu.tax_group_afa_5
 #: model:account.report.line,name:l10n_hu.tax_report_alap_fiz_afa_5
 #: model:account.report.line,name:l10n_hu.tax_report_alap_viss_5
 #: model:account.report.line,name:l10n_hu.tax_report_fizetndo_5
 #: model:account.report.line,name:l10n_hu.tax_report_fizetndo_viss_5
-#: model:account.tax.template,description:l10n_hu.F5
-#: model:account.tax.template,description:l10n_hu.V5
-#: model:account.tax.template,name:l10n_hu.F5
-#: model:account.tax.template,name:l10n_hu.V5
+#: model:account.tax.group,name:l10n_hu.tax_group_afa_5
 msgid "5% VAT"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.tax,name:l10n_hu.1_VKOMP7
-#: model:account.tax,name:l10n_hu.2_VKOMP7
-#: model:account.tax.template,name:l10n_hu.VKOMP7
-msgid "7% Comp."
 msgstr ""
 
 #. module: l10n_hu
 #: model:account.tax,description:l10n_hu.1_VKOMP7
 #: model:account.tax,description:l10n_hu.2_VKOMP7
+#: model:account.tax,name:l10n_hu.1_VKOMP7
+#: model:account.tax,name:l10n_hu.2_VKOMP7
 #: model:account.tax.template,description:l10n_hu.VKOMP7
-msgid "7% Compensation Surcharge"
+#: model:account.tax.template,name:l10n_hu.VKOMP7
+msgid "7% CS"
 msgstr ""
 
 #. module: l10n_hu
@@ -523,10 +493,8 @@ msgid "Anniversary reward, object reward"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.account,name:l10n_hu.1_l10n_hu_418
-#: model:account.account,name:l10n_hu.2_l10n_hu_418
-#: model:account.account.template,name:l10n_hu.l10n_hu_418
-msgid "Balance sheet result from the correction of previous years"
+#: model:account.report.column,name:l10n_hu.tax_report_balance
+msgid "Balance"
 msgstr ""
 
 #. module: l10n_hu
@@ -1631,11 +1599,6 @@ msgid "Housing subsidy, rent contribution"
 msgstr ""
 
 #. module: l10n_hu
-#: model:ir.ui.menu,name:l10n_hu.hu_reports_menu
-msgid "Hungary"
-msgstr ""
-
-#. module: l10n_hu
 #: model:account.chart.template,name:l10n_hu.hungarian_chart_template
 msgid "Hungary - National Chart of Accounts"
 msgstr ""
@@ -2716,13 +2679,6 @@ msgid "Production machines, equipment, tools, production tools"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.account,name:l10n_hu.1_l10n_hu_419
-#: model:account.account,name:l10n_hu.2_l10n_hu_419
-#: model:account.account.template,name:l10n_hu.l10n_hu_419
-msgid "Profit after tax"
-msgstr ""
-
-#. module: l10n_hu
 #: model:account.account,name:l10n_hu.1_l10n_hu_413
 #: model:account.account,name:l10n_hu.2_l10n_hu_413
 #: model:account.account.template,name:l10n_hu.l10n_hu_413
@@ -3283,6 +3239,11 @@ msgid "Suppliers"
 msgstr ""
 
 #. module: l10n_hu
+#: model:account.report,name:l10n_hu.tax_report
+msgid "Tax Report"
+msgstr ""
+
+#. module: l10n_hu
 #: model:account.report.line,name:l10n_hu.tax_report_alap
 msgid "Tax base"
 msgstr ""
@@ -3656,129 +3617,4 @@ msgstr ""
 #: model:account.group,name:l10n_hu.2_l10n_hu_group_23
 #: model:account.group.template,name:l10n_hu.l10n_hu_group_23
 msgid "Work in progress and semi-finished products"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_afa_18
-msgid "base_pay_18"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_afa_27
-msgid "base_pay_27"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_afa_5
-msgid "base_pay_5"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_koron_kivuli
-msgid "base_pay_exempt"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_targyi
-msgid "base_pay_exempt_property"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_alanyi
-msgid "base_pay_exempt_tax"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_export
-msgid "base_pay_exports"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_eu
-msgid "base_pay_intra"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_viss_18
-msgid "base_rec_18"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_viss_27
-msgid "base_rec_27"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_viss_5
-msgid "base_rec_5"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_komp
-msgid "base_rec_compensation"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_viss_koron_kivuli
-msgid "base_rec_exempt"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_viss_targyi
-msgid "base_rec_exempt_material"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_viss_alanyi
-msgid "base_rec_exempt_tax"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_import
-msgid "base_rec_import"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_viss
-msgid "base_rec_intra"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_forditott
-msgid "base_rec_reverse"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_fizetndo_18
-msgid "vat_pay_18"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_fizetndo_27
-msgid "vat_pay_27"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_fizetndo_5
-msgid "vat_pay_5"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_fizetndo_viss_18
-msgid "vat_rec_18"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_fizetndo_viss_27
-msgid "vat_rec_27"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_fizetndo_viss_5
-msgid "vat_rec_5"
-msgstr ""
-
-#. module: l10n_hu
-#: model:account.report.line,tag_name:l10n_hu.tax_report_fizetndo_viss_komp
-msgid "vat_rec_compensation"
 msgstr ""


### PR DESCRIPTION
In #97883, the Hungarian localization was translated from Hungarian into English. After that, some Hungarian translations for tax names, tax descriptions and tax report lines were lost.

This commit aims at ensuring the translations are added and bringing Hungarian taxes in conformity with best practices.

Specifically, this commit changes tax names in descriptions according to the tax naming conventions.

task-4132407


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
