### PR TITLE
[PERF] bus: do not use registry to dispatch notifications

### DIFF
--- a/addons/bus/controllers/websocket.py
+++ b/addons/bus/controllers/websocket.py
@@ -3,7 +3,7 @@
 import json
 
 from odoo.http import Controller, request, route, SessionExpiredException
-from ..models.bus import channel_with_db
+from ..models.bus import channel_with_db, fetch_notifications
 from ..websocket import WebsocketConnectionHandler
 
 
@@ -39,7 +39,7 @@ class WebsocketController(Controller):
         if bus_target := request.env["ir.websocket"]._get_missed_presences_bus_target():
             subscribe_data["missed_presences"]._send_presence(bus_target=bus_target)
         channels_with_db = [channel_with_db(request.db, c) for c in subscribe_data["channels"]]
-        notifications = request.env["bus.bus"]._poll(channels_with_db, subscribe_data["last"])
+        notifications = fetch_notifications(request.env.cr, channels_with_db, subscribe_data["last"])
         return {"channels": channels_with_db, "notifications": notifications}
 
     @route('/websocket/update_bus_presence', type='json', auth='public', cors='*')

--- a/addons/bus/models/bus.py
+++ b/addons/bus/models/bus.py
@@ -15,7 +15,7 @@ import odoo
 from odoo import api, fields, models
 from odoo.service.server import CommonServer
 from odoo.tools.misc import DEFAULT_SERVER_DATETIME_FORMAT
-from odoo.tools import date_utils
+from odoo.tools import date_utils, SQL
 
 _logger = logging.getLogger(__name__)
 
@@ -82,6 +82,26 @@ def get_notify_payloads(channels):
                 get_notify_payloads(channels[pivot:]))
 
 
+def fetch_notifications(cr, channels, last=0):
+    """
+    Fetch bus notifications from the database for the specified channels.
+
+    :param cr: Database cursor.
+    :param channels: List of channels for which notifications should be
+        fetched.
+    :param last: The ID of the last fetched notification.
+    :return List[Dict[str, Any]]: List of notifications.
+    """
+    where = SQL("channel IN %s", tuple(json_dump(channel_with_db(cr.dbname, c)) for c in channels))
+    if last == 0:
+        timeout_ago = datetime.datetime.utcnow() - datetime.timedelta(seconds=TIMEOUT)
+        where = SQL("%s AND create_date > %s", where, timeout_ago)
+    else:
+        where = SQL("%s AND id > %s", where, last)
+    query = SQL("SELECT id, message FROM bus_bus WHERE %s ORDER BY id", where)
+    cr.execute(query)
+    return [{"id": r[0], "message": json.loads(r[1])} for r in cr.fetchall()]
+
 class ImBus(models.Model):
 
     _name = 'bus.bus'
@@ -133,23 +153,7 @@ class ImBus(models.Model):
 
     @api.model
     def _poll(self, channels, last=0):
-        # first poll return the notification in the 'buffer'
-        if last == 0:
-            timeout_ago = datetime.datetime.utcnow()-datetime.timedelta(seconds=TIMEOUT)
-            domain = [('create_date', '>', timeout_ago.strftime(DEFAULT_SERVER_DATETIME_FORMAT))]
-        else:  # else returns the unread notifications
-            domain = [('id', '>', last)]
-        channels = [json_dump(channel_with_db(self.env.cr.dbname, c)) for c in channels]
-        domain.append(('channel', 'in', channels))
-        notifications = self.sudo().search_read(domain, ["message"])
-        # list of notification to return
-        result = []
-        for notif in notifications:
-            result.append({
-                'id': notif['id'],
-                'message': json.loads(notif['message']),
-            })
-        return result
+        return fetch_notifications(self.env.cr, channels, last)
 
     def _bus_last_id(self):
         last = self.env['bus.bus'].search([], order='id desc', limit=1)

--- a/addons/bus/static/src/workers/websocket_worker.js
+++ b/addons/bus/static/src/workers/websocket_worker.js
@@ -33,7 +33,7 @@ export const WEBSOCKET_CLOSE_CODES = Object.freeze({
     RECONNECTING: 4003,
 });
 /** @deprecated worker version is now retrieved from `session.websocket_worker_bundle` */
-export const WORKER_VERSION = "17.0-1";
+export const WORKER_VERSION = "17.0-2";
 const MAXIMUM_RECONNECT_DELAY = 60000;
 
 /**

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -79,6 +79,7 @@ class configmanager(object):
             'reportgz': False,
             'root_path': None,
             'websocket_keep_alive_timeout': 3600,
+            'websocket_session_check_interval': 1800,  # 30 minutes
             'websocket_rate_limit_burst': 10,
             'websocket_rate_limit_delay': 0.2,
         }


### PR DESCRIPTION
This PR aims to make the bus faster and more efficient. When there
are more databases than what the LRU cache can hold, the gevent
worker struggles to keep notifications flowing. Each incoming or
outgoing message requires a registry, which is highly inefficient.
Many notifications need to build the registry from scratch (since they
don't fit in the cache), blocking a cursor for a long time and
preventing other greenlets from waking up.

This PR removes the need to build an environment for outgoing
messages:
- Notifications are fetched with a raw cursor.
- Session validation isn't performed for every message, as it's
unnecessary and slows down the entire process.

Instead, sessions are validated for each incoming message, which is
far less frequent. If no message is received within
`websocket_session_check_delay` (set to 30 minutes by default), the
session will be checked even for outgoing messages.