### PR TITLE
[FIX] html_editor: collapse selection on replace image

### DIFF
--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -9,6 +9,7 @@ import { backgroundImageCssToParts, backgroundImagePartsToCss } from "@html_edit
 import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
 import { MediaDialog } from "./media_dialog/media_dialog";
+import { rightPos } from "@html_editor/utils/position";
 
 const MEDIA_SELECTOR = `${ICON_SELECTOR} , .o_image, .media_iframe_video`;
 
@@ -148,6 +149,10 @@ export class MediaPlugin extends Plugin {
         } else {
             this.shared.domInsert(element);
         }
+        // Collapse selection after the inserted/replaced element.
+        const [anchorNode, anchorOffset] = rightPos(element);
+        this.shared.setSelection({ anchorNode, anchorOffset });
+
         this.dispatch("ADD_STEP");
     }
 

--- a/addons/html_editor/static/tests/media.test.js
+++ b/addons/html_editor/static/tests/media.test.js
@@ -1,8 +1,10 @@
 import { expect, test } from "@odoo/hoot";
-import { click, waitFor } from "@odoo/hoot-dom";
+import { click, press, waitFor } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { setupEditor } from "./_helpers/editor";
 import { makeMockEnv, onRpc } from "@web/../tests/web_test_helpers";
+import { getContent } from "./_helpers/selection";
+import { insertText } from "./_helpers/user_actions";
 
 test("Can replace an image", async () => {
     onRpc("/web/dataset/call_kw/ir.attachment/search_read", () => {
@@ -29,4 +31,58 @@ test("Can replace an image", async () => {
     await animationFrame();
     expect("img[src='/web/static/img/logo.png']").toHaveCount(0);
     expect("img[src='/web/static/img/logo2.png']").toHaveCount(1);
+});
+
+test("Selection is collapsed after the image after replacing it", async () => {
+    onRpc("/web/dataset/call_kw/ir.attachment/search_read", () => {
+        return [
+            {
+                id: 1,
+                name: "logo",
+                mimetype: "image/png",
+                image_src: "/web/static/img/logo2.png",
+                access_token: false,
+                public: true,
+            },
+        ];
+    });
+    const env = await makeMockEnv();
+    const { el } = await setupEditor(
+        `<p>abc<img class="img-fluid" src="/web/static/img/logo.png">def</p>`,
+        { env }
+    );
+    click("img");
+    await waitFor(".o-we-toolbar");
+    expect("button[name='replace_image']").toHaveCount(1);
+    click("button[name='replace_image']");
+    await animationFrame();
+    click("img.o_we_attachment_highlight");
+    await animationFrame();
+    expect(getContent(el).replace(/<img.*?>/, "<img>")).toBe("<p>abc<img>[]def</p>");
+});
+
+test("Can insert an image, and selection should be collapsed after it", async () => {
+    onRpc("/web/dataset/call_kw/ir.attachment/search_read", () => {
+        return [
+            {
+                id: 1,
+                name: "logo",
+                mimetype: "image/png",
+                image_src: "/web/static/img/logo2.png",
+                access_token: false,
+                public: true,
+            },
+        ];
+    });
+    const env = await makeMockEnv();
+    const { editor, el } = await setupEditor("<p>a[]bc</p>", { env });
+    insertText(editor, "/image");
+    await animationFrame();
+    expect(".o-we-powerbox").toHaveCount(1);
+    press("Enter");
+    await animationFrame();
+    click("img.o_we_attachment_highlight");
+    await animationFrame();
+    expect("img[src='/web/static/img/logo2.png']").toHaveCount(1);
+    expect(getContent(el).replace(/<img.*?>/, "<img>")).toBe("<p>a<img>[]bc</p>");
 });


### PR DESCRIPTION
Steps:
- insert an image with /image
- click on the image
- click on the "Replace" button on the toolbar
- pick (or upload) a new image

Result: The toolbar is still opened after the image is replaced, even though the selection is apparently collapsed.

After this commit, when replacing an image in the HTML editor, the selection is collapsed after it. The same behavior is applied when inserting an image (for instance, via the powerbox). As a result, in case of replacing an image via the toolbar, the toolbar is closed after the replacement is done.

