### PR TITLE
[FIX] web: back button color contrast on navbar for small screens

### DIFF
--- a/addons/web/static/src/webclient/navbar/navbar.scss
+++ b/addons/web/static/src/webclient/navbar/navbar.scss
@@ -211,7 +211,7 @@
         }
     }
 
-    .o_menu_brand, .o_navbar_breadcrumbs {
+    .o_menu_brand, .o_navbar_breadcrumbs, .o_navbar_breadcrumbs .btn {
         color: var(--NavBar-brand-color, #{$o-navbar-brand-color});
     }
 


### PR DESCRIPTION
[FIX] web: back button color contrast on navbar for small screens

This commit follows 80fe389347838d502addcfd2e521d7516b5e86a0. It fixes
color contrast of the back button in the breadcrumb on the navbar.

Steps to reproduce:

- Open "Project" on small screen
- Open a task
- Check color of the back button in the breadcrumb on the navbar;
  it’s unreadable => bug

Note: a similar fix was provided for the dialog at aa748820d06ddd84465c404ce158e882307dbda6

task-3336242