### PR TITLE
[FIX] l10n_in_withholding: load taxes for company only in post_init_hook

### DIFF
--- a/addons/l10n_in_withholding/__init__.py
+++ b/addons/l10n_in_withholding/__init__.py
@@ -17,7 +17,7 @@ def _l10n_in_withholding_post_init(env):
             'account.tax',
         ]
     }
-    for company in env['res.company'].search([('chart_template', '=', 'in')]):
+    for company in env['res.company'].search([('chart_template', '=', 'in'), ('parent_id', '=', False)]):
         _logger.info("Company %s already has the Indian localization installed, updating...", company.name)
         ChartTemplate = env['account.chart.template'].with_company(company)
         try:
@@ -28,5 +28,6 @@ def _l10n_in_withholding_post_init(env):
         except ValidationError as e:
             _logger.warning("Error while updating Chart of Accounts for company %s: %s", company.name, e.args[0])
         tds_group_id = env.ref(f'account.{company.id}_tds_group', raise_if_not_found=False)
-        tds_purchase_taxes = env['account.tax'].with_context(active_test=False).search([('tax_group_id', '=', tds_group_id.id), ('type_tax_use', '=', 'purchase')])
-        tds_purchase_taxes.write({'l10n_in_tds_tax_type': 'purchase', 'type_tax_use': 'none'})
+        if tds_group_id:
+            tds_purchase_taxes = env['account.tax'].with_context(active_test=False).search([('tax_group_id', '=', tds_group_id.id), ('type_tax_use', '=', 'purchase')])
+            tds_purchase_taxes.write({'l10n_in_tds_tax_type': 'purchase', 'type_tax_use': 'none'})


### PR DESCRIPTION
- Install `l10n_in`
- create a branch for the Indian company
- install `l10n_in_withholding`
- traceback

If there an Indian company has a branch, installing `l10n_in_withholding` raises an RPC error on the branch company, because the TDS group is not set on it. Since branches use the COA of the parent company, we don't need to load further.

Task [link](https://www.odoo.com/odoo/project/967/tasks/4143223)
task-4143223