### PR TITLE
[FIX] web_editor: fix custom block translations

### DIFF
--- a/addons/web_editor/models/ir_ui_view.py
+++ b/addons/web_editor/models/ir_ui_view.py
@@ -132,8 +132,10 @@ class IrUiView(models.Model):
 
     @api.model
     def _copy_field_terms_translations(self, record_from, name_field_from, record_to, name_field_to):
-        """ Copy the terms translation from a record/field ``Model1.Field1``
-        to a (possibly) completely different record/field ``Model2.Field2``.
+        """ Copy model terms translations from ``record_from.name_field_from``
+        to ``record_to.name_field_to`` for all activated languages if the term
+        in ``record_to.name_field_to`` is untranslated (the term matches the
+        one in the current language).
 
         For instance, copy the translations of a
         ``product.template.html_description`` field to a ``ir.ui.view.arch_db``
@@ -172,7 +174,12 @@ class IrUiView(models.Model):
             record_from[name_field_from],
             {lang: record_from.with_context(prefetch_langs=True, lang=lang)[name_field_from] for lang in langs if lang != lang_env}
         )
-        existing_translation_dictionary.update(extra_translation_dictionary)
+        for term, extra_translation_values in extra_translation_dictionary.items():
+            existing_translation_values = existing_translation_dictionary.setdefault(term, {})
+            # Update only default translation values that aren't customized by the user.
+            for lang, extra_translation in extra_translation_values.items():
+                if existing_translation_values.get(lang, term) == term:
+                    existing_translation_values[lang] = extra_translation
         translation_dictionary = existing_translation_dictionary
 
         # The `en_US` jsonb value should always be set, even if english is not

--- a/addons/website/tests/test_custom_snippets.py
+++ b/addons/website/tests/test_custom_snippets.py
@@ -160,6 +160,38 @@ class TestCustomSnippet(TransactionCase):
             'Texte Francais',
             custom_snippet_view.with_context(lang=parseltongue.code).arch)
 
+        # Check that a translated page/view with a custom snippet won't copy
+        # the translation from the saved custom view for the terms that are
+        # "already translated".
+        view = View.create({
+            'name': 'Custom Snippet Test View',
+            'type': 'qweb',
+            'arch': """
+                <body>
+                    <section class="s_title">
+                        <h1>English Text</h1>
+                    </section>
+                    <div/>
+                </body>
+            """,
+            'key': 'test.custom_snippet_test_view',
+            'website_id': website.id,
+        })
+
+        view.update_field_translations('arch_db', {
+           parseltongue.code: {
+                'English Text': 'Parseltongue Text',
+            }
+        })
+        self.assertIn(
+            'Parseltongue Text',
+            view.with_context(lang=parseltongue.code).arch)
+
+        view.save(f'<div>{snippet_arch}</div>', xpath='/body[1]/div[1]')
+        self.assertIn(
+            'Parseltongue Text',
+            view.with_context(lang=parseltongue.code).arch)
+
 
 @tagged('post_install', '-at_install')
 class TestHttpCustomSnippet(HttpCase):


### PR DESCRIPTION
Steps to reproduce:

- Add a "Call To Action" block on the homepage > Save it as a custom
snippet.
- Add a new page > Drop the saved custom block on it > Drop Also
another "Title" block.
- Translate the custom block in the new page > At this point, the
translation is fine.
- Go to "Edit" mode > Edit the other block ("Title") > Save.
- The translations for the custom "Call To Action" is lost.

Starting from [1], the translation of custom snippets was supported and
when dropping a saved custom snippet in a page/view, the snippet will
copy its translation from the saved view (see:
`_copy_custom_snippet_translations()`). This code will always update the
terms in the translation dictionary, even when the page has its custom
translation for them.

The goal of this commit is to fix this behavior by only allowing the
update of a term translation when the page has no custom translation
for it.

[1]: https://github.com/odoo/odoo/commit/d3426b7714012e833caae10281cfb8433223299a

opw-3930862
opw-4141290