### PR TITLE
[FIX] pos_account_tax_python: missing field pos python tax

### DIFF
--- a/addons/pos_account_tax_python/__init__.py
+++ b/addons/pos_account_tax_python/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/pos_account_tax_python/models/__init__.py
+++ b/addons/pos_account_tax_python/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_tax

--- a/addons/pos_account_tax_python/models/account_tax.py
+++ b/addons/pos_account_tax_python/models/account_tax.py
@@ -1,0 +1,9 @@
+from odoo import api, models
+
+
+class AccountTax(models.Model):
+    _inherit = 'account.tax'
+
+    @api.model
+    def _load_pos_data_fields(self, config_id):
+        return super()._load_pos_data_fields(config_id) + ['formula_decoded_info']


### PR DESCRIPTION
Steps to reproduce:
- create a custom formula tax
- add this tax to a product available in the POS
- open a POS and try to add this product to your order
- traceback is shown

This commit adds the missing field to the loaded fields for account_tax.

task-id: 4169338

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
