### PR TITLE
[FIX] rating: allow portal user to post rating

### DIFF
--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -195,14 +195,14 @@ class LivechatController(http.Controller):
 
     def _post_feedback_message(self, channel, rating, reason):
         reason = Markup("<br>" + re.sub(r'\r\n|\r|\n', "<br>", reason) if reason else "")
-        body = Markup('''
-            <div class="o_mail_notification o_hide_author">
-                %(rating)s: <img class="o_livechat_emoji_rating" src="%(rating_url)s" alt="rating"/>%(reason)s
-            </div>
-        ''') % {
-            'rating': _('Rating'),
-            'rating_url': rating.rating_image_url,
-            'reason': reason,
+        body = Markup(
+            """<div class="o_mail_notification o_hide_author">"""
+            """%(rating)s: <img class="o_livechat_emoji_rating" src="%(rating_url)s" alt="rating"/>%(reason)s"""
+            """</div>"""
+        ) % {
+            "rating": _("Rating"),
+            "rating_url": rating.rating_image_url,
+            "reason": reason,
         }
         # sudo: discuss.channel - not necessary for posting, but necessary to update related rating
         channel.sudo().message_post(

--- a/addons/im_livechat/models/discuss_channel_member.py
+++ b/addons/im_livechat/models/discuss_channel_member.py
@@ -26,7 +26,7 @@ class ChannelMember(models.Model):
     def _to_store(self, store: Store, **kwargs):
         super()._to_store(store, **kwargs)
         for member in self.filtered(lambda m: m.channel_id.channel_type == "livechat"):
-            # sudo: mail.channel - reading livechat channel to check whether current member is a bot is allowed
+            # sudo: discuss.channel - reading livechat channel to check whether current member is a bot is allowed
             store.add(
                 member,
                 {

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2873,6 +2873,14 @@ class MailThread(models.AbstractModel):
     def _message_create(self, values_list):
         """ Low-level helper to create mail.message records. It is mainly used
         to hide the cleanup of given values, for mail gateway or helpers."""
+        values_list = [
+            {
+                key: val
+                for key, val in values.items()
+                if key not in self._get_message_create_ignore_field_names()
+            }
+            for values in values_list
+        ]
         create_values_list = []
 
         # preliminary value safety check
@@ -2928,6 +2936,12 @@ class MailThread(models.AbstractModel):
             'subtype_id',
             'tracking_value_ids',
         }
+
+    def _get_message_create_ignore_field_names(self):
+        """Some fields should be silently ignored when creating a mail.message,
+        without raising an exception. Those fields are generally handled in
+        _message_post_after_hook, which also receives message values."""
+        return set()
 
     def _get_source_from_ref(self, source_ref):
         """ From a source_reference, return either a mail template, either

--- a/addons/test_mail_full/models/test_mail_models_mail.py
+++ b/addons/test_mail_full/models/test_mail_models_mail.py
@@ -121,3 +121,13 @@ class MailTestRatingThread(models.Model):
 
     def _rating_get_partner(self):
         return self.customer_id or super()._rating_get_partner()
+
+
+class MailTestRatingThreadRead(models.Model):
+    """Same as MailTestRatingThread but post accessible on read by portal users."""
+
+    _description = "Read-post rating model"
+    _name = "mail.test.rating.thread.read"
+    _inherit = "mail.test.rating.thread"
+    _order = "name asc, id asc"
+    _mail_post_access = "read"

--- a/addons/test_mail_full/security/ir.model.access.csv
+++ b/addons/test_mail_full/security/ir.model.access.csv
@@ -8,3 +8,5 @@ access_mail_test_rating_user,mail.test.rating.user,model_mail_test_rating,base.g
 access_mail_test_rating_thread_all,mail.test.rating.thread.all,model_mail_test_rating_thread,,0,0,0,0
 access_mail_test_rating_thread_portal,mail.test.rating.thread.portal,model_mail_test_rating_thread,base.group_portal,1,0,0,0
 access_mail_test_rating_thread_user,mail.test.rating.thread.user,model_mail_test_rating_thread,base.group_user,1,1,1,1
+access_mail_test_rating_thread_read_portal,mail.test.rating.thread.read.portal,model_mail_test_rating_thread_read,base.group_portal,1,0,0,0
+access_mail_test_rating_thread_read_user,mail.test.rating.thread.read.user,model_mail_test_rating_thread_read,base.group_user,1,1,1,1


### PR DESCRIPTION
Follow up of https://github.com/odoo/odoo/pull/176203

Issue: any posting of rating as portal user on a thread with read access for posting. The simplest use case is posting a review on a product (website_sale) after the feature is enabled.

When writing `rating_ids` on message, it actually writes `message_id` on rating, however the portal user doesn't have access to this model.