### PR TITLE
[FIX] hr_timesheet: assign the extra domain to the variable

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -48,7 +48,7 @@ class AccountAnalyticLine(models.Model):
     def _domain_employee_id(self):
         domain = [('company_id', 'in', self._context.get('allowed_company_ids'))]
         if not self.user_has_groups('hr_timesheet.group_hr_timesheet_approver'):
-            expression.AND([domain, ('user_id', '=', self.env.user.id)])
+            domain = expression.AND([domain, ('user_id', '=', self.env.user.id)])
         return domain
 
     task_id = fields.Many2one(


### PR DESCRIPTION
We missed to assign the extra domain to variable after adding them. Now assigning after domain addition.

task-3918572
