### PR TITLE
[FIX] stock: incorrect UoM for quantity in the past

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -177,8 +177,15 @@ class Product(models.Model):
             # Calculate the moves that were done before now to calculate back in time (as most questions will be recent ones)
             domain_move_in_done = [('state', '=', 'done'), ('date', '>', to_date)] + domain_move_in_done
             domain_move_out_done = [('state', '=', 'done'), ('date', '>', to_date)] + domain_move_out_done
-            moves_in_res_past = {product.id: product_qty for product, product_qty in Move._read_group(domain_move_in_done, ['product_id'], ['quantity:sum'])}
-            moves_out_res_past = {product.id: product_qty for product, product_qty in Move._read_group(domain_move_out_done, ['product_id'], ['quantity:sum'])}
+
+            groupby = ['product_id', 'product_uom']
+            moves_in_res_past = defaultdict(float)
+            for product, uom, quantity in Move._read_group(domain_move_in_done, groupby, ['quantity:sum']):
+                moves_in_res_past[product.id] += uom._compute_quantity(quantity, product.uom_id)
+
+            moves_out_res_past = defaultdict(float)
+            for product, uom, quantity in Move._read_group(domain_move_out_done, groupby, ['quantity:sum']):
+                moves_out_res_past[product.id] += uom._compute_quantity(quantity, product.uom_id)
 
         res = dict()
         for product in self.with_context(prefetch_fields=False):

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -2144,10 +2144,10 @@ class StockMove(TransactionCase):
         self.env["stock.quant"].create({
             "product_id": self.product.id,
             "location_id": self.stock_location.id,
-            "inventory_quantity": 3.0,
+            "inventory_quantity": 15.0,
         }).action_apply_inventory()
         product_in_past = self.product.with_context(to_date=fields.Date.add(fields.Date.today(), days=-7))
-        self.assertAlmostEqual(self.product.qty_available, 3.0)
+        self.assertAlmostEqual(self.product.qty_available, 15.0)
         self.assertAlmostEqual(product_in_past.qty_available, 0)
 
         # Make a move with a demand of 2, but confirms only 1
@@ -2171,7 +2171,24 @@ class StockMove(TransactionCase):
         self.assertAlmostEqual(move_partial.quantity, 1)
 
         # Check the quantity in the past is still 0
-        self.assertAlmostEqual(self.product.qty_available, 2.0)
+        self.assertAlmostEqual(self.product.qty_available, 14.0)
+        self.assertAlmostEqual(product_in_past.qty_available, 0)
+
+        # Make a move with another UoM
+        move = self.env["stock.move"].create({
+            "name": "test_move",
+            "location_id": self.stock_location.id,
+            "location_dest_id": self.customer_location.id,
+            "product_id": self.product.id,
+            "product_uom": self.uom_dozen.id,
+            "product_uom_qty": 1.0,
+        })
+        move._action_confirm()
+        move._action_assign()
+        move.picked = True
+        move._action_done()
+
+        self.assertAlmostEqual(self.product.qty_available, 2.0)  # 14 - a dozen
         self.assertAlmostEqual(product_in_past.qty_available, 0)
 
     def test_product_tree_views(self):


### PR DESCRIPTION
In commit https://github.com/odoo/odoo/commit/513dde64c736f1ff9141825b06c93666b67131db, we changed the field from `product_qty` to `quantity`, however, the latter use the move's UoM instead of the product's UoM.

With this commit, we convert the quantities to the product's UoM to ensure the correct quantity is used.
