### PR TITLE
[IMP] website: introduce `s_references_grid` snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -70,6 +70,7 @@
         'views/snippets/s_company_team_shapes.xml',
         'views/snippets/s_call_to_action.xml',
         'views/snippets/s_references.xml',
+        'views/snippets/s_references_grid.xml',
         'views/snippets/s_popup.xml',
         'views/snippets/s_faq_collapse.xml',
         'views/snippets/s_features_grid.xml',

--- a/addons/website/views/snippets/s_references_grid.xml
+++ b/addons/website/views/snippets/s_references_grid.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_references_grid" name="References Grid">
+    <section class="s_references_grid o_cc o_cc1 pt64 pb64">
+        <div class="container">
+            <div class="row o_grid_mode" data-row-count="4">
+                <div class="o_grid_item g-height-4 g-col-lg-5 col-lg-5" style="grid-area: 1 / 1 / 5 / 6; z-index: 1;">
+                    <h2>Trusted references</h2>
+                    <p class="lead">We are in good company.</p>
+                    <a href="#" class="btn btn-primary">See our case studies</a>
+                </div>
+                <div class="o_grid_item o_grid_item_image g-col-lg-2 g-height-2 col-6 col-lg-2" style="grid-area: 1 / 7 / 3 / 9; z-index: 2;">
+                    <img src="/web/image/website.s_reference_demo_image_1" class="img img-fluid" alt=""/>
+                </div>
+                <div class="o_grid_item o_grid_item_image g-col-lg-2 g-height-2 col-6 col-lg-2" style="grid-area: 1 / 9 / 3 / 11; z-index: 3;">
+                    <img src="/web/image/website.s_reference_demo_image_2" class="img img-fluid" alt=""/>
+                </div>
+                <div class="o_grid_item o_grid_item_image g-col-lg-2 g-height-2 col-6 col-lg-2" style="grid-area: 1 / 11 / 3 / 13; z-index: 4;">
+                    <img src="/web/image/website.s_reference_demo_image_3" class="img img-fluid" alt=""/>
+                </div>
+                <div class="o_grid_item o_grid_item_image g-col-lg-2 g-height-2 col-6 col-lg-2" style="grid-area: 3 / 7 / 5 / 9; z-index: 5;">
+                    <img src="/web/image/website.s_reference_demo_image_4" class="img img-fluid" alt=""/>
+                </div>
+                <div class="o_grid_item o_grid_item_image g-col-lg-2 g-height-2 col-6 col-lg-2" style="grid-area: 3 / 9 / 5 / 11; z-index: 6;">
+                    <img src="/web/image/website.s_reference_demo_image_5" class="img img-fluid" alt=""/>
+                </div>
+                <div class="o_grid_item o_grid_item_image g-col-lg-2 g-height-2 col-6 col-lg-2" style="grid-area: 3 / 11 / 5 / 13; z-index: 7;">
+                    <img src="/web/image/website.s_reference_default_image_6" class="img img-fluid" alt=""/>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -201,6 +201,9 @@
                 <t t-snippet="website.s_references" string="References" group="people">
                     <keywords>customers, clients</keywords>
                 </t>
+                <t t-snippet="website.s_references_grid" string="References Grid" group="people">
+                    <keywords>customers, clients, sponsors, partners, supporters, case-studies, collaborators, associations, associates, testimonials, endorsements</keywords>
+                </t>
                 <t t-snippet="website.s_quotes_carousel" string="Quotes" group="people">
                     <keywords>testimonials</keywords>
                 </t>


### PR DESCRIPTION
This commit adds the new `s_references_grid` snippet.

task-4146798
Part-of: task-4077427

| ![image](https://github.com/user-attachments/assets/fbe01605-4409-4a99-adf6-ec5980dc0641) |
|--------|

Design-themes PR: https://github.com/odoo/design-themes/pull/891

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
