### PR TITLE
[FIX] point_of_sale: remove obsolete `getUTCString` method

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -1,15 +1,9 @@
 import { registry } from "@web/core/registry";
 import { Base } from "./related_models";
 import { _t } from "@web/core/l10n/translation";
-import { formatDate, formatDateTime } from "@web/core/l10n/dates";
+import { formatDate, formatDateTime, serializeDateTime } from "@web/core/l10n/dates";
 import { omit } from "@web/core/utils/objects";
-import {
-    getUTCString,
-    parseUTCString,
-    qrCodeSrc,
-    random5Chars,
-    uuidv4,
-} from "@point_of_sale/utils";
+import { parseUTCString, qrCodeSrc, random5Chars, uuidv4 } from "@point_of_sale/utils";
 import { renderToElement } from "@web/core/utils/render";
 import { floatIsZero, roundPrecision } from "@web/core/utils/numbers";
 import { computeComboLines } from "./utils/compute_combo_lines";
@@ -25,7 +19,7 @@ export class PosOrder extends Base {
         super.setup(vals);
 
         // Data present in python model
-        this.date_order = vals.date_order || getUTCString(luxon.DateTime.now());
+        this.date_order = vals.date_order || serializeDateTime(luxon.DateTime.now());
         this.to_invoice = vals.to_invoice || false;
         this.shipping_date = vals.shipping_date || false;
         this.state = vals.state || "draft";

--- a/addons/point_of_sale/static/src/app/models/pos_payment.js
+++ b/addons/point_of_sale/static/src/app/models/pos_payment.js
@@ -1,7 +1,8 @@
 import { registry } from "@web/core/registry";
 import { Base } from "./related_models";
+import { serializeDateTime } from "@web/core/l10n/dates";
 import { roundDecimals } from "@web/core/utils/numbers";
-import { getUTCString, uuidv4 } from "@point_of_sale/utils";
+import { uuidv4 } from "@point_of_sale/utils";
 
 const { DateTime } = luxon;
 
@@ -10,7 +11,7 @@ export class PosPayment extends Base {
 
     setup(vals) {
         super.setup(...arguments);
-        this.payment_date = getUTCString(DateTime.now());
+        this.payment_date = serializeDateTime(DateTime.now());
         this.uuid = vals.uuid ? vals.uuid : uuidv4();
         this.amount = vals.amount || 0;
         this.ticket = vals.ticket || "";

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -14,11 +14,11 @@ import { usePos } from "@point_of_sale/app/store/pos_hook";
 import { Component, useState, onMounted } from "@odoo/owl";
 import { Numpad, enhancedButtons } from "@point_of_sale/app/generic_components/numpad/numpad";
 import { floatIsZero, roundPrecision as round_pr } from "@web/core/utils/numbers";
+import { sprintf } from "@web/core/utils/strings";
+import { serializeDateTime } from "@web/core/l10n/dates";
 import { OrderReceipt } from "@point_of_sale/app/screens/receipt_screen/receipt/order_receipt";
 import { ask } from "@point_of_sale/app/store/make_awaitable_dialog";
 import { handleRPCError } from "@point_of_sale/app/errors/error_handlers";
-import { getUTCString } from "@point_of_sale/utils";
-import { sprintf } from "@web/core/utils/strings";
 
 export class PaymentScreen extends Component {
     static template = "point_of_sale.PaymentScreen";
@@ -248,7 +248,7 @@ export class PaymentScreen extends Component {
             this.hardwareProxy.openCashbox();
         }
 
-        this.currentOrder.date_order = getUTCString(luxon.DateTime.now());
+        this.currentOrder.date_order = serializeDateTime(luxon.DateTime.now());
         for (const line of this.paymentLines) {
             if (!line.amount === 0) {
                 this.currentOrder.remove_paymentline(line);

--- a/addons/point_of_sale/static/src/utils.js
+++ b/addons/point_of_sale/static/src/utils.js
@@ -1,4 +1,4 @@
-import { serializeDateTime, parseDateTime } from "@web/core/l10n/dates";
+import { parseDateTime } from "@web/core/l10n/dates";
 
 /*
  * comes from o_spreadsheet.js
@@ -120,11 +120,6 @@ export function loadAllImages(el) {
     const images = el.querySelectorAll("img");
     return Promise.all(Array.from(images).map((img) => loadImage(img.src)));
 }
-
-export function getUTCString(datetimeObj) {
-    return serializeDateTime(datetimeObj);
-}
-
 export function parseUTCString(utcStr) {
     return parseDateTime(utcStr, { format: "yyyy-MM-dd HH:mm:ss", tz: "utc" });
 }

--- a/addons/pos_razorpay/static/src/app/payment_razorpay.js
+++ b/addons/pos_razorpay/static/src/app/payment_razorpay.js
@@ -1,7 +1,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { PaymentInterface } from "@point_of_sale/app/payment/payment_interface";
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
-import { getUTCString } from "@point_of_sale/utils";
+import { serializeDateTime } from "@web/core/l10n/dates";
 
 const REQUEST_TIMEOUT = 10000;
 const { DateTime } = luxon;
@@ -184,7 +184,7 @@ export class PaymentRazorpay extends PaymentInterface {
         const utcDate = timeMillis
             ? DateTime.fromMillis(timeMillis, { zone: "utc" })
             : DateTime.now();
-        return getUTCString(utcDate);
+        return serializeDateTime(utcDate);
     }
 
     _stop_pending_payment() {


### PR DESCRIPTION
This commit removes the `getUTCString` method from PoS, as it is no longer relevant to the current implementation.

opw-4109126

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
