### PR TITLE
[FW][FIX] tools: classify \uFEFF as whitespace for translations

### DIFF
--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -189,6 +189,7 @@ TRANSLATED_ATTRS.update(
 )
 
 avoid_pattern = re.compile(r"\s*<!DOCTYPE", re.IGNORECASE | re.MULTILINE | re.UNICODE)
+space_pattern = re.compile(r"[\s\uFEFF]*")  # web_editor uses \uFEFF as ZWNBSP
 
 
 def translate_xml_node(node, callback, parse, serialize):
@@ -202,7 +203,7 @@ def translate_xml_node(node, callback, parse, serialize):
 
     def nonspace(text):
         """ Return whether ``text`` is a string with non-space characters. """
-        return bool(text) and not text.isspace()
+        return bool(text) and not space_pattern.fullmatch(text)
 
     def translatable(node):
         """ Return whether the given node can be translated as a whole. """


### PR DESCRIPTION
Versions
--------
- 15.0+

Issue
-----
Commit 9426ee54b927 introduced the \uFEFF character to web_editor as a zero-width non-breaking whitespace. When this gets added to a HTML node, and processed for translation, it throws an "empty document" error.

Cause
-----
When passed to the `get_text_content` function, the call to `html.fromstring('\uFEFF').text_content()` throws an error. \uFEFF is not technically classified as whitespace, so the `nonspace` function which attempts to prevent processing empty documents doesn't catch it.

Solution
--------
Instead of the `isspace` method, use a regex which matches on all whitespace as well as \uFEFF.

opw-3957259

Forward-Port-Of: #171685
Forward-Port-Of: #169122