### PR TITLE
[FIX] web_editor: concurrent deletion causes traceback

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -1036,14 +1036,14 @@ export function getDeepestPosition(node, offset) {
         } else if (
             direction &&
             next.nextSibling &&
-            closestBlock(node).contains(next.nextSibling)
+            closestBlock(node)?.contains(next.nextSibling)
         ) {
             // Invalid node: skip to next sibling (without crossing blocks).
             next = next.nextSibling;
         } else {
             // Invalid node: skip to previous sibling (without crossing blocks).
             direction = DIRECTIONS.LEFT;
-            next = closestBlock(node).contains(next.previousSibling) && next.previousSibling;
+            next = closestBlock(node)?.contains(next.previousSibling) && next.previousSibling;
         }
         // Avoid too-deep ranges inside self-closing elements like [BR, 0].
         next = !isSelfClosingElement(next) && next;

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/utils.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/utils.test.js
@@ -1878,6 +1878,13 @@ describe('Utils', () => {
                 `),
             });
         });
+        it('should not traceback when detached node', async () => {
+            const detached = document.createTextNode('');
+            let [node, offset] = getDeepestPosition(detached, 0);
+            window.chai
+                .expect([node, offset])
+                .to.eql([detached, 0]);
+        });
     });
     // TODO:
     // - getCursors


### PR DESCRIPTION
Current behaviour:
---
On Knowledge, when multiple people are looking at the same page, 
if one of them deletes the end of a sentence, the others have a traceback.

Steps to reproduce:
---
1. Install knowledge
2. On one browser tab, connect admin
3. On another, connect demo
4. With admin, go to knowledge
5. Create a page in workspace
6. In Share, change visibility to everyone
7. With demo, join the page
8. With admin, write a long word
9. Place both cursors at the end of the word
10. With admin, select a few letters at the end of the word
11. Delete those letters
12. Demo should have a traceback

Cause of the issue:
---
In `getDeepestPosition` > `closestBlock` > `findNode`
`findNode` can return `null`

opw-4072333

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
