### PR TITLE
[FIX] hr_timesheet: prevent the creation of fsm task without partner

### DIFF
--- a/addons/hr_timesheet/models/project_project.py
+++ b/addons/hr_timesheet/models/project_project.py
@@ -202,6 +202,10 @@ class Project(models.Model):
                 warning_msg, self.env.ref('hr_timesheet.timesheet_action_project').id,
                 _('See timesheet entries'), {'active_ids': projects_with_timesheets.ids})
 
+    @api.model
+    def get_create_edit_project_ids(self):
+        return []
+
     def _convert_project_uom_to_timesheet_encode_uom(self, time):
         uom_from = self.company_id.project_time_mode_id
         uom_to = self.env.company.timesheet_encode_uom_id

--- a/addons/hr_timesheet/static/tests/task_with_hours_tests.js
+++ b/addons/hr_timesheet/static/tests/task_with_hours_tests.js
@@ -34,6 +34,11 @@ QUnit.module("hr_timesheet", (hooks) => {
     QUnit.test("quick create is enabled when project_id is set", async function (assert) {
         await makeView({
             serverData,
+            mockRPC: function (route, args) {
+                if (route === '/web/dataset/call_kw/project.project/get_create_edit_project_ids') {
+                    return [];
+                }
+            },
             type: "list",
             resModel: "account.analytic.line",
         });
@@ -44,6 +49,11 @@ QUnit.module("hr_timesheet", (hooks) => {
     QUnit.test("quick create is no enabled when project_id is not set", async function (assert) {
         await makeView({
             serverData,
+            mockRPC: function (route, args) {
+                if (route === '/web/dataset/call_kw/project.project/get_create_edit_project_ids') {
+                    return [];
+                }
+            },
             type: "list",
             resModel: "account.analytic.line",
         });
@@ -54,6 +64,11 @@ QUnit.module("hr_timesheet", (hooks) => {
     QUnit.test("the text of the task includes hours in the drop down but not in the line", async function (assert) {
         await makeView({
             serverData,
+            mockRPC: function (route, args) {
+                if (route === '/web/dataset/call_kw/project.project/get_create_edit_project_ids') {
+                    return [];
+                }
+            },
             type: "list",
             resModel: "account.analytic.line",
         });
@@ -67,6 +82,11 @@ QUnit.module("hr_timesheet", (hooks) => {
     QUnit.test("project task progress bar color", async function (assert) {
         await makeView({
             serverData,
+            mockRPC: function (route, args) {
+                if (route === '/web/dataset/call_kw/project.project/get_create_edit_project_ids') {
+                    return [];
+                }
+            },
             type: "list",
             resModel: "project.task",
             arch: `


### PR DESCRIPTION
This commit's purpose is to prevent the creation of a task with quick create with the 'withTaskHour' widget if the project is an fsm one. This is done to prevent the creation of fsm task without a partner set (the field is required).
