### PR TITLE
[FIX] purchase_edi_ubl_bis3: Use purchase description

### DIFF
--- a/addons/purchase_edi_ubl_bis3/models/purchase_edi_xml_ubl_bis3.py
+++ b/addons/purchase_edi_ubl_bis3/models/purchase_edi_xml_ubl_bis3.py
@@ -178,7 +178,7 @@ class PurchaseEdiXmlUBLBIS3(models.AbstractModel):
 
         vals = {
             'name': product.name,
-            'description': product.description,
+            'description': order_line.name,
             'standard_item_identification': product.barcode,
             'classified_tax_category_vals': self._get_tax_category_vals(order, order_line)
         }

--- a/addons/purchase_edi_ubl_bis3/tests/data/test_po_edi.xml
+++ b/addons/purchase_edi_ubl_bis3/tests/data/test_po_edi.xml
@@ -71,6 +71,7 @@
       </cac:Price>
       <cac:Item>
         <cbc:Name>product_a</cbc:Name>
+        <cbc:Description>Product A description</cbc:Description>
         <cac:ClassifiedTaxCategory>
           <cbc:ID>S</cbc:ID>
           <cbc:Percent>15.0</cbc:Percent>
@@ -92,6 +93,7 @@
       </cac:Price>
       <cac:Item>
         <cbc:Name>product_a</cbc:Name>
+        <cbc:Description>Product A description</cbc:Description>
         <cac:ClassifiedTaxCategory>
           <cbc:ID>S</cbc:ID>
           <cbc:Percent>15.0</cbc:Percent>

--- a/addons/purchase_edi_ubl_bis3/tests/test_purchase_order_edi_gen.py
+++ b/addons/purchase_edi_ubl_bis3/tests/test_purchase_order_edi_gen.py
@@ -16,11 +16,13 @@ class TestPurchaseOrderEDIGen(AccountTestInvoicingCommon):
             'order_line': [
                 (0, 0, {
                     'product_id': self.product_a.id,
+                    'name': 'Product A description',
                     'product_qty': 10.0,
                     'price_unit': 50.0,
                 }),
                 (0, 0, {
                     'product_id': self.product_a.id,
+                    'name': 'Product A description',
                     'product_qty': 1.0,
                     'price_unit': 10.0,
                 }),


### PR DESCRIPTION
Issue:
When the purchase_edi_ubl_bis3 module is installed, if a product's internal description contains invalid HTML, the purchase order with that product cannot be printed or sent.

Steps to reproduce:
- Install purchase_edi_ubl_bis3
- In a product, press enter in the internal description field (resulting in the HTML code `<p><br></p>`)
- Create a purchase order containing this product
- Attempt to print the purchase order
- An error will occur, indicating an unclosed `<b>` tag.

Fix:
After discussing with AELS, we decided to use the description_purchase field instead of description. This makes more sense in this context, and since description_purchase is a text field (while description is an HTML field), it eliminates HTML-related issues.

opw-4142522
opw-4142378
opw-4142367
opw-4141322
