### PR TITLE
[FIX] l10n_fr_invoice_addr: Correct print format for the Customer Address column

### DIFF
--- a/addons/l10n_fr_invoice_addr/views/report_invoice.xml
+++ b/addons/l10n_fr_invoice_addr/views/report_invoice.xml
@@ -20,7 +20,7 @@
         <xpath expr="//div[@id='informations']" position="inside">
             <t t-if="o.l10n_fr_is_company_french and o.partner_id.commercial_partner_id != o.partner_id and o.move_type.startswith('out_')">
                 <t t-set="partner" t-value="o.partner_id.commercial_partner_id"/>
-                <div class="col mb-2" name="customer_address">
+                <div t-attf-class="#{'col-auto col-3 mw-100' if report_type != 'html' else 'col'} mb-2" name="customer_address">
                     <strong>Customer Address:</strong>
                     <br/>
                     <address t-field="partner.self" class="m-0" t-options="{'widget': 'contact', 'fields': ['address'], 'no_marker': True}"/>


### PR DESCRIPTION
Version: 17.0+

Issue:
When the Customer Address column is included in the report pdf, the table format breaks. This column is added when the `partner_id.commercial_partner_id` is different than the `partner_id` of the invoice or invoice refund.

Purpose of this PR:
To restore the format of the information table when the Customer Address column is included. 
Similar to #176209

Steps to Reproduce on Runbot:
1) Install l10n_fr and switch to FR Company
2) Configure contacts a French company to have a child contact with a different address. 
3) Create invoice with the child contact as the customer. 
4) Print invoice and the informations table will be formatted incorrectly.

opw-4122930
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
