### PR TITLE
[IMP] mail: increase same-authored message squash time to 5 min.

### DIFF
--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -516,7 +516,7 @@ export class Thread extends Component {
         if (msg.parentMessage) {
             return false;
         }
-        return msg.datetime.ts - prevMsg.datetime.ts < 60 * 1000;
+        return msg.datetime.ts - prevMsg.datetime.ts < 5 * 60 * 1000;
     }
 
     scrollToHighlighted() {

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -16,7 +16,7 @@ import {
     hover,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, expect, test } from "@odoo/hoot";
-import { Deferred, mockDate, mockTimeZone, tick } from "@odoo/hoot-mock";
+import { Deferred, mockDate, tick } from "@odoo/hoot-mock";
 import { leave, press } from "@odoo/hoot-dom";
 import {
     Command,
@@ -765,12 +765,8 @@ test.skip("squashed transient message should not have date in the sidebar", asyn
     });
 });
 
-test.skip("message comment of same author within 1min. should be squashed", async () => {
-    // messages are squashed when "close", e.g. less than 1 minute has elapsed
-    // from messages of same author and same thread. Note that this should
-    // be working in non-mailboxes
-    // FIXME: timezone mocking does not work somehow...
-    mockTimeZone(0); // so it matches server timezone
+test("message comment of same author within 5min. should be squashed", async () => {
+    mockDate("2024-03-26 10:00:00", 0);
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "general" });
     const partnerId = pyEnv["res.partner"].create({ name: "Demo" });
@@ -786,7 +782,7 @@ test.skip("message comment of same author within 1min. should be squashed", asyn
         {
             author_id: partnerId,
             body: "<p>body2</p>",
-            date: "2019-04-20 10:00:30",
+            date: "2019-04-20 10:02:30",
             message_type: "comment",
             model: "discuss.channel",
             res_id: channelId,
@@ -813,7 +809,7 @@ test.skip("message comment of same author within 1min. should be squashed", asyn
     await contains(".o-mail-Message", {
         contains: [
             [".o-mail-Message-content", { text: "body2" }],
-            [".o-mail-Message-sidebar .o-mail-Message-date", { text: "12:00" }], // FIXME: should be 10:00 (mockTimeZone)
+            [".o-mail-Message-sidebar .o-mail-Message-date", { text: "10:02" }],
         ],
     });
 });


### PR DESCRIPTION
Same authored message were squashed when they were up to 1min. apart. Reasoning is that these messages being sent closeby are most likely related to same topic so reducing UI noise by not showing avatar nor message header helps readability of conversation.

1 min is a bit too short: sometimes composing a message can take more than 1 minute in an active exchange of message. When this timing is too short, message header and avatars are too noisy in the conversation. Squashed messages are minimal and helps focusing on just the message content, which is appropriate when the people involved is obvious. When 1st message has avatar of author, the short time between messages makes it clear who has sent the message.

This commit increases this timing to 5min. This assumes that after 5 minutes, a new message from same author is usually considered as a new active exchange of messages. Of course this doesn't work in all circumstances, but this is relatively true for many people.

We cautiously put a short timer, otherwise some humans may have forgotten the last person who has talked and it puts unnecessary effort and stress to scroll up to see the author of squashed message.

Before
<img width="510" alt="Screenshot 2024-08-29 at 18 43 08" src="https://github.com/user-attachments/assets/31a5b719-0c28-4179-be9d-cebd83683464">
After
<img width="512" alt="Screenshot 2024-08-29 at 18 42 53" src="https://github.com/user-attachments/assets/d18eabd1-0a66-4273-83a5-bb2f9d5159ee">
