### PR TITLE
[FIX] website_sale_loyalty: only show `ecommerce_ok` programs in cart

### DIFF
--- a/addons/website_sale_loyalty/models/sale_order.py
+++ b/addons/website_sale_loyalty/models/sale_order.py
@@ -202,8 +202,7 @@ class SaleOrder(models.Model):
         res = self._get_claimable_rewards()
         loyality_cards = self.env['loyalty.card'].search([
             ('partner_id', '=', self.partner_id.id),
-            ('program_id.website_id', 'in', [False, self.website_id.id]),
-            ('program_id.company_id', 'in', [False, self.company_id.id]),
+            ('program_id', 'any', self._get_program_domain()),
             '|',
                 ('program_id.trigger', '=', 'with_code'),
                 '&', ('program_id.trigger', '=', 'auto'), ('program_id.applies_on', '=', 'future'),

--- a/addons/website_sale_loyalty/static/tests/tours/test_ewallet_tour.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_ewallet_tour.js
@@ -13,7 +13,16 @@ registry.category("web_tour.tours").add('shop_sale_ewallet', {
         ...tourUtils.addToCart({productName: "TEST - Small Drawer"}),
         tourUtils.goToCart(),
         {
-            trigger: 'a:contains("Pay with eWallet")'
+            trigger: 'a:contains("Pay with eWallet")',
+            extra_trigger: 'form[name="claim_reward"]',
+            run() {
+                const rewards = document.querySelectorAll('form[name="claim_reward"]');
+                if (rewards.length === 1) {
+                    this.$anchor.click();
+                } else {
+                    throw new TourError(`Expected 1 claimable reward, got: ${rewards.length}`);
+                }
+            },
         },
         tourUtils.goToCheckout(),
         tourUtils.pay(),

--- a/addons/website_sale_loyalty/tests/test_shop_sale_coupon.py
+++ b/addons/website_sale_loyalty/tests/test_shop_sale_coupon.py
@@ -217,7 +217,7 @@ class WebsiteSaleLoyaltyTestUi(TestSaleProductAttributeValueCommon, HttpCase):
         self.assertEqual(len(gift_card_program.coupon_ids), 2, 'There should be two coupons, one with points, one without')
         self.assertEqual(len(gift_card_program.coupon_ids.filtered('points')), 1, 'There should be two coupons, one with points, one without')
 
-    def test_02_admin_shop_ewallet_tour(self):
+    def test_03_admin_shop_ewallet_tour(self):
         public_category = self.env['product.public.category'].create({'name': 'Public Category'})
         self.env['product.product'].create({
             'name': 'TEST - Small Drawer',
@@ -230,23 +230,23 @@ class WebsiteSaleLoyaltyTestUi(TestSaleProductAttributeValueCommon, HttpCase):
         })
         # Disable any other program
         self.env['loyalty.program'].search([]).write({'active': False})
-        ewallet_program = self.env['loyalty.program'].create({
-            'name': 'ewallet - test',
+        ewallet_programs = self.env['loyalty.program'].create([{
+            'name': f"ewallet - test - {ecommerce_ok=}",
             'applies_on': 'future',
             'trigger': 'auto',
             'program_type': 'ewallet',
+            'ecommerce_ok': ecommerce_ok,
             'reward_ids': [Command.create({
                 'reward_type': 'discount',
                 'discount_mode': 'per_point',
                 'discount': 1,
             })],
-        })
-        ewallet_program.currency_id = self.env.ref('base.USD')
-        self.env['loyalty.card'].create({
+        } for ecommerce_ok in (True, False)])
+        self.env['loyalty.card'].create([{
             'partner_id': self.env.ref('base.partner_admin').id,
-            'program_id': ewallet_program.id,
+            'program_id': program_id,
             'points': 1000,
-        })
+        } for program_id in ewallet_programs.ids])
         self.start_tour('/', 'shop_sale_ewallet', login='admin')
 
 


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Create a loyalty program that applies on future orders;
2. disable it for eCommerce;
3. create a card for you with adequate points for a reward;
4. go to website shop;
5. add product to cart;
6. go to shopping cart view.

Issue
-----
Claimable reward is display despite being disabled for eCommerce.

Cause
-----
The `_get_claimable_and_showable_rewards` method doesn't take a program's `ecommerce_ok` field into account when searching for cards.

Solution
--------
In the domain used, use the result of `_get_program_domain` to ensure only applicable cards from applicable program's are retrieved.

opw-3997371