### PR TITLE
[IMP] mail: improve sizing of message action extra menu

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -167,9 +167,9 @@
                         <t t-call="mail.Message.expandAction"/>
                         <t t-set-slot="content">
                             <t t-foreach="messageActions.actions.slice(quickActionCount - 1)" t-as="action" t-key="action.id">
-                                <DropdownItem class="'px-2 d-flex align-items-center rounded-0'" onSelected="action.onClick" attrs="{ title: action.title}">
-                                    <i class="fa fa-lg fa-fw pe-2" t-att-class="action.icon"/>
-                                    <t t-esc="action.title"/>
+                                <DropdownItem class="'px-2 py-1 d-flex align-items-center rounded-0'" onSelected="action.onClick" attrs="{ title: action.title}">
+                                    <i class="fa fa-fw" t-att-class="action.icon"/>
+                                    <span class="mx-2" t-esc="action.title"/>
                                 </DropdownItem>
                             </t>
                         </t>


### PR DESCRIPTION
Icons were too big, which gave the impression they were not properly aligned with text.

The chat window actions look nice, so the change reflect the same visual as with chat window actions.

![Screenshot 2024-08-27 at 19 12 09](https://github.com/user-attachments/assets/9715b7ee-f95a-489a-95d6-566f0d2e8abb)
