### PR TITLE
[FIX] web_editor: remove extra small memory leak

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1507,8 +1507,9 @@ var SnippetsMenu = Widget.extend({
                 return;
             }
             const range = selection.getRangeAt(0);
-            $(range.startContainer).closest('.o_default_snippet_text').removeClass('o_default_snippet_text');
-            alreadySelectedElements.delete(range.startContainer);
+            const $defaultTextEl = $(range.startContainer).closest('.o_default_snippet_text');
+            $defaultTextEl.removeClass('o_default_snippet_text');
+            alreadySelectedElements.delete($defaultTextEl[0]);
         });
         const refreshSnippetEditors = _.debounce(() => {
             for (const snippetEditor of this.snippetEditors) {


### PR DESCRIPTION
No visual bug, just a small coding mistake made with [1].

[1]: https://github.com/odoo/odoo/commit/e2cd6940bd29670ea0e76cd4bb95489a12588f55

Related to task-3957198
