### PR TITLE
[IMP] project: enable milestones for technical tours

### DIFF
--- a/addons/project/tests/test_project_sharing_ui.py
+++ b/addons/project/tests/test_project_sharing_ui.py
@@ -36,6 +36,7 @@ class TestProjectSharingUi(HttpCase):
                 Command.create({'name': 'Done', 'sequence': 10})
             ],
         })
+        cls.env['res.config.settings'].create({'group_project_milestone': True}).execute()
 
     def test_01_project_sharing(self):
         """ Test Project Sharing UI with an internal user """

--- a/addons/project/tests/test_project_ui.py
+++ b/addons/project/tests/test_project_ui.py
@@ -6,6 +6,11 @@ import odoo.tests
 @odoo.tests.tagged('post_install', '-at_install')
 class TestUi(odoo.tests.HttpCase):
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env['res.config.settings'].create({'group_project_milestone': True}).execute()
+
     def test_01_project_tour(self):
         self.start_tour("/web", 'project_tour', login="admin")
 


### PR DESCRIPTION
Some project tours rely on the milestones feature being enabled.
While this is the case when demo data are installed, it's not when they aren't, and the tours fail.
To solve this issue, and prevent future ones from being created, PR enables the feature before each tour.

Task-4132639