### PR TITLE
[FIX] web: pager should reset scroll

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -162,9 +162,12 @@ export class KanbanController extends Component {
                     offset: offset,
                     limit: limit,
                     total: count,
-                    onUpdate: async ({ offset, limit }) => {
+                    onUpdate: async ({ offset, limit }, hasNavigated) => {
                         await this.model.root.load({ offset, limit });
                         await this.onUpdatedPager();
+                        if (hasNavigated) {
+                            this.onPageChangeScroll();
+                        }
                     },
                     updateTotal: hasLimitedCount ? () => root.fetchCount() : undefined,
                 };
@@ -310,6 +313,16 @@ export class KanbanController extends Component {
                 l.records.find((r) => r.id === record.id)
             );
             this.progressBarState?.updateCounts(group);
+        }
+    }
+
+    onPageChangeScroll() {
+        if (this.rootRef && this.rootRef.el) {
+            if (this.env.isSmall) {
+                this.rootRef.el.scrollTop = 0;
+            } else {
+                this.rootRef.el.querySelector(".o_content").scrollTop = 0;
+            }
         }
     }
 

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -331,7 +331,11 @@ export class ListController extends Component {
 
     onPageChangeScroll() {
         if (this.rootRef && this.rootRef.el) {
-            this.rootRef.el.querySelector(".o_content").scrollTop = 0;
+            if (this.env.isSmall) {
+                this.rootRef.el.scrollTop = 0;
+            } else {
+                this.rootRef.el.querySelector(".o_content .o_list_renderer").scrollTop = 0;
+            }
         }
     }
 

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -10896,6 +10896,10 @@ test(`list view move to previous page when all records from last page archive/un
 });
 
 test(`list should ask to scroll to top on page changes`, async () => {
+    // add records to be able to scroll
+    for (let i = 5; i < 55; i++) {
+        Foo._records.push({ id: i, foo: "foo" });
+    }
     patchWithCleanup(ListController.prototype, {
         onPageChangeScroll() {
             super.onPageChangeScroll(...arguments);
@@ -10916,16 +10920,21 @@ test(`list should ask to scroll to top on page changes`, async () => {
 
     // change the limit (should not ask to scroll)
     await contains(`.o_pager_value`).click();
-    await contains(`.o_pager_value`).edit("1-2");
+    await contains(`.o_pager_value`).edit("1-25");
     await animationFrame();
-    expect(getPagerValue()).toEqual([1, 2]);
+    expect(getPagerValue()).toEqual([1, 25]);
     // should not ask to scroll when changing the limit
     expect.verifySteps([]);
+
+    await contains(".o_list_renderer").scroll({ top: 250 });
+    expect(".o_list_renderer").toHaveProperty("scrollTop", 250);
 
     // switch pages again (should still ask to scroll)
     await pagerNext();
     // this is still working after a limit change
     expect.verifySteps(["scroll"]);
+    // Should effectively reset the scroll position
+    expect(".o_list_renderer").toHaveProperty("scrollTop", 0);
 });
 
 test(`list with handle field, override default_get, bottom when inline`, async () => {


### PR DESCRIPTION
This commit fixes an issue where using the pager in list and kanban view would'nt reset the scroll value of the list view. This is due to the fact that the code which was supposed to handle this functionality in list view was targeting the wrong HTML element and there was no equivalent in kanban.

task-4134026
