### PR TITLE
[IMP] crm: allow leads to unfollow

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1928,9 +1928,10 @@ class Lead(models.Model):
             message, msg_vals, model_description=model_description,
             force_email_company=force_email_company, force_email_lang=force_email_lang
         )
-        if self.date_deadline:
+        if self.date_deadline and render_context.get('is_portal'):
             render_context['subtitles'].append(
                 _('Deadline: %s', self.date_deadline.strftime(get_lang(self.env).date_format)))
+
         return render_context
 
     def _notify_get_recipients_groups(self, message, model_description, msg_vals=None):

--- a/addons/mail/data/mail_templates_email_layouts.xml
+++ b/addons/mail/data/mail_templates_email_layouts.xml
@@ -11,63 +11,64 @@
 <!-- HEADER -->
 <t t-call="mail.notification_preview"/>
 <div style="max-width: 900px; width: 100%;">
-<div t-if="has_button_access" itemscope="itemscope" itemtype="http://schema.org/EmailMessage">
-    <div itemprop="potentialAction" itemscope="itemscope" itemtype="http://schema.org/ViewAction">
-        <link itemprop="target" t-att-href="button_access['url']"/>
-        <link itemprop="url" t-att-href="button_access['url']"/>
-        <meta itemprop="name" t-att-content="button_access['title']"/>
+<t t-if="show_header">
+    <div t-if="has_button_access" itemscope="itemscope" itemtype="http://schema.org/EmailMessage">
+        <div itemprop="potentialAction" itemscope="itemscope" itemtype="http://schema.org/ViewAction">
+            <link itemprop="target" t-att-href="button_access['url']"/>
+            <link itemprop="url" t-att-href="button_access['url']"/>
+            <meta itemprop="name" t-att-content="button_access['title']"/>
+        </div>
     </div>
-</div>
-<div t-if="subtitles or has_button_access or actions or not is_discussion"
-        summary="o_mail_notification" style="padding: 0px;">
-    <table role="presentation" cellspacing="0" cellpadding="0" border="0" style="width: 100%; margin-top: 5px;">
-        <tbody>
-            <tr>
-                <td valign="center" style="white-space:nowrap;">
-                    <table cellspacing="0" cellpadding="0" border="0">
-                        <tbody>
-                            <tr>
-                                <td t-if="has_button_access" t-att-style="'border-radius: 3px; text-align: center; background: ' + (company.email_secondary_color or '#875A7B') + ';'">
-                                    <a t-att-href="button_access['url']" style="font-size: 12px; color: #FFFFFF; display: block; padding: 8px 12px 11px; text-decoration: none !important; font-weight: bold;">
-                                        <t t-out="button_access['title']"/>
-                                    </a>
-                                </td>
-                                <td t-if="has_button_access">&amp;nbsp;&amp;nbsp;</td>
-
-                                <td t-if="actions">
-                                    <t t-foreach="actions" t-as="action">
-                                        <a t-att-href="action['url']" t-att-style="'font-size: 12px; color: ' + (company.email_secondary_color or '#875A7B')+ '; text-decoration:none !important;'">
-                                            <t t-out="action['title']"/>
+    <div t-if="subtitles or has_button_access or actions or not is_discussion"
+            summary="o_mail_notification" style="padding: 0px;">
+        <table role="presentation" cellspacing="0" cellpadding="0" border="0" style="width: 100%; margin-top: 5px;">
+            <tbody>
+                <tr>
+                    <td valign="center" style="white-space:nowrap;">
+                        <table cellspacing="0" cellpadding="0" border="0">
+                            <tbody>
+                                <tr>
+                                    <td t-if="has_button_access" t-att-style="'border-radius: 3px; text-align: center; background: ' + (company.email_secondary_color or '#875A7B') + ';'">
+                                        <a t-att-href="button_access['url']" style="font-size: 12px; color: #FFFFFF; display: block; padding: 8px 12px 11px; text-decoration: none !important; font-weight: bold;">
+                                            <t t-out="button_access['title']"/>
                                         </a>
-                                        &amp;nbsp;&amp;nbsp;
-                                    </t>
-                                </td>
-                                <td t-if="subtitles" style="font-size: 12px;">
-                                     <t t-foreach="subtitles" t-as="subtitle">
-                                        <span t-attf-style="{{ 'font-weight:bold;' if subtitle_first else '' }}"
-                                              t-out="subtitle"/>
-                                        <br t-if="not subtitle_last"/>
-                                    </t>
-                                </td>
-                                <td t-else=""><span style="font-weight:bold;" t-out="record_name"/><br/></td>
+                                    </td>
+                                    <td t-if="has_button_access">&amp;nbsp;&amp;nbsp;</td>
 
-                            </tr>
-                        </tbody>
-                    </table>
-                </td>
-            </tr>
-            <tr>
-                <td valign="center">
-                    <hr width="100%"
-                        style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0;margin: 10px 0px;"/>
-                    <p t-if="subtype_internal" style="background-color: #f2dede; padding: 5px; margin-bottom: 16px; font-size: 13px;">
-                        <strong>Internal communication</strong>: Replying will post an internal note. Followers won't receive any email notification.
-                    </p>
-                </td>
-            </tr>
-        </tbody>
-    </table>
-</div>
+                                    <td t-if="actions">
+                                        <t t-foreach="actions" t-as="action">
+                                            <a t-att-href="action['url']" t-att-style="'font-size: 12px; color: ' + (company.email_secondary_color or '#875A7B')+ '; text-decoration:none !important;'">
+                                                <t t-out="action['title']"/>
+                                            </a>
+                                            &amp;nbsp;&amp;nbsp;
+                                        </t>
+                                    </td>
+                                    <td t-if="subtitles" style="font-size: 12px;">
+                                        <t t-foreach="subtitles" t-as="subtitle">
+                                            <span t-attf-style="{{ 'font-weight:bold;' if subtitle_first else '' }}"
+                                                t-out="subtitle"/>
+                                            <br t-if="not subtitle_last"/>
+                                        </t>
+                                    </td>
+                                    <td t-else=""><span style="font-weight:bold;" t-out="record_name"/><br/></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                <tr>
+                    <td valign="center">
+                        <hr width="100%"
+                            style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0;margin: 10px 0px;"/>
+                        <p t-if="subtype_internal" style="background-color: #f2dede; padding: 5px; margin-bottom: 16px; font-size: 13px;">
+                            <strong>Internal communication</strong>: Replying will post an internal note. Followers won't receive any email notification.
+                        </p>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</t>
 <!-- CONTENT -->
 <div t-out="message.body" style="font-size: 13px;"/>
 <ul t-if="tracking_values">
@@ -78,25 +79,26 @@
 <t class="o_signature">
     <div t-if="email_add_signature and not is_html_empty(signature)" t-out="signature" style="font-size: 13px;"/>
 </t>
-<!-- FOOTER -->
-<div style="margin-top:16px;">
-    <hr width="100%" style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin: 16px 0px 4px 0px;"/>
-    <b t-out="company.name" style="font-size:11px;"/><br/>
-    <p style="color: #999999; margin-top:2px; font-size:11px;">
-        <t t-out="company.phone"/>
-        <t t-if="company.email and company.phone"> |</t>
-        <a t-if="company.email" t-att-href="'mailto:%s' % company.email" style="text-decoration:none; color: #999999;" t-out="company.email"/>
-        <t t-if="company.website and (company.phone or company.email)"> |</t>
-        <a t-if="company.website" t-att-href="'%s' % company.website" style="text-decoration:none; color: #999999;" t-out="company.website"/>
-    </p>
-</div>
-<div style="color: #555555; font-size:11px;">
-    Powered by <a target="_blank" href="https://www.odoo.com?utm_source=db&amp;utm_medium=email"
-                  t-att-style="'color: ' + (company.email_secondary_color or '#875A7B') + ';'">Odoo</a>
-    <span id="mail_unfollow">
-        | <a href="/mail/unfollow" style="text-decoration:none; color:#555555;">Unfollow</a>
-    </span>
-</div>
+<t t-if="show_footer">
+    <div style="margin-top:16px;">
+        <hr width="100%" style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin: 16px 0px 4px 0px;"/>
+        <b t-out="company.name" style="font-size:11px;"/><br/>
+        <p style="color: #999999; margin-top:2px; font-size:11px;">
+            <t t-out="company.phone"/>
+            <t t-if="company.email and company.phone"> |</t>
+            <a t-if="company.email" t-att-href="'mailto:%s' % company.email" style="text-decoration:none; color: #999999;" t-out="company.email"/>
+            <t t-if="company.website and (company.phone or company.email)"> |</t>
+            <a t-if="company.website" t-att-href="'%s' % company.website" style="text-decoration:none; color: #999999;" t-out="company.website"/>
+        </p>
+    </div>
+    <div style="color: #555555; font-size:11px;">
+        Powered by <a target="_blank" href="https://www.odoo.com?utm_source=db&amp;utm_medium=email"
+                    t-att-style="'color: ' + (company.email_secondary_color or '#875A7B') + ';'">Odoo</a>
+        <span id="mail_unfollow">
+            | <a href="/mail/unfollow" style="text-decoration:none; color:#555555;">Unfollow</a>
+        </span>
+    </div>
+</t>
 </div>
 </body></html>
         </template>

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -738,7 +738,7 @@ class MailComposer(models.TransientModel):
                     raise UserError(_("No recipient found."))
                 messages += message
             else:
-                messages += ActiveModel.browse(res_id).message_post(**post_values)
+                messages += ActiveModel.browse(res_id).message_post(**{**post_values, 'show_footer': True})
         return messages
 
     def _action_send_mail_mass_mail(self, res_ids, auto_commit=False):

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1720,10 +1720,10 @@ class SaleOrder(models.Model):
         return groups
 
     def _notify_by_email_prepare_rendering_context(self, message, msg_vals=False, model_description=False,
-                                                   force_email_company=False, force_email_lang=False):
+                                                   force_email_company=False, force_email_lang=False, show_footer=None):
         render_context = super()._notify_by_email_prepare_rendering_context(
             message, msg_vals, model_description=model_description,
-            force_email_company=force_email_company, force_email_lang=force_email_lang
+            force_email_company=force_email_company, force_email_lang=force_email_lang, show_footer=show_footer,
         )
         lang_code = render_context.get('lang')
         record = render_context['record']

--- a/addons/test_mail/tests/test_mail_followers.py
+++ b/addons/test_mail/tests/test_mail_followers.py
@@ -1107,17 +1107,6 @@ class UnfollowFromEmailTest(MailCommon, HttpCase):
             unfollow_url = self._post_message_and_get_unfollow_urls(test_record, test_partner)[0]
             self.assertFalse(unfollow_url)
 
-    @mute_logger('odoo.models')
-    def test_unfollow_partner_with_no_user(self):
-        """ External partner must not receive an unfollow URL. """
-        test_partner = self.partner_without_user
-        test_record = self.test_record
-
-        test_record._message_subscribe(partner_ids=test_partner.ids)
-        with self.subTest('External partner must not receive an unfollow URL'):
-            unfollow_url = self._post_message_and_get_unfollow_urls(test_record, test_partner)[0]
-            self.assertFalse(unfollow_url)
-
     @mute_logger('odoo.addons.mail.controllers.mail', 'odoo.models', 'odoo.http')
     def test_unfollow_partner_without_access_on_record_unfollow_enabled(self):
         """ Partner without access must receive an unfollow URL for message
@@ -1145,19 +1134,9 @@ class UnfollowFromEmailTest(MailCommon, HttpCase):
 
     def test_unfollow_partner_multi_recipients_multi_messages(self):
         """ Test most of the cases above but with multiple recipients and messages. """
-        # On a record with unfollow attribute disabled.
         test_record = self.test_record
         partners = self.partner_without_user + self.partner_portal + self.partner_employee
-        test_record._message_subscribe(partner_ids=partners.ids)
-        urls = self._post_message_and_get_unfollow_urls(test_record, partners)
-        url_partner_without_user, url_partner_portal, url_employee = urls[0], urls[1], urls[2]
 
-        self.assertFalse(url_partner_without_user)
-        self.assertFalse(url_partner_portal)
-        self.assertTrue(url_employee)
-        self._test_unfollow_url(test_record, url_employee, self.partner_employee)
-
-        # On a record with unfollow attribute enabled.
         test_record = self.test_record_unfollow
         test_record._message_subscribe(partner_ids=partners.ids)
         urls = self._post_message_and_get_unfollow_urls(test_record, partners)


### PR DESCRIPTION
After the change leads will no longer recieve deadling information,
additionally all mails will contain unfollow button so that users can 
unsubscribe from it. The altered functionality requires some tests to  
be adapted, because now every mail supports unfollow button no matter
the user type.

task-4128966

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
