### PR TITLE
[FIX] sale: salesman unable to create global discount

### DIFF
--- a/addons/sale/wizard/sale_order_discount.py
+++ b/addons/sale/wizard/sale_order_discount.py
@@ -68,7 +68,7 @@ class SaleOrderDiscount(models.TransientModel):
         self.ensure_one()
         discount_product = self.company_id.sale_discount_product_id
         if not discount_product:
-            self.company_id.sale_discount_product_id = self.env['product.product'].create(
+            self.company_id.sudo().sale_discount_product_id = self.env['product.product'].sudo().create(
                 self._prepare_discount_product_values()
             )
             discount_product = self.company_id.sale_discount_product_id


### PR DESCRIPTION
If nobody gave a global discount (fixed amount/on SO) in a given company before, the first user to give a global discount through the dedicated wizard would create the dedicated Discount product for that company.

Nevertheless, it was not done in sudo, so the user would get a traceback if he didn't have admin rights (for company update) or manager rights (for the product creation).

opw-4048403





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
