### PR TITLE
[FIX] web_tour: fix snippets drag in tour

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_compilers.js
+++ b/addons/web_tour/static/src/tour_service/tour_compilers.js
@@ -162,7 +162,7 @@ function getAnchorEl(el, consumeEvent) {
         // jQuery-ui draggable triggers 'drag' events on the .ui-draggable element,
         // but the tip is attached to the .ui-draggable-handle element which may
         // be one of its children (or the element itself)
-        return el.closest(".ui-draggable, .o_draggable");
+        return el.closest(".ui-draggable, .o_draggable, .o_we_draggable");
     }
 
     if (consumeEvent === "input" && !["textarea", "input"].includes(el.tagName.toLowerCase())) {


### PR DESCRIPTION
Fix the tour cursor being displayed out of the website snippets when the step is to drag and drop a snippets from the website editor.

Adding the '.o_we_draggable' class to the tour compiler so that the drag event is correctly handled in the editor.

Related commit: odoo/odoo@5a990d8d8ba2ec2999f84d2f1dae7aeec0f2d9b5

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
