### PR TITLE
[IMP] l10n_ec: Update author

### DIFF
--- a/addons/l10n_ec/__manifest__.py
+++ b/addons/l10n_ec/__manifest__.py
@@ -33,7 +33,7 @@ Master Data:
 * Ecuador banks
 * Partners: Consumidor Final, SRI, IESS, and also basic VAT validation
 """,
-    'author': 'TRESCLOUD, OPA CONSULTING (https://opa-consulting.com)',
+    'author': 'TRESCLOUD (https://trescloud.com)',
     'category': 'Accounting/Localizations/Account Charts',
     'maintainer': 'TRESCLOUD',
     'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/ecuador.html',


### PR DESCRIPTION
The work was derived from the public PR for v13 by Trescloud, refactored almost entirely for v16 by Trescloud, and again for v17 by replacing the chart templates with csv files. The author of the l10n_ec module should be Trescloud.