### PR TITLE
[FIX] website_sale_*: don't initialize new SOs with unmodifyable shipping/invoice partners

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import SUPERUSER_ID, _, _lt, api, fields, models, tools
@@ -428,10 +427,18 @@ class Website(models.Model):
                 order="date_order desc, id desc",
             )
             if last_sale_order:
-                if last_sale_order.partner_shipping_id.active:  # first = me
-                    addr['delivery'] = last_sale_order.partner_shipping_id.id
-                if last_sale_order.partner_invoice_id.active:
-                    addr['invoice'] = last_sale_order.partner_invoice_id.id
+                partner_shipping = last_sale_order.partner_shipping_id
+                if (
+                    partner_shipping.active
+                    and partner_shipping.commercial_partner_id == partner_sudo
+                ):
+                    addr['delivery'] = partner_shipping.id
+                partner_invoice = last_sale_order.partner_invoice_id
+                if (
+                    partner_invoice.active
+                    and partner_invoice.commercial_partner_id == partner_sudo
+                ):
+                    addr['invoice'] = partner_invoice.id
 
         affiliate_id = request.session.get('affiliate_id')
         salesperson_user_sudo = self.env['res.users'].sudo().browse(affiliate_id).exists()

--- a/addons/website_sale_picking/models/sale_order.py
+++ b/addons/website_sale_picking/models/sale_order.py
@@ -22,3 +22,8 @@ class SaleOrder(models.Model):
             if self.fiscal_position_id != fpos_before:
                 self._recompute_taxes()
         return res
+
+    def _remove_delivery_line(self):
+        if self.carrier_id.delivery_type == 'onsite' and self.carrier_id.warehouse_id:
+            self.env.add_to_compute(self._fields['partner_shipping_id'], self)
+        super()._remove_delivery_line()


### PR DESCRIPTION
This change fixes 2 related issues:
- If a user went to their cart after setting their order's delivery method to "pickup in store", they'd get an error if the store's partner was incomplete. Indeed, going to the cart would trigger the shipping partner's (i.e. the store partner's) validation. Since the shipping method is cleared anyway when going to the cart, we now now also clear the shipping address if the delivery method was "pickup in store".
- When creating a new SO, we automatically set its shipping/invoice partners to those from the last SO. If the last SO had a "pickup in store" delivery method, then the store's partner was used as the new SO's shipping partner. If the user tried to edit the address, they'd get an access error. Now, we don't use the last SO's shipping/invoice partner if they don't belong to the current partner (i.e. if they belong to the store).

opw-4126140
opw-4114139
opw-4115510
opw-4117520
opw-4109625
opw-4115415
opw-4143237
opw-4123382
opw-4136888
opw-4125807