### PR TITLE
[FIX] account: allow doc,docx,txt attachment from alias

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -32,7 +32,6 @@ from odoo.tools import (
     is_html_empty,
     create_index,
 )
-from odoo.addons.base_import.models.base_import import FILE_TYPE_DICT
 
 _logger = logging.getLogger(__name__)
 
@@ -56,6 +55,17 @@ TYPE_REVERSE_MAP = {
     'in_refund': 'entry',
     'out_receipt': 'out_refund',
     'in_receipt': 'in_refund',
+}
+
+ALLOWED_MIMETYPES = {
+    'text/plain',
+    'text/csv',
+    'application/pdf',
+    'application/vnd.ms-excel',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'application/vnd.oasis.opendocument.spreadsheet',
+    'application/msword',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
 }
 
 EMPTY = object()
@@ -3153,7 +3163,7 @@ class AccountMove(models.Model):
                 file_data['type'] == 'binary'
                 and self._context.get('from_alias')
                 and not attachments_by_invoice.get(file_data['attachment'])
-                and file_data['attachment'].mimetype not in FILE_TYPE_DICT
+                and file_data['attachment'].mimetype not in ALLOWED_MIMETYPES
             ):
                 close_file(file_data)
                 continue
@@ -3191,7 +3201,7 @@ class AccountMove(models.Model):
                         invoice = current_invoice or self.create({})
                         success = decoder(invoice, file_data, new)
 
-                        if success or file_data['type'] == 'pdf' or file_data['attachment'].mimetype in FILE_TYPE_DICT:
+                        if success or file_data['attachment'].mimetype in ALLOWED_MIMETYPES:
                             invoice._link_bill_origin_to_purchase_orders(timeout=4)
                             invoices |= invoice
                             current_invoice = self.env['account.move']

--- a/addons/account/tests/test_account_incoming_supplier_invoice.py
+++ b/addons/account/tests/test_account_incoming_supplier_invoice.py
@@ -54,6 +54,38 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon):
             'mimetype': 'image/gif',
         })
 
+    def _create_dummy_xlsx_attachment(self):
+        self.attachment_number += 1
+        return self.env['ir.attachment'].create({
+            'name': f"attachment_{self.attachment_number}",
+            'raw': 'test',
+            'mimetype': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        })
+
+    def _create_dummy_docx_attachment(self):
+        self.attachment_number += 1
+        return self.env['ir.attachment'].create({
+            'name': f"attachment_{self.attachment_number}",
+            'raw': 'test',
+            'mimetype': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        })
+
+    def _create_dummy_txt_attachment(self):
+        self.attachment_number += 1
+        return self.env['ir.attachment'].create({
+            'name': f"attachment_{self.attachment_number}",
+            'raw': 'test',
+            'mimetype': 'text/plain',
+        })
+
+    def _create_dummy_csv_attachment(self):
+        self.attachment_number += 1
+        return self.env['ir.attachment'].create({
+            'name': f"attachment_{self.attachment_number}",
+            'raw': 'test',
+            'mimetype': 'text/csv',
+        })
+
     def _disable_ocr(self, company):
         if 'extract_in_invoice_digitalization_mode' in company._fields:
             company.extract_in_invoice_digitalization_mode = 'no_send'
@@ -267,3 +299,21 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon):
         with self.with_success_decoder() as decoded_files, self.with_simulated_embedded_xml(pdf1):
             self._assert_extend_with_attachments({pdf1: 1, xml1: 1}, new=True, from_alias=True)
             self.assertEqual(decoded_files, {xml1.name})
+
+    def test_extend_with_attachments_document_formats(self):
+        txt = self._create_dummy_txt_attachment()
+        csv = self._create_dummy_csv_attachment()
+        xlsx = self._create_dummy_xlsx_attachment()
+        docx = self._create_dummy_docx_attachment()
+        with self.with_success_decoder() as decoded_files:
+            self._assert_extend_with_attachments({txt: 1}, new=True, from_alias=True)
+            self.assertEqual(decoded_files, {txt.name})
+        with self.with_success_decoder() as decoded_files:
+            self._assert_extend_with_attachments({csv: 1}, new=True, from_alias=True)
+            self.assertEqual(decoded_files, {csv.name})
+        with self.with_success_decoder() as decoded_files:
+            self._assert_extend_with_attachments({xlsx: 1}, new=True, from_alias=True)
+            self.assertEqual(decoded_files, {xlsx.name})
+        with self.with_success_decoder() as decoded_files:
+            self._assert_extend_with_attachments({docx: 1}, new=True, from_alias=True)
+            self.assertEqual(decoded_files, {docx.name})


### PR DESCRIPTION
Set up email alias for Vendor Bill journal
Send email with docx attachment to alias
Bill is created
Issue: No attachment is present

This commit will extend 827b536942a67e91d4283ebd2bf50db5141f0abe to allow more formats

opw-4092311

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
