### PR TITLE
[IMP] event_sale: apply discount in sale stat button

### DIFF
--- a/addons/event_sale/tests/test_event_sale.py
+++ b/addons/event_sale/tests/test_event_sale.py
@@ -365,6 +365,18 @@ class TestEventSale(TestEventSaleCommon):
         with self.assertRaises(ValidationError):
             editor.action_make_registration()
 
+    def test_event_sale_price_total(self):
+        """ Test that the `sale_amount_total` matches the total amount of all concerned orders.
+        """
+        self.env['sale.order.line'].create({
+            'product_id': self.event_product.id,
+            'order_id': self.sale_order.id,
+            'event_id': self.event_0.id,
+            'event_ticket_id': self.ticket.id,
+        })
+        expected_price = sum(self.event_0.sale_order_lines_ids.mapped('price_total'))
+        self.assertEqual(self.event_0.sale_price_total, expected_price)
+
     def test_ticket_price_with_currency_conversion(self):
         def _prepare_currency(self, currency_name):
             currency = self.env['res.currency'].with_context(active_test=False).search(

--- a/addons/event_sale/views/event_views.xml
+++ b/addons/event_sale/views/event_views.xml
@@ -13,10 +13,10 @@
                         type="object" class="oe_stat_button" icon="fa-dollar"
                         groups="sales_team.group_sale_salesman"
                         help="Total sales for this event"
-                        invisible="sale_price_subtotal == 0 or not sale_price_subtotal">
+                        invisible="sale_price_total == 0 or not sale_price_total">
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_value">
-                            <field string="Sales" name="sale_price_subtotal"
+                            <field string="Sales" name="sale_price_total"
                                 widget="monetary" options="{'currency_field': 'currency_id'}"/>
                             </span>
                         <span class="o_stat_text">Sales</span>


### PR DESCRIPTION
Currently, when a discount is applied to some tickets there's a discrepancy between the total amount of sale stat button displayed on the event form view and the total displayed for the sale order list view to an event.

The objective is to include the discount value **`(Excluding the fixed amount and Global discount)`** in the stats button to ensure consistent totals are shown throughout.

Task-4107360