### PR TITLE
[FIX] l10n_uk: auto-install l10n_uk_bacs

### DIFF
--- a/addons/l10n_uk/__init__.py
+++ b/addons/l10n_uk/__init__.py
@@ -1,2 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import models
+
+
+def _l10n_uk_post_init(env):
+    bacs_module = env['ir.module.module'].search([('name', '=', 'l10n_uk_bacs'), ('state', '=', 'uninstalled')])
+    if bacs_module:
+        bacs_module.sudo().button_install()

--- a/addons/l10n_uk/__manifest__.py
+++ b/addons/l10n_uk/__manifest__.py
@@ -28,5 +28,6 @@ This is the latest UK Odoo localisation necessary to run Odoo accounting for UK 
         'demo/l10n_uk_demo.xml',
         'demo/demo_company.xml',
     ],
+    'post_init_hook': '_l10n_uk_post_init',
     'license': 'LGPL-3',
 }


### PR DESCRIPTION
### Steps to reproduce:
- Install the 'l10n_uk' module
- The module "l10n_uk_bacs" is not installed, but it should

### Solution:
Add a post init hook in `l10n_uk` to download `l10n_uk_bacs`.

opw-4122475
