### PR TITLE
[FIX] account: empty screen image

### DIFF
--- a/addons/account/static/src/img/multi_ledger.svg
+++ b/addons/account/static/src/img/multi_ledger.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="120" height="140" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="140" viewBox="0 0 120 140" fill="none">
   <g clip-path="url(#a)">
     <g filter="url(#b)">
       <path fill="#000" d="M60 134.614c30.928 0 56-25.072 56-56s-25.072-56-56-56-56 25.072-56 56 25.072 56 56 56Z"/>


### PR DESCRIPTION
In this commit: https://github.com/odoo/odoo/pull/174988/commits/24c4a170d4e9ff46982f744de83b9d248115b867

We added an empty screen image but the viewbox was missing from the svg.

no task-id




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
