### PR TITLE
[FIX] sale: fix zero division error in sale_make_invoice_advance

### DIFF
--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -368,7 +368,11 @@ class SaleAdvancePaymentInv(models.TransientModel):
                 analytic_map.setdefault(grouping_key, [])
                 analytic_map[grouping_key].append((price_subtotal, analytic_distribution))
 
+        lines_values = []
         for key, line_vals in downpayment_line_map.items():
+            # don't add line if price is 0 and prevent division by zero
+            if order.currency_id.is_zero(line_vals['price_unit']):
+                continue
             # weight analytic account distribution
             if analytic_map.get(key):
                 line_analytic_distribution = {}
@@ -379,8 +383,9 @@ class SaleAdvancePaymentInv(models.TransientModel):
                 line_vals['analytic_distribution'] = line_analytic_distribution
             # round price unit
             line_vals['price_unit'] = order.currency_id.round(line_vals['price_unit'] * percentage)
+            lines_values.append(line_vals)
 
-        return list(downpayment_line_map.values())
+        return lines_values
 
     def _prepare_base_downpayment_line_values(self, order):
         self.ensure_one()


### PR DESCRIPTION
With negative unit price it was possible to have a zero division error when ventilating the analytic distributions. Example:
Create a new sale order, set the business partner and other header data. Add a line, with a VAT of 15% for example. With a product, It doesn't matter which one. a price. To this line, add 2 analytics distributions. Add a second line whit an other product, a price and an other VAT 7% for example. Add the same analytic distribution. Add a third line, a discount one, same price * -1 then then second. same VAT then the second. Add analytic distribution. Make a down payment

This fix also remove the 0 amount down payment line this would create.

opw-4140669