### PR TITLE
[FIX] account: Fix account.display_name

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -773,7 +773,7 @@ class AccountAccount(models.Model):
     @api.depends('code')
     def _compute_display_name(self):
         for account in self:
-            account.display_name = f"{account.code} {account.name}"
+            account.display_name = f"{account.code} {account.name}" if account.code else account.name
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default)


### PR DESCRIPTION
Since making `account.code` a company-dependent field in 854c3b27aa5, `account.code` is `False` when the account code is not defined from the perspective of the currently-active company. In this case, we don't want `False` to appear in the `display_name`.

taskid: none