### PR TITLE
[FIX] bus: update presence sent too early

### DIFF
--- a/addons/bus/static/src/im_status_service.js
+++ b/addons/bus/static/src/im_status_service.js
@@ -35,7 +35,7 @@ export const imStatusService = {
 
         const startAwayTimeout = () => {
             clearTimeout(becomeAwayTimeout);
-            const awayTime = AWAY_DELAY - lastSentInactivity;
+            const awayTime = AWAY_DELAY - presence.getInactivityPeriod();
             if (awayTime > 0) {
                 becomeAwayTimeout = browser.setTimeout(() => updateBusPresence(), awayTime);
             }


### PR DESCRIPTION
Before this PR, the update presence sent when the user switches to away could be sent a bit too early. As a result, two updates would be needed instead of one.

Steps:
- Initial update presence is sent, let's assume the last activity was 5000 ms ago.
- The away update presence should be planned for AWAY_TIMER - 5000.
- Click on the page, the new update presence is still planned for AWAY_TIMER- 5000 but it should instead be computed based on the new inactivity period.

This is not critical as the early update would plan another update based on the newly sent value. But it can be avoided by using the actual inactivity value to plan the next update presence sending.