### PR TITLE
[IMP] web: fix command palette vertical position

### DIFF
--- a/addons/web/static/src/core/commands/command_palette.scss
+++ b/addons/web/static/src/core/commands/command_palette.scss
@@ -1,5 +1,7 @@
 .o_command_palette {
     $-app-icon-size: 1.8rem;
+    top: 120px;
+    position: absolute;
 
     > .modal-body {
         padding: 0;

--- a/addons/web/static/src/core/commands/command_palette.xml
+++ b/addons/web/static/src/core/commands/command_palette.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
   <t t-name="web.CommandPalette">
-    <Dialog header="false" footer="false" size="'md'" contentClass="'o_command_palette mt-5'">
+    <Dialog header="false" footer="false" size="'md'" contentClass="'o_command_palette'">
       <div t-ref="root">
         <div class="o_command_palette_search input-group mb-2 px-4 py-3 border-bottom">
           <span t-if="state.namespace !== 'default'" class="o_namespace d-flex align-items-center me-1" t-out="state.namespace"/>

--- a/addons/web/static/src/core/dialog/dialog.js
+++ b/addons/web/static/src/core/dialog/dialog.js
@@ -90,21 +90,24 @@ export class Dialog extends Component {
         );
         this.id = `dialog_${this.data.id}`;
         useChildSubEnv({ inDialog: true, dialogId: this.id });
-        this.position = useState({ left: 0, top: 0 });
-        useDialogDraggable({
-            enable: () => !this.env.isSmall,
-            ref: this.modalRef,
-            elements: ".modal-content",
-            handle: ".modal-header",
-            ignore: "button, input",
-            edgeScrolling: { enabled: false },
-            onDrop: ({ top, left }) => {
-                this.position.left += left;
-                this.position.top += top;
-            },
-        });
-        const throttledResize = throttleForAnimation(this.onResize.bind(this));
-        useExternalListener(window, "resize", throttledResize);
+        this.isMovable = this.props.header;
+        if (this.isMovable) {
+            this.position = useState({ left: 0, top: 0 });
+            useDialogDraggable({
+                enable: () => !this.env.isSmall,
+                ref: this.modalRef,
+                elements: ".modal-content",
+                handle: ".modal-header",
+                ignore: "button, input",
+                edgeScrolling: { enabled: false },
+                onDrop: ({ top, left }) => {
+                    this.position.left += left;
+                    this.position.top += top;
+                },
+            });
+            const throttledResize = throttleForAnimation(this.onResize.bind(this));
+            useExternalListener(window, "resize", throttledResize);
+        }
         onWillDestroy(() => {
             if (this.env.isSmall) {
                 this.data.scrollToOrigin();
@@ -117,7 +120,10 @@ export class Dialog extends Component {
     }
 
     get contentStyle() {
-        return `top: ${this.position.top}px; left: ${this.position.left}px;`;
+        if (this.isMovable) {
+            return `top: ${this.position.top}px; left: ${this.position.left}px;`;
+        }
+        return "";
     }
 
     onResize() {

--- a/addons/web/static/tests/core/commands/command_palette.test.js
+++ b/addons/web/static/tests/core/commands/command_palette.test.js
@@ -512,6 +512,47 @@ test("open the command palette with a searchValue already in the searchbar", asy
     expect(queryAllTexts(".o_command")).toEqual(["Command1"]);
 });
 
+test("command palette keeps the same top position when its content changes", async () => {
+    await mountWithCleanup(MainComponentsContainer);
+    const action = () => {};
+    const providers = [
+        {
+            provide: () => [
+                {
+                    name: "Command1",
+                    action,
+                },
+                {
+                    name: "Command2",
+                    action,
+                },
+                {
+                    name: "Command3",
+                    action,
+                },
+                {
+                    name: "Command4",
+                    action,
+                },
+            ],
+        },
+    ];
+    const config = {
+        providers,
+    };
+    getService("dialog").add(CommandPalette, {
+        config,
+    });
+    await animationFrame();
+    expect(".o_command_palette").toHaveCount(1);
+    expect(".o_command").toHaveCount(4);
+    expect(".o_command_palette").toHaveRect({ top: 120 });
+    await contains(".o_command_palette_search input").edit("z", { confirm: false });
+    await runAllTimers();
+    expect(".o_command").toHaveCount(0);
+    expect(".o_command_palette").toHaveRect({ top: 120 });
+});
+
 test("open the command palette with a namespace already in the searchbar", async () => {
     await mountWithCleanup(MainComponentsContainer);
     const action = () => {};


### PR DESCRIPTION
The current command palette will resize a lot when the user is typing things due to the variation in number of search results. This causes a lot of resizing for this specific dialog and therefore a lot of movement which can be annoying for the user. This commit tackles this problem by freezing the top position of the command palette dialog so that resizing it only results in the bottom moving instead of the whole thing. This involves a small tweak in the dialog position logic which is that dialogs without header shouldn't need to have their position handled by the component because they cannot be moved anyway (which is the case for the command palette). This allows the parent component of the dialog to set its position with css in this case.

task-3978382