### PR TITLE
[IMP] website: introduce `s_company_team_basic` snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -67,6 +67,7 @@
         'views/snippets/s_product_catalog.xml',
         'views/snippets/s_comparisons.xml',
         'views/snippets/s_company_team.xml',
+        'views/snippets/s_company_team_basic.xml',
         'views/snippets/s_company_team_shapes.xml',
         'views/snippets/s_call_to_action.xml',
         'views/snippets/s_references.xml',

--- a/addons/website/views/snippets/s_company_team_basic.xml
+++ b/addons/website/views/snippets/s_company_team_basic.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_company_team_basic" name="Team Basic">
+    <section class="s_company_team_basic o_cc o_cc1 pt64 pb64">
+        <div class="container">
+            <div class="row o_grid_mode" data-row-count="10">
+                <div class="o_grid_item g-col-lg-12 g-height-2 col-lg-12" style="grid-area: 1 / 1 / 3 / 13; --grid-item-padding-y: 32px; --grid-item-padding-x: 32px; z-index: 1;">
+                    <h3 class="o_default_snippet_text" style="text-align: center;">Discover our executive team</h3>
+                </div>
+                <div class="o_grid_item g-col-6 g-col-lg-3 g-height-8 col-6 col-lg-3" data-name="Team Member" style="grid-area: 3 / 1 / 11 / 4; --grid-item-padding-y: 16px; --grid-item-padding-x: 32px; z-index: 2;">
+                    <p class="o_not_editable" contenteditable="false" style="text-align: center;">
+                        <img alt="" class="o_editable_media img-fluid rounded-circle" src="/web/image/website.s_company_team_image_1" style="width: 100% !important;"/>
+                    </p>
+                    <h4 class="h5-fs" style="text-align: center;">Tony Fred, CEO</h4>
+                    <p class="o_small-fs text-muted" style="text-align: center;">Chief Executive Officer</p>
+                </div>
+                <div class="o_grid_item g-col-6 g-col-lg-3 g-height-8 col-6 col-lg-3" data-name="Team Member" style="grid-area: 3 / 4 / 11 / 7; --grid-item-padding-y: 16px; --grid-item-padding-x: 32px; z-index: 3;">
+                    <p class="o_not_editable" contenteditable="false" style="text-align: center;">
+                        <img alt="" class="o_editable_media img-fluid rounded-circle" src="/web/image/website.s_company_team_image_2" style="width: 100% !important;"/>
+                    </p>
+                    <h4 class="h5-fs" style="text-align: center;">Mich Stark, COO</h4>
+                    <p class="o_small-fs text-muted" style="text-align: center;">Chief Operational Officer</p>
+                </div>
+                <div class="o_grid_item g-col-6 g-col-lg-3 g-height-8 col-6 col-lg-3" data-name="Team Member" style="grid-area: 3 / 7 / 11 / 10; --grid-item-padding-y: 16px; --grid-item-padding-x: 32px; z-index: 4;">
+                    <p class="o_not_editable" contenteditable="false" style="text-align: center;">
+                        <img alt="" class="o_editable_media img-fluid rounded-circle" src="/web/image/website.s_company_team_image_3" style="width: 100% !important;"/>
+                    </p>
+                    <h4 class="h5-fs" style="text-align: center;">Aline Turner, CTO</h4>
+                    <p class="o_small-fs text-muted" style="text-align: center;">Chief Technical Officer</p>
+                </div>
+                <div class="o_grid_item g-col-6 g-col-lg-3 g-height-8 col-6 col-lg-3" data-name="Team Member" style="grid-area: 3 / 10 / 11 / 13; --grid-item-padding-y: 16px; --grid-item-padding-x: 32px; z-index: 5;">
+                    <p class="o_not_editable" contenteditable="false" style="text-align: center;">
+                        <img alt="" class="o_editable_media img-fluid rounded-circle" src="/web/image/website.s_company_team_image_4" style="width: 100% !important;"/>
+                    </p>
+                    <h4 class="h5-fs" style="text-align: center;">Iris Joe, CFO</h4>
+                    <p class="o_small-fs text-muted" style="text-align: center;">Chief Financial Officer</p>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -198,6 +198,9 @@
                 <t t-snippet="website.s_company_team" string="Team" group="people">
                     <keywords>organization, structure</keywords>
                 </t>
+                <t t-snippet="website.s_company_team_basic" string="Team Basic" group="people">
+                    <keywords>organization, company, people, members, staffs, profiles, bios, roles, personnel, crew, patterned, trendy</keywords>
+                </t>
                 <t t-snippet="website.s_company_team_shapes" string="Team Shapes" group="people">
                     <keywords>organization, structure, people, team, name, role, position, image, portrait, photo, employees, shapes</keywords>
                 </t>


### PR DESCRIPTION
This commit adds the new `s_company_team_basic` snippet.

task-4144648
Part-of: task-4077427

| ![image](https://github.com/user-attachments/assets/572d3e6d-010f-4def-97f2-9384a716a26c) |
|--------|

Design-Themes: https://github.com/odoo/design-themes/pull/892

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
