### PR TITLE
[FIX] tests: support Chrome 128 headless window_size syntax

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -946,7 +946,7 @@ class ChromeBrowser():
         self.screencast_frames = []
         os.makedirs(self.screenshots_dir, exist_ok=True)
 
-        self.window_size = window_size
+        self.window_size = window_size.replace('x', ',')
         self.sigxcpu_handler = None
         self._chrome_start()
         self._find_websocket()


### PR DESCRIPTION
Since Chrome 128, the default headless mode has been updated to the
"new" engine (which is closer to the regular rendering engine). This new
mode only supports the window_size syntax where the seperator is a
colon.

Note: this syntax was already supported by previous Chrome versions.

This commit forces the conversion to this new syntax because the old one
is plainly ignored starting from Chrome 128, preventing "mobile" tests -
at least - from being run in the proper resolution.

Reference:
https://chromium.googlesource.com/chromium/src/+/b9b39a430f71c710d16aafcc67278ef77440c18d