### PR TITLE
[FIX] website_sale: show multi option values in mobile view

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1539,7 +1539,7 @@
                             <h6 t-field="line.name_short" class="d-inline align-top h6 fw-bold"/>
                         </t>
                         <t t-call="website_sale.cart_line_description_following_lines">
-                            <t t-set="div_class" t-valuef="d-none d-md-block"/>
+                            <t t-set="div_class" t-value="''"/>
                         </t>
                         <div>
                             <a href='#'


### PR DESCRIPTION
Steps to reproduce:
-go to shop
-choose product which has multi option attribute
-tick atleast one attribute
-add to cart

Issue:
-multi option values are not visible in cart description in mobile view.

Cause:
-the issue caused due to use of d-none and d-md-block classes, due to this it
 will not show in small size devices.

Fix:
-replace d-none and d-md-block with empty string, so now the values will show for all
 devices.

opw-3853263

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
