### PR TITLE
[FIX] point_of_sale: restore cash in/out list in session closing

### DIFF
--- a/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.js
+++ b/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.js
@@ -254,8 +254,4 @@ export class ClosePosPopup extends Component {
             this.pos.redirectToBackend();
         }
     }
-    getMovesTotalAmount() {
-        const amounts = this.props.default_cash_details.moves.map((move) => move.amount);
-        return amounts.reduce((acc, x) => acc + x, 0);
-    }
 }

--- a/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.xml
+++ b/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.xml
@@ -43,18 +43,15 @@
                                     <td>Opening</td>
                                     <td class="align-top" t-esc="env.utils.formatCurrency(props.default_cash_details.opening)"/>
                                 </tr>
-                                <t t-set="_totalAmount" t-value="getMovesTotalAmount()" />
-                                <t t-if="_totalAmount != 0">
-                                    <tr>
-                                        <td>
-                                            <div class="flex d-flex flex-row text-nowrap">
-                                                <div class="cash-sign me-1" t-esc="_totalAmount &lt; 0 ? '-' : '+'"/>
-                                                Total Moves
-                                            </div>
-                                        </td>
-                                        <td class="align-top" t-esc="env.utils.formatCurrency(Math.abs(_totalAmount))"/>
-                                    </tr>
-                                </t>
+                                <tr t-foreach="props.default_cash_details.moves" t-as="move" t-key="move_index">
+                                    <td>
+                                        <div class="flex d-flex flex-row text-nowrap">
+                                            <div class="cash-sign me-1" t-esc="move.amount lt 0 ? '-' : '+'"/>
+                                            <t t-esc="move.name"/>
+                                        </div>
+                                    </td>
+                                    <td class="align-top" t-esc="env.utils.formatCurrency(Math.abs(move.amount))"/>
+                                </tr>
                                 <tr t-if="props.default_cash_details.payment_amount">
                                     <td>
                                         <div class="flex d-flex flex-row text-nowrap">


### PR DESCRIPTION
This commit reverts the previous change where the detailed list of cash in/out transactions was removed from the session closing screen, leaving only the total amount. The total amount display will also be removed as it was not necessary according to the updated requirements.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
