### PR TITLE
[REF] pos_restaurant: remove derived state

### DIFF
--- a/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.js
+++ b/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.js
@@ -21,7 +21,6 @@ export class OrderTabs extends Component {
         this.dialog = useService("dialog");
     }
     async newFloatingOrder() {
-        this.pos.selectedTable = null;
         const order = await this.pos.add_new_order();
         this.pos.showScreen("ProductScreen");
         this.dialog.closeAll();
@@ -29,7 +28,6 @@ export class OrderTabs extends Component {
     }
     selectFloatingOrder(order) {
         this.pos.set_order(order);
-        this.pos.selectedTable = null;
         const previousOrderScreen = order.get_screen_data();
 
         const props = {};

--- a/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
+++ b/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
@@ -83,7 +83,6 @@ export class SplitBillScreen extends Component {
     async createSplittedOrder() {
         const curOrderUuid = this.currentOrder.uuid;
         const originalOrder = this.pos.models["pos.order"].find((o) => o.uuid === curOrderUuid);
-        this.pos.selectedTable = null;
         const originalOrderName = this._getOrderName(originalOrder);
         const newOrderName = this._getSplitOrderName(originalOrderName);
 

--- a/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
@@ -38,7 +38,6 @@ patch(Navbar.prototype, {
         return true;
     },
     setFloatingOrder(floatingOrder) {
-        this.pos.selectedTable = null;
         this.pos.set_order(floatingOrder);
 
         const props = {};

--- a/addons/pos_restaurant/static/src/overrides/components/ticket_screen/ticket_screen.js
+++ b/addons/pos_restaurant/static/src/overrides/components/ticket_screen/ticket_screen.js
@@ -105,15 +105,6 @@ patch(TicketScreen.prototype, {
         }
         return result;
     },
-    async onDoRefund() {
-        const order = this.getSelectedOrder();
-        if (this.pos.config.module_pos_restaurant && order && !this.pos.selectedTable) {
-            await this.pos.setTable(
-                order.table ? order.table : this.pos.models["restaurant.table"].getAll()[0]
-            );
-        }
-        await super.onDoRefund(...arguments);
-    },
     isDefaultOrderEmpty(order) {
         if (this.pos.config.module_pos_restaurant) {
             return false;


### PR DESCRIPTION
In `pos_restaurant` we independently keep track of the current order and the current table, but at any given point, the current table is the table of the current order, so there is no need to keep track of the current table.

In this commit we replace the `selectedTable` property of `pos` with a getter that returns the table of the current order.

Task: 4143958






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
