### PR TITLE
[IMP] point_of_sale, pos_hr: allow payment_ids editing for pos_order

### DIFF
--- a/addons/l10n_fr_pos_cert/views/pos_views.xml
+++ b/addons/l10n_fr_pos_cert/views/pos_views.xml
@@ -7,6 +7,9 @@
             <xpath expr="//field[@name='pos_reference']" position='after'>
                 <field string='Hash' name="l10n_fr_hash" groups="base.group_no_one"/>
             </xpath>
+            <field name="payment_ids" position="attributes">
+                <attribute name="readonly" add="country_code in ['FR', 'MF', 'MQ', 'NC', 'PF', 'RE', 'GF', 'GP', 'TF']" separator=" or " />
+            </field>
         </field>
     </record>
 </odoo>

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -11,7 +11,7 @@ import pytz
 import re
 
 from odoo import api, fields, models, tools, _
-from odoo.tools import float_is_zero, float_round, float_repr, float_compare
+from odoo.tools import float_is_zero, float_round, float_repr, float_compare, formatLang
 from odoo.exceptions import ValidationError, UserError
 from odoo.osv.expression import AND
 import base64
@@ -274,6 +274,7 @@ class PosOrder(models.Model):
         help="Employee who uses the cash register.",
         default=lambda self: self.env.uid,
     )
+    amount_difference = fields.Float(string='Difference', digits=0, readonly=True)
     amount_tax = fields.Float(string='Taxes', digits=0, readonly=True, required=True)
     amount_total = fields.Float(string='Total', digits=0, readonly=True, required=True)
     amount_paid = fields.Float(string='Paid', digits=0, required=True)
@@ -316,7 +317,7 @@ class PosOrder(models.Model):
         comodel_name='account.fiscal.position', string='Fiscal Position',
         readonly=False,
     )
-    payment_ids = fields.One2many('pos.payment', 'pos_order_id', string='Payments', readonly=True)
+    payment_ids = fields.One2many('pos.payment', 'pos_order_id', string='Payments')
     session_move_id = fields.Many2one('account.move', string='Session Journal Entry', related='session_id.move_id', readonly=True, copy=False)
     to_invoice = fields.Boolean('To invoice', copy=False)
     shipping_date = fields.Date('Shipping Date')
@@ -334,6 +335,7 @@ class PosOrder(models.Model):
     is_edited = fields.Boolean(string='Edited', compute='_compute_is_edited')
     has_deleted_line = fields.Boolean(string='Has Deleted Line')
     order_edit_tracking = fields.Boolean(related="config_id.order_edit_tracking", readonly=True)
+    available_payment_method_ids = fields.Many2many('pos.payment.method', related='config_id.payment_method_ids', string='Available Payment Methods', readonly=True, store=False)
 
     def _search_tracking_number(self, operator, value):
         #search is made over the pos_reference field
@@ -423,6 +425,9 @@ class PosOrder(models.Model):
 
     @api.onchange('payment_ids', 'lines')
     def _onchange_amount_all(self):
+        self._compute_prices()
+
+    def _compute_prices(self):
         for order in self:
             if not order.currency_id:
                 raise UserError(_("You can't: create a pos order from the backend interface, or unset the pricelist, or create a pos.order in a python test with Form tool, or edit the form view in studio if no PoS order exist"))
@@ -430,8 +435,8 @@ class PosOrder(models.Model):
             order.amount_paid = sum(payment.amount for payment in order.payment_ids)
             order.amount_return = sum(payment.amount < 0 and payment.amount or 0 for payment in order.payment_ids)
             order.amount_tax = currency.round(sum(self._amount_line_tax(line, order.fiscal_position_id) for line in order.lines))
-            amount_untaxed = currency.round(sum(line.price_subtotal for line in order.lines))
-            order.amount_total = order.amount_tax + amount_untaxed
+            order.amount_total = order.amount_tax + currency.round(sum(line.price_subtotal for line in order.lines))
+            order.amount_difference = order.amount_paid - order.amount_total
 
     def _compute_batch_amount_all(self):
         """
@@ -496,7 +501,87 @@ class PosOrder(models.Model):
                         country=order.partner_id.country_id or self.env.company.country_id)
             if vals.get('has_deleted_line') is not None and self.has_deleted_line:
                 del vals['has_deleted_line']
-        return super(PosOrder, self).write(vals)
+
+        list_line = self._create_pm_change_log(vals)
+        res = super().write(vals)
+        for order in self:
+            if vals.get('payment_ids'):
+                order._compute_prices()
+                totally_paid_or_more = float_compare(order.amount_paid, order.amount_total, precision_rounding=order.currency_id.rounding)
+                if totally_paid_or_more < 0 and order.state in ['paid', 'done', 'invoiced']:
+                    raise UserError(_('The paid amount is different from the total amount of the order.'))
+                elif totally_paid_or_more > 0 and order.state == 'paid':
+                    list_line.append(_("Warning, the paid amount is higher than the total amount. (Difference: %s)", formatLang(self.env, order.amount_paid - order.amount_total, currency_obj=order.currency_id)))
+
+        if len(list_line) > 0:
+            body = _("Payment changes:")
+            body += self._markup_list_message(list_line)
+            for order in self:
+                if vals.get('payment_ids'):
+                    order.message_post(body=body)
+
+        return res
+
+    def _create_pm_change_log(self, vals):
+        if not vals.get('payment_ids'):
+            return []
+
+        message_list = []
+        new_pms = vals.get('payment_ids', [])
+        for new_pm in new_pms:
+            orm_command = new_pm[0]
+
+            if orm_command == 0:
+                payment_method_id = self.env['pos.payment.method'].browse(new_pm[2].get('payment_method_id'))
+                amount = formatLang(self.env, new_pm[2].get('amount'), currency_obj=self.currency_id)
+                message_list.append(_("Added %(payment_method)s with %(amount)s",
+                    payment_method=payment_method_id.name,
+                    amount=amount))
+            elif orm_command == 1:
+                pm_id = self.env['pos.payment'].browse(new_pm[1])
+                old_pm = pm_id.payment_method_id.name
+                old_amount = formatLang(self.env, pm_id.amount, currency_obj=pm_id.currency_id)
+                new_amount = False
+                new_payment_method = False
+
+                if new_pm[2].get('payment_method_id'):
+                    new_payment_method = self.env['pos.payment.method'].browse(new_pm[2].get('payment_method_id'))
+                if new_pm[2].get('amount'):
+                    new_amount = formatLang(self.env, new_pm[2].get('amount'), currency_obj=pm_id.currency_id)
+
+                if new_payment_method and new_amount:
+                    message_list.append(_("%(old_pm)s changed to %(new_pm)s and from %(old_amount)s to %(new_amount)s",
+                        old_pm=old_pm,
+                        new_pm=new_payment_method.name,
+                        old_amount=old_amount,
+                        new_amount=new_amount))
+                elif new_payment_method:
+                    message_list.append(_("%(old_pm)s changed to %(new_pm)s for %(old_amount)s",
+                        old_pm=old_pm,
+                        new_pm=new_payment_method.name,
+                        old_amount=old_amount))
+                elif new_amount:
+                    message_list.append(_("Amount for %(old_pm)s changed from %(old_amount)s to %(new_amount)s",
+                        old_amount=old_amount,
+                        new_amount=new_amount,
+                        old_pm=old_pm))
+            elif orm_command == 2:
+                pm_id = self.env['pos.payment'].browse(new_pm[1])
+                amount = formatLang(self.env, pm_id.amount, currency_obj=pm_id.currency_id)
+                message_list.append(_("Removed %(payment_method)s with %(amount)s",
+                    payment_method=pm_id.payment_method_id.name,
+                    amount=amount))
+
+        return message_list
+
+    def _markup_list_message(self, message):
+        body = Markup("<ul>")
+        for line in message:
+            body += Markup("<li>")
+            body += line
+            body += Markup("</li>")
+        body += Markup("</ul>")
+        return body
 
     def _compute_order_name(self):
         if self.refunded_order_id.exists():

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.xml
@@ -10,7 +10,10 @@
                             <div class="d-flex flex-column align-items-center p-1 p-lg-3 border border-success rounded-3 bg-success-subtle text-success fs-3">
                                 <i t-if="!ui.isSmall" class="fa fa-fw fa-2x fa-check-circle"/>
                                 <span class="fs-3 fw-bolder">Payment Successful</span>
-                                <span class="fs-4 fw-bold"><t t-esc="orderAmountPlusTip" /></span>
+                                <div class="fs-4 fw-bold d-flex justify-content-center align-items-center gap-2">
+                                    <span t-esc="orderAmountPlusTip" />
+                                    <span class="edit-order-payment badge bg-success text-white rounded cursor-pointer pt-1" t-on-click="() => this.pos.orderDetails(this.pos.get_order())">Edit payment</span>
+                                </div>
                             </div>
                             <hr />
                             <div class="receipt-options d-flex flex-column gap-2">

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/invoice_button/invoice_button.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/invoice_button/invoice_button.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="point_of_sale.InvoiceButton">
-        <button class="control-button btn btn-light btn-lg lh-lg flex-grow-1 flex-shrink-1 flex-basis-50" t-on-click="() => this.click()" t-ref="invoice-button">
+        <button class="control-button btn btn-light btn-lg lh-lg flex-grow-1 flex-shrink-1" t-on-click="() => this.click()" t-ref="invoice-button">
             <i class="fa fa-file-pdf-o me-1"></i>
             <span> </span>
             <span><t t-esc="commandName"></t></span>

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/reprint_receipt_button/reprint_receipt_button.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/reprint_receipt_button/reprint_receipt_button.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="point_of_sale.ReprintReceiptButton">
-        <button class="control-button btn btn-light btn-lg lh-lg flex-grow-1 flex-shrink-1 flex-basis-50" t-on-click="() => this.click()">
+        <button class="control-button btn btn-light btn-lg lh-lg flex-grow-1 flex-shrink-1" t-on-click="() => this.click()">
             <i class="fa fa-print me-1"></i>
             <span> </span>
             <span>Print Receipt</span>

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -156,6 +156,9 @@
                         <div class="pads">
                             <t t-if="isOrderSynced">
                                 <div class="control-buttons d-flex gap-2 pb-2">
+                                    <button class="edit-order-payment control-button btn btn-light btn-lg lh-lg flex-grow-1 flex-shrink-1" t-on-click="() => this.pos.orderDetails(_selectedSyncedOrder)">
+                                        <i class="fa fa-pencil-square-o me-1" /> Details
+                                    </button>
                                     <InvoiceButton
                                         onInvoiceOrder.bind="onInvoiceOrder"
                                         order="_selectedSyncedOrder" />
@@ -163,7 +166,7 @@
                                 </div>
                                 <div class="subpads d-flex flex-column">
                                     <Numpad class="'pb-2'" buttons="getNumpadButtons()"/>
-                                    <ActionpadWidget 
+                                    <ActionpadWidget
                                         partner="getSelectedOrder()?.get_partner()"
                                         actionName.translate="Refund"
                                         actionToTrigger.bind="onDoRefund"

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -31,6 +31,7 @@ import { changesToOrder, getOrderChanges } from "../models/utils/order_change";
 import { getTaxesAfterFiscalPosition, getTaxesValues } from "../models/utils/tax_utils";
 import { QRPopup } from "@point_of_sale/app/utils/qr_code_popup/qr_code_popup";
 import { ActionScreen } from "@point_of_sale/app/screens/action_screen";
+import { FormViewDialog } from "@web/views/view_dialogs/form_view_dialog";
 
 const { DateTime } = luxon;
 
@@ -1443,6 +1444,18 @@ export class PosStore extends Reactive {
                 },
             }
         );
+    }
+    async orderDetails(order) {
+        this.dialog.add(FormViewDialog, {
+            resModel: "pos.order",
+            resId: order.id,
+            onRecordSaved: (record) => {
+                this.data.read("pos.order", [record.evalContext.id]);
+                this.action.doAction({
+                    type: "ir.actions.act_window_close",
+                });
+            },
+        });
     }
     async closePos() {
         // If pos is not properly loaded, we just go back to /web without

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -150,18 +150,23 @@
                         <div class="clearfix"/>
                     </page>
                     <page string="Payments" name="payments">
-                        <field name="payment_ids" colspan="4" nolabel="1">
-                            <tree string="Payments">
+                        <field name="payment_ids" colspan="4" nolabel="1" readonly="state in ['invoiced', 'done']">
+                            <tree string="Payments" create="1" editable="bottom">
                                 <field name="currency_id" column_invisible="True" />
                                 <field name="payment_date"/>
-                                <field name="payment_method_id"/>
+                                <field name="payment_method_id" domain="[('id', 'in', parent.available_payment_method_ids)]" />
+                                <field name="amount"/>
                                 <field name="payment_method_payment_mode" optional="hide"/>
                                 <field name="card_no" invisible="not card_no"/>
                                 <field name="card_brand" string="Card's Brand" invisible="not card_brand or not card_no"/>
                                 <field name="cardholder_name" invisible="not cardholder_name or not card_no"/>
-                                <field name="amount"/>
                             </tree>
                         </field>
+                        <group class="oe_subtotal_footer" colspan="2" name="order_total">
+                            <field name="amount_total" class="h3" widget="monetary"/>
+                            <field name="amount_paid" widget="monetary" class="h3" readonly="1" />
+                            <field name="amount_difference" widget="monetary" force_save="1" />
+                        </group>
                     </page>
                     <page name="extra" string="Extra Info">
                         <group >

--- a/addons/pos_hr/static/src/overrides/screens/receipt_screen/receipt_screen.xml
+++ b/addons/pos_hr/static/src/overrides/screens/receipt_screen/receipt_screen.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="ReceiptScreen" t-inherit="point_of_sale.ReceiptScreen" t-inherit-mode="extension">
+        <xpath expr="//span[hasclass('edit-order-payment')]" position="attributes">
+            <attribute name="t-if">!this.pos.config.module_pos_hr || this.pos.employeeIsAdmin</attribute>
+        </xpath>
+    </t>
+</templates>

--- a/addons/pos_hr/static/src/overrides/screens/screens/ticket_screen/ticket_screen.xml
+++ b/addons/pos_hr/static/src/overrides/screens/screens/ticket_screen/ticket_screen.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="pos_event.TicketScreen" t-inherit="point_of_sale.TicketScreen" t-inherit-mode="extension">
+        <xpath expr="//button[hasclass('edit-order-payment')]" position="attributes">
+            <attribute name="t-if">!this.pos.config.module_pos_hr || this.pos.employeeIsAdmin</attribute>
+        </xpath>
+    </t>
+</templates>


### PR DESCRIPTION
Before, it was not possible to edit the payment_ids of a pos_order when the order was paid but not posted.

Now, we allow editing the payment_ids of a pos_order when the order is paid but not posted. Only for advanced user in pos_hr

taskId: 4143603
