### PR TITLE
[FIX] product: increase container size for price/unit in pricelist item view

### DIFF
--- a/addons/product/views/product_pricelist_item_views.xml
+++ b/addons/product/views/product_pricelist_item_views.xml
@@ -124,7 +124,7 @@
                                 options="{'horizontal': true}"
                                 invisible="display_applied_on == '1_product' and compute_price == 'fixed_price'"/>
                             <label for="fixed_price" invisible="compute_price != 'fixed'"/>
-                            <div class="o_row" invisible="compute_price != 'fixed'" style="width: 40% !important;">
+                            <div class="o_row" invisible="compute_price != 'fixed'" style="width: 60% !important;">
                                 <field name="fixed_price" widget="monetary"
                                     options="{'currency_field': 'currency_id'}"/>
                                 <span class="d-flex gap-2 p-0" invisible="not product_uom ">per<field


### PR DESCRIPTION
Problem:
The container for the price/unit field was too small, causing the price input and unit label to overlap.

Steps to reproduce:

- Change the language to Spanish.
- Create a pricelist.
- Under Rules, click "Add a Line."
- The fixed price input should not overlap with the unit label.

opw-4142779

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
