### PR TITLE
[REF] web_tour: macroEngine only in tour_automatic

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_automatic.js
@@ -1,13 +1,14 @@
 import { tourState } from "./tour_state";
 import { config as transitionConfig } from "@web/core/transition";
 import { TourStepAutomatic } from "./tour_step_automatic";
+import { MacroEngine } from "@web/core/macro";
 
 export class TourAutomatic {
     mode = "auto";
-    constructor(data, macroEngine) {
+    constructor(data) {
         Object.assign(this, data);
         this.steps = this.steps.map((step, index) => new TourStepAutomatic(step, this, index));
-        this.macroEngine = macroEngine;
+        this.macroEngine = new MacroEngine({ target: document });
         this.stepDelay = +tourState.get(this.name, "stepDelay") || 0;
     }
 
@@ -37,6 +38,7 @@ export class TourAutomatic {
 
         pointer.start();
         transitionConfig.disabled = true;
+        //Activate macro in exclusive mode (only one macro per MacroEngine)
         this.macroEngine.activate(macro, true);
     }
 }

--- a/addons/web_tour/static/src/tour_service/tour_service.js
+++ b/addons/web_tour/static/src/tour_service/tour_service.js
@@ -3,7 +3,6 @@
 import { EventBus, markup, whenReady, reactive, validate } from "@odoo/owl";
 import { browser } from "@web/core/browser/browser";
 import { _t } from "@web/core/l10n/translation";
-import { MacroEngine } from "@web/core/macro";
 import { registry } from "@web/core/registry";
 import { session } from "@web/session";
 import { TourPointer } from "../tour_pointer/tour_pointer";
@@ -127,7 +126,6 @@ export const tourService = {
         });
 
         const bus = new EventBus();
-        const macroEngine = new MacroEngine({ target: document });
 
         const pointers = reactive({});
         /** @type {Set<string>} */
@@ -265,7 +263,7 @@ export const tourService = {
 
             if (!willUnload) {
                 if (options.mode === "auto") {
-                    new TourAutomatic(tour, macroEngine).start(pointer, () => {
+                    new TourAutomatic(tour).start(pointer, () => {
                         pointer.stop();
                         endTour(tour);
                     });
@@ -292,7 +290,7 @@ export const tourService = {
                 bounce: !(mode === "auto" && keepWatchBrowser),
             });
             if (mode === "auto") {
-                new TourAutomatic(tour, macroEngine).start(pointer, () => {
+                new TourAutomatic(tour).start(pointer, () => {
                     pointer.stop();
                     endTour(tour);
                 });

--- a/addons/web_tour/static/src/tour_service/tour_step.js
+++ b/addons/web_tour/static/src/tour_service/tour_step.js
@@ -1,6 +1,29 @@
 import { session } from "@web/session";
 import { utils } from "@web/core/ui/ui_service";
 import * as hoot from "@odoo/hoot-dom";
+import { pick } from "@web/core/utils/objects";
+
+export class Step {
+    constructor(data) {
+        Object.assign(this, data);
+    }
+
+    get stringify() {
+        return (
+            JSON.stringify(
+                pick(this, "isActive", "content", "trigger", "run", "tooltipPosition", "timeout"),
+                (_key, value) => {
+                    if (typeof value === "function") {
+                        return "[function]";
+                    } else {
+                        return value;
+                    }
+                },
+                2
+            ) + ","
+        );
+    }
+}
 
 /**
  * @typedef TourStep
@@ -12,11 +35,10 @@ import * as hoot from "@odoo/hoot-dom";
  * @property {RunCommand} [run] The action to perform when trigger conditions are verified.
  * @property {number} [timeout] By default, when the trigger node isn't found after 10000 milliseconds, it throws an error.
  * You can change this value to lengthen or shorten the time before the error occurs [ms].
- * @property {string} [title]
  */
-export class TourStep {
+export class TourStep extends Step {
     constructor(data, tour) {
-        Object.assign(this, data);
+        super(data);
         this.tour = tour;
         if (!this.tour) {
             throw new Error(`TourStep instance must have a tour`);

--- a/addons/web_tour/static/src/tour_service/tour_step_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_step_automatic.js
@@ -5,8 +5,7 @@ import * as hoot from "@odoo/hoot-dom";
 import { setupEventActions } from "@web/../lib/hoot-dom/helpers/events";
 import { callWithUnloadCheck } from "./tour_utils";
 import { TourHelpers } from "./tour_helpers";
-import { TourStep } from "./tour_step";
-import { pick } from "@web/core/utils/objects";
+import { Step, TourStep } from "./tour_step";
 
 export class TourStepAutomatic extends TourStep {
     triggerFound = false;
@@ -47,7 +46,11 @@ export class TourStepAutomatic extends TourStep {
             },
             {
                 action: async () => {
-                    console.log(this.describeMe);
+                    console.groupCollapsed(this.describeMe);
+                    if (debugMode !== false) {
+                        console.log(this.stringify);
+                    }
+                    console.groupEnd();
                     this._timeout = browser.setTimeout(
                         () => this.throwError(),
                         (this.timeout || 10000) + this.tour.stepDelay
@@ -152,26 +155,7 @@ export class TourStepAutomatic extends TourStep {
         const end = Math.min(this.index + offset, this.tour.steps.length - 1);
         const result = [];
         for (let i = start; i <= end; i++) {
-            const stepString =
-                JSON.stringify(
-                    pick(
-                        this.tour.steps[i],
-                        "isActive",
-                        "content",
-                        "trigger",
-                        "run",
-                        "tooltipPosition",
-                        "timeout"
-                    ),
-                    (_key, value) => {
-                        if (typeof value === "function") {
-                            return "[function]";
-                        } else {
-                            return value;
-                        }
-                    },
-                    2
-                ) + ",";
+            const stepString = new Step(this.tour.steps[i]).stringify;
             const text = [stepString];
             if (i === this.index) {
                 const line = "-".repeat(10);
@@ -208,11 +192,7 @@ export class TourStepAutomatic extends TourStep {
         tourState.set(this.tour.name, "stepState", "errored");
         const debugMode = tourState.get(this.tour.name, "debug");
         // console.error notifies the test runner that the tour failed.
-        const errors = [
-            `FAILED: ${this.describeMe}.`,
-            this.describeWhyIFailed,
-            error,
-        ]
+        const errors = [`FAILED: ${this.describeMe}.`, this.describeWhyIFailed, error];
         console.error(errors.filter(Boolean).join("\n"));
         // The logged text shows the relative position of the failed step.
         // Useful for finding the failed step.


### PR DESCRIPTION
In this commit, we move macroEngine from tour_service to put it in tour_automatic. Indeed, only tour_automatic is concerned by the macroEngine. What's more, it is useless to create a single macroEngine for the tours because, in any case, they are launched one by one (in exclusive mode).
We take advantage of this PR and this refactoring to improve the console log in debugMode (to have more information on the current step in the debugger)