### PR TITLE
[FIX] pos_loyalty: use max points on discount rewards

### DIFF
--- a/addons/pos_loyalty/static/src/tours/PosLoyaltyRewardButtonTour.js
+++ b/addons/pos_loyalty/static/src/tours/PosLoyaltyRewardButtonTour.js
@@ -154,11 +154,10 @@ ProductScreen.do.clickDisplayedProduct('Test Product A');
 ProductScreen.check.selectedOrderlineHas('Test Product A', '1.00', '40.00');
 ProductScreen.do.clickDisplayedProduct('Test Product B');
 ProductScreen.check.selectedOrderlineHas('Test Product B', '1.00', '40.00');
-PosLoyalty.do.clickRewardButton();
-PosLoyalty.check.hasRewardLine('$ 10 per order on specific products', '-10.00', '1.00');
+PosLoyalty.check.hasRewardLine('$ 10 per order on specific products', '-20.00', '1.00');
 PosLoyalty.check.orderTotalIs('60.00');
 
-Tour.register('PosLoyaltySpecificDiscountTour', { test: true, url: '/pos/web' }, getSteps());
+Tour.register('PosLoyaltyOrderDiscountMerge', { test: true, url: '/pos/web' }, getSteps());
 
 startSteps();
 

--- a/addons/pos_loyalty/static/src/tours/PosLoyaltyTour.js
+++ b/addons/pos_loyalty/static/src/tours/PosLoyaltyTour.js
@@ -255,10 +255,9 @@ ProductScreen.do.clickDisplayedProduct('Product A');
 ProductScreen.check.totalAmountIs('210.00');
 PosLoyalty.check.isRewardButtonHighlighted(true);
 PosLoyalty.do.clickRewardButton();
-ProductScreen.check.totalAmountIs('205.00');
-PosLoyalty.check.isRewardButtonHighlighted(true);
-PosLoyalty.do.clickRewardButton();
-ProductScreen.check.totalAmountIs('200.00');
+PosLoyalty.check.hasRewardLine('$ 5 per order on your order', '-110');
+PosLoyalty.check.hasRewardLine('$ 5 per order on your order', '-100');
+ProductScreen.check.totalAmountIs('0.00');
 
 Tour.register('PosLoyaltyTour9', { test: true, url: '/pos/web' }, getSteps());
 

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -871,7 +871,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             })],
         })
         self.main_pos_config.open_ui()
-        self.start_tour("/pos/web?config_id=%d" % self.main_pos_config.id, "PosLoyaltySpecificDiscountTour", login="accountman")
+        self.start_tour("/pos/web?config_id=%d" % self.main_pos_config.id, "PosLoyaltyOrderDiscountMerge", login="accountman")
 
     def test_discount_specific_product_with_free_product(self):
         LoyaltyProgram = self.env['loyalty.program']


### PR DESCRIPTION
Currently, depending on the setting `discount_mode`, the reward would either use all points or just the minium required.

Steps to reproduce:
-------------------
* Go to the **Point of sale** App
* Under **Products** select **Disount & Loyalty**
* Create a new loyalty program:
  * Program type: Loyalty cards
  * Rule: If minimum 1 item bought, 1 point per $ spent
  * Reward: 1$ per order discount on the order in exchange of 100 points
* Open shop session
* Select any customer
* Make an order for `Acoustic Bloc Screens` (295 points awarded)
* Apply reward
> Observation: 1$ off, used 100 points. If we had set the reward to be:
0.01$ per point discount on the order in exchange of 100 points it would have used 200 points to award 2$.

Why the fix:
------------
Originally, the difference between the two settings come from here: https://github.com/odoo/odoo/blob/d924341c6fc9556339042769f2c6516ea4b1031d/addons/pos_loyalty/static/src/js/Loyalty.js#L1382-L1388

We could re-use `points` which represents the maximum points that can (and will) be used and we devide it by the `required_points` which represents the number of times the reward can be applied max.
https://github.com/odoo/odoo/blob/d924341c6fc9556339042769f2c6516ea4b1031d/addons/pos_loyalty/static/src/js/Loyalty.js#L1383-L1385

`pointCost` also need to be updated to account for the number of times the reward was applied. We also account for the case where `discountable` is smaller than `maxDiscount`.
* In the case where `discountable > maxDiscount` it means that there is still some amount to pay after the discount is being applied. It this case we will have `pointCost = maxDiscount * pointCost`
* In the case where `discountable < maxDiscount` it means that there will be nothing to pay after the discount is being applied. It this case we will have `pointCost = discountable * reward.required_points / reward.discount`

opw-4093855

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
