### PR TITLE
[FIX] mail: hover effect on channel member list item

### DIFF
--- a/addons/mail/static/src/discuss/core/common/channel_member_list.dark.scss
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.dark.scss
@@ -1,0 +1,3 @@
+.o-discuss-ChannelMember {
+    --discuss-ChannelMember-hoverBg: #{$gray-300};
+}

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.scss
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.scss
@@ -1,5 +1,5 @@
 .o-discuss-ChannelMember.cursor-pointer:hover {
-    background-color: $gray-200;
+    background-color: var(--discuss-ChannelMember-hoverBg, $gray-200);
 }
 
 .o-discuss-ChannelMember-avatar {

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -27,7 +27,7 @@
     </t>
 
     <t t-name="discuss.channel_member">
-        <div class="o-discuss-ChannelMember d-flex align-items-center p-2 bg-view" t-att-class="{ 'cursor-pointer': canOpenChatWith(member) }" t-on-click.stop="() => this.openChatAvatar(member)">
+        <div class="o-discuss-ChannelMember d-flex align-items-center p-2 bg-inherit" t-att-class="{ 'cursor-pointer': canOpenChatWith(member) }" t-on-click.stop="() => this.openChatAvatar(member)">
             <div class="bg-inherit o-discuss-ChannelMember-avatar position-relative d-flex ms-4 flex-shrink-0">
                 <img class="w-100 h-100 rounded o_object_fit_cover"
                      t-att-src="threadService.avatarUrl(member.persona, props.thread)"/>


### PR DESCRIPTION
Mouse hovering on channel member list item had no background color change. This happens because `bg-view` had more specificity than the SCSS rule.

This commit fixes the issue by replacing `bg-view` by `bg-inherit`, which makes background unchanged (matches global channel member list background) but inherit is necessary for proper IM status background in all cases. `bg-inherit` also has less specificity because it hasn't the `!important` like `bg-view`.

In dark theme, color is adjusted because `bg-view` and `gray-200` are the same.

Before (hover on Marc Demo)
<img width="405" alt="Screenshot 2024-08-29 at 15 23 54" src="https://github.com/user-attachments/assets/6ae8815e-9c0c-41d2-b369-9d9c78b920b1">


After
<img width="402" alt="Screenshot 2024-08-29 at 15 18 49" src="https://github.com/user-attachments/assets/2a0f04e6-4dd6-4c63-aa0e-882f7b54d8b7">
