### PR TITLE
[FIX] mail: do not show push notif request in iOS

### DIFF
--- a/addons/mail/static/src/core/web/messaging_menu.js
+++ b/addons/mail/static/src/core/web/messaging_menu.js
@@ -4,7 +4,7 @@ import { onExternalClick, useDiscussSystray } from "@mail/utils/common/hooks";
 
 import { Component, useState } from "@odoo/owl";
 
-import { hasTouch } from "@web/core/browser/feature_detection";
+import { hasTouch, isIOS } from "@web/core/browser/feature_detection";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
 import { _t } from "@web/core/l10n/translation";
@@ -70,7 +70,7 @@ export class MessagingMenu extends Component {
             (this.store.failures.length > 0 &&
                 this.store.discuss.activeTab === "main" &&
                 !this.env.inDiscussApp) ||
-            (this.notification.permission === "prompt" &&
+            (this.shouldAskPushPermission &&
                 this.store.discuss.activeTab === "main" &&
                 !this.env.inDiscussApp) ||
             (this.canPromptToInstall &&
@@ -98,9 +98,7 @@ export class MessagingMenu extends Component {
             displayName: _t("%s has a request", this.store.odoobot.name),
             iconSrc: this.store.odoobot.avatarUrl,
             partner: this.store.odoobot,
-            isShown:
-                this.store.discuss.activeTab === "main" &&
-                this.notification.permission === "prompt",
+            isShown: this.store.discuss.activeTab === "main" && this.shouldAskPushPermission,
         };
     }
 
@@ -224,7 +222,7 @@ export class MessagingMenu extends Component {
         if (this.canPromptToInstall) {
             value++;
         }
-        if (this.notification.permission === "prompt") {
+        if (this.shouldAskPushPermission) {
             value++;
         }
         return value;
@@ -232,6 +230,10 @@ export class MessagingMenu extends Component {
 
     get displayStartConversation() {
         return this.store.discuss.activeTab !== "channel" && !this.state.adding;
+    }
+
+    get shouldAskPushPermission() {
+        return this.notification.permission === "prompt" && !isIOS();
     }
 }
 


### PR DESCRIPTION
Before this commit, it was showing a "enable push notification" messaging menu item on iOS devices.

This item was persistent and could not be removed, because iOS does not allow to enable specifically push notifcation on web apps, except if there are installed as PWA in which case they necessarily authorized push notifications based on OS app preferences.