### PR TITLE
[FIX] point_of_sale: fix typo

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -7570,7 +7570,7 @@ msgstr ""
 msgid ""
 "To delete a product, make sure all point of sale sessions are closed.\n"
 "\n"
-"Deleting a product available in a session would be like attempting to snatch ahamburger from a customer’s hand mid-bite; chaos will ensue as ketchup and mayo go flying everywhere!"
+"Deleting a product available in a session would be like attempting to snatch a hamburger from a customer’s hand mid-bite; chaos will ensue as ketchup and mayo go flying everywhere!"
 msgstr ""
 
 #. module: point_of_sale

--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -29,7 +29,7 @@ class ProductTemplate(models.Model):
         if self.with_context(product_ctx).search_count([('id', 'in', self.ids), ('available_in_pos', '=', True)]):
             if self.env['pos.session'].sudo().search_count([('state', '!=', 'closed')]):
                 raise UserError(_("To delete a product, make sure all point of sale sessions are closed.\n\n"
-                    "Deleting a product available in a session would be like attempting to snatch a"
+                    "Deleting a product available in a session would be like attempting to snatch a "
                     "hamburger from a customer’s hand mid-bite; chaos will ensue as ketchup and mayo go flying everywhere!"))
 
     @api.onchange('sale_ok')
@@ -94,7 +94,7 @@ class ProductProduct(models.Model):
         if self.env['pos.session'].sudo().search_count([('state', '!=', 'closed')]):
             if self.with_context(product_ctx).search_count([('id', 'in', self.ids), ('product_tmpl_id.available_in_pos', '=', True)]):
                 raise UserError(_("To delete a product, make sure all point of sale sessions are closed.\n\n"
-                    "Deleting a product available in a session would be like attempting to snatch a"
+                    "Deleting a product available in a session would be like attempting to snatch a "
                     "hamburger from a customer’s hand mid-bite; chaos will ensue as ketchup and mayo go flying everywhere!"))
 
     def get_product_info_pos(self, price, quantity, pos_config_id):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- There is an typo in error message of methods, called when trying to delete a product, which is already listed in pos(open/active) session.

**step to reproduce error**
- Install 'point_of_sale' and create a product e.g 'test' which must be also available in pos.
- open pos session and search for that product.
- come out of the session ( use backend menu option from pos UI, session should be active) 
- Try to delete this product i.e. 'test'

Current behavior before PR:
![pos error](https://github.com/user-attachments/assets/23eee48d-a3c7-4035-91d6-271f2eada434)

Desired behavior after PR is merged:
![pos error fix](https://github.com/user-attachments/assets/09efdc58-b721-4bf2-b2ad-bf45b4582935)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
