### PR TITLE
[FIX] website: avoid blocking the carousel controls in translate mode

### DIFF
--- a/addons/website/static/src/js/content/snippets.animation.js
+++ b/addons/website/static/src/js/content/snippets.animation.js
@@ -455,7 +455,8 @@ registry.slider = publicWidget.Widget.extend({
 
         // Only for carousels having the `Carousel` and `CarouselItem` options
         // (i.e. matching the `section > .carousel` selector).
-        if (this.editableMode && this.el.matches("section > .carousel")) {
+        if (this.editableMode && this.el.matches("section > .carousel")
+                && !this.options.wysiwyg.options.enableTranslation) {
             this.controlEls = this.el.querySelectorAll(".carousel-control-prev, .carousel-control-next");
             const indicatorEls = this.el.querySelectorAll(".carousel-indicators > li");
             // Deactivate the carousel controls to handle the slides manually in
@@ -489,7 +490,8 @@ registry.slider = publicWidget.Widget.extend({
         $(window).off('.slider');
         this.$target.off('.slider'); // TODO remove in master
 
-        if (this.editableMode && this.el.matches("section > .carousel")) {
+        if (this.editableMode && this.el.matches("section > .carousel")
+                && !this.options.wysiwyg.options.enableTranslation) {
             // Restore the carousel controls.
             const indicatorEls = this.el.querySelectorAll(".carousel-indicators > li");
             this.options.wysiwyg.odooEditor.observerUnactive("restore_controls");


### PR DESCRIPTION
In commit [1], the carousel controls have been deactivated in edit mode, in order to control the carousel sliding manually so everything is done in the mutex. This was done to avoid asynchronous issues and to have a correct history when using the carousel options.

However, these controls are also blocked in translate mode, because it is considered as if it was in edit mode, which should not be the case. This made it impossible to translate the other slides, since we cannot slide the carousel anymore.

This commit fixes this by not deactivating the carousel controls if we are in translate mode.

Steps to reproduce:
- Install an other language.
- In edit mode, drop the "Carousel" or the "Quotes" snippet and save.
- Change the language of the website and translate it.
- Try to slide the carousel. 
=> It is impossible.

[1]: https://github.com/odoo/odoo/commit/93ec3ac285dc9ffd363e185a1dc238c6135d79dd

opw-4134824