### PR TITLE
[FIX] pos_sale: include POS down payments in amount_to_invoice compute

### DIFF
--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -34,6 +34,13 @@ class SaleOrder(models.Model):
             total_pos_paid = sum(sale_order.order_line.filtered(lambda l: not l.display_type).mapped('pos_order_line_ids.price_subtotal_incl'))
             sale_order.amount_unpaid = sale_order.amount_total - (total_invoice_paid + total_pos_paid)
 
+    @api.depends('pos_order_line_ids')
+    def _compute_amount_to_invoice(self):
+        super()._compute_amount_to_invoice()
+        for order in self:
+            down_payment_total = sum(line.price_subtotal_incl for line in order.pos_order_line_ids if line.down_payment_details)
+            order.amount_to_invoice -= down_payment_total
+
 class SaleOrderLine(models.Model):
     _inherit = 'sale.order.line'
 

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -760,3 +760,77 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         })
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PoSDownPaymentLinesPerFixedTax', login="accountman")
+
+    def test_pos_payment_reflected_in_amount_to_invoice(self):
+        '''
+            Ensure that a downpayment paid from POS updates the 'already invoiced'
+             field on the SO correctly.
+        '''
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.env['res.partner'].create({'name': 'Test Partner'}).id,
+            'order_line': [(0, 0, {
+                'product_id': self.product_a.id,
+                'name': self.product_a.name,
+                'product_uom_qty': 1,
+                'price_unit': 100,
+                'product_uom': self.product_a.uom_id.id
+            })],
+        })
+        sale_order.action_confirm()
+
+        self.assertEqual(sale_order.amount_total, 115)
+        self.assertEqual(sale_order.amount_invoiced, 0)
+        self.assertEqual(sale_order.amount_to_invoice, 115)
+
+        self.main_pos_config.open_ui()
+        current_session = self.main_pos_config.current_session_id
+        partner_test = self.env['res.partner'].create({'name': 'Test Partner'})
+        downpayment_product = self.env['product.product'].create({
+            'name': 'Down Payment',
+            'available_in_pos': True,
+            'type': 'service',
+        })
+        self.main_pos_config.write({
+            'down_payment_product_id': downpayment_product.id,
+        })
+
+        pos_order = {'data':
+          {'amount_paid': 10,
+           'amount_return': 0,
+           'amount_tax': 0,
+           'amount_total': 10,
+           'date_order': fields.Datetime.to_string(fields.Datetime.now()),
+           'fiscal_position_id': False,
+           'to_invoice': True,
+           'partner_id': partner_test.id,
+           'pricelist_id': self.main_pos_config.available_pricelist_ids[0].id,
+           'lines': [[0,
+             0,
+             {'discount': 0,
+              'pack_lot_ids': [],
+              'price_unit': 10,
+              'product_id': downpayment_product.id,
+              'price_subtotal': 10,
+              'price_subtotal_incl': 10,
+              'sale_order_line_id': sale_order.order_line[0],
+              'sale_order_origin_id': sale_order,
+              'down_payment_details': 'PoS downpayment detail',
+              'qty': 1,
+              'tax_ids': []}]],
+           'name': 'Order 00044-003-0019',
+           'pos_session_id': current_session.id,
+           'sequence_number': self.main_pos_config.journal_id.id,
+           'statement_ids': [[0,
+             0,
+             {'amount': 10,
+              'name': fields.Datetime.now(),
+              'payment_method_id': self.main_pos_config.payment_method_ids[0].id}]],
+           'uid': '00044-003-0019',
+           'user_id': self.env.uid},
+            }
+
+        self.env['pos.order'].create_from_ui([pos_order])
+
+        self.assertEqual(sale_order.amount_total, 115)
+        self.assertEqual(sale_order.amount_invoiced, 10)
+        self.assertEqual(sale_order.amount_to_invoice, 105)


### PR DESCRIPTION
## Issue:
- When paying a down payment for an existing SO through the POS, the payment is not reflected in the "Already invoiced" and "Amount to invoice" fields of the Sales Order.

## Steps To Reproduce:
- Open an existing SO in POS.
- Click on "Apply Down Payment" and register the payment.
- Navigate to the Sales application and open the specific SO.
- Click on "Create an Invoice", notice the amount of `Already invoiced` and `Amount to invoice` are wrong on the wizard.

## Solution:
- I fixed the issue by overriding `_compute_amount_to_invoice` in the `pos_sale`. This method now adjusts the "Amount to Invoice" by subtracting the unit price of POS order lines from it.

opw-4071469

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
