### PR TITLE
[WIP] l10n_ec: Improvements for Ec

### DIFF
--- a/addons/l10n_ec/__manifest__.py
+++ b/addons/l10n_ec/__manifest__.py
@@ -67,6 +67,7 @@ Master Data:
         # Other data
         "data/l10n_latam.document.type.csv",
         "data/l10n_ec.sri.payment.csv",
+        "data/res_country_data.xml",
         # Views
         "views/root_sri_menu.xml",
         "views/account_tax_view.xml",

--- a/addons/l10n_ec/data/account.account.template.csv
+++ b/addons/l10n_ec/data/account.account.template.csv
@@ -7,12 +7,17 @@ ec110203,110203,Activos financieros mantenidos hasta su vencimiento,FALSE,asset_
 ec110204,110204,Provision por deterioro,FALSE,asset_current,l10n_ec_ifrs
 ec1102050101,1102050101,Cuentas por cobrar clientes no relacionados locales,TRUE,asset_receivable,l10n_ec_ifrs
 ec1102050102,1102050102,Cuentas por cobrar clientes no relacionados extranjeros,TRUE,asset_receivable,l10n_ec_ifrs
+ec1102050103,1102050103,Cuentas por cobrar clientes para punto de venta,TRUE,asset_receivable,l10n_ec_ifrs
+ec1102050201,1102050201,Cheques de cliente por depositar,FALSE,asset_current,l10n_ec_ifrs
+ec1102050202,1102050202,Cheques protestados,TRUE,asset_receivable,l10n_ec_ifrs
 ec11020601,11020601,Documentos y cuentas por cobrar cliente relacionados locales,TRUE,asset_receivable,l10n_ec_ifrs
 ec11020602,11020602,Documentos y cuentas por cobrar cliente relacionados extranjeros,TRUE,asset_receivable,l10n_ec_ifrs
 ec11020701,11020701,Anticipo sueldos,TRUE,asset_current,l10n_ec_ifrs
 ec11020702,11020702,Anticipo décimo tercer sueldo,TRUE,asset_current,l10n_ec_ifrs
 ec11020703,11020703,Anticipo décimo cuarto sueldo,TRUE,asset_current,l10n_ec_ifrs
 ec11020704,11020704,Anticipo utilidades,TRUE,asset_current,l10n_ec_ifrs
+ec11020705,11020705,Prestamos Empleados,TRUE,asset_current,l10n_ec_ifrs
+ec11020706,11020706,Anticipo por sobregiro en Rol,TRUE,asset_current,l10n_ec_ifrs
 ec110208,110208,Otras cuentas por cobrar relacionadas,TRUE,asset_receivable,l10n_ec_ifrs
 ec110209,110209,Otras cuentas por cobrar,TRUE,asset_receivable,l10n_ec_ifrs
 ec110210,110210,Provision por cuentas incobrables,FALSE,asset_current,l10n_ec_ifrs
@@ -36,13 +41,17 @@ ec_purchase_vat_goods_imports,11050104,IVA pagado en importacion de bienes,FALSE
 ec_purchase_vat_assets_imports,11050105,IVA pagado en importacion de activos fijos,FALSE,asset_current,l10n_ec_ifrs
 ec_sale_vat_outstanding_withholds,11050106,IVA pagado en retenciones de la fuente,FALSE,asset_current,l10n_ec_ifrs
 ec_purchase_vat_zero,11050107,IVA en compras 0%,FALSE,asset_current,l10n_ec_ifrs
+ec_purchase_vat_credit_cards,11050108,IVA pagado en retenciones de la fuente de tarjetas de crédito,FALSE,asset_current,l10n_ec_ifrs
 ec_profit_tax_credit,11050201,Crédito tributario por Impuesto a la Renta,FALSE,asset_current,l10n_ec_ifrs
 ec_vat_tax_credit,11050202,Crédito tributario de IVA,FALSE,asset_current,l10n_ec_ifrs
 ec_withhold_tax_credit,11050203,Crédito tributario por Retenciones IVA,FALSE,asset_current,l10n_ec_ifrs
 ec_isd_tax_credit,11050204,Crédito tributario por ISD,FALSE,asset_current,l10n_ec_ifrs
-ec_others_tax_credit,11050205,Credito Tributario por otros conceptos,FALSE,asset_current,l10n_ec_ifrs
+ec_bank_withhold,11050205,Cuenta Transitoria Retenciones Bancarias por Conciliar,FALSE,asset_current,l10n_ec_ifrs
+ec_others_tax_credit,11050206,Crédito Tributario por otros conceptos,FALSE,asset_current,l10n_ec_ifrs
 ec110503,110503,Anticipo de impuesto a la renta,FALSE,asset_current,l10n_ec_ifrs
 ec_sale_profit_withhold,110504,Retenciones en la fuente pagadas,FALSE,asset_current,l10n_ec_ifrs
+ec110505,110505,Retenciones en la fuente pagadas de tarjetas de crédito,FALSE,asset_current,l10n_ec_ifrs
+ec_sale_withhold_tax_base,110506,Base Imponible de Retenciones en Ventas,FALSE,asset_current,l10n_ec_ifrs
 ec1106,1106,Activos no corrientes mantenidos para la venta y operaciones discontinuadas,FALSE,asset_current,l10n_ec_ifrs
 ec1107,1107,Construcciones en proceso (nic 11 y secc.23 pymes),FALSE,asset_current,l10n_ec_ifrs
 ec1108,1108,Otros activos corrientes,FALSE,asset_current,l10n_ec_ifrs
@@ -151,13 +160,13 @@ ret_ir_1x100,2114010201,Retenciones de la fuente 1%,FALSE,liability_current,l10n
 ret_ir_1_75x100,2114010202,Retenciones de la fuente 1.75%,FALSE,liability_current,l10n_ec_ifrs
 ret_ir_2x100,2114010203,Retenciones de la fuente 2%,FALSE,liability_current,l10n_ec_ifrs
 ret_ir_2_75x100,2114010204,Retenciones de la fuente 2.75%,FALSE,liability_current,l10n_ec_ifrs
-ret_ir_5x100,2114010205,Retenciones de la fuente 5%,FALSE,liability_current,l10n_ec_ifrs
-ret_ir_8x100,2114010206,Retenciones de la fuente 8%,FALSE,liability_current,l10n_ec_ifrs
-ret_ir_10x100,2114010207,Retenciones de la fuente 10%,FALSE,liability_current,l10n_ec_ifrs
-ret_ir_15x100,2114010208,Retenciones de la fuente 15%,FALSE,liability_current,l10n_ec_ifrs
-ret_ir_22x100,2114010209,Retenciones de la fuente 22%,FALSE,liability_current,l10n_ec_ifrs
-ret_ir_others,2114010210,Otras retenciones,FALSE,liability_current,l10n_ec_ifrs
-ret_ir_3x100,2114010211,Retenciones de la fuente 3%,FALSE,liability_current,l10n_ec_ifrs
+ret_ir_3x100,2114010205,Retenciones de la fuente 3%,FALSE,liability_current,l10n_ec_ifrs
+ret_ir_5x100,2114010206,Retenciones de la fuente 5%,FALSE,liability_current,l10n_ec_ifrs
+ret_ir_8x100,2114010207,Retenciones de la fuente 8%,FALSE,liability_current,l10n_ec_ifrs
+ret_ir_10x100,2114010208,Retenciones de la fuente 10%,FALSE,liability_current,l10n_ec_ifrs
+ret_ir_15x100,2114010209,Retenciones de la fuente 15%,FALSE,liability_current,l10n_ec_ifrs
+ret_ir_22x100,2114010210,Retenciones de la fuente 22%,FALSE,liability_current,l10n_ec_ifrs
+ret_ir_others,2114010211,Otras retenciones,FALSE,liability_current,l10n_ec_ifrs
 ec_vat_withhold_10,2114010301,Retenciones de IVA 10%,FALSE,liability_current,l10n_ec_ifrs
 ec_vat_withhold_20,2114010302,Retenciones de IVA 20%,FALSE,liability_current,l10n_ec_ifrs
 ec_vat_withhold_30,2114010303,Retenciones de IVA 30%,FALSE,liability_current,l10n_ec_ifrs
@@ -165,6 +174,7 @@ ec_vat_withhold_50,2114010304,Retenciones de IVA 50%,FALSE,liability_current,l10
 ec_vat_withhold_70,2114010305,Retenciones de IVA 70%,FALSE,liability_current,l10n_ec_ifrs
 ec_vat_withhold_100,2114010306,Retenciones de IVA 100%,FALSE,liability_current,l10n_ec_ifrs
 ec_vat_withhold_others,2114010307,Otras retenciones,FALSE,liability_current,l10n_ec_ifrs
+ec_purchase_withhold_tax_base,21140104,Base Imponible de Retenciones en Compras,FALSE,liability_current,l10n_ec_ifrs
 ec2201,2201,Pasivos por contratos de arrendamiento financiero,TRUE,liability_current,l10n_ec_ifrs
 ec220201,220201,Cuentas y documentos por pagar locales,TRUE,liability_payable,l10n_ec_ifrs
 ec220202,220202,Cuentas y documentos por pagar del exterior,TRUE,liability_payable,l10n_ec_ifrs
@@ -387,6 +397,7 @@ ec52020404,52020404,Alimentacion,FALSE,expense,l10n_ec_ifrs
 ec52020405,52020405,Otros gastos de planes de beneficios a empleados,FALSE,expense,l10n_ec_ifrs
 ec5202040501,5202040501,Impuesto a la renta empleados asumido por la empresa,FALSE,expense,l10n_ec_ifrs
 ec5202040502,5202040502,Transporte,FALSE,expense,l10n_ec_ifrs
+ec5202040503,5202040503,Aporte de IESS personal asumido por la empresa,FALSE,expense,l10n_ec_ifrs
 ec520205,520205,"Honorarios, comisiones y dietas a personas naturales",FALSE,expense,l10n_ec_ifrs
 ec520206,520206,Remuneraciones a otros trabajadores autonomos,FALSE,expense,l10n_ec_ifrs
 ec520207,520207,Honorarios a extranjeros por servicios ocasionales,FALSE,expense,l10n_ec_ifrs
@@ -404,6 +415,7 @@ ec52021801,52021801,Agua potable,FALSE,expense,l10n_ec_ifrs
 ec52021802,52021802,Energia electrica,FALSE,expense,l10n_ec_ifrs
 ec52021803,52021803,Telefonia fija,FALSE,expense,l10n_ec_ifrs
 ec52021804,52021804,Telefonia movil,FALSE,expense,l10n_ec_ifrs
+ec52011805,52011805,Comisiones de tarjetas de crédito,FALSE,expense,l10n_ec_ifrs
 ec520219,520219,Notarios y registradores de la propiedad o mercantiles,FALSE,expense,l10n_ec_ifrs
 ec52022001,52022001,Patente municipal,FALSE,expense,l10n_ec_ifrs
 ec52022002,52022002,1.5x mil activos totales,FALSE,expense,l10n_ec_ifrs

--- a/addons/l10n_ec/data/account_chart_template_setup_accounts.xml
+++ b/addons/l10n_ec/data/account_chart_template_setup_accounts.xml
@@ -14,7 +14,7 @@
         <field name="property_stock_valuation_account_id" ref="ec110306"/>
         <field name="default_cash_difference_income_account_id" ref="ec_income_cash_difference"/>
         <field name="default_cash_difference_expense_account_id" ref="ec_expense_cash_difference"/>
-        <field name="default_pos_receivable_account_id" ref="ec1102050101"/>
+        <field name="default_pos_receivable_account_id" ref="ec1102050103"/>
         <field name="account_journal_early_pay_discount_loss_account_id" ref="ec_early_pay_discount_loss"/>
         <field name="account_journal_early_pay_discount_gain_account_id" ref="ec_early_pay_discount_gain"/>
     </record>

--- a/addons/l10n_ec/data/account_fiscal_position_template.xml
+++ b/addons/l10n_ec/data/account_fiscal_position_template.xml
@@ -2,7 +2,7 @@
 <odoo>
     <record id="fp_local" model="account.fiscal.position.template">
         <field name="sequence">10</field>
-        <field name="chart_template_id" ref="l10n_ec_ifrs"/>
+        <field name="chart_template_id" ref="l10n_ec.l10n_ec_ifrs"/>
         <field name="name">Régimen nacional</field>
         <field name="auto_apply" eval="True"/>
         <field name="vat_required" eval="True"/>
@@ -10,7 +10,7 @@
     </record>
     <record id="fp_foreign" model="account.fiscal.position.template">
         <field name="sequence">20</field>
-        <field name="chart_template_id" ref="l10n_ec_ifrs"/>
+        <field name="chart_template_id" ref="l10n_ec.l10n_ec_ifrs"/>
         <field name="name">Régimen extranjero</field>
         <field name="auto_apply" eval="True"/>
         <field name="vat_required" eval="True"/>

--- a/addons/l10n_ec/data/account_group_template_data.xml
+++ b/addons/l10n_ec/data/account_group_template_data.xml
@@ -73,6 +73,13 @@
             <field name="parent_id" ref="ec110205"/>
         </record>
 
+        <record id="ec11020502" model="account.group.template">
+            <field name="chart_template_id" ref="l10n_ec.l10n_ec_ifrs"/>
+            <field name="code_prefix_start">11020502</field>
+            <field name="name">Cheques de cliente</field>
+            <field name="parent_id" ref="ec110205"/>
+        </record>
+
         <record id="ec110206" model="account.group.template">
             <field name="chart_template_id" ref="l10n_ec.l10n_ec_ifrs"/>
             <field name="code_prefix_start">110206</field>

--- a/addons/l10n_ec/data/account_tax_report_data.xml
+++ b/addons/l10n_ec/data/account_tax_report_data.xml
@@ -1759,27 +1759,54 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_parent_line_report_178" model="account.report.line">
-                                <field name="name">Compras al Comercializador: de Bienes de Origen Bioacuático, Forestal y los Descritos el Art.27.1 de LRTI</field>
+                                    <field name="name">Compras al Comercializador: de Bienes de Origen Bioacuático, Forestal y los Descritos el Art.27.1 de LRTI</field>
+                                    <field name="children_ids">
+                                        <record id="tax_report_line_103_3121" model="account.report.line">
+                                            <field name="name">Base imponible(3121)</field>
+                                            <field name="code">c3121</field>
+                                            <field name="expression_ids">
+                                                <record id="tax_report_line_103_3121_tag" model="account.report.expression">
+                                                    <field name="label">balance</field>
+                                                    <field name="engine">tax_tags</field>
+                                                    <field name="formula">3121 (Reporte 103)</field>
+                                                </record>
+                                            </field>
+                                        </record>
+                                        <record id="tax_report_line_103_3621" model="account.report.line">
+                                            <field name="name">Valor retenido(3621)</field>
+                                            <field name="code">c3621</field>
+                                            <field name="expression_ids">
+                                                <record id="tax_report_line_103_3621_tag" model="account.report.expression">
+                                                    <field name="label">balance</field>
+                                                    <field name="engine">tax_tags</field>
+                                                    <field name="formula">3621 (Reporte 103)</field>
+                                                </record>
+                                            </field>
+                                        </record>
+                                    </field>
+                                </record>
+                            <record id="tax_report_line_parent_line_report_179" model="account.report.line">
+                                <field name="name">Compra de bienes de origen agrícola, avícola, pecuario, apícola, cunícula, bioacuático, forestal y carnes en estado natural </field>
                                 <field name="children_ids">
-                                    <record id="tax_report_line_103_3121" model="account.report.line">
-                                        <field name="name">Base imponible(3121)</field>
-                                        <field name="code">c3121</field>
+                                    <record id="tax_report_line_103_3210" model="account.report.line">
+                                        <field name="name">Base imponible(3210)</field>
+                                        <field name="code">c3210</field>
                                         <field name="expression_ids">
-                                            <record id="tax_report_line_103_3121_tag" model="account.report.expression">
+                                            <record id="tax_report_line_103_3210_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
                                                 <field name="engine">tax_tags</field>
-                                                <field name="formula">3121 (Reporte 103)</field>
+                                                <field name="formula">3210 (Reporte 103)</field>
                                             </record>
                                         </field>
                                     </record>
-                                    <record id="tax_report_line_103_3621" model="account.report.line">
-                                        <field name="name">Valor retenido(3621)</field>
-                                        <field name="code">c3621</field>
+                                    <record id="tax_report_line_103_3620" model="account.report.line">
+                                        <field name="name">Valor retenido(3620)</field>
+                                        <field name="code">c3620</field>
                                         <field name="expression_ids">
-                                            <record id="tax_report_line_103_3621_tag" model="account.report.expression">
+                                            <record id="tax_report_line_103_3620_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
                                                 <field name="engine">tax_tags</field>
-                                                <field name="formula">3621 (Reporte 103)</field>
+                                                <field name="formula">3620 (Reporte 103)</field>
                                             </record>
                                         </field>
                                     </record>
@@ -2647,6 +2674,75 @@
                                     </record>
                                 </field>
                             </record>
+                            <record id="tax_report_line_parent_line_report_277" model="account.report.line">
+                                <field name="name">Dividendos distribuidos a personas naturales</field>
+                                <field name="children_ids">
+                                    <record id="tax_report_line_103_405" model="account.report.line">
+                                        <field name="name">Base imponible(405)</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_103_405_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">405 (Reporte 103)</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                </field>
+                            </record>
+                            <!-- TODO: Revisar los xmls_ids de donde saco el id -->
+                            <record id="tax_report_line_parent_line_report_280" model="account.report.line">
+                                <field name="name">Dividendos distribuidos a sociedades</field>
+                                <field name="children_ids">
+                                    <record id="tax_report_line_103_406" model="account.report.line">
+                                        <field name="name">Base imponible(406)</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_103_406_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">406 (Reporte 103)</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="tax_report_line_103_456" model="account.report.line">
+                                        <field name="name">Valor retenido(456)</field>
+                                        <field name="code">c456</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_103_456_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">456 (Reporte 103)</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                </field>
+                            </record>
+                            <!-- TODO: Revisar los xmls_ids de donde saco el id -->
+                            <record id="tax_report_line_parent_line_report_286" model="account.report.line">
+                                <field name="name">Dividendos distribuidos a fideicomisos</field>
+                                <field name="children_ids">
+                                    <record id="tax_report_line_103_407" model="account.report.line">
+                                        <field name="name">Base imponible(407)</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_103_407_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">407 (Reporte 103)</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="tax_report_line_103_457" model="account.report.line">
+                                        <field name="name">Valor retenido(457)</field>
+                                        <field name="code">c457</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_103_457_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">457 (Reporte 103)</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                </field>
+                            </record>
                             <record id="tax_report_line_parent_line_report_278" model="account.report.line">
                                 <field name="name">Dividendos sin beneficiario efectivo persona natural residente en Ecuador</field>
                                 <field name="children_ids">
@@ -2931,6 +3027,74 @@
                                     </record>
                                 </field>
                             </record>
+                            <record id="tax_report_line_parent_line_report_309" model="account.report.line">
+                                <field name="name">Dividendos distribuidos a personas naturales</field>
+                                <field name="children_ids">
+                                    <record id="tax_report_line_103_416" model="account.report.line">
+                                        <field name="name">Base imponible(416)</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_103_416_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">416 (Reporte 103)</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                </field>
+                            </record>
+                            <!-- TODO: Revisar los xmls_ids de donde saco el id -->
+                            <record id="tax_report_line_parent_line_report_310" model="account.report.line">
+                                <field name="name">Dividendos distribuidos a sociedades</field>
+                                <field name="children_ids">
+                                    <record id="tax_report_line_103_417" model="account.report.line">
+                                        <field name="name">Base imponible(417)</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_103_417_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">417 (Reporte 103)</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="tax_report_line_103_467" model="account.report.line">
+                                        <field name="name">Valor retenido(467)</field>
+                                        <field name="code">c467</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_103_467_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">467 (Reporte 103)</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_319" model="account.report.line">
+                                <field name="name">Dividendos distribuidos a fideicomisos</field>
+                                <field name="children_ids">
+                                    <record id="tax_report_line_103_418" model="account.report.line">
+                                        <field name="name">Base imponible(418)</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_103_418_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">418 (Reporte 103)</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="tax_report_line_103_468" model="account.report.line">
+                                        <field name="name">Valor retenido(468)</field>
+                                        <field name="code">c468</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_103_468_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">468 (Reporte 103)</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                </field>
+                            </record>
                             <record id="tax_report_line_parent_line_report_311" model="account.report.line">
                                 <field name="name">Dividendos sin beneficiario efectivo persona natural residente en Ecuador</field>
                                 <field name="children_ids">
@@ -3185,6 +3349,87 @@
                                                 <field name="label">balance</field>
                                                 <field name="engine">tax_tags</field>
                                                 <field name="formula">475 (Reporte 103)</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_339" model="account.report.line">
+                                <field name="name">Dividendos distribuidos a personas naturales</field>
+                                <field name="children_ids">
+                                    <record id="tax_report_line_103_426" model="account.report.line">
+                                        <field name="name">Base imponible(426)</field>
+                                        <field name="code">c426</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_103_426_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">426 (Reporte 103)</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="tax_report_line_103_476" model="account.report.line">
+                                        <field name="name">Valor retenido(476)</field>
+                                        <field name="code">c476</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_103_476_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">476 (Reporte 103)</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_340" model="account.report.line">
+                                <field name="name">Dividendos distribuidos a personas naturales</field>
+                                <field name="children_ids">
+                                    <record id="tax_report_line_103_427" model="account.report.line">
+                                        <field name="name">Base imponible(427)</field>
+                                        <field name="code">c427</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_103_427_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">427 (Reporte 103)</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="tax_report_line_103_477" model="account.report.line">
+                                        <field name="name">Valor retenido(477)</field>
+                                        <field name="code">c477</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_103_477_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">477 (Reporte 103)</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_parent_line_report_343" model="account.report.line">
+                                <field name="name">Dividendos distribuidos a fideicomisos</field>
+                                <field name="children_ids">
+                                    <record id="tax_report_line_103_428" model="account.report.line">
+                                        <field name="name">Base imponible(428)</field>
+                                        <field name="code">c428</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_103_428_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">428 (Reporte 103)</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="tax_report_line_103_478" model="account.report.line">
+                                        <field name="name">Valor retenido(478)</field>
+                                        <field name="code">c478</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_103_478_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">478 (Reporte 103)</field>
                                             </record>
                                         </field>
                                     </record>

--- a/addons/l10n_ec/data/account_tax_template_vat_data.xml
+++ b/addons/l10n_ec/data/account_tax_template_vat_data.xml
@@ -2164,6 +2164,40 @@
                     'account_id': ref('l10n_ec.ec_purchase_vat_zero'),
                 })]"/>
         </record>
+        <!--IVA 0% (No Objeto de IVA)-->
+        <record id="tax_vat_541_sup_02_dividend" model="account.tax.template">
+            <!-- Adquisiciones no objeto de IVA -->
+            <field name="name">No Objeto IVA 0% (541, 10 Dividendos)</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="amount_type">percent</field>
+            <field name="sequence">40</field>
+            <field name="amount">0.0</field>
+            <field name="description">IVA 0%</field>
+            <field name="l10n_ec_code_base">541</field>
+            <field name="chart_template_id" ref="l10n_ec.l10n_ec_ifrs"/>
+            <field name="tax_group_id" ref="tax_group_vat_not_charged"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_expression_ids': [ref('l10n_ec.tax_report_line_104_531_tag'), ref('l10n_ec.tax_report_line_104_541_tag')],
+                }),
+                (0,0, {
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ec_purchase_vat_zero'),
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_expression_ids': [ref('l10n_ec.tax_report_line_104_541_tag')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ec_purchase_vat_zero'),
+                })]"/>
+        </record>
         <record id="tax_vat_510_08_sup_01" model="account.tax.template">
             <field name="name">IVA 8% (510, 01 Crédito IVA)</field>
             <field name="type_tax_use">purchase</field>

--- a/addons/l10n_ec/data/account_tax_template_withhold_profit_data.xml
+++ b/addons/l10n_ec/data/account_tax_template_withhold_profit_data.xml
@@ -2347,5 +2347,456 @@
                     'account_id': ref('l10n_ec.ec_sale_profit_withhold'),
                 })]"/>
         </record>
+
+        <!-- dividents withholds -->
+
+        <record id="tax_withhold_profit_325" model="account.tax.template">
+            <field name="name">325 22% Anticipo dividendos a residentes o establecidos en el Ecuador</field>
+            <field name="type_tax_use">none</field>
+            <field name="amount_type">percent</field>
+            <field name="sequence">70</field>
+            <field name="amount">-22.0</field>
+            <field name="description">325</field>
+            <field name="l10n_ec_code_applied">375</field>
+            <field name="l10n_ec_code_base">325</field>
+            <field name="l10n_ec_code_ats">325</field>
+            <field name="chart_template_id" ref="l10n_ec.l10n_ec_ifrs"/>
+            <field name="tax_group_id" ref="tax_group_withhold_income_purchase"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'repartition_type': 'base',
+                    'plus_report_expression_ids': [ref('tax_report_line_103_325_tag')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_22x100'),
+                    'plus_report_expression_ids': [ref('tax_report_line_103_375_tag')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'repartition_type': 'base',
+                    'minus_report_expression_ids': [ref('tax_report_line_103_325_tag')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_22x100'),
+                    'minus_report_expression_ids': [ref('tax_report_line_103_375_tag')],
+                })]"/>
+        </record>
+        <record id="tax_withhold_profit_325A" model="account.tax.template">
+            <field name="name">325A 22% Dividendos anticipados prestamos accionistas, beneficiarios o partìcipes a residentes o establecidos en el Ecuador</field>
+            <field name="type_tax_use">none</field>
+            <field name="amount_type">percent</field>
+            <field name="sequence">70</field>
+            <field name="amount">-22.0</field>
+            <field name="description">325</field>
+            <field name="l10n_ec_code_applied">375</field>
+            <field name="l10n_ec_code_base">325</field>
+            <field name="l10n_ec_code_ats">325A</field>
+            <field name="chart_template_id" ref="l10n_ec.l10n_ec_ifrs"/>
+            <field name="tax_group_id" ref="tax_group_withhold_income_purchase"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'repartition_type': 'base',
+                    'plus_report_expression_ids': [ref('tax_report_line_103_325_tag')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_22x100'),
+                    'plus_report_expression_ids': [ref('tax_report_line_103_375_tag')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'repartition_type': 'base',
+                    'minus_report_expression_ids': [ref('tax_report_line_103_325_tag')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_22x100'),
+                    'minus_report_expression_ids': [ref('tax_report_line_103_375_tag')],
+                })]"/>
+        </record>
+        <record id="tax_withhold_profit_327" model="account.tax.template">
+            <field name="name">327 13% Dividendos distribuidos a personas naturales residentes (1% al 13%)</field>
+            <field name="type_tax_use">none</field>
+            <field name="amount_type">percent</field>
+            <field name="sequence">70</field>
+            <field name="amount">-13.0</field>
+            <field name="description">327</field>
+            <field name="l10n_ec_code_applied">377</field>
+            <field name="l10n_ec_code_base">327</field>
+            <field name="l10n_ec_code_ats">327</field>
+            <field name="chart_template_id" ref="l10n_ec.l10n_ec_ifrs"/>
+            <field name="tax_group_id" ref="tax_group_withhold_income_purchase"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'repartition_type': 'base',
+                    'plus_report_expression_ids': [ref('tax_report_line_103_327_tag')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_others'),
+                    'plus_report_expression_ids': [ref('tax_report_line_103_377_tag')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'repartition_type': 'base',
+                    'minus_report_expression_ids': [ref('tax_report_line_103_327_tag')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_others'),
+                    'minus_report_expression_ids': [ref('tax_report_line_103_377_tag')],
+                })]"/>
+        </record>
+        <record id="tax_withhold_profit_328" model="account.tax.template">
+            <field name="name">328 0% Dividendos distribuidos a sociedades residentes</field>
+            <field name="type_tax_use">none</field>
+            <field name="amount_type">percent</field>
+            <field name="sequence">70</field>
+            <field name="amount">0.0</field>
+            <field name="description">328</field>
+            <field name="l10n_ec_code_applied">378</field>
+            <field name="l10n_ec_code_base">328</field>
+            <field name="l10n_ec_code_ats">328</field>
+            <field name="chart_template_id" ref="l10n_ec.l10n_ec_ifrs"/>
+            <field name="tax_group_id" ref="tax_group_withhold_income_purchase"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'repartition_type': 'base',
+                    'plus_report_expression_ids': [ref('tax_report_line_103_328_tag')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_others'),
+                    'plus_report_expression_ids': [ref('tax_report_line_103_378_tag')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'repartition_type': 'base',
+                    'minus_report_expression_ids': [ref('tax_report_line_103_328_tag')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_others'),
+                    'minus_report_expression_ids': [ref('tax_report_line_103_378_tag')],
+                })]"/>
+        </record>
+        <record id="tax_withhold_profit_329" model="account.tax.template">
+            <field name="name">329 0% Dividendos distribuidos a fideicomisos residentes</field>
+            <field name="type_tax_use">none</field>
+            <field name="amount_type">percent</field>
+            <field name="sequence">70</field>
+            <field name="amount">0.0</field>
+            <field name="description">329</field>
+            <field name="l10n_ec_code_applied">379</field>
+            <field name="l10n_ec_code_base">329</field>
+            <field name="l10n_ec_code_ats">329</field>
+            <field name="chart_template_id" ref="l10n_ec.l10n_ec_ifrs"/>
+            <field name="tax_group_id" ref="tax_group_withhold_income_purchase"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'repartition_type': 'base',
+                    'plus_report_expression_ids': [ref('tax_report_line_103_329_tag')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_others'),
+                    'plus_report_expression_ids': [ref('tax_report_line_103_379_tag')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'repartition_type': 'base',
+                    'minus_report_expression_ids': [ref('tax_report_line_103_329_tag')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_others'),
+                    'minus_report_expression_ids': [ref('tax_report_line_103_379_tag')],
+                })]"/>
+        </record>
+        <record id="tax_withhold_profit_331" model="account.tax.template">
+            <field name="name">331 0% Dividendos exentos distribuidos en acciones (reinversión de utilidades con derecho a reducción tarifa ir)</field>
+            <field name="type_tax_use">none</field>
+            <field name="amount_type">percent</field>
+            <field name="sequence">70</field>
+            <field name="amount">0.0</field>
+            <field name="description">331</field>
+            <field name="l10n_ec_code_base">331</field>
+            <field name="l10n_ec_code_ats">331</field>
+            <field name="chart_template_id" ref="l10n_ec.l10n_ec_ifrs"/>
+            <field name="tax_group_id" ref="tax_group_withhold_income_purchase"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'repartition_type': 'base',
+                    'plus_report_expression_ids': [ref('tax_report_line_103_331_tag')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_others'),
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'repartition_type': 'base',
+                    'minus_report_expression_ids': [ref('tax_report_line_103_331_tag')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_others'),
+                })]"/>
+        </record>
+        <record id="tax_withhold_profit_504E_404" model="account.tax.template">
+            <field name="name">504E-404 22% Pago al exterior - anticipo dividendos (excepto paraísos fiscales o de regimen de menor imposición) (con convenio de doble tributación)</field>
+            <field name="type_tax_use">none</field>
+            <field name="amount_type">percent</field>
+            <field name="sequence">70</field>
+            <field name="amount">-22.0</field>
+            <field name="description">404</field>
+            <field name="l10n_ec_code_applied">454</field>
+            <field name="l10n_ec_code_base">404</field>
+            <field name="l10n_ec_code_ats">504E</field>
+            <field name="chart_template_id" ref="l10n_ec.l10n_ec_ifrs"/>
+            <field name="tax_group_id" ref="tax_group_withhold_income_purchase"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'repartition_type': 'base',
+                    'plus_report_expression_ids': [ref('tax_report_line_103_404_tag')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_22x100'),
+                    'plus_report_expression_ids': [ref('tax_report_line_103_454_tag')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'repartition_type': 'base',
+                    'minus_report_expression_ids': [ref('tax_report_line_103_404_tag')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_22x100'),
+                    'minus_report_expression_ids': [ref('tax_report_line_103_454_tag')],
+                })]"/>
+        </record>
+        <record id="tax_withhold_profit_504_405" model="account.tax.template">
+            <field name="name">504-405 25% Pago al exterior- dividendos distribuidos a personas naturales (con convenio de doble tributación)</field>
+            <field name="type_tax_use">none</field>
+            <field name="amount_type">percent</field>
+            <field name="sequence">70</field>
+            <field name="amount">-25.0</field>
+            <field name="description">405</field>
+            <field name="l10n_ec_code_base">405</field>
+            <field name="l10n_ec_code_ats">504</field>
+            <field name="chart_template_id" ref="l10n_ec.l10n_ec_ifrs"/>
+            <field name="tax_group_id" ref="tax_group_withhold_income_purchase"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'repartition_type': 'base',
+                    'plus_report_expression_ids': [ref('tax_report_line_103_405_tag')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_others'),
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'repartition_type': 'base',
+                    'minus_report_expression_ids': [ref('tax_report_line_103_405_tag')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_others'),
+                })]"/>
+        </record>
+        <record id="tax_withhold_profit_504A_406" model="account.tax.template">
+            <field name="name">504A-406 25% Pago al exterior - Dividendos distribuidos a sociedades (con convenio de doble tributación)</field>
+            <field name="type_tax_use">none</field>
+            <field name="amount_type">percent</field>
+            <field name="sequence">70</field>
+            <field name="amount">-25.0</field>
+            <field name="description">406</field>
+            <field name="l10n_ec_code_applied">456</field>
+            <field name="l10n_ec_code_base">406</field>
+            <field name="l10n_ec_code_ats">504A</field>
+            <field name="chart_template_id" ref="l10n_ec.l10n_ec_ifrs"/>
+            <field name="tax_group_id" ref="tax_group_withhold_income_purchase"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'repartition_type': 'base',
+                    'plus_report_expression_ids': [ref('tax_report_line_103_406_tag')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_others'),
+                    'plus_report_expression_ids': [ref('tax_report_line_103_456_tag')],
+                })]"/>
+                <!-- TODO: Crear a mano los tax_report_line -->
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'repartition_type': 'base',
+                    'minus_report_expression_ids': [ref('tax_report_line_103_406_tag')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_others'),
+                    'minus_report_expression_ids': [ref('tax_report_line_103_456_tag')],
+                })]"/>
+        </record>
+        <record id="tax_withhold_profit_504E_415" model="account.tax.template">
+            <field name="name">504E-415 22% Pago al exterior - anticipo dividendos (excepto paraisos fiscales o de regimen de menor imposicion) (sin convenio de doble tributación)</field>
+            <field name="type_tax_use">none</field>
+            <field name="amount_type">percent</field>
+            <field name="sequence">70</field>
+            <field name="amount">-22.0</field>
+            <field name="description">415</field>
+            <field name="l10n_ec_code_base">415</field>
+            <field name="l10n_ec_code_applied">465</field>
+            <field name="l10n_ec_code_ats">504E</field>
+            <field name="chart_template_id" ref="l10n_ec.l10n_ec_ifrs"/>
+            <field name="tax_group_id" ref="tax_group_withhold_income_purchase"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'repartition_type': 'base',
+                    'plus_report_expression_ids': [ref('tax_report_line_103_415_tag')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_22x100'),
+                    'plus_report_expression_ids': [ref('tax_report_line_103_465_tag')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'repartition_type': 'base',
+                    'minus_report_expression_ids': [ref('tax_report_line_103_415_tag')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_22x100'),
+                    'minus_report_expression_ids': [ref('tax_report_line_103_465_tag')],
+                })]"/>
+        </record>
+        <record id="tax_withhold_profit_504_416" model="account.tax.template">
+            <field name="name">504-416 25% Pago al exterior - dividendos distribuidos a personas naturales (sin convenio de doble tributación)</field>
+            <field name="type_tax_use">none</field>
+            <field name="amount_type">percent</field>
+            <field name="sequence">70</field>
+            <field name="amount">-25.0</field>
+            <field name="description">416</field>
+            <field name="l10n_ec_code_base">416</field>
+            <field name="l10n_ec_code_ats">504</field>
+            <field name="chart_template_id" ref="l10n_ec.l10n_ec_ifrs"/>
+            <field name="tax_group_id" ref="tax_group_withhold_income_purchase"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'repartition_type': 'base',
+                    'plus_report_expression_ids': [ref('tax_report_line_103_416_tag')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_others'),
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'repartition_type': 'base',
+                    'minus_report_expression_ids': [ref('tax_report_line_103_416_tag')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_others'),
+                })]"/>
+        </record>
+        <record id="tax_withhold_profit_504A_417" model="account.tax.template">
+            <field name="name">504A-417 25% Pago al exterior - Dividendos distribuidos a sociedades (sin convenio de doble tributación)</field>
+            <field name="type_tax_use">none</field>
+            <field name="amount_type">percent</field>
+            <field name="sequence">70</field>
+            <field name="amount">-25.0</field>
+            <field name="description">417</field>
+            <field name="l10n_ec_code_applied">467</field>
+            <field name="l10n_ec_code_base">417</field>
+            <field name="l10n_ec_code_ats">504A</field>
+            <field name="chart_template_id" ref="l10n_ec.l10n_ec_ifrs"/>
+            <field name="tax_group_id" ref="tax_group_withhold_income_purchase"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'repartition_type': 'base',
+                    'plus_report_expression_ids': [ref('tax_report_line_103_417_tag')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_others'),
+                    'plus_report_expression_ids': [ref('tax_report_line_103_467_tag')],
+                })]"/>
+                <!-- TODO: Crear a mano los tax_report_line -->
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'repartition_type': 'base',
+                    'minus_report_expression_ids': [ref('tax_report_line_103_417_tag')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_others'),
+                    'minus_report_expression_ids': [ref('tax_report_line_103_467_tag')],
+                })]"/>
+        </record>
+        <record id="tax_withhold_profit_504E_425" model="account.tax.template">
+            <field name="name">504E-425 22% Pago al exterior - anticipo dividendos (en paraísos fiscales o regímenes fiscales preferentes)</field>
+            <field name="type_tax_use">none</field>
+            <field name="amount_type">percent</field>
+            <field name="sequence">70</field>
+            <field name="amount">-22.0</field>
+            <field name="description">425</field>
+            <field name="l10n_ec_code_base">425</field>
+            <field name="l10n_ec_code_applied">475</field>
+            <field name="l10n_ec_code_ats">504E</field>
+            <field name="chart_template_id" ref="l10n_ec.l10n_ec_ifrs"/>
+            <field name="tax_group_id" ref="tax_group_withhold_income_purchase"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'repartition_type': 'base',
+                    'plus_report_expression_ids': [ref('tax_report_line_103_425_tag')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_others'),
+                    'plus_report_expression_ids': [ref('tax_report_line_103_475_tag')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'repartition_type': 'base',
+                    'minus_report_expression_ids': [ref('tax_report_line_103_425_tag')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_others'),
+                    'minus_report_expression_ids': [ref('tax_report_line_103_475_tag')],
+                })]"/>
+        </record>
     </data>
 </odoo>

--- a/addons/l10n_ec/data/account_tax_template_withhold_vat_data.xml
+++ b/addons/l10n_ec/data/account_tax_template_withhold_vat_data.xml
@@ -4,6 +4,30 @@
         <!-- 
         Purchase withholds computed over VAT *retenciones iva compras
         -->
+        <record id="tax_withhold_vat_0" model="account.tax.template">
+            <field name="name">0% Retención IVA</field>
+            <field name="type_tax_use">none</field>
+            <field name="amount_type">percent</field>
+            <field name="sequence">40</field>
+            <field name="amount">-0.0</field>
+            <field name="description">RET IVA 0%</field>
+            <field name="chart_template_id" ref="l10n_ec.l10n_ec_ifrs"/>
+            <field name="tax_group_id" ref="tax_group_withhold_vat_purchase"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {'repartition_type': 'base'}),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ec_vat_withhold_others'),
+                }),]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {'repartition_type': 'base'}),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ec_vat_withhold_others'),
+                }),]"/>
+        </record>
         <record id="tax_withhold_vat_10" model="account.tax.template">
             <field name="name">10% Retención IVA</field>
             <field name="type_tax_use">none</field>

--- a/addons/l10n_ec/data/l10n_latam_identification_type_data.xml
+++ b/addons/l10n_ec/data/l10n_latam_identification_type_data.xml
@@ -16,7 +16,7 @@
         </record>
         <!-- TODO: Remove in master -->
         <record id='ec_passport' model='l10n_latam.identification.type'>
-            <field name='name'>Pasaporte</field>
+            <field name='name'>Pasaporte (Deprecated)</field>
             <field name='description'>Pasaporte para extranjeros con domicilio en el país (Deprecado)</field>
             <field name='country_id' ref='base.ec'/>
             <field name='active' eval="False"/>
@@ -24,7 +24,7 @@
         </record>
         <!-- TODO: Remove in master -->
         <record id='ec_unknown' model='l10n_latam.identification.type'>
-            <field name='name'>Unknown</field>
+            <field name='name'>Unknown (Deprecated)</field>
             <field name='description'>Por identificar, util para registro rápido de ventas (Deprecado)</field>
             <field name='country_id' ref='base.ec'/>
             <field name='active' eval="False"/>

--- a/addons/l10n_ec/data/res_country_data.xml
+++ b/addons/l10n_ec/data/res_country_data.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data>
+        <record id="base.ec" model="res.country">
+            <field name="zip_required">False</field>
+            <field name="address_format" eval="'%(street)s\n%(street2)s\n%(city)s\n%(country_name)s'" />
+        </record>
+    </data>
+</odoo>

--- a/addons/l10n_ec/models/res_partner.py
+++ b/addons/l10n_ec/models/res_partner.py
@@ -30,7 +30,9 @@ class PartnerIdTypeEc(enum.Enum):
         Returns ID code for move and partner based on subset of Table 2 of SRI's ATS specification
         """
         partner_id_type = partner._l10n_ec_get_identification_type()
-        if move_type.startswith('in_'):
+        if partner.vat and verify_final_consumer(partner.vat):
+            return cls.FINAL_CONSUMER
+        elif move_type.startswith('in_'):
             if partner_id_type == 'ruc':  # includes final consumer
                 return cls.IN_RUC
             elif partner_id_type == 'cedula':


### PR DESCRIPTION
- Add Customer accounts receivable for point-of-sale module
- Add new accounting account group for customer checks
- Add 3210 tax code in report 103 of Ecuador
- Add 0% Non-Object VAT tax for dividends
- Add withholding tax on undistributed earnings for dividends
- Add the 0% withholding tax
- Add the following accounting accounts
  * 1102050103, Customer accounts receivable for point of sale
  * 1102050201, Customer checks to be deposited
  * 1102050202, Protested checks *11020705, Employee Loans
  * 11020706, Advance for overdraft in Role
  * 11050108, VAT paid on credit card withholding taxes
  * 11050108, VAT paid on credit card withholdings at source
  * 11050205,Bank Withholdings to be Reconciled Transitory Account
  * 110505, Credit Card Withholding Tax Paid at Source
  * 110506,Taxable Base of Withholding Taxes on Sales
  * 21140104,Taxable basis of withholdings on purchases
  * 5202040503,IESS contribution of personnel assumed by the company
  * 52011805, Credit card commissions
- Add the word "deprecated" to the name of the customer document types: Passport and UNKNOWN.
- Change Ecuador country configuration, to avoid the zip code to be mandatory when making Ecommerce transactions. This helps us to make ecommerce sales smoother. In addition to this we modify the way the name is configured in the report.
- Set default accounting taxes, for 15 % VAT
- add extra validation when getting the ats code from the contact, in case it is an End Consumer.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
