### PR TITLE
[FIX] barcodes_gs1_nomenclature: escape FNC1 ascii

### DIFF
--- a/addons/barcodes_gs1_nomenclature/models/barcode_nomenclature.py
+++ b/addons/barcodes_gs1_nomenclature/models/barcode_nomenclature.py
@@ -98,9 +98,9 @@ class BarcodeNomenclature(models.Model):
         if self.gs1_separator_fnc1:
             separator_group = "(?:%s)?" % self.gs1_separator_fnc1
         # zxing-library patch, removing GS1 identifiers
-        for identifier in [']C1', ']e0', ']d2', ']Q3', ']J1']:
+        for identifier in [']C1', ']e0', ']d2', ']Q3', ']J1', FNC1_CHAR]:
             if barcode.startswith(identifier):
-                barcode = barcode.replace(identifier, '')
+                barcode = barcode.replace(identifier, '', 1)
                 break
         results = []
         gs1_rules = self.rule_ids.filtered(lambda r: r.encoding == 'gs1-128')

--- a/addons/barcodes_gs1_nomenclature/tests/test_barcodes_gs1_nomenclature.py
+++ b/addons/barcodes_gs1_nomenclature/tests/test_barcodes_gs1_nomenclature.py
@@ -29,7 +29,7 @@ class TestBarcodeGS1Nomenclature(TransactionCase):
     def test_gs1_extanded_barcode_1(self):
         barcode_nomenclature = self.env['barcode.nomenclature'].browse(self.ref('barcodes_gs1_nomenclature.default_gs1_nomenclature'))
         # (01)94019097685457(10)33650100138(3102)002004(15)131018
-        code128 = "01940190976854571033650100138\x1D310200200415131018"
+        code128 = "\x1D01940190976854571033650100138\x1D310200200415131018"
         res = barcode_nomenclature.gs1_decompose_extanded(code128)
         self.assertEqual(len(res), 4)
         self.assertEqual(res[0]["ai"], "01")


### PR DESCRIPTION
### Current Behavior:

When scanning a barcode like attached, ascii 29 (FNC1) will be added to the beginning of the final code.

### Expected Behavior:

FNC1 should be removed from the final code.

### Steps to Reproduce

1.  With barcode installed, set the barcode nomenclature in settings to "Default GS1 Nomenclature"
2. Attempt to scan this barcode
![barcode](https://github.com/user-attachments/assets/26f48ab5-f0b0-4d50-81a2-799b601eddc3)
3. If you debug [here](https://github.com/odoo-dev/odoo/blob/b387345f557adace35767ec2ca7ada271cca8423/addons/barcodes_gs1_nomenclature/models/barcode_nomenclature.py#L101), you will find that `barcode` starts with ascii 29, but it isn't removed.

### Details

This commit adds ascii code 29 (FNC1) to the list of strings to be escaped from in gs1 decomposition.

In PR #163404, logic was added to escape barcode scan results that start with FNC1. This is only specifically checking ']C1', but it is possible for the literal ascii code 29 to be present in the beginning of the string as well. This should also be escaped.

You can see that ascii 29 is added in `zxing-library.js` [here](https://github.com/odoo-dev/odoo/blob/b387345f557adace35767ec2ca7ada271cca8423/addons/web/static/lib/zxing-library/zxing-library.js#L12308) in this case. It also could potentially be added in several other places such as [here](https://github.com/odoo-dev/odoo/blob/b387345f557adace35767ec2ca7ada271cca8423/addons/web/static/lib/zxing-library/zxing-library.js#L6932)

opw-3965925
