### PR TITLE
[FIX] mail_plugin: fix underministic test_get_partner_blacklisted_domain

### DIFF
--- a/addons/mail_plugin/tests/test_controller.py
+++ b/addons/mail_plugin/tests/test_controller.py
@@ -34,7 +34,7 @@ class TestMailPluginController(TestMailPluginControllerCommon):
     @mock_auth_method_outlook('employee')
     def test_get_partner_blacklisted_domain(self):
         """Test enrichment on a blacklisted domain, should return an error."""
-        domain = list(iap_tools._MAIL_DOMAIN_BLACKLIST)[0]
+        domain = min(iap_tools._MAIL_PROVIDERS)
 
         data = {
             "id": 0,


### PR DESCRIPTION
This test was underministically failing due to a combination of two factors:
- The domain chosen for the test is selected by
```py
domain = list(iap_tools._MAIL_DOMAIN_BLACKLIST)[0]
```
  which was undeterministic since `iap_tools._MAIL_DOMAIN_BLACKLIST` is a set.
- Since commit 02b5d47, a distinction was made between email providers `_MAIL_PROVIDERS` and the domain blacklist `_MAIL_DOMAIN_BLACKLIST`. The test used `_MAIL_DOMAIN_BLACKLIST` instead of `_MAIL_PROVIDERS`, it should have been adapted. The only difference between the two, at the moment, is the addition of "odoo.com" in the domain blacklist. When that domain is selected, the test crashes.
There is approximately a 1/124 chance of that happening.
