### PR TITLE
[IMP] web{_tour},html_editor: smarter position hook

### DIFF
--- a/addons/html_editor/static/src/main/table/table_ui_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_ui_plugin.js
@@ -58,13 +58,7 @@ export class TableUIPlugin extends Plugin {
         this.colMenu = this.dependencies.overlay.createOverlay(TableMenu, {
             positionOptions: {
                 position: "top-fit",
-                onPositioned: (el, solution) => {
-                    // Only accept top position as solution.
-                    if (solution.direction !== "top") {
-                        el.style.display = "none"; // avoid glitch
-                        this.colMenu.close();
-                    }
-                },
+                flip: false,
             },
         });
         /** @type {import("@html_editor/core/overlay_plugin").Overlay} */

--- a/addons/html_editor/static/tests/overlay.test.js
+++ b/addons/html_editor/static/tests/overlay.test.js
@@ -1,6 +1,6 @@
 import { expect, test } from "@odoo/hoot";
 import { setSelection } from "./_helpers/selection";
-import { click, hover, queryAll, queryOne, waitFor, waitForNone } from "@odoo/hoot-dom";
+import { click, hover, queryOne, waitFor, waitForNone } from "@odoo/hoot-dom";
 import { defineModels, fields, models, mountView } from "@web/../tests/web_test_helpers";
 import { animationFrame } from "@odoo/hoot-mock";
 import { unformat } from "./_helpers/format";
@@ -105,7 +105,7 @@ test("Table column control should always be displayed on top of the table", asyn
     const scrollableElement = queryOne(".o_content");
     const table = queryOne(".odoo-editor-editable table");
     await hover(".odoo-editor-editable td");
-    const columnControl = await waitFor(".o-we-table-menu[data-type='column']");
+    let columnControl = await waitFor(".o-we-table-menu[data-type='column']");
 
     // Table column control displayed on hover should be above the table
     expect(bottom(columnControl)).toBeLessThan(top(table));
@@ -116,11 +116,13 @@ test("Table column control should always be displayed on top of the table", asyn
     await animationFrame();
 
     await hover(".odoo-editor-editable td");
-    await animationFrame();
+    columnControl = await waitFor(".o-we-table-menu[data-type='column']");
 
-    // Table control should not be displayed (it should not overflow the scroll
-    // container, nor be placed below the first row).
-    expect(queryAll(".o-we-table-menu[data-type='column']")).toHaveCount(0);
+    // Table column control still above the table,
+    // even though the table is close to the top
+    // of its container, but it should be hidden
+    expect(bottom(columnControl)).toBeLessThan(top(table));
+    expect(columnControl).not.toBeVisible();
 });
 
 test.tags("desktop")("Table menu should close on scroll", async () => {

--- a/addons/web/static/src/core/model_field_selector/model_field_selector_popover.scss
+++ b/addons/web/static/src/core/model_field_selector/model_field_selector_popover.scss
@@ -1,10 +1,9 @@
 .o_model_field_selector_popover {
     width: 17rem;
+    max-height: 40vh;
 
     .o_model_field_selector_popover_body {
         .o_model_field_selector_popover_page {
-            height: 20rem;
-
             > .o_model_field_selector_popover_item {
                 background: $dropdown-bg;
 

--- a/addons/web/static/src/core/model_field_selector/model_field_selector_popover.xml
+++ b/addons/web/static/src/core/model_field_selector/model_field_selector_popover.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.ModelFieldSelectorPopover">
-        <div class="o_model_field_selector_popover" tabindex="-1" t-ref="root" t-on-keydown="onInputKeydown">
+        <div class="o_model_field_selector_popover d-flex flex-column" tabindex="-1" t-ref="root" t-on-keydown="onInputKeydown">
             <div class="border-bottom p-2 text-dark fw-bolder">
                 <div class="d-flex justify-content-between align-items-center">
                     <t t-if="state.page.previousPage">
@@ -33,15 +33,15 @@
                     </div>
                 </t>
             </div>
-            <div class="o_model_field_selector_popover_body">
-                <ul class="o_model_field_selector_popover_page list-unstyled mb-0 overflow-auto">
+            <div class="o_model_field_selector_popover_body overflow-auto">
+                <ul class="o_model_field_selector_popover_page list-unstyled mb-0">
                     <t t-foreach="state.page.fieldNames" t-as="fieldName" t-key="fieldName">
                         <t t-set="fieldDef" t-value="state.page.fieldDefs[fieldName]" />
                         <li class="o_model_field_selector_popover_item d-flex border-bottom" t-att-class="{ 'active': fieldName === state.page.focusedFieldName }" t-att-data-name="fieldName">
-                            <button t-attf-class="o_model_field_selector_popover_item_name btn btn-light flex-fill border-0 rounded-0 text-start fw-normal" t-on-click="() => this.selectField(fieldDef)">
+                            <button t-attf-class="o_model_field_selector_popover_item_name btn btn-light flex-fill border-0 rounded-0 text-break text-start fw-normal" t-on-click="() => this.selectField(fieldDef)">
                                 <t t-esc="fieldDef.string" />
                                 <t t-if="fieldDef.record_name"> (<t t-esc="fieldDef.record_name" />)</t>
-                                <div t-if="props.isDebugMode" class="o_model_field_selector_popover_item_title text-muted small"><t t-esc="fieldName"/> (<t t-esc="fieldDef.type"/>)</div>
+                                <div t-if="props.isDebugMode" class="o_model_field_selector_popover_item_title text-break text-muted small"><t t-esc="fieldName"/> (<t t-esc="fieldDef.type"/>)</div>
                             </button>
                             <t t-if="(!fieldDef.is_property and fieldDef.relation and props.followRelations) or fieldDef.type === 'properties'">
                                 <button class="o_model_field_selector_popover_item_relation btn btn-light border-0 border-start rounded-0" t-on-click.stop="() => this.followRelation(fieldDef)">

--- a/addons/web/static/src/core/popover/popover.scss
+++ b/addons/web/static/src/core/popover/popover.scss
@@ -1,27 +1,29 @@
-/*!rtl:begin:ignore*/
 .o_popover {
-	&.o-popover--with-arrow {
-		margin: map-get($spacers, 2);
+	> .popover-arrow {
+		--safety-margin: calc((var(--popover-arrow-width) / 4) - 1px);
+		--position-min: var(--safety-margin);
+		--position-center: calc(50% - var(--popover-arrow-width) / 2);
+		--position-max: calc(100% - var(--popover-arrow-width) - var(--safety-margin));
+		transition: opacity var(--animation-time), transform var(--animation-time);
+		opacity: 1;
 	}
 
-	.popover-arrow {
-		position: absolute;
+	/* rtl:begin:ignore */
+	&[data-popper-placement^="top"] > .popover-arrow.sucked {
+		opacity: 0;
+		transform: translateY(-100%);
 	}
-
-	&.o-popover--ts .popover-arrow, &.o-popover--bs .popover-arrow {
-		left: $popover-border-radius;
+	&[data-popper-placement^="right"] > .popover-arrow.sucked {
+		opacity: 0;
+		transform: translateX(100%);
 	}
-
-	&.o-popover--te .popover-arrow, &.o-popover--be .popover-arrow {
-		right: $popover-border-radius;
+	&[data-popper-placement^="bottom"] > .popover-arrow.sucked {
+		opacity: 0;
+		transform: translateY(100%);
 	}
-
-	&.o-popover--ls .popover-arrow, &.o-popover--rs .popover-arrow {
-		top: $popover-border-radius;
+	&[data-popper-placement^="left"] > .popover-arrow.sucked {
+		opacity: 0;
+		transform: translateX(-100%);
 	}
-
-	&.o-popover--le .popover-arrow, &.o-popover--re .popover-arrow {
-		bottom: $popover-border-radius;
-	}
+	/* rtl:end:ignore */
 }
-/*!rtl:end:ignore*/

--- a/addons/web/static/src/core/popover/popover.xml
+++ b/addons/web/static/src/core/popover/popover.xml
@@ -5,6 +5,7 @@
         <div
             t-ref="ref"
             t-att-class="defaultClassObj"
+            t-attf-style="--animation-time: {{ constructor.animationTime }}ms"
             t-att-role="props.role"
             t-on-pointerenter="() => props.holdOnHover and position.lock()"
             t-on-pointerleave="() => props.holdOnHover and position.unlock()"
@@ -14,7 +15,7 @@
                 t-props="props.componentProps"
                 close="props.close"
             />
-            <div t-if="props.arrow" class="popover-arrow"/>
+            <div t-if="props.arrow" class="popover-arrow position-absolute z-n1"/>
         </div>
     </t>
 

--- a/addons/web/static/src/core/position/position_hook.js
+++ b/addons/web/static/src/core/position/position_hook.js
@@ -24,12 +24,6 @@ import {
  * @property {() => void} unlock allows further positioning updates (triggers an update right away)
  */
 
-/** @type {UsePositionOptions} */
-const DEFAULTS = {
-    margin: 0,
-    position: "bottom",
-};
-
 const POSITION_BUS = Symbol("position-bus");
 
 /**
@@ -59,8 +53,9 @@ export function usePosition(refName, getTarget, options = {}) {
             // No compute needed
             return;
         }
-        const repositionOptions = { ...DEFAULTS, ...omit(options, "onPositioned") };
+        const repositionOptions = omit(options, "onPositioned");
         const solution = reposition(ref.el, targetEl, repositionOptions);
+        options.position = `${solution.direction}-${solution.variant}`; // memorize last position
         options.onPositioned?.(ref.el, solution);
     };
 

--- a/addons/web/static/tests/core/popover/popover.test.js
+++ b/addons/web/static/tests/core/popover/popover.test.js
@@ -1,11 +1,11 @@
 import { expect, getFixture, test } from "@odoo/hoot";
-import { queryOne, resize, scroll, waitFor } from "@odoo/hoot-dom";
-import { animationFrame, runAllTimers } from "@odoo/hoot-mock";
-import { Component, xml } from "@odoo/owl";
-import { mountWithCleanup } from "@web/../tests/web_test_helpers";
-
+import { queryOne, queryRect, resize, scroll, waitFor } from "@odoo/hoot-dom";
+import { animationFrame } from "@odoo/hoot-mock";
+import { Component, useRef, xml } from "@odoo/owl";
+import { defineStyle, mountWithCleanup } from "@web/../tests/web_test_helpers";
 import { Popover } from "@web/core/popover/popover";
-import { usePosition } from "@web/core/position/position_hook";
+import { usePopover } from "@web/core/popover/popover_hook";
+import { patch } from "@web/core/utils/patch";
 
 class Content extends Component {
     static props = ["*"];
@@ -38,229 +38,183 @@ test("popover can have more than one custom class", async () => {
 
 test("popover is rendered nearby target (default)", async () => {
     expect.assertions(2);
-    class TestPopover extends Popover {
-        onPositioned(el, { direction, variant }) {
-            expect(direction).toBe("bottom");
-            expect(variant).toBe("middle");
-        }
-    }
-
-    await mountWithCleanup(TestPopover, {
+    await mountWithCleanup(
+        `<div id="target" style="background-color: royalblue; width: 50px; height: 50px; position: absolute; top: 50%; left: 50%;"/>`
+    );
+    await mountWithCleanup(Popover, {
         props: {
-            target: getFixture(),
-            class: "custom-popover popover-custom",
+            target: queryOne("#target"),
             component: Content,
+            onPositioned: (_, { direction, variant }) => {
+                expect(direction).toBe("bottom");
+                expect(variant).toBe("middle");
+            },
         },
+        noMainContainer: true,
     });
 });
 
 test("popover is rendered nearby target (bottom)", async () => {
     expect.assertions(2);
-    class TestPopover extends Popover {
-        onPositioned(el, { direction, variant }) {
-            expect(direction).toBe("bottom");
-            expect(variant).toBe("middle");
-        }
-    }
+    await mountWithCleanup(
+        `<div id="target" style="background-color: royalblue; width: 50px; height: 50px; position: absolute; top: 50%; left: 50%;"/>`
+    );
 
-    await mountWithCleanup(TestPopover, {
+    await mountWithCleanup(Popover, {
         props: {
-            target: getFixture(),
+            target: queryOne("#target"),
             position: "bottom",
             component: Content,
+            onPositioned: (_, { direction, variant }) => {
+                expect(direction).toBe("bottom");
+                expect(variant).toBe("middle");
+            },
         },
+        noMainContainer: true,
     });
 });
 
 test("popover is rendered nearby target (top)", async () => {
     expect.assertions(2);
-    class TestPopover extends Popover {
-        onPositioned(el, { direction, variant }) {
-            expect(direction).toBe("top");
-            expect(variant).toBe("middle");
-        }
-    }
+    await mountWithCleanup(
+        `<div id="target" style="background-color: royalblue; width: 50px; height: 50px; position: absolute; top: 50%; left: 50%;"/>`
+    );
 
-    await mountWithCleanup(TestPopover, {
+    await mountWithCleanup(Popover, {
         props: {
-            target: getFixture(),
+            target: queryOne("#target"),
             position: "top",
             component: Content,
+            onPositioned: (_, { direction, variant }) => {
+                expect(direction).toBe("top");
+                expect(variant).toBe("middle");
+            },
         },
+        noMainContainer: true,
     });
 });
 
 test("popover is rendered nearby target (left)", async () => {
     expect.assertions(2);
-    class TestPopover extends Popover {
-        onPositioned(el, { direction, variant }) {
-            expect(direction).toBe("left");
-            expect(variant).toBe("middle");
-        }
-    }
+    await mountWithCleanup(
+        `<div id="target" style="background-color: royalblue; width: 50px; height: 50px; position: absolute; top: 50%; left: 50%;"/>`
+    );
 
-    await mountWithCleanup(TestPopover, {
+    await mountWithCleanup(Popover, {
         props: {
-            target: getFixture(),
+            target: queryOne("#target"),
             position: "left",
             component: Content,
+            onPositioned: (_, { direction, variant }) => {
+                expect(direction).toBe("left");
+                expect(variant).toBe("middle");
+            },
         },
+        noMainContainer: true,
     });
 });
 
 test("popover is rendered nearby target (right)", async () => {
     expect.assertions(2);
-    class TestPopover extends Popover {
-        onPositioned(el, { direction, variant }) {
-            expect(direction).toBe("right");
-            expect(variant).toBe("middle");
-        }
-    }
+    await mountWithCleanup(
+        `<div id="target" style="background-color: royalblue; width: 50px; height: 50px; position: absolute; top: 50%; left: 50%;"/>`
+    );
 
-    await mountWithCleanup(TestPopover, {
+    await mountWithCleanup(Popover, {
         props: {
-            target: getFixture(),
+            target: queryOne("#target"),
             position: "right",
             component: Content,
+            onPositioned: (_, { direction, variant }) => {
+                expect(direction).toBe("right");
+                expect(variant).toBe("middle");
+            },
         },
+        noMainContainer: true,
     });
 });
 
 test("popover is rendered nearby target (bottom-start)", async () => {
     expect.assertions(2);
-    class TestPopover extends Popover {
-        onPositioned(el, { direction, variant }) {
-            expect(direction).toBe("bottom");
-            expect(variant).toBe("start");
-        }
-    }
+    await mountWithCleanup(
+        `<div id="target" style="background-color: royalblue; width: 50px; height: 50px; position: absolute; top: 50%; left: 50%;"/>`
+    );
 
-    await mountWithCleanup(TestPopover, {
+    await mountWithCleanup(Popover, {
         props: {
-            target: getFixture(),
+            target: queryOne("#target"),
             position: "bottom-start",
             component: Content,
+            onPositioned: (_, { direction, variant }) => {
+                expect(direction).toBe("bottom");
+                expect(variant).toBe("start");
+            },
         },
+        noMainContainer: true,
     });
 });
 
 test("popover is rendered nearby target (bottom-middle)", async () => {
     expect.assertions(2);
-    class TestPopover extends Popover {
-        onPositioned(el, { direction, variant }) {
-            expect(direction).toBe("bottom");
-            expect(variant).toBe("middle");
-        }
-    }
+    await mountWithCleanup(
+        `<div id="target" style="background-color: royalblue; width: 50px; height: 50px; position: absolute; top: 50%; left: 50%;"/>`
+    );
 
-    await mountWithCleanup(TestPopover, {
+    await mountWithCleanup(Popover, {
         props: {
-            target: getFixture(),
+            target: queryOne("#target"),
             position: "bottom-middle",
             component: Content,
+            onPositioned: (_, { direction, variant }) => {
+                expect(direction).toBe("bottom");
+                expect(variant).toBe("middle");
+            },
         },
+        noMainContainer: true,
     });
 });
 
 test("popover is rendered nearby target (bottom-end)", async () => {
     expect.assertions(2);
-    class TestPopover extends Popover {
-        onPositioned(el, { direction, variant }) {
-            expect(direction).toBe("bottom");
-            expect(variant).toBe("end");
-        }
-    }
+    await mountWithCleanup(
+        `<div id="target" style="background-color: royalblue; width: 50px; height: 50px; position: absolute; top: 50%; left: 50%;"/>`
+    );
 
-    await mountWithCleanup(TestPopover, {
+    await mountWithCleanup(Popover, {
         props: {
-            target: getFixture(),
+            target: queryOne("#target"),
             position: "bottom-end",
             component: Content,
+            onPositioned: (_, { direction, variant }) => {
+                expect(direction).toBe("bottom");
+                expect(variant).toBe("end");
+            },
         },
+        noMainContainer: true,
     });
 });
 
 test("popover is rendered nearby target (bottom-fit)", async () => {
     expect.assertions(2);
-    class TestPopover extends Popover {
-        onPositioned(el, { direction, variant }) {
-            expect(direction).toBe("bottom");
-            expect(variant).toBe("fit");
-        }
-    }
+    await mountWithCleanup(
+        `<div id="target" style="background-color: royalblue; width: 50px; height: 50px; position: absolute; top: 50%; left: 50%;"/>`
+    );
 
-    await mountWithCleanup(TestPopover, {
+    await mountWithCleanup(Popover, {
         props: {
-            target: getFixture(),
+            target: queryOne("#target"),
             position: "bottom-fit",
             component: Content,
+            onPositioned: (_, { direction, variant }) => {
+                expect(direction).toBe("bottom");
+                expect(variant).toBe("fit");
+            },
         },
+        noMainContainer: true,
     });
-});
-
-test("reposition popover should properly change classNames", async () => {
-    await resize({ height: 300 });
-
-    class TestPopover extends Popover {
-        setup() {
-            // Don't call super.setup() in order to replace the use of usePosition hook...
-            this.position = usePosition("ref", () => this.props.target, {
-                container,
-                onPositioned: this.onPositioned.bind(this),
-                position: this.props.position,
-            });
-        }
-    }
-
-    // Force some style, to make this test independent of screen size
-    await mountWithCleanup(/* xml */ `
-        <div class="container" style="width: 450px; height: 450px; display: flex; align-items: center; justify-content: center;">
-            <div class="popover-target" style="width: 50px; height: 50px;" />
-        </div>
-    `);
-
-    const container = queryOne(".container");
-
-    await mountWithCleanup(TestPopover, {
-        props: {
-            target: queryOne(".popover-target"),
-            component: Content,
-            animation: false,
-        },
-    });
-
-    const popover = queryOne("#popover");
-    popover.style.height = "100px";
-    popover.style.width = "100px";
-
-    // Should have classes for a "bottom-middle" placement
-    expect(".o_popover").toHaveClass(
-        "o_popover popover mw-100 o-popover--with-arrow bs-popover-bottom o-popover--bm"
-    );
-    expect(".popover-arrow").toHaveClass("popover-arrow start-0 end-0 mx-auto");
-
-    // Change container style and force update
-    container.style.height = "125px"; // height of popper + 1/2 reference
-    container.style.alignItems = "flex-end";
-    await resize();
-    await runAllTimers();
-    await animationFrame();
-
-    expect(".o_popover").toHaveClass(
-        "o_popover popover mw-100 o-popover--with-arrow bs-popover-end o-popover--re"
-    );
-    expect(".popover-arrow").toHaveClass("popover-arrow");
 });
 
 test("within iframe", async () => {
-    let popoverEl;
-    class TestPopover extends Popover {
-        onPositioned(el, { direction }) {
-            popoverEl = el;
-            expect.step(direction);
-        }
-    }
-
     await mountWithCleanup(/* xml */ `
         <iframe class="container" style="height: 200px; display: flex" srcdoc="&lt;div id='target' style='height:400px;'&gt;Within iframe&lt;/div&gt;" />
     `);
@@ -268,11 +222,14 @@ test("within iframe", async () => {
     await waitFor(":iframe #target");
 
     const popoverTarget = queryOne(":iframe #target");
-    await mountWithCleanup(TestPopover, {
+    const comp = await mountWithCleanup(Popover, {
         props: {
             target: popoverTarget,
             component: Content,
             animation: false,
+            onPositioned: (_, { direction }) => {
+                expect.step(direction);
+            },
         },
     });
 
@@ -281,10 +238,10 @@ test("within iframe", async () => {
     expect(":iframe .o_popover").toHaveCount(0);
 
     // The popover should be rendered in the correct position
-    const marginTop = parseFloat(getComputedStyle(popoverEl).marginTop);
+    const marginTop = queryRect(".popover-arrow").height;
     const { top: targetTop, left: targetLeft } = popoverTarget.getBoundingClientRect();
     const { top: iframeTop, left: iframeLeft } = queryOne("iframe").getBoundingClientRect();
-    let popoverBox = popoverEl.getBoundingClientRect();
+    let popoverBox = comp.popoverRef.el.getBoundingClientRect();
     let expectedTop = iframeTop + targetTop + popoverTarget.offsetHeight + marginTop;
     const expectedLeft =
         iframeLeft + targetLeft + (popoverTarget.offsetWidth - popoverBox.width) / 2;
@@ -294,7 +251,7 @@ test("within iframe", async () => {
     await scroll(popoverTarget.ownerDocument.documentElement, { y: 100 });
     await animationFrame();
     expect.verifySteps(["bottom"]);
-    popoverBox = popoverEl.getBoundingClientRect();
+    popoverBox = comp.popoverRef.el.getBoundingClientRect();
     expectedTop -= 100;
     expect(Math.floor(popoverBox.top)).toBe(Math.floor(expectedTop));
     expect(Math.floor(popoverBox.left)).toBe(Math.floor(expectedLeft));
@@ -336,13 +293,6 @@ test("within iframe -- wrong element class", async () => {
 });
 
 test("popover fixed position", async () => {
-    class TestPopover extends Popover {
-        onPositioned() {
-            super.onPositioned(...arguments);
-            expect.step("onPositioned");
-        }
-    }
-
     await mountWithCleanup(/* xml */ `
         <div class="container" style="width: 450px; height: 450px; display: flex">
             <div class="popover-target" style="width: 50px; height: 50px;" />
@@ -351,12 +301,15 @@ test("popover fixed position", async () => {
 
     const container = queryOne(".container");
 
-    await mountWithCleanup(TestPopover, {
+    await mountWithCleanup(Popover, {
         props: {
             target: container,
             position: "bottom-fit",
             fixedPosition: true,
             component: Content,
+            onPositioned() {
+                expect.step("onPositioned");
+            },
         },
     });
 
@@ -392,8 +345,91 @@ test("popover with arrow and onPositioned", async () => {
     });
 
     expect.verifySteps(["onPositioned (from override)", "onPositioned (from props)"]);
-    expect(".o_popover").toHaveClass(
-        "o_popover popover mw-100 o-popover--with-arrow bs-popover-bottom o-popover--bm"
-    );
-    expect(".o_popover > .popover-arrow").toHaveClass("start-0 end-0 mx-auto");
+    expect(".o_popover").toHaveClass("o_popover popover mw-100 bs-popover-auto");
+    expect(".o_popover").toHaveAttribute("data-popper-placement", "bottom");
+    expect(".o_popover > .popover-arrow").toHaveClass("position-absolute z-n1");
+});
+
+test("arrow follows target and can get sucked", async () => {
+    let container;
+    patch(Popover, { animationTime: 0 });
+    patch(Popover.prototype, {
+        get positioningOptions() {
+            return {
+                ...super.positioningOptions,
+                container: () => container.el,
+            };
+        },
+    });
+    defineStyle(/* css */ `
+        .my-popover {
+            height: 100px;
+            width: 100px;
+        }
+        .popover-container {
+            background-color: beige;
+            display: flex;
+            width: 200px;
+            height: 200px;
+            justify-content: center;
+            align-items: flex-start;
+        }
+        .popover-target {
+            background-color: bisque;
+            width: 50px;
+            height: 50px;
+        }
+    `);
+    class Parent extends Component {
+        static props = ["*"];
+        static template = xml`
+            <div class="popover-container" t-ref="popover-container">
+                <div class="popover-target" t-ref="popover-target" t-on-click="openPopover"/>
+            </div>
+        `;
+        setup() {
+            container = useRef("popover-container");
+            this.target = useRef("popover-target");
+            this.popover = usePopover(Content, { popoverClass: "my-popover" });
+        }
+    }
+    const parent = await mountWithCleanup(Parent);
+    async function openPopover() {
+        parent.popover.open(parent.target.el);
+        return animationFrame();
+    }
+    await openPopover();
+
+    // Initial position of arrow should be at the middle of the target
+    let arrowRect = queryRect(".popover-arrow");
+    let targetRect = queryRect(".popover-target");
+    const initial = {
+        top: targetRect.bottom,
+        left: targetRect.left + targetRect.width / 2 - arrowRect.width / 2,
+    };
+    expect(".popover-arrow").toHaveRect(initial);
+    expect(".popover-arrow").not.toHaveClass("sucked");
+
+    // Move the target to the left of the container, arrow should still be at the middle
+    container.el.style.justifyContent = "flex-start";
+    await openPopover();
+    arrowRect = queryRect(".popover-arrow");
+    targetRect = queryRect(".popover-target");
+    const newPosition = {
+        top: targetRect.bottom,
+        left: targetRect.left + targetRect.width / 2 - arrowRect.width / 2,
+    };
+    expect(newPosition).not.toBe(initial);
+    expect(".popover-arrow").toHaveRect(newPosition);
+    expect(".popover-arrow").not.toHaveClass("sucked");
+
+    // Move the target further to the left, arrow should get sucked
+    parent.target.el.style.marginLeft = "-100px";
+    await openPopover();
+    arrowRect = queryRect(".popover-arrow");
+    const popoverRect = queryRect(".my-popover");
+    expect(arrowRect.top).toBeWithin(popoverRect.top, popoverRect.bottom - arrowRect.height);
+    expect(arrowRect.left).toBeWithin(popoverRect.left, popoverRect.right - arrowRect.width);
+    expect(".popover-arrow").toHaveClass("sucked");
+    expect(".popover-arrow").not.toBeVisible();
 });

--- a/addons/web_tour/static/src/tour_pointer/tour_pointer.js
+++ b/addons/web_tour/static/src/tour_pointer/tour_pointer.js
@@ -67,6 +67,7 @@ export class TourPointer extends Component {
         };
         Object.defineProperty(positionOptions, "position", {
             get: () => this.position,
+            set: () => {}, // do not let the position hook change the position
             enumerable: true,
         });
         const position = usePosition(


### PR DESCRIPTION
## [IMP] web{_tour},html_editor: smarter position hook
This commit improves how the position hook can reposition elements by:
- shifting the popper element to keep it in its container
- reusing the last direction in order to flip only when necessary
- allowing the user to impeach the flipping behavior (add: flip option).

The popover's arrows needed adaptations as well so now:
- they follow their target's center (for 'middle' variants)
- they are sucked through an animation if they won't point their target.

Other changes:
- html_editor's table UI column menu has been adapted,
- as well as the web_tour's tour pointer.

## [FIX] web: make dynamic placeholder visible
**Scenario**
- set the desktop test browser size (1366x768)
- create a new email template,
- select a model
- open a DPH popover as first character of the content field

- Before:
  - the dynamic placeholder is in the DOM but not displayed as it has
    `visibility: hidden;` applied to its style attribute.

- After:
  - it is now properly displayed due to the ModelFieldSelectorPopover
    component's style changes introduced in this commit.

**Explanations**
This is a multifactor issue.

A) since the parent commit of this one, the new positioning now allows
   for an offset and thus does not try anymore to shift the orientation
   (from vertical to horizontal and opposite), leading to less tried
   directions (i.e. shifting is no more allowed from bottom to right)

B) the .o_model_field_selector_popover_page element has a fixed height,
   which in that scenario was large enough to make the repositioning
   computation not being able to fully place the popover at the bottom
   nor at the top of its target.

C) since [1], the EditorOverlay hides any overlay that overflows the
   top edge of its container.

In the current scenario:
- A's side-effect on B
- leads C to hide the DPH popover