### PR TITLE
[FIX] stock: pick move lines linking to a picked move

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -325,10 +325,13 @@ class StockMoveLine(models.Model):
             if move_line.picking_id.state != 'done':
                 moves = move_line._get_linkable_moves()
                 if moves:
-                    move_line.write({
+                    vals = {
                         'move_id': moves[0].id,
                         'picking_id': moves[0].picking_id.id,
-                    })
+                    }
+                    if moves[0].picked:
+                        vals['picked'] = True
+                    move_line.write(vals)
                 else:
                     create_move(move_line)
             else:

--- a/addons/stock/tests/test_move2.py
+++ b/addons/stock/tests/test_move2.py
@@ -2487,6 +2487,39 @@ class TestSinglePicking(TestStockCommon):
         self.env['procurement.group'].run_scheduler()
         self.assertRecordValues(picking.move_line_ids, [{'state': 'assigned', 'quantity': 10.0}])
 
+    def test_create_picked_move_line(self):
+        """
+        Check that a move line created and auto assigned to a picked move will also be picked
+        """
+        product = self.productA
+        picking_type_out = self.env['stock.picking.type'].browse(self.picking_type_out)
+        picking_type_out.reservation_method = 'at_confirm'
+        picking = self.env['stock.picking'].create({
+            'location_id': self.stock_location,
+            'location_dest_id': self.customer_location,
+            'picking_type_id': self.picking_type_out,
+            'move_ids': [Command.create({
+                'name': product.name,
+                'product_id': product.id,
+                'product_uom_qty': 10,
+                'product_uom': product.uom_id.id,
+                'location_id': self.stock_location,
+                'location_dest_id': self.customer_location,
+            })],
+        })
+        picking.action_confirm()
+        picking.move_ids.quantity = 5
+        picking.move_ids.picked = True
+        sml = self.env['stock.move.line'].create({
+            'location_id': self.stock_location,
+            'location_dest_id': self.customer_location,
+            'product_id': product.id,
+            'picking_id': picking.id,
+            'quantity': 1.0,
+        })
+        self.assertEqual(picking.move_ids.quantity, 6.0)
+        self.assertTrue(sml.picked)
+
 class TestStockUOM(TestStockCommon):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
### Steps to reproduce:

- Create and confirm a delivery for 10 units of a product P
- Change the quantity of the move to 5 and mark it as picked
- Click on the "detailed operations" button of the picking
- Change the quantity of the move line to 3
- Create a new line for 2 units (this would make sense if you want to register 2 lots for instance the flow is kepts as simple possible)
- Go back to the delivery, validate and create a back order

#### > A back order is created for 7 units rather than 5 and the original delivery was validated for only 3 units.

### Cause of the issue:

When you create a new move line on the picking from the detailed operation it is linked to the move of the picking via these lines: https://github.com/odoo/odoo/blob/4c79aceb3a6c08453f9ec66131e1bc525eae140c/addons/stock/models/stock_move_line.py#L325-L331 However, while the move is marked as picked, the newly created move line is not. As such during the `_action_done` of the stock move, the new sml will be unlinked from the move:
https://github.com/odoo/odoo/blob/4c79aceb3a6c08453f9ec66131e1bc525eae140c/addons/stock/models/stock_move.py#L1865-L1872

opw-4100293
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
