### PR TITLE
[IMP] web: display avatar instead of counter +1

### DIFF
--- a/addons/calendar/static/src/views/fields/many2many_attendee_expandable.xml
+++ b/addons/calendar/static/src/views/fields/many2many_attendee_expandable.xml
@@ -6,7 +6,7 @@
             <attribute name="class" remove="mw-100" add="w-100" separator=" "/>
         </xpath>
         <xpath expr="//TagsList" position="attributes">
-            <attribute name="itemsVisible">state.expanded ? tags.length : 5</attribute>
+            <attribute name="visibleItemsLimit">state.expanded ? tags.length : 5</attribute>
         </xpath>
         <xpath expr="//TagsList" position="before">
             <t t-if="tags.length > 5">

--- a/addons/hr_skills/static/src/components/avatar_card_resource/avatar_card_resource_popover.xml
+++ b/addons/hr_skills/static/src/components/avatar_card_resource/avatar_card_resource_popover.xml
@@ -5,7 +5,7 @@
             <div t-if="skills?.length" class="d-flex align-items-start pt-1">
                 <i class="fa fa-fw fa-graduation-cap me-1" data-tooltip="Skills"/>
                 <div class="d-flex flex-wrap gap-1 o_employee_skills_tags overflow-hidden">
-                    <TagsList tags="skillTags" itemsVisible="5"/>
+                    <TagsList tags="skillTags" visibleItemsLimit="5"/>
                 </div>
             </div>
         </xpath>

--- a/addons/web/static/src/core/tags_list/tags_list.js
+++ b/addons/web/static/src/core/tags_list/tags_list.js
@@ -7,20 +7,23 @@ export class TagsList extends Component {
     };
     static props = {
         displayText: { type: Boolean, optional: true },
-        itemsVisible: { type: Number, optional: true },
+        visibleItemsLimit: { type: Number, optional: true },
         tags: { type: Object },
     };
     get visibleTagsCount() {
-        return this.props.itemsVisible - 1;
+        return this.props.visibleItemsLimit - 1;
     }
     get visibleTags() {
-        if (this.props.itemsVisible && this.props.tags.length > this.props.itemsVisible) {
+        if (this.props.visibleItemsLimit && this.props.tags.length > this.props.visibleItemsLimit) {
             return this.props.tags.slice(0, this.visibleTagsCount);
         }
         return this.props.tags;
     }
     get otherTags() {
-        if (!this.props.itemsVisible || this.props.tags.length <= this.props.itemsVisible) {
+        if (
+            !this.props.visibleItemsLimit ||
+            this.props.tags.length <= this.props.visibleItemsLimit
+        ) {
             return [];
         }
         return this.props.tags.slice(this.visibleTagsCount);

--- a/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.js
@@ -41,7 +41,7 @@ export const many2ManyTagsAvatarField = {
 registry.category("fields").add("many2many_tags_avatar", many2ManyTagsAvatarField);
 
 export class ListMany2ManyTagsAvatarField extends Many2ManyTagsAvatarField {
-    itemsVisible = 5;
+    visibleItemsLimit = 5;
 }
 
 export const listMany2ManyTagsAvatarField = {
@@ -106,9 +106,6 @@ export class KanbanMany2ManyTagsAvatarFieldTagsList extends TagsList {
             closeOnClickAway: (target) => !target.closest(".modal"),
         });
     }
-    get visibleTagsCount() {
-        return this.props.itemsVisible;
-    }
     openPopover(ev) {
         if (this.props.readonly) {
             return;
@@ -137,7 +134,7 @@ export class KanbanMany2ManyTagsAvatarField extends Many2ManyTagsAvatarField {
         ...Many2ManyTagsAvatarField.props,
         isEditable: { type: Boolean, optional: true },
     };
-    itemsVisible = 2;
+    visibleItemsLimit = 3;
 
     get popoverProps() {
         const props = {

--- a/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.xml
+++ b/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.xml
@@ -7,7 +7,7 @@
             t-att-class="{'o_tags_input o_input': !props.readonly}"
             t-ref="many2ManyTagsField"
         >
-            <TagsList tags="tags" itemsVisible="itemsVisible"/>
+            <TagsList tags="tags" visibleItemsLimit="visibleItemsLimit"/>
             <div t-if="showM2OSelectionField" class="o_field_many2many_selection d-inline-flex w-100" t-ref="autoComplete">
                 <Many2XAutocomplete
                     id="props.id"

--- a/addons/web/static/tests/views/fields/many2many_tags_avatar_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_avatar_field.test.js
@@ -256,7 +256,7 @@ test("widget many2many_tags_avatar in kanban view", async () => {
 
     expect(
         ".o_kanban_record:nth-child(2) .o_field_many2many_tags_avatar .o_avatar img"
-    ).toHaveCount(2);
+    ).toHaveCount(3);
     expect(
         ".o_kanban_record:nth-child(3) .o_field_many2many_tags_avatar .o_avatar img"
     ).toHaveCount(2);
@@ -283,27 +283,27 @@ test("widget many2many_tags_avatar in kanban view", async () => {
         ".o_kanban_record:nth-child(4) .o_field_many2many_tags_avatar .o_m2m_avatar_empty"
     ).toHaveText("9+");
     expect(".o_field_many2many_tags_avatar .o_field_many2many_selection").toHaveCount(0);
-    await contains(".o_kanban_record:nth-child(2) .o_field_tags > .o_m2m_avatar_empty").click();
+    await contains(".o_kanban_record:nth-child(3) .o_field_tags > .o_m2m_avatar_empty").click();
     await animationFrame();
     expect(".o-overlay-container input").toBeFocused();
-    expect(".o-overlay-container .o_tag").toHaveCount(3);
+    expect(".o-overlay-container .o_tag").toHaveCount(4);
     // delete inside the popover
     await contains(".o-overlay-container .o_tag .o_delete:eq(0)", {
         visible: false,
         displayed: true,
     }).click();
-    expect(".o-overlay-container .o_tag").toHaveCount(2);
-    expect(".o_kanban_record:nth-child(2) .o_tag").toHaveCount(2);
-    // select first non selected input
-    await contains(".o-overlay-container .o-autocomplete--dropdown-item:eq(2)").click();
     expect(".o-overlay-container .o_tag").toHaveCount(3);
-    expect(".o_kanban_record:nth-child(2) .o_tag").toHaveCount(2);
+    expect(".o_kanban_record:nth-child(3) .o_tag").toHaveCount(3);
+    // select first non selected input
+    await contains(".o-overlay-container .o-autocomplete--dropdown-item:eq(4)").click();
+    expect(".o-overlay-container .o_tag").toHaveCount(4);
+    expect(".o_kanban_record:nth-child(3) .o_tag").toHaveCount(2);
     // load more
     await contains(".o-overlay-container .o_m2o_dropdown_option_search_more").click();
     // first non already selected item
     await contains(".o_dialog .o_list_table .o_data_row .o_data_cell:eq(3)").click();
-    expect(".o-overlay-container .o_tag").toHaveCount(4);
-    expect(".o_kanban_record:nth-child(2) .o_tag").toHaveCount(2);
+    expect(".o-overlay-container .o_tag").toHaveCount(5);
+    expect(".o_kanban_record:nth-child(3) .o_tag").toHaveCount(2);
     expect(
         `.o_kanban_record:nth-child(2) img.o_m2m_avatar[data-src='${getOrigin()}/web/image/partner/4/avatar_128']`
     ).toHaveCount(1);


### PR DESCRIPTION
Before this commit, the user avatar tag list displayed the counter with +1 when there was only 1 tag left to display.
Now, the last tag is displayed instead of the counter.

task-4134018