### PR TITLE
[FIX] account: prevent traceback when adding barcode for product

### DIFF
--- a/addons/account/models/product.py
+++ b/addons/account/models/product.py
@@ -143,7 +143,7 @@ class ProductTemplate(models.Model):
         """ Get the product sales price from a public price based on taxes defined on the product """
         self.ensure_one()
         if not self.taxes_id:
-            return self.super._get_list_price(price)
+            return super()._get_list_price(price)
         computed_price = self.taxes_id.compute_all(price, self.currency_id)
         total_included = computed_price["total_included"]
 


### PR DESCRIPTION
When the user tries to add a barcode without Customer Taxes,
a traceback will appear.

Traceback:
```
AttributeError: 'product.template' object has no attribute 'super'
  File "odoo/http.py", line 2374, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1904, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1967, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1934, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2178, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 223, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 755, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 35, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 459, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/web/models/models.py", line 1008, in onchange
    record._apply_onchange_methods(field_name, result)
  File "odoo/models.py", line 7042, in _apply_onchange_methods
    res = method(self)
  File "home/odoo/src/enterprise/saas-17.4/product_barcodelookup/models/product_template.py", line 20, in _onchange_barcode
    product._update_product_by_barcodelookup(product, barcode_lookup_data)
  File "home/odoo/src/enterprise/saas-17.4/product_barcodelookup/models/product_template.py", line 77, in _update_product_by_barcodelookup
    product.list_price = self._get_list_price(price)
  File "addons/account/models/product.py", line 154, in _get_list_price
    return self.super._get_list_price(price)
```

https://github.com/odoo/odoo/blob/42fa237296f9b1fa556ae310b3273f863420e659/addons/account/models/product.py#L146 Here, self.super is used instead of super() .
so, it will lead to the above traceback.

sentry-5766033395

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
