### PR TITLE
[FIX] mail: more visible message bubble in inbox dark theme

### DIFF
--- a/addons/mail/static/src/core/common/message.dark.scss
+++ b/addons/mail/static/src/core/common/message.dark.scss
@@ -1,3 +1,7 @@
+.o-mail-Message.o-card {
+    background-color: mix($gray-100, $gray-200);
+}
+
 .o-mail-Message-author {
     opacity: 75%;
 }
@@ -7,7 +11,9 @@
 }
 
 .o-mail-Message-bubble {
-    --border-opacity: 0;
+    .o-mail-Message:not(.o-card) & {
+        --border-opacity: 0;
+    }
 
     &.o-blue {
         background-color: mix($gray-100, $info, 87.5%) !important;

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -195,7 +195,7 @@ export class Message extends Component {
     get attClass() {
         return {
             [this.props.className]: true,
-            "o-card p-2 mt-2 bg-view": this.props.asCard,
+            "o-card p-2 mt-2": this.props.asCard,
             "pt-1": !this.props.asCard,
             "o-selfAuthored": this.message.isSelfAuthored && !this.env.messageCard,
             "o-selected": this.props.messageToReplyTo?.isSelected(

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -4,6 +4,7 @@
     &.o-card {
         outline: $border-width solid $border-color;
         outline-offset: -$border-width;
+        background-color: $o-view-background-color;
     }
 
     &.o-highlighted {


### PR DESCRIPTION
In inbox, messages are displayed in a card layout, with each item having bg-view background.

This is white in white theme so constrast stay good in white theme. In dark theme however, this is gray and blue bubble is also close to grey, thus resulting to bubble being barely visible.

This commit fixes the issue by slightly darkening the background of cards in dark theme, and also removing the border around messages in dark theme only outside of cards.

Before:
<img width="1219" alt="Screenshot 2024-08-28 at 11 40 05" src="https://github.com/user-attachments/assets/72267b68-5534-4e7b-acaa-0b13d20596fd">
After:
<img width="1223" alt="Screenshot 2024-08-28 at 11 39 45" src="https://github.com/user-attachments/assets/afe4131b-f5f3-406b-ad86-ef9a98e53d1f">
