### PR TITLE
[IMP] loyalty,_*: domain in cheapest reward

### DIFF
--- a/addons/loyalty/views/loyalty_reward_views.xml
+++ b/addons/loyalty/views/loyalty_reward_views.xml
@@ -45,10 +45,10 @@
                                 invisible="discount_applicability != 'order' or
                                     discount_mode not in ('per_order','per_point')"
                             />
-                            <field name="discount_product_domain" groups="base.group_no_one" widget="domain" options="{'model': 'product.product', 'in_dialog': true}" invisible="discount_applicability != 'specific'"/>
-                            <field name="discount_product_ids" widget="many2many_tags" invisible="discount_applicability != 'specific'"/>
-                            <field name="discount_product_category_id" invisible="discount_applicability != 'specific'"/>
-                            <field name="discount_product_tag_id" invisible="discount_applicability != 'specific'"/>
+                            <field name="discount_product_domain" groups="base.group_no_one" widget="domain" options="{'model': 'product.product', 'in_dialog': true}" invisible="discount_applicability == 'order'"/>
+                            <field name="discount_product_ids" widget="many2many_tags" invisible="discount_applicability == 'order'"/>
+                            <field name="discount_product_category_id" invisible="discount_applicability == 'order'"/>
+                            <field name="discount_product_tag_id" invisible="discount_applicability == 'order'"/>
                         </group>
                     </group>
                     <group string="Points" invisible="not user_has_debug and program_type not in ('loyalty', 'buy_x_get_y')">

--- a/addons/pos_loyalty/static/src/app/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/app/models/pos_order.js
@@ -908,11 +908,17 @@ patch(PosOrder.prototype, {
         return { discountable, discountablePerTax };
     },
     /**
-     * @returns the order's cheapest line
+     * @param {loyalty.reward} reward
+     * @returns the cheapest line from all the lines where the program is applicable
      */
-    _getCheapestLine() {
+    _getCheapestLine(reward) {
+        const applicableProductIds = new Set(reward.all_discount_product_ids.map((p) => p.id));
         const filtered_lines = this.getOrderlines().filter(
-            (line) => !line.comboParent && !line.reward_id && line.getQuantity
+            (line) =>
+                !line.combo_parent_id &&
+                !line.reward_id &&
+                line.getQuantity() &&
+                applicableProductIds.has(line.getProduct().id)
         );
         return filtered_lines.toSorted(
             (lineA, lineB) => lineA.getComboTotalPrice() - lineB.getComboTotalPrice()
@@ -922,7 +928,7 @@ patch(PosOrder.prototype, {
      * @returns the discountable and discountable per tax for this discount on cheapest reward.
      */
     _getDiscountableOnCheapest(reward) {
-        const cheapestLine = this._getCheapestLine();
+        const cheapestLine = this._getCheapestLine(reward);
         if (!cheapestLine) {
             return { discountable: 0, discountablePerTax: {} };
         }
@@ -1010,7 +1016,7 @@ patch(PosOrder.prototype, {
             }
             let discountedLines = orderLines;
             if (lineReward.discount_applicability === "cheapest") {
-                cheapestLine = cheapestLine || this._getCheapestLine();
+                cheapestLine = cheapestLine || this._getCheapestLine(lineReward);
                 discountedLines = [cheapestLine];
             } else if (lineReward.discount_applicability === "specific") {
                 discountedLines = this._getSpecificDiscountableLines(lineReward);


### PR DESCRIPTION
_* = sale_loyalty, pos_loyalty
Prior to this commit:
- No way to set domain for products in loyalty reward for reward type discount 
and discount_applicability cheapest product

Post this commit:
- Updated discount_product_ids, discount_product_category_id, 
discount_product_tag_id to be available on discount_applicability cheapest  in 
loyalty reward form.

Task-3976068

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
