### PR TITLE
[FIX] pos_loyalty: fix discount on specific product value

### DIFF
--- a/addons/pos_loyalty/static/src/tours/PosLoyaltyRewardButtonTour.js
+++ b/addons/pos_loyalty/static/src/tours/PosLoyaltyRewardButtonTour.js
@@ -155,8 +155,16 @@ ProductScreen.check.selectedOrderlineHas('Test Product A', '1.00', '40.00');
 ProductScreen.do.clickDisplayedProduct('Test Product B');
 ProductScreen.check.selectedOrderlineHas('Test Product B', '1.00', '40.00');
 PosLoyalty.do.clickRewardButton();
+SelectionPopup.do.clickItem("$ 10 per order on specific products");
 PosLoyalty.check.hasRewardLine('$ 10 per order on specific products', '-10.00', '1.00');
+PosLoyalty.check.orderTotalIs('70.00');
+PosLoyalty.do.clickRewardButton();
+SelectionPopup.do.clickItem("$ 10 per order on specific products");
 PosLoyalty.check.orderTotalIs('60.00');
+PosLoyalty.do.clickRewardButton();
+SelectionPopup.do.clickItem("$ 30 per order on specific products");
+PosLoyalty.check.hasRewardLine('$ 30 per order on specific products', '-30.00', '1.00');
+PosLoyalty.check.orderTotalIs('30.00');
 
 Tour.register('PosLoyaltySpecificDiscountTour', { test: true, url: '/pos/web' }, getSteps());
 

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -857,7 +857,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'pos_ok': True,
             'rule_ids': [(0, 0, {
                 'reward_point_mode': 'order',
-                'reward_point_amount': 5,
+                'reward_point_amount': 10,
                 'minimum_qty': 2,
                 'product_ids': [(6, 0, [self.product_a.id, self.product_b.id])],
             })],
@@ -866,6 +866,13 @@ class TestUi(TestPointOfSaleHttpCommon):
                 'discount_mode': 'per_order',
                 'required_points': 2,
                 'discount': 10,
+                'discount_applicability': 'specific',
+                'discount_product_ids': (self.product_a | self.product_b).ids,
+            }), (0, 0, {
+                'reward_type': 'discount',
+                'discount_mode': 'per_order',
+                'required_points': 5,
+                'discount': 30,
                 'discount_applicability': 'specific',
                 'discount_product_ids': (self.product_a | self.product_b).ids,
             })],


### PR DESCRIPTION
Currently, when applying two discounts (from loyalty programs) that are applied on specific products, the second discount value does not match with the setup of the reward.

Steps to reproduce:
-------------------
* Go to the **Point of Sale** App
* Create a new product, P -> Price 100$, no tax applied
* Under **Products** select **Discount & loyalty**
* Create a new loyalty program
  * Rule 10 points per $ spent
  * Reward 1: 10$ on P for 10 points
  * Reward 2: 50$ on P for 40 points
* Open shop session
* Add P to the order
* Add reward 1
* Add reward 2
> Observation: The first reward is 10$ but the second is 55$

Why the fix:
------------
We will use the example from the given steps to explain what happens.

https://github.com/odoo/odoo/blob/e01df041b9428cf14cb150bdb0803c6f5ff2d80f/addons/pos_loyalty/static/src/js/Loyalty.js#L1376-L1377

On the first line of the above `discountable` and `discountablePerTax` will be
100. On the second line `discountable` will be 90 as the order total is 90, as the discount is counted here.

https://github.com/odoo/odoo/blob/e01df041b9428cf14cb150bdb0803c6f5ff2d80f/addons/pos_loyalty/static/src/js/Loyalty.js#L1417

Here we have `masDiscount` being 50 (`reward.discount`). Thus we end up with `discountFactor = min(1, 0.555)`. This factor is later on used to set the price of the discount line. The price is set up as follow.

https://github.com/odoo/odoo/blob/e01df041b9428cf14cb150bdb0803c6f5ff2d80f/addons/pos_loyalty/static/src/js/Loyalty.js#L1426

Where entry one corresponds to the value of `discountablePerTax` which is 100. Thus the discount is valued at `0.555 * 100 = 55.5$`.

To solve this we make `discountable` and `discountablePerTax` account for the discounts that aleady apply on the same product. We then look at what happens in the function `_getDiscountableOnSpecific` as in our case it corresponds to `getDiscountable`.

https://github.com/odoo/odoo/blob/e01df041b9428cf14cb150bdb0803c6f5ff2d80f/addons/pos_loyalty/static/src/js/Loyalty.js#L1250-L1251

As this comment says we don't want to discount more than what is available. In our case only 90$ are available since we have already applied the 10$ discount.

https://github.com/odoo/odoo/blob/e01df041b9428cf14cb150bdb0803c6f5ff2d80f/addons/pos_loyalty/static/src/js/Loyalty.js#L1269-L1273

We see that when we scan through the order lines, only discount from the same reward as the one we are trying to apply are counted. In short, if we were trying to apply another 10$ discount instead of the 50, then the line would be counted. But since the 10$ and 50$ discounts apply on the same product, they should both be counted.

We want to add more discount lines to `linesToDisount` because at the end, it is used compute `discountable` and `discountablePerTax`.

https://github.com/odoo/odoo/blob/e01df041b9428cf14cb150bdb0803c6f5ff2d80f/addons/pos_loyalty/static/src/js/Loyalty.js#L1331-L1341

We want to add the discount lines that applies to at least one product of the current reward. But we also need to check if that common product is on the order. If we imagine reward 1 applied on P1, reward 2 applied on P1 and P2 but we only have P2 in the order then reward 1 should not count when applying reward 2.

We filter on the `reward_type` to exclude lines that are related to free products rewards. 

With the current change there is a difference in behaviors when the discount is a percentage or a fixed amount. Since we now count the discounts at the end, we can remove this part of the code as it would count twice the discounts that are percentages.

https://github.com/odoo/odoo/blob/e01df041b9428cf14cb150bdb0803c6f5ff2d80f/addons/pos_loyalty/static/src/js/Loyalty.js#L1298-L1309

opw-4083557