### PR TITLE
[FIX] point_of_sale: mobile: scroll bar when adding product

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
@@ -22,7 +22,7 @@
                 </div>
             </div>
             <div class="rightpane d-flex flex-grow-1 flex-column" t-if="!ui.isSmall || pos.mobile_pane === 'right'">
-                <div class="position-relative d-flex flex-column flex-grow-1 overflow-y-auto">
+                <div class="position-relative d-flex flex-column flex-grow-1 overflow-hidden">
                     <CategorySelector class="'p-2'" categories="getCategoriesAndSub()" onClick="(id) => this.pos.setSelectedCategory(id)"/>
                     <CameraBarcodeScanner t-if="pos.scanning"/>
                     <div t-elif="productsToDisplay.length != 0 and pos.session._has_available_products" t-attf-class="product-list {{this.pos.productListViewMode}} overflow-y-auto px-2 pt-0 pb-2">


### PR DESCRIPTION
**Steps to reproduce**

1. Open pos in narrow view such that in can be considered mobile.
2. Click a product then a toast notification appears at the bottom.
  - [ISSUE] Right after the notification appears, a scroll bar appears, then disappears in few milliseconds.

[Odoo POS.webm](https://github.com/user-attachments/assets/edf98540-8937-4830-9df7-f7e3c265ffe6)

**Description of fix**

This commit proposes to just hide the overflow on the product list column of the product screen. This prevents the annoying scroll bar to appear.

TASK: https://www.odoo.com/odoo/project/1737/tasks/4144905

 


