### PR TITLE
[IMP] hw_posbox_homepage: sanitize url on connection to db

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -18,6 +18,7 @@ import requests
 import secrets
 import socket
 import subprocess
+from urllib.parse import parse_qs
 import urllib3
 from threading import Thread, Lock
 import time
@@ -524,3 +525,38 @@ def disconnect_from_server():
     """Disconnect the IoT Box from the server"""
     unlink_file('odoo-remote-server.conf')
     get_odoo_server_url.cache_clear()
+
+
+def url_is_valid(url):
+    """
+    Checks whether the provided url is a valid one or not
+    :param url: the URL to check
+    :return: boolean indicating if the URL is valid.
+    """
+    try:
+        result = urllib3.util.parse_url(url.strip())
+        return all([result.scheme in ["http", "https"], result.netloc, result.host != 'localhost'])
+    except urllib3.exceptions.LocationParseError:
+        return False
+
+
+def parse_url(url):
+    """
+    Parses URL params and returns them as a dictionary starting by the url.
+
+    Does not allow multiple params with the same name (e.g. <url>?a=1&a=2 will return the same as <url>?a=1)
+    :param url: the URL to parse
+    :return: the dictionary containing the URL and params
+    """
+    if not url_is_valid(url):
+        raise ValueError("Invalid URL provided.")
+
+    url = urllib3.util.parse_url(url.strip())
+    search_params = {
+        key: value[0]
+        for key, value in parse_qs(url.query, keep_blank_values=True).items()
+    }
+    return {
+        "url": f"{url.scheme}://{url.netloc}",
+        **search_params,
+    }

--- a/addons/hw_posbox_homepage/controllers/main.py
+++ b/addons/hw_posbox_homepage/controllers/main.py
@@ -256,13 +256,16 @@ class IoTboxHomepage(Home):
     @http.route('/server_connect', type='http', auth='none', cors='*', csrf=False)
     def connect_to_server(self, token, iotname):
         if token:
-            credential = token.split('|')
-            url = credential[0]
-            token = credential[1]
-            db_uuid = credential[2]
-            enterprise_code = credential[3]
+            # credential = token.split('|')
+            # url = credential[0]
+            # token = credential[1]
+            # db_uuid = credential[2]
+            # enterprise_code = credential[3]
             try:
-                helpers.save_conf_server(url, token, db_uuid, enterprise_code)
+                configuration = helpers.parse_url(token)
+                helpers.save_conf_server(**configuration)
+            except ValueError:
+                return 'Invalid URL provided.'
             except (subprocess.CalledProcessError, OSError, Exception):
                 return 'Failed to write server configuration files on IoT. Please try again.'
 

--- a/addons/hw_posbox_homepage/views/server_config.html
+++ b/addons/hw_posbox_homepage/views/server_config.html
@@ -10,8 +10,8 @@
         }
 
         $(function () {
-            $('#server-config').on("submit", (function(e){
-                const server_token = $('#server-token').val().split('|')[0]; // only url
+            $('#server-config').on("submit", (function(e) {
+                const server_token = new URL($('#server-token').val()).origin; // only url
                 e.preventDefault();
                 $('.loading-block').removeClass('o_hide');
                 $.ajax({


### PR DESCRIPTION
We could not ensure that the url provided to the IoT Box to connect to Odoo db is correct. It could result on Odoo being down on the IoT Box, and thus being forced to flash the SD card again. We now use standard URL formatting, and ensure the url is correct before writing it on the IoT Box.

Enterprise PR: [https://github.com/odoo/enterprise/pull/68926](https://github.com/odoo/enterprise/pull/68926)
Task: 4116429
