### PR TITLE
[FIX] microsoft_calendar: add condition on check

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -442,6 +442,12 @@ class Meeting(models.Model):
                     )
                 )
 
+    def _check_organizer_validation_conditions(self, vals_list):
+        """ Method for check in the microsoft_calendar module that needs to be
+            overridden in appointment.
+        """
+        return [True] * len(vals_list)
+
     @api.depends('recurrence_id', 'recurrency')
     def _compute_rrule_type_ui(self):
         defaults = self.env["calendar.recurrence"].default_get(["interval", "rrule_type"])

--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -86,7 +86,8 @@ class Meeting(models.Model):
         if self._check_microsoft_sync_status() and not notify_context and recurrency_in_batch:
             self._forbid_recurrence_creation()
 
-        for vals in vals_list:
+        vals_check_organizer = self._check_organizer_validation_conditions(vals_list)
+        for vals in [vals for vals, check_organizer in zip(vals_list, vals_check_organizer) if check_organizer]:
             # If event has a different organizer, check its sync status and verify if the user is listed as attendee.
             sender_user, partner_ids = self._get_organizer_user_change_info(vals)
             partner_included = partner_ids and len(partner_ids) > 0 and sender_user.partner_id.id in partner_ids

--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -74,7 +74,7 @@ class Meeting(models.Model):
         """If microsoft calendar is not syncing, don't send a mail."""
         user_id = self._get_event_user_m()
         if self.with_user(user_id)._check_microsoft_sync_status() and user_id._get_microsoft_sync_status() == "sync_active":
-            return True
+            return self.microsoft_id or self.need_sync_m
         return super()._skip_send_mail_status_update()
 
     @api.model_create_multi

--- a/addons/microsoft_calendar/tests/test_create_events.py
+++ b/addons/microsoft_calendar/tests/test_create_events.py
@@ -589,7 +589,7 @@ class TestSyncOdoo2MicrosoftMail(TestCommon, MailCommon):
         }
         for create_user, organizer, expect_mail in [
             (user_root, self.users[0], True), (user_root, None, True),
-                (self.users[0], None, False), (self.users[0], self.users[1], False)]:
+                (self.users[0], None, False), (self.users[0], self.users[0], False), (self.users[0], self.users[1], False)]:
             with self.subTest(create_uid=create_user.name if create_user else None, user_id=organizer.name if organizer else None):
                 with self.mock_mail_gateway(), patch.object(MicrosoftCalendarService, 'insert') as mock_insert:
                     mock_insert.return_value = ('1', '1')

--- a/addons/microsoft_calendar/tests/test_create_events.py
+++ b/addons/microsoft_calendar/tests/test_create_events.py
@@ -572,7 +572,7 @@ class TestSyncOdoo2MicrosoftMail(TestCommon, MailCommon):
                 'microsoft_synchronization_stopped': False,
                 'microsoft_calendar_sync_token': f'{n}_sync_token',
             })]
-        } for n in range(1, 3)).user_ids
+        } for n in range(1, 4))
 
     @freeze_time("2020-01-01")
     @patch.object(User, '_get_microsoft_calendar_token', lambda user: user.microsoft_calendar_token)
@@ -587,15 +587,31 @@ class TestSyncOdoo2MicrosoftMail(TestCommon, MailCommon):
             'start': datetime(2020, 1, 15, 8, 0),
             'stop': datetime(2020, 1, 15, 18, 0),
         }
-        for create_user, organizer, expect_mail in [
-            (user_root, self.users[0], True), (user_root, None, True),
-                (self.users[0], None, False), (self.users[0], self.users[0], False), (self.users[0], self.users[1], False)]:
-            with self.subTest(create_uid=create_user.name if create_user else None, user_id=organizer.name if organizer else None):
+        
+        paused_sync_user = self.users[2]
+        paused_sync_user.write({
+            'email': 'ms.sync.paused@test.lan',
+            'microsoft_synchronization_stopped': True,
+            'name': 'Paused Microsoft Sync User',
+            'login': 'ms_sync_paused_user',
+        })
+        self.assertTrue(paused_sync_user.microsoft_synchronization_stopped)
+
+        for create_user, organizer, expect_mail, attendee in [
+            (user_root, self.users[0], True, partner), # emulates online appointment with user 0
+            (user_root, None, True, partner), # emulates online resource appointment
+            (self.users[0], None, False, partner),
+            (self.users[0], self.users[0], False, partner),
+            (self.users[0], self.users[1], False, partner),
+            # create user has paused sync and organizer can sync -> will not sync because of bug
+            (paused_sync_user, self.users[0], True, paused_sync_user.partner_id),
+        ]:
+            with self.subTest(create_uid=create_user.name if create_user else None, user_id=organizer.name if organizer else None, attendee=attendee.name):
                 with self.mock_mail_gateway(), patch.object(MicrosoftCalendarService, 'insert') as mock_insert:
                     mock_insert.return_value = ('1', '1')
-                    self.env['calendar.event'].with_user(create_user).create({
+                    self.env['calendar.event'].with_user(create_user).with_context(mail_notify_author=True).create({
                         **event_values,
-                        'partner_ids': [(4, organizer.partner_id.id), (4, partner.id)] if organizer else [(4, partner.id)],
+                        'partner_ids': [(4, organizer.partner_id.id), (4, attendee.id)] if organizer else [(4, attendee.id)],
                         'user_id': organizer.id if organizer else False,
                     })
                     self.env.cr.postcommit.run()
@@ -605,6 +621,6 @@ class TestSyncOdoo2MicrosoftMail(TestCommon, MailCommon):
                     self.assert_dict_equal(mock_insert.call_args[0][0]['organizer'], {
                         'emailAddress': {'address': organizer.email if organizer else '', 'name': organizer.name if organizer else ''}
                     })
-                else:
+                elif expect_mail:
                     mock_insert.assert_not_called()
-                    self.assertMailMail(partner, 'sent', author=(organizer or create_user).partner_id)
+                    self.assertMailMail(attendee, 'sent', author=(organizer or create_user).partner_id)


### PR DESCRIPTION
Added condition on check that ensured the organizer was an attendee on the event on create. This was added in a change that allowed the organizer to be changed on the Odoo side. However, this caused issues with the appointments app when creating an appointment that only used resources. The "organizer" who in this case is the creator of the appointment type would not be an attendee and therefore would cause an error and make the appointment type unbookable.

Adding this condition allows the appointment to bypass the check if the appointment type uses resources instead of users.

opw-3841495
