### PR TITLE
[REF] *: remove dead code in tours

### DIFF
--- a/addons/mass_mailing/static/tests/tours/snippets_mailing_menu_tabs.js
+++ b/addons/mass_mailing/static/tests/tours/snippets_mailing_menu_tabs.js
@@ -40,7 +40,6 @@ registry.category("web_tour.tours").add('snippets_mailing_menu_tabs', {
     {
         content: "Verify that the customize panel is not empty.",
         trigger: '.o_we_customize_panel .snippet-option-DesignTab',
-        run: () => null, // it's a check
     },
     {
         content: "Click on the style tab.",
@@ -55,7 +54,6 @@ registry.category("web_tour.tours").add('snippets_mailing_menu_tabs', {
     {
         content: "Verify that the customize panel is not empty.",
         trigger: '.o_we_customize_panel .snippet-option-DesignTab',
-        run: () => null, // it's a check
     },
     ...stepUtils.discardForm(),
 ]});

--- a/addons/mass_mailing/static/tests/tours/snippets_mailing_menu_toolbar.js
+++ b/addons/mass_mailing/static/tests/tours/snippets_mailing_menu_toolbar.js
@@ -35,7 +35,6 @@ registry.category("web_tour.tours").add('snippets_mailing_menu_toolbar', {
     {
         content: "Make sure the empty template is an option on non-mobile devices.",
         trigger: ':iframe #empty',
-        run: () => null,
     },
     {
         content: "Click on the default 'welcome' template.",
@@ -51,12 +50,10 @@ registry.category("web_tour.tours").add('snippets_mailing_menu_toolbar', {
     {
         content: "Make sure the snippets menu is not hidden",
         trigger: '#oe_snippets:not(.d-none)',
-        run: () => null,
     },
     {
         content: "Wait for .s_text_block to be populated",
         trigger: ':iframe .s_text_block p',
-        run: () => null,
     },
     {
         content: "Click and select p block inside the editor",
@@ -76,7 +73,6 @@ registry.category("web_tour.tours").add('snippets_mailing_menu_toolbar', {
     {
         content: "Make sure the toolbar is there",
         trigger: '#oe_snippets .o_we_customize_panel #toolbar',
-        run: () => null,
     },
     ...stepUtils.discardForm(),
     ],

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -287,7 +287,6 @@ registry.category("web_tour.tours").add("CheckProductInformation", {
             ProductScreen.clickInfoProduct("product_a"),
             {
                 trigger: ".section-financials :contains('Margin')",
-                run: () => {},
             },
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/tours/utils/partner_list_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/partner_list_util.js
@@ -25,12 +25,10 @@ export function checkContactValues(name, address = "", phone = "", mobile = "", 
         {
             content: `Check partner "${name}" from partner list screen`,
             trigger: `.partner-list .partner-info:contains("${name}")`,
-            run: () => {},
         },
         {
             content: `Check address "${address}" for partner "${name}"`,
             trigger: `.partner-list .partner-info:contains("${name}") .partner-line-adress:contains("${address}")`,
-            run: () => {},
         },
     ];
 
@@ -38,7 +36,6 @@ export function checkContactValues(name, address = "", phone = "", mobile = "", 
         steps.push({
             content: `Check phone number "${phone}" for partner "${name}"`,
             trigger: `.partner-list .partner-info:contains("${name}") .partner-line-email:contains("${phone}")`,
-            run: () => {},
         });
     }
 
@@ -46,7 +43,6 @@ export function checkContactValues(name, address = "", phone = "", mobile = "", 
         steps.push({
             content: `Check mobile number "${mobile}" for partner "${name}"`,
             trigger: `.partner-list .partner-info:contains("${name}") .partner-line-email:contains("${mobile}")`,
-            run: () => {},
         });
     }
 
@@ -54,7 +50,6 @@ export function checkContactValues(name, address = "", phone = "", mobile = "", 
         steps.push({
             content: `Check email address "${email}" for partner "${name}"`,
             trigger: `.partner-list .partner-info:contains("${name}") .partner-line-email .email-field:contains("${email}")`,
-            run: () => {},
         });
     }
 
@@ -77,7 +72,6 @@ export function searchCustomerValue(val) {
         {
             content: `Check "${val}" is shown`,
             trigger: `.partner-list .partner-info:nth-child(1):contains("${val}")`,
-            run: () => {},
         },
     ];
 }

--- a/addons/pos_loyalty/static/tests/tours/utils/pos_loyalty_util.js
+++ b/addons/pos_loyalty/static/tests/tours/utils/pos_loyalty_util.js
@@ -99,7 +99,6 @@ export function pointsAwardedAre(points_str) {
         {
             content: "loyalty points awarded " + points_str,
             trigger: '.loyalty-points-won:contains("' + points_str + '")',
-            run: function () {}, // it's a check
         },
     ];
 }

--- a/addons/pos_self_order/static/tests/tours/utils/landing_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/landing_page_util.js
@@ -17,6 +17,5 @@ export function isOpened() {
     return {
         content: `Check if the POS is opened`,
         trigger: `body:not(:has(.o-self-closed))`,
-        run: () => {},
     };
 }

--- a/addons/project_todo/static/tests/tours/project_todo_main_functions.js
+++ b/addons/project_todo/static/tests/tours/project_todo_main_functions.js
@@ -79,7 +79,6 @@ registry.category("web_tour.tours").add('project_todo_main_functions', {
     run: "click",
 }, {
     trigger: "a:contains('Set Cover Image')",
-    run: () => {}, // is a check
 }, {
     trigger: ".o_kanban_record:first",//:contains(Send message)
     content: "Open the first todo record",

--- a/addons/test_website/static/tests/tours/page_manager.js
+++ b/addons/test_website/static/tests/tours/page_manager.js
@@ -11,11 +11,9 @@ registry.category("web_tour.tours").add('test_website_page_manager', {
     content: "Check that we see records from My Website",
     trigger: ".o_list_table .o_data_row .o_data_cell[name=name]:contains('Test Multi Model Website 1') " +
              "~ .o_data_cell[name=website_id]:contains('My Website')",
-    run: () => null, // it's a check
 }, {
     content: "Check that there is only 2 records in the pager",
     trigger: ".o_pager .o_pager_value:contains('1-2')",
-    run: () => null, // it's a check
 }, {
     content: "Click on the 'Select all records' checkbox",
     trigger: "thead .o_list_record_selector",
@@ -23,7 +21,6 @@ registry.category("web_tour.tours").add('test_website_page_manager', {
 }, {
     content: "Check that there is only 2 records selected",
     trigger: ".o_list_selection_box:contains(2):contains(selected)",
-    run: () => null, // it's a check
 }, {
     content: "Click on the 'Select all records' checkbox again to unselect all records and see the search bar",
     trigger: "thead .o_list_record_selector",
@@ -42,7 +39,6 @@ registry.category("web_tour.tours").add('test_website_page_manager', {
     content: "Check that we see records from My Website 2",
     trigger: ".o_list_table .o_data_row .o_data_cell[name=name]:contains('Test Model Multi Website 2') " +
              "~ .o_data_cell[name=website_id]:contains('My Website 2')",
-    run: () => null, // it's a check
 },
 // Part 2: ensure Kanban View is working / not crashing
 {
@@ -60,7 +56,6 @@ registry.category("web_tour.tours").add('test_website_page_manager', {
 }, {
     content: "Wait for List View to be loaded",
     trigger: '.o_list_renderer',
-    run: () => null, // it's a check
 }]
 });
 
@@ -75,7 +70,6 @@ registry.category("web_tour.tours").add('test_website_page_manager_js_class_bug'
 }, {
     content: "Wait for Kanban View to be loaded",
     trigger: '.o_kanban_renderer',
-    run: () => null, // it's a check
 }]
 });
 
@@ -90,6 +84,5 @@ registry.category("web_tour.tours").add('test_website_page_manager_no_website_id
 }, {
     content: "Wait for Kanban View to be loaded",
     trigger: '.o_kanban_renderer',
-    run: () => null, // it's a check
 }]
 });

--- a/addons/website/static/tests/tours/client_action_redirect.js
+++ b/addons/website/static/tests/tours/client_action_redirect.js
@@ -13,7 +13,6 @@ const goToFrontendSteps = [{
 }, {
     content: "Check we are in the frontend",
     trigger: 'body:not(:has(.o_website_preview)) #test_contact_FE',
-    run: () => null, // it's a check
 }];
 const goToBackendSteps = [{
     content: "Go to the backend",
@@ -24,13 +23,11 @@ const goToBackendSteps = [{
 }, {
     content: "Check we are in the backend",
     trigger: '.o_website_preview',
-    run: () => null, // it's a check
 }];
 const checkEditorSteps = [{
     content: "Check that the editor is loaded",
     trigger: ':iframe body.editor_enable',
     timeout: 30000,
-    run: () => null, // it's a check
 }, {
     content: "exit edit mode",
     trigger: '.o_we_website_top_actions button.btn-primary:contains("Save")',
@@ -38,7 +35,6 @@ const checkEditorSteps = [{
 }, {
     content: "wait for editor to close",
     trigger: ':iframe body:not(.editor_enable)',
-    run: () => null, // It's a check
 }];
 
 registry.category("web_tour.tours").add('client_action_redirect', {

--- a/addons/website/static/tests/tours/snippet_popup_display_on_click.js
+++ b/addons/website/static/tests/tours/snippet_popup_display_on_click.js
@@ -69,7 +69,6 @@ registerWebsitePreviewTour("snippet_popup_display_on_click", {
     {
         content: "wait for the page to be loaded",
         trigger: ".o_website_preview[data-view-xmlid='website.contactus']",
-        run: () => null, // it"s a check
     },
     ...clickOnEditAndWaitEditMode(),
     ...dragNDrop({id: "s_text_image", name: "Image - Text", groupName: "Content"}),

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -214,7 +214,6 @@ registerWebsitePreviewTour("website_form_editor_tour", {
     {
         content: "Check that 'Conditional Visibility Check 2' is not in the list of the visibility selector of Conditional Visibility Check 1",
         trigger: "we-select[data-name='hidden_condition_opt']:not(:has(we-button[data-set-visibility-dependency='Conditional Visibility Check 2']))",
-        run: () => null,
     },
     ...addCustomField("char", "text", "Conditional Visibility Check 3", false),
     ...addCustomField("char", "text", "Conditional Visibility Check 4", false),
@@ -229,7 +228,6 @@ registerWebsitePreviewTour("website_form_editor_tour", {
     {
         content: "Check that the conditional visibility of the renamed field is removed",
         trigger: "we-customizeblock-option.snippet-option-WebsiteFieldEditor we-select:contains('Visibility'):has(we-toggler:contains('Always Visible'))",
-        run: () => null,
     },
     ...addCustomField("char", "text", "Conditional Visibility Check 5", false),
     ...addCustomField("char", "text", "Conditional Visibility Check 6", false),
@@ -243,7 +241,6 @@ registerWebsitePreviewTour("website_form_editor_tour", {
     {
         content: "Check that 'Conditional Visibility Check 5' is not in the list of the renamed field",
         trigger: "we-customizeblock-option.snippet-option-WebsiteFieldEditor we-select[data-name='hidden_condition_opt']:not(:has(we-button:contains('Conditional Visibility Check 5')))",
-        run: () => null,
     },
     ...addExistingField('email_cc', 'text', 'Test conditional visibility', false, {visibility: CONDITIONALVISIBILITY, condition: 'odoo'}),
     {
@@ -968,7 +965,6 @@ registerWebsitePreviewTour("website_form_editable_content", {
     {
         content: "Check that the new text value was correctly set",
         trigger: ":iframe section.s_website_form h3:contains(/^ABC$/)",
-        run: () => null, // it's a check
     },
     {   content: "Remove the dropped column",
         trigger: ":iframe .oe_overlay.oe_active .oe_snippet_remove",

--- a/addons/website/static/tests/tours/website_no_dirty_page.js
+++ b/addons/website/static/tests/tours/website_no_dirty_page.js
@@ -29,7 +29,6 @@ const makeSteps = (steps = []) => [
         // this tour makes sense.
         content: "Confirm we are in edit mode",
         trigger: 'body.editor_has_snippets',
-        run: () => null,
     },
     ...steps,
     {
@@ -58,7 +57,6 @@ const makeSteps = (steps = []) => [
     }, {
         content: "Confirm we are not in edit mode anymore",
         trigger: 'body:not(.editor_has_snippets)',
-        run: () => null,
     },
 ];
 
@@ -89,7 +87,6 @@ registerWebsitePreviewTour('website_no_dirty_page', {
         // task will review this feature.
         content: "Make sure the paragraph still acts as a default paragraph",
         trigger: ':iframe .s_text_image h2 + p.o_default_snippet_text',
-        run: () => null,
     }, {
         content: "Click on button",
         trigger: ':iframe .s_text_image .btn',
@@ -148,6 +145,5 @@ registerWebsitePreviewTour('website_no_dirty_lazy_image', {
     }, {
         content: "Check previous step went through correctly about dirty flags",
         trigger: ':iframe #wrap.o_dirty_as_expected',
-        run: () => null, // it's a check
     }
 ]);

--- a/addons/website_links/static/tests/tours/website_links.js
+++ b/addons/website_links/static/tests/tours/website_links.js
@@ -23,7 +23,6 @@ function fillSelect2(inputID, search) {
         {
             content: "Check that select2 is properly filled",
             trigger: `.o_website_links_utm_forms div.select2-container#s2id_${inputID} .select2-chosen:contains("/^${search}$/")`,
-            run: () => null,
         },
     ];
 }
@@ -68,7 +67,6 @@ registry.category("web_tour.tours").add('website_links_tour', {
         {
             content: "Check that select2 is properly filled",
             trigger: ".o_website_links_utm_forms div.select2-container#s2id_campaign-select .select2-chosen:contains(/^Create 'Some new campaign'$/)",
-            run: () => null,
         },
         // Then proceed by using existing ones
         ...fillSelect2('campaign-select', campaignValue),

--- a/addons/website_sale/static/tests/tours/website_sale_fiscal_position_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_fiscal_position_tour.js
@@ -9,7 +9,6 @@ registry.category("web_tour.tours").add('website_sale_fiscal_position_portal_tou
         {
             content: "Check price",
             trigger: ".oe_product:contains('Super product') .product_price:contains('80.00')",
-            run: function() {} // Check
         },
 ]});
 
@@ -30,6 +29,5 @@ registry.category("web_tour.tours").add('website_sale_fiscal_position_public_tou
         {
             content: "Check price",
             trigger: ".oe_product:contains('Super product') .product_price:contains('92.00')",
-            run: function() {} // Check
         },
 ]});

--- a/addons/website_sale/static/tests/tours/website_sale_remove_product_image.js
+++ b/addons/website_sale/static/tests/tours/website_sale_remove_product_image.js
@@ -16,7 +16,6 @@ const clickOnImgAndWaitForLoad = [
     {
         content: "Check that the snippet editor of the clicked image has been loaded",
         trigger: "we-customizeblock-options:has(we-title:contains('Re-order'))",
-        run: () => null,
     },
 ];
 const enterEditModeOfTestProduct = () => [
@@ -40,7 +39,6 @@ const removeImg = [
     {
         content: "Check that the snippet editor is not visible",
         trigger: ".o_we_customize_panel:not(:has(we-customizeblock-options:has(we-title:contains('Re-order'))))",
-        run: () => null,
     },
 ];
 
@@ -62,7 +60,6 @@ registerWebsitePreviewTour("add_and_remove_main_product_image_no_variant", {
     {
         content: "Check that the snippet editor of the clicked image has been loaded",
         trigger: "we-customizeblock-options:has(we-title:contains('Re-order'))",
-        run: () => null,
     },
     ...removeImg,
 ]);

--- a/addons/website_sale/static/tests/tours/website_sale_shop_pricelist_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_pricelist_tour.js
@@ -11,7 +11,6 @@ registry.category("web_tour.tours").add(
             {
                 content: "Check pricelist",
                 trigger: ".o_pricelist_dropdown .dropdown-toggle:not(:contains('User Pricelist'))",
-                run: function() {} // Check
             },
             {
                 content: "Go to login page",
@@ -31,7 +30,6 @@ registry.category("web_tour.tours").add(
             {
                 content: "Check pricelist",
                 trigger: ".o_pricelist_dropdown .dropdown-toggle:contains('User Pricelist')",
-                run: function() {} // Check
             },
         ]
     }

--- a/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
+++ b/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
@@ -95,7 +95,6 @@ registerWebsitePreviewTour('course_publisher_standard', {
     content: "eLearning: check editor is loaded for article",
     trigger: ':iframe body.editor_enable',
     timeout: 30000,
-    run: () => null, // it's a check
 }, {
     content: "eLearning: save article",
     trigger: '.o_we_website_top_actions button.btn-primary:contains("Save")',


### PR DESCRIPTION
In this commit, we remove no longer useful **run** tour step key. Let's see 2452a1607f295c7fd19fa271e4665a3820aec613 for more informations.