### PR TITLE
[IMP] core: simplify `assertRecordValues`

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -497,8 +497,8 @@ class AccountTestInvoicingCommon(ProductCommon):
     def assertInvoiceValues(self, move, expected_lines_values, expected_move_values):
         def sort_lines(lines):
             return lines.sorted(lambda line: (line.sequence, not bool(line.tax_line_id), line.name or line.product_id.display_name or '', line.balance))
-        self.assertRecordValues(sort_lines(move.line_ids.sorted()), expected_lines_values)
-        self.assertRecordValues(move, [expected_move_values])
+        self.assertRecordValues(sort_lines(move.line_ids.sorted()), expected_lines_values, field_names=expected_lines_values[0].keys())
+        self.assertRecordValues(move, [expected_move_values], field_names=expected_move_values.keys())
 
     def assert_tax_totals(self, tax_totals, currency, expected_values):
         main_keys_to_ignore = {'formatted_amount_total', 'formatted_amount_untaxed'}

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -122,7 +122,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             'journal_id': cls.company_data['default_journal_purchase'].id,
             'date': fields.Date.from_string('2019-01-01'),
             'fiscal_position_id': False,
-            'payment_reference': '',
+            'payment_reference': False,
             'invoice_payment_term_id': cls.pay_terms_a.id,
             'amount_untaxed': 960.0,
             'amount_tax': 168.0,

--- a/addons/account/tests/test_account_move_in_refund.py
+++ b/addons/account/tests/test_account_move_in_refund.py
@@ -120,7 +120,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
             'journal_id': cls.company_data['default_journal_purchase'].id,
             'invoice_date': fields.Date.from_string('2019-01-01'),
             'fiscal_position_id': False,
-            'payment_reference': '',
+            'payment_reference': False,
             'invoice_payment_term_id': cls.pay_terms_a.id,
             'amount_untaxed': 960.0,
             'amount_tax': 168.0,

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -125,7 +125,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             'journal_id': cls.company_data['default_journal_sale'].id,
             'date': fields.Date.from_string('2019-01-01'),
             'fiscal_position_id': False,
-            'payment_reference': '',
+            'payment_reference': False,
             'invoice_payment_term_id': cls.pay_terms_a.id,
             'amount_untaxed': 1200.0,
             'amount_tax': 210.0,

--- a/addons/account/tests/test_account_move_out_refund.py
+++ b/addons/account/tests/test_account_move_out_refund.py
@@ -118,7 +118,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
             'journal_id': cls.company_data['default_journal_sale'].id,
             'date': fields.Date.from_string('2019-01-01'),
             'fiscal_position_id': False,
-            'payment_reference': '',
+            'payment_reference': False,
             'invoice_payment_term_id': cls.pay_terms_a.id,
             'amount_untaxed': 1200.0,
             'amount_tax': 210.0,

--- a/addons/account/tests/test_early_payment_discount.py
+++ b/addons/account/tests/test_early_payment_discount.py
@@ -153,14 +153,10 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
         })._create_payments()
 
         self.assertTrue(payments.is_reconciled)
-        self.assertRecordValues(payments.line_ids.sorted('balance'), [
-            {'amount_currency': -1000.0},
-            {
-                'account_id': self.env.company['account_journal_early_pay_discount_loss_account_id'].id,
-                'amount_currency': 100.0,
-            },
-            {'amount_currency': 900.0},
-        ])
+        self.assertEqual(
+            payments.line_ids.sorted('balance').mapped('amount_currency'),
+            [-1000.0, 100.0, 900.0],
+        )
 
     def test_register_discounted_payment_on_single_invoice_with_fixed_tax_1(self):
         self.early_pay_10_percents_10_days.early_pay_discount_computation = 'included'

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -166,7 +166,7 @@ class TestExpenses(TestExpenseCommon):
             {'balance':   208.70, 'account_id': tax_account_id,             'name': '15%',                                'date': date(2021, 10, 31),           'invoice_date': date(2021, 10, 10)},
             {'balance':    18.46, 'account_id': tax_account_id,             'name': '15%',                                'date': date(2021, 10, 31),           'invoice_date': date(2021, 10, 10)},
             {'balance':    18.46, 'account_id': tax_account_id,             'name': '15% (Copy)',                         'date': date(2021, 10, 31),           'invoice_date': date(2021, 10, 10)},
-            {'balance': -1760.00, 'account_id': default_account_payable_id, 'name': False,                                'date': date(2021, 10, 31),           'invoice_date': date(2021, 10, 10)},
+            {'balance': -1760.00, 'account_id': default_account_payable_id, 'name': '',                                   'date': date(2021, 10, 31),           'invoice_date': date(2021, 10, 10)},
 
             # company_account expense 2 move
             {'balance':  123.08, 'account_id': product_b_account_id,        'name': 'expense_employee: PB 160 + 2*15% 2', 'date': date(2021, 10, 12),           'invoice_date': False},

--- a/addons/sale/tests/test_sale_order_down_payment.py
+++ b/addons/sale/tests/test_sale_order_down_payment.py
@@ -670,7 +670,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
             # keys
             ['account_id',               'tax_ids',    'balance', 'price_total'],
             # line section
-            [[],                         [],           0.0,       0.0          ],
+            [False,                      [],           0.0,       0.0          ],
             # down payment
             [self.revenue_account.id,    tax_21_a.ids, 82.64,     100.0        ],
             [self.revenue_account.id,    tax_21_b.ids, 82.64,     100.0        ],
@@ -698,7 +698,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
             [self.revenue_account.id,    tax_21_a.ids, -1000.0,   1210.0       ],
             [self.revenue_account.id,    tax_21_b.ids, -1000.0,   1210.0       ],
             # line section
-            [[],                         [],           0.0,       0.0          ],
+            [False,                      [],           0.0,       0.0          ],
             # down payment
             [self.revenue_account.id,    tax_21_a.ids, 82.64,     -100.0       ],
             [self.revenue_account.id,    tax_21_b.ids, 82.64,     -100.0       ],
@@ -774,7 +774,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
             # keys
             ['account_id',               'tax_ids',    'balance', 'price_total'],
             # line section
-            [[],                         [],           0.0,       0.0          ],
+            [False,                      [],           0.0,       0.0          ],
             # down payment
             [self.revenue_account.id,    tax_24_a.ids, 80.65,     100.0        ],
             [self.revenue_account.id,    tax_24_b.ids, 80.65,     100.0        ],
@@ -802,7 +802,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
             [self.revenue_account.id,    tax_24_a.ids, -1000.0,   1240.0       ],
             [self.revenue_account.id,    tax_24_b.ids, -1000.0,   1240.0       ],
             # line section
-            [[],                         [],            0.0,      0.0          ],
+            [False,                      [],            0.0,      0.0          ],
             # down payment
             [self.revenue_account.id,    tax_24_a.ids,  80.65,    -100.0       ],
             [self.revenue_account.id,    tax_24_b.ids,  80.65,    -100.0       ],
@@ -913,7 +913,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
             [self.revenue_account.id,   tax_25_b.ids,  -968.0,    1210.0       ],
             [self.revenue_account.id,   tax_25_c.ids,  -968.0,    1210.0       ],
             # line section
-            [[],                        [],            0.0,       0.0          ],
+            [False,                     [],            0.0,       0.0          ],
             # down payment
             [self.revenue_account.id,    tax_21_a.ids, 82.64,    -100.0       ],
             [self.revenue_account.id,    tax_21_b.ids, 82.64,    -100.0       ],
@@ -1038,7 +1038,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
             # base lines
             [self.revenue_account.id,   self.tax_15.ids,    -100.0,             115.0],
             # line section
-            [[],                        [],                 0.0,                0.0],
+            [False,                     [],                 0.0,                0.0],
             # down payment
             [self.revenue_account.id,   self.tax_15.ids,    43.48,              -50.0],
             # taxes

--- a/addons/stock_account/tests/test_account_move.py
+++ b/addons/stock_account/tests/test_account_move.py
@@ -280,13 +280,10 @@ class TestAccountMove(TestAccountMoveStockCommon):
             'property_stock_journal': self.stock_journal.id,
         })
 
-        amls = self.env['account.move.line'].search([('product_id', '=', product.id)])
-        if amls[0].account_id == self.stock_valuation_account:
-            stock_valuation_line = amls[0]
-            output_line = amls[1]
-        else:
-            output_line = amls[0]
-            stock_valuation_line = amls[1]
+        amls = self.env['account.move.line'].search([('product_id', '=', product.id)]).sorted(
+            # ensure the aml with the stock_valuation_account is the first one
+            lambda amls: amls.account_id != self.stock_valuation_account
+        )
 
         expected_valuation_line = {
             'account_id': self.stock_valuation_account.id,
@@ -298,10 +295,7 @@ class TestAccountMove(TestAccountMoveStockCommon):
             'credit': 0,
             'debit': product.standard_price,
         }
-        self.assertRecordValues(
-            [stock_valuation_line, output_line],
-            [expected_valuation_line, expected_output_line]
-        )
+        self.assertRecordValues(amls, [expected_valuation_line, expected_output_line])
 
     def test_stock_account_move_automated_not_standard_with_branch_company(self):
         """

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
@@ -289,7 +289,7 @@ class TestLandedCosts(TestStockLandedCostsCommon):
                 {'name': 'equal split - Refrigerator: 2.0 already out',         'debit': 0.0,   'credit': 1.0},
             ]
         self.assertRecordValues(
-            sorted(stock_negative_landed_cost.account_move_id.line_ids, key=lambda d: (d['name'], d['debit'])),
+            stock_negative_landed_cost.account_move_id.line_ids.sorted(lambda d: (d['name'], d['debit'])),
             sorted(move_lines, key=lambda d: (d['name'], d['debit'])),
         )
 

--- a/odoo/addons/test_testing_utilities/tests/test_methods.py
+++ b/odoo/addons/test_testing_utilities/tests/test_methods.py
@@ -39,6 +39,13 @@ class TestBasic(common.TransactionCase):
         with self.assertRaises(AssertionError):
             self.assertRecordValues(records, [Y3, X1])
 
+    def test_assertRecordValues_floats(self):
+        r = self.env['test_testing_utilities.onchange_line'].create({
+            'dummy': 42,
+        })
+
+        self.assertRecordValues(r, [{'dummy': 42}])
+
     def test_assertRaises_rollbacks(self):
         """Checks that a "correctly" executing assertRaises (where the expected
         exception has been raised and caught) will properly rollback.


### PR DESCRIPTION
Current version seems way over-complicated for what it does, and furthermore shows less information than useful:

- The diff it shows lacks context which makes it harder to understand than necessary.
- It assumes new records only happen at the end, so is unable to properly show middle-endian insertions.

Instead of trying to do all the things by hand, produce a consistent serialization and leave the entire diffing to Python.