### PR TITLE
[FIX] base: translation export model_name cannot be specified

### DIFF
--- a/odoo/addons/base/wizard/base_export_language_views.xml
+++ b/odoo/addons/base/wizard/base_export_language_views.xml
@@ -13,6 +13,7 @@
                         <field name="export_type"/>
                         <field name="modules" widget="many2many_tags" options="{'no_create': True}" invisible="export_type == 'model'"/>
                         <field name="model_id" options="{'no_create': True}" invisible="export_type == 'module'"/>
+                        <field name="model_name" invisible="1"/> <!-- The model_name is needed for the option of the domain -->
                         <field name="domain" widget="domain" options="{'model': 'model_name'}" invisible="export_type == 'module'"/>
                     </group>
                     <div invisible="state != 'get'">


### PR DESCRIPTION
This recent [commit] removed all uncommented invisible fields from views. This lead to the Translation Export Wizard having the exported model_name missing when the export_type is Model

This commit fixes that by re-adding the invisible `model_name` field to the view of the Translation Export Wizard.

[commit]: https://github.com/odoo/odoo/commit/5639ed865c5a3b82bab25b0ecac28c68c02e9306

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
