### PR TITLE
[IMP] calendar: use ACL instead of user_can_edit field for readonly

### DIFF
--- a/addons/calendar/security/calendar_security.xml
+++ b/addons/calendar/security/calendar_security.xml
@@ -9,13 +9,6 @@
             <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
         </record>
 
-        <record id="calendar_event_rule_employee" model="ir.rule">
-            <field ref="model_calendar_event" name="model_id"/>
-            <field name="name">All Calendar Event for employees</field>
-            <field name="domain_force">[(1, '=', 1)]</field>
-            <field eval="[(4,ref('base.group_user'))]" name="groups"/>
-        </record>
-
         <record id="calendar_attendee_rule_my" model="ir.rule">
             <field name="name">Own attendees</field>
             <field ref="model_calendar_attendee" name="model_id"/>
@@ -23,14 +16,48 @@
             <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
         </record>
 
+        <record id="calendar_event_admin_write" model="ir.rule">
+            <field name="name">Calendar Event: Admin can write all events</field>
+            <field ref="model_calendar_event" name="model_id"/>
+            <field name="domain_force">[('privacy', '!=', 'private')]</field>
+            <field name="perm_unlink" eval="1"/>
+            <field name="perm_write" eval="1"/>
+            <field name="perm_read" eval="1"/>
+            <field name="perm_create" eval="1"/>
+            <field name="groups" eval="[(4, ref('base.group_partner_manager'))]"/>
+        </record>
+
+        <record id="calendar_event_own_event_write" model="ir.rule">
+            <field name="name">Calendar Event: write own events</field>
+            <field ref="model_calendar_event" name="model_id"/>
+            <field name="domain_force">['|', '|', ('partner_ids.user_ids', 'in', user.id), ('user_id.id', '=', user.id),  ('create_uid', '=', user.id)]</field>
+            <field name="perm_unlink" eval="1"/>
+            <field name="perm_write" eval="1"/>
+            <field name="perm_read" eval="1"/>
+            <field name="perm_create" eval="1"/>
+            <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+        </record>
+
+        <record id="calendar_event_rule_employee" model="ir.rule">
+            <field ref="model_calendar_event" name="model_id"/>
+            <field name="name">Calendar Event: Internal user can read all events</field>
+            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="perm_unlink" eval="0"/>
+            <field name="perm_write" eval="0"/>
+            <field name="perm_read" eval="1"/>
+            <field name="perm_create" eval="1"/>
+            <field name="groups" eval="[(4,ref('base.group_user'))]"/>
+        </record>
+
         <record id="calendar_event_rule_private" model="ir.rule">
             <field ref="model_calendar_event" name="model_id"/>
             <field name="name">Private events</field>
-            <field name="domain_force">['|', ('privacy', '!=', 'private'), '&amp;', ('privacy', '=', 'private'), '|', ('user_id', '=', user.id), ('partner_ids', 'in', user.partner_id.id)]</field>
+            <field name="domain_force">[('privacy', '=', 'private'), '|', ('user_id', '=', user.id), ('partner_ids', 'in', user.partner_id.id)]</field>
             <field name="perm_read" eval="False"/>
             <field name="perm_write" eval="True"/>
             <field name="perm_create" eval="True"/>
             <field name="perm_unlink" eval="True"/>
+            <field name="groups" eval="[(4,ref('base.group_user'))]"/>
         </record>
 
     </data>

--- a/addons/calendar/tests/test_attendees.py
+++ b/addons/calendar/tests/test_attendees.py
@@ -66,9 +66,9 @@ class TestEventNotifications(TransactionCase):
             'name': "Doom's day",
             'start': datetime(2019, 10, 25, 8, 0),
             'stop': datetime(2019, 10, 27, 18, 0),
+            'partner_ids': [Command.set(self.partner.ids)],
         })
         events = self.event | event
-        events.partner_ids = self.partner
         self.assertEqual(len(events.attendee_ids), 2, "It should have created one attendee per event")
 
     def test_attendee_added_write(self):

--- a/addons/calendar/tests/test_calendar.py
+++ b/addons/calendar/tests/test_calendar.py
@@ -147,6 +147,7 @@ class TestCalendar(SavepointCaseWithUserDemo):
             'start': now + timedelta(days=-1),
             'stop': now + timedelta(hours=2),
             'user_id': self.env.user.id,
+            'partner_ids': [Command.link(self.user_demo.partner_id.id)]
         })
         self.assertEqual(test_event.res_model, test_record._name)
         self.assertEqual(test_event.res_id, test_record.id)

--- a/addons/calendar/tests/test_event_notifications.py
+++ b/addons/calendar/tests/test_event_notifications.py
@@ -118,6 +118,7 @@ class TestCalendarMail(CalendarMailCommon):
         ], 'Correctly filters out robodoo and aliases')
 
     def test_event_template(self):
+        self.event.partner_ids = [fields.Command.link(self.user_employee.partner_id.id)]
         event, template = self.event.with_user(self.user_employee), self.test_template_event.with_user(self.user_employee)
         message = event.message_post_with_source(
             template,
@@ -187,6 +188,7 @@ class TestEventNotifications(CalendarMailCommon):
         )
 
     def test_message_invite_self(self):
+        self.event.user_id = self.user
         with self.assertNoNotifications():
             self.event.with_user(self.user).partner_ids = self.partner
 
@@ -308,11 +310,11 @@ class TestEventNotifications(CalendarMailCommon):
                 'interval': 'minutes',
                 'duration': 20,
             })
+            self.event.partner_ids = [fields.Command.link(self.partner.id)]  # Add the partner to the attendees list in order to grant edit permissions for the event
             self.event.with_user(self.user).write({
                 'name': 'test event',
                 'start': now + relativedelta(minutes=15),
                 'stop': now + relativedelta(minutes=18),
-                'partner_ids': [fields.Command.link(self.partner.id)],
                 'alarm_ids': [fields.Command.link(alarm.id)],
             })
             self.env.flush_all()  # flush is required to make partner_ids be present in the event

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -116,7 +116,6 @@
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                     <field name="res_id" invisible="1" />
                     <field name="active" invisible="1"/>
-                    <field name="user_can_edit" invisible="1"/>
                     <field name="invalid_email_partner_ids" invisible="1"/> <!-- this field will be used in
                         many2many_attendees widget -->
                     <div class="oe_title mb-3">

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -1099,7 +1099,7 @@ class HrLeave(models.Model):
         validated_holidays.write({'state': 'refuse', 'first_approver_id': current_employee.id})
         (self - validated_holidays).write({'state': 'refuse', 'second_approver_id': current_employee.id})
         # Delete the meeting
-        self.mapped('meeting_id').write({'active': False})
+        self.mapped('meeting_id').sudo().write({'active': False})
         # Post a second message, more verbose than the tracking message
         for holiday in self:
             if holiday.employee_id.user_id:

--- a/addons/microsoft_calendar/models/microsoft_sync.py
+++ b/addons/microsoft_calendar/models/microsoft_sync.py
@@ -410,7 +410,9 @@ class MicrosoftCalendarSync(models.AbstractModel):
             if token:
                 self._ensure_attendees_have_email()
                 event_id, uid = microsoft_service.insert(values, token=token, timeout=timeout)
-                self.with_context(dont_notify=True).write({
+                # Attendees can sync calendar of another organizer (user_id). We update the microsoft_id in sudo
+                # to avoid triggering acl in that case
+                self.with_context(dont_notify=True).sudo().write({
                     'microsoft_id': event_id,
                     'ms_universal_event_id': uid,
                     'need_sync_m': False,


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/112964 and task 3185743 only attendee can edit an event.

user_can_edit field is used in the UI to put fields in read only.

Before this commit, this limitation was only cosmetic. It was still possible to use RPC to update the event. This commit relies on standard Odoo ACL to prevent event modification. This prevents write calls update an event when an user is not in the attendees or the organizer.

The rationale behind this change is that Edit action on UI should be aligned with edit rights, hence we should avoid having two ways of computing the "can edit".

taskid: 4137628



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
