### PR TITLE
[FIX] pos_restaurant: deleted order is accessible

### DIFF
--- a/addons/point_of_sale/static/src/app/models/data_service.js
+++ b/addons/point_of_sale/static/src/app/models/data_service.js
@@ -345,12 +345,7 @@ export class PosData extends Reactive {
                     }
                 }
 
-                if (nonExistentRecords.length) {
-                    console.warn(
-                        "Warning, attempt to load a non-existent record with limited fields."
-                    );
-                    result = nonExistentRecords;
-                }
+                result = nonExistentRecords;
             }
 
             if (this.models[model] && this.opts.autoLoadedOrmMethods.includes(type)) {

--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -254,7 +254,7 @@ patch(PosStore.prototype, {
 
         const ordersStatus =
             syncedOrderIds.length > 0
-                ? await this.data.read("pos.order", syncedOrderIds, ["state"])
+                ? await this.data.read("pos.order", [...new Set(syncedOrderIds)], ["state"])
                 : [];
 
         // cancelled, posted, paid and invoiced orders can be removed


### PR DESCRIPTION
**Steps to reproduce**

1. Open restaurant.
2. In a different tab, delete the order in table 1.
3. In the opened restaurant, open table 1.
4. [ISSUE 1] the table has an order.
5. [ISSUE 2] try paying the order, you get a server error: `Record does not exist or has been deleted. (Record: pos.order(11,), User: 2)`

**Fix description**

The issue is caused by not removing the locally created order if its corresponding record in the server is already paid. So in this commit, we check if the local order can be deleted or not by checking its copy in the server.

