### PR TITLE
 [FIX] delivery: convert currency for base on rule shipping

### DIFF
--- a/addons/delivery/models/delivery_grid.py
+++ b/addons/delivery/models/delivery_grid.py
@@ -68,12 +68,13 @@ class ProviderGrid(models.Model):
                 'warning_message': False}
 
     def _get_conversion_currencies(self, order, conversion):
-        if conversion == 'company_to_pricelist':
-            from_currency, to_currency = order.company_id.currency_id, order.pricelist_id.currency_id
-        elif conversion == 'pricelist_to_company':
-            from_currency, to_currency = order.currency_id, order.company_id.currency_id
+        company_currency = (self.company_id or self.env['res.company']._get_main_company()).currency_id
+        pricelist_currency = order.currency_id
 
-        return from_currency, to_currency
+        if conversion == 'company_to_pricelist':
+            return company_currency, pricelist_currency
+        elif conversion == 'pricelist_to_company':
+            return pricelist_currency, company_currency
 
     def _compute_currency(self, order, price, conversion):
         from_currency, to_currency = self._get_conversion_currencies(order, conversion)

--- a/addons/delivery/tests/test_delivery_cost.py
+++ b/addons/delivery/tests/test_delivery_cost.py
@@ -433,3 +433,73 @@ class TestDeliveryCost(common.TransactionCase):
             qty * list_price * weight * volume,
             "The shipping price is not correctly computed with variable weight*volume.",
         )
+
+    def test_base_on_rule_currency_is_converted(self):
+        """
+        For based on rules delivery method without a company, check that the price
+        is converted from the main's company's currency to the current company's on SOs
+        """
+
+        # Create a company that uses a different currency
+        currency_bells = self.env['res.currency'].create({
+            'name': 'Bell',
+            'symbol': 'C',
+        })
+
+        nook_inc = self.env['res.company'].create({
+            'name': 'Nook inc.',
+            'currency_id': currency_bells.id,
+        })
+
+        self.env['res.currency.rate'].with_company(nook_inc).create({
+            'currency_id': currency_bells.id,
+            'company_rate': 0.5,
+            'inverse_company_rate': 2,
+        })
+
+        # Company less shipping method
+        product_delivery_rule = self.env['product.product'].with_company(nook_inc).create({
+            'name': 'rule delivery charges',
+            'type': 'service',
+            'list_price': 10.0,
+            'categ_id': self.env.ref('delivery.product_category_deliveries').id,
+        })
+
+        delivery = self.env['delivery.carrier'].with_company(nook_inc).create({
+            'name': 'Rule Delivery',
+            'delivery_type': 'base_on_rule',
+            'product_id': product_delivery_rule.id,
+            'price_rule_ids': [(0, 0, {
+                'variable': 'price',
+                'operator': '>=',
+                'max_value': 0,
+                'variable_factor': 'weight',
+                'list_base_price': 15,
+            })]
+        })
+
+        # Create sale using the shipping method
+        so = self.SaleOrder.with_company(nook_inc).create({
+            'partner_id': self.partner_18.id,
+            'partner_invoice_id': self.partner_18.id,
+            'partner_shipping_id': self.partner_18.id,
+            'order_line': [(0, 0, {
+                'name': 'PC Assamble + 2GB RAM',
+                'product_id': self.product_4.id,
+                'product_uom_qty': 1,
+                'product_uom': self.product_uom_unit.id,
+                'price_unit': 750.00,
+            })],
+        })
+
+        delivery_wizard = Form(self.env['choose.delivery.carrier'].with_company(nook_inc).with_context({
+            'default_order_id': so.id,
+            'default_carrier_id': delivery.id,
+        }))
+        choose_delivery_carrier = delivery_wizard.save()
+        choose_delivery_carrier.button_confirm()
+
+        # check delivery price was properly converted
+        delivery_sol = so.order_line[-1]
+        self.assertEqual(delivery_sol.product_id, delivery.product_id)
+        self.assertEqual(delivery_sol.price_subtotal, 7.5)


### PR DESCRIPTION
Steps
---
* create a set-up with 2 companies using different currencies. eg:
  * company 1: usd
  * company 2: eur
* from the company 2: set a conversion rate from eur to usd in
  *Currencies*
* from company 1: create a based on rules shipping method (with prices
  in usd)
* from company 2:
  * create an SO for some products
  * add the shipping method
* => the price in dollars is used unconverted as the price in eur

Cause
---
when we have a base_on_rule delivery without a specified company,
we convert prices as if the price was in the current company's currency.

Fix
---
Consider the price to be in the main company's currency instead

opw-4105047