### PR TITLE
[FIX] account: enable retrieval of duplicated partners based on vat

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -912,6 +912,10 @@ class ResPartner(models.Model):
                 [('company_id', '=', False)],
             ):
                 partner = search_method(extra_domain)
+
+                # The VAT should be a sufficiently distinctive criterion
+                if partner and search_method == search_with_vat:
+                    return partner[:1]
                 if partner and len(partner) == 1:
                     return partner
         return self.env['res.partner']


### PR DESCRIPTION
Steps to reproduce:
* install `l10n_mx`
* Create a partner
* duplicate it
* upload an invoice/bill xml with the duplicated partner

Issue:
A new duplication of the partner will be created

Cause:
If no partner is found, we will create another one https://github.com/odoo/enterprise/blob/c66a452661c1e5ff9f837e7e1e21e068fec4c124/l10n_mx_edi/models/account_move.py#L2524-L2545

Solution:
The VAT should be a sufficiently distinctive criterion to link a partner

Ticket [link](https://www.odoo.com/odoo/project/967/tasks/4124253)
opw-4124253