### PR TITLE
[FIX] project: restrict access to project in email sent

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -738,6 +738,19 @@ class Project(models.Model):
                 res -= dependency_subtype
         return res
 
+    def _notify_get_recipients_groups(self, msg_vals=None):
+        """ Give access to the portal user/customer if the project visibility is portal. """
+        groups = super()._notify_get_recipients_groups(msg_vals=msg_vals)
+        if not self:
+            return groups
+
+        self.ensure_one()
+        portal_privacy = self.privacy_visibility == 'portal'
+        for group_name, _group_method, group_data in groups:
+            if group_name in ('customer', 'user') or group_name == 'portal_customer' and not portal_privacy:
+                group_data['has_button_access'] = False
+        return groups
+
     # ---------------------------------------------------
     #  Actions
     # ---------------------------------------------------


### PR DESCRIPTION
[FIX] project: restrict access to project in email sent

Before this commit, when the `Project Stages` feature is enabled and the
user set an email template on a project stage, if the user moves a
project to that stage with the email template, an email is sent to the
customer (if set on the project) and the customer can click on the project name
to see all tasks inside that project even if the project is private.

This commit makes sure the project name displayed in the template is
only clickable is the project visibility is 'portal'
(`Invited portal users and all internal users`).

Steps to reproduce:
------------------
1. Install project
2. Go to Project > Configuration > Settings
3. Enable Project Stages feature
4. Set email template to project stage
5. Create a project with a customer set and project visibility is not
   set to "Invited portal users and all internal users".
6. Move the project to the project stage with the email template set.

Current behavior:
----------------
An email is sent based on the email template set but the project name is
clickable to allow the customer to see the tasks of the project in the
portal even if the project is not public.

Expected behavior:
-----------------
The project name should not be clickable inside the email sent when the
project visibility is not "Invited portal users and all internal users".

Close #175396

