### PR TITLE
[IMP] web: web_read: support active_test context key in x2many

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -132,8 +132,15 @@ class Base(models.AbstractModel):
             elif field.type in ('one2many', 'many2many'):
                 if not field_spec:
                     continue
-
                 co_records = self[field_name]
+
+                if 'context' in field_spec:
+                    co_records = co_records.with_context(**field_spec['context'])
+                    if field.type == 'one2many':
+                        relation_field = co_records.fields_get([field_name], ["relation_field"])[field_name]["relation_field"]
+                        co_records = co_records.search([(relation_field, "=", self.id)])
+                        for values in values_list:
+                            values[field_name] = co_records.mapped('id')
 
                 if 'order' in field_spec and field_spec['order']:
                     co_records = co_records.search([('id', 'in', co_records.ids)], order=field_spec['order'])
@@ -145,9 +152,6 @@ class Base(models.AbstractModel):
                         # filter out inaccessible corecords in case of "cache pollution"
                         values[field_name] = [id_ for id_ in values[field_name] if id_ in order_key]
                         values[field_name] = sorted(values[field_name], key=order_key.__getitem__)
-
-                if 'context' in field_spec:
-                    co_records = co_records.with_context(**field_spec['context'])
 
                 if 'fields' in field_spec:
                     if field_spec.get('limit') is not None:

--- a/addons/web/tests/__init__.py
+++ b/addons/web/tests/__init__.py
@@ -15,6 +15,7 @@ from . import test_session_info
 from . import test_assets
 from . import test_login
 from . import test_web_search_read
+from . import test_web_read
 from . import test_web_read_group
 from . import test_domain
 from . import test_translate

--- a/addons/web/tests/test_web_read.py
+++ b/addons/web/tests/test_web_read.py
@@ -1,0 +1,41 @@
+from odoo.addons.base.tests.common import SavepointCaseWithUserDemo
+from odoo.tests.common import tagged
+from odoo import Command
+
+
+@tagged("post_install", "-at_install")
+class TestWebRead(SavepointCaseWithUserDemo):
+
+    def test_web_read_x2many_with_archived_records(self):
+        self._load_partners_set()
+        Partner = self.env["res.partner"]
+        vals = {
+            "name": "OpenERP Test",
+            "category_id": [Command.set([self.partner_category.id])],
+            "child_ids": [
+                Command.create(
+                    {
+                        "name": "address of OpenERP Test",
+                        "country_id": self.ref("base.be"),
+                        "active": False,
+                    }
+                )
+            ],
+        }
+        test_partner = Partner.create(vals)
+        web_partner = test_partner.web_read(
+            specification={
+                "child_ids": {"context": {"active_test": False}, "fields": {"id": {}}},
+                "category_id": {
+                    "context": {"active_test": False},
+                    "fields": {"id": {}},
+                },
+            }
+        )[0]
+        self.assertTrue(web_partner["category_id"], "Record not Found with category.")
+
+        # testing for one2many field with country Belgium and active=False
+        self.assertTrue(
+            web_partner["child_ids"],
+            "Record not Found with country Belgium and active False.",
+        )


### PR DESCRIPTION
In web_read (python), use the context specified in the spec before searching for x2many records. That way, if the key active_test is set to false in the context, archived records won't be filtered out.

task-4023291


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
