### PR TITLE
[IMP] website: improve website name with text truncation

### DIFF
--- a/addons/website/static/src/client_actions/website_dashboard/website_dashboard.xml
+++ b/addons/website/static/src/client_actions/website_dashboard/website_dashboard.xml
@@ -7,7 +7,7 @@
             <t t-set-slot="control-panel-navigation-additional">
                 <div class="btn-group d-none d-md-inline-block float-end" style="margin-right: 20px;">
                     <t t-foreach="state.websites" t-as="website" t-key="website.id">
-                        <button class="btn btn-secondary js_website" t-att-class="{'active': website.selected}"
+                        <button class="btn btn-secondary text-truncate js_website" style="max-width: 200px;" t-att-class="{'active': website.selected}"
                                 t-on-click="() => this.state.website = website.id">
                             <t t-esc="website.name"/>
                         </button>

--- a/addons/website/static/src/systray_items/website_switcher.js
+++ b/addons/website/static/src/systray_items/website_switcher.js
@@ -63,7 +63,7 @@ export class WebsiteSwitcherSystray extends Component {
                     }
                 }
             },
-            class: website.id === this.websiteService.currentWebsite.id ? 'active' : '',
+            class: website.id === this.websiteService.currentWebsite.id ? 'text-truncate active' : 'text-truncate',
         }));
     }
 }

--- a/addons/website/static/src/systray_items/website_switcher.xml
+++ b/addons/website/static/src/systray_items/website_switcher.xml
@@ -2,10 +2,10 @@
 <templates xml:space="preserve">
 <t t-name="website.WebsiteSwitcherSystray">
     <div class="o_menu_systray_item o_website_switcher_container">
-        <Dropdown>
+        <Dropdown menuClass="{'mw-100': false}">
             <button data-hotkey="w" class="mx-1 border-0">
-                <div class="d-none d-md-block">
-                    <span t-esc="websiteService.currentWebsite.name" class="me-2"/>
+                <div class="d-none d-md-flex align-items-md-center">
+                    <span t-esc="websiteService.currentWebsite.name" class="me-2 text-truncate" style="max-width: 200px"/>
                     <i class="fa fa-caret-down"/>
                 </div>
                 <div class="d-md-none">


### PR DESCRIPTION
This commit enhances the display of the website name in the dropdown menu and the website systray item by utilizing the `text-truncate` class to manage long names more effectively.

task-4069591