### PR TITLE
[FIX] mail: prevent cross-company access for same email users

### DIFF
--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -152,13 +152,14 @@ class Partner(models.Model):
             for name, email_normalized in name_emails
             if not email_normalized and name.strip()
         }
+        company_domain = ['|', '|', ('partner_share', '=', False), ('company_id', 'parent_of', self.env.companies.ids), ('company_id', '=', False)]
         if emails_normalized or names:
             domains = []
             if emails_normalized:
                 domains.append([('email_normalized', 'in', list(emails_normalized))])
             if names:
                 domains.append([('email', 'in', list(names))])
-            partners += self.search(expression.OR(domains))
+            partners += self.search(expression.AND([company_domain, expression.OR(domains)]))
 
         # create partners for valid email without any existing partner. Keep
         # only first found occurrence of each normalized email, aka: ('Norbert',

--- a/addons/mail/tests/test_res_partner.py
+++ b/addons/mail/tests/test_res_partner.py
@@ -546,3 +546,21 @@ class TestPartner(MailCommon):
         all_msg = p2_msg_ids_init + p1_msg_ids_init + p1_msg1
         self.assertEqual(len(p2.message_ids), len(all_msg) + 1, 'Should have original messages + a log')
         self.assertTrue(all(msg in p2.message_ids for msg in all_msg))
+
+    def test_find_or_create_from_emails_multi_company(self):
+        # Create a partner with the same email in the other company
+        partner2 = self.env['res.partner'].with_company(self.company_2).create({
+            'name': 'Partner 2',
+            'email': 'partner1@example.com',
+            'company_id': self.company_2.id,
+        })
+
+        # Call find_or_create_from_emails with current company
+        new_samples = ['partner1@example.com']
+        new_partners = self.env['res.partner'].with_company(self.env.company)._find_or_create_from_emails(
+            new_samples,
+            additional_values=None,
+        )
+
+        # Check if creates a new partner because the one available is in another company
+        self.assertNotEqual(partner2, new_partners[0])


### PR DESCRIPTION
## Issue:
When we have two partners with the same email address but in different companies, when trying to send an email to one of them, the system will raise an access error because it will try to access the partner from the other company.

## Steps to reproduce:
- modify the email template for the "Sales: Send Quotation" `email to` field to for example: `test@example.com`
- in a multi company environment with two companies, create a new odoo user with the same email: `test@example.com` having access to both companies
- logged in as the odoo user, create a new partner with the same email
- create a new quotation with the user's partner as a customer and try to send the quotation
- the system will raise an access error

## Solution:
- in the `_find_or_create_from_emails` method of the res.partner model, we applied the company-based filtering to the search for the existing partner with the given email address to avoid accessing partners from other companies.

OPW-4043762

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
