### PR TITLE
[IMP] account: tax_details is wrong with group of tax and analytic

### DIFF
--- a/addons/account/models/account_move_line_tax_details.py
+++ b/addons/account/models/account_move_line_tax_details.py
@@ -185,7 +185,7 @@ class AccountMoveLine(models.Model):
                         OR (tax.tax_exigibility = 'on_payment' AND tax.cash_basis_transition_account_id IS NOT NULL)
                     )
                     AND (
-                        NOT tax.analytic
+                        (tax.analytic IS NULL OR tax.analytic = FALSE)
                         OR (base_line.analytic_distribution IS NULL AND account_move_line.analytic_distribution IS NULL)
                         OR base_line.analytic_distribution = account_move_line.analytic_distribution
                     )


### PR DESCRIPTION
Create group of tax 5% + 5% and create invoice with two lines with same tax and one line with analytic and another line without analytic

then tax_details is wrong because tax.analytic is NULL

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
