### PR TITLE
[FIX] account: set currency_id in multicurrency accrual moves

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -3297,6 +3297,13 @@ msgstr ""
 
 #. module: account
 #. odoo-python
+#: code:addons/account/wizard/accrued_orders.py:0
+#, python-format
+msgid "Cannot create an accrual entry with orders in different currencies."
+msgstr ""
+
+#. module: account
+#. odoo-python
 #: code:addons/account/models/account_move.py:0
 #, python-format
 msgid ""

--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -243,6 +243,7 @@ class AccruedExpenseRevenue(models.TransientModel):
             'journal_id': self.journal_id.id,
             'date': self.date,
             'line_ids': move_lines,
+            'currency_id': orders.currency_id.id or self.company_id.currency_id.id,
         }
         return move_vals, orders_with_entries
 
@@ -251,6 +252,9 @@ class AccruedExpenseRevenue(models.TransientModel):
 
         if self.reversal_date <= self.date:
             raise UserError(_('Reversal date must be posterior to date.'))
+        orders = self.env[self._context['active_model']].with_company(self.company_id).browse(self._context['active_ids'])
+        if len({order.currency_id or order.company_id.currency_id for order in orders}) != 1:
+            raise UserError(_('Cannot create an accrual entry with orders in different currencies.'))
 
         move_vals, orders_with_entries = self._compute_move_vals()
         move = self.env['account.move'].create(move_vals)

--- a/addons/purchase/tests/test_accrued_purchase_orders.py
+++ b/addons/purchase/tests/test_accrued_purchase_orders.py
@@ -97,7 +97,10 @@ class TestAccruedPurchaseOrders(AccountTestInvoicingCommon):
         self.purchase_order.order_line.qty_received = 5
         # set currency != company currency
         self.purchase_order.currency_id = self.currency_data['currency']
-        self.assertRecordValues(self.env['account.move'].search(self.wizard.create_entries()['domain']).line_ids, [
+        moves = self.env['account.move'].search(self.wizard.create_entries()['domain'])
+        for move in moves:
+            self.assertEqual(move.currency_id, self.purchase_order.currency_id)
+        self.assertRecordValues(moves.line_ids, [
             # reverse move lines
             {'account_id': self.account_expense.id, 'debit': 0, 'credit': 5000 / 2, 'amount_currency': -5000},
             {'account_id': self.alt_exp_account.id, 'debit': 0, 'credit': 1000 / 2, 'amount_currency': -1000},


### PR DESCRIPTION
Issue:
* Accrued Expense Entry shows wrong currency symbol for 'Total in Currency' for multicurrency POs.

Steps To Reproduce:
* In a multicurrency environmentcreate a PO with a currency different  than the one of the company and confirm it.
* Receive the product and validate it.
* On the PO action wheel, create `Accrued Expense Entry`.
* Notice 'Total in Currency' is set to the wrong currency.

Solution:
* In `_compute_move_vals` I set the move's `currency_id` of the accrual move to that of the order's currency.
* in `create_entries` I prevent the creation of the accrual move if orders have different currencies.
* Please note that there were no issues with currency conversions.

opw-4072932

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
