### PR TITLE
[FIX] mail: avoid duplicates in channel members

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -316,7 +316,7 @@ class Channel(models.Model):
     def _subscribe_users_automatically_get_members(self):
         """ Return new members per channel ID """
         return dict(
-            (channel.id, (channel.group_ids.users.partner_id - channel.channel_partner_ids).ids)
+            (channel.id, (channel.group_ids.users.partner_id - channel.channel_member_ids.partner_id).ids)
             for channel in self
         )
 


### PR DESCRIPTION
The compute for `channel_partner_ids` keeps only the active partners while `channel.group_ids.users.partner_id` may include inactive partners, so we end up with an existing member getting recreated violating the constraint
`discuss_channel_member_partner_unique`.

the issue is encountered during upgrades

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
