### PR TITLE
Show the invoice name that has negative amount

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2729,7 +2729,7 @@ class AccountMove(models.Model):
                     raise UserError(_("The field 'Vendor' is required, please complete it to validate the Vendor Bill."))
 
             if move.is_invoice(include_receipts=True) and float_compare(move.amount_total, 0.0, precision_rounding=move.currency_id.rounding) < 0:
-                raise UserError(_("You cannot validate an invoice with a negative total amount. You should create a credit note instead. Use the action menu to transform it into a credit note or refund."))
+                raise UserError(_("You cannot validate an invoice with a negative total amount. You should create a credit note instead. Use the action menu to transform it into a credit note or refund. Move name: %s") % move.name)
 
             if move.line_ids.account_id.filtered(lambda account: account.deprecated):
                 raise UserError(_("A line of this move is using a deprecated account, you cannot post it."))


### PR DESCRIPTION
When posting multiple invoice we don't know which one has a negative value. So we show the invoice name at the raise.

Description of the issue/feature this PR addresses:

Current behavior before PR:
Just show the error not not knowing which move has negativa value.

Desired behavior after PR is merged:
Show the error and the move name




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
