### PR TITLE
[IMP] mail: replied message inside message bubble

### DIFF
--- a/addons/mail/static/src/core/common/message.dark.scss
+++ b/addons/mail/static/src/core/common/message.dark.scss
@@ -12,7 +12,7 @@
 
 .o-mail-Message-bubble {
     .o-mail-Message:not(.o-card) & {
-        --border-opacity: 0;
+        --border-opacity: 0.1;
     }
 
     &.o-blue {

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -17,7 +17,6 @@
                 t-ref="root"
                 t-if="message.exists()"
             >
-                <MessageInReply t-if="message.parentMessage" alignedRight="isAlignedRight" message="message" onClick="props.onParentMessageClick"/>
                 <div class="o-mail-Message-core position-relative d-flex flex-shrink-0">
                     <div class="o-mail-Message-sidebar d-flex flex-shrink-0" t-att-class="{ 'justify-content-end': isAlignedRight, 'align-items-start justify-content-start': !isAlignedRight, 'o-inChatWindow': env.inChatWindow }">
                         <div t-if="!props.squashed" class="o-mail-Message-avatarContainer position-relative bg-view" t-att-class="getAvatarContainerAttClass()">
@@ -72,10 +71,11 @@
                                             <div class="position-relative overflow-x-auto d-inline-block" t-att-class="{ 'w-100': state.isEditing }">
                                                 <div class="o-mail-Message-bubble rounded-bottom-3 position-absolute top-0 start-0 w-100 h-100" t-att-class="{
                                                     'border': state.isEditing and !message.is_note,
-                                                    'o-blue border border-info': !message.isSelfAuthored and !message.is_note and !message.isHighlightedFromMention,
-                                                    'o-green border border-success': message.isSelfAuthored and !message.is_note and !message.isHighlightedFromMention,
-                                                    'o-orange border border-warning': message.isHighlightedFromMention,
+                                                    'o-blue border border-info': message.bubbleColor === 'blue',
+                                                    'o-green border border-success': message.bubbleColor === 'green',
+                                                    'o-orange border border-warning': message.bubbleColor === 'orange',
                                                     }" t-attf-class="{{ isAlignedRight ? 'rounded-start-3' : 'rounded-end-3' }}"/>
+                                                <MessageInReply t-if="message.parentMessage" message="message" onClick="props.onParentMessageClick"/>
                                                 <div class="position-relative text-break o-mail-Message-body" t-att-class="{
                                                             'p-1': message.is_note,
                                                             'fs-1': !state.isEditing and !env.inChatter and message.onlyEmojis,

--- a/addons/mail/static/src/core/common/message_in_reply.dark.scss
+++ b/addons/mail/static/src/core/common/message_in_reply.dark.scss
@@ -1,0 +1,18 @@
+.o-mail-MessageInReply-core {
+    --border-opacity: 0;
+    background-color: rgba($gray-100, .35) !important;
+
+    &.o-otherMessageBlue {
+        border-left-color: mix($gray-100, $info, 50%) !important
+    }
+    &.o-otherMessageGreen {
+        border-left-color: mix($gray-100, $success, 50%) !important
+    }
+    &.o-otherMessageOrange {
+        border-left-color: mix($gray-100, $warning, 40%) !important
+    }
+
+    &:hover {
+        filter: brightness(1.1);
+    }
+}

--- a/addons/mail/static/src/core/common/message_in_reply.js
+++ b/addons/mail/static/src/core/common/message_in_reply.js
@@ -4,7 +4,7 @@ import { useService } from "@web/core/utils/hooks";
 import { url } from "@web/core/utils/urls";
 
 export class MessageInReply extends Component {
-    static props = ["message", "alignedRight", "onClick?"];
+    static props = ["message", "onClick?"];
     static template = "mail.MessageInReply";
 
     setup() {

--- a/addons/mail/static/src/core/common/message_in_reply.scss
+++ b/addons/mail/static/src/core/common/message_in_reply.scss
@@ -1,26 +1,25 @@
-.o-mail-MessageInReply-corner {
-    &.o-isLeftAlign {
-        left: $o-mail-Message-sidebarWidth / 2;
-        border-radius: $o-RoundedRectangle-small 0 0 0;
-
-        &.o-inChatWindow {
-            left: $o-mail-Message-sidebarSmallWidth / 2;
-        }
-    }
-
-    &.o-isRightAlign {
-        right: $o-mail-Message-sidebarWidth / 2;
-        border-radius: 0 $o-RoundedRectangle-small 0 0;
-
-        &.o-inChatWindow {
-            right: $o-mail-Message-sidebarSmallWidth / 2;
-        }
-    }
-}
-
 .o-mail-MessageInReply-avatar {
     width: $o-mail-Avatar-size / 2;
     height: $o-mail-Avatar-size / 2;
+}
+
+.o-mail-MessageInReply-core {
+    border-left: 3px solid transparent !important;
+    background-color: rgba($o-view-background-color, .5) !important;
+    --border-opacity: 0.15;
+
+    &.o-otherMessageBlue {
+        border-left-color: mix($o-view-background-color, $info, 50%) !important
+    }
+    &.o-otherMessageGreen {
+        border-left-color: mix($o-view-background-color, $success, 50%) !important
+    }
+    &.o-otherMessageOrange {
+        border-left-color: mix($o-view-background-color, $warning, 40%) !important
+    }
+    &:hover {
+        filter: brightness(.975);
+    }
 }
 
 .o-mail-MessageInReply-content {

--- a/addons/mail/static/src/core/common/message_in_reply.xml
+++ b/addons/mail/static/src/core/common/message_in_reply.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.MessageInReply">
-        <div class="o-mail-MessageInReply" t-att-class="{
-                'me-5': store.discuss?.isActive or (env.inChatWindow and !props.alignedRight),
-                'd-flex justify-content-end ms-5': env.inChatWindow and props.alignedRight,
+        <div class="o-mail-MessageInReply mx-2 mt-1 p-1 pb-0">
+            <small class="o-mail-MessageInReply-core position-relative d-flex px-2 py-1" t-att-class="{
+                'o-otherMessageBlue border border-info': props.message.parentMessage.bubbleColor === 'blue',
+                'o-otherMessageGreen border border-success': props.message.parentMessage.bubbleColor === 'green',
+                'o-otherMessageOrange border border-warning': props.message.parentMessage.bubbleColor === 'orange',
             }">
-            <small class="position-relative d-block text-small mb-1" t-attf-class="{{ env.inChatWindow and props.alignedRight ? 'justify-content-end pe-5': 'ps-5' }}">
-                <span class="o-mail-MessageInReply-corner position-absolute bottom-0 top-50 pe-4 border-top text-300" t-attf-class="{{ env.inChatWindow and props.alignedRight ? 'o-isRightAlign border-end' : 'o-isLeftAlign border-start' }}" t-att-class="{ 'ms-n2': store.discuss?.isActive, 'o-inChatWindow': env.inChatWindow }"/>
-                <span t-if="!props.message.parentMessage.isEmpty" class="d-inline-flex align-items-center text-muted opacity-75" t-att-class="{ 'cursor-pointer opacity-100-hover': props.onClick }" t-on-click="() => this.props.onClick?.()">
+                <span t-if="!props.message.parentMessage.isEmpty" class="d-inline-flex align-items-center text-muted" t-att-class="{ 'cursor-pointer': props.onClick }" t-on-click="() => this.props.onClick?.()">
                     <img class="o-mail-MessageInReply-avatar me-2 rounded" t-att-src="authorAvatarUrl" t-att-title="props.message.parentMessage.author?.name ?? props.message.parentMessage.email_from" alt="Avatar"/>
                     <span class="o-mail-MessageInReply-content overflow-hidden smaller">
-                        <b>@<t t-out="props.message.parentMessage.author?.name ?? props.message.parentMessage.email_from"/></b>:
-                        <br t-if="env.inChatWindow and !props.alignedRight"/>
+                        <b><t t-out="props.message.parentMessage.author?.name ?? props.message.parentMessage.email_from"/></b>:
                         <span class="o-mail-MessageInReply-message ms-1 text-break">
                             <t t-if="!props.message.parentMessage.isBodyEmpty">
                                 <t t-out="props.message.parentMessage.body"/>

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -181,6 +181,19 @@ export class Message extends Record {
         return this.store.self.isAdmin || this.isSelfAuthored;
     }
 
+    get bubbleColor() {
+        if (!this.isSelfAuthored && !this.is_note && !this.isHighlightedFromMention) {
+            return "blue";
+        }
+        if (this.isSelfAuthored && !this.is_note && !this.isHighlightedFromMention) {
+            return "green";
+        }
+        if (this.isHighlightedFromMention) {
+            return "orange";
+        }
+        return undefined;
+    }
+
     get editable() {
         if (!this.allowsEdition) {
             return false;

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -545,9 +545,6 @@ export class Thread extends Component {
         if (!msg.thread?.eq(prevMsg.thread)) {
             return false;
         }
-        if (msg.parentMessage) {
-            return false;
-        }
         return msg.datetime.ts - prevMsg.datetime.ts < 5 * 60 * 1000;
     }
 


### PR DESCRIPTION
Before this commit, the replied message of a message was displayed above the bubble of message.

This made reading conversation with lots of replies hard, because it reduces the effectiveness of bubble layout that helps shaping the conversation at a glance.

This commit improves this by putting the replied message inside the bubble, so that most content of message is inside the bubble.

Thanks to improved style of replied message inside bubble, these messages can now be squashed, which this commit also made it possible.


Before
<img width="508" alt="Screenshot 2024-08-29 at 17 43 20" src="https://github.com/user-attachments/assets/11663612-2944-497d-8192-f61d813f4047">


After
<img width="511" alt="Screenshot 2024-08-29 at 17 43 28" src="https://github.com/user-attachments/assets/c75960ba-e817-4b0c-9d04-ac12a78a3157">
