### PR TITLE
[IMP] stock: print packaging label

### DIFF
--- a/addons/product/models/product_packaging.py
+++ b/addons/product/models/product_packaging.py
@@ -1,9 +1,7 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
-from odoo.osv import expression
 
 
 from odoo.tools import float_compare, float_round
@@ -26,6 +24,14 @@ class ProductPackaging(models.Model):
         ('positive_qty', 'CHECK(qty > 0)', 'Contained Quantity should be positive.'),
         ('barcode_uniq', 'unique(barcode)', 'A barcode can only be assigned to one packaging.'),
     ]
+
+    @api.depends('name', 'product_id')
+    def _compute_display_name(self):
+        for packaging in self:
+            if packaging.product_id:
+                packaging.display_name = f'{packaging.product_id.display_name} - {packaging.name}'
+            else:
+                packaging.display_name = packaging.name
 
     @api.constrains('barcode')
     def _check_barcode_uniqueness(self):

--- a/addons/product/report/product_label_report.py
+++ b/addons/product/report/product_label_report.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import defaultdict
@@ -34,23 +33,32 @@ def _prepare_data(env, docids, data):
         return {}
 
     total = 0
-    qty_by_product_in = data.get('quantity_by_product')
+    qty_by_product_in = data.get('quantity_by_product', [])
+    qty_by_packaging_in = data.get('quantity_by_packaging', [])
     # search for products all at once, ordered by name desc since popitem() used in xml to print the labels
     # is LIFO, which results in ordering by product name in the report
-    products = Product.search([('id', 'in', [int(p) for p in qty_by_product_in.keys()])], order='name desc')
-    quantity_by_product = defaultdict(list)
+    products = Product.search([('id', 'in', [int(p) for p in qty_by_product_in])], order='name desc')
+    quantity = defaultdict(list)
     for product in products:
         q = qty_by_product_in[str(product.id)]
-        quantity_by_product[product].append((product.barcode, q))
+        quantity[product].append(('product', product.barcode, q))
         total += q
     if data.get('custom_barcodes'):
-        # we expect custom barcodes format as: {product: [(barcode, qty_of_barcode)]}
+        # we expect custom barcodes format as: {product: [('product', barcode, qty_of_barcode)]}
         for product, barcodes_qtys in data.get('custom_barcodes').items():
-            quantity_by_product[Product.browse(int(product))] += (barcodes_qtys)
-            total += sum(qty for _, qty in barcodes_qtys)
+            quantity[Product.browse(int(product))] += (barcodes_qtys)
+            total += sum(qty for _type, _barcode, qty in barcodes_qtys)
+
+    if qty_by_packaging_in:
+        packaging_ids = [int(p) for p in qty_by_packaging_in]
+        packagings = env['product.packaging'].search([('id', 'in', packaging_ids)], order='name desc')
+        for packaging in packagings:
+            q = qty_by_packaging_in[str(packaging.id)]
+            quantity[packaging].append(('packaging', packaging.barcode, q))
+            total += q
 
     return {
-        'quantity': quantity_by_product,
+        'quantity': quantity,
         'page_numbers': (total - 1) // (layout_wizard.rows * layout_wizard.columns) + 1,
         'price_included': data.get('price_included'),
         'extra_html': layout_wizard.extra_html,

--- a/addons/product/report/product_product_templates.xml
+++ b/addons/product/report/product_product_templates.xml
@@ -1,14 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
     <data>
+        <!-- Template's parts -->
+        <template id="report_product_template_label_name">
+            <div class="o_label_name">
+                <strong t-if="packaging">
+                    <span t-field="packaging.product_id.display_name"/> - <span t-field="packaging.name"/>
+                </strong>
+                <strong t-else="" t-field="product.display_name"/>
+            </div>
+        </template>
+
+        <!-- Templates -->
         <template id="report_simple_label2x7">
             <t t-set="barcode_size" t-value="'width:33mm;height:14mm'"/>
             <t t-set="table_style" t-value="'width:97mm;height:37.1mm;' + table_style"/>
-            <td t-att-style="make_invisible and 'visibility:hidden;'" >
+            <td t-att-style="make_invisible and 'visibility:hidden;'">
                 <div class="o_label_full" t-att-style="table_style">
-                    <div class="o_label_name">
-                        <strong t-field="product.display_name"/>
-                    </div>
+                    <t t-call="product.report_product_template_label_name"/>
                     <div class="o_label_data">
                         <div class="text-center o_label_left_column">
                             <span class="text-nowrap" t-field="product.default_code"/>
@@ -17,11 +26,17 @@
                                 <span class="text-center" t-out="barcode"/>
                             </t>
                         </div>
-                        <div class="text-end" style="line-height:normal">
+                        <div class="text-end o_label_right_column" style="line-height:normal">
                             <div class="o_label_extra_data">
                                 <t t-out="extra_html"/>
                             </div>
-                            <strong class="o_label_price" t-out="pricelist._get_product_price(product, 1, pricelist.currency_id or product.currency_id)"
+                            <strong t-if="packaging" class="o_label_quantity">
+                                <span t-if="packaging.qty % 1 == 0" t-field="packaging.qty" t-options='{"widget": "integer"}'/>
+                                <span t-else="" t-field="packaging.qty"/>
+                                <span t-field="packaging.product_uom_id.name"/>
+                            </strong>
+                            <strong t-else="" class="o_label_price"
+                                    t-out="pricelist._get_product_price(product, 1, pricelist.currency_id or product.currency_id)"
                                     t-options="{'widget': 'monetary', 'display_currency': pricelist.currency_id or product.currency_id, 'label_price': True}"/>
                         </div>
                         <div class="o_label_clear"></div>
@@ -35,14 +50,18 @@
             <t t-set="table_style" t-value="'width:47mm;height:37.1mm;' + table_style"/>
             <td t-att-style="make_invisible and 'visibility:hidden;'" >
                 <div class="o_label_full" t-att-style="table_style">
-                    <div class="o_label_name">
-                        <strong t-field="product.display_name"/>
-                    </div>
+                    <t t-call="product.report_product_template_label_name"/>
                     <div class="text-end" style="padding-top:0;padding-bottom:0">
-                        <strong class="o_label_price_medium" t-out="pricelist._get_product_price(product, 1, pricelist.currency_id or product.currency_id)"
+                        <strong t-if="packaging" class="o_label_quantity">
+                            <span t-if="packaging.qty % 1 == 0" t-field="packaging.qty" t-options='{"widget": "integer"}'/>
+                            <span t-else="" t-field="packaging.qty"/>
+                            <span t-field="packaging.product_uom_id.name"/>
+                        </strong>
+                        <strong t-else="" class="o_label_price_medium"
+                                t-out="pricelist._get_product_price(product, 1, pricelist.currency_id or product.currency_id)"
                                 t-options="{'widget': 'monetary', 'display_currency': pricelist.currency_id or product.currency_id, 'label_price': True}"/>
                     </div>
-                    <div class= "text-center o_label_small_barcode">
+                    <div class="text-center o_label_small_barcode">
                         <span class="text-nowrap" t-field="product.default_code"/>
                         <t t-if="barcode">
                             <div t-out="barcode" style="padding:0" t-options="{'widget': 'barcode', 'symbology': 'auto', 'img_style': barcode_size}"/>
@@ -58,13 +77,16 @@
             <t t-set="table_style" t-value="'width:43mm;height:19mm;' + table_style"/>
             <td t-att-style="make_invisible and 'visibility:hidden;'" >
                 <div class="o_label_full o_label_small_text" t-att-style="table_style">
-                    <div class="o_label_name">
-                        <strong t-field="product.display_name"/>
-                    </div>
+                    <t t-call="product.report_product_template_label_name"/>
                     <div class="o_label_left_column">
                         <span class="text-nowrap" t-field="product.default_code"/>
                     </div>
-                    <div class="o_label_price_medium text-end">
+                    <div t-if="packaging" class="o_label_quantity text-end">
+                        <span t-if="packaging.qty % 1 == 0" t-field="packaging.qty" t-options='{"widget": "integer"}'/>
+                        <span t-else="" t-field="packaging.qty"/>
+                        <span t-field="packaging.product_uom_id.name"/>
+                    </div>
+                    <div t-else="" class="o_label_price_medium text-end">
                         <strong t-out="pricelist._get_product_price(product, 1, pricelist.currency_id or product.currency_id)"
                             t-options="{'widget': 'monetary', 'display_currency': pricelist.currency_id or product.currency_id, 'label_price': True}"/>
                     </div>
@@ -83,9 +105,7 @@
             <t t-set="table_style" t-value="'width:43mm;height:19mm;' + table_style"/>
             <td t-att-style="make_invisible and 'visibility:hidden;'" >
                 <div class="o_label_full o_label_small_text" t-att-style="table_style">
-                    <div class="o_label_name">
-                        <strong t-field="product.display_name"/>
-                    </div>
+                    <t t-call="product.report_product_template_label_name"/>
                     <div class="o_label_left_column o_label_full_with">
                         <span class="text-nowrap" t-field="product.default_code"/>
                     </div>
@@ -112,15 +132,25 @@
                         </t>
                     </div>
                     <div class="o_label_name" style="line-height: 100%;background-color: transparent;padding-top: 1px;">
-                        <span t-if="product.is_product_variant" t-field="product.display_name"/>
+                        <t t-if="packaging">
+                            <span t-field="packaging.product_id.name"/> - <span t-field="packaging.name"/>
+                        </t>
+                        <span t-elif="product.is_product_variant" t-field="product.display_name"/>
                         <span t-else="" t-field="product.name"/>
                     </div>
                     <div class="o_label_left_column">
                         <small class="text-nowrap" t-field="product.default_code"/>
                     </div>
-                    <div class="text-end" style="padding: 0 4px;">
+                    <div t-if="packaging" class="o_label_full" t-att-style="table_style">
+                        <strong class="text-end o_label_quantity_small" style="padding: 0 4px;">
+                            <span t-if="packaging.qty % 1 == 0" t-field="packaging.qty" t-options='{"widget": "integer"}'/>
+                            <span t-else="" t-field="packaging.qty"/>
+                            <span t-field="packaging.product_uom_id.name"/>
+                        </strong>
+                    </div>
+                    <div t-else="" class="text-end" style="padding: 0 4px;">
                         <strong class="o_label_price_small" t-out="pricelist._get_product_price(product, 1, pricelist.currency_id or product.currency_id)"
-                                t-options="{'widget': 'monetary', 'display_currency': pricelist.currency_id or product.currency_id, 'label_price': True}"/>
+                            t-options="{'widget': 'monetary', 'display_currency': pricelist.currency_id or product.currency_id, 'label_price': True}"/>
                     </div>
                 </div>
             </div>
@@ -149,10 +179,12 @@
                                         <t t-foreach="range(columns)" t-as="column">
                                             <t t-if="not current_quantity and quantity and not (current_data and current_data[1])">
                                                 <t t-set="current_data" t-value="quantity.popitem()"/>
-                                                <t t-set="product" t-value="current_data[0]"/>
                                                 <t t-set="barcode_and_qty" t-value="current_data[1].pop()"/>
-                                                <t t-set="barcode" t-value="barcode_and_qty[0]"/>
-                                                <t t-set="current_quantity" t-value="barcode_and_qty[1]"/>
+                                                <t t-set="type" t-value="barcode_and_qty[0]"/>
+                                                <t t-set="barcode" t-value="barcode_and_qty[1]"/>
+                                                <t t-set="packaging" t-value="current_data[0] if type == 'packaging' else False"/>
+                                                <t t-set="product" t-value="packaging.product_id if packaging else current_data[0]"/>
+                                                <t t-set="current_quantity" t-value="barcode_and_qty[2]"/>
                                             </t>
                                             <t t-if="current_quantity">
                                                 <t t-set="make_invisible" t-value="False"/>
@@ -160,8 +192,8 @@
                                             </t>
                                             <t t-elif="current_data and current_data[1]">
                                                 <t t-set="barcode_and_qty" t-value="current_data[1].pop()"/>
-                                                <t t-set="barcode" t-value="barcode_and_qty[0]"/>
-                                                <t t-set="current_quantity" t-value="barcode_and_qty[1] - 1"/>
+                                                <t t-set="barcode" t-value="barcode_and_qty[1]"/>
+                                                <t t-set="current_quantity" t-value="barcode_and_qty[2] - 1"/>
                                             </t>
                                             <t t-else="">
                                                 <t t-set="make_invisible" t-value="True"/>
@@ -198,10 +230,13 @@
                 <t t-set="table_style" t-value="'width:100%;height:32mm;'"/>
                 <t t-set="padding_page" t-value="'padding: 2mm'"/>
                 <t t-foreach="quantity.items()" t-as="barcode_and_qty_by_product">
-                    <t t-set="product" t-value="barcode_and_qty_by_product[0]"/>
+                    <t t-set="entity" t-value="barcode_and_qty_by_product[0]"/>
                     <t t-foreach="barcode_and_qty_by_product[1]" t-as="barcode_and_qty">
-                        <t t-set="barcode" t-value="barcode_and_qty[0]"/>
-                        <t t-foreach="range(barcode_and_qty[1])" t-as="qty">
+                        <t t-set="type" t-value="barcode_and_qty[0]"/>
+                        <t t-set="barcode" t-value="barcode_and_qty[1]"/>
+                        <t t-set="packaging" t-value="barcode_and_qty_by_product[0] if type == 'packaging' else False"/>
+                        <t t-set="product" t-value="packaging.product_id if packaging else barcode_and_qty_by_product[0]"/>
+                        <t t-foreach="range(barcode_and_qty[2])" t-as="qty">
                             <t t-call="product.report_simple_label_dymo"/>
                         </t>
                     </t>

--- a/addons/product/static/src/scss/report_label_sheet.scss
+++ b/addons/product/static/src/scss/report_label_sheet.scss
@@ -47,13 +47,13 @@
     strong.o_label_price {
         font-size: 2em;
     }
-    strong.o_label_price_medium {
+    strong.o_label_price_medium,.o_label_quantity {
         font-size: 1.3em;
         line-height: normal;
         padding: 0;
         padding-right: 2mm;
     }
-    strong.o_label_price_small {
+    strong.o_label_price_small,.o_label_quantity_small {
         font-size: 0.9em;
         padding: 0 4px;
         padding-right: 2mm;

--- a/addons/product/wizard/product_label_layout.py
+++ b/addons/product/wizard/product_label_layout.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
@@ -18,10 +16,13 @@ class ProductLabelLayout(models.TransientModel):
     custom_quantity = fields.Integer('Quantity', default=1, required=True)
     product_ids = fields.Many2many('product.product')
     product_tmpl_ids = fields.Many2many('product.template')
+    product_packaging_ids = fields.One2many('product.packaging', compute='_compute_product_packaging_ids')
+    packaging_id = fields.Many2one('product.packaging', string="", domain="[('id', 'in', product_packaging_ids)]")
     extra_html = fields.Html('Extra Content', default='')
     rows = fields.Integer(compute='_compute_dimensions')
     columns = fields.Integer(compute='_compute_dimensions')
     pricelist_id = fields.Many2one('product.pricelist', string="Pricelist")
+    hide_pricelist = fields.Boolean(compute='_compute_hide_pricelist')
 
     @api.depends('print_format')
     def _compute_dimensions(self):
@@ -33,42 +34,60 @@ class ProductLabelLayout(models.TransientModel):
             else:
                 wizard.columns, wizard.rows = 1, 1
 
-    def _prepare_report_data(self):
-        if self.custom_quantity <= 0:
-            raise UserError(_('You need to set a positive quantity.'))
+    @api.depends('packaging_id')
+    def _compute_hide_pricelist(self):
+        for wizard in self:
+            wizard.hide_pricelist = bool(wizard.packaging_id)
 
+    @api.depends('product_ids', 'product_tmpl_ids')
+    def _compute_product_packaging_ids(self):
+        for wizard in self:
+            wizard.product_packaging_ids = wizard.product_ids.packaging_ids | wizard.product_tmpl_ids.packaging_ids
+
+    def _get_report_template(self):
         # Get layout grid
+        xml_id = ''
         if self.print_format == 'dymo':
             xml_id = 'product.report_product_template_label_dymo'
         elif 'x' in self.print_format:
             xml_id = 'product.report_product_template_label_%sx%s' % (self.columns, self.rows)
             if 'xprice' not in self.print_format:
                 xml_id += '_noprice'
-        else:
-            xml_id = ''
+        return xml_id
 
-        active_model = ''
-        if self.product_tmpl_ids:
-            products = self.product_tmpl_ids.ids
-            active_model = 'product.template'
-        elif self.product_ids:
-            products = self.product_ids.ids
-            active_model = 'product.product'
-        else:
+    def _get_quantity_by_packaging(self):
+        if not self.packaging_id:
+            return {}
+        quantity_by_packaging = {self.packaging_id.id: self.custom_quantity}
+        return {'quantity_by_packaging': quantity_by_packaging}
+
+    def _get_quantity_by_product(self):
+        if self.packaging_id:
+            return {}
+        product_ids = self.product_tmpl_ids.ids if self.product_tmpl_ids else self.product_ids.ids
+        return {'quantity_by_product': dict.fromkeys(product_ids, self.custom_quantity)}
+
+    def _prepare_report_data(self):
+        if self.custom_quantity <= 0:
+            raise UserError(_('You need to set a positive quantity.'))
+        if not self.product_tmpl_ids and not self.product_ids:
             raise UserError(_("No product to print, if the product is archived please unarchive it before printing its label."))
 
         # Build data to pass to the report
+        active_model = 'product.template' if self.product_tmpl_ids else 'product.product'
         data = {
             'active_model': active_model,
-            'quantity_by_product': {p: self.custom_quantity for p in products},
             'layout_wizard': self.id,
             'price_included': 'xprice' in self.print_format,
+            **self._get_quantity_by_packaging(),
+            **self._get_quantity_by_product(),
         }
-        return xml_id, data
+        return data
 
     def process(self):
         self.ensure_one()
-        xml_id, data = self._prepare_report_data()
+        data = self._prepare_report_data()
+        xml_id = self._get_report_template()
         if not xml_id:
             raise UserError(_('Unable to find report template for %s format', self.print_format))
         report_action = self.env.ref(xml_id).report_action(None, data=data, config=False)

--- a/addons/product/wizard/product_label_layout_views.xml
+++ b/addons/product/wizard/product_label_layout_views.xml
@@ -11,10 +11,14 @@
                         <field name="product_ids" invisible="1"/>
                         <field name="product_tmpl_ids" invisible="1"/>
                         <field name="custom_quantity"/>
+                        <field name="packaging_id"
+                               groups="product.group_stock_packaging"
+                               invisible="not product_packaging_ids"
+                               options="{'no_create': 1, 'no_open': 1}"/>
                         <field name="print_format" widget="radio"/>
                     </group>
                     <group>
-                        <field name="pricelist_id" groups="product.group_product_pricelist"/>
+                        <field name="pricelist_id" invisible="hide_pricelist" groups="product.group_product_pricelist"/>
                         <field name="extra_html" invisible="print_format != '2x7xprice'"/>
                     </group>
                 </group>

--- a/addons/stock/report/product_label_report.py
+++ b/addons/stock/report/product_label_report.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import defaultdict
@@ -20,31 +19,46 @@ class ReportStockLabel_Product_Product_View(models.AbstractModel):
         else:
             raise UserError(_('Product model not defined, Please contact your administrator.'))
 
-        quantity_by_product = defaultdict(list)
-        for p, q in data.get('quantity_by_product').items():
+        quantity = defaultdict(list)
+        for p, q in data.get('quantity_by_product', {}).items():
             product = Product.browse(int(p))
             default_code_markup = markupsafe.Markup(product.default_code) if product.default_code else ''
             product_info = {
                 'barcode': markupsafe.Markup(product.barcode) if product.barcode else '',
                 'quantity': q,
                 'display_name_markup': markupsafe.Markup(product.display_name),
-                'default_code': (default_code_markup[:15], default_code_markup[15:30])
+                'default_code': (default_code_markup[:15], default_code_markup[15:30]),
+                'type': 'product'
             }
-            quantity_by_product[product].append(product_info)
+            quantity[product].append(product_info)
         if data.get('custom_barcodes'):
             # we expect custom barcodes to be: {product: [(barcode, qty_of_barcode)]}
             for product, barcodes_qtys in data.get('custom_barcodes').items():
                 product = Product.browse(int(product))
                 default_code_markup = markupsafe.Markup(product.default_code) if product.default_code else ''
-                for barcode_qty in barcodes_qtys:
-                    quantity_by_product[product].append({
-                        'barcode': markupsafe.Markup(barcode_qty[0]),
-                        'quantity': barcode_qty[1],
+                for (barcode, qty) in barcodes_qtys:
+                    quantity[product].append({
+                        'barcode': markupsafe.Markup(barcode),
+                        'quantity': qty,
                         'display_name_markup': markupsafe.Markup(product.display_name),
-                        'default_code': (default_code_markup[:15], default_code_markup[15:30])
-                    }
-                    )
-        data['quantity'] = quantity_by_product
+                        'default_code': (default_code_markup[:15], default_code_markup[15:30]),
+                        'type': 'product'
+                    })
+
+        if data.get('quantity_by_packaging'):
+            packaging_ids = [int(p) for p in data['quantity_by_packaging']]
+            packagings = self.env['product.packaging'].search([('id', 'in', packaging_ids)], order='name desc')
+            for packaging in packagings:
+                default_code_markup = markupsafe.Markup(packaging.product_id.default_code) if packaging.product_id.default_code else ''
+                quantity[packaging].append({
+                    'barcode': markupsafe.Markup(packaging.barcode) if packaging.barcode else '',
+                    'quantity': packaging.qty,
+                    'display_name_markup': markupsafe.Markup(packaging.display_name),
+                    'default_code': (default_code_markup[:15], default_code_markup[15:30]),
+                    'type': 'packaging'
+                })
+
+        data['quantity'] = quantity
         layout_wizard = self.env['product.label.layout'].browse(data.get('layout_wizard'))
         data['pricelist'] = layout_wizard.pricelist_id
 

--- a/addons/stock/report/product_templates.xml
+++ b/addons/stock/report/product_templates.xml
@@ -3,11 +3,18 @@
     <data>
         <template id="label_product_product_view">
 		<t t-foreach="quantity.items()" t-as="barcode_and_qty_by_product">
-                <t t-set="product" t-value="barcode_and_qty_by_product[0]"/>
+                <t t-set="entity" t-value="barcode_and_qty_by_product[0]"/>
                 <t t-foreach="barcode_and_qty_by_product[1]" t-as="product_info">
+                    <t t-set="type" t-value="product_info['type']"/>
+                    <t t-if="type == 'product'">
+                        <t t-set="product" t-value="entity"/>
+                    </t>
+                    <t t-elif="type == 'packaging'">
+                        <t t-set="product" t-value="entity.product_id"/>
+                    </t>
                     <t t-set="barcode" t-value="product_info['barcode']"/>
                     <t t-set="currency_id" t-value="pricelist.currency_id or product.currency_id"/>
-                    <t t-foreach="range(product_info['quantity'])" t-as="qty">
+                    <t t-foreach="range(int(product_info['quantity']))" t-as="qty">
                         <t t-translation="off">
 ^XA^CI28
 ^FT100,80^A0N,40,30^FD<t t-out="product_info['display_name_markup']"/>^FS
@@ -18,14 +25,18 @@
 <t t-else="">
 ^FT100,150^A0N,30,24^FD<t t-out="product_info['default_code'][0]"/>^FS
 </t>
-<t t-if="price_included">
+<t t-if="type == 'product' and price_included">
 ^FO600,100,1
-<t t-if="currency_id.position == 'after'">
+<t t-if="type == 'product' and currency_id.position == 'after'">
 ^A0N,66,48^FH^FD<t t-esc="pricelist._get_product_price(product, 1, currency_id)" t-options='{"widget": "float", "precision": 2}'/><t t-esc="currency_id.symbol"/>^FS
 </t>
-<t t-if="currency_id.position == 'before'">
+<t t-if="type == 'product' and currency_id.position == 'before'">
 ^A0N,66,48^FH^FD<t t-esc="currency_id.symbol"/><t t-esc="pricelist._get_product_price(product, 1, currency_id)" t-options='{"widget": "float", "precision": 2}'/>^FS
 </t>
+</t>
+<t t-if="type == 'packaging'">
+^FO600,100,1
+^A0N,66,48^FH^FD<t t-esc="entity.qty"/> <t t-esc="entity.product_uom_id.name"/>^FS
 </t>
 <t t-if="barcode">
 ^FO100,160^BY3

--- a/addons/stock/wizard/product_label_layout.py
+++ b/addons/stock/wizard/product_label_layout.py
@@ -1,8 +1,8 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import defaultdict
-from odoo import fields, models
+from math import floor
+from odoo import api, fields, models
 from odoo.tools import float_compare, float_is_zero
 
 
@@ -17,34 +17,87 @@ class ProductLabelLayout(models.TransientModel):
         ('zpl', 'ZPL Labels'),
         ('zplxprice', 'ZPL Labels with price')
     ], ondelete={'zpl': 'set default', 'zplxprice': 'set default'})
+    print_packaging_labels = fields.Boolean(
+        string="Packaging Label", help="Print only one label per complete packaging")
 
-    def _prepare_report_data(self):
-        xml_id, data = super()._prepare_report_data()
+    @api.depends('print_packaging_labels')
+    def _compute_hide_pricelist(self):
+        super()._compute_hide_pricelist()
+        for wizard in self:
+            wizard.hide_pricelist = wizard.hide_pricelist or wizard.print_packaging_labels
 
+    def _get_report_template(self):
         if 'zpl' in self.print_format:
-            xml_id = 'stock.label_product_product'
+            return 'stock.label_product_product'
+        return super()._get_report_template()
 
-        quantities = defaultdict(int)
+    def _get_quantity_by_packaging(self):
+        if not self.print_packaging_labels or not self.move_ids:
+            return super()._get_quantity_by_packaging()
+
+        moves_with_packaging = self.move_ids.filtered(lambda mv: mv.product_packaging_id)
+        quantity_by_product = defaultdict(int)
+        quantity_by_packaging = defaultdict(int)
+        for move in moves_with_packaging:
+            if self.move_quantity == 'custom':
+                quantity_by_packaging[move.product_packaging_id.id] += self.custom_quantity
+            elif move.product_packaging_qty:
+                interger_packaging_qty = floor(move.product_packaging_qty)
+                remaining_qty = move.quantity - (interger_packaging_qty * move.product_packaging_id.qty)
+                if interger_packaging_qty:
+                    # One packaging label by full packaging.
+                    quantity_by_packaging[move.product_packaging_id.id] += interger_packaging_qty
+                if remaining_qty:
+                    # One product label for each product in incomplete packaging.
+                    quantity_by_product[move.product_id.id] += remaining_qty
+        return {
+            'quantity_by_packaging': quantity_by_packaging,
+            'additional_quantity_by_product': quantity_by_product,
+        }
+
+    def _get_quantity_by_product(self):
+        if self.move_quantity != 'move':
+            return super()._get_quantity_by_product()
+
+        product_quantities = defaultdict(int)
+        moves_without_packaging = self.move_ids.filtered(lambda mv: not mv.product_packaging_id)
         uom_unit = self.env.ref('uom.product_uom_categ_unit', raise_if_not_found=False)
-        if self.move_quantity == 'move' and self.move_ids and all(float_is_zero(ml.quantity, precision_rounding=ml.product_uom_id.rounding) for ml in self.move_ids.move_line_ids):
-            for move in self.move_ids:
+        no_move_lines_done = all(float_is_zero(ml.quantity, precision_rounding=ml.product_uom_id.rounding) for ml in moves_without_packaging.move_line_ids)
+
+        if self.move_quantity == 'move' and moves_without_packaging and no_move_lines_done:
+            for move in moves_without_packaging:
                 if move.product_uom.category_id == uom_unit:
                     use_reserved = float_compare(move.quantity, 0, precision_rounding=move.product_uom.rounding) > 0
                     useable_qty = move.quantity if use_reserved else move.product_uom_qty
                     if not float_is_zero(useable_qty, precision_rounding=move.product_uom.rounding):
-                        quantities[move.product_id.id] += useable_qty
-            data['quantity_by_product'] = {p: int(q) for p, q in quantities.items()}
-        elif self.move_quantity == 'move' and self.move_ids.move_line_ids:
+                        product_quantities[move.product_id.id] += useable_qty
+            quantity_by_product = {p: int(q) for p, q in product_quantities.items()}
+            return {'quantity_by_product': quantity_by_product}
+        elif self.move_quantity == 'move' and moves_without_packaging.move_line_ids:
+            # Pass only products with some quantity done to the report
             custom_barcodes = defaultdict(list)
-            for line in self.move_ids.move_line_ids:
+            for line in moves_without_packaging.move_line_ids:
                 if line.product_uom_id.category_id == uom_unit:
                     if (line.lot_id or line.lot_name) and int(line.quantity):
-                        custom_barcodes[line.product_id.id].append((line.lot_id.name or line.lot_name, int(line.quantity)))
+                        custom_barcodes[line.product_id.id].append(('product', line.lot_id.name or line.lot_name, int(line.quantity)))
                         continue
-                    quantities[line.product_id.id] += line.quantity
+                    product_quantities[line.product_id.id] += line.quantity
                 else:
-                    quantities[line.product_id.id] = 1
-            # Pass only products with some quantity done to the report
-            data['quantity_by_product'] = {p: int(q) for p, q in quantities.items() if q}
-            data['custom_barcodes'] = custom_barcodes
-        return xml_id, data
+                    product_quantities[line.product_id.id] = 1
+            return {
+                'quantity_by_product': product_quantities,
+                'custom_barcodes': custom_barcodes,
+            }
+        return {}
+
+    def _prepare_report_data(self):
+        data = super()._prepare_report_data()
+        # Products in incomplete packagins are printed separately (incomplete
+        # packaging labels aren't printed.)
+        if data.get('additional_quantity_by_product'):
+            for product_id, qty in data['additional_quantity_by_product'].items():
+                if not data.get('quantity_by_product'):
+                    data['quantity_by_product'] = defaultdict(int)
+                data['quantity_by_product'][product_id] += qty
+            del data['additional_quantity_by_product']
+        return data

--- a/addons/stock/wizard/product_label_layout_views.xml
+++ b/addons/stock/wizard/product_label_layout_views.xml
@@ -13,6 +13,12 @@
             <xpath expr="//field[@name='custom_quantity']" position="attributes">
                 <attribute name="invisible">move_quantity == 'move'</attribute>
             </xpath>
+            <field name="pricelist_id" position="before">
+                <field name="print_packaging_labels" groups="product.group_stock_packaging"/>
+            </field>
+            <field name="packaging_id" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Before this commit, when labels for picking's moves are printed, they are generated for the move's product itself, even if a packaging is set on the move.

This commit adds the option to print the label for the product's packaging itself of the product itself. In such a case, the label contains following information:
- The product name and the packaging name;
- The packaging's barcode;
- The packaging's quantity.

Also, instead of printing a label by quantity, it will print only needed label. For example, for a delivery of 12 units of product A packaged into a packaging of 6 units, 2 labels for the packaging will be printed.

task-3959326