### PR TITLE
[FIX] web: Command (macos) + left click on a href opens a new tab

### DIFF
--- a/addons/web/static/src/webclient/webclient.js
+++ b/addons/web/static/src/webclient/webclient.js
@@ -106,7 +106,7 @@ export class WebClient extends Component {
         // we let the browser do the default behavior and
         // we do not want any other listener to execute.
         if (
-            ev.ctrlKey &&
+            (ev.ctrlKey || ev.metaKey) &&
             ((ev.target instanceof HTMLAnchorElement && ev.target.href) ||
                 (ev.target instanceof HTMLElement && ev.target.closest("a[href]:not([href=''])")))
         ) {


### PR DESCRIPTION
On linux and Windows, CTRL + left clic on links,
e.g. a customer on an invoice
opens a new tab.

This browser behavior is similar with regular links using Command + Left clic on MacOS.

It wasn't working for many2one links in Odoo because the clic was captured and prevented the browser default behavior. It was not captured only for the `ctrlKey` currently.

This revision adds the `metaKey` in addition to the `ctrlKey` to the non-capture condition.

There are similar conditions a bit everywhere in the code:
- https://github.com/odoo/odoo/blob/9beccc94ba6c140d6e1eb43c34d811c424f5ea2c/addons/barcodes/static/src/js/barcode_events.js#L170-L171
- https://github.com/odoo/odoo/blob/9beccc94ba6c140d6e1eb43c34d811c424f5ea2c/addons/mail/static/src/models/user_setting/user_setting.js#L163
- https://github.com/odoo/odoo/blob/9beccc94ba6c140d6e1eb43c34d811c424f5ea2c/addons/web/static/src/core/hotkeys/hotkey_service.js#L250
- https://github.com/odoo/odoo/blob/9beccc94ba6c140d6e1eb43c34d811c424f5ea2c/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js#L1705-L1710
- https://github.com/odoo/odoo/blob/9beccc94ba6c140d6e1eb43c34d811c424f5ea2c/addons/website_slides/static/src/js/slides_embed.js#L178
- https://github.com/odoo/enterprise/blob/6dc662dfca8e1d277df19aa377bcdc761f7e7bf3/documents/static/src/js/documents_controller_mixin.js#L975
- https://github.com/odoo/enterprise/blob/6dc662dfca8e1d277df19aa377bcdc761f7e7bf3/documents_spreadsheet/static/src/js/o_spreadsheet/o_spreadsheet.js#L31440
- https://github.com/odoo/enterprise/blob/6dc662dfca8e1d277df19aa377bcdc761f7e7bf3/timesheet_grid/static/src/js/timesheet_grid/timesheet_timer_grid_renderer.js#L301
- https://github.com/odoo/enterprise/blob/6dc662dfca8e1d277df19aa377bcdc761f7e7bf3/web_enterprise/static/src/webclient/home_menu/home_menu.js#L434
- https://github.com/odoo/enterprise/blob/6dc662dfca8e1d277df19aa377bcdc761f7e7bf3/web_gantt/static/src/js/gantt_renderer.js#L163
- https://github.com/odoo/enterprise/blob/6dc662dfca8e1d277df19aa377bcdc761f7e7bf3/web_gantt/static/src/js/gantt_row.js#L159

Unfortunately, given the nature of this behavior (requires a Command keystroke + check that a new tab is opened), it cannot really be tested in a unit test, not even a web tour.
