### PR TITLE
[FIX] point_of_sale: install pos with demo data

### DIFF
--- a/addons/point_of_sale/data/point_of_sale_demo.xml
+++ b/addons/point_of_sale/data/point_of_sale_demo.xml
@@ -71,6 +71,10 @@
 
         <!-- Taxes -->
 
+        <record id="pos_taxes_group_0" model="account.tax.group">
+            <field name="name">Default Tax group for PoS</field>
+        </record>
+
         <record id="pos_taxes_0" model="account.tax">
             <field name="name">Default Tax for PoS</field>
             <field name="amount">0</field>


### PR DESCRIPTION
### Steps to reproduce:

- Create a fresh db with demo data
- Activate the "stock_barcode" module
- Activate the "point_of_sale" module
#### > Error: operation cannot be completed

### Cause of the issue:

Activating the "stock_barcode" module will create a second company. When you activate point of sale with the demo data, it will first install accounting and create a tax group for company 2 and then create the pos demo data:
https://github.com/odoo/odoo/blob/42fa237296f9b1fa556ae310b3273f863420e659/addons/point_of_sale/data/point_of_sale_demo.xml#L74-L78 However, during since no tax group is specified for this account.tax, it is expected to be computed here:
https://github.com/odoo/odoo/blob/42fa237296f9b1fa556ae310b3273f863420e659/addons/account/models/account_tax.py#L221-L222 But since no tax group was created for the current company, this computation will fail to give a result
https://github.com/odoo/odoo/blob/42fa237296f9b1fa556ae310b3273f863420e659/addons/account/models/account_tax.py#L232-L235 and the transaction will be aborted.

### Fix:

We create a tax group demo data that will be associated to the same company as the one for which our demo tax is created and hence provide a fall back value in case no other tax group was created.

opw-4141575
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
