### PR TITLE
[IMP] html_editor: skip preserve selection on clean

### DIFF
--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -374,7 +374,7 @@ export class FormatPlugin extends Plugin {
         delete element.dataset.oeZwsEmptyInline;
         if (!allWhitespaceRegex.test(element.textContent)) {
             // The element has some meaningful text. Remove the ZWS in it.
-            this.cleanZWS(element);
+            this.cleanZWS(element, { preserveSelection: false });
             return;
         }
         if (this.resources.isUnremovable.some((predicate) => predicate(element))) {
@@ -392,13 +392,13 @@ export class FormatPlugin extends Plugin {
         restore();
     }
 
-    cleanZWS(element) {
+    cleanZWS(element, { preserveSelection = true } = {}) {
         const textNodes = descendants(element).filter(isTextNode);
-        const cursors = this.shared.preserveSelection();
+        const cursors = preserveSelection ? this.shared.preserveSelection() : null;
         for (const node of textNodes) {
             cleanTextNode(node, "\u200B", cursors);
         }
-        cursors.restore();
+        cursors?.restore();
     }
 
     insertText(selection, content) {

--- a/addons/html_editor/static/src/main/link/link_selection_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_selection_plugin.js
@@ -84,7 +84,7 @@ export class LinkSelectionPlugin extends Plugin {
      * @param {Element} root
      */
     clean(root) {
-        this.removeFEFFs(root);
+        this.removeFEFFs(root, { preserveSelection: false });
         this.clearLinkInSelectionClass(root);
     }
 
@@ -106,7 +106,7 @@ export class LinkSelectionPlugin extends Plugin {
      * @param {Object} [options]
      * @param {Function} [options.exclude]
      */
-    removeFEFFs(root, { exclude = () => false } = {}) {
+    removeFEFFs(root, { exclude = () => false, preserveSelection = true } = {}) {
         const defaultFilter = (node) =>
             node.nodeType === Node.TEXT_NODE &&
             node.textContent.includes("\uFEFF") &&
@@ -117,7 +117,7 @@ export class LinkSelectionPlugin extends Plugin {
         const combinedFilter = (node) => defaultFilter(node) && !exclude(node);
         const nodes = descendants(root).filter(combinedFilter);
         if (nodes.length > 0) {
-            const cursors = this.shared.preserveSelection();
+            const cursors = preserveSelection ? this.shared.preserveSelection() : null;
             for (const node of nodes) {
                 // Remove all FEFF within a `prepareUpdate` to make sure to make <br>
                 // nodes visible if needed.
@@ -125,7 +125,7 @@ export class LinkSelectionPlugin extends Plugin {
                 cleanTextNode(node, "\uFEFF", cursors);
                 restoreSpaces();
             }
-            cursors.restore();
+            cursors?.restore();
         }
 
         // Comment in the original code:

--- a/addons/html_editor/static/src/utils/dom.js
+++ b/addons/html_editor/static/src/utils/dom.js
@@ -220,12 +220,12 @@ export function toggleClass(node, className) {
 }
 
 /**
- * Remove all occurrences of a character from a text node and update cursors for
- * for later selection restore.
+ * Remove all occurrences of a character from a text node and optionally update
+ * cursors for later selection restore.
  *
  * @param {Node} node text node
  * @param {String} char character to remove (string of length 1)
- * @param {Cursors} cursors
+ * @param {Cursors} [cursors]
  */
 export function cleanTextNode(node, char, cursors) {
     const removedIndexes = [];
@@ -233,7 +233,7 @@ export function cleanTextNode(node, char, cursors) {
         removedIndexes.push(offset);
         return "";
     });
-    cursors.update((cursor) => {
+    cursors?.update((cursor) => {
         if (cursor.node === node) {
             cursor.offset -= removedIndexes.filter((index) => cursor.offset > index).length;
         }


### PR DESCRIPTION
When cleaning the clone of the editor's content, it is useless to preserve the selection. This commit makes sure the steps to update and restore the selection in such cases are skipped.
