### PR TITLE
[IMP] website: introduce `s_opening_hours` snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -81,6 +81,7 @@
         'views/snippets/s_masonry_block.xml',
         'views/snippets/s_media_list.xml',
         'views/snippets/s_showcase.xml',
+        'views/snippets/s_opening_hours.xml',
         'views/snippets/s_timeline.xml',
         'views/snippets/s_process_steps.xml',
         'views/snippets/s_accordion.xml',

--- a/addons/website/views/snippets/s_opening_hours.xml
+++ b/addons/website/views/snippets/s_opening_hours.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_opening_hours" name="Opening Hours">
+    <section class="s_opening_hours">
+        <div class="container-fluid">
+            <div class="row o_grid_mode" data-row-count="13">
+                <div class="o_grid_item o_grid_item_image g-col-lg-12 g-height-13 col-lg-12" style="z-index: 1; grid-area: 1 / 1 / 14 / 13; --grid-item-padding-y: 0px; --grid-item-padding-x: 0px;">
+                    <img class="img img-fluid" src="/web/image/website.s_cover_default_image" alt=""/>
+                </div>
+                <!-- This next div is intended to correct a visual issue, specifically a vertical line anomaly next to the hours, that appears only in the modal preview.-->
+                <div class="s_dialog_preview o_grid_item o_cc o_cc1 g-col-lg-10 g-height-7 col-lg-10" style="z-index: 2; grid-area: 7 / 2 / 14 / 12; --grid-item-padding-y: 0px; --grid-item-padding-x: 0px;"/>
+                <div class="o_grid_item o_cc o_cc1 g-col-lg-6 g-height-7 col-lg-6" style="grid-area: 7 / 2 / 14 / 8; z-index: 3; --grid-item-padding-y: 32px; --grid-item-padding-x: 40px;">
+                    <h2 class="display-4-fs">Let’s get in touch</h2>
+                    <p class="lead"><u>info@yourcompany.example.com</u></p>
+                </div>
+                <div class="o_grid_item o_cc o_cc1 g-col-lg-2 g-height-7 col-lg-2 col-6" style="grid-area: 7 / 8 / 14 / 10; z-index: 4; --grid-item-padding-y: 32px; --grid-item-padding-x: 40px;">
+                    <p class="o_small"><u>Monday</u><br/>8.00am-6.00pm</p>
+                    <p class="o_small"><u>Tuesday</u><br/>8.00am-6.00pm</p>
+                    <p class="o_small"><u>Wednesday</u><br/>8.00am-12.00am</p>
+                    <p class="o_small"><u>Thursday</u><br/>8.00am-6.00pm</p>
+                </div>
+                <div class="o_grid_item o_cc o_cc1 g-col-lg-2 g-height-7 col-lg-2 col-6" style="grid-area: 7 / 10 / 14 / 12; z-index:5; --grid-item-padding-y: 32px; --grid-item-padding-x: 40px;">
+                    <p class="o_small"><u>Friday</u><br/>8.00am-6.00pm</p>
+                    <p class="o_small"><u>Saturday</u><br/>8.00am-6.00pm</p>
+                    <p class="o_small"><u>Sunday</u><br/>Closed</p>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -198,6 +198,7 @@
 
                 <!-- Contact & Forms group -->
                 <t t-snippet="website.s_website_form" string="Form" t-forbid-sanitize="form" t-thumbnail="/website/static/src/img/snippets_thumbs/s_website_form.svg" group="contact_and_forms"/>
+                <t t-snippet="website.s_opening_hours" string="Opening Hours" group="contact_and_forms"/>
 
                 <!-- Products group -->
                 <t id="sale_products_hook"/>


### PR DESCRIPTION
This commit adds the new `s_opening_hours` snippet.

task-4140779
Part-of: task-4077427

| New snippet: Opening Hours |
|--------|
|  ![Capture d’écran 2024-09-05 à 16 39 42](https://github.com/user-attachments/assets/b0253f3c-7f18-4af8-bae7-dfc73dcd7e63)  | 



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
