### PR TITLE
[FIX] sale_loyalty: fetch discounts & loyalty from parent company

### DIFF
--- a/addons/loyalty/security/loyalty_security.xml
+++ b/addons/loyalty/security/loyalty_security.xml
@@ -4,25 +4,25 @@
         <record id="sale_loyalty_program_company_rule" model="ir.rule">
             <field name="name">Loyalty program multi company rule</field>
             <field name="model_id" ref="model_loyalty_program"/>
-            <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
+            <field name="domain_force">['|', ('company_id', 'in', company_ids + [False]), ('company_id', 'parent_of', company_ids)]</field>
         </record>
 
         <record id="sale_loyalty_card_company_rule" model="ir.rule">
             <field name="name">Loyalty card multi company rule</field>
             <field name="model_id" ref="model_loyalty_card"/>
-            <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
+            <field name="domain_force">['|', ('company_id', 'in', company_ids + [False]), ('company_id', 'parent_of', company_ids)]</field>
         </record>
 
         <record id="sale_loyalty_rule_company_rule" model="ir.rule">
             <field name="name">Loyalty rule multi company rule</field>
             <field name="model_id" ref="model_loyalty_rule"/>
-            <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
+            <field name="domain_force">['|', ('company_id', 'in', company_ids + [False]), ('company_id', 'parent_of', company_ids)]</field>
         </record>
 
         <record id="sale_loyalty_reward_company_rule" model="ir.rule">
             <field name="name">Loyalty reward multi company rule</field>
             <field name="model_id" ref="model_loyalty_reward"/>
-            <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
+            <field name="domain_force">['|', ('company_id', 'in', company_ids + [False]), ('company_id', 'parent_of', company_ids)]</field>
         </record>
     </data>
 </odoo>

--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -450,7 +450,7 @@ class SaleOrder(models.Model):
         """
         self.ensure_one()
         return [('active', '=', True), ('sale_ok', '=', True),
-                ('company_id', 'in', (self.company_id.id, False)),
+                ('company_id', 'in', (self.company_id.id, self.company_id.parent_id.id, False)),
                 '|', ('date_to', '=', False), ('date_to', '>=', fields.Date.context_today(self))]
 
     def _get_trigger_domain(self):
@@ -459,7 +459,7 @@ class SaleOrder(models.Model):
         """
         self.ensure_one()
         return [('active', '=', True), ('program_id.sale_ok', '=', True),
-                ('company_id', 'in', (self.company_id.id, False)),
+                ('company_id', 'in', (self.company_id.id, self.company_id.parent_id.id, False)),
                 '|', ('program_id.date_to', '=', False), ('program_id.date_to', '>=', fields.Date.context_today(self))]
 
     def _get_applicable_program_points(self, domain=None):

--- a/addons/sale_loyalty/tests/test_program_multi_company.py
+++ b/addons/sale_loyalty/tests/test_program_multi_company.py
@@ -4,6 +4,7 @@
 from odoo.addons.sale_loyalty.tests.common import TestSaleCouponCommon
 from odoo.exceptions import UserError
 from odoo.tests import tagged
+from odoo import Command
 
 
 @tagged('post_install', '-at_install')
@@ -81,3 +82,33 @@ class TestSaleCouponMultiCompany(TestSaleCouponCommon):
         order_b._update_programs_and_rewards()
         self.assertIn(self.immediate_promotion_program_c2, order_b._get_applied_programs())
         self.assertNotIn(self.immediate_promotion_program, order_b._get_applied_programs())
+
+    def test_applicable_programs_on_branch(self):
+        # create a branch
+        branch_a = self.env['res.company'].create(
+            {'name': 'Branch A', 'parent_id': self.company_a.id}
+        )
+
+        # create an order
+        order = self.env['sale.order'].create(
+            {'order_line': [
+                Command.create({
+                    'product_id': self.product_A.id,
+                    'name': '1 Product A',
+                    'product_uom': self.uom_unit.id,
+                    'product_uom_qty': 1.0,
+                }),
+                Command.create({
+                    'product_id': self.product_B.id,
+                    'name': '2 Product B',
+                    'product_uom': self.uom_unit.id,
+                    'product_uom_qty': 1.0,
+                })
+            ],
+            'company_id': branch_a.id,
+            'partner_id': self.steve.id
+            }
+        )
+
+        order._update_programs_and_rewards()
+        self.assertIn(self.immediate_promotion_program, order._get_applied_programs())


### PR DESCRIPTION
Problem: When a user is on a branch, they are unable to view the parent company's discounts and are unable to apply it to the sales orders.

Purpose: The branch should have access to the discounts & loyalty programs from the parent company.

Steps to Reproduce on Runbot:
1. Install sale_loyalty
2. Create a branch
3. On the branch company, observe that no discounts & loyalty programs from the parennt company are displayed
4. Attempt to apply a coupon code from a discount belonging to the parent company on a sales order and receive a ValidationError

opw-4079487

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
