### PR TITLE
[FIX] product: enable favorite toggle on product page

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -49,7 +49,7 @@
                         <label for="name" string="Product Name"/>
                         <h1>
                             <div class="d-flex">
-                                <field name="is_favorite" widget="boolean_favorite" class="me-3" nolabel="1" readonly="1"/>
+                                <field name="is_favorite" widget="boolean_favorite" class="me-3" nolabel="1"/>
                                 <field class="text-break" name="name" options="{'line_breaks': False}" widget="text" placeholder="e.g. Cheese Burger"/>
                             </div>
                         </h1>


### PR DESCRIPTION
Problem:
The `is_favorite` field was set to read-only on the product page, preventing users from toggling the favorite status.

Steps to reproduce:

- Open any product page.
- Try to toggle the favorite status.

opw-4139344

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
