### PR TITLE
[FIX] web: make export consistent for int/float/monetary field

### DIFF
--- a/addons/test_import_export/tests/test_export.py
+++ b/addons/test_import_export/tests/test_export.py
@@ -386,9 +386,9 @@ class TestGroupedExport(XlsxCreatorCase):
             params={
                 'groupby': ['int_sum', 'date_max:month'],
                 'fields': [
-                    {'name': 'int_sum', 'label': 'Int Sum'},
-                    {'name': 'date_max', 'label': 'Date Max'},
-                    {'name': 'many2one/value', 'label': 'Many2One/Value'},
+                    {'name': 'int_sum', 'label': 'Int Sum', 'type': 'integer'},
+                    {'name': 'date_max', 'label': 'Date Max', 'type': 'date'},
+                    {'name': 'many2one/value', 'label': 'Many2One/Value', 'type': 'many2one'},
                 ],
             },
         )
@@ -420,8 +420,8 @@ class TestGroupedExport(XlsxCreatorCase):
             params={
                 'groupby': ['int_sum'],
                 'fields': [
-                    {'name': 'int_sum', 'label': 'Int Sum'},
-                    {'name': 'one2many/value', 'label': 'One2many/Value'},
+                    {'name': 'int_sum', 'label': 'Int Sum', 'type': 'integer'},
+                    {'name': 'one2many/value', 'label': 'One2many/Value', 'type': 'integer'},
                 ],
             },
         )

--- a/addons/web/static/src/views/view_dialogs/export_data_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/export_data_dialog.js
@@ -249,12 +249,8 @@ export class ExportDataDialog extends Component {
             model: this.props.root.resModel,
             export_id: Number(value),
         });
-        this.state.exportList = fields.map(({ label, name }) => {
-            return {
-                string: label,
-                id: name,
-            };
-        });
+        // Don't safe the result in this.knownFields because, the result is only partial
+        this.state.exportList = fields;
     }
 
     async loadFields(id, preventLoad = false) {

--- a/addons/web/static/tests/views/view_dialogs/export_data_dialog.test.js
+++ b/addons/web/static/tests/views/view_dialogs/export_data_dialog.test.js
@@ -234,7 +234,7 @@ test("Export dialog: interacting with export templates", async () => {
     onRpc("/web/export/namelist", async (request) => {
         const { params } = await request.json();
         if (params.export_id === 1) {
-            return Promise.resolve([{ name: "activity_ids", label: "Activities" }]);
+            return Promise.resolve([{ id: "activity_ids", string: "Activities" }]);
         }
         return Promise.resolve([]);
     });
@@ -343,7 +343,7 @@ test("Export dialog: interacting with export templates in debug", async () => {
     onRpc("/web/export/namelist", async (request) => {
         const { params } = await request.json();
         if (params.export_id === 1) {
-            return Promise.resolve([{ name: "activity_ids", label: "Activities" }]);
+            return Promise.resolve([{ id: "activity_ids", string: "Activities" }]);
         }
         return Promise.resolve([]);
     });

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1479,7 +1479,7 @@ class Boolean(Field[bool]):
         return bool(value)
 
     def convert_to_export(self, value, record):
-        return value
+        return bool(value)
 
 
 class Integer(Field[int]):
@@ -1713,6 +1713,11 @@ class Monetary(Field[float]):
 
     def convert_to_write(self, value, record):
         return value
+
+    def convert_to_export(self, value, record):
+        if value or value == 0.0:
+            return value
+        return ''
 
 
 class _String(Field[str | typing.Literal[False]]):


### PR DESCRIPTION
The float/monetary/int can be in an incorrect format depending of the
other columns format. Then int was sometimes show as float (1.00 by
example). Same situation for monetary, that was often export as an
integer.

It was because we changed the `base_style` instead of having one by type
of field.

Fix these kinds of inconsistency.

task-4129701