### PR TITLE
[FIX] stock: give empty list when there is no domain in name search method

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -285,6 +285,7 @@ class PickingType(models.Model):
     def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
         # Try to reverse the `display_name` structure
         parts = name.split(': ')
+        domain = domain or []
         if len(parts) == 2:
             name_domain = [('warehouse_id.name', operator, parts[0]), ('name', operator, parts[1])]
             return self._search(expression.AND([name_domain, domain]), limit=limit, order=order)


### PR DESCRIPTION
Currently, a traceback may arise when the user tries to import a record in stock picking.

Error:-

```
AssertionError: Domains to normalize must have a 'domain' form: a list or tuple of domain components
  File "odoo/http.py", line 2373, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1903, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1966, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1933, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2177, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 223, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 754, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 35, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 459, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "home/odoo/src/enterprise/saas-17.4/account_bank_statement_import_csv/wizard/account_bank_statement_import_csv.py", line 146, in execute_import
    return super(AccountBankStmtImportCSV, self).execute_import(fields, columns, options, dryrun=dryrun)
  File "addons/base_import/models/base_import.py", line 1382, in execute_import
    import_result = model.load(import_fields, merged_data)
  File "odoo/models.py", line 1335, in load
    for id, xid, record, info in converted:
  File "odoo/models.py", line 1497, in _convert_records
    converted = convert(record, functools.partial(_log, extras, stream.index))
  File "odoo/addons/base/models/ir_fields.py", line 118, in fn
    converted[field], ws = converters[field](value)
  File "odoo/addons/base/models/ir_fields.py", line 565, in _str_to_many2one
    id, _, w2 = self.db_id_for(model, field, subfield, record[subfield])
  File "odoo/addons/base/models/ir_fields.py", line 460, in db_id_for
    ids = RelatedModel.name_search(name=value, operator='=')
  File "odoo/models.py", line 1724, in name_search
    ids = self._name_search(name, args, operator, limit=limit, order=self._order)
  File "addons/stock/models/stock_picking.py", line 290, in _name_search
    return self._search(expression.AND([name_domain, domain]), limit=limit, order=order)
  File "odoo/osv/expression.py", line 293, in AND
    return combine(AND_OPERATOR, [TRUE_LEAF], [FALSE_LEAF], domains)
  File "odoo/osv/expression.py", line 280, in combine
    domain = normalize_domain(domain)
  File "odoo/osv/expression.py", line 210, in normalize_domain
    assert isinstance(domain, (list, tuple)), "Domains to normalize must have a 'domain' form: a list or tuple of domain components"
```

In the `name_search` method, when there is no domain its default value is `None`. 
Which leads to a traceback when in the `_search` method as `osv.expression.AND` 
is used between two domains (if one of them is None).

https://github.com/odoo/odoo/blob/08e2371fc7364732b913dd7e40afc11056b1e364/addons/stock/models/stock_picking.py#L259-L264

This issue is occurring after the below commit, as the `normalize_domain` is used
before checking the domain

https://github.com/odoo/odoo/blob/c5fb5a17fe14c30e64ae954a0baef22e204260cb/odoo/osv/expression.py#L280
Commit:- https://github.com/odoo/odoo/commit/450f5c9307a71d3ccd7b1ba2ce6d5d90f8a352f3

By passing an empty list if there is no domain, we can resolve this issue.

sentry-5738324909

