### PR TITLE
Pytest support

### DIFF
--- a/odoo/tests/autotags.py
+++ b/odoo/tests/autotags.py
@@ -1,0 +1,97 @@
+import inspect
+import re
+import urllib.error
+import urllib.request
+from typing import Callable
+
+import pytest
+
+SKIP_TAGGED = pytest.mark.skip(reason="tagged on runbot")
+
+Tags = pytest.StashKey[list]()
+TagPredicate = pytest.StashKey[Callable[[pytest.Item], None]]()
+# TODO: use `TagsSelector` to parse this shit, add support for test parameters maybe
+tag_re = re.compile(r"""
+    # runbot automatically prepends `-` to disable
+    -
+    (:?/(?P<module>[\w/.]+))?
+    (:?:(?P<class>\w+))?
+    (:?\.(?P<method>\w+))?
+""" , re.VERBOSE)
+
+pytest_plugins = ["odoo.tests.pytest"]
+
+
+def pytest_configure(config: pytest.Config):
+    if config.getoption('--help'):
+        return
+
+    tagged = lambda _: False
+    config.stash[Tags] = []
+    try:
+        # TODO: have runbot to provide more useful cache headers so we don't
+        #       need to read & parse the body if the version we have is still
+        #       valid?
+        r = urllib.request.urlopen("https://runbot.odoo.com/runbot/auto-tags", timeout=1)
+    except TimeoutError:
+        # FIXME: cache `predicates`, and get the previous version from the cache if none can be retrieved?
+        pass
+    else:
+        # ignore match failure as technically the runbot *could* use an actual tag(ged)
+        predicates = []
+        tags = []
+        for m in filter(None, map(tag_re.fullmatch, r.read().decode().strip().split(','))):
+            pred = []
+            if n := m['method']:
+                pred.append(f'fn.__name__ == {n!r}')
+            if n := m['class']:
+                n += '.'
+                pred.append(f'fn.__qualname__.startswith({n!r})')
+            if n := m['module']:
+                if '/' in n:  # assume path
+                    pred.append(f'getfile(fn).endswith({n!r})')
+                else:
+                    n = f'odoo.addons.{n}.'
+                    pred.append(f'fn.__module__.startswith({n!r})')
+
+            if pred:
+                predicates.append(" and ".join(pred))
+                tags.append("".join(filter(None, [
+                    m['module'] and (
+                        f"odoo/addons/{m['module']}"
+                        if '/' in m['module'] else
+                        f"odoo/addons/{m['module']}/*"
+                    ),
+                    m['class'] and f"::{m['class']}",
+                    m['method'] and f"::{m['method']}",
+                ])))
+        if tags:
+            config.stash[Tags] = tags
+        if predicates:
+            tagged = eval(
+                "lambda fn: " + " or ".join(f"({p})" for p in predicates),
+                {
+                    '__builtins__': {},
+                    'getmodule': inspect.getmodule,
+                    'getfile': inspect.getfile,
+                },
+                {},
+            )
+
+    config.stash[TagPredicate] = tagged
+
+
+# tryfist because pytest displays these in reverse loading order by default,
+# so the last hook to run has its contents displayed first
+@pytest.hookimpl(tryfirst=True)
+def pytest_report_header(config: pytest.Config):
+    tags = config.stash[Tags]
+    return f"autotags ({len(tags)}): not ({' or '.join(tags)})"
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    p = config.stash[TagPredicate]
+    for item in items:
+        # all items here seem to be function but might as well check
+        if isinstance(item, pytest.Function) and p(item.function):
+            item.add_marker(SKIP_TAGGED)

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -90,7 +90,7 @@ except ImportError:
     websocket = None
 
 _logger = logging.getLogger(__name__)
-if config['test_enable']:
+if 'pytest' in sys.modules or config['test_enable']:
     _logger.info("Importing test framework", stack_info=_logger.isEnabledFor(logging.DEBUG))
 else:
     _logger.error(

--- a/odoo/tests/pytest.py
+++ b/odoo/tests/pytest.py
@@ -1,0 +1,348 @@
+""" Odoo pytest plugin
+
+If this plugin is loaded, only Odoo post-install tests will be discovered, and
+only when their containing modules are installed in the provided database.
+
+## Sadness on the stack:
+
+- parametrization is not supported with unittest, and pytest-repeat uses
+  parametrization meaning pytest-repeat can't be used to work with (or try and
+  suss out) nondeterminism
+- pytest-rerunfailures seems to not work at all
+- xdist broadly works fine but causes persistent false positive tour failures,
+  which generally but don't necessarily disappear when re-running the tours
+  (using `--lf`) without xdist
+"""
+import importlib
+import os
+import pathlib
+import secrets
+import shutil
+import sys
+import threading
+import unittest
+from collections.abc import Iterator
+from contextlib import closing
+from os import environ
+from pathlib import Path
+from shutil import copytree
+from types import SimpleNamespace, ModuleType
+from typing import Iterable, cast
+
+import _pytest.python
+import _pytest.unittest
+import appdirs
+import psycopg2
+import py
+import pytest
+
+import odoo
+import odoo.api
+import odoo.http
+import odoo.tools
+from odoo.modules import module, registry
+from odoo.modules.loading import load_module_graph
+from odoo.orm import environments
+from odoo.service import server
+from odoo.sql_db import close_db, db_connect, Cursor
+from odoo.tests import HttpCase, BaseCase
+from odoo.tests.case import _Outcome
+
+try:
+    # odoo 19
+    # noinspection PyUnresolvedReferences
+    from odoo.modules import module_graph
+    def load_module_code(cr: Cursor) -> None:
+        g = module_graph.ModuleGraph(cr, 'load')
+        g.extend(["base"])
+        cr.execute("SELECT name FROM ir_module_module WHERE state = 'installed'")
+        if modules := [m for [m] in cr.fetchall()]:
+            g.extend(modules)
+        env = environments.Environment(cr, 1, {})
+        load_module_graph(env, g)
+except ImportError:
+    # odoo 18 and older
+    # noinspection PyUnresolvedReferences
+    from odoo.modules import graph, loading
+    def load_module_code(cr: Cursor) -> None:
+        g = graph.Graph()
+        g.add_module(cr, "base", ())
+        env = environments.Environment(cr, 1, {})
+        # noinspection PyNoneFunctionAssignment,PyTupleAssignmentBalance,PyArgumentList
+        loaded_modules, processed_modules = load_module_graph(env, g, perform_checks=False)
+
+        previously_processed = -1
+        while previously_processed < len(processed_modules):
+            previously_processed = len(processed_modules)
+            # noinspection PyUnresolvedReferences
+            processed_modules += loading.load_marked_modules(
+                env, g, ['installed'], (),
+                None, None, loaded_modules, False)
+
+LoadedModules = pytest.StashKey[set[str]]()
+
+SKIP_NON_POST = pytest.mark.skip(reason="non post-install tests are skipped by default")
+SKIP_NON_STANDARD = pytest.mark.skip(reason="non-standard tests are skipped by default")
+SKIP_INHERITED = pytest.mark.skip(
+    reason="inherited tests are skipped unless `allow_inherited_tests_method` "
+           "is set on the class also they're bad and should be fixed"
+)
+
+# pytest does not implement TestCase.subTest by default
+pytest_plugins = ["pytest_subtests"]
+
+collect_ignore = [
+    "__*__",
+    # irrelevant frontend stuff
+    "static",
+    # packaging
+    "debian",
+    "setup",
+]
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        # sadly -d is off-limit
+        "--database", "--db",
+        help="Database to run tests on. Only tests belonging to modules "
+             "installed into the database will be collected.",
+    )
+    parser.addoption(
+        "--addons-path", default="",
+        help="Odoo addons path for resolving imports, using PEP 420 namespaces packages is strongly recommended.",
+    )
+    parser.addoption('--non-standard', action="store_true", help="runs tests which are not marked 'standard', they are skipped by default")
+    parser.addoption('--non-post', action="store_true", help="runs tests which are not marked as 'post_install', they are skipped by default")
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_configure(config: pytest.Config) -> None:
+    if config.getoption("--help"):
+        return
+
+    dbname = config.getoption("--database")
+    if not dbname:
+        raise ValueError("No database specified")
+
+    for ad in filter(None, config.getoption("--addons-path").split(",")):
+        ad = os.path.normcase(os.path.abspath(ad.strip()))
+        if ad not in odoo.addons.__path__:
+            odoo.addons.__path__.append(ad)
+
+    with closing(psycopg2.connect(dbname=dbname)) as conn, conn.cursor() as cr:
+        cr.execute("SELECT name FROM ir_module_module WHERE state = 'installed'")
+        config.stash[LoadedModules] = {name for [name] in cr}
+
+    # Configuration for Odoo setup
+    if not config.getini('python_files'):
+        config.addinivalue_line("python_files", "*/tests/test_*.py")
+
+
+def pytest_ignore_collect(collection_path: pathlib.Path, path: py.path.local, config: pytest.Config) -> bool | None:
+    """ Skips collection for modules which are not installed in the current
+    database.
+    """
+    if collection_path.joinpath('__manifest__.py').exists():
+        if collection_path.name not in config.stash[LoadedModules]:
+            return True
+
+
+def _get_default_datadir() -> str:
+    home = os.path.expanduser('~')
+    if os.path.isdir(home):
+        func = appdirs.user_data_dir
+    else:
+        if sys.platform in ['win32', 'darwin']:
+            func = appdirs.site_data_dir
+        else:
+            func = lambda **kwarg: "/var/lib/%s" % kwarg['appname'].lower()
+    # copies from release.py
+    return func(appname="Odoo", appauthor="OpenERP S.A.")
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_collection(session: pytest.Session) -> Iterator[None]:
+    database = session.config.getoption('--database')
+    cr = db_connect(database).cursor()
+    cr.transaction = environments.Transaction(cast(registry.Registry, SimpleNamespace(
+        _init_modules=set(),
+        load=lambda *args: [],
+        descendants=lambda *args: [],
+    )))
+
+    # ensures all the module code is imported in the correct (dependency) order,
+    # and pytest will not be reimporting files in the wrong order
+    load_module_code(cr)
+
+    registry.Registry.delete(database)
+    close_db(database)
+
+    return (yield)
+
+
+@pytest.fixture(scope='session')
+def odoo_session(pytestconfig: pytest.Config) -> Iterator[registry.Registry]:
+    # remove odoo test harness's retry magic, pytest has rerunfailures as well
+    # as failure selection (--lf, --sw, ...) and it breaks because pytest
+    # doesn't fully implement `unittest.TestResult`
+    del BaseCase.run
+    # patch cut down _Outcome for bit required by pytest_subtest on 3.10, it's
+    # probably not *correct* as pytest_subtest could need that info frfr but...
+    old_init = _Outcome.__init__
+    def outcome_init(self, test, result):
+        old_init(self, test, result)
+        self.skipped = []
+        self.errors = []
+    _Outcome.__init__ = outcome_init
+
+    # odoo.cli.server.main()
+    template = pytestconfig.getoption('--database')
+
+    # alternatively we could request.getfixturevalue('worker_id') but that raises...
+    if environ.get('PYTEST_XDIST_WORKER') is not None:
+        # if we run multiple test workers against the same db, we get deadlocks
+        # and additional failures, so create a copy per worker
+        dbname = "testdb_" + secrets.token_urlsafe(16)
+        with closing(psycopg2.connect(dbname='postgres')) as conn, conn.cursor() as cr:
+            conn.autocommit = True
+            cr.execute(f'CREATE DATABASE "{dbname}" TEMPLATE "{template}"')
+        dbfilestore = copytree(
+            os.path.join(_get_default_datadir(), "filestore", template),
+            os.path.join(_get_default_datadir(), "filestore", dbname),
+        )
+    else:
+        dbfilestore = None
+        dbname = template
+
+    odoo.tools.config.parse_config(['-d', dbname], setup_logging=False)
+    # tell the web client to load the test assets (so tours can run and shit),
+    # but prevent running tests via odoo (mostly at_install)
+    odoo.tools.config['test_enable'] = True
+    odoo.tools.config['test_tags'] = ''
+    server.load_server_wide_modules()
+
+    module.current_test = threading.current_thread().testing = True
+    module.current_test = threading.current_thread().dbname = dbname
+
+    # preload registry
+    yield registry.Registry.new(dbname)
+
+    del threading.current_thread().dbname
+    threading.current_thread().testing = module.current_test = False
+
+    registry.Registry.delete(dbname)
+    close_db(dbname)
+
+    if dbfilestore:
+        shutil.rmtree(dbfilestore)
+        with closing(psycopg2.connect(dbname='postgres')) as conn, conn.cursor() as cr:
+            conn.autocommit = True
+            cr.execute(f'DROP DATABASE "{dbname}"')
+
+
+@pytest.fixture
+def odoo_test(odoo_session: registry.Registry, request: pytest.FixtureRequest) -> Iterator[None]:
+    module.current_test = request.node.instance
+    yield
+    module.current_test = True
+
+
+@pytest.fixture(scope='session')
+def odoo_http(odoo_session: registry.Registry) -> Iterator[None]:
+    """For :class:`HttpCase` tests, we need to start the http server and
+    pregenerate the assets.
+    """
+    server.server = server.ThreadedServer(odoo.http.root)
+    # keep the server running until we stop it
+    server.server.start(stop=False)
+    with odoo_session.cursor() as cr:
+        odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})['ir.qweb'] \
+            ._pregenerate_assets_bundles()
+
+    yield
+
+    server.server.stop()
+
+
+def import_path(
+    path: str | os.PathLike[str],
+    *,
+    mode: str,
+    root: Path,
+    consider_namespace_packages: bool,
+) -> ModuleType:
+    path = Path(path)
+    if not path.exists():
+        raise ImportError(path)
+
+    for p in path.parents:
+        if str(p) in odoo.addons.__path__:
+            prefix = ['odoo', 'addons']
+            break
+        if str(p) in sys.path:
+            prefix = []
+            break
+    else: # no break
+        raise ImportError(f"Can't resolve module for location {path}")
+
+    names = list(path.with_suffix("").relative_to(p).parts)
+    if names[-1] == '__init__':
+        names.pop()
+
+    modname = '.'.join(prefix + names)
+    importlib.import_module(modname)
+    return sys.modules[modname]
+_pytest.python.import_path = import_path
+
+
+def pytest_pycollect_makemodule(module_path: pathlib.Path, path: py.path.local, parent: pytest.Item) -> pytest.Module:
+    return OdooModule.from_parent(parent, path=module_path)
+
+
+class OdooModule(pytest.Module):
+    def collect(self) -> Iterable[pytest.Item | pytest.Collector]:
+        for item in super().collect():
+            if isinstance(item, pytest.Class) and issubclass(item.obj, BaseCase):
+                item.add_marker(pytest.mark.usefixtures("odoo_test"))
+                if issubclass(item.obj, HttpCase):
+                    item.add_marker(pytest.mark.usefixtures("odoo_http"))
+            yield item
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """
+    - adds the `odoo_test` and `odoo_fixtures` to the relevant classes
+    - converts test tags to markers
+    - skip any test which is not tagged as standard or post_install unless the
+      relevant option is set
+    """
+    skip_non_standard = None if config.getoption('--non-standard') else SKIP_NON_STANDARD
+    skip_non_post = None if config.getoption('--non-post') else SKIP_NON_POST
+
+    for item in items:
+        cls = item.parent if isinstance(item.parent, pytest.Class) and issubclass(item.parent.obj, unittest.TestCase) else None
+        if cls and item.originalname not in cls.obj.__dict__:
+            # if a test method was inherited, skip it unless the class is marked
+            # to allow it
+            if not getattr(cls.obj, 'allow_inherited_tests_method', False):
+                item.add_marker(SKIP_INHERITED)
+
+        ut = cls if cls and hasattr(cls.obj, 'test_tags') else None
+
+        tags = () if ut is None else ut.obj.test_tags
+
+        # marking needs to be done on the item to avoid inheritance issues
+        # mucking things up, as markers are additive through inheritance
+        #
+        # also we want to skip free functions (e.g. standalone) and non-odoo test cases
+        if skip_non_standard and 'standard' not in tags:
+            item.add_marker(skip_non_standard)
+        if skip_non_post and 'post_install' not in tags:
+            item.add_marker(skip_non_post)
+        for tag in tags:
+            item.add_marker(tag)
+
+        # JS tests functions require a `_test_params`, add a fake one here for
+        # now (maybe JS tests could be treated as parametric eventually?)
+        if isinstance(item, _pytest.unittest.TestCaseFunction):
+            item.instance._test_params = ()


### PR DESCRIPTION
This PR provides a glue plugin allowing running Odoo tests using pytest. By default it will only run which are `standard` and `post_install`, and only of modules which are installed in the provided database.

- [x] namespace-based setup
- [x] addons-path based setup
- [x] automatically retrieve, translate, and skip tests tagged (ignored) by runbot (opt in via a second plugin)

## Why

- Pytest has a much more thorough test discovery system, which does not require explicit imports of test files anywhere, and thus actually runs them instead of having a bunch of tests that are never run because they're not `import-ed`, or the test directory itself doesn't even have an `__init__`
- Pytest provides a much terser test runner as by default it will capture all test output (stdout, stderr, logging) and only print them out on failure, this makes test failures much easier to find than having to trawl through pages of logs, and pytest also reports specifically which tests failed by fully qualified name (nodeid)
- Pytest provides a suite of flags to stop at first failure (`-x`), re-run only failures (`--lf`), continue from last failure (`--sw`), ..., makes it much easier to go through a suite of failing tests
- Pytest provides a convenient interface which supersedes both post install and file-based (`--test-file`) runs, with selection by path::class::method (nodeids), tags (via marker translation), and name substrings (expressions): https://docs.pytest.org/en/8.3.x/how-to/usage.html
- pytest provides a simpler interface to run tests than Odoo's CLI, even accounting for the db parameter and addons path (might need to add support for configuration files if lots of people use those for testing?)
- Pytest provides built-in support for parallelisation (xdist), using database duplication to avoid cross-worker concurrency issues.
- Pytest has a number of plugins for feature, convenience, or ease of use (though not all of them are currently compatible with the odoo test suite)

## Limitations

- pytest can not (reliably) run `at_install` tests as they need to be interspersed with installation and can't be guaranteed to run on an installed database
- because parameterization is not supported with unittest-based tests, some plugins using parameterization as implementation detail don't work at all (e.g. pytest-repeat)

## Issues

- Because pytest doesn't discover tests the way Odoo/unittest does, it will find tests which are not normally runnable, this is good because these tests usually *should* be run, but an issue because they're systematically broken, several such have been discovered here (e.g. ``lunch`, `sale_purchase_stock`).
- Depending on test scheduling, pytest can run as many tours / js tests as there are workers, which can consume a significant amount of memory (especially when there's a leak in the client).

## xdist

xdist allows parallelising tests across multiple workers and thus speeding up the wallclock time tremendously. 

However because of the need for postgres and chrome, the number of workers should probably be limited to half the logical cores (this is what `-n auto` does on CPUs with hyperthreading), running as many workers as there are cores causes significantly increased failures *and* run time, both wallclock and CPU, on a 4 cores / 8 threads machine

|machine|concurrency|wallclock|user|system|%cpu|
|-:|-:|-:|-:|-:|-:|
|4/8|1|23365.08s (6:29:25)|11290.59|828.64|51|
|4/8|4|8577.68s (2:22:57)|18743.94|1225.48|232|
|4/8|8|12130.51s (3:22:10)|28812.17|1963.45|250|
|6/12|1|22162.12s (6:09:22)|9674.88|1248.03|49|
|6/12|6|4831.48s (1:20:31)|13554.84|1605.50|313|
|6/12|8|4083.04s (1:08:03)|15082.64|1723.42|410|

### notes

- increasing the number of workers (too much) leads to an increase in sprurious failures / false negatives due to ?timing?
- these stats are running post_install tests with all non-l10n modules installed, "l10n" modules are all modules with `l10n` in their names