### PR TITLE
[FIX] account: prevent error while foreign taxes creation

### DIFF
--- a/addons/l10n_at/data/account_tax_template.xml
+++ b/addons/l10n_at/data/account_tax_template.xml
@@ -1177,7 +1177,7 @@
             <field name="price_include" eval="0"/>
             <field name="active" eval="False"/>
             <field name="amount">19</field>
-            <field name="amount_type">group</field>
+            <field name="amount_type">percent</field>
             <field name="tax_group_id" ref="tax_group_0"/>
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0,{


### PR DESCRIPTION
Currently, an error occurs when creating foreign taxes for 'Austria'.

Steps to produce:

- Installing the 'account' module.
- Go to Invoicing / Configuration / Accounting / Fiscal Positions.
- Create a Fiscal Position, Set the Country as 'Austria', and enter an 'FR23334175221'(For example) as 'Foreign Tax ID'.
- And Create the taxes for this country.

Stack Trace:

```
KeyError: 'children_tax_ids'
  File "odoo/http.py", line 2374, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1904, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1967, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1934, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2178, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 223, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 755, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 40, in call_button
    action = call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 459, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/account/models/partner.py", line 289, in action_create_foreign_taxes
    self.env["account.chart.template"]._instantiate_foreign_taxes(self.country_id, self.company_id)
  File "addons/account/models/chart_template.py", line 929, in _instantiate_foreign_taxes
    children_taxes = tax_data['children_tax_ids'].split(',')
```

An error occurs when the system tries to get a 'children_tax_ids' key from tax data at [1] while foreign tax creation, But it is not available.

link [1]: https://github.com/odoo/odoo/blob/4c79aceb3a6c08453f9ec66131e1bc525eae140c/addons/account/models/chart_template.py#L936

To resolve the issue, make small changes into tax data where 'amount_type' = 'percent' instead of 'amount_type' ='group'.

Sentry-5730875398

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
