### PR TITLE
[FIX] web_editor: prevent crash when cancelling report discard

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1101,21 +1101,23 @@ export class Wysiwyg extends Component {
      * @param {boolean} [reload=true]
      *        true if the page has to be reloaded when the user answers yes
      *        (do nothing otherwise but add this to allow class extension)
-     * @returns {Promise}
+     * @returns {Promise<boolean>}
+     *        true if the cancellation has been confirmed
      */
     cancel(reload) {
         var self = this;
         return new Promise((resolve, reject) => {
             this.env.services.dialog.add(ConfirmationDialog, {
                 body: _t("If you discard the current edits, all unsaved changes will be lost. You can cancel to return to edit mode."),
-                confirm: () => resolve(),
-                cancel: () => reject()
+                confirm: () => resolve(true),
+                cancel: () => resolve(false)
             });
-        }).then(function () {
-            if (reload !== false) {
+        }).then(function (cancelled) {
+            if (cancelled && reload !== false) {
                 window.onbeforeunload = null;
                 return self._reload();
             }
+            return cancelled;
         });
     }
     /**


### PR DESCRIPTION
Steps to reproduce
==================

- Open studio
- Edit any report
- Make some changes
- Click on discard
- Click on cancel

=> UncaughtPromiseError

Cause of the issue
==================

When clicking on cancel, the promise is rejected

https://github.com/odoo/odoo/blob/1ffcea337ba463c383483ca53ff57aa6b725b5a2/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js#L1112

Solution
========

Instead of rejecting the promise, resolve it with the confirmation status

opw-4141192