### PR TITLE
[FIX] account: handle multiple payment duplication

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -940,13 +940,17 @@ class AccountPayment(models.Model):
             payment.display_name = payment.move_id.name if payment.move_id.name != '/' else _('Draft Payment')
 
     def copy(self, default=None):
-        if not self.is_internal_transfer:
-            default = {
-                'journal_id': self.journal_id.id,
-                'payment_method_line_id': self.payment_method_line_id.id,
-                **(default or {}),
-            }
-        return super().copy(default=default)
+        copied_payments = self.env['account.payment']
+        for payment in self:
+            payment_default = default
+            if not payment.is_internal_transfer:
+                payment_default = {
+                    'journal_id': payment.journal_id.id,
+                    'payment_method_line_id': payment.payment_method_line_id.id,
+                    **(default or {}),
+                }
+            copied_payments += super(AccountPayment, payment).copy(default=payment_default)
+        return copied_payments
 
     # -------------------------------------------------------------------------
     # SYNCHRONIZATION account.payment <-> account.move

--- a/addons/account/tests/test_account_payment_duplicate.py
+++ b/addons/account/tests/test_account_payment_duplicate.py
@@ -255,3 +255,24 @@ class TestAccountPaymentDuplicateMoves(AccountTestInvoicingCommon):
         payment_1 = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=self.out_invoice_1.ids).create({})
 
         self.assertRecordValues(payment_1, [{'duplicate_move_ids': [self.payment_in.move_id.id]}])
+
+    def test_bulk_copy_payments(self):
+        """ Ensure that bulk copying of multiple payments correctly identifies duplicates for both
+        inbound and outbound payment types.
+        """
+        payment_in_1 = self.payment_in
+        payment_out_1 = self.payment_out
+
+        copied_payments = (payment_in_1 + payment_out_1).copy()
+
+        # Check that the copied payments are separate instances with new IDs
+        self.assertNotEqual(copied_payments[0].id, payment_in_1.id, "The copied inbound payment should have a different ID")
+        self.assertNotEqual(copied_payments[1].id, payment_out_1.id, "The copied outbound payment should have a different ID")
+
+        # Check that each copied payment correctly identifies the original as a duplicate
+        self.assertRecordValues(copied_payments[0], [{
+            'duplicate_move_ids': [payment_in_1.move_id.id],
+        }])
+        self.assertRecordValues(copied_payments[1], [{
+            'duplicate_move_ids': [payment_out_1.move_id.id],
+        }])


### PR DESCRIPTION
Problem:
After this [commit](https://github.com/odoo/odoo/pull/166494/commits/c61adb511d002d74ec763e7dd113d18734d861ff), attempting to copy multiple payments fails because the case where `self` contains multiple records is not handled.

Steps to reproduce:

- Go to Accounting > Vendors > Payments.
- Select two payment lines and duplicate them.
- Traceback occurs.

opw-4144848

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
