### PR TITLE
[IMP] mail: improve slightly 'new message' chat window

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -118,7 +118,7 @@ export class ChatWindow extends Component {
     }
 
     onClickHeader() {
-        if (this.ui.isSmall || this.state.editingName) {
+        if (this.ui.isSmall || this.state.editingName || !this.thread) {
             return;
         }
         this.toggleFold();

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -12,7 +12,7 @@
         t-on-keydown="onKeydown"
         tabindex="1"
     >
-        <div class="o-mail-ChatWindow-header d-flex align-items-center flex-shrink-0 bg-100 z-1" t-on-click="onClickHeader" t-att-class="{ 'cursor-pointer': !ui.isSmall }">
+        <div class="o-mail-ChatWindow-header d-flex align-items-center flex-shrink-0 bg-100 z-1" t-on-click="onClickHeader" t-att-class="{ 'cursor-pointer': !ui.isSmall and thread, 'pt-2': !thread }">
             <t t-if="threadActions.actions.length > 3">
                 <div class="d-flex text-truncate">
                     <Dropdown position="'left-start'" onStateChanged="isOpen => this.onActionsMenuStateChanged(isOpen)" menuClass="'d-flex flex-column py-0'">
@@ -105,15 +105,16 @@
 </t>
 
 <t t-name="mail.ChatWindow.headerContent">
-    <div t-if="thread" class="o-mail-ChatWindow-threadAvatar my-0 me-1" t-att-class="{
-        'py-2': threadActions.actions.length lte 3,
-        'ms-1': threadActions.actions.length > 4,
-        'ms-3': threadActions.actions.length lte 4,
+    <div class="o-mail-ChatWindow-threadAvatar my-0 me-1" t-att-class="{
+        'py-2': thread and threadActions.actions.length lte 3,
+        'ms-1': thread and threadActions.actions.length > 4,
+        'ms-3': threadActions.actions.length lte 4 or !thread,
     }">
-        <img class="rounded" t-att-src="thread.avatarUrl" alt="Thread Image"/>
+        <img t-if="thread" class="rounded" t-att-src="thread.avatarUrl" alt="Thread Image"/>
+        <i t-else="" class="fa fa-pencil fa-lg fa-fw py-1"/>
     </div>
     <ThreadIcon t-if="thread and thread.channel_type === 'chat' and thread.correspondent" thread="thread"/>
     <CountryFlag t-if="thread?.anonymous_country" country="thread.anonymous_country" class="'o-mail-ChatWindow-country border'"/>
-    <div t-if="!state.editingName" class="text-truncate fw-bolder border border-transparent me-1 my-0" t-att-title="props.chatWindow.displayName" t-esc="props.chatWindow.displayName" t-att-class="{ 'ms-1': thread, 'ms-3': !thread, 'fs-4': ui.isSmall }"/>
+    <div t-if="!state.editingName" class="text-truncate fw-bolder border border-transparent mx-1 my-0" t-att-title="props.chatWindow.displayName" t-esc="props.chatWindow.displayName" t-att-class="{ 'fs-4': ui.isSmall }"/>
 </t>
 </templates>

--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -9,7 +9,11 @@ export const threadActionsRegistry = registry.category("mail.thread/actions");
 threadActionsRegistry
     .add("fold-chat-window", {
         condition(component) {
-            return !component.ui.isSmall && component.props.chatWindow;
+            return (
+                !component.ui.isSmall &&
+                component.props.chatWindow &&
+                component.props.chatWindow.thread
+            );
         },
         icon: "fa fa-fw fa-minus",
         name(component) {

--- a/addons/mail/static/src/discuss/core/web/channel_selector.js
+++ b/addons/mail/static/src/discuss/core/web/channel_selector.js
@@ -12,7 +12,7 @@ import { useSequential } from "@mail/utils/common/hooks";
 
 export class ChannelSelector extends Component {
     static components = { TagsList, NavigableList };
-    static props = ["category", "onValidate?", "autofocus?", "multiple?", "close?", "class?"];
+    static props = ["category", "onValidate?", "autofocus?", "multiple?", "close?"];
     static defaultProps = { multiple: true };
     static template = "discuss.ChannelSelector";
 

--- a/addons/mail/static/src/discuss/core/web/channel_selector.xml
+++ b/addons/mail/static/src/discuss/core/web/channel_selector.xml
@@ -2,10 +2,10 @@
 <templates xml:space="preserve">
 
 <t t-name="discuss.ChannelSelector">
-    <div class="o-discuss-ChannelSelector d-flex flex-wrap form-control rounded" t-att-class="props.class" t-ref="root">
+    <div class="o-discuss-ChannelSelector d-flex flex-wrap form-control rounded p-0" t-ref="root">
         <TagsList t-if="props.multiple" tags="tagsList"/>
         <input
-            class="text-truncate form-control flex-grow-1 border-0 px-2 py-0"
+            class="text-truncate form-control flex-grow-1 border-0 px-2 py-1"
             t-att-placeholder="inputPlaceholder"
             t-model="state.value"
             t-ref="input"

--- a/addons/mail/static/src/discuss/core/web/chat_window_patch.xml
+++ b/addons/mail/static/src/discuss/core/web/chat_window_patch.xml
@@ -4,7 +4,7 @@
         <xpath expr="//t[@name='thread content']" position="after">
             <div t-if="!thread" class="d-flex align-items-center m-3">
                 <span class="flex-shrink-0 me-2">To :</span>
-                <ChannelSelector autofocus="props.chatWindow.autofocus" category="store.discuss.chats" onValidate="() => this.close()" multiple="false" class="'p-1'"/>
+                <ChannelSelector autofocus="props.chatWindow.autofocus" category="store.discuss.chats" onValidate="() => this.close()" multiple="false"/>
             </div>
         </xpath>
     </t>

--- a/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories_patch.xml
+++ b/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories_patch.xml
@@ -3,14 +3,14 @@
     <t t-inherit="mail.DiscussSidebarCategory.main" t-inherit-mode="extension">
         <xpath expr="//*[@name='header']" position="after">
             <div t-if="state.editing and !store.discuss.isSidebarCompact" class="p-2" t-ref="selector">
-                <ChannelSelector category="category" onValidate.bind="stopEditing" autofocus="true" close.bind="stopEditing" class="'p-1'"/>
+                <ChannelSelector category="category" onValidate.bind="stopEditing" autofocus="true" close.bind="stopEditing"/>
             </div>
         </xpath>
     </t>
     <t t-inherit="mail.DiscussSidebarCategory.actions" t-inherit-mode="extension">
         <xpath expr="//*[@name='action-group']" position="replace">
             <t t-if="state.editing and store.discuss.isSidebarCompact">
-                <ChannelSelector category="category" onValidate.bind="stopEditing" autofocus="true" close.bind="stopEditing" class="'p-0'"/>
+                <ChannelSelector category="category" onValidate.bind="stopEditing" autofocus="true" close.bind="stopEditing"/>
             </t>
             <t t-else="">
                 <t>$0</t>

--- a/addons/mail/static/src/discuss/core/web/messaging_menu_patch.xml
+++ b/addons/mail/static/src/discuss/core/web/messaging_menu_patch.xml
@@ -7,7 +7,7 @@
                 <div t-if="state.adding" class="w-100 p-1 bg-light" t-ref="selector">
                     <t t-if="state.adding === 'chat'" t-set="category" t-value="store.discuss.chats"/>
                     <t t-if="state.adding === 'channel'" t-set="category" t-value="store.discuss.channels"/>
-                    <ChannelSelector category="category" autofocus="true" class="'p-1'"/>
+                    <ChannelSelector category="category" autofocus="true"/>
                 </div>
             </t>
             <button t-if="!ui.isSmall and !store.discuss.isActive" t-att-class="ui.isSmall ? 'w-50 p-2 btn btn-secondary m-1' : 'btn btn-link px-2 py-1'" t-on-click.stop="onClickNewMessage">

--- a/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
+++ b/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
@@ -52,10 +52,7 @@ test("'New message' chat window can only be open [REQUIRE FOCUS]", async () => {
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-MessagingMenu button", { text: "New Message" });
     await contains(".o-mail-ChatWindow", { count: 1 });
-    await click(".o-mail-ChatWindow-command[title='Fold']");
-    await contains(".o-mail-ChatBubble", { count: 0 }); // folded 'new message' is equivalent to close
-    await click(".o_menu_systray i[aria-label='Messages']");
-    await click(".o-mail-MessagingMenu button", { text: "New Message" });
+    await contains("[title='Fold']", { count: 0 });
     await insertText(".o-discuss-ChannelSelector input", "John");
     await click(".o-discuss-ChannelSelector-suggestion");
     triggerHotkey("Enter");

--- a/addons/mail/static/tests/discuss/core/web/chat_window_new_message.test.js
+++ b/addons/mail/static/tests/discuss/core/web/chat_window_new_message.test.js
@@ -21,8 +21,7 @@ test("basic rendering", async () => {
     await contains(".o-mail-ChatWindow");
     await contains(".o-mail-ChatWindow-header");
     await contains(".o-mail-ChatWindow-header", { text: "New message" });
-    await contains(".o-mail-ChatWindow-header .o-mail-ChatWindow-command", { count: 2 });
-    await contains(".o-mail-ChatWindow-header .o-mail-ChatWindow-command[title='Fold']");
+    await contains(".o-mail-ChatWindow-header .o-mail-ChatWindow-command", { count: 1 });
     await contains(
         ".o-mail-ChatWindow-header .o-mail-ChatWindow-command[title*='Close Chat Window']"
     );
@@ -42,16 +41,6 @@ test("close", async () => {
     await click(".o_menu_systray i[aria-label='Messages']");
     await click("button", { text: "New Message" });
     await click(".o-mail-ChatWindow-command[title*='Close Chat Window']");
-    await contains(".o-mail-ChatWindow", { count: 0 });
-});
-
-test("fold", async () => {
-    await start();
-    await click(".o_menu_systray i[aria-label='Messages']");
-    await click("button", { text: "New Message" });
-    await contains(".o-discuss-ChannelSelector");
-    await click(".o-mail-ChatWindow-command[title='Fold']");
-    await contains(".o-mail-ChatWindow .o-discuss-ChannelSelector", { count: 0 });
     await contains(".o-mail-ChatWindow", { count: 0 });
 });
 


### PR DESCRIPTION
- Add new pencil icon next to "new message"
- Size chat window header similarly to chat windows with thread
- Remove "fold" actions and clickable header, as new message is not foldable.
- Align input color with border

Before
<img width="1030" alt="Screenshot 2024-08-29 at 18 16 15" src="https://github.com/user-attachments/assets/15954b9d-8008-494e-bc89-19f8769075ec">

After
<img width="1032" alt="Screenshot 2024-08-29 at 18 15 55" src="https://github.com/user-attachments/assets/cf0bc755-a80a-4f4d-aa9f-e16fb456b22e">
