### PR TITLE
[FIX] point_of_sale: show correct on hand quantity on the info popup

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -132,7 +132,7 @@ class PosSession(models.Model):
             'pos.category', 'pos.bill', 'res.company', 'account.tax', 'product.product', 'product.attribute', 'product.attribute.custom.value',
             'product.template.attribute.line', 'product.template.attribute.value', 'pos.combo', 'pos.combo.line', 'product.packaging', 'res.users', 'res.partner',
             'decimal.precision', 'uom.uom', 'uom.category', 'res.country', 'res.country.state', 'res.lang', 'product.pricelist', 'product.pricelist.item', 'product.category',
-            'account.cash.rounding', 'account.fiscal.position', 'account.fiscal.position.tax', 'stock.picking.type', 'res.currency', 'pos.note', 'ir.ui.view']
+            'account.cash.rounding', 'account.fiscal.position', 'account.fiscal.position.tax', 'stock.picking.type', 'res.currency', 'pos.note', 'ir.ui.view', 'stock.location', 'stock.warehouse']
 
     @api.model
     def _load_pos_data_domain(self, data):

--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -207,7 +207,9 @@ class ProductProduct(models.Model):
             {'name': w.name,
             'available_quantity': self.with_context({'warehouse_id': w.id}).qty_available,
             'forecasted_quantity': self.with_context({'warehouse_id': w.id}).virtual_available,
-            'uom': self.uom_name}
+            'uom': self.uom_name,
+            'id': w.id,
+            }
             for w in self.env['stock.warehouse'].search([])]
 
         # Suppliers

--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -180,7 +180,7 @@ class StockPickingType(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config_id):
-        return ['id', 'use_create_lots', 'use_existing_lots']
+        return ['id', 'use_create_lots', 'use_existing_lots', 'default_location_src_id']
 
 class ProcurementGroup(models.Model):
     _inherit = 'procurement.group'

--- a/addons/point_of_sale/models/stock_warehouse.py
+++ b/addons/point_of_sale/models/stock_warehouse.py
@@ -48,3 +48,44 @@ class Warehouse(models.Model):
         for warehouse in warehouses:
             new_vals = warehouse._create_or_update_sequences_and_picking_types()
             warehouse.write(new_vals)
+
+    def _load_pos_data(self, data):
+        domain = self._load_pos_data_domain(data)
+        fields = self._load_pos_data_fields(self.id)
+        data = self.search_read(domain, fields, load=False)
+
+        return {
+            'data': data,
+            'fields': fields,
+        }
+
+    @api.model
+    def _load_pos_data_fields(self, config_id):
+        return ["id"]
+
+    @api.model
+    def _load_pos_data_domain(self, data):
+        return []
+
+
+
+class StockLocation(models.Model):
+    _inherit = 'stock.location'
+
+    def _load_pos_data(self, data):
+        domain = self._load_pos_data_domain(data)
+        fields = self._load_pos_data_fields(self.id)
+        data = self.search_read(domain, fields, load=False)
+
+        return {
+            'data': data,
+            'fields': fields,
+        }
+
+    @api.model
+    def _load_pos_data_fields(self, config_id):
+        return ["id", "warehouse_id"]
+
+    @api.model
+    def _load_pos_data_domain(self, data):
+        return []

--- a/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.js
+++ b/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.js
@@ -38,9 +38,10 @@ export class ProductInfoBanner extends Component {
                     }
 
                     if (result) {
+                        debugger;
                         const productInfo = result.productInfo;
-                        this.state.available_quantity =
-                            productInfo.warehouses[0]?.available_quantity;
+                        const warehouse = productInfo.warehouses.find(wh => wh.id == this.pos.config.picking_type_id.default_location_src_id.warehouse_id.id)
+                        this.state.available_quantity = warehouse.available_quantity || 0;
                         this.state.price_with_tax = productInfo.all_prices.price_with_tax;
                         this.state.price_without_tax = productInfo.all_prices.price_without_tax;
                         this.state.tax_name = productInfo.all_prices.tax_details[0]?.name || "";

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -324,3 +324,16 @@ registry.category("web_tour.tours").add("PosCustomerAllFieldsDisplayed", {
             PartnerList.searchCustomerValue("john@doe.com"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("CheckProductInformationQuantity", {
+    test: true,
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            ProductScreen.clickInfoProduct("Product 3"),
+            {
+                trigger: ".h4:contains('On hand'):contains('10 Units')",
+                run: () => {},
+            },
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1453,6 +1453,33 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'PosComboChangeFP', login="pos_user")
 
+    def test_product_info_quantity(self):
+        warehouse_test = self.env['stock.warehouse'].create({'name': 'WH C', 'code': 'WHC', 'company_id': self.env.company.id, 'partner_id': self.env.company.partner_id.id})
+        self.product4 = self.env['product.product'].create({
+            'name': 'Product 3',
+            'lst_price': 10,
+            'is_storable': True,
+            'available_in_pos': True,
+        })
+        self.env['stock.quant'].with_context(inventory_mode=True).create({
+            'product_id': self.product4.id,
+            'inventory_quantity': 10,
+            'location_id': warehouse_test.lot_stock_id.id,
+            'owner_id': self.partner_a.id,
+        }).action_apply_inventory()
+
+        self.env['stock.quant'].with_context(inventory_mode=True).create({
+            'product_id': self.product4.id,
+            'inventory_quantity': 20,
+            'location_id': self.main_pos_config.picking_type_id.default_location_src_id.id,
+            'owner_id': self.partner_a.id,
+        }).action_apply_inventory()
+
+        self.main_pos_config.picking_type_id.default_location_src_id = warehouse_test.lot_stock_id
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'CheckProductInformationQuantity', login="pos_user")
+
+
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):
     browser_size = '375x667'


### PR DESCRIPTION
When you have multiple warehouses, the quantity shown on the product information popup was always the one of the first warehouse of the list. But it should always show the quantity of the warehouse selected in the picking type of the PoS config.

Steps to reproduce:
-------------------
* Create atleast 2 warehouses W1 and W2
* Order the warehouse list so that W1 is above W2
* Set W2 as the warehouse used in the picking type of the PoS
* Add 10 quantity of product A in W1 and 20 of product B in W2
> Observation: When opening PoS and opening the product info popup the
on hand quantity would be 10. But it should be 20 as W2 is the warehouse used in the pos picking type

Why the fix:
------------
We make sure to select the correct warehouse to get the available quantity of product A

opw-4130533
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
