### PR TITLE
[FIX] web_editor:  fix signature command

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -2445,9 +2445,10 @@ export class Wysiwyg extends Component {
                 fontawesome: 'fa-pencil-square-o',
                 isDisabled: () => !this.odooEditor.isSelectionInBlockRoot(),
                 callback: async () => {
+                    const uid = Array.isArray(session.user_id) ? session.user_id[0] : session.user_id;
                     const [user] = await this.orm.read(
                         'res.users',
-                        [session.user_id],
+                        [uid],
                         ['signature'],
                     );
                     if (user && user.signature) {


### PR DESCRIPTION
Commit that introduced the issue: https://github.com/odoo/odoo/commit/1ffcea337ba463c383483ca53ff57aa6b725b5a2

Issue:
======
Traceback after signature command

Steps to reproduce the issue:
=============================
- Go to chatter
- Open mail composer
- type /signature + enter
- traceback

Origin of the issue:
====================
The change in the mentioned commit added an issue , becuase `user_id` isn't always a number sometimes it's an array.

Solution:
=========
We copy the same logic done here https://github.com/odoo/odoo/blob/fd830fd9171e52d379f82b4adee221a6cf83d8eb/addons/bus/static/src/services/bus_service.js#L125

task-4143860