### PR TITLE
[FIX] purchase_mrp,mrp_account: no force price_unit when component

### DIFF
--- a/addons/mrp_account/models/stock_move.py
+++ b/addons/mrp_account/models/stock_move.py
@@ -20,7 +20,9 @@ class StockMove(models.Model):
 
     def _should_force_price_unit(self):
         self.ensure_one()
-        return self.picking_type_id.code == 'mrp_operation' or super()._should_force_price_unit()
+        return ((self.picking_type_id.code == 'mrp_operation' and self.production_id) or
+                super()._should_force_price_unit()
+        )
 
     def _ignore_automatic_valuation(self):
         return bool(self.raw_material_production_id)


### PR DESCRIPTION
**Current behavior:**
Having some product with FIFO cost method, if you use it as a
component in an MO, confirm and produce all, then unlock the MO
and adjust the component quantity to be smaller than originally
entered, the standard price of the product will be set to zero.

**Expected behavior:**
This operation should not affect the standard price of the
product.

**Steps to reproduce:**
1. Create a product with FIFO cost method and real time
     valuation

2. Create a purchase order for 10 of the fifo product, set the
     price unit on the order line to 100

3. Confirm the order and receive the product

4. Create a manufacturing order for 1 of some other product, and
     set the components to be 100 of the fifo product

5. Confirm the MO, consume the fifo product and produce all

6. Unlock the order and set the quantity of components consumed
     to 1 (from 100)

7. Observe that the standard price of fifo product is now 0

**Cause of the issue:**
A move for an MrpProduction record has a price unit == 0. Commit
https://github.com/odoo/odoo/commit/1fb4d356b5115a82dbbb004efe2e26917021b339 forces use of this when a move's picking type is
manufacturing, however it should be a narrower condition to only
do so when the move corresponds to the finished moves of a
manufacturing order.

**Fix:**
Moves for components of a production should not be able to
modify the `standard_price` of the moved product- only the final
product's cost should be able to change based on the value of
such a move.

Use a product's `standard_price` field when creating SVLs for
moves corresponding to raw production moves.

opw-4134037