### PR TITLE
[FIX] base_import_module: show imported modules at uninstall

### DIFF
--- a/addons/base_import_module/__init__.py
+++ b/addons/base_import_module/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import controllers
 from . import models
+from . import wizard

--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -88,6 +88,8 @@ class IrModule(models.Model):
         values = self.get_values_from_terp(terp)
         if 'version' in terp:
             values['latest_version'] = adapt_version(terp['version'])
+        if self.env.context.get('data_module'):
+            values['module_type'] = 'industries'
 
         unmet_dependencies = set(terp.get('depends', [])).difference(installed_mods)
 

--- a/addons/base_import_module/wizard/__init__.py
+++ b/addons/base_import_module/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import base_module_uninstall

--- a/addons/base_import_module/wizard/base_module_uninstall.py
+++ b/addons/base_import_module/wizard/base_module_uninstall.py
@@ -1,0 +1,10 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class BaseModuleUninstall(models.TransientModel):
+    _inherit = "base.module.uninstall"
+
+    def _modules_to_display(self, modules):
+        return super()._modules_to_display(modules) | modules.filtered('imported')

--- a/odoo/addons/base/wizard/base_module_uninstall.py
+++ b/odoo/addons/base/wizard/base_module_uninstall.py
@@ -27,7 +27,11 @@ class BaseModuleUninstall(models.TransientModel):
     def _compute_module_ids(self):
         for wizard in self:
             modules = wizard._get_modules().sorted(lambda m: (not m.application, m.sequence))
-            wizard.module_ids = modules if wizard.show_all else modules.filtered('application')
+            wizard.module_ids = modules if wizard.show_all else wizard._modules_to_display(modules)
+
+    @api.model
+    def _modules_to_display(self, modules):
+        return modules.filtered('application')
 
     def _get_models(self):
         """ Return the models (ir.model) to consider for the impact. """


### PR DESCRIPTION
When uninstalling a module, a wizard displays the dependent modules that will also be uninstalled if the user confirms. By default, only the applications are displayed. This commit adds the imported modules to the default list to prevent unforeseen issues.

Task-4144690
