### PR TITLE
[IMP] web: viewbutton block-ui attribute

### DIFF
--- a/addons/web/static/src/views/utils.js
+++ b/addons/web/static/src/views/utils.js
@@ -19,6 +19,7 @@ export const BUTTON_CLICK_PARAMS = [
     "name",
     "type",
     "args",
+    "block-ui", // Blocks UI with a spinner until the action is done
     "context",
     "close",
     "confirm",

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -30,6 +30,7 @@ import { downloadReport, getReportUrl } from "./reports/utils";
 import { omit, pick, shallowEqual } from "@web/core/utils/objects";
 import { zip } from "@web/core/utils/arrays";
 import { session } from "@web/session";
+import { exprToBoolean } from "@web/core/utils/strings";
 
 class BlankComponent extends Component {
     static props = ["onMounted", "withControlPanel", "*"];
@@ -1385,6 +1386,10 @@ export function makeActionManager(env, router = _router) {
         // determine the action to execute according to the params
         let action;
         const context = makeContext([params.context, params.buttonContext]);
+        const blockUi = exprToBoolean(params["block-ui"]);
+        if (blockUi) {
+            env.services.ui.block();
+        }
         if (params.special) {
             action = { type: "ir.actions.act_window_close", infos: { special: true } };
         } else if (params.type === "object") {
@@ -1422,6 +1427,9 @@ export function makeActionManager(env, router = _router) {
             context.active_model = params.resModel;
             action = await keepLast.add(_loadAction(params.name, context));
         } else {
+            if (blockUi) {
+                env.services.ui.unblock();
+            }
             throw new InvalidButtonParamsError("Missing type for doActionButton request");
         }
         // filter out context keys that are specific to the current action, because:
@@ -1447,6 +1455,9 @@ export function makeActionManager(env, router = _router) {
         await doAction(action, options);
         if (params.close) {
             await _executeCloseAction();
+        }
+        if (blockUi) {
+            env.services.ui.unblock();
         }
         if (effect) {
             env.services.effect.add(effect);

--- a/addons/web/static/tests/webclient/actions/window_action.test.js
+++ b/addons/web/static/tests/webclient/actions/window_action.test.js
@@ -956,6 +956,39 @@ test.tags("desktop")("execute_action of type object: disable buttons (2)", async
     });
 });
 
+test.tags("desktop")("view button: block ui attribute", async () => {
+    Partner._views["form,false"] = `
+            <form>
+                <header>
+                    <button name="4" string="Execute action" type="action" block-ui="1"/>
+                </header>
+            </form>`;
+
+    const def = new Deferred();
+    // delay the action
+    onRpc("onchange", () => def);
+
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction(3);
+    expect(".o_list_view").toHaveCount(1);
+
+    // open first record in form view
+    await contains(".o_list_view .o_data_cell").click();
+    expect(".o_form_view").toHaveCount(1);
+    expect(".o-main-components-container .o_blockUI").toHaveCount(0);
+
+    // click on 'Execute action', to execute action 4
+    await contains('.o_form_view button[name="4"]').click();
+    expect(".o-main-components-container .o_blockUI").toHaveCount(1, {
+        message: "interface should be blocked during loading",
+    });
+
+    def.resolve();
+    await animationFrame();
+    expect(".o_kanban_view").toHaveCount(1);
+    expect(".o-main-components-container .o_blockUI").toHaveCount(0);
+});
+
 test("execute_action of type object raises error: re-enables buttons", async () => {
     expect.errors(1);
 

--- a/odoo/addons/base/wizard/base_language_install_views.xml
+++ b/odoo/addons/base/wizard/base_language_install_views.xml
@@ -36,7 +36,7 @@
                         <field name="overwrite" groups="base.group_no_one"/>
                     </group>
                     <footer>
-                        <button name="lang_install" string="Add" data-hotkey="q" type="object" class="btn-primary"/>
+                        <button name="lang_install" block-ui="1" string="Add" data-hotkey="q" type="object" class="btn-primary"/>
                         <button special="cancel" data-hotkey="x" string="Cancel" class="btn-secondary"/>
                     </footer>
                 </form>


### PR DESCRIPTION
This commit adds the block-ui attribute to view buttons which allows to automatically block the interface with the BlockUI component loading overlay while the action related to the button is still loading. This is directly put to use in the add language modal where the loading is quite long and the user could think he could still interact with the interface during this time.

task-4052812
