### PR TITLE
[IMP] ir_module: Adding the cloc_exlude

### DIFF
--- a/odoo/addons/base/tests/test_module.py
+++ b/odoo/addons/base/tests/test_module.py
@@ -42,6 +42,7 @@ class TestModuleManifest(BaseCase):
             'auto_install': False,
             'bootstrap': False,
             'category': 'Uncategorized',
+            'cloc_exclude': [],
             'configurator_snippets': {},
             'countries': [],
             'data': [],

--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -32,6 +32,7 @@ _DEFAULT_MANIFEST = {
     'author': 'Odoo S.A.',
     'auto_install': False,
     'category': 'Uncategorized',
+    'cloc_exclude': [],
     'configurator_snippets': {},  # website themes
     'countries': [],
     'data': [],


### PR DESCRIPTION
In the context of the industries we want to create custome js tours. The role of these tours is to explain some flows to the user in a more intuitive version than text. Currently those tours are counted in the mainenance line of code. This comportment is not intended.

After this commit, we will look at the cloc_excluded argument in the manifest and exclude those from the maintenance line of code.

task-4056239

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
