### PR TITLE
[FIX] mail: hide thread unread indicator when there's badge counter

### DIFF
--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -12,7 +12,7 @@
 
     <t t-name="mail.ChatBubble.core">
         <div class="o-mail-ChatBubble bg-view position-relative" t-att-name="props.chatWindow.displayName" t-att-class="{ 'o-bouncing': state.bouncing, 'position-fixed': env.embedLivechat, 'position-relative': !env.embedLivechat, 'o-active': preview.isOpen }" t-att-style="env.embedLivechat ? `top: ${ position.top }; left: ${ position.left };` : ''" t-on-click="() => props.chatWindow.open()" t-on-animationend="() => state.bouncing = false" t-ref="root">
-            <span class="o-mail-ChatBubble-unreadIndicator position-absolute" t-att-class="{ 'opacity-50': thread?.isUnread, 'opacity-0': !thread?.isUnread }"><i class="fa fa-circle"/></span>
+            <span class="o-mail-ChatBubble-unreadIndicator position-absolute" t-att-class="{ 'opacity-50': thread?.isUnread and !thread?.importantCounter, 'opacity-0': !thread?.isUnread or thread?.importantCounter }"><i class="fa fa-circle"/></span>
             <div t-if="thread?.importantCounter > 0" class="o-mail-ChatBubble-counter position-absolute badge rounded-pill fw-bold o-discuss-badge shadow" t-out="thread?.importantCounter"/>
             <button t-if="state.showClose and !env.embedLivechat" class="o-mail-ChatBubble-close position-absolute shadow rounded-circle fw-bold bg-view" title="Close Chat Window" t-on-click.stop="() => this.props.chatWindow.close()"><i class="oi oi-close"/></button>
             <ImStatus t-if="thread?.correspondent?.persona?.im_status and thread?.correspondent?.persona?.im_status != 'offline'" className="'o-mail-ChatBubble-status position-absolute o-mail-brighter'" member="thread.correspondent"/>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -128,7 +128,7 @@
                     <t t-component="indicators[0]" t-props="{ thread }"/>
                 </div>
             </t>
-            <span t-if="thread.selfMember?.message_unread_counter > 0 and !thread.mute_until_dt" class="o-mail-DiscussSidebarChannel-unreadIndicator position-absolute" name="unread-indicator" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }" title="Thread has unread messages"><i class="fa fa-circle smaller"/></span>
+            <span t-if="thread.selfMember?.message_unread_counter > 0 and !thread.mute_until_dt and thread.importantCounter === 0" class="o-mail-DiscussSidebarChannel-unreadIndicator position-absolute" name="unread-indicator" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }" title="Thread has unread messages"><i class="fa fa-circle smaller"/></span>
             <span t-if="thread.importantCounter > 0" t-attf-class="o-mail-DiscussSidebar-badge badge rounded-pill o-discuss-badge fw-bold {{thread.mute_until_dt ? 'o-muted' : ''}}" t-att-class="{ 'ms-1 me-2': !store.discuss.isSidebarCompact, 'position-absolute top-0 o-compact': store.discuss.isSidebarCompact }" t-esc="thread.importantCounter"/>
         </div>
     </t>


### PR DESCRIPTION
Before this commit, a Discuss sidebar item or chat bubble could display both an unread indicator (dot) and the badge counter.

When the conversation has badge counter, this means it has some important messages. The unread indicator means there are some unread messages. Important messages are necessarily unread, so having both at the same time makes UI more noisy than it should.

This commit fixes the issue by hiding the unread indicator when there are some important messages, as the badge is enough to tell there are unread messages.

Note that the unread indicator is specifically there to better spot conversations with unread but non-important messages. In this context, in the past the conversations only had bolder name, which is not enough to easily distinguish them from read conversations.

Before / after

<img width="82" alt="Screenshot 2024-08-26 at 17 04 20" src="https://github.com/user-attachments/assets/2fc5a3cd-84f0-4f62-9301-73e2bd37efab"> <img width="79" alt="Screenshot 2024-08-26 at 16 58 28" src="https://github.com/user-attachments/assets/ef1d0380-573b-4f7c-9402-e3fd891d8a38">

