### PR TITLE
[IMP] website: introduce `s_contact_info` snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -79,6 +79,7 @@
         'views/snippets/s_parallax.xml',
         'views/snippets/s_quotes_carousel.xml',
         'views/snippets/s_numbers.xml',
+        'views/snippets/s_contact_info.xml',
         'views/snippets/s_cta_box.xml',
         'views/snippets/s_masonry_block.xml',
         'views/snippets/s_sidegrid.xml',

--- a/addons/website/views/snippets/s_contact_info.xml
+++ b/addons/website/views/snippets/s_contact_info.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_contact_info" name="Contact Info">
+    <section class="s_contact_info pt48 pb64 o_cc o_cc1">
+        <div class="container">
+            <div class="row o_grid_mode" data-row-count="11">
+                <div class="o_grid_item g-col-lg-6 g-height-5 col-lg-6 col-10 offset-1 order-lg-0" style="order: 2;--grid-item-padding-x: 0px; --grid-item-padding-y: 24px; grid-area: 1 / 1 / 6 / 7; z-index: 1;" data-name="Title block">
+                    <h2>Contact Us</h2>
+                    <p class="lead">We'd love to hear from you! If you have any questions, feedback, or need assistance, please feel free to reach out to us using the contact details provided. Our team is here to help and will respond as soon as possible. Thank you for getting in touch!</p>
+                </div>
+                <div class="o_grid_item g-col-lg-6 g-height-2 col-lg-6 col-10 offset-1 order-lg-0" style="order: 3; --grid-item-padding-x: 0px; --grid-item-padding-y: 16px; grid-area: 6 / 1 / 8 / 7; z-index: 2;" data-name="Info block">
+                    <h3 class="h5-fs">
+                        <i class="fa fa-fw fa-envelope-o" role="presentation"/>
+                        Email
+                    </h3>
+                    <p>
+                        &#160;&#160;&#160;&#160;&#160;&#160;&#160;<a href="mail-to:info@yourcompany.example.com" title="Send an email">info@yourcompany.example.com</a>
+                    </p>
+                </div>
+                <div class="o_grid_item g-col-lg-6 g-height-2 col-lg-6 col-10 offset-1 order-lg-0" style="order: 4; --grid-item-padding-x: 0px; --grid-item-padding-y: 16px; grid-area: 8 / 1 / 10 / 7; z-index: 3;" data-name="Info block">
+                    <h3 class="h5-fs">
+                        <i class="fa fa-fw fa-phone" role="presentation"/>
+                        Phone
+                    </h3>
+                    <p>
+                        &#160;&#160;&#160;&#160;&#160;&#160;&#160;<a href="tel:+1555-555-5556" title="Call Customer Service">+1555-555-5556</a>
+                    </p>
+                </div>
+                <div class="o_grid_item g-col-lg-6 g-height-2 col-lg-6 col-10 offset-1 order-lg-0" style="order: 5; --grid-item-padding-x: 0px; --grid-item-padding-y: 16px; grid-area: 10 / 1 / 12 / 7; z-index: 4;" data-name="Info block">
+                    <h3 class="h5-fs">
+                        <i class="fa fa-fw fa-building-o" role="presentation"/>
+                        Office
+                    </h3>
+                    <p>&#160;&#160;&#160;&#160;&#160;&#160;&#160;3575 Fake Buena Vista Avenue</p>
+                </div>
+                <div class="o_grid_item o_grid_item_image g-col-lg-6 g-height-6 col-lg-6 col-10 offset-1 order-lg-0" style="order: 1; --grid-item-padding-x: 0px; --grid-item-padding-y: 0px; grid-area: 6 / 7 / 12 / 13; z-index: 5;" data-name="Image block">
+                    <img class="img img-fluid rounded" src="/web/image/website.s_cover_default_image" alt=""/>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -222,6 +222,7 @@
 
                 <!-- Contact & Forms group -->
                 <t t-snippet="website.s_website_form" string="Form" t-forbid-sanitize="form" t-thumbnail="/website/static/src/img/snippets_thumbs/s_website_form.svg" group="contact_and_forms"/>
+                <t t-snippet="website.s_contact_info" string="Contact Info" group="contact_and_forms"/>
 
                 <!-- Products group -->
                 <t id="sale_products_hook"/>
@@ -736,7 +737,7 @@
 
     <!-- Grid only -->
     <div data-js="layout_column"
-        data-selector="section.s_masonry_block"
+        data-selector="section.s_masonry_block, section.s_contact_info"
         data-target="> *:has(> .row)">
         <t t-call="website.grid_layout_options"/>
     </div>
@@ -745,7 +746,7 @@
     <div data-js="layout_column"
         data-selector="section"
         data-target="> *:has(> .row), > .s_allow_columns"
-        data-exclude=".s_dynamic, .s_dynamic_snippet_content, .s_dynamic_snippet_title, .s_masonry_block, .s_features_grid, .s_media_list, .s_table_of_content, .s_process_steps, .s_image_gallery, .s_timeline, .s_pricelist_boxed, .s_quadrant">
+        data-exclude=".s_dynamic, .s_dynamic_snippet_content, .s_dynamic_snippet_title, .s_masonry_block, .s_features_grid, .s_media_list, .s_table_of_content, .s_process_steps, .s_image_gallery, .s_timeline, .s_pricelist_boxed, .s_quadrant, .s_contact_info">
         <we-row>
             <we-button-group string="Layout" data-no-preview="true">
                 <we-button data-select-layout="grid" data-name="grid_mode">Grid</we-button>


### PR DESCRIPTION
This commit adds the new `s_contact_info` snippet.

task-4142017
Part-of: task-4077427

| New snippet: Contact Info |
|--------|
| ![image](https://github.com/user-attachments/assets/60c66e68-e923-49fa-b89c-5d7d441b1efc) | 
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
