### PR TITLE
[FIX] web: prevent force focus in search bar when clicking out

### DIFF
--- a/addons/web/static/src/search/search_bar/search_bar.js
+++ b/addons/web/static/src/search/search_bar/search_bar.js
@@ -240,9 +240,11 @@ export class SearchBar extends Component {
         this.inputRef.el.focus();
     }
 
-    resetState() {
+    resetState(options = { focus: true }) {
         this.computeState({ expanded: [], focusedIndex: 0, query: "", subItems: [] });
-        this.inputRef.el.focus();
+        if (options.focus) {
+            this.inputRef.el.focus();
+        }
     }
 
     /**
@@ -443,7 +445,7 @@ export class SearchBar extends Component {
      */
     onWindowClick(ev) {
         if (this.items.length && !this.root.el.contains(ev.target)) {
-            this.resetState();
+            this.resetState({ focus: false });
         }
     }
 

--- a/addons/web/static/tests/search/search_bar_tests.js
+++ b/addons/web/static/tests/search/search_bar_tests.js
@@ -259,7 +259,7 @@ QUnit.module("Search", (hooks) => {
     });
 
     QUnit.test("autocomplete menu clickout interactions", async function (assert) {
-        assert.expect(9);
+        assert.expect(10);
 
         await makeWithSearch({
             serverData,
@@ -280,6 +280,10 @@ QUnit.module("Search", (hooks) => {
 
         const input = target.querySelector(".o_searchview input");
 
+        // Create an input outside of the search panel to simulate another input outside of the search panel
+        const outsideInput = document.createElement('input');
+        getFixture().appendChild(outsideInput);
+
         assert.containsNone(target, ".o_searchview_autocomplete");
 
         await editSearch(target, "Hello there");
@@ -297,10 +301,12 @@ QUnit.module("Search", (hooks) => {
         assert.strictEqual(input.value, "General Kenobi", "input value should be updated");
         assert.containsOnce(target, ".o_searchview_autocomplete");
 
-        await click(document.body);
+        outsideInput.focus();
+        await click(outsideInput);
 
         assert.strictEqual(input.value, "", "input value should be empty");
         assert.containsNone(target, ".o_searchview_autocomplete");
+        assert.strictEqual(document.activeElement, outsideInput);
     });
 
     QUnit.test("select an autocomplete field", async function (assert) {


### PR DESCRIPTION
In the accounting reconciliation tool:
- Click in one of the 2 search inputs
- Start typing
- Single click on the second search input
- Start typing
- Notice it still types in the first search input instead of the second.

The search input you choose first doesn't matter.
You can start with the upper one or the bottom one, the issue is the same, just reversed.

Before:
![before](https://github.com/user-attachments/assets/3f43c437-9937-452b-b0ab-029cacafbd7e)

After:
![after](https://github.com/user-attachments/assets/b3a02df7-5773-4d55-be6f-d01711d6c7cc)
