### PR TITLE
[FIX] website: fix highlighted text added to view

### DIFF
--- a/addons/website/static/src/js/content/snippets.animation.js
+++ b/addons/website/static/src/js/content/snippets.animation.js
@@ -1952,6 +1952,13 @@ registry.TextHighlight = publicWidget.Widget.extend({
         // to block the callback on this first notification for observed items.
         this.observerLock = new Map();
         this.resizeObserver = new window.ResizeObserver(entries => {
+            // Some options, like the popup, trigger a resize after a delay
+            // before the page is saved. This causes the highlights to be added
+            // back to the DOM after the "TextHighlight" widget has been
+            // destroyed. This is why the following line is needed.
+            if (this.isDestroyed()) {
+                return;
+            }
             window.requestAnimationFrame(() => {
                 const textHighlightEls = new Set();
                 entries.forEach(entry => {
@@ -2028,6 +2035,9 @@ registry.TextHighlight = publicWidget.Widget.extend({
         // we use a lock map (`observerLocked`) to block the callback on this
         // first notification for observed items.
         this.resizeObserver = new window.ResizeObserver(entries => {
+            if (this.isDestroyed()) {
+                return;
+            }
             window.requestAnimationFrame(() => {
                 const topTextEls = new Set();
                 entries.forEach(entry => {


### PR DESCRIPTION
Steps to reproduce the bug:

- Turn on the Cookies from setting for the website.
- Go to front end, click on editor, go to theme tab.
- Click on any Font Family, and select add a google font.
- After adding, save.
- Add a "Title" block, go to "mobile view", and add a text highlight.
- Save the page.
- Bug: If you switch between mobile and desktop views, the highlights are not updated (because the SVGs are fixed and get added to the view of the page).

The bug occurred because some options, like the popup, trigger a resize after a delay before the page is saved. This causes the highlights to be added back to the DOM after the "TextHighlight" widget has been destroyed.

To fix this, we prevent adding highlights if the "TextHighlight" widget has been destroyed.

opw-4081390