### PR TITLE
[FIX] html_editor: keep wysiwyg in collab

### DIFF
--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -1,7 +1,8 @@
+import { stripHistoryIds } from "@html_editor/others/collaboration/collaboration_odoo_plugin";
 import {
     COLLABORATION_PLUGINS,
-    MAIN_PLUGINS,
     DYNAMIC_PLACEHOLDER_PLUGINS,
+    MAIN_PLUGINS,
 } from "@html_editor/plugin_sets";
 import { Wysiwyg } from "@html_editor/wysiwyg";
 import { Component, status, useRef, useState } from "@odoo/owl";
@@ -12,8 +13,8 @@ import { Mutex } from "@web/core/utils/concurrency";
 import { useBus, useService } from "@web/core/utils/hooks";
 import { useRecordObserver } from "@web/model/relational_model/utils";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
-import { HtmlViewer } from "./html_viewer";
 import { TranslationButton } from "@web/views/fields/translation_button";
+import { HtmlViewer } from "./html_viewer";
 
 /**
  * Check whether the current value contains nodes that would break
@@ -73,15 +74,19 @@ export class HtmlField extends Component {
                 this.props.record.data[this.props.name]
             ),
         });
-        this.lastValue = this.props.record.data[this.props.name].toString();
+
         useRecordObserver((record) => {
             // Reset Wysiwyg when we discard or onchange value
-            if (!this.isDirty && this.lastValue !== record.data[this.props.name].toString()) {
-                this.state.key++;
-                this.state.containsComplexHTML = computeContainsComplexHTML(
-                    record.data[this.props.name]
-                );
-                this.lastValue = record.data[this.props.name].toString();
+            const newValue = record.data[this.props.name];
+            if (!this.isDirty) {
+                const value = this.clearValueToCompare(newValue.toString());
+                if (this.lastValue !== value) {
+                    this.state.key++;
+                    this.state.containsComplexHTML = computeContainsComplexHTML(
+                        record.data[this.props.name]
+                    );
+                    this.lastValue = value;
+                }
             }
         });
         useRecordObserver((record) => {
@@ -113,8 +118,15 @@ export class HtmlField extends Component {
         return this.props.record.fields[this.props.name].translate;
     }
 
+    clearValueToCompare(value) {
+        if (this.props.isCollaborative) {
+            value = stripHistoryIds(value);
+        }
+        return value;
+    }
+
     async updateValue(value) {
-        this.lastValue = value;
+        this.lastValue = this.clearValueToCompare(value);
         this.isDirty = false;
         await this.props.record.update({ [this.props.name]: this.lastValue }).catch(() => {
             this.isDirty = true;

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -1,6 +1,8 @@
 import { HtmlField } from "@html_editor/fields/html_field";
 import { MediaDialog } from "@html_editor/main/media/media_dialog/media_dialog";
+import { stripHistoryIds } from "@html_editor/others/collaboration/collaboration_odoo_plugin";
 import { parseHTML } from "@html_editor/utils/html";
+import { Wysiwyg } from "@html_editor/wysiwyg";
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import {
     click,
@@ -13,6 +15,7 @@ import {
 } from "@odoo/hoot-dom";
 import { Deferred, animationFrame, mockSendBeacon, tick } from "@odoo/hoot-mock";
 import {
+    clickSave,
     contains,
     defineModels,
     defineParams,
@@ -1059,6 +1062,49 @@ test("edit and enable/disable codeview with editor toolbar", async () => {
     // Switch to editor
     await contains(".o_codeview_btn").click();
     expect("[name='txt'] .odoo-editor-editable").toHaveInnerHTML("<p> Yop </p>");
+});
+
+test("edit and save a html field in collaborative should keep the same wysiwyg", async () => {
+    patchWithCleanup(Wysiwyg.prototype, {
+        setup() {
+            super.setup();
+            expect.step("Setup Wysiwyg");
+        },
+    });
+
+    onRpc("partner", "web_save", ({ args }) => {
+        const txt = args[1].txt;
+        expect(stripHistoryIds(txt)).toBe("<p>Hello first</p>");
+        expect.step("web_save");
+        args[1].txt = txt.replace(
+            /\sdata-last-history-steps="[^"]*?"/,
+            ' data-last-history-steps="12345"'
+        );
+    });
+    onRpc("/html_editor/get_ice_servers", () => {
+        return [];
+    });
+    onRpc("/html_editor/bus_broadcast", (params) => {
+        return { id: 10 };
+    });
+
+    await mountView({
+        type: "form",
+        resId: 1,
+        resModel: "partner",
+        arch: `
+            <form>
+                <field name="txt" widget="html" options="{'collaborative': true}"/>
+            </form>`,
+    });
+
+    setSelectionInHtmlField();
+    insertText(htmlEditor, "Hello ");
+    expect("[name='txt'] .odoo-editor-editable").toHaveInnerHTML("<p>Hello first </p>");
+    expect.verifySteps(["Setup Wysiwyg"]);
+
+    await clickSave();
+    expect.verifySteps(["web_save"]);
 });
 
 describe("sandbox", () => {


### PR DESCRIPTION
Before to this commit, editing an html field in collaborative mode and then saving it caused a rebuild of the Wysiwyg and therefore the creation of a new editor. This causes a restart of the collaborative plugin, which can cause various bugs.

Reason:
======
The html field rebuilds the wysiwyg when a new value is received (change of record or onchange). In collaborative, the attribute ‘data-last-history-steps’ is added, which represents the id of the list of known steps. When you save, the value returned no longer contains the list of ids, just the last one. The value is therefore considered to be different by the html field. This causes a wysiwyg rebuild.

Solution:
========
Add ‘clearValueToCompare’ whose purpose is to clean up the value by removing information that must be ignored to detect a change or not. In our case, we ignore ‘data-last-history-steps’.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
