### PR TITLE
[FIX] point_of_sale: traceback on validating order during refund

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1106,7 +1106,7 @@ export class PosStore extends Reactive {
 
                 if (refundedOrderLine) {
                     const order = refundedOrderLine.order_id;
-                    delete order.uiState.lineToRefund[refundedOrderLine.uuid];
+                    delete order?.uiState.lineToRefund[refundedOrderLine.uuid];
                     refundedOrderLine.refunded_qty += Math.abs(line.qty);
                 }
             }


### PR DESCRIPTION
Steps:
- open POS and navigate to Orders > Paid Orders.
- select an order and initiate a refund.
- click the refund button and reload the page.
- validate the order.

Issue:
- A traceback error occurs when validating the order.

Fix:
- Added validation while deleting an order to prevent the error.

Task-4077214