### PR TITLE
 [FIX] sale_stock: correct delivered quantity for multi-step returns

### DIFF
--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -274,7 +274,7 @@ class SaleOrderLine(models.Model):
             if move.location_dest_id.usage == "customer":
                 if not move.origin_returned_move_id or (move.origin_returned_move_id and move.to_refund):
                     outgoing_moves |= move
-            elif move.location_dest_id.usage != "customer" and move.to_refund:
+            elif move.location_id.usage == "customer" and move.to_refund:
                 incoming_moves |= move
 
         return outgoing_moves, incoming_moves

--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -1879,3 +1879,63 @@ class TestSaleStock(TestSaleCommon, ValuationReconciliationTestCommon):
         ship02.move_ids.write({'quantity': 7, 'picked': True})
         ship02.button_validate()
         self.assertEqual(so.delivery_status, 'full')
+
+    def test_return_from_customer_multi_step(self):
+        """
+        Check that, when using multi-step routes, returned quantities are counted on
+        the corresponding SO's delivered quantity only once for the whole move chain
+        """
+        # Set-up multi-step routes
+        self.env.user.groups_id += self.env.ref('stock.group_stock_multi_locations')
+        self.env.user.groups_id += self.env.ref('stock.group_adv_location')
+        warehouse = self.company_data['default_warehouse']
+
+        with Form(warehouse) as w:
+            w.reception_steps = 'two_steps'
+
+        # Make *Stock/Input* a return location
+        loc_input = warehouse.wh_input_stock_loc_id
+        loc_input.return_location = True
+
+        # Make SO and confirm
+        product = self.env['product.product'].create({
+            'name': 'Delivered Product',
+            'type': 'product',
+        })
+        so = self._get_new_sale_order(product=product)
+        so.action_confirm()
+
+        # Validate delivery
+        picking = so.picking_ids
+        self.assertEqual(len(picking), 1)
+
+        def validate_picking(picking, qty=10):
+            picking.move_ids.quantity = qty
+            picking.move_ids.picked = True
+            picking.button_validate()
+
+        validate_picking(picking)
+        self.assertEqual(so.order_line[0].qty_delivered, 10)
+
+        # Create return picking chain
+        stock_return_picking_form = Form(
+            self.env['stock.return.picking'].with_context(
+                active_ids=picking.ids,
+                active_id=picking.ids[0],
+                active_model='stock.picking'
+            )
+        )
+
+        stock_return_picking_form.location_id = loc_input
+        stock_return_picking = stock_return_picking_form.save()
+        stock_return_picking.create_returns()
+
+        return_1 = so.picking_ids.filtered(lambda r: r.location_dest_id.name == 'Input')
+        return_2 = so.picking_ids.filtered(lambda r: r.location_dest_id.name == 'Stock')
+
+        # Check that validating returns correctly updates the SO's delivered qty
+        validate_picking(return_1)
+        self.assertEqual(so.order_line[0].qty_delivered, 0)
+
+        validate_picking(return_2)
+        self.assertEqual(so.order_line[0].qty_delivered, 0)


### PR DESCRIPTION
Steps
---
* install `stock`, `sale_management`
* configure reception in 2 steps
  (*Setting > Multi-step routes* + *Configure Warehouse Routes*)
* make *Stock/Input* a return location
  (*Inventory* > *Configuration* > *Stock/Input* form)
* create an SO for 5 units of a storable product (say P)
* (put at least 5 of P available in stock)
* confirm it > go to the delivery > validate
* *Return* > from the wizard set *Stock/Input* as the return location
* validate the `Customers -> Input` receipt
* validate the `Input -> Stock` internal transfer
* => on the orignal SO the delivered quantity is now -5 instead of 0

Cause
---
When generating moves in a push rules, we copy the fields of the
generating move, including `to_refund`, so both moves affect the
delivered quantity.
But when we check if a return move should affect the delivered/received
qty on SO/POs, we only check the `usage` of the destination location;
so in the case of multi-step routes, moves further down the chain
will affect the qty twice or more, and we will have a negative
delivered quantity

Fix
---
Use a stricter check to determined which moves should affect SO
quantities

opw-4129497