### PR TITLE
[FIX] account: unreconciled filter

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -332,7 +332,11 @@
                     <separator/>
                     <filter string="To check" name="to_check" domain="[('move_id.checked', '=', False), ('parent_state', '!=', 'draft')]"/>
                     <separator/>
-                    <filter string="Unreconciled" domain="[('account_id.reconcile', '=', True)]" name="reconcilable_account" help="Journal items where the account allows reconciliation no matter the residual amount"/>
+                    <filter string="Unreconciled"
+                            domain="[('account_id.reconcile', '=', True), '|', ('matching_number', '=', False), ('matching_number', '=like', 'P%')]"
+                            name="reconcilable_account"
+                            help="Journal items where the account allows reconciliation no matter the residual amount"
+                    />
                     <filter string="With residual" domain="[('amount_residual', '!=', 0), ('account_id.reconcile', '=', True)]" help="Journal items where matching number isn't set" name="unreconciled"/>
                     <separator/>
                     <filter string="Sales" name="sales" domain="[('journal_id.type', '=', 'sale')]" context="{'default_journal_type': 'sale'}"/>


### PR DESCRIPTION
In this commit: https://github.com/odoo/odoo/pull/174988/commits/b4cd8529eb8c3bd4780137cfec9314d1450de358 we added new filters but the original spec was wrong, this commit will change those filters.

- For the two filters, the accounts must be reconciliable
- To distinguish the two filters: 
Unreconciled >> Will match move line with no matching number or partial entries 
With Residual >> Will match move like that have a residual != 0

task: 4141159

Enterprise PR: https://github.com/odoo/enterprise/pull/68972


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
