### PR TITLE
  [FIX] mrp: correctly match replenishments in overview 

### DIFF
--- a/addons/mrp/tests/test_stock_report.py
+++ b/addons/mrp/tests/test_stock_report.py
@@ -395,3 +395,66 @@ class TestMrpStockReports(TestReportsCommon):
         with Form(mo) as mo_form:
             mo_form.qty_producing = 2.0
         self.assertEqual(mo.components_availability, 'Available')
+
+    def test_mo_overview_same_component(self):
+        """
+        Test that for an mo for a product which has 2+ component lines for the same product,
+        if there is some quantity of the component reserved, we properly match replenishments with
+        components lines
+        """
+        # BOM structure:
+        # 'finished', manufactured:
+        #    - 1 'part'
+        #    - 1 'part'
+        part, finished = self.env['product.product'].create([
+            {
+                'name': name,
+                'type': 'product',
+            } for name in ['Part', 'Finished']
+        ])
+        self.env['mrp.bom'].create([
+            {
+                'product_id': finished.id,
+                'product_tmpl_id': finished.product_tmpl_id.id,
+                'product_qty': 1.0,
+                'type': 'normal',
+                'bom_line_ids': [
+                    Command.create({'product_id': part.id, 'product_qty': 1.0})
+                ] * 2,
+            }
+        ])
+        # Put 2 parts in stock
+        self.env['stock.quant']._update_available_quantity(part, self.stock_location, 2)
+
+        # Receive 20 parts
+        self.env['stock.picking'].create({
+            'picking_type_id': self.picking_type_in.id,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'move_type': 'one',
+            'move_ids_without_package': [Command.create({
+                    'name': 'test_out_1',
+                    'product_id': part.id,
+                    'product_uom_qty': 20,
+                    'location_id': self.env.ref('stock.stock_location_suppliers').id,
+                    'location_dest_id': self.stock_location.id,
+                }),
+            ],
+        }).action_confirm()
+
+        # Create an MO for 5 finished product
+        mo = self.env['mrp.production'].create({
+            'name': 'MO',
+            'product_qty': 5.0,
+            'product_id': finished.id,
+        })
+        mo.action_confirm()
+
+        # Test overview report values
+        overview_values = self.env['report.mrp.report_mo_overview'].get_report_values(mo.id)
+        [line0, line1] = overview_values['data']['components']
+        [repl0, repl1] = line0['replenishments'], line1['replenishments']
+        self.assertEqual(len(repl0), 1)
+        self.assertEqual(len(repl1), 1)
+        self.assertEqual(repl0[0]['summary']['quantity'], 3)
+        self.assertEqual(repl1[0]['summary']['quantity'], 5)


### PR DESCRIPTION
Steps
---
* install `mrp`, `purchase`
* create the following products:
    * P, storable, route = manucfature, bom:
            * C storable (qty = 1)
            * K storable, (qty = 1) kit bom:
                * C (qty = 1)
* set the quantiy on hand for C to 1
* create a purchase order for 20 C
* create an MO for 5 P > *Confirm*
* in the overview we have 2 component line (each for C), but the 2nd
  line's status is *To Order* even though we already have a PO.
  if we look at the details of the first line, we can see the replenishment
  for the second line was wrongly assigned to the first.

Cause
---
When matching replenishments to bom line moves, we check if quantity
from the replenishments is enough for the move, if so we go on to the
next move. But when we do this we do not account for pre-reserved
quantity of partially available moves.

opw-4128775