### PR TITLE
[FIX] l10n_cl: Remove the additional tax totals table

### DIFF
--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -104,10 +104,6 @@
                 <span t-out="o.invoice_date_due" t-options='{"widget": "date"}'/>
                 <br/>
 
-                <strong>Payment Terms:</strong>
-                <span t-out="o.invoice_payment_term_id.name or ''"/>
-
-
                 <t t-if="o.invoice_incoterm_id">
                     <br/>
                     <strong>Incoterm:</strong>
@@ -213,6 +209,10 @@
                 <div name="transferable-legend" class="col-6 text-end"/>
             </div>
         </xpath>
+
+        <!-- Disable the recap of tax totals in company currency at the bottom right of the invoice
+        to prevent duplicate info since it's already present in our custom tax totals-->
+        <xpath expr="//div[@id='right-elements']/t[@t-call='account.document_tax_totals_company_currency_template']" position="replace"/>
 
         <xpath expr="//span[@t-field='line.name']" position="replace">
             <t t-set="all_taxes" t-value="'all_taxes'"/>


### PR DESCRIPTION
Versions: 
17.0, saas-17.1, saas-17.2

Issue:
The tax totals company currency table displays repetitive information.

Purpose of this PR:
To remove the repetitive tax totals table.

Steps to Reproduce:
- Install l10n_cl_edi
- Set up a currency rate for any active foreign currency (different from CLP) (Using USD for the example)
- Create an invoice using a foreign currency (USD in the example)

opw-4127839
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
