### PR TITLE
[FIX] project: correct the grammar mistake of the 'blocked by' stat button

### DIFF
--- a/addons/project/i18n/project.pot
+++ b/addons/project/i18n/project.pot
@@ -430,7 +430,7 @@ msgstr ""
 
 #. module: project
 #: model_terms:ir.ui.view,arch_db:project.project_sharing_project_task_view_form
-msgid "<span class=\"o_stat_text\">Blocking Tasks</span>"
+msgid "<span class=\"o_stat_text\">Blocked Tasks</span>"
 msgstr ""
 
 #. module: project
@@ -1071,14 +1071,14 @@ msgid "Blocked By"
 msgstr ""
 
 #. module: project
-#: model:ir.actions.act_window,name:project.project_sharing_project_task_action_blocking_tasks
-#: model_terms:ir.ui.view,arch_db:project.view_task_search_form_base
-msgid "Blocking"
+#: model_terms:ir.ui.view,arch_db:project.view_task_form2
+msgid "Blocked Tasks"
 msgstr ""
 
 #. module: project
-#: model_terms:ir.ui.view,arch_db:project.view_task_form2
-msgid "Blocking Tasks"
+#: model:ir.actions.act_window,name:project.project_sharing_project_task_action_blocking_tasks
+#: model_terms:ir.ui.view,arch_db:project.view_task_search_form_base
+msgid "Blocking"
 msgstr ""
 
 #. module: project

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -135,7 +135,7 @@
                         </button>
                         <button name="action_project_sharing_open_blocking" type="object" invisible="not dependent_tasks_count" class="oe_stat_button" icon="fa-tasks">
                             <div class="o_field_widget o_stat_info">
-                                <span class="o_stat_text">Blocking Tasks</span>
+                                <span class="o_stat_text">Blocked Tasks</span>
                                 <span class="o_stat_value ">
                                     <field name="dependent_tasks_count" widget="statinfo" nolabel="1" />
                                 </span>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -387,7 +387,7 @@
                             </div>
                         </button>
                         <button name="action_dependent_tasks" type="object" invisible="dependent_tasks_count == 0" class="oe_stat_button" icon="fa-check" groups="project.group_project_task_dependencies">
-                            <field name="dependent_tasks_count" widget="statinfo" string="Blocking Tasks" />
+                            <field name="dependent_tasks_count" widget="statinfo" string="Blocked Tasks" />
                         </button>
                         <!-- Dummy tag used to organize buttons -->
                         <span id="end_button_box" invisible="1"/>


### PR DESCRIPTION
Before:
The 'blocked by' stat button in the Project module incorrectly displays as 'Blocking Tasks'.

After:
The text of the 'blocked by' stat button has been updated from 'Blocking Tasks' to 'Blocked Tasks' in the Project module.

task-4119271