### PR TITLE
[PERF] base_vat: avoid checking vat validity with vies on import

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -821,10 +821,16 @@ class ResPartner(models.Model):
             if values.get('vat'):
                 country_id = values.get('country_id')
                 values['vat'] = self._fix_vat_number(values['vat'], country_id)
-        return super(ResPartner, self).create(vals_list)
+        res = super().create(vals_list)
+        if self.env.context.get('import_file'):
+            res.env.remove_to_compute(self._fields['vies_valid'], res)
+        return res
 
     def write(self, values):
         if values.get('vat') and len(self.mapped('country_id')) == 1:
             country_id = values.get('country_id', self.country_id.id)
             values['vat'] = self._fix_vat_number(values['vat'], country_id)
-        return super(ResPartner, self).write(values)
+        res = super().write(values)
+        if self.env.context.get('import_file'):
+            self.env.remove_to_compute(self._fields['vies_valid'], self)
+        return res


### PR DESCRIPTION
The vies check service may limit ip addresses when:
- checking too many vat numbers per day
- checking the same vat number multiple times
- checking too many invalid number




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
