### PR TITLE
[IMP] website: introduce `s_website_form_cover` snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -167,6 +167,7 @@
         'views/snippets/s_cta_card.xml',
         'views/snippets/s_image_frame.xml',
         'views/snippets/s_cta_mobile.xml',
+        'views/snippets/s_website_form_cover.xml',
         'views/new_page_template_templates.xml',
         'views/website_views.xml',
         'views/website_pages_views.xml',

--- a/addons/website/data/image_library.xml
+++ b/addons/website/data/image_library.xml
@@ -1057,5 +1057,11 @@
     <field name="type">url</field>
     <field name="url">/website/static/src/img/snippets_demo/s_website_form_info.jpg</field>
 </record>
+<record id="website.s_website_form_cover_default_image" model="ir.attachment">
+    <field name="public" eval="True"/>
+    <field name="name">s_website_form_cover_default_image.jpg</field>
+    <field name="type">url</field>
+    <field name="url">/web/image/website.s_cover_default_image</field>
+</record>
 
 </odoo>

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1032,6 +1032,7 @@ class Website(models.Model):
             fallback_create_missing_industry_image('s_carousel_intro_default_image_2', 's_image_text_default_image')
             fallback_create_missing_industry_image('s_carousel_intro_default_image_3', 's_text_image_default_image')
             fallback_create_missing_industry_image('s_website_form_overlay_default_image', 's_cover_default_image')
+            fallback_create_missing_industry_image('s_website_form_cover_default_image', 's_cover_default_image')
             fallback_create_missing_industry_image('s_framed_intro_default_image', 's_cover_default_image')
             fallback_create_missing_industry_image('s_wavy_grid_default_image_1', 's_cover_default_image')
             fallback_create_missing_industry_image('s_wavy_grid_default_image_2', 's_image_text_default_image')

--- a/addons/website/static/src/snippets/s_website_form_cover/000.scss
+++ b/addons/website/static/src/snippets/s_website_form_cover/000.scss
@@ -1,0 +1,9 @@
+.s_website_form_cover {
+    // Needed to be able to stretch the inner container so that
+    // the snippet works with the 50% and 100% height
+    > *:not(.o_scroll_button) {
+        &, > .row {
+            min-height: inherit;
+        }
+    }
+}

--- a/addons/website/views/snippets/s_website_form_cover.xml
+++ b/addons/website/views/snippets/s_website_form_cover.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_website_form_cover" name="Form Cover">
+    <section class="s_website_form_cover" data-snippet="s_website_form_cover">
+        <div class="container-fluid">
+            <div class="row s_nb_column_fixed">
+                <div class="col-lg-6 oe_img_bg o_bg_img_center o_not_editable pt128 pb128" data-name="Image" style="background-image: url('/web/image/website.s_website_form_cover_default_image');"/>
+                <div class="col-lg-6 pt48 pb48 px-4">
+                    <h2>Send us a message</h2>
+                    <p class="lead">Get in touch with your customers to provide them with better service. You can modify the form fields to gather more precise information.</p>
+                    <t t-snippet-call="website.s_website_form"/>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+<record id="website.s_website_form_cover_000_scss" model="ir.asset">
+    <field name="name">Website Form Cover 000 SCSS</field>
+    <field name="bundle">web.assets_frontend</field>
+    <field name="path">website/static/src/snippets/s_website_form_cover/000.scss</field>
+</record>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -355,6 +355,9 @@
                 <t t-snippet="website.s_website_form_info" string="Form Info" group="contact_and_forms">
                     <keywords>contact, collect, submission, input, fields, questionnaire, survey, registration, request, image, picture, photo, illustration, media, visual, company, organization, address, phone, email, location, get-in-touch</keywords>
                 </t>
+                <t t-snippet="website.s_website_form_cover" string="Form Cover" group="contact_and_forms">
+                    <keywords>contact, collect, submission, input, fields, questionnaire, survey, registration, request, image, picture, photo, illustration, media, visual</keywords>
+                </t>
 
                 <!-- Products group -->
                 <t id="sale_products_hook"/>
@@ -946,13 +949,13 @@
 
     <!-- Background -->
     <t t-set="only_bg_color_selector" t-value="'section .row > div, .s_text_highlight, .s_mega_menu_thumbnails_footer, .s_hr, .s_cta_badge'"/>
-    <t t-set="only_bg_color_exclude" t-valuef=".s_col_no_bgcolor, .s_col_no_bgcolor.row > div, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .s_image_gallery .row > div, .s_text_cover .row > .o_not_editable, [data-snippet] :not(.oe_structure) > .s_hr, #{card_parent_handlers}"/>
+    <t t-set="only_bg_color_exclude" t-valuef=".s_col_no_bgcolor, .s_col_no_bgcolor.row > div, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .s_image_gallery .row > div, .s_text_cover .row > .o_not_editable, [data-snippet] :not(.oe_structure) > .s_hr, #{card_parent_handlers}, .s_website_form_cover .row > .o_not_editable"/>
 
     <t t-set="base_only_bg_image_selector" t-value="'.s_tabs .oe_structure > *, footer .oe_structure > *'"/>
     <t t-set="only_bg_image_selector" t-value="base_only_bg_image_selector"/>
     <t t-set="only_bg_image_exclude" t-value="''"/>
 
-    <t t-set="both_bg_color_image_selector" t-value="'section, .carousel-item, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .parallax, .s_text_cover .row > .o_not_editable'"/>
+    <t t-set="both_bg_color_image_selector" t-value="'section, .carousel-item, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .parallax, .s_text_cover .row > .o_not_editable, .s_website_form_cover .row > .o_not_editable'"/>
     <t t-set="both_bg_color_image_exclude" t-value="base_only_bg_image_selector + ', .s_carousel_wrapper, .s_image_gallery .carousel-item, .s_google_map, .s_map, [data-snippet] :not(.oe_structure) > [data-snippet], .s_masonry_block .s_col_no_resize, .s_quotes_carousel_wrapper, .s_carousel_intro_wrapper'"/>
 
     <t t-call="website.snippet_options_background_options">


### PR DESCRIPTION
This PR adds the new `s_website_form_cover` snippet.

- requires https://github.com/odoo/design-themes/pull/1010

task-4138250
Part-of: task-4077427

| New snippet: Form Cover |
|--------|
| ![image](https://github.com/user-attachments/assets/389b00b8-1b95-4e22-b0bd-7a0c69cf03f7) | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
