### PR TITLE
[IMP] l10n_fr_facturx_chorus_pro: Peppol for Chorus Pro

### DIFF
--- a/addons/l10n_fr_facturx_chorus_pro/__manifest__.py
+++ b/addons/l10n_fr_facturx_chorus_pro/__manifest__.py
@@ -7,7 +7,7 @@
     'version': '1.0',
     'category': 'Accounting/Localizations/EDI',
     'description': """
-Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.
+Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.
 """,
     'depends': [
         'account',

--- a/addons/l10n_fr_facturx_chorus_pro/models/__init__.py
+++ b/addons/l10n_fr_facturx_chorus_pro/models/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import account_move
+from . import account_edi_xml_ubl_bis3

--- a/addons/l10n_fr_facturx_chorus_pro/models/account_edi_xml_ubl_bis3.py
+++ b/addons/l10n_fr_facturx_chorus_pro/models/account_edi_xml_ubl_bis3.py
@@ -1,0 +1,39 @@
+from odoo import models
+
+
+CHORUS_PRO_PEPPOL_ID = "0009:11000201100044"
+
+
+class AccountEdiXmlUBLBIS3(models.AbstractModel):
+    _inherit = 'account.edi.xml.ubl_bis3'
+
+    """ See Pagero documentation: https://www.pagero.com/onboarding/aife/aife-en#requirements """
+
+    def _get_partner_party_identification_vals_list(self, partner):
+        """
+        Pagero doc states that the 'siret' of the final customer (that has the Chorus peppol ID) should be located in
+        the PartyIdentificiation node
+        """
+        # EXTENDS 'account.edi.xml.ubl_bis3'
+        if (
+            partner.peppol_eas
+            and partner.peppol_endpoint
+            and partner.peppol_eas + ":" + partner.peppol_endpoint == CHORUS_PRO_PEPPOL_ID
+            and 'siret' in partner._fields
+            and partner.siret
+        ):
+            return [{
+                'id': partner.siret,
+            }]
+        return super()._get_partner_party_identification_vals_list(partner)
+
+    def _export_invoice_vals(self, invoice):
+        # EXTENDS 'account.edi.xml.ubl_bis3'
+        vals = super()._export_invoice_vals(invoice)
+        if invoice.buyer_reference:
+            # Pagero doc states that the 'Service Code' should be in the BuyerReference node
+            vals['vals']['buyer_reference'] = invoice.buyer_reference
+        if invoice.purchase_order_reference:
+            # Pagero doc states that the 'Commitment Number' should be in the OrderReference/ID node
+            vals['vals']['order_reference'] = invoice.purchase_order_reference
+        return vals

--- a/addons/l10n_fr_facturx_chorus_pro/tests/__init__.py
+++ b/addons/l10n_fr_facturx_chorus_pro/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_chorus_pro_xml

--- a/addons/l10n_fr_facturx_chorus_pro/tests/test_chorus_pro_xml.py
+++ b/addons/l10n_fr_facturx_chorus_pro/tests/test_chorus_pro_xml.py
@@ -1,0 +1,52 @@
+from lxml import etree
+
+from odoo import Command
+from odoo.tests import tagged
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.l10n_fr_facturx_chorus_pro.models.account_edi_xml_ubl_bis3 import CHORUS_PRO_PEPPOL_ID
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestChorusProXml(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref='fr'):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+        cls.company = cls.company_data['company']
+        chorus_eas, chorus_endpoint = CHORUS_PRO_PEPPOL_ID.split(":")
+        cls.chorus_pro_partner = cls.env['res.partner'].create({
+            'name': "Chorus Pro - Commune de Nantes",
+            # Commune de Nantes
+            'vat': "FR74214401093",
+            'siret': "21440109300015",
+            # Peppol ID for the AIFE (= Chorus Pro)
+            'peppol_eas': chorus_eas,
+            'peppol_endpoint': chorus_endpoint,
+        })
+
+    def test_export_invoice_chorus_pro(self):
+        invoice = self.env['account.move'].create({
+            'company_id': self.company.id,
+            'partner_id': self.chorus_pro_partner.id,
+            'move_type': 'out_invoice',
+            'buyer_reference': 'buyer_ref_123',
+            'purchase_order_reference': 'order_ref_123',
+            'invoice_line_ids': [Command.create({
+                'product_id': self.product_a.id,
+                'price_unit': 100.0,
+            })],
+        })
+        invoice.action_post()
+        xml = self.env['account.edi.xml.ubl_bis3']._export_invoice(invoice)[0]
+        xml_etree = etree.fromstring(xml)
+
+        endpoint_node = xml_etree.find("{*}AccountingCustomerParty/{*}Party/{*}EndpointID")
+        chorus_eas, chorus_endpoint = CHORUS_PRO_PEPPOL_ID.split(":")
+        self.assertEqual(endpoint_node.text, chorus_endpoint)
+        self.assertEqual(endpoint_node.attrib, {'schemeID': chorus_eas})
+
+        final_receiver = xml_etree.findtext("{*}AccountingCustomerParty/{*}Party/{*}PartyIdentification/{*}ID")
+        self.assertEqual(final_receiver, "21440109300015")
+
+        self.assertEqual(xml_etree.findtext("{*}BuyerReference"), "buyer_ref_123")
+        self.assertEqual(xml_etree.findtext("{*}OrderReference/{*}ID"), "order_ref_123")

--- a/odoo/addons/base/i18n/af.po
+++ b/odoo/addons/base/i18n/af.po
@@ -2287,7 +2287,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/am.po
+++ b/odoo/addons/base/i18n/am.po
@@ -2283,7 +2283,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/ar.po
+++ b/odoo/addons/base/i18n/ar.po
@@ -2101,7 +2101,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 "\n"
 "إضافة الدعم لملء ثلاثة حقول اختيارية تُستخدم عند استخدام Chorus Pro، خاصة عند فوترة الخدمات العامة.\n"

--- a/odoo/addons/base/i18n/az.po
+++ b/odoo/addons/base/i18n/az.po
@@ -2644,7 +2644,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -1352,7 +1352,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/bg.po
+++ b/odoo/addons/base/i18n/bg.po
@@ -1406,7 +1406,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/bs.po
+++ b/odoo/addons/base/i18n/bs.po
@@ -2296,7 +2296,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/ca.po
+++ b/odoo/addons/base/i18n/ca.po
@@ -1548,7 +1548,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 "\n"
 "Afegiu suports per omplir tres camps opcionals que s'utilitzen quan feu servir Chorus Pro, especialment quan es fabriquen serveis públics.\n"

--- a/odoo/addons/base/i18n/cs.po
+++ b/odoo/addons/base/i18n/cs.po
@@ -1899,7 +1899,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 "\n"
 "Přidá možnost pro vyplnění tří volitelných polí v případě použití Chorus Pro, zvláště při fakturaci veřejných služeb.\n"

--- a/odoo/addons/base/i18n/da.po
+++ b/odoo/addons/base/i18n/da.po
@@ -1510,7 +1510,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/de.po
+++ b/odoo/addons/base/i18n/de.po
@@ -2119,7 +2119,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 "\n"
 "Fügen Sie Unterstützung zum Ausfüllen von drei optionalen Feldern, die bei der Verwendung von Chorus Pro verwendet werden, hinzu, insbesondere bei der Rechnungsstellung für öffentliche Dienstleistungen.\n"

--- a/odoo/addons/base/i18n/el.po
+++ b/odoo/addons/base/i18n/el.po
@@ -2340,7 +2340,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/es.po
+++ b/odoo/addons/base/i18n/es.po
@@ -2117,7 +2117,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 "\n"
 "Agregue soportes para llenar tres campos opcionales al usar Chorus Pro, especialmente al facturar servicios públicos.\n"

--- a/odoo/addons/base/i18n/es_419.po
+++ b/odoo/addons/base/i18n/es_419.po
@@ -2119,7 +2119,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 "\n"
 "Agregue soporte para completar tres campos opcionales al usar Chorus Pro, en particular al facturar servicios públicos.\n"

--- a/odoo/addons/base/i18n/es_CL.po
+++ b/odoo/addons/base/i18n/es_CL.po
@@ -2287,7 +2287,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/et.po
+++ b/odoo/addons/base/i18n/et.po
@@ -1936,7 +1936,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 "\n"
 "Lisab võimaluse täita kolm valikulist välja kasutades Chorus Pro tarkvara. Kasutuselt kui esitada arveid avalikele teenustele.\n"

--- a/odoo/addons/base/i18n/eu.po
+++ b/odoo/addons/base/i18n/eu.po
@@ -2286,7 +2286,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/fa.po
+++ b/odoo/addons/base/i18n/fa.po
@@ -1391,7 +1391,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/fi.po
+++ b/odoo/addons/base/i18n/fi.po
@@ -2115,7 +2115,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 "\n"
 "Lisää tuet kolmen valinnaisen kentän täyttämiselle, joita käytetään Chorus Pro -palvelua käytettäessä, erityisesti kun laskutetaan julkisia palveluja.\n"

--- a/odoo/addons/base/i18n/fo.po
+++ b/odoo/addons/base/i18n/fo.po
@@ -2286,7 +2286,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/fr.po
+++ b/odoo/addons/base/i18n/fr.po
@@ -2107,10 +2107,10 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 "\n"
-"Ajoutez des supports pour remplir trois champs optionnels utilisés lors de l'utilisation de Chorus Pro, notamment lors de la facturation de services publics.\n"
+"Ajout de la prise en charge des trois champs optionnels utilisés lors de l'utilisation de Chorus Pro, notamment lors de la facturation de services publics.\n"
 
 #. module: base
 #: model:ir.module.module,description:base.module_documents_project

--- a/odoo/addons/base/i18n/fr_BE.po
+++ b/odoo/addons/base/i18n/fr_BE.po
@@ -2281,7 +2281,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/fr_CA.po
+++ b/odoo/addons/base/i18n/fr_CA.po
@@ -2286,7 +2286,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/gl.po
+++ b/odoo/addons/base/i18n/gl.po
@@ -2286,7 +2286,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/gu.po
+++ b/odoo/addons/base/i18n/gu.po
@@ -2294,7 +2294,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/he.po
+++ b/odoo/addons/base/i18n/he.po
@@ -1422,7 +1422,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/hr.po
+++ b/odoo/addons/base/i18n/hr.po
@@ -2456,7 +2456,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/hu.po
+++ b/odoo/addons/base/i18n/hu.po
@@ -1379,7 +1379,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/hy.po
+++ b/odoo/addons/base/i18n/hy.po
@@ -1352,7 +1352,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/id.po
+++ b/odoo/addons/base/i18n/id.po
@@ -2103,7 +2103,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 "\n"
 "Tambahkan dukungan agar dapat mengisi tiga field opsional yang digunakan saat menggunakan Chorus Pro, terutama saat membuat faktur untuk layanan publik.\n"

--- a/odoo/addons/base/i18n/is.po
+++ b/odoo/addons/base/i18n/is.po
@@ -1358,7 +1358,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/it.po
+++ b/odoo/addons/base/i18n/it.po
@@ -2119,7 +2119,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 "\n"
 "Aggiunge supporto per riempire i tre campi opzionali utilizzati quando si usa Chorus Pro, in particolare per la fatturazione di servizi pubblici.\n"

--- a/odoo/addons/base/i18n/ja.po
+++ b/odoo/addons/base/i18n/ja.po
@@ -2104,7 +2104,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 "\n"
 "Chorus Proを使用する際に使用される3つのオプションフィールド、特に公共サービスの請求書作成時への入力サポートを追加しました。\n"

--- a/odoo/addons/base/i18n/ka.po
+++ b/odoo/addons/base/i18n/ka.po
@@ -2286,7 +2286,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/kab.po
+++ b/odoo/addons/base/i18n/kab.po
@@ -2286,7 +2286,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/km.po
+++ b/odoo/addons/base/i18n/km.po
@@ -2291,7 +2291,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/ko.po
+++ b/odoo/addons/base/i18n/ko.po
@@ -2105,7 +2105,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 "\n"
 "Chorus Pro를 사용할 경우, 특히 공공 서비스 부문에 대한 청구서 발송 시 사용되는 세 가지 선택 항목을 채우기 위한 지원을 추가합니다.\n"

--- a/odoo/addons/base/i18n/lb.po
+++ b/odoo/addons/base/i18n/lb.po
@@ -2287,7 +2287,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/lo.po
+++ b/odoo/addons/base/i18n/lo.po
@@ -2286,7 +2286,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/lt.po
+++ b/odoo/addons/base/i18n/lt.po
@@ -1392,7 +1392,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/lv.po
+++ b/odoo/addons/base/i18n/lv.po
@@ -1396,10 +1396,10 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 
 #. module: base
 #: model:ir.module.module,description:base.module_documents_project

--- a/odoo/addons/base/i18n/mk.po
+++ b/odoo/addons/base/i18n/mk.po
@@ -2286,7 +2286,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/mn.po
+++ b/odoo/addons/base/i18n/mn.po
@@ -2493,7 +2493,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/nb.po
+++ b/odoo/addons/base/i18n/nb.po
@@ -1372,7 +1372,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/nl.po
+++ b/odoo/addons/base/i18n/nl.po
@@ -2092,7 +2092,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 "\n"
 "Voeg ondersteuningen toe om drie optionele velden in te vullen die worden gebruikt bij het gebruik van Chorus Pro, vooral bij het factureren van openbare diensten.\n"

--- a/odoo/addons/base/i18n/pl.po
+++ b/odoo/addons/base/i18n/pl.po
@@ -1557,7 +1557,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 "\n"
 "Dodano obsługę wypełniania trzech opcjonalnych pól używanych podczas korzystania z aplikacji Chorus Pro, zwłaszcza podczas fakturowania usług publicznych.\n"

--- a/odoo/addons/base/i18n/pt.po
+++ b/odoo/addons/base/i18n/pt.po
@@ -1380,7 +1380,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/pt_BR.po
+++ b/odoo/addons/base/i18n/pt_BR.po
@@ -2089,7 +2089,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 "\n"
 "Adiciona suporte para preencher três campos opcionais usados ao usar o Chorus Pro, especialmente ao faturar serviços públicos.\n"

--- a/odoo/addons/base/i18n/ro.po
+++ b/odoo/addons/base/i18n/ro.po
@@ -1410,7 +1410,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/ru.po
+++ b/odoo/addons/base/i18n/ru.po
@@ -2108,7 +2108,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 "\n"
 "Добавьте поддержку заполнения трех необязательных полей, используемых при использовании Chorus Pro, особенно при выставлении счетов на оплату услуг населению.\n"

--- a/odoo/addons/base/i18n/sk.po
+++ b/odoo/addons/base/i18n/sk.po
@@ -1391,7 +1391,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/sl.po
+++ b/odoo/addons/base/i18n/sl.po
@@ -1375,7 +1375,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/sq.po
+++ b/odoo/addons/base/i18n/sq.po
@@ -2286,7 +2286,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/sr.po
+++ b/odoo/addons/base/i18n/sr.po
@@ -1394,10 +1394,10 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 
 #. module: base
 #: model:ir.module.module,description:base.module_documents_project

--- a/odoo/addons/base/i18n/sr@latin.po
+++ b/odoo/addons/base/i18n/sr@latin.po
@@ -2304,7 +2304,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/sv.po
+++ b/odoo/addons/base/i18n/sv.po
@@ -2106,7 +2106,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 "\n"
 "Lägg till stöd för att fylla i tre valfria fält som används vid användning av Chorus Pro, särskilt vid fakturering av offentliga tjänster.\n"

--- a/odoo/addons/base/i18n/th.po
+++ b/odoo/addons/base/i18n/th.po
@@ -2085,7 +2085,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 "\n"
 "เพิ่มการรองรับเพื่อกรอกช่องตัวเลือกสามช่องที่ใช้ เมื่อใช้ Chorus Pro โดยเฉพาะการออกใบแจ้งหนี้บริการสาธารณะ\n"

--- a/odoo/addons/base/i18n/tr.po
+++ b/odoo/addons/base/i18n/tr.po
@@ -1552,7 +1552,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 "\n"
 "Chorus Pro'yu kullanırken, özellikle kamu hizmetlerini faturalandırırken kullanılan üç isteğe bağlı alanı doldurmak için destekler ekleyin.\n"

--- a/odoo/addons/base/i18n/uk.po
+++ b/odoo/addons/base/i18n/uk.po
@@ -1731,7 +1731,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 "\n"
 "Додайте підтримку для заповнення трьох необов’язкових полів, які використовуються під час використання Chorus Pro, особливо під час виставлення рахунків за державні послуги.\n"

--- a/odoo/addons/base/i18n/vi.po
+++ b/odoo/addons/base/i18n/vi.po
@@ -2109,7 +2109,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 "\n"
 "Thêm hỗ trợ để điền vào ba trường tùy chọn được sử dụng khi dùng Chorus Pro, đặc biệt là khi lập hóa đơn cho các dịch vụ công.\n"

--- a/odoo/addons/base/i18n/zh_CN.po
+++ b/odoo/addons/base/i18n/zh_CN.po
@@ -2109,7 +2109,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 "\n"
 "添加支持，以填写使用 Chorus Pro 时使用的三个可选字段，尤其是在开具公共服务发票时。\n"

--- a/odoo/addons/base/i18n/zh_TW.po
+++ b/odoo/addons/base/i18n/zh_TW.po
@@ -2101,7 +2101,7 @@ msgstr ""
 #: model:ir.module.module,description:base.module_l10n_fr_facturx_chorus_pro
 msgid ""
 "\n"
-"Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
+"Add support to fill three optional fields used when using Chorus Pro, especially when invoicing public services.\n"
 msgstr ""
 "\n"
 "添加支持，以填寫使用 Chorus Pro 時使用的三個可選字段，尤其是在開具公共服務發票時。\n"


### PR DESCRIPTION
Allow to send UBL Bis 3 invoices using Peppol to Chorus Pro (B2G plaftorm in France).

This requires to send the information contained in the already existing fields `buyer_reference`, `contract_reference`,
`purchase_order_reference` in the Bis 3 xmls.

task-4147787
opw-4139689