### PR TITLE
[FIX] point_of_sale,pos_self_order: fix language selector in kiosk

### DIFF
--- a/addons/point_of_sale/models/res_lang.py
+++ b/addons/point_of_sale/models/res_lang.py
@@ -7,4 +7,4 @@ class ResLang(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config_id):
-        return ['id', 'name', 'code']
+        return ['id', 'name', 'code', 'flag_image_url', 'display_name']

--- a/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
@@ -126,3 +126,13 @@ registry.category("web_tour.tours").add("self_order_price_null", {
         Utils.checkBtn("Close"),
     ],
 });
+
+registry.category("web_tour.tours").add("self_order_language_changes", {
+    test: true,
+    steps: () => [
+        LandingPage.checkLanguageSelected("English"),
+        LandingPage.checkCountryFlagShown("us"),
+        Utils.openLanguageSelector(),
+        Utils.checkLanguageIsAvailable("French"),
+    ],
+});

--- a/addons/pos_self_order/static/tests/tours/utils/common.js
+++ b/addons/pos_self_order/static/tests/tours/utils/common.js
@@ -39,3 +39,19 @@ export function checkIsDisabledBtn(buttonName) {
         trigger: `button.disabled:contains("${buttonName}")`,
     };
 }
+
+export function checkLanguageIsAvailable(language) {
+    return {
+        content: `Check that the language is available`,
+        trigger: `.self_order_language_popup .btn:contains(${language})`,
+        in_modal: false,
+    };
+}
+
+export function openLanguageSelector() {
+    return {
+        content: `Click on language selector`,
+        trigger: `.self_order_language_selector`,
+        run: "click",
+    };
+}

--- a/addons/pos_self_order/static/tests/tours/utils/landing_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/landing_page_util.js
@@ -20,3 +20,17 @@ export function isOpened() {
         run: () => {},
     };
 }
+
+export function checkLanguageSelected(language) {
+    return {
+        content: `Check what the current language is`,
+        trigger: `.self_order_language_selector:contains("${language}")`,
+    };
+}
+
+export function checkCountryFlagShown(country_code) {
+    return {
+        content: `Check what the current flag is`,
+        trigger: `.self_order_language_selector > img[src*=${country_code}]`,
+    };
+}

--- a/addons/pos_self_order/tests/test_self_order_kiosk.py
+++ b/addons/pos_self_order/tests/test_self_order_kiosk.py
@@ -3,6 +3,7 @@
 
 import odoo.tests
 from odoo.addons.pos_self_order.tests.self_order_common_test import SelfOrderCommonTest
+from odoo import Command
 
 
 @odoo.tests.tagged("post_install", "-at_install")
@@ -57,3 +58,16 @@ class TestSelfOrderKiosk(SelfOrderCommonTest):
         self.pos_config.with_user(self.pos_user).open_ui()
         self_route = self.pos_config._get_self_order_route()
         self.start_tour(self_route, "self_order_price_null")
+
+    def test_self_order_language_changes(self):
+        self.env['res.lang']._activate_lang('fr_FR')
+        self.pos_config.write({
+            'self_ordering_available_language_ids': [Command.link(lang.id) for lang in self.env['res.lang'].search([])],
+            'self_ordering_takeaway': False,
+            'self_ordering_mode': 'kiosk',
+            'self_ordering_pay_after': 'each'
+        })
+
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self_route = self.pos_config._get_self_order_route()
+        self.start_tour(self_route, "self_order_language_changes")


### PR DESCRIPTION
If you allowed multiple languages in your kiosk the language selector was not working properly. You were not able to change the language

Steps to reproduce:
-------------------
* Activate atleast 2 languages
* Add those language as available in the kiosk config
* Open the kiosk
> Observation: The language selector is empty and you can't change the
language

Why the fix:
------------
It wasn't working because the fields used for the language selector were not loaded in the PoS. So we just needed to add those in the `_load_pos_data_fields` function from `res_lang`.

opw-4108870
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
