### PR TITLE
[FIX] html_editor, project: split internal link preview controller test

### DIFF
--- a/addons/html_editor/tests/test_controller.py
+++ b/addons/html_editor/tests/test_controller.py
@@ -16,23 +16,12 @@ class TestController(HttpCase):
     def setUpClass(cls):
         super().setUpClass()
         portal_user = new_test_user(cls.env, login='portal_user', groups='base.group_portal')
+        cls.portal_user = portal_user
         cls.portal = portal_user.login
         admin_user = new_test_user(cls.env, login='admin_user', groups='base.group_user,base.group_system')
         cls.admin = admin_user.login
         cls.headers = {"Content-Type": "application/json"}
         cls.pixel = 'R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs='
-        cls.project_internal_link_display = cls.env['project.project'].create({
-            'name': 'project',
-            'display_name': 'project_display_name',
-            'description': 'project_description',
-        })
-        cls.task_internal_link_customized = cls.env['project.task'].create({
-            'name': 'task1',
-            'display_name': 'task1_display_name',
-            'link_preview_name': 'test1 | test parent',
-            'project_id': cls.project_internal_link_display.id,
-            'description': 'task1_description',
-        })
 
     def _build_payload(self, params=None):
         """
@@ -165,25 +154,12 @@ class TestController(HttpCase):
 
     def test_05_internal_link_preview(self):
         self.authenticate(self.admin, self.admin)
-        # retrieve metadata of an record with customerized link_preview_name
-        response_with_preview_name = self.url_open(
-            '/html_editor/link_preview_internal',
-            data=json_safe.dumps({
-                "params": {
-                    "preview_url": f"/odoo/all-tasks/{self.task_internal_link_customized.id}",
-                }
-            }),
-            headers=self.headers
-        )
-        self.assertEqual(200, response_with_preview_name.status_code)
-        self.assertTrue('link_preview_name' in response_with_preview_name.text)
-
         # retrieve metadata of an record without customerized link_preview_name but with display_name
         response_without_preview_name = self.url_open(
             '/html_editor/link_preview_internal',
             data=json_safe.dumps({
                 "params": {
-                    "preview_url": f"/odoo/project/{self.project_internal_link_display.id}",
+                    "preview_url": f"/odoo/users/{self.portal_user.id}",
                 }
             }),
             headers=self.headers
@@ -196,7 +172,7 @@ class TestController(HttpCase):
             '/html_editor/link_preview_internal',
             data=json_safe.dumps({
                 "params": {
-                    "preview_url": "/odoo/projectInvalid/1",
+                    "preview_url": "/odoo/actionInvalid/1",
                 }
             }),
             headers=self.headers
@@ -209,7 +185,7 @@ class TestController(HttpCase):
             '/html_editor/link_preview_internal',
             data=json_safe.dumps({
                 "params": {
-                    "preview_url": "/odoo/project/999",
+                    "preview_url": "/odoo/users/9999",
                 }
             }),
             headers=self.headers
@@ -222,7 +198,7 @@ class TestController(HttpCase):
             '/html_editor/link_preview_internal',
             data=json_safe.dumps({
                 "params": {
-                    "preview_url": "/odoo/project",
+                    "preview_url": "/odoo/users",
                 }
             }),
             headers=self.headers

--- a/addons/project/tests/__init__.py
+++ b/addons/project/tests/__init__.py
@@ -29,3 +29,4 @@ from . import test_project_report
 from . import test_project_task_quick_create
 from . import test_task_state
 from . import test_project_task_mail_tracking_duration
+from . import test_task_link_preview_name

--- a/addons/project/tests/test_task_link_preview_name.py
+++ b/addons/project/tests/test_task_link_preview_name.py
@@ -1,0 +1,41 @@
+import odoo.tests
+from odoo.tests.common import HttpCase, new_test_user
+from odoo.tools.json import scriptsafe as json_safe
+
+
+@odoo.tests.tagged('post_install', '-at_install')
+class TestTaskLinkPreviewName(HttpCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        admin_user = new_test_user(cls.env, login='admin_user', groups='base.group_user,base.group_system')
+        cls.admin = admin_user.login
+
+        cls.project_internal_link_display = cls.env['project.project'].create({
+            'name': 'project',
+            'display_name': 'project_display_name',
+            'description': 'project_description',
+        })
+        cls.task_internal_link_customized = cls.env['project.task'].create({
+            'name': 'task1',
+            'display_name': 'task1_display_name',
+            'link_preview_name': 'test1 | test parent',
+            'project_id': cls.project_internal_link_display.id,
+            'description': 'task1_description',
+        })
+
+    def test_01_task_link_preview_name(self):
+        self.authenticate(self.admin, self.admin)
+        # retrieve metadata of an record with customerized link_preview_name
+        response_with_preview_name = self.url_open(
+            '/html_editor/link_preview_internal',
+            data=json_safe.dumps({
+                "params": {
+                    "preview_url": f"/odoo/all-tasks/{self.task_internal_link_customized.id}",
+                }
+            }),
+            headers={"Content-Type": "application/json"}
+        )
+        self.assertEqual(200, response_with_preview_name.status_code)
+        self.assertTrue('link_preview_name' in response_with_preview_name.text)


### PR DESCRIPTION
Before this commit: The link preview controller test was using a task record to test the link_preview_name field, leading to a dependency issue

After this commit: The testing of the link_preview_name field has been moved to the project module, resolving the dependency issue


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
