### PR TITLE
[FIX] web: paste text in input field with no line break

### DIFF
--- a/addons/web/static/src/views/fields/input_field_hook.js
+++ b/addons/web/static/src/views/fields/input_field_hook.js
@@ -46,6 +46,9 @@ export function useInputField(params) {
      */
     function onInput(ev) {
         isDirty = ev.target.value !== lastSetValue;
+        if (params.preventLineBreaks && ev.inputType === "insertFromPaste") {
+            ev.target.value = ev.target.value.replace(/[\r\n]+/g, " ");
+        }
         component.props.record.model.bus.trigger("FIELD_IS_DIRTY", isDirty);
         if (!component.props.record.isValid) {
             component.props.record.resetFieldValidity(component.props.name);

--- a/addons/web/static/tests/views/fields/text_field_tests.js
+++ b/addons/web/static/tests/views/fields/text_field_tests.js
@@ -675,4 +675,27 @@ QUnit.module("Fields", (hooks) => {
 
         assert.ok(afterHeight > initialHeight, "Should be taller than one character");
     });
+
+    QUnit.test("text field without line breaks", async function (assert) {
+        serverData.models.partner.fields.foo.type = "text";
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            resId: 1,
+            serverData,
+            arch: `<form><field name="foo" options="{'line_breaks': False}"/></form>`,
+        });
+
+        assert.containsOnce(target, ".o_field_text textarea", "should have a text area");
+        const textarea = target.querySelector(".o_field_text textarea");
+        assert.strictEqual(textarea.value, "yop");
+        textarea.focus();
+        const keydownEvent = await triggerEvent(textarea, null, "keydown", { key: "Enter" });
+        assert.strictEqual(keydownEvent.defaultPrevented, true);
+        assert.strictEqual(textarea.value, "yop", "no line break should appear");
+        // Simulate a (very artificial) paste event
+        textarea.value = "text\nwith\nline\nbreaks\n";
+        await triggerEvent(textarea, null, "input", { inputType: "insertFromPaste" });
+        assert.strictEqual(textarea.value, "text with line breaks ", "no line break should appear");
+    });
 });


### PR DESCRIPTION
This commit fixes an issue that allowed users to paste text containing line breaks inside of a no line break input (like text fields with line_break = False option). This is resolved by replacing line breaks by white spaces on input when the event originates from a paste action.

Task 4130435