### PR TITLE
[FIX] html_editor: patch caretPositionFromPoint in tests

### DIFF
--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -3117,12 +3117,7 @@ describe("onDrop", () => {
         const textNode = pElement.firstChild;
 
         patchWithCleanup(document, {
-            caretRangeFromPoint: () => {
-                const range = document.createRange();
-                range.setStart(textNode, 3);
-                range.setEnd(textNode, 3);
-                return range;
-            },
+            caretPositionFromPoint: () => ({ offsetNode: textNode, offset: 3 }),
         });
 
         const dropData = new DataTransfer();
@@ -3138,12 +3133,7 @@ describe("onDrop", () => {
         const textNode = pElement.firstChild;
 
         patchWithCleanup(document, {
-            caretRangeFromPoint: () => {
-                const range = document.createRange();
-                range.setStart(textNode, 3);
-                range.setEnd(textNode, 3);
-                return range;
-            },
+            caretPositionFromPoint: () => ({ offsetNode: textNode, offset: 3 }),
         });
 
         const dropData = new DataTransfer();
@@ -3160,12 +3150,7 @@ describe("onDrop", () => {
         const textNode = pElement.firstChild;
 
         patchWithCleanup(document, {
-            caretRangeFromPoint: () => {
-                const range = document.createRange();
-                range.setStart(textNode, 3);
-                range.setEnd(textNode, 3);
-                return range;
-            },
+            caretPositionFromPoint: () => ({ offsetNode: textNode, offset: 3 }),
         });
 
         const base64Image =
@@ -3192,12 +3177,7 @@ describe("onDrop", () => {
         const bcTextNode = pElement.childNodes[2];
 
         patchWithCleanup(document, {
-            caretRangeFromPoint: () => {
-                const range = document.createRange();
-                range.setStart(bcTextNode, 1);
-                range.setEnd(bcTextNode, 1);
-                return range;
-            },
+            caretPositionFromPoint: () => ({ offsetNode: bcTextNode, offset: 1 }),
         });
 
         const dragdata = new DataTransfer();


### PR DESCRIPTION
Since Chrome 128 the `caretPositionFromPoint` method is available on the document object. This method is called by ClipboardPlugin.onDrop if available, otherwise it falls back to `caretRangeFromPoint`.

Before this commit, the tests for (drag and) drop assumed that the `caretPositionFromPoint` method was not available and patched only the `caretRangeFromPoint` method. As this no longer holds true since Chrome 128, this commit patches the `caretPositionFromPoint` method in the tests as well.

As a bonus, the affected tests now pass on Firefox as well.
