### PR TITLE
[FIX] web_editor: hide replace block button for structure solo

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -283,7 +283,8 @@ var SnippetEditor = Widget.extend({
         // Snippets are replaceable only if they are not within another snippet.
         // (e.g., a "s_countdown" is not replaceable when it is dropped as inner
         // content)
-        if (this.$target[0].matches("[data-snippet]:not([data-snippet] *), .oe_structure > *")) {
+        if (this.$target[0].matches("[data-snippet]:not([data-snippet] *), .oe_structure > *")
+                && !this.$target[0].matches(".oe_structure_solo *")) {
             this.trigger_up('find_snippet_template', {
                 snippet: this.$target[0],
                 callback: (snippet) => {


### PR DESCRIPTION
Steps to reproduce the bug:

- Enter edit mode.
- Click on the footer.
- Click on the orange "replace" button that appears above the footer.
- Bug: nothing happens, the snippets modal doesn't open.

Instead of making it work, this commit hides the button in this specific case. The footer is an "oe_structure_solo" element, meaning only one block can be dropped inside. We don’t want users to replace this block with just any other. It’s better for them to choose a different footer template. If the user really wants to replace this block, they can still delete it and drop another one in its place.

The same issue existed with the "Contact Us" button in the header. We also don't want to encourage users to replace it.

task-4072655