### PR TITLE
[FIX] sale_purchase_stock: ensure test file is in __init__.py

### DIFF
--- a/addons/sale_purchase_stock/tests/__init__.py
+++ b/addons/sale_purchase_stock/tests/__init__.py
@@ -3,4 +3,5 @@
 
 from . import test_sale_purchase_stock_flow
 from . import test_access_rights
+from . import test_lead_time
 from . import test_unwanted_replenish_flow

--- a/addons/sale_purchase_stock/tests/test_lead_time.py
+++ b/addons/sale_purchase_stock/tests/test_lead_time.py
@@ -25,13 +25,12 @@ class TestLeadTime(TestCommonSalePurchaseNoChart):
             'email': 'grand.horus@chansonbelge.dz',
         })
 
-
     def test_supplier_lead_time(self):
         """ Basic stock configuration and a supplier with a minimum qty and a lead time """
 
         self.env.user.company_id.po_lead = 7
         seller = self.env['product.supplierinfo'].create({
-            'name': self.vendor.id,
+            'partner_id': self.vendor.id,
             'min_qty': 1,
             'price': 10,
             'date_start': fields.Date.today() - timedelta(days=1),


### PR DESCRIPTION
This commit add the missing test file in `__init__.py`

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
