### PR TITLE
[FIX] l10n_mt: fix typo from "Matla" to "Malta"

### DIFF
--- a/addons/l10n_mt/data/account_tax_report_data.xml
+++ b/addons/l10n_mt/data/account_tax_report_data.xml
@@ -33,7 +33,7 @@
                         </field>
                     </record>
                     <record id="tax_report_line_I_2" model="account.report.line">
-                        <field name="name">Supplies of Goods and Services where place of supply is outside Matla - EU and non EU</field>
+                        <field name="name">Supplies of Goods and Services where place of supply is outside Malta - EU and non EU</field>
                         <field name="code">mt_I_2</field>
                         <field name="expression_ids">
                             <record id="tax_report_line_I_2_tag_column1" model="account.report.expression">

--- a/addons/l10n_mt/i18n/l10n_mt.pot
+++ b/addons/l10n_mt/i18n/l10n_mt.pot
@@ -145,7 +145,7 @@ msgstr ""
 #. module: l10n_mt
 #: model:account.report.line,name:l10n_mt.tax_report_line_I_2
 msgid ""
-"Supplies of Goods and Services where place of supply is outside Matla - EU "
+"Supplies of Goods and Services where place of supply is outside Malta - EU "
 "and non EU"
 msgstr ""
 


### PR DESCRIPTION
Problem: The account tax report was displaying "Matla" instead of "Malta"

Purpose: Fix the type to stay consistent with naming conventions 

opw-4134520




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
