### PR TITLE
[FIX] web_editor: restore font application on default text

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -221,6 +221,7 @@ export class OdooEditor extends EventTarget {
                     }
                 },
                 preHistoryUndo: () => {},
+                beforeAnyCommand: () => {},
                 onChange: () => {},
                 isHintBlacklisted: () => false,
                 filterMutationRecords: (records) => records,
@@ -1723,6 +1724,9 @@ export class OdooEditor extends EventTarget {
                 return true;
             }
         }
+
+        this.options.beforeAnyCommand();
+
         if (editorCommands[method]) {
             return editorCommands[method](this, ...args);
         }

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -222,6 +222,7 @@ const Wysiwyg = Widget.extend({
                 }
             },
             commands: commands,
+            beforeAnyCommand: this._beforeAnyCommand.bind(this),
             onChange: options.onChange,
             plugins: options.editorPlugins,
             direction: localization.direction || 'ltr',
@@ -2338,8 +2339,23 @@ const Wysiwyg = Widget.extend({
                 });
             }
         }
-    }
-
+    },
+    /**
+     * @private
+     */
+    _beforeAnyCommand: function () {
+        // Remove any marker of default text in the selection on which the
+        // command is being applied. Note that this needs to be done *before*
+        // the command and not after because some commands (e.g. font-size)
+        // rely on some elements not to have the class to fully work.
+        for (const node of OdooEditorLib.getSelectedNodes(this.$editable[0])) {
+            const el = node.nodeType === Node.TEXT_NODE ? node.parentElement : node;
+            const defaultTextEl = el.closest('.o_default_snippet_text');
+            if (defaultTextEl) {
+                defaultTextEl.classList.remove('o_default_snippet_text');
+            }
+        }
+    },
 });
 Wysiwyg.activeCollaborationChannelNames = new Set();
 Wysiwyg.activeWysiwygs = new Set();

--- a/addons/website/static/tests/tours/website_no_dirty_page.js
+++ b/addons/website/static/tests/tours/website_no_dirty_page.js
@@ -61,6 +61,7 @@ tour.register('website_no_dirty_page', {
         // TODO this should be done in a dedicated test which would be testing
         // all default snippet texts behaviors. Will be done in master where a
         // task will review this feature.
+        // TODO also test that applying an editor command removes that class.
         content: "Make sure the paragraph still acts as a default paragraph",
         trigger: '.s_text_image h2 + p.o_default_snippet_text',
         run: () => null,


### PR DESCRIPTION
Since [1], applying a font-size on some snippet default text was not working properly anymore. As soon as the actual text was changed, the features were working again.

Steps to reproduce:
- Enter website edit mode.
- Add a "Title" snippet.
- Triple-click on the default text.
- Hit the font-size "Default" button.
 => Nothing happens, you cannot restore the default title size.

Other steps to reproduce:
- Enter website edit mode.
- Add a "Title" snippet.
- Triple-click on the default text.
- Choose a font-size (like "8").
 => It is applied but inside the pre-existing 62px environment instead of replacing it, meaning the DOM looks like this:
   ```xml
    <font style="font-size: 62px;">
        <font style="font-size: 8px;">Title</font>
    </font>
    ```
    While it seems insignificant, this creates vertical misalignment.
    Depending on the use case, it might be problematic (e.g. a long
    paragraph instead of a title: it would have a big line spacing for
    no apparent reason). Note that this one is actually a more generic
    problem already but [1] worsened it. We might fully solve that issue
    in future versions.

To fix the issue, we now ensure that applying any editor command on some
default text makes it not-default text anymore.

opw-3957198
