### PR TITLE
[IMP] pos_restaurant: remove black badge on the table

### DIFF
--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
@@ -100,7 +100,7 @@
                         </div>
                         <div t-else="" t-ref="map" t-att-class="{'floor-kanban d-grid gap-3 p-3': pos.floorPlanStyle == 'kanban'}">
                            <t t-foreach="activeTables.sort((a,b)=>a.id-b.id)" t-as="table" t-key="table.id" >
-                                <t t-set="isOccupied" t-value="table.hasOrder"/>
+                                <t t-set="isOccupied" t-value="pos.tableHasOrders(table)"/>
                                 <t t-set="isIntersecting" t-value="state.potentialLink?.child?.id === table.id"/>
                                 <t t-set="isIntersected" t-value="state.potentialLink?.parent?.id === table.id"/>
                                 <div
@@ -143,12 +143,11 @@
                                     </div>
                                     <t t-set="data" t-value="getChangeCount(table)"/>
                                     <div
-                                        t-if="data.changes > 0 || data.skip > 0 || table.hasOrder"
-                                        t-esc="data.changes > 0 ? data.changes : table.hasOrder ? 1 : data.skip"
+                                        t-if="data.changes > 0 || data.skip > 0"
+                                        t-esc="data.changes > 0 ? data.changes : data.skip"
                                         t-att-class="{
                                             'text-bg-danger': data.changes,
                                             'text-bg-info'  : !data.changes and data.skip,
-                                            'text-bg-dark'  : !data.changes and !data.skip
                                         }"
                                         class="order-count d-flex align-items-center justify-content-center position-absolute top-0 start-100 translate-middle rounded-circle smaller fw-bolder z-2"
                                         t-attf-style="width: 2rem; height: 2rem;"

--- a/addons/pos_restaurant/static/src/app/models/restaurant_table.js
+++ b/addons/pos_restaurant/static/src/app/models/restaurant_table.js
@@ -73,10 +73,6 @@ export class RestaurantTable extends Base {
     getOrder() {
         return this.parent_id?.getOrder?.() || this["<-pos.order.table_id"][0];
     }
-    get hasOrder() {
-        const order = this.getOrder();
-        return order && !order.finalized;
-    }
     setPositionAsIfLinked(parent, side) {
         // console.log("132")
         this.parent_id = parent;


### PR DESCRIPTION
Before this commit:
===================
Initially, If I place the order from the frontend then it will show the black badge on the floor plan for the specific table, similarly, if I place another order  for the same table from the ticket screen then it will increment the current black badge count on the floor plan

After this commit:
====================
As of now, If we do the order from the frontend and also do the order from the ticket screen, it will create multiple orders and increment the black badge that we don't want. To prevent this behavior we are removing the black badge

task - 4138483
