### PR TITLE
[FIX] html_editor: address non-deterministic link test

### DIFF
--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -2,7 +2,16 @@ import { describe, expect, test } from "@odoo/hoot";
 import { animationFrame, tick } from "@odoo/hoot-mock";
 import { setContent, getContent, setSelection } from "../_helpers/selection";
 import { setupEditor } from "../_helpers/editor";
-import { waitUntil, waitFor, click, queryOne, press, select, queryText } from "@odoo/hoot-dom";
+import {
+    waitUntil,
+    waitFor,
+    click,
+    queryOne,
+    press,
+    select,
+    queryText,
+    queryAllTexts,
+} from "@odoo/hoot-dom";
 import { insertText, splitBlock, insertLineBreak } from "../_helpers/user_actions";
 import { contains, onRpc } from "@web/../tests/web_test_helpers";
 import { cleanLinkArtifacts } from "../_helpers/format";
@@ -138,8 +147,9 @@ describe("popover should edit,copy,remove the link", () => {
         await setupEditor('<p>this is a <a href="http://test.com/">li[]nk</a></p>');
         await waitFor(".o-we-linkpopover");
         click(".o_we_copy_link");
-        await waitFor(".o_notification_body");
-        expect(".o_notification_body").toHaveCount(1);
+        await waitFor(".o_notification_bar.bg-success");
+        const notifications = queryAllTexts(".o_notification_body");
+        expect(notifications).toInclude("Link copied to clipboard.");
         await animationFrame();
         expect(".o-we-linkpopover").toHaveCount(0);
         await expect(navigator.clipboard.readText()).resolves.toBe("http://test.com/");


### PR DESCRIPTION
Before this commit: The test was checking for notification counts, but it could also capture the notification triggered by bus_service.js for the outdated case, leading to an incorrect count of notifications.

After this commit: The test now waits specifically for the success notification triggered by the link copying action and verifies the exact content to ensure accuracy.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
