### PR TITLE
[IMP] mail: improve visual of jump to present

### DIFF
--- a/addons/mail/static/src/chatter/web/chatter_patch.js
+++ b/addons/mail/static/src/chatter/web/chatter_patch.js
@@ -147,6 +147,12 @@ patch(Chatter.prototype, {
             },
             () => [this.state.thread?.status, this.attachments]
         );
+        useEffect(
+            () => {
+                this.state.aside = this.props.isChatterAside;
+            },
+            () => [this.props.isChatterAside]
+        );
     },
 
     /**
@@ -165,7 +171,9 @@ patch(Chatter.prototype, {
     },
 
     get childSubEnv() {
-        return { ...super.childSubEnv, messageHighlight: this.messageHighlight };
+        const res = Object.assign(super.childSubEnv, { messageHighlight: this.messageHighlight });
+        res.inChatter.aside = this.props.isChatterAside;
+        return res;
     },
 
     get followerButtonLabel() {

--- a/addons/mail/static/src/chatter/web_portal/chatter.js
+++ b/addons/mail/static/src/chatter/web_portal/chatter.js
@@ -30,6 +30,7 @@ export class Chatter extends Component {
             jumpThreadPresent: 0,
             /** @type {import("models").Thread} */
             thread: undefined,
+            aside: false,
         });
         this.rootRef = useRef("root");
         this.onScrollDebounced = useThrottleForAnimation(this.onScroll);
@@ -57,7 +58,7 @@ export class Chatter extends Component {
     }
 
     get childSubEnv() {
-        return { inChatter: true };
+        return { inChatter: this.state };
     }
 
     get requestList() {

--- a/addons/mail/static/src/core/common/thread.scss
+++ b/addons/mail/static/src/core/common/thread.scss
@@ -1,6 +1,11 @@
 .o-mail-Thread:focus-visible {
     outline: 0;
 }
+
+.o-mail-Thread-jumpPresent {
+    z-index: $o-mail-NavigableList-zIndex - 1;
+}
+
 .o-mail-Thread-newMessage {
     transition: opacity 0.5s;
 

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -2,9 +2,8 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.Thread">
-    <t t-if="env.inChatter" t-call="mail.Thread.jumpPresent"/> <!-- chatter has its own scrollable, this ensures proper sticky showing -->
-    <t t-else="" t-call="mail.Thread.jumpUnread"/>
-    <div class="o-mail-Thread position-relative flex-grow-1 d-flex flex-column overflow-auto" t-att-class="{ 'pb-4':  props.showJumpPresent and !state.showJumpPresent, 'px-3': !env.inChatter and !props.isInChatWindow }" t-ref="messages" tabindex="-1">
+    <t t-if="!env.inChatter" t-call="mail.Thread.jumpUnread"/>
+    <div class="o-mail-Thread position-relative flex-grow-1 d-flex flex-column overflow-auto" t-att-class="{ 'pb-5': env.inChatter?.aside, 'pb-4': !env.inChatter?.aside, 'px-3': !env.inChatter and !props.isInChatWindow }" t-ref="messages" tabindex="-1">
         <t t-if="!props.thread.isEmpty or props.thread.loadOlder or props.thread.hasLoadingFailed" name="content">
             <div class="d-flex flex-column position-relative flex-grow-1" t-att-class="{'justify-content-end': !env.inChatter and props.thread.model !== 'mail.box'}">
                 <span class="position-absolute w-100 invisible" t-att-class="props.order === 'asc' ? 'bottom-0' : 'top-0'" t-ref="present-treshold" t-att-style="`height: Min(${PRESENT_THRESHOLD}px, 100%)`"/>
@@ -13,7 +12,7 @@
                     <t t-if="props.thread.loadOlder and !props.thread.isTransient and !props.thread.hasLoadingFailed" t-call="mail.Thread.loadOlder"/>
                     <t t-if="props.thread.hasLoadingFailed" t-call="mail.Thread.loadingError"/>
                 </t>
-                <span t-else="" t-ref="load-newer"/>
+                <span t-else="" class="pt-1" t-ref="load-newer"/>
                 <t t-set="messages" t-value="props.order === 'asc' ? props.thread.nonEmptyMessages : [...props.thread.nonEmptyMessages].reverse()"/>
                 <t t-if="state.mountedAndLoaded" t-foreach="messages" t-as="msg" t-key="msg.id">
                     <t t-set="prevMsg" t-value="messages[msg_index -1]"/>
@@ -41,7 +40,7 @@
                         showDates="props.showDates"
                     />
                 </t>
-                <span t-if="props.order === 'asc'" t-ref="load-newer"/>
+                <span t-if="props.order === 'asc'" class="pt-1" t-ref="load-newer"/>
                 <t t-else="">
                     <t t-if="props.thread.loadOlder and !props.thread.isTransient and !props.thread.hasLoadingFailed" t-call="mail.Thread.loadOlder"/>
                     <t t-if="props.thread.hasLoadingFailed" t-call="mail.Thread.loadingError"/>
@@ -55,17 +54,12 @@
                 </t>
             </div>
         </t>
+        <t t-call="mail.Thread.jumpPresent"/>
     </div>
-    <t t-if="!env.inChatter" t-call="mail.Thread.jumpPresent"/>
 </t>
 
 <t t-name="mail.Thread.jumpPresent">
-    <span t-if="props.showJumpPresent and state.showJumpPresent" t-att-class="{
-        'm-0 px-4 position-sticky top-0': env.inChatter,
-    }" class="o-mail-Thread-banner o-mail-Thread-bannerHover d-flex d-print-none justify-content-between alert alert-secondary border-0 rounded-0 mb-0 py-1 cursor-pointer shadow-sm small fw-bold" t-on-click="() => this.jumpToPresent()">
-        <span>You're viewing older messages</span>
-        <span>Jump to Present<i class="ms-2 fa" t-att-class="{ 'fa-caret-up': props.order !== 'asc', 'fa-caret-down': props.order === 'asc' }"/></span>
-    </span>
+    <button t-if="props.showJumpPresent and state.showJumpPresent" class="o-mail-Thread-jumpPresent position-fixed p-2 rounded-circle lh-1 m-n3 user-select-none btn btn-light border" t-ref="jump-present" t-on-click="() => this.jumpToPresent()" title="Jump to Present"><i class="oi" t-att-class="{ 'oi-chevron-down': props.order === 'asc', 'oi-chevron-up': props.order !== 'asc' }"/></button>
 </t>
 
 <t t-name="mail.Thread.jumpUnread">

--- a/addons/mail/static/tests/discuss_app/jump_to_present.test.js
+++ b/addons/mail/static/tests/discuss_app/jump_to_present.test.js
@@ -40,13 +40,8 @@ test("Basic jump to present when scrolling to outdated messages", async () => {
         PRESENT_VIEWPORT_THRESHOLD * document.querySelector(".o-mail-Thread").clientHeight,
         { message: "should have enough scroll height to trigger jump to present" }
     );
-    await click(".o-mail-Thread-banner", {
-        text: "You're viewing older messagesJump to Present",
-    });
-    await contains(".o-mail-Thread-banner", {
-        count: 0,
-        text: "You're viewing older messagesJump to Present",
-    });
+    await click("[title='Jump to Present']");
+    await contains("[title='Jump to Present']", { count: 0 });
     await contains(".o-mail-Thread", { scroll: "bottom" });
 });
 
@@ -72,13 +67,8 @@ test("Basic jump to present when scrolling to outdated messages (chatter, DESC)"
     );
     await contains(".o-mail-Chatter", { scroll: 0 });
     await scroll(".o-mail-Chatter", "bottom");
-    await click(".o-mail-Thread-banner", {
-        text: "You're viewing older messagesJump to Present",
-    });
-    await contains(".o-mail-Thread-banner", {
-        count: 0,
-        text: "You're viewing older messagesJump to Present",
-    });
+    await click("[title='Jump to Present']");
+    await contains("[title='Jump to Present']", { count: 0 });
     await contains(".o-mail-Chatter", { scroll: 0 });
 });
 
@@ -124,13 +114,8 @@ test("Jump to old reply should prompt jump to present", async () => {
     await click(".o-mail-MessageInReply .cursor-pointer");
     await contains(".o-mail-Message", { count: 30 });
     await contains(":nth-child(1 of .o-mail-Message)", { text: "Hello world!" });
-    await click(".o-mail-Thread-banner", {
-        text: "You're viewing older messagesJump to Present",
-    });
-    await contains(".o-mail-Thread-banner", {
-        count: 0,
-        text: "You're viewing older messagesJump to Present",
-    });
+    await click("[title='Jump to Present']");
+    await contains("[title='Jump to Present']", { count: 0 });
     await contains(".o-mail-Message", { count: 30 });
     await contains(".o-mail-Thread", { scroll: "bottom" });
 });
@@ -177,13 +162,8 @@ test("Jump to old reply should prompt jump to present (RPC small delay)", async 
     await openDiscuss(channelId);
     await contains(".o-mail-Message", { count: 30 });
     await click(".o-mail-MessageInReply .cursor-pointer");
-    await click(".o-mail-Thread-banner", {
-        text: "You're viewing older messagesJump to Present",
-    });
-    await contains(".o-mail-Thread-banner", {
-        count: 0,
-        text: "You're viewing older messagesJump to Present",
-    });
+    await click("[title='Jump to Present']");
+    await contains("[title='Jump to Present']", { count: 0 });
     await contains(".o-mail-Thread", { scroll: "bottom" });
 });
 
@@ -220,15 +200,10 @@ test("Post message when seeing old message should jump to present", async () => 
     await openDiscuss(channelId);
     await contains(".o-mail-Message", { count: 30 });
     await click(".o-mail-MessageInReply .cursor-pointer");
-    await contains(".o-mail-Thread-banner", {
-        text: "You're viewing older messagesJump to Present",
-    });
+    await contains("[title='Jump to Present']");
     await insertText(".o-mail-Composer-input", "Newly posted");
     await click(".o-mail-Composer button[aria-label='Send']:enabled");
-    await contains(".o-mail-Thread-banner", {
-        count: 0,
-        text: "You're viewing older messagesJump to Present",
-    });
+    await contains("[title='Jump to Present']", { count: 0 });
     await contains(".o-mail-Thread", { scroll: "bottom" });
     await contains(".o-mail-Message-content", {
         text: "Newly posted",
@@ -277,19 +252,11 @@ test("show jump to present banner after scrolling up 10 messages", async () => {
     const messageHeight = top2 - top1;
     // scroll slightly (1 long message)
     await scroll(".o-mail-Thread", queryFirst(".o-mail-Thread").scrollTop - messageHeight);
-    await contains(".o-mail-Thread-banner", {
-        count: 0,
-        text: "You're viewing older messagesJump to Present",
-    });
+    await contains("[title='Jump to Present']", { count: 0 });
     // scroll to 5th message before newest
     await scroll(".o-mail-Thread", queryFirst(".o-mail-Thread").scrollTop - 4 * messageHeight);
-    await contains(".o-mail-Thread-banner", {
-        count: 0,
-        text: "You're viewing older messagesJump to Present",
-    });
+    await contains("[title='Jump to Present']", { count: 0 });
     // scroll to around 10th message before newest
     await scroll(".o-mail-Thread", queryFirst(".o-mail-Thread").scrollTop - 5 * messageHeight);
-    await contains(".o-mail-Thread-banner", {
-        text: "You're viewing older messagesJump to Present",
-    });
+    await contains("[title='Jump to Present']");
 });

--- a/addons/mail/static/tests/thread/unread_messages_banner.test.js
+++ b/addons/mail/static/tests/thread/unread_messages_banner.test.js
@@ -96,9 +96,7 @@ test("scroll to the first unread message (slow ref registration)", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await click(".o-mail-Thread-banner", {
-        text: "You're viewing older messagesJump to Present",
-    });
+    await click("[title='Jump to Present']");
     await scroll(".o-mail-Thread", "bottom");
     await contains(".o-mail-Thread", { scroll: "bottom" });
     slowRegisterMessageRef = true;


### PR DESCRIPTION
Before this commit, jump to present was a whole width bar. This was taking too much space, especially in chat windows.

This commit improves by replacing the bar by a circle floating button on bottom right side of scrollable thread.

In chatter, the button is shown on left side, because chat windows and bubbles might overlap the button.

task-3930968

Before / After

<img width="509" alt="Screenshot 2024-08-26 at 20 29 38" src="https://github.com/user-attachments/assets/299a7266-8634-49e0-a025-222679a502ff"> <img width="512" alt="Screenshot 2024-08-26 at 20 29 17" src="https://github.com/user-attachments/assets/82f5090e-5f9c-4919-906b-bd15df4e3f62">

<img width="1280" alt="Screenshot 2024-08-29 at 13 32 51" src="https://github.com/user-attachments/assets/c18afc9e-4f14-4609-95cb-3d5c4588f228">
