### PR TITLE
[IMP] mail,im_livechat: shorten access of channel settings

### DIFF
--- a/addons/im_livechat/static/tests/channel_join_leave.test.js
+++ b/addons/im_livechat/static/tests/channel_join_leave.test.js
@@ -42,9 +42,11 @@ test("from the discuss app", async () => {
     await click("[title='Join HR']", {
         parent: [".o-mail-DiscussSidebarCategory-livechat", { text: "HR" }],
     });
-    await click("[title='Unpin Conversation']", {
+    await click("[title='Channel settings']", {
         parent: [".o-mail-DiscussSidebarChannel", { text: "Visitor" }],
     });
+    await contains(".o-mail-DiscussSidebar-commandsPopover");
+    await click("[title='Unpin Conversation']");
     await click("[title='Leave HR']", {
         parent: [".o-mail-DiscussSidebarCategory-livechat", { text: "HR" }],
     });

--- a/addons/im_livechat/static/tests/sidebar_patch.test.js
+++ b/addons/im_livechat/static/tests/sidebar_patch.test.js
@@ -329,7 +329,11 @@ test("Clicking on unpin button unpins the channel", async () => {
     });
     await start();
     await openDiscuss();
-    await click(".o-mail-DiscussSidebarChannel [title='Unpin Conversation']");
+    await click("[title='Channel settings']", {
+        parent: [".o-mail-DiscussSidebarChannel"],
+    });
+    await contains(".o-mail-DiscussSidebar-commandsPopover");
+    await click("[title='Unpin Conversation']");
     await contains(".o_notification", { text: "You unpinned your conversation with Visitor 11" });
 });
 
@@ -393,9 +397,11 @@ test("unknown livechat can be displayed and interacted with", async () => {
     await waitNotifications([env, "discuss.channel/new_message"]);
     await click("button", { text: "Inbox" });
     await contains(".o-mail-DiscussSidebarChannel:not(.o-active)", { text: "Jane" });
-    await click("[title='Unpin Conversation']", {
+    await click("[title='Channel settings']", {
         parent: [".o-mail-DiscussSidebarChannel", { text: "Jane" }],
     });
+    await contains(".o-mail-DiscussSidebar-commandsPopover");
+    await click("[title='Unpin Conversation']");
     await contains(".o-mail-DiscussSidebarCategory-livechat", { count: 0 });
     await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
 });

--- a/addons/mail/static/src/discuss/core/common/channel_actions.js
+++ b/addons/mail/static/src/discuss/core/common/channel_actions.js
@@ -1,0 +1,249 @@
+import { useComponent, useState } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+import { _t } from "@web/core/l10n/translation";
+import { usePopover } from "@web/core/popover/popover_hook";
+import { NotificationSettings } from "@mail/discuss/core/common/notification_settings";
+import { ChannelInvitation } from "./channel_invitation";
+
+export const sidebarActionsRegistry = registry.category("discuss.sidebar/actions");
+
+sidebarActionsRegistry
+    .add("mark-as-read", {
+        condition: (component) => {
+            return (
+                component.props.thread?.selfMember?.message_unread_counter > 0 &&
+                !component.props.thread.mute_until_dt
+            );
+        },
+        executeAction(component) {
+            component.props.thread.markAsRead({ sync: true });
+        },
+        icon: "fa fa-fw fa-check",
+        iconLarge: "fa fa-fw fa-lg fa-check",
+        name: _t("Mark as read"),
+        nameActive: _t("Mark as read"),
+        sequence: 1,
+    })
+    .add("add-users", {
+        condition(component) {
+            return component.props.thread?.model === "discuss.channel";
+        },
+        close(component, action) {
+            action.popover?.close();
+        },
+        component: ChannelInvitation,
+        setup(action) {
+            this.popover = usePopover(ChannelInvitation, {
+                onClose: () => this.close(),
+                popoverClass: action.panelOuterClass,
+                position: "right-start",
+            });
+        },
+        icon: "fa fa-fw fa-user-plus",
+        iconLarge: "fa fa-fw fa-lg fa-user-plus",
+        name: _t("Invite People"),
+        nameActive: _t("Stop Inviting"),
+        open(component, action) {
+            action.popover?.open(
+                component.root.el.querySelector(`[title="${action.name.toString()}"]`),
+                {
+                    hasSizeConstraints: true,
+                    thread: component.props.thread,
+                }
+            );
+        },
+        panelOuterClass: "o-discuss-ChannelInvitation",
+        popover: true,
+        sequence: 2,
+        subMenu: true,
+        toggle: true,
+    })
+    .add("notification-settings", {
+        condition: (component) => {
+            return (
+                component.props.thread?.model === "discuss.channel" &&
+                !component.store.discuss.chatWindow &&
+                component.store.self.type !== "guest"
+            );
+        },
+        close(component, action) {
+            action.popover?.close();
+        },
+        component: NotificationSettings,
+        setup(action) {
+            this.popover = usePopover(NotificationSettings, {
+                onClose: () => {
+                    this.close();
+                },
+                position: "right-start",
+                fixedPosition: true,
+                popoverClass: action.panelOuterClass,
+            });
+        },
+        icon(component) {
+            return component.props.thread.mute_until_dt
+                ? "fa fa-fw fa-bell-slash"
+                : "fa fa-fw fa-bell";
+        },
+        iconLarge(component) {
+            return component.props.thread.mute_until_dt
+                ? "fa fa-fw fa-lg fa-bell-slash"
+                : "fa fa-fw fa-lg fa-bell";
+        },
+        name: _t("Notification Settings"),
+        open(component, action) {
+            action.popover?.open(
+                component.root.el.querySelector(`[title="${action.name.toString()}"]`),
+                {
+                    hasSizeConstraints: true,
+                    thread: component.props.thread,
+                }
+            );
+        },
+        popover: true,
+        subMenu: true,
+        sequence: 3,
+        toggle: true,
+    })
+    .add("channel-details", {
+        condition: (component) => {
+            return component.props.thread;
+        },
+        executeAction(component) {
+            component.channelInfo(component.props.thread);
+        },
+        icon: "fa fa-fw fa-cog",
+        iconLarge: "fa fa-fw fa-lg fa-cog",
+        name: _t("Channel Info"),
+        nameActive: _t("Channel Info"),
+        sequence: 4,
+        toggle: true,
+    })
+    .add("leave-channel", {
+        condition: (component) => {
+            return component.props.thread.canLeave;
+        },
+        executeAction(component) {
+            component.leaveChannel(component.props.thread);
+            component.props.close();
+        },
+        icon: "fa fa-fw fa-sign-out",
+        iconLarge: "fa fa-fw fa-sign-out",
+        name: _t("Leave this channel"),
+        nameActive: _t("Leave this channel"),
+        sequence: 5,
+        toggle: true,
+    })
+    .add("unpin-channel", {
+        condition: (component) => {
+            return component.props.thread.canUnpin;
+        },
+        executeAction(component) {
+            component.props.thread.unpin();
+            component.props.close();
+        },
+        icon: "fa fa-fw fa-times",
+        iconLarge: "fa fa-fw fa-times",
+        name: _t("Unpin Conversation"),
+        nameActive: _t("Unpin Conversation"),
+        sequence: 6,
+        toggle: true,
+    });
+
+function transformAction(component, id, action) {
+    return {
+        /** Closes this action. */
+        close() {
+            if (this.toggle) {
+                component.sidebarChannelActions.activeAction =
+                    component.sidebarChannelActions.actionStack.pop();
+            }
+            action.close?.(component, this);
+        },
+        /** Optional component that should be displayed in the view when this action is active. */
+        component: action.component,
+        /** Condition to display this action. */
+        get condition() {
+            return action.condition(component);
+        },
+        /** Condition to disable the sub-menu icon */
+        get subMenu() {
+            return action.subMenu;
+        },
+        /** Icon for the button this action. */
+        get icon() {
+            return typeof action.icon === "function" ? action.icon(component) : action.icon;
+        },
+        /** Large icon for the button this action. */
+        get iconLarge() {
+            return typeof action.iconLarge === "function"
+                ? action.iconLarge(component)
+                : action.iconLarge ?? action.icon;
+        },
+        /** Unique id of this action. */
+        id,
+        /** Name of this action, displayed to the user. */
+        get name() {
+            const res = this.isActive && action.nameActive ? action.nameActive : action.name;
+            return typeof res === "function" ? res(component) : res;
+        },
+        /** Action to execute when this action is selected. */
+        onSelect() {
+            if (action.popover) {
+                this.open();
+            } else {
+                action.executeAction(component);
+                component.props.close();
+            }
+        },
+        /** Opens this action. */
+        open() {
+            if (this.toggle) {
+                if (component.sidebarChannelActions.activeAction) {
+                    component.sidebarChannelActions.actionStack.push(
+                        component.sidebarChannelActions.activeAction
+                    );
+                }
+                component.sidebarChannelActions.activeAction = this;
+            }
+            action.open?.(component, this);
+        },
+        panelOuterClass: action.panelOuterClass,
+        /** Determines whether this is a popover linked to this action. */
+        popover: null,
+        /** Determines the order of this action (smaller first). */
+        get sequence() {
+            return typeof action.sequence === "function"
+                ? action.sequence(component)
+                : action.sequence;
+        },
+        /** Component setup to execute when this action is registered. */
+        setup: action.setup,
+        /** Text for the button of this action */
+        text: action.text,
+        /** Determines whether this action is a one time effect or can be toggled (on or off). */
+        toggle: action.toggle,
+    };
+}
+
+export function useSidebarActions() {
+    const component = useComponent();
+    const transformedActions = sidebarActionsRegistry
+        .getEntries()
+        .map(([id, action]) => transformAction(component, id, action));
+    for (const action of transformedActions) {
+        if (action.setup) {
+            action.setup(component);
+        }
+    }
+    const state = useState({
+        get actions() {
+            return transformedActions
+                .filter((action) => action.condition)
+                .sort((a1, a2) => a1.sequence - a2.sequence);
+        },
+        actionStack: [],
+        activeAction: null,
+    });
+    return state;
+}

--- a/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.scss
+++ b/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.scss
@@ -11,11 +11,10 @@
 
 .o-mail-DiscussSidebar-item {
     &:hover .o-mail-DiscussSidebarChannel-commands {
-        display: flex !important;
-        .btn-group .btn:not(:hover) {
-            border-color: transparent;
-            background-color: transparent;
-        }
+        opacity: 1 !important;
+    }
+    .activate-settings {
+        opacity: 1 !important;
     }
 }
 

--- a/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.xml
@@ -63,23 +63,17 @@
                     <t t-esc="thread.displayName"/>
                 </span>
             </button>
-            <div class="flex-grow-1"/>
-            <div class="o-mail-DiscussSidebarChannel-commands d-none ms-1 me-2">
-                <div class="btn-group btn-group-sm">
-                    <button t-if="thread.channel_type === 'channel'" class="btn btn-secondary" t-on-click.stop="() => this.openSettings(thread)" title="Channel settings">
-                        <i t-attf-class="fa fa-cog" role="img"/>
-                    </button>
-                    <button t-if="thread.canLeave" class="btn btn-secondary" t-on-click.stop="() => this.leaveChannel(thread)" title="Leave this channel">
-                        <i t-attf-class="fa fa-times" role="img"/>
-                    </button>
-                    <button t-if="thread.canUnpin" class="btn btn-secondary" t-on-click.stop="() => thread.unpin()" title="Unpin Conversation">
-                        <i t-attf-class="fa fa-times" role="img"/>
-                    </button>
-                </div>
-            </div>
             <t t-foreach="channelIndicators" t-as="indicator" t-key="indicator_index" t-component="indicator" t-props="{ thread }"/>
             <div t-if="thread.importantCounter > 0">
                 <span t-attf-class="o-mail-DiscussSidebar-badge badge rounded-pill o-discuss-badge ms-1 me-2 fw-bold {{thread.mute_until_dt ? 'o-muted' : ''}}" t-esc="thread.importantCounter"/>
+            </div>
+            <div class="flex-grow-1"/>
+            <div class="o-mail-DiscussSidebarChannel-commands ms-1 me-2 opacity-0" t-att-class="{'activate-settings':thread.settingsVisibility}" >
+                <div class="btn-group btn-group-sm">
+                    <button class="o-mail-DiscussSidebarChannel-commandButton btn btn-secondary" t-on-click.stop="(event) => this.onClickCommands(event,thread)" title="Channel settings">
+                        <i class="fa fa-ellipsis-h"/>
+                    </button>
+                </div>
             </div>
         </div>
     </t>

--- a/addons/mail/static/src/discuss/core/web/discuss_sidebar_channel_commands.js
+++ b/addons/mail/static/src/discuss/core/web/discuss_sidebar_channel_commands.js
@@ -1,0 +1,68 @@
+import { Component, useState, useRef } from "@odoo/owl";
+import { useSidebarActions } from "../common/channel_actions";
+import { useService } from "@web/core/utils/hooks";
+import { _t } from "@web/core/l10n/translation";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+
+export class DiscussSidebarChannelCommands extends Component {
+    static template = "mail.DiscussSidebar.channelCommands";
+    static props = {
+        thread: { optional: true, type: Object },
+        close: { optional: true, type: Function },
+    };
+    static components = { ConfirmationDialog };
+
+    setup() {
+        this.actionService = useService("action");
+        this.dialogService = useService("dialog");
+        this.orm = useService("orm");
+        this.root = useRef("root");
+        this.sidebarChannelActions = useSidebarActions();
+        this.store = useState(useService("mail.store"));
+    }
+
+    askConfirmation(body) {
+        return new Promise((resolve) => {
+            this.dialogService.add(ConfirmationDialog, {
+                body: body,
+                confirmLabel: _t("Leave Conversation"),
+                confirm: resolve,
+                cancel: () => {},
+            });
+        });
+    }
+
+    /**
+     * @param {import("models").Thread} thread
+     */
+    async leaveChannel(thread) {
+        if (thread.channel_type !== "group" && thread.create_uid === thread.store.self.userId) {
+            await this.askConfirmation(
+                _t("You are the admistrator of this channel. Are you sure you want to leave?")
+            );
+        }
+        if (thread.channel_type === "group") {
+            await this.askConfirmation(
+                _t(
+                    "You are about to leave this group conversation and will no longer have access to it unless you are invited again. Are you sure you want to continue?"
+                )
+            );
+        }
+        thread.leave();
+    }
+
+    /**
+     * @param {import("models").Thread} thread
+     */
+    channelInfo(thread) {
+        if (thread) {
+            this.actionService.doAction({
+                type: "ir.actions.act_window",
+                res_model: "discuss.channel",
+                views: [[false, "form"]],
+                res_id: thread.id,
+                target: "current",
+            });
+        }
+    }
+}

--- a/addons/mail/static/src/discuss/core/web/discuss_sidebar_channel_commands.scss
+++ b/addons/mail/static/src/discuss/core/web/discuss_sidebar_channel_commands.scss
@@ -1,0 +1,5 @@
+.o-mail-DiscussSidebar-channelCommands {
+    &:hover {
+        background-color: mix($o-gray-100, $o-gray-200);
+    }
+}

--- a/addons/mail/static/src/discuss/core/web/discuss_sidebar_channel_commands.xml
+++ b/addons/mail/static/src/discuss/core/web/discuss_sidebar_channel_commands.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="mail.DiscussSidebar.channelCommands">
+        <div class="btn-group btn-group-sm d-flex flex-column" t-ref="root">
+            <t t-if="this.props.thread">
+                <t t-set="actions" t-value="sidebarChannelActions.actions"/>
+                <t t-foreach="actions" t-as="action" t-key="action.id">
+                    <div
+                        t-attf-title="{{action.name}}"
+                        class="o-mail-DiscussSidebar-channelCommands btn rounded-0 d-flex px-2 m-0 opacity-75 opacity-100-hover"
+                        t-on-click="() => action.onSelect()"
+                    >
+                        <button class="btn" t-att-name="action.id">
+                            <i t-att-class="action.icon" />
+                            <span class="mx-2" t-out="action.name" />
+                            <i t-if="action.subMenu" class="fa fa-fw fa-angle-right" />
+                        </button>
+                    </div>
+                </t>
+            </t>
+        </div>
+    </t>
+</templates>

--- a/addons/mail/static/tests/discuss/core/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/discuss.test.js
@@ -80,6 +80,8 @@ test("bus subscription is refreshed when channel is left", async () => {
     await assertSteps([`subscribe - [${imStatusChannels.join(",")}]`]);
     await openDiscuss();
     await assertSteps([]);
+    await click("[title='Channel settings']");
+    await contains(".o-mail-DiscussSidebar-commandsPopover");
     await click("[title='Leave this channel']");
     await assertSteps([`subscribe - [${imStatusChannels.join(",")}]`]);
 });

--- a/addons/mail/static/tests/discuss/core/public_web/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/public_web/discuss.test.js
@@ -27,6 +27,8 @@ test("bus subscription updated when joining/leaving thread as non member", async
     await start();
     await openDiscuss(channelId);
     await waitForChannels([`discuss.channel_${channelId}`]);
+    await click("[title='Channel settings']");
+    await contains(".o-mail-DiscussSidebar-commandsPopover");
     await click("[title='Leave this channel']");
     await click("button", { text: "Leave Conversation" });
     await waitForChannels([`discuss.channel_${channelId}`], { operation: "delete" });

--- a/addons/mail/static/tests/discuss/core/web/sidebar.test.js
+++ b/addons/mail/static/tests/discuss/core/web/sidebar.test.js
@@ -82,9 +82,11 @@ test("unknown channel can be displayed and interacted with", async () => {
     await waitNotifications([env, "discuss.channel/new_message"]);
     await click("button", { text: "Inbox" });
     await contains(".o-mail-DiscussSidebarChannel:not(.o-active)", { text: "Not So Secret" });
-    await click("[title='Leave this channel']", {
+    await click("[title='Channel settings']", {
         parent: [".o-mail-DiscussSidebarChannel", { text: "Not So Secret" }],
     });
+    await contains(".o-mail-DiscussSidebar-commandsPopover");
+    await click("[title='Leave this channel']");
     await click("button", { text: "Leave Conversation" });
     await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
 });

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -547,13 +547,11 @@ test("sidebar: basic channel rendering", async () => {
     await openDiscuss();
     await contains(".o-mail-DiscussSidebarChannel", { text: "General" });
     await contains(".o-mail-DiscussSidebarChannel img[data-alt='Thread Image']");
-    await contains(".o-mail-DiscussSidebarChannel .o-mail-DiscussSidebarChannel-commands.d-none");
-    await contains(
+    await click(
         ".o-mail-DiscussSidebarChannel .o-mail-DiscussSidebarChannel-commands [title='Channel settings']"
     );
-    await contains(
-        ".o-mail-DiscussSidebarChannel .o-mail-DiscussSidebarChannel-commands [title='Leave this channel']"
-    );
+    await contains(".o-mail-DiscussSidebar-commandsPopover");
+    await contains("[title='Leave this channel']");
 });
 
 test("channel become active", async () => {
@@ -1900,6 +1898,8 @@ test("Correct breadcrumb when open discuss from chat window then see settings", 
     await click("[title='Channel settings']", {
         parent: [".o-mail-DiscussSidebarChannel", { text: "General" }],
     });
+    await contains(".o-mail-DiscussSidebar-commandsPopover");
+    await click("[title='Channel Info']");
     await contains(".o_breadcrumb", { text: "GeneralGeneral" });
 });
 

--- a/addons/mail/views/discuss_channel_views.xml
+++ b/addons/mail/views/discuss_channel_views.xml
@@ -133,5 +133,13 @@
         <field name="params" eval="&quot;{ 'default_active_id': 'mail.box_inbox' }&quot;"/>
     </record>
 
+    <record id="mail.discuss_channel_action" model="ir.actions.act_window">
+        <field name="name">Discuss Channels</field>
+        <field name="res_model">discuss.channel</field>
+        <field name="view_mode">kanban</field>
+        <field name="domain" eval="[(('channel_type','=','channel'))]" />
+        <field name="search_view_id" ref="discuss_channel_view_search"/>
+    </record>
+
     </data>
 </odoo>

--- a/addons/mail/views/mail_menus.xml
+++ b/addons/mail/views/mail_menus.xml
@@ -8,10 +8,17 @@
         sequence="5"
     />
     <menuitem
+        id="mail.menu_channel"
+        name="Channels"
+        parent="mail.menu_root_discuss"
+        action="mail.discuss_channel_action"
+        sequence="1"
+    />
+    <menuitem
         id="mail.menu_configuration"
         name="Configuration"
         parent="mail.menu_root_discuss"
-        sequence="1"
+        sequence="2"
     />
     <menuitem name="Notification"
         id="mail.menu_notification_settings"

--- a/addons/project/static/src/core/web/thread_model_patch.js
+++ b/addons/project/static/src/core/web/thread_model_patch.js
@@ -8,6 +8,7 @@ const threadPatch = {
     setup() {
         super.setup();
         this.collaborator_ids = Record.many("Persona");
+        this.settingsVisibility = false;
     },
 };
 patch(Thread.prototype, threadPatch);


### PR DESCRIPTION
Purpose of this PR:

1. Add a 'Channel' menu button that, when clicked, displays all the channels the current user is a member of.
![image](https://github.com/user-attachments/assets/cf2b6a80-763b-4633-a421-7a80ad3ebc5b)

2. Instead of opening the channel info when click on the channel settings button, open a popover containing setting options like,
 - Mark all as read
 - Notification Settings
 - Invite a User
 - Channel Info
 - Leave/Unpin Channel
 
![image](https://github.com/user-attachments/assets/e16aa753-7302-4520-afab-4a05420a8875)

Enterprise PR: https://github.com/odoo/enterprise/pull/69270
task-4100138
