### PR TITLE
[IMP] l10n_co: National Bank API for Currency Rates

### DIFF
--- a/odoo/_monkeypatches/__init__.py
+++ b/odoo/_monkeypatches/__init__.py
@@ -29,3 +29,5 @@ def patch_all():
     patch_stdnum()
     from .werkzeug_urls import patch_werkzeug
     patch_werkzeug()
+    from .zeep import patch_zeep
+    patch_zeep()

--- a/odoo/_monkeypatches/zeep.py
+++ b/odoo/_monkeypatches/zeep.py
@@ -1,0 +1,9 @@
+from zeep.xsd import visitor
+from zeep.xsd.const import xsd_ns
+
+
+def patch_zeep():
+    # see https://github.com/mvantellingen/python-zeep/issues/1185
+    if visitor.tags.notation.localname != 'notation':
+        visitor.tags.notation = xsd_ns('notation')
+        visitor.SchemaVisitor.visitors[visitor.tags.notation] = visitor.SchemaVisitor.visit_notation

--- a/odoo/tools/zeep/client.py
+++ b/odoo/tools/zeep/client.py
@@ -179,5 +179,5 @@ class SerialProxy(SimpleNamespace):
 
     @classmethod
     def __check(cls, key, value):
-        assert not key.startswith('_')
+        assert not key.startswith('_') or key.startswith('_value_')
         assert type(value) in SERIALIZABLE_TYPES + (SerialProxy,)


### PR DESCRIPTION
The Colombian localization does not have a provider for automatic currency rates yet. This commit implements the API of the Banco de la Republica (because most of the Colombian clients already use this rate) to get the daily rate.

- Add a monkeypatch for zeep because the 'notation' xsd namespace is not recognized, and does not have a visitor in zeep
- Add an exception to the odoo zeep client for edge cases where zeep generates object arguments with a name starting with '\_value_'

task: 4043989

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
