### PR TITLE
[FIX] hr: Create new partner for employees when user_id is removed

### DIFF
--- a/addons/hr/tests/test_hr_employee.py
+++ b/addons/hr/tests/test_hr_employee.py
@@ -231,6 +231,7 @@ class TestHrEmployee(TestHrCommon):
         employee_B.work_email = 'new_email@example.com'
         self.assertEqual(employee_A.work_email, 'employee_A@example.com')
         self.assertEqual(employee_B.work_email, 'new_email@example.com')
+        self.assertTrue(employee_A.work_contact_id.id)
 
     @users('admin')
     def test_change_user_on_employee(self):


### PR DESCRIPTION
Version: 17.0+

Issue:
When the `user_id` is removed from the employee, the corresponding account move entries created from payslips do not have an attached partner.

Purpose of this PR:
If the user is removed, we search for existing partners that do not have a related user id that could be potentially linked to the userless employee record. If there are no existing partners for the employee, then we create a partner record and link it to the employee so that the accounting entries from payslips have an attached partner.

Steps to reproduce on runbot:
1) install payroll, accounting and l10n_us_hr_payroll modules. 
2) create an employee from the maggie user record. 
3) set up a contract for maggie employee so that we can create a payslip. 
4) create a new payslip for maggie and compute the sheet. 
5) go to the maggie employee record, remove the `user_id` field. 
6) go to the payslip and create the draft entries. 
7) on the draft entry, the account move lines are missing the partner record.

opw-4118286
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
