### PR TITLE
[FIX] web: deepMerge function type support backport

### DIFF
--- a/addons/web/static/src/core/utils/objects.js
+++ b/addons/web/static/src/core/utils/objects.js
@@ -104,7 +104,12 @@ export function deepMerge(target, extension) {
     const output = Object.assign({}, target);
     if (isObject(extension)) {
         for (const key of Reflect.ownKeys(extension)) {
-            if (key in target && isObject(extension[key]) && !Array.isArray(extension[key])) {
+            if (
+                key in target &&
+                isObject(extension[key]) &&
+                !Array.isArray(extension[key]) &&
+                typeof extension[key] !== "function"
+            ) {
                 output[key] = deepMerge(target[key], extension[key]);
             } else {
                 Object.assign(output, { [key]: extension[key] });

--- a/addons/web/static/tests/core/utils/objects.test.js
+++ b/addons/web/static/tests/core/utils/objects.test.js
@@ -182,6 +182,9 @@ test("deepMerge", () => {
     expect(deepMerge("foo", 1)).toBe(undefined);
     expect(deepMerge(null, null)).toBe(undefined);
 
+    const f = () => {};
+    expect(deepMerge({ a: undefined }, { a: f })).toEqual({ a: f });
+
     // There's no current use for arrays, support can be added if needed
     expect(deepMerge({ a: [1, 2, 3] }, { a: [4] })).toEqual({ a: [4] });
 


### PR DESCRIPTION
Before this commit:
Functions where treated as object by the deepMerge utils, causing it to merge function properties.

After this commit:
Functions are now treated as values

(This commit is a backport of [03f7b5f](https://github.com/odoo/odoo/commit/03f7b5f4f79b31c373b0f5a57a7bcced1e5a26b0) from 17.4 to 17.2)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
