### PR TITLE
[IMP] html_editor: refactor getEditableSelection

### DIFF
--- a/addons/html_editor/static/src/main/hint_plugin.js
+++ b/addons/html_editor/static/src/main/hint_plugin.js
@@ -4,15 +4,21 @@ import { removeClass } from "@html_editor/utils/dom";
 import { selectElements } from "@html_editor/utils/dom_traversal";
 
 function isMutationRecordSavable(record) {
-    if (record.type === "attributes" && record.attributeName === "placeholder") {
-        return false;
-    }
-    return true;
+    return !(record.type === "attributes" && record.attributeName === "placeholder");
 }
 
-function target(selection, editable) {
+/**
+ * @param {SelectionData} selectionData
+ * @param {HTMLElement} editable
+ */
+function target(selectionData, editable) {
     const el = editable.firstChild;
-    if (!selection.inEditable && el && el.tagName === "P" && editable.textContent === "") {
+    if (
+        !selectionData.documentSelectionIsInEditable &&
+        el &&
+        el.tagName === "P" &&
+        editable.textContent === ""
+    ) {
         return el;
     }
 }
@@ -67,7 +73,7 @@ export class HintPlugin extends Plugin {
     updateHints(root = this.editable) {
         this.clearHints(root);
         this.makeEmptyBlockHints(root);
-        this.updateTempHint(this.shared.getEditableSelection());
+        this.updateTempHint(this.shared.getSelectionData());
     }
 
     makeEmptyBlockHints(root) {
@@ -81,14 +87,14 @@ export class HintPlugin extends Plugin {
         }
     }
 
-    updateTempHint(selection) {
+    updateTempHint(selectionData) {
         if (this.tempHint) {
             this.removeHint(this.tempHint);
         }
 
-        if (selection.isCollapsed) {
+        if (selectionData.editableSelection.isCollapsed) {
             for (const hint of this.resources["temp_hints"]) {
-                const target = hint.target(selection, this.editable);
+                const target = hint.target(selectionData, this.editable);
                 // Do not replace an existing empty block hint by a temp hint.
                 if (target && !target.classList.contains("o-we-hint")) {
                     this.makeHint(target, hint.text);

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -182,7 +182,7 @@ export class LinkPlugin extends Plugin {
             {
                 hotkey: "control+k",
                 category: "shortcut_conflict",
-                isAvailable: () => this.shared.getEditableSelection().inEditable,
+                isAvailable: () => this.shared.getSelectionData().documentSelectionIsInEditable,
             }
         );
         this.ignoredClasses = new Set(this.resources["link_ignore_classes"] || []);
@@ -295,15 +295,15 @@ export class LinkPlugin extends Plugin {
         }
     }
 
-    handleSelectionChange(selection) {
+    handleSelectionChange(selectionData) {
+        const selection = selectionData.editableSelection;
         if (!selection.isCollapsed) {
             this.overlay.close();
-        } else if (!selection.inEditable) {
-            const selection = this.document.getSelection();
+        } else if (!selectionData.documentSelectionIsInEditable) {
             // note that data-prevent-closing-overlay also used in color picker but link popover
             // and color picker don't open at the same time so it's ok to query like this
             const popoverEl = document.querySelector("[data-prevent-closing-overlay=true]");
-            if (popoverEl?.contains(selection.anchorNode)) {
+            if (popoverEl?.contains(selectionData.documentSelection.anchorNode)) {
                 return;
             }
             this.overlay.close();

--- a/addons/html_editor/static/src/main/link/link_selection_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_selection_plugin.js
@@ -189,12 +189,12 @@ export class LinkSelectionPlugin extends Plugin {
      * Apply the o_link_in_selection class if the selection is in a single link,
      * remove it otherwise.
      *
-     * @param {EditorSelection} [selection]
+     * @param {SelectionData} [selectionData]
      */
-    resetLinkInSelection(selection = this.shared.getEditableSelection()) {
+    resetLinkInSelection(selectionData = this.shared.getSelectionData()) {
         this.clearLinkInSelectionClass(this.editable);
 
-        const { anchorNode, focusNode } = selection;
+        const { anchorNode, focusNode } = selectionData.editableSelection;
         const [anchorLink, focusLink] = [anchorNode, focusNode].map((node) =>
             closestElement(node, "a")
         );

--- a/addons/html_editor/static/src/main/list/utils.js
+++ b/addons/html_editor/static/src/main/list/utils.js
@@ -1,13 +1,13 @@
 export function getListMode(pnode) {
-    if (pnode.tagName == "OL") {
+    if (pnode.tagName === "OL") {
         return "OL";
     }
     return pnode.classList.contains("o_checklist") ? "CL" : "UL";
 }
 
 export function createList(document, mode) {
-    const node = document.createElement(mode == "OL" ? "OL" : "UL");
-    if (mode == "CL") {
+    const node = document.createElement(mode === "OL" ? "OL" : "UL");
+    if (mode === "CL") {
         node.classList.add("o_checklist");
     }
     return node;

--- a/addons/html_editor/static/src/main/powerbox/powerbox_plugin.js
+++ b/addons/html_editor/static/src/main/powerbox/powerbox_plugin.js
@@ -23,10 +23,17 @@ import { Powerbox } from "./powerbox";
  * @property {Command[]} commands
  */
 
-function target(selection) {
-    const node = selection.anchorNode;
+/**
+ * @param {SelectionData} selectionData
+ */
+function target(selectionData) {
+    const node = selectionData.editableSelection.anchorNode;
     const el = node.nodeType === Node.ELEMENT_NODE ? node : node.parentElement;
-    if (selection.inEditable && (el.tagName === "DIV" || el.tagName === "P") && isEmpty(el)) {
+    if (
+        selectionData.documentSelectionIsInEditable &&
+        (el.tagName === "DIV" || el.tagName === "P") &&
+        isEmpty(el)
+    ) {
         return el;
     }
 }

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -423,9 +423,9 @@ export class TablePlugin extends Plugin {
         return true;
     }
 
-    updateSelectionTable(selection) {
+    updateSelectionTable(selectionData) {
         this.deselectTable();
-
+        const selection = selectionData.editableSelection;
         const startTd = closestElement(selection.startContainer, "td");
         const endTd = closestElement(selection.endContainer, "td");
         const startTable = ancestors(selection.startContainer, this.editable)

--- a/addons/html_editor/static/src/others/collaboration/collaboration_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_plugin.js
@@ -129,7 +129,7 @@ export class CollaborationPlugin extends Plugin {
             this.externalStepsBuffer.push(...newSteps);
         }
         this.shared.disableObserver();
-        const selection = this.shared.getEditableSelection();
+        const selectionData = this.shared.getSelectionData();
 
         let stepIndex = 0;
         const steps = this.shared.getHistorySteps();
@@ -157,8 +157,8 @@ export class CollaborationPlugin extends Plugin {
         }
 
         this.shared.enableObserver();
-        if (selection.inEditable) {
-            this.shared.rectifySelection(selection);
+        if (selectionData.documentSelectionIsInEditable) {
+            this.shared.rectifySelection(selectionData.editableSelection);
         }
 
         this.resources.onExternalHistorySteps?.forEach((cb) => cb());

--- a/addons/html_editor/static/src/others/qweb_plugin.js
+++ b/addons/html_editor/static/src/others/qweb_plugin.js
@@ -60,12 +60,15 @@ export class QWebPlugin extends Plugin {
         }
     }
 
-    onSelectionChange(selection) {
-        const documentSelection = this.document.getSelection();
+    /**
+     * @param { SelectionData } selectionData
+     */
+    onSelectionChange(selectionData) {
+        const selection = selectionData.documentSelection;
         const qwebNode =
-            documentSelection &&
-            documentSelection.anchorNode &&
-            closestElement(documentSelection.anchorNode, "[t-field],[t-esc],[t-out]");
+            selection &&
+            selection.anchorNode &&
+            closestElement(selection.anchorNode, "[t-field],[t-esc],[t-out]");
         if (qwebNode && this.editable.contains(qwebNode)) {
             // select the whole qweb node
             this.shared.setSelection(selection);

--- a/addons/html_editor/static/src/plugin.js
+++ b/addons/html_editor/static/src/plugin.js
@@ -27,6 +27,7 @@
  * @property { HistoryPlugin['historyResetFromSteps'] } historyResetFromSteps
  * @property { HistoryPlugin['serializeSelection'] } serializeSelection
  * @property { HistoryPlugin['getNodeById'] } getNodeById
+ * @property { SelectionPlugin['getSelectionData'] } getSelectionData
  * @property { SelectionPlugin['getEditableSelection'] } getEditableSelection
  * @property { SelectionPlugin['getSelectedNodes'] } getSelectedNodes
  * @property { SelectionPlugin['getTraversedNodes'] } getTraversedNodes

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -1578,6 +1578,12 @@ describe("Selection not collapsed", () => {
         await tick();
         // The Editor corrects it on selection change
         expect(getContent(el)).toBe("<h1>[abc]</h1><p>def</p>");
+        tripleClick(el.querySelector("h1"));
+        // Chrome puts the cursor at the start of next sibling
+        expect(getContent(el)).toBe("<h1>[abc</h1><p>]def</p>");
+        await tick();
+        // The Editor corrects it repeatedly on selection change
+        expect(getContent(el)).toBe("<h1>[abc]</h1><p>def</p>");
         deleteBackward(editor);
         expect(getContent(el)).toBe(
             '<h1 placeholder="Heading 1" class="o-we-hint">[]<br></h1><p>def</p>'

--- a/addons/html_editor/static/tests/selection.test.js
+++ b/addons/html_editor/static/tests/selection.test.js
@@ -71,28 +71,28 @@ test("fix selection P in the beggining being a direct child of the editable p be
     expect(getContent(el)).toBe(`<p>a[]</p><div>b</div>`);
 });
 
-describe("inEditable", () => {
-    test("inEditable should be true", async () => {
+describe("documentSelectionIsInEditable", () => {
+    test("documentSelectionIsInEditable should be true", async () => {
         const { editor } = await setupEditor("<p>a[]b</p>");
-        const selection = editor.shared.getEditableSelection();
-        expect(selection.inEditable).toBe(true);
+        const selectionData = editor.shared.getSelectionData();
+        expect(selectionData.documentSelectionIsInEditable).toBe(true);
     });
 
-    test("inEditable should be false when it is set outside the editable", async () => {
+    test("documentSelectionIsInEditable should be false when it is set outside the editable", async () => {
         const { editor } = await setupEditor("<p>ab</p>");
-        const selection = editor.shared.getEditableSelection();
-        expect(selection.inEditable).toBe(false);
+        const selectionData = editor.shared.getSelectionData();
+        expect(selectionData.documentSelectionIsInEditable).toBe(false);
     });
 
-    test("inEditable should be false when it is set outside the editable after retrieving it", async () => {
+    test("documentSelectionIsInEditable should be false when it is set outside the editable after retrieving it", async () => {
         const { editor } = await setupEditor("<p>ab[]</p>");
         const selection = document.getSelection();
-        let editableSelection = editor.shared.getEditableSelection();
-        expect(editableSelection.inEditable).toBe(true);
+        let selectionData = editor.shared.getSelectionData();
+        expect(selectionData.documentSelectionIsInEditable).toBe(true);
         selection.setPosition(document.body);
         // value is updated directly !
-        editableSelection = editor.shared.getEditableSelection();
-        expect(editableSelection.inEditable).toBe(false);
+        selectionData = editor.shared.getSelectionData();
+        expect(selectionData.documentSelectionIsInEditable).toBe(false);
     });
 });
 


### PR DESCRIPTION
Improve the capabilities and clarify the data provided by the selection plugins. Mainly in the getEditableSelection case.

* Add a `getSelectionData` that provided all information you could need about the selection.
* Remove the `deep` flag from getEditableSelection ( see getSelectionData().deepEditableSelection).
* Move and rename the `isInEditable` flag from a selection POV to a selectionData POV (see: `documentSelectionIsInEditable`).
* symplify the auto List creation logic. (see `toggleList` changes bellow)
* onSelectionChange subscribers now receive a selectionData object insted of an editableSelection.

Improve the `toggleList` method to include a `listStyle` options. This allow the related logic to live in the same place as the ListElement creation.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
