### PR TITLE
[IMP] payment_authorize: display the reason for declining the payment

### DIFF
--- a/addons/payment/static/src/xml/payment_post_processing.xml
+++ b/addons/payment/static/src/xml/payment_post_processing.xml
@@ -134,7 +134,10 @@
                             </h4>
                             <small class="list-group-item-text">
                                 This payment has been canceled.<br/>
-                                No payment has been processed.
+                                No payment has been processed.<br/>
+                                <t t-if="tx['state_message']">
+                                    <strong>Reason:</strong> <t t-esc="tx['state_message']"/>
+                                </t>
                             </small>
                         </a>
                     </t>

--- a/addons/payment_authorize/models/payment_transaction.py
+++ b/addons/payment_authorize/models/payment_transaction.py
@@ -242,7 +242,7 @@ class PaymentTransaction(models.Model):
                 # triggered by a customer browsing the transaction from the portal.
                 self.env.ref('payment.cron_post_process_payment_tx')._trigger()
         elif status_code == '2':  # Declined
-            self._set_canceled()
+            self._set_canceled(state_message=response_content.get('x_response_reason_text'))
         elif status_code == '4':  # Held for Review
             self._set_pending()
         else:  # Error / Unknown code


### PR DESCRIPTION
In some occasions, Authorize would decline a payment and provide the reason for it, but not mark the payment as in error. The customer would see that their payment is cancelled but not know what to do. That is because error messages were not processed in the case of declined payments.

This commit makes eventual error messages (decline reasons) logged on the linked document's chatter and displayed on the /payment/status page.

opw-4125895
