### PR TITLE
[FIX] point_of_sale/saas~17.4: Ensure Unique IDs for POS Order Lines in Processing Fractional Quantity 

### DIFF
--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -151,7 +151,9 @@ patch(PosStore.prototype, {
             if (product_unit && !product_unit.is_pos_groupable) {
                 let remaining_quantity = newLine.qty;
                 while (!this.env.utils.floatIsZero(remaining_quantity)) {
-                    const splitted_line = this.models["pos.order.line"].create(newLineValues);
+                    const splitted_line = this.models["pos.order.line"].create({
+                        ...newLineValues,
+                    });
                     splitted_line.set_quantity(Math.min(remaining_quantity, 1.0), true);
                     remaining_quantity -= splitted_line.qty;
                 }


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

- When splitting the quantity into smaller units and creating multiple lines for the product while settling a sale order, the current implementation does not generate a unique id for each newly created line after the first iteration of the loop. As a result, subsequent lines share the same id, leading to incorrect calculations and data retrieval based on the shared id. This results in incorrect receipt generation and inconsistent data.

Steps to Reproduce
- install point_of_sale and sale_management in fresh database of version saas~17.4.
- do the following settings.

![unit setting](https://github.com/user-attachments/assets/af6a99e3-4745-4c0d-aecc-8aac67a8235c)

- create a product eg. 'test' which is available in POS. keep its unit in `lb`. (see example)
![product](https://github.com/user-attachments/assets/6c32bd00-7077-432f-9f93-e3688a5f4d87)

- create a sale order for this product, with fractional quantity.
![SO](https://github.com/user-attachments/assets/d7526c8a-2b81-43dd-862e-a5462259266b)

- open this sale order from on of the POS instance to settle.
![pos setttle so](https://github.com/user-attachments/assets/a74b68c7-d711-4859-8f88-7238a0586f1e)

- you should see something like this.
![pos list](https://github.com/user-attachments/assets/7b5648ce-edd0-4303-916a-edfb6975e425)

- validate this order and generate receipt .

Current behavior before PR:
- faulty receipt is generated.
![faulty receit](https://github.com/user-attachments/assets/effd85c1-d8d0-42cd-b83e-100d85e144ff)


Desired behavior after PR is merged:
- Correct quantities are calculated and receipt is generated properly.
![pos receit fix](https://github.com/user-attachments/assets/5227132e-2073-40aa-8ec4-a157a6e8f848)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
