### PR TITLE
[FIX] mail: click on 'cancel' or 'save' once when editing message

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -540,7 +540,9 @@ export class Composer extends Component {
                     this.notifySendFromMailbox();
                 }
                 if (accidentalDiscard) {
-                    const editor = document.querySelector(".o_mail_composer_form_view .note-editable");
+                    const editor = document.querySelector(
+                        ".o_mail_composer_form_view .note-editable"
+                    );
                     const editorIsEmpty = !editor || !editor.innerText.replace(/^\s*$/gm, "");
                     if (!editorIsEmpty) {
                         this.saveContent();
@@ -688,6 +690,16 @@ export class Composer extends Component {
         const composer = toRaw(this.props.composer);
         composer.isFocused = true;
         composer.thread?.markAsRead();
+    }
+
+    onFocusout(ev) {
+        if (
+            [EDIT_CLICK_TYPE.CANCEL, EDIT_CLICK_TYPE.SAVE].includes(ev.relatedTarget?.dataset?.type)
+        ) {
+            // Edit or Save most likely clicked: early return as to not re-render (which prevents click)
+            return;
+        }
+        this.props.composer.isFocused = false;
     }
 
     saveContent() {

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -49,7 +49,7 @@
                             style="height:40px;"
                             t-on-keydown="onKeydown"
                             t-on-focusin="onFocusin"
-                            t-on-focusout="() => this.props.composer.isFocused = false"
+                            t-on-focusout="onFocusout"
                             t-on-click="(ev) => markEventHandled(ev, 'composer.onClickTextarea')"
                             t-on-paste="onPaste"
                             t-model="props.composer.text"

--- a/addons/mail/static/tests/mail_test_helpers_contains.js
+++ b/addons/mail/static/tests/mail_test_helpers_contains.js
@@ -241,7 +241,15 @@ function _click(
     return _triggerEvents(
         el,
         selector,
-        ["pointerdown", "mousedown", "focus", "pointerup", "mouseup", ["click", mouseEventInit]],
+        [
+            "pointerdown",
+            "mousedown",
+            "focus",
+            "focusin",
+            "pointerup",
+            "mouseup",
+            ["click", mouseEventInit],
+        ],
         { skipVisibilityCheck }
     );
 }

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -42,7 +42,9 @@ test("Start edition on click edit", async () => {
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message-moreMenu [title='Edit']");
-    await contains(".o-mail-Message.o-editing .o-mail-Composer-input", { value: "Hello world" });
+    await contains(".o-mail-Message .o-mail-Composer-input", { value: "Hello world" });
+    await click("a[role='button']", { text: "cancel" });
+    await contains(".o-mail-Message .o-mail-Composer-input", { count: 0 });
 });
 
 test("Edit message (mobile)", async () => {


### PR DESCRIPTION
Before this commit, when editing a message, we had to click twice on "Cancel" or "Save" to register the edit message action.

This happens because while clicking on these action for the 1st time, composer intercepts a "focusout" event, which re-renders the template and thus the "Cancel" & "Save" buttons too, thus cancelling their action. The 2nd click doesn't trigger this focusout thus it works.

This commit fixes the issue by moving code that generates the "Cancel or Save" text in a sub-component. Doing so ensures that the component is only rendered when needed, in this case when Composer.mode or ui.isSmall change.

opw-4119283

Before
![before](https://github.com/user-attachments/assets/d63e27d5-2c0d-4e55-a69f-dcc15de21067)

After
![after](https://github.com/user-attachments/assets/ad5c7f61-3dfb-4a2c-91c2-6ea9680061cc)
