### PR TITLE
[FIX] point_of_sale: fix negative price extra

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -701,7 +701,7 @@ export class PosStore extends Reactive {
             values.price_unit = values.product_id.get_price(order.pricelist_id, values.qty);
         }
 
-        if (values.price_extra > 0) {
+        if (values.price_extra) {
             const price = values.product_id.get_price(
                 order.pricelist_id,
                 values.qty,


### PR DESCRIPTION
In the point of sale products with variants with negative price extra have their price computed as if they have no price extra.

Steps to reproduce:

1. Create a product with variants of type "never create" and give a negative price extra to one of the variants
2. Observe that adding that product in the cart will show that the price is the whole price, and not the expected lower price.

Task: 4148183




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
