### PR TITLE
[FIX] product: discount policy reset on settings save

### DIFF
--- a/addons/product/models/res_config_settings.py
+++ b/addons/product/models/res_config_settings.py
@@ -65,8 +65,9 @@ class ResConfigSettings(models.TransientModel):
 
     def set_values(self):
         had_group_pl = self.default_get(['group_product_pricelist'])['group_product_pricelist']
+        had_discount_group = self.default_get(['group_discount_per_so_line'])['group_discount_per_so_line']
         super().set_values()
-        if not self.group_discount_per_so_line:
+        if had_discount_group and not self.group_discount_per_so_line:
             pl = self.env['product.pricelist'].search([('discount_policy', '=', 'without_discount')])
             pl.write({'discount_policy': 'with_discount'})
 


### PR DESCRIPTION
The pricelist discount policy is always visibile in 17+, and some users may change it to display discounts in the PoS.

Nevertheless, if the sale discounts are not enabled, saving the settings will reset the value to 'hide discounts'.

Since the group is ambiguous, has been moved to sale in 17.2, and the discount policy feature is removed in 18, we'll restrict the reset of the discount policies only when the discount group is effectively disabled manually, not any time the settings are saved.

opw-4019168




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
