### PR TITLE
[FIX] web_editor: use user_id as fallback for signature callback read

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -2447,7 +2447,7 @@ export class Wysiwyg extends Component {
                 callback: async () => {
                     const [user] = await this.orm.read(
                         'res.users',
-                        [session.user_id],
+                        [session.uid || session.user_id],
                         ['signature'],
                     );
                     if (user && user.signature) {


### PR DESCRIPTION
A change was made in https://github.com/odoo/odoo/pull/175573 that used the session.user_id in favor of the uid in order to fix the signature powerbox option on the forum module. However, this caused a regression in every other module that has the user id saved in session.uid. Adding back session.uid and instead using session.user_id should fix this issue across every module.

opw-414079
