### PR TITLE
[IMP] web, *: form: nolabel fields should take all width

### DIFF
--- a/addons/account/views/account_account_views.xml
+++ b/addons/account/views/account_account_views.xml
@@ -73,7 +73,7 @@
                                 </group>
                             </page>
                             <page name="mapping" string="Mapping" groups="base.group_multi_company">
-                                <field name="code_mapping_ids" colspan="2" nolabel="1">
+                                <field name="code_mapping_ids" nolabel="1">
                                     <tree editable="bottom">
                                         <field name="company_id"/>
                                         <field name="code"/>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1213,7 +1213,7 @@
                                 </field>
                                 <group col="12" class="oe_invoice_lines_tab overflow-hidden">
                                     <group colspan="8">
-                                        <field name="narration" placeholder="Terms and Conditions" colspan="2" nolabel="1"/>
+                                        <field name="narration" placeholder="Terms and Conditions" nolabel="1"/>
                                     </group>
                                     <!-- Totals (only invoices / receipts) -->
                                     <group colspan="4">

--- a/addons/account/views/account_payment_term_views.xml
+++ b/addons/account/views/account_payment_term_views.xml
@@ -63,7 +63,7 @@
                         </group>
                         <group>
                             <group string="Due Terms">
-                                <field name="line_ids" widget="payment_term_line_ids" nolabel="1" colspan="2">
+                                <field name="line_ids" widget="payment_term_line_ids" nolabel="1">
                                     <tree string="Payment Terms" editable="bottom" no_open="True">
                                         <field name="value_amount"/>
                                         <field name="value" nolabel="1"/>

--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -154,10 +154,10 @@
                             <div invisible="amount_type == 'group'">
                                 <field name="country_code" invisible="1"/>
                                 <group string="Distribution for Invoices" class="mw-100">
-                                    <field name="invoice_repartition_line_ids" nolabel="1" colspan="2"/>
+                                    <field name="invoice_repartition_line_ids" nolabel="1"/>
                                 </group>
                                 <group string="Distribution for Refunds" class="mw-100">
-                                    <field name="refund_repartition_line_ids" nolabel="1" colspan="2"/>
+                                    <field name="refund_repartition_line_ids" nolabel="1"/>
                                 </group>
                             </div>
                             <field name="children_tax_ids" invisible="amount_type != 'group' or type_tax_use == 'none'" domain="[('type_tax_use','in',('none',type_tax_use)), ('amount_type','!=','group')]">

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -198,7 +198,7 @@
                         <field name="show_credit_limit" invisible="1"/>
                         <group>
                             <group string="Bank Accounts" name="banks" groups="account.group_account_invoice,account.group_account_readonly">
-                                <field name="bank_ids" nolabel="1" colspan="2" context="{'default_partner_id': id}" widget="auto_save_res_partner">
+                                <field name="bank_ids" nolabel="1" context="{'default_partner_id': id}" widget="auto_save_res_partner">
                                     <tree>
                                         <field name="sequence" widget="handle"/>
                                         <field name="acc_number"/>

--- a/addons/account_payment/wizards/payment_link_wizard_views.xml
+++ b/addons/account_payment/wizards/payment_link_wizard_views.xml
@@ -30,7 +30,7 @@
                     invisible="not open_installments"
                     class="mt-n4"
                 >
-                    <field name="open_installments_preview" colspan="2" nolabel="1"/>
+                    <field name="open_installments_preview" nolabel="1"/>
                 </group>
             </group>
         </field>

--- a/addons/crm/wizard/crm_lead_to_opportunity_mass_views.xml
+++ b/addons/crm/wizard/crm_lead_to_opportunity_mass_views.xml
@@ -18,7 +18,7 @@
                 </group>
                 <label for="duplicated_lead_ids" string="Leads with existing duplicates (for information)" help="Leads that you selected that have duplicates. If the list is empty, it means that no duplicates were found" invisible="not deduplicate"/>
                 <group invisible="not deduplicate">
-                    <field name="duplicated_lead_ids" colspan="2" nolabel="1" readonly="1">
+                    <field name="duplicated_lead_ids" nolabel="1" readonly="1">
                         <tree create="false" delete="false">
                             <field name="create_date"/>
                             <field name="name"/>

--- a/addons/crm/wizard/crm_lead_to_opportunity_views.xml
+++ b/addons/crm/wizard/crm_lead_to_opportunity_views.xml
@@ -14,7 +14,7 @@
                 </group>
                 <group string="Opportunities" invisible="name != 'merge'">
                     <field name="lead_id" invisible="1"/>
-                    <field name="duplicated_lead_ids" colspan="2" nolabel="1">
+                    <field name="duplicated_lead_ids" nolabel="1">
                         <tree>
                             <field name="create_date"/>
                             <field name="name"/>

--- a/addons/delivery/views/delivery_carrier_views.xml
+++ b/addons/delivery/views/delivery_carrier_views.xml
@@ -141,7 +141,7 @@
                     <notebook>
                         <page name="pricing" string="Pricing" invisible="delivery_type != 'base_on_rule'">
                             <group name="general">
-                                <field name="price_rule_ids" nolabel="1" colspan="2"/>
+                                <field name="price_rule_ids" nolabel="1"/>
                             </group>
                         </page>
                         <page string="Availability" name="destination">

--- a/addons/event_crm/views/event_lead_rule_views.xml
+++ b/addons/event_crm/views/event_lead_rule_views.xml
@@ -61,7 +61,7 @@
                         </group>
                     </group>
                     <group string="If the Attendees meet these Conditions">
-                        <field name="event_registration_filter" widget="domain" options="{'foldable': True, 'model': 'event.registration'}" nolabel="1" colspan="2"/>
+                        <field name="event_registration_filter" widget="domain" options="{'foldable': True, 'model': 'event.registration'}" nolabel="1"/>
                     </group>
                     <group string="Lead Default Values">
                         <group class="col">

--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -243,7 +243,7 @@
                                 <group name="contract_details" col="2"/>
                                 <group name="contract_details_2"/>
                                 <group name="notes_group" string="Notes">
-                                    <field name="notes" nolabel="1" colspan="2" placeholder="Type in notes about this contract..."/>
+                                    <field name="notes" nolabel="1" placeholder="Type in notes about this contract..."/>
                                 </group>
                             </page>
                         </notebook>

--- a/addons/im_livechat/views/chatbot_script_step_views.xml
+++ b/addons/im_livechat/views/chatbot_script_step_views.xml
@@ -30,7 +30,7 @@
                             </field>
                         </group>
                         <group>
-                            <field name="answer_ids" invisible="step_type != 'question_selection'" nolabel="1" colspan="2">
+                            <field name="answer_ids" invisible="step_type != 'question_selection'" nolabel="1">
                                 <tree editable="bottom">
                                     <field name="sequence" widget="handle"/>
                                     <field name="display_name" column_invisible="True"/>

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -47,7 +47,7 @@
                     <div invisible="composition_mode == 'mass_mail'">
                         <field name="body" widget="html_composer_message" class="oe-bordered-editor" placeholder="Write your message here..." readonly="not can_edit_body" force_save="1"/>
                         <group>
-                            <field name="attachment_ids" widget="many2many_binary" string="Attach a file" nolabel="1" colspan="2"/>
+                            <field name="attachment_ids" widget="many2many_binary" string="Attach a file" nolabel="1"/>
                         </group>
                         <group>
                             <field name="template_id" string="Load template" options="{'no_create': True}" class="w-50"
@@ -59,7 +59,7 @@
                             <div>
                                 <field name="body" widget="html_composer_message" class="oe-bordered-editor" placeholder="Write your message here..." readonly="not can_edit_body" force_save="1"/>
                                 <group>
-                                    <field name="attachment_ids" widget="many2many_binary" string="Attach a file" nolabel="1" colspan="2"/>
+                                    <field name="attachment_ids" widget="many2many_binary" string="Attach a file" nolabel="1"/>
                                 </group>
                                 <group>
                                     <field name="template_id" string="Load template" options="{'no_create': True}" class="w-50"

--- a/addons/marketing_card/views/card_campaign_views.xml
+++ b/addons/marketing_card/views/card_campaign_views.xml
@@ -74,7 +74,7 @@
                     <page name="Card Layout">
                         <group>
                         <group>
-                            <field name="card_element_ids" nolabel="1" colspan="2">
+                            <field name="card_element_ids" nolabel="1">
                                 <tree create="0" delete="0" open_form_view="1">
                                     <field name="card_element_role"/>
                                     <field name="card_element_text_value"/>

--- a/addons/marketing_card/views/card_template_views.xml
+++ b/addons/marketing_card/views/card_template_views.xml
@@ -17,7 +17,7 @@
                             <field name="primary_text_color" widget="color"/>
                             <field name="secondary_text_color" widget="color"/>
                         </group>
-                        <field name="body" widget="code" options="{'mode': 'xml'}" colspan="2" nolabel="1"/>
+                        <field name="body" widget="code" options="{'mode': 'xml'}"/>
                     </group>
                 </sheet>
             </form>

--- a/addons/onboarding/views/onboarding_views.xml
+++ b/addons/onboarding/views/onboarding_views.xml
@@ -37,7 +37,7 @@
                     <notebook>
                         <page name="Onboarding steps">
                             <group string="Steps">
-                                <field name="step_ids" nolabel="1" colspan="2"/>
+                                <field name="step_ids" nolabel="1"/>
                             </group>
                         </page>
                     </notebook>
@@ -75,7 +75,7 @@
                     <notebook>
                         <page name="Onboardings using this step">
                             <group string="Onboardings">
-                                <field name="onboarding_ids" nolabel="1" colspan="2"/>
+                                <field name="onboarding_ids" nolabel="1"/>
                             </group>
                         </page>
                         <page name="Step rendering">

--- a/addons/payment/views/payment_transaction_views.xml
+++ b/addons/payment/views/payment_transaction_views.xml
@@ -58,7 +58,7 @@
                     <separator string="Child transactions" invisible="not child_transaction_ids"/>
                     <field name="child_transaction_ids" invisible="not child_transaction_ids"/>
                     <group string="Message" invisible="not state_message">
-                        <field name="state_message" colspan="2" nolabel="1"/>
+                        <field name="state_message" nolabel="1"/>
                     </group>
                 </sheet>
             </form>

--- a/addons/point_of_sale/wizard/pos_details.xml
+++ b/addons/point_of_sale/wizard/pos_details.xml
@@ -10,7 +10,7 @@
                         <field name="end_date"/>
                     </group>
                     <group>
-                        <field name="pos_config_ids" mode="tree" colspan="2" nolabel="1" />
+                        <field name="pos_config_ids" mode="tree" nolabel="1" />
                     </group>
                     <footer>
                         <button name="generate_report" string="Print" type="object" class="btn-primary" data-hotkey="q"/>

--- a/addons/purchase/views/product_views.xml
+++ b/addons/purchase/views/product_views.xml
@@ -71,7 +71,7 @@
                 <group name="purchase" position="inside">
                     <group col="1">
                         <group string="Purchase Description">
-                           <field name="description_purchase" nolabel="1" colspan="2"
+                           <field name="description_purchase" nolabel="1"
                                 placeholder="This note is added to purchase orders."/>
                         </group>
                         <group string="Warning when Purchasing this Product" groups="purchase.group_warning_purchase">

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -362,7 +362,7 @@
                                     <field colspan="2" name="notes" nolabel="1" placeholder="Define your terms and conditions ..."/>
                                 </group>
                                 <group class="oe_subtotal_footer">
-                                    <field name="tax_totals" widget="account-tax-totals-field" nolabel="1" colspan="2" readonly="1"/>
+                                    <field name="tax_totals" widget="account-tax-totals-field" nolabel="1" readonly="1"/>
                                 </group>
                             </group>
                             <div class="clearfix"/>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -739,7 +739,7 @@
                                 <field  colspan="2" name="note" nolabel="1" placeholder="Terms and conditions..."/>
                             </group>
                             <group class="oe_subtotal_footer d-flex order-0 order-lg-1 flex-column gap-0 gap-sm-3" colspan="2" name="sale_total">
-                                <field name="tax_totals" widget="account-tax-totals-field" nolabel="1" colspan="2" readonly="1"/>
+                                <field name="tax_totals" widget="account-tax-totals-field" nolabel="1" readonly="1"/>
                             </group>
                         </group>
                     </page>

--- a/addons/sms/views/sms_template_views.xml
+++ b/addons/sms/views/sms_template_views.xml
@@ -53,7 +53,7 @@
                     <notebook>
                         <page string="Content" name="content">
                             <group>
-                                <field name="body" widget="sms_widget" nolabel="1" colspan="2"/>
+                                <field name="body" widget="sms_widget" nolabel="1"/>
                             </group>
                         </page>
                     </notebook>

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -151,13 +151,13 @@
                 <page name="inventory" position="inside">
                     <group>
                         <group string="Description for Receipts">
-                            <field name="description_pickingin" colspan="2" nolabel="1" placeholder="This note is added to receipt orders (e.g. where to store the product in the warehouse)."/>
+                            <field name="description_pickingin" nolabel="1" placeholder="This note is added to receipt orders (e.g. where to store the product in the warehouse)."/>
                         </group>
                         <group string="Description for Delivery Orders">
-                            <field name="description_pickingout" colspan="2" nolabel="1" placeholder="This note is added to delivery orders."/>
+                            <field name="description_pickingout" nolabel="1" placeholder="This note is added to delivery orders."/>
                         </group>
                         <group string="Description for Internal Transfers" groups="stock.group_stock_multi_locations">
-                            <field name="description_picking" colspan="2" placeholder="This note is added to internal transfer orders (e.g. where to pick the product in the warehouse)." nolabel="1"/>
+                            <field name="description_picking" nolabel="1" placeholder="This note is added to internal transfer orders (e.g. where to pick the product in the warehouse)."/>
                         </group>
                     </group>
                 </page>

--- a/addons/stock/views/stock_location_views.xml
+++ b/addons/stock/views/stock_location_views.xml
@@ -219,7 +219,7 @@
                         </group>
                     </group>
                     <group string="Rules" >
-                        <field name="rule_ids" colspan="2" nolabel="1" context="{'default_company_id': company_id, 'form_view_ref':'stock.view_route_rule_form'}">
+                        <field name="rule_ids" nolabel="1" context="{'default_company_id': company_id, 'form_view_ref':'stock.view_route_rule_form'}">
                             <tree>
                                 <field name="sequence" widget="handle"/>
                                 <field name="action"/>

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -428,6 +428,10 @@
         gap: map-get($spacers, 2) $o-horizontal-padding;
         margin-bottom: map-get($spacers, 2);
 
+        .o_cell:first-child:last-child {
+            grid-column: span 2;
+        }
+
         span, .o_field_boolean, .oe_avatar, .o_form_uri {
             &.o_field_widget {
                 width: auto;

--- a/addons/website_event_track_quiz/views/event_quiz_question_views.xml
+++ b/addons/website_event_track_quiz/views/event_quiz_question_views.xml
@@ -53,7 +53,7 @@
                         <field name="awarded_points" invisible="1"/>
                     </group>
                     <group name="questions">
-                        <field name="answer_ids" nolabel="1" colspan="2">
+                        <field name="answer_ids" nolabel="1">
                             <tree editable="bottom" create="true" delete="true">
                                 <field name="sequence" widget="handle"/>
                                 <field name="text_value"/>

--- a/addons/website_event_track_quiz/views/event_quiz_views.xml
+++ b/addons/website_event_track_quiz/views/event_quiz_views.xml
@@ -48,7 +48,7 @@
                         </group>
                     </group>
                     <group name="questions">
-                        <field name="question_ids" nolabel="1" colspan="2"
+                        <field name="question_ids" nolabel="1"
                             context="{
                                 'tree_view_ref': 'website_event_track_quiz.event_quiz_question_view_tree_from_quiz',
                                 'form_view_ref': 'website_event_track_quiz.event_quiz_question_view_form_from_quiz'

--- a/addons/website_forum/views/forum_post_views.xml
+++ b/addons/website_forum/views/forum_post_views.xml
@@ -49,7 +49,7 @@
                     </group>
                 </group>
                 <group name="answers" string="Answers" invisible="parent_id">
-                    <field name="child_ids" nolabel="1" colspan="2">
+                    <field name="child_ids" nolabel="1">
                         <tree>
                             <field name="create_uid" string="Answered by"/>
                             <field name="vote_count"/>

--- a/addons/website_slides/views/slide_slide_views.xml
+++ b/addons/website_slides/views/slide_slide_views.xml
@@ -139,7 +139,7 @@
                             </page>
                             <page string="Additional Resources" name="external_links" >
                                 <group>
-                                    <field name="slide_resource_ids" widget="one2many" nolabel="1" colspan="2">
+                                    <field name="slide_resource_ids" widget="one2many" nolabel="1">
                                         <tree editable="top">
                                             <field name="sequence" widget="handle"/>
                                             <field name="resource_type"/>
@@ -164,7 +164,7 @@
                                         </group>
                                     </group>
                                     <group name="questions" string="Questions">
-                                        <field name="question_ids" nolabel="1" colspan="2">
+                                        <field name="question_ids" nolabel="1">
                                             <tree>
                                                 <field name="sequence" widget="handle"/>
                                                 <field name="question" string="Question"/>

--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -169,7 +169,7 @@
                             </group>
                         </group>
                         <group name="help" string="Help">
-                            <field name="help" colspan="2" nolabel="1" class="oe-bordered-editor"/>
+                            <field name="help" nolabel="1" class="oe-bordered-editor"/>
                         </group>
                     </sheet>
                 </form>

--- a/odoo/addons/base/views/ir_attachment_views.xml
+++ b/odoo/addons/base/views/ir_attachment_views.xml
@@ -34,10 +34,10 @@
                             </div>
                         </group>
                         <group name="description_group" string="Description" groups="base.group_no_one" colspan="4">
-                            <field name="description" nolabel="1" colspan="2"/>
+                            <field name="description" nolabel="1"/>
                         </group>
                         <group groups="base.group_no_one" string="Indexed Content" colspan="4">
-                            <field name="index_content" nolabel="1" colspan="2"/>
+                            <field name="index_content" nolabel="1"/>
                         </group>
                     </group>
                   </sheet>

--- a/odoo/addons/base/views/ir_module_views.xml
+++ b/odoo/addons/base/views/ir_module_views.xml
@@ -94,7 +94,7 @@
                             </group>
                             <group>
                                 <group string="Dependencies">
-                                    <field name="dependencies_id" colspan="2" nolabel="1">
+                                    <field name="dependencies_id" nolabel="1">
                                         <tree string="Dependencies">
                                             <field name="name"/>
                                             <field name="state"/>
@@ -102,7 +102,7 @@
                                     </field>
                                 </group>
                                 <group string="Exclusions">
-                                    <field name="exclusion_ids" colspan="2" nolabel="1">
+                                    <field name="exclusion_ids" nolabel="1">
                                         <tree string="Exclusions">
                                             <field name="name"/>
                                             <field name="state"/>

--- a/odoo/addons/base/views/ir_profile_views.xml
+++ b/odoo/addons/base/views/ir_profile_views.xml
@@ -43,7 +43,7 @@
                     <field name="speedscope_url" widget="url"/>
                 </group>
                 <group invisible="not qweb">
-                    <field name="qweb" widget="profiling_qweb_view" nolabel="1" colspan="2"/>
+                    <field name="qweb" widget="profiling_qweb_view" nolabel="1"/>
                 </group>
             </form>
         </field>

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -286,7 +286,7 @@
                                             </group>
                                         </group>
                                         <group>
-                                            <field name="comment" placeholder="Internal notes..." nolabel="1" colspan="2"/>
+                                            <field name="comment" placeholder="Internal notes..." nolabel="1"/>
                                         </group>
                                         <field name="lang" invisible="True"/>  <!-- Need to add lang to save default value from parented record -->
                                     </sheet>


### PR DESCRIPTION
Grid is set to use 2 columns in a `<group/>` used as an inner group.
So before this commit, we had to put `colspan="2"` to force no label
fields to take all the available space.
If not, the field was located in the first column and you had some
empty space on the right due to the second column.

In this commit, we want to make this attribute optional when
`nolabel="1"` by collapsing these 2 columns automatically.

Note that we use a CSS selector to make sure that the element was
alone in his row because sometimes a `<field/>` has the `nolabel`
property set but a `<label/>` node is also present. In this case,
we want to keep these two columns.

<group string="...">
    <field name="x2many_field" nolabel="1"/>
</group>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
