### PR TITLE
[IMP] website_sale_wishlist: add wishlist to cart page

### DIFF
--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -206,7 +206,7 @@
                                         t-att-data-product-id="wish.product_id.id"
                                         t-att-data-product-tracking-info="'product_tracking_info' in combination_info and json.dumps(combination_info['product_tracking_info'])"
                                     >
-                                        <td class='td-img align-middle'>
+                                        <td class='td-img align-middle d-none d-md-block'>
                                             <a t-att-href="wish.product_id.website_url">
                                                 <img t-attf-src="/web/image/product.product/#{wish.product_id.id}/image_128" class="img img-fluid" style="margin:auto;" alt="Product image"/>
                                             </a>


### PR DESCRIPTION
**Steps:**
- Go to Shop
- Add a product to the wishlist.
- Access the Wishlist page and apply the Mobile View.
- Apply Zoom on the mobile view

**Issue:**
- For some languages (like French) the full button can't be seen at the standard 100% view.  Also a column of image is shown extra even though the image is not displayed

**Fix:**
- Removing the column of image for smaller screens will resolve our issue, and we would be able to see the button upto a lot more zooming ratio.

**Affected version:** 17.0~master
opw-4089951