### PR TITLE
[FIX] mail: properly sync activities between tabs (user avatar)

### DIFF
--- a/addons/mail/static/src/model/record.js
+++ b/addons/mail/static/src/model/record.js
@@ -14,6 +14,7 @@ import {
     isRelation,
     modelRegistry,
 } from "./misc";
+import { serializeDate, serializeDateTime } from "@web/core/l10n/dates";
 
 /** @typedef {import("./misc").FieldDefinition} FieldDefinition */
 /** @typedef {import("./misc").RecordField} RecordField */
@@ -433,9 +434,17 @@ export class Record {
                 });
             } else if (isOne(Model, name)) {
                 const otherRecord = toRaw(record._proxyInternal[name])?._raw;
-                data[name] = otherRecord?.toIdData.call(record._proxyInternal);
+                data[name] = otherRecord?.toIdData.call(otherRecord._proxyInternal);
             } else {
-                data[name] = recordProxy[name]; // Record.attr()
+                // Record.attr()
+                const value = recordProxy[name];
+                if (Model._.fieldsType.get(name) === "datetime" && value) {
+                    data[name] = serializeDateTime(value);
+                } else if (Model._.fieldsType.get(name) === "date" && value) {
+                    data[name] = serializeDate(value);
+                } else {
+                    data[name] = value;
+                }
             }
         }
         delete data._;

--- a/addons/mail/static/tests/core/record.test.js
+++ b/addons/mail/static/tests/core/record.test.js
@@ -11,6 +11,7 @@ import { mockService } from "@web/../tests/web_test_helpers";
 import { Record, Store, makeStore } from "@mail/core/common/record";
 import { Markup } from "@mail/model/misc";
 import { registry } from "@web/core/registry";
+import { serializeDateTime } from "@web/core/l10n/dates";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -808,28 +809,43 @@ test("record.toData() is JSON stringified and can be reinserted as record", asyn
         static id = "id";
         id;
         names = Record.attr([]);
+        due_datetime = Record.attr(undefined, { type: "datetime" });
         messages = Record.many("Message");
+        team = Record.one("Team");
     }).register(localRegistry);
     (class Message extends Record {
         static id = "body";
         body = Record.attr("");
     }).register(localRegistry);
+    (class Team extends Record {
+        static id = "name";
+        name;
+    }).register(localRegistry);
     const store = await start();
     const p = store.Person.insert({
         id: 1,
+        due_datetime: "2024-08-28 10:19:44",
         names: ["John", "Marc"],
         messages: [{ body: "1" }, { body: "2" }],
+        team: "Discuss",
     });
     expect(p.names).toEqual(["John", "Marc"]);
     expect(p.messages.map((msg) => msg.body)).toEqual(["1", "2"]);
+    expect(p.team.name).toEqual("Discuss");
     expect(toRaw(store.Person.records[p.localId])).toBe(toRaw(p));
+    expect(serializeDateTime(p.due_datetime)).toBe("2024-08-28 10:19:44");
     // export data, delete, then insert back
     const data = JSON.parse(JSON.stringify(p.toData()));
     p.delete();
+    store.Message.get("1").delete();
+    store.Message.get("2").delete();
+    store.Team.get("Discuss").delete();
     expect(toRaw(store.Person.records[p.localId])).toBe(undefined);
     const p2 = store.Person.insert(data);
     // Same assertions as before
     expect(p2.names).toEqual(["John", "Marc"]);
     expect(p2.messages.map((msg) => msg.body)).toEqual(["1", "2"]);
+    expect(p2.team.name).toEqual("Discuss");
     expect(toRaw(store.Person.records[p2.localId])).toBe(toRaw(p2));
+    expect(serializeDateTime(p2.due_datetime)).toBe("2024-08-28 10:19:44");
 });


### PR DESCRIPTION
Before this commit, when opening a form view of record containing an activity on 2 different tabs, one of tab showed the user avatar while the other doesn't.

Steps to reproduce:
- open Contact form view
- schedule an activity
- open this form view on another tab => the new tab has user avatar on activity while previous tab
   doesn't

This happens because the state of activities is shared between tabs, and the newer tab shares its state to other tabs. However, activity state was not properly passing relational field values notably for the author: instead of passing `type` and `id` identifying values, it only passes `id`. This comes from a typo in code where the `toIdData()` was used on current model (Activity) rather than the target model (Persona), thus only persona id was retrieved.

This commit fixes the issue by properly using `toIdData` on target model of relational field.

Also the date and datetime fields were not properly serialized, which also result in breaking the datetime in other tabs. This commit also fixes this issue.

Task-4143781

Before / After
<img width="300" alt="Screenshot 2024-08-28 at 17 10 25" src="https://github.com/user-attachments/assets/e4422b69-8800-4dc3-ba16-515ea6b7392d"> <img width="369" alt="Screenshot 2024-08-28 at 17 10 30" src="https://github.com/user-attachments/assets/4d5783bd-2935-4630-8ea1-d94264b739bf">
