### PR TITLE
[FIX] barcodes: forbid creation of invalid barcode pattern

### DIFF
--- a/addons/barcodes/i18n/barcodes.pot
+++ b/addons/barcodes/i18n/barcodes.pot
@@ -230,6 +230,13 @@ msgid "The barcode matching pattern"
 msgstr ""
 
 #. module: barcodes
+#: code:addons/barcodes/models/barcode_rule.py:0
+#, python-format
+msgid ""
+"The barcode pattern %(pattern)s does not lead to a valid regular expression."
+msgstr ""
+
+#. module: barcodes
 #: model:ir.model.fields,help:barcodes.field_barcode_nomenclature__rule_ids
 msgid "The list of barcode rules"
 msgstr ""

--- a/addons/barcodes/models/barcode_rule.py
+++ b/addons/barcodes/models/barcode_rule.py
@@ -41,3 +41,7 @@ class BarcodeRule(models.Model):
                 raise ValidationError(_("There is a syntax error in the barcode pattern %(pattern)s: a rule can only contain one pair of braces.", pattern=rule.pattern))
             elif p == '*':
                 raise ValidationError(_(" '*' is not a valid Regex Barcode Pattern. Did you mean '.*' ?"))
+            try:
+                re.compile(re.sub('{N+D*}', '', p))
+            except re.error:
+                raise ValidationError(_("The barcode pattern %(pattern)s does not lead to a valid regular expression.", pattern=rule.pattern))

--- a/addons/barcodes/tests/test_barcode_nomenclature.py
+++ b/addons/barcodes/tests/test_barcode_nomenclature.py
@@ -79,6 +79,12 @@ class TestBarcodeNomenclature(common.TransactionCase):
             # Must fail because '*' isn't accepted (should be '.*' instead).
             barcode_rule.pattern = '*'
 
+        with self.assertRaises(ValidationError), self.cr.savepoint():
+            # Must fail because '**' isn't even a valid regular expression.
+            barcode_rule.pattern = '**>>>{ND}'
+        # Allowed since it leads to a valid regular expression.
+        barcode_rule.pattern = '..>>>{ND}'
+
     def test_barcode_nomenclature_parse_barcode_ean8_03_value(self):
         """ Parses some barcodes with a EAN-8 barcode rule who convert the
         barcode into value and checks the result.


### PR DESCRIPTION
### Steps to reproduce:

- Go to Inventory > Configutation > Products > Barcode Nomenclatures
- Click on Default Nomenclature > Add a line with the invalid barcode Pattern: "****" and  put that one on the top of the list
- Open a POS session > click on the list icon on the right corner
- Debug window > enter any barcode and scan

#### > Odoo Error: Invalid regular expression "****"

### Cause of the issue:

The pattern field of the barcode.rule model that we created does not lead to a valid regular expression but is used as such by the String.match calls done in the "barcode_parser":
https://github.com/odoo/odoo/blob/28871371c39bcc164e167842cf7212ce05f49a51/addons/barcodes/static/src/js/barcode_parser.js#L124-L130

opw-4100030
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
