### PR TITLE
[FIX] pos_sale: fix invoice with multiple tax combination downpayment

### DIFF
--- a/addons/pos_sale/static/tests/tours/PosSaleTour.js
+++ b/addons/pos_sale/static/tests/tours/PosSaleTour.js
@@ -262,5 +262,10 @@ registry.category("web_tour.tours").add("PoSDownPaymentLinesPerTax", {
                 quantity: "1.0",
                 price: "3.00",
             }),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickInvoiceButton(),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
         ].flat(),
 });

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -657,6 +657,12 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PoSDownPaymentLinesPerTax', login="accountman")
 
+        # We check the content of the invoice to make sure Product A/B/C only appears only once
+        invoice_pdf_content = str(self.env['pos.order'].search([]).account_move.get_invoice_pdf_report_attachment()[0])
+        self.assertEqual(invoice_pdf_content.count('Product A'), 1)
+        self.assertEqual(invoice_pdf_content.count('Product B'), 1)
+        self.assertEqual(invoice_pdf_content.count('Product C'), 1)
+
     def test_settle_draft_order_service_product(self):
         """
         Checks that, when settling a draft order (quotation), the quantity set on the corresponding

--- a/addons/pos_sale/views/point_of_sale_report.xml
+++ b/addons/pos_sale/views/point_of_sale_report.xml
@@ -11,7 +11,7 @@
                         <t t-if="sale_orders">
                             <t t-set="sale_order" t-value="sale_orders[0]"/>
                             <t t-foreach="sale_order.order_line" t-as="sale_order_line">
-                                <t t-if="sale_order_line.product_id != down_payment_product">
+                                <t t-if="sale_order_line.product_id != down_payment_product and sale_order_line.tax_id == line.tax_ids">
                                     <div>
                                         <span style="margin-right: 5px;"><t t-esc="int(sale_order_line.product_uom_qty)"/>x</span>
                                         <span t-esc="sale_order_line.name" />


### PR DESCRIPTION
When you made a downpayment on an order that contains different products with different unique tax combination, each invoice line would show that it's linked to all the sale order lines.

Steps to reproduce:
-------------------
* Create some taxes T1 T2 and T3
* Create an order with 3 lines and put one tax on each line
* Open the PoS and make a downpayment for the order
* Pay and invoice the order
> Observation: Each line in the invoice show that it is applying the
downpayment to the complete sale order

Why the fix:
------------
We make sure to only show the sale order line that have the same tax combination

opw-4089408
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
