### PR TITLE
[FIX] account: When changing CoA, reset company.anglo_saxon_accounting

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -190,6 +190,8 @@ class AccountChartTemplate(models.AbstractModel):
         if not reload_template and (not company._existing_accounting() or self.env.ref('base.module_account').demo):
             for model in ('account.move',) + TEMPLATE_MODELS[::-1]:
                 self.env[model].sudo().with_context(active_test=False).search([('company_id', '=', company.id)]).with_context({MODULE_UNINSTALL_FLAG: True}).unlink()
+            # Reset company fields that should depend on CoA to their default values.
+            company.write({'anglo_saxon_accounting': False})
 
         data = self._get_chart_template_data(template_code)
         template_data = data.pop('template_data')

--- a/addons/account/tests/test_chart_template.py
+++ b/addons/account/tests/test_chart_template.py
@@ -547,12 +547,17 @@ class TestChartTemplate(TransactionCase):
                 'parent': None,
             }}
 
+        # Check that company fields that should depend on CoA are reset when changing CoA
+        # (afaik there is only `anglo_saxon_accounting`)
+        self.company_1.anglo_saxon_accounting = True
+
         with (
             patch.object(AccountChartTemplate, '_get_chart_template_mapping', _get_chart_template_mapping),
             patch.object(AccountChartTemplate, '_get_chart_template_data', side_effect=test_get_data, autospec=True)
         ):
             self.env['account.chart.template'].try_loading('other_test', company=self.company_1, install_demo=True)
         self.assertEqual(self.company_1.chart_template, 'other_test')
+        self.assertFalse(self.company_1.anglo_saxon_accounting)
 
         with patch.object(AccountChartTemplate, '_get_chart_template_data', side_effect=test_get_data, autospec=True):
             self.env['account.chart.template'].try_loading('test', company=self.company_1, install_demo=True)


### PR DESCRIPTION
To reproduce:
- Install `account` in a fresh DB
- Change the CoA to one which doesn't use anglo-saxon accounting
- Notice how anglo-saxon accounting is still activated on the company

Analysis:
- Since `anglo_saxon_accounting` has a default value of False, we don't bother to specify its value in the templates which don't use it.
- So, when switching CoA from one which uses anglo-saxon accounting to one which doesn't, False doesn't get written.

Solution:
- We explicitly reset it when changing CoA.
- We could have put a default value of False in the values we write on the company, but that doesn't combine as nicely with the existing code, so this solution is preferred.

This has been causing issues for new SaaS databases, since the `saas_worker` first generates a database template for the Accounting app (which installs the generic CoA), and only afterwards generates database templates for each localization by changing the CoA.

As far as I can see, no other fields need the same treatment.

taskid: none