### PR TITLE
[FIX] mail: don't try to re-send already sent mail

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -584,6 +584,7 @@ class MailMail(models.Model):
         # to actually commit during tests
         if getattr(threading.current_thread(), 'testing', False):
             self.send()
+            return
 
         email_ids = self.ids
         dbname = self.env.cr.dbname


### PR DESCRIPTION
Since when we are in test the mail is sent before commit, we don't need to re-call send after commit (which won't do anything as the object mail is not outgoing anymore)

So we just return after the sent.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
