### PR TITLE
[IMP] hr_timesheet: exclude projects/tasks without timesheets from report

### DIFF
--- a/addons/hr_timesheet/report/report_timesheet_templates.xml
+++ b/addons/hr_timesheet/report/report_timesheet_templates.xml
@@ -82,18 +82,20 @@
             <t t-call="web.internal_layout">
                 <div class="page">
                     <t t-foreach="docs" t-as="doc">
-                        <div class="oe_structure"/>
-                        <div class="mt8">
-                            <h1>
-                                <t t-out="title"/>: <t t-out="doc.name"/>
-                            </h1>
-                            <t t-set="lines" t-value="doc.timesheet_ids if from_project else timesheets_per_task.get(doc, doc.env['account.analytic.line'])"/>
-                            <t t-call="hr_timesheet.timesheet_table"/>
-                            <t t-if="not from_project">
-                                <t t-set="task_id" t-value="doc.id"/>
-                                <t t-call="hr_timesheet.timesheet_report_subtask"/>
-                            </t>
-                        </div>
+                        <t t-set="lines" t-value="doc.timesheet_ids if from_project else timesheets_per_task.get(doc, doc.env['account.analytic.line'])"/>
+                        <t t-if="lines">
+                            <div class="oe_structure"/>
+                            <div class="mt8">
+                                <h1>
+                                    <t t-out="title"/>: <t t-out="doc.name"/>
+                                </h1>
+                                <t t-call="hr_timesheet.timesheet_table"/>
+                                <t t-if="not from_project">
+                                    <t t-set="task_id" t-value="doc.id"/>
+                                    <t t-call="hr_timesheet.timesheet_report_subtask"/>
+                                </t>
+                            </div>
+                        </t>
                     </t>
                 </div>
             </t>


### PR DESCRIPTION
We do not want to pollute the report with projects/tasks that have no timesheets.

task-4029587

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
