### PR TITLE
[FIX] base: prevent rtlcss compilation errors

### DIFF
--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -689,16 +689,18 @@ class AssetsBundle(object):
             self.css_errors.append(msg)
             return ''
 
-        result = rtlcss.communicate(input=source.encode('utf-8'))
-        if rtlcss.returncode:
-            cmd_output = ''.join(misc.ustr(result))
-            if not cmd_output:
+        stdout, stderr = rtlcss.communicate(input=source.encode('utf-8'))
+        if rtlcss.returncode or (source and not stdout):
+            cmd_output = ''.join(misc.ustr(stderr))
+            if not cmd_output and rtlcss.returncode:
                 cmd_output = "Process exited with return code %d\n" % rtlcss.returncode
+            elif not cmd_output:
+                cmd_output = "rtlcss: error processing payload\n"
             error = self.get_rtlcss_error(cmd_output, source=source)
             _logger.warning(error)
             self.css_errors.append(error)
             return ''
-        rtlcss_result = result[0].strip().decode('utf8')
+        rtlcss_result = stdout.strip().decode('utf8')
         return rtlcss_result
 
     def get_preprocessor_error(self, stderr, source=None):

--- a/odoo/addons/test_assetsbundle/__manifest__.py
+++ b/odoo/addons/test_assetsbundle/__manifest__.py
@@ -58,6 +58,9 @@
             ('include', 'test_assetsbundle.manifest4'),
         ],
         'test_assetsbundle.manifest_multi_module1': [],
+        'test_assetsbundle.broken_css': [
+            'test_assetsbundle/static/invalid_src/css/invalid_css.css',
+        ],
     },
     'license': 'LGPL-3',
 }

--- a/odoo/addons/test_assetsbundle/static/invalid_src/css/invalid_css.css
+++ b/odoo/addons/test_assetsbundle/static/invalid_src/css/invalid_css.css
@@ -1,0 +1,8 @@
+.rule1 {
+    color: black,
+}
+
+.rule2 {
+    color: yellow; !important;
+}
+

--- a/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
+++ b/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
@@ -431,9 +431,20 @@ class TestJavascriptAssetsBundle(FileTouchable):
         # trigger the first generation and, thus, the first save in database
         self.bundle.css()
 
+        # there should be no compilation errors
+        self.assertEqual(len(self.bundle.css_errors), 0)
+
         # there should be one attachment associated to this bundle
         self.assertEqual(len(self._any_ira_for_bundle('min.css', lang='ar_SY')), 1)
         self.assertEqual(len(self.bundle.get_attachments('min.css')), 1)
+
+    def test_15_rtl_invalid_css_generation(self):
+        """ Checks that erroneous css cannot be compiled by rtlcss and that errors are registered """
+        self.bundle = self._get_asset('test_assetsbundle.broken_css', env=self.env(context={'lang': 'ar_SY'}))
+        with mute_logger('odoo.addons.base.models.assetsbundle'):
+            self.bundle.css()
+        self.assertEqual(len(self.bundle.css_errors), 1)
+        self.assertIn('rtlcss: error processing payload', self.bundle.css_errors[0])
 
     def test_16_ltr_and_rtl_css_access(self):
         """ Checks that the bundle's cache is working, i.e. that the bundle creates only one


### PR DESCRIPTION
Steps to reproduce:

- Include in your assets a CSS file with invalid formatting.
- Translate your website in RTL language.
> The website will never load and you will be left with a blank page.

Cause of the issue:
`rtlcss` never exit with a returncode, consequently our error management there is useless. As from `rtlcss` 4.1.0 [1], an error code is returned but only when using a CSS file. In our case, Odoo pass the CSS payload via the `stdin`. A PR [2] has been opened on `rtlcss` to also exit with a return code in this scenario (and log details to `stderr`). In the meantime and also for earlier versions, the error management had to be slightly adjusted. As we cannot deduce any informations from the return code (and the `stderr` is completely empty), we can exploit the fact that, in case of errors, `rtlcss` doesn't output anything to `stdout`.

[1]: https://github.com/MohammadYounes/rtlcss/commit/4e625458cb236a4a21cb6d5e54283a9d5244fdc8
[2]: https://github.com/MohammadYounes/rtlcss/pull/342

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
