### PR TITLE
[FIX] account: resolve rounding inconsistency

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -2160,7 +2160,7 @@ class AccountTax(models.Model):
                 'formatted_tax_group_base_amount': formatLang(self.env, tax_detail['display_base_amount_currency'], currency_obj=currency),
                 'display_formatted_tax_group_base_amount': not all(x['amount_type'] == 'fixed' for x in tax_detail['group_tax_details']),
             })
-            encountered_base_amounts.add(tax_detail['display_base_amount_currency'])
+            encountered_base_amounts.add(currency.round(tax_detail['display_base_amount_currency']))
 
         # Compute amounts.
         subtotals = []

--- a/addons/account/tests/test_invoice_tax_totals.py
+++ b/addons/account/tests/test_invoice_tax_totals.py
@@ -1174,3 +1174,21 @@ class TestTaxTotals(AccountTestInvoicingCommon):
                 ],
                 'subtotals_order': ["Untaxed Amount"],
             })
+
+    def test_display_tax_base_rounding(self):
+        tax_19 = self.env['account.tax'].create({
+            'name': "tax_19",
+            'amount_type': 'percent',
+            'amount': 19.0,
+        })
+
+        self.company_data['company'].currency_id = self.currency_data['currency']
+        self.company_data['company'].tax_calculation_rounding_method = 'round_globally'
+        self.currency_data['currency'].rounding = 1.00
+        for amount in (23.0, 23.67):
+            document = self._create_document_for_tax_totals_test([
+                (amount, tax_19),
+            ])
+            document.currency_id = self.currency_data['currency']
+            document.invalidate_model(fnames=['tax_totals'])
+            self.assertFalse(document.tax_totals['display_tax_base'])


### PR DESCRIPTION
Steps to reproduce:
- Install 'Purchase'
- Create a new company with CLP currency.
- Select Chile fiscal localization in Settings.
- Make a new Request for Quotation
- Add any product set price to 23.67
- Add VAT of 19%
- Confirm the order
- Click on the Action button -> Print -> Purchase Order.

Issues:
On the downloaded pdf, the tax base is displayed as "VAT 19% on $24". It shouldn't be the case as we have a single VAT so no need to display this.

The reason for this appearing is because we have a rounding incosistency.

Here we apply `currency.round` on the amount.
https://github.com/odoo/odoo/blob/42fa237296f9b1fa556ae310b3273f863420e659/addons/account/models/account_tax.py#L2116

This is not the case here.
https://github.com/odoo/odoo/blob/42fa237296f9b1fa556ae310b3273f863420e659/addons/account/models/account_tax.py#L2163

Because of this we will have 2 amount in `encountered_base_amounts` whiche means that `'display_tax_base'` will be set to True. https://github.com/odoo/odoo/blob/42fa237296f9b1fa556ae310b3273f863420e659/addons/account/models/account_tax.py#L2188

opw-4039152