### PR TITLE
[I18N] [16.0] website_hr_recruitment: add translates

### DIFF
--- a/addons/website_hr_recruitment/i18n/website_hr_recruitment.pot
+++ b/addons/website_hr_recruitment/i18n/website_hr_recruitment.pot
@@ -17,6 +17,22 @@ msgstr ""
 
 #. module: website_hr_recruitment
 #. odoo-python
+#: code:addons/website_hr_recruitment/models/hr_job.py:0
+#, python-format
+msgid ""
+"\n"
+"            <span class=\"text-muted small\">Time to Answer</span>\n"
+"            <h6>2 open days</h6>\n"
+"            <span class=\"text-muted small\">Process</span>\n"
+"            <h6>1 Phone Call</h6>\n"
+"            <h6>1 Onsite Interview</h6>\n"
+"            <span class=\"text-muted small\">Days to get an Offer</span>\n"
+"            <h6>4 Days after Interview</h6>\n"
+"        "
+msgstr ""
+
+#. module: website_hr_recruitment
+#. odoo-python
 #: code:addons/website_hr_recruitment/models/hr_recruitment.py:0
 #, python-format
 msgid "%s's Application"

--- a/addons/website_hr_recruitment/models/hr_job.py
+++ b/addons/website_hr_recruitment/models/hr_job.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models, api
+from odoo import fields, models, api, _
 from odoo.addons.http_routing.models.ir_http import slug
 from odoo.tools import mute_logger
 from odoo.tools.translate import html_translate
@@ -15,6 +15,17 @@ class Job(models.Model):
     def _get_default_website_description(self):
         return self.env['ir.qweb']._render("website_hr_recruitment.default_website_description", raise_if_not_found=False)
 
+    def _get_default_job_details(self):
+        return _("""
+            <span class="text-muted small">Time to Answer</span>
+            <h6>2 open days</h6>
+            <span class="text-muted small">Process</span>
+            <h6>1 Phone Call</h6>
+            <h6>1 Onsite Interview</h6>
+            <span class="text-muted small">Days to get an Offer</span>
+            <h6>4 Days after Interview</h6>
+        """)
+
     website_published = fields.Boolean(help='Set if the application is published on the website of the company.')
     website_description = fields.Html(
         'Website description', translate=html_translate,
@@ -26,15 +37,7 @@ class Job(models.Model):
         translate=True,
         help="Complementary information that will appear on the job submission page",
         sanitize_attributes=False,
-        default="""
-            <span class="text-muted small">Time to Answer</span>
-            <h6>2 open days</h6>
-            <span class="text-muted small">Process</span>
-            <h6>1 Phone Call</h6>
-            <h6>1 Onsite Interview</h6>
-            <span class="text-muted small">Days to get an Offer</span>
-            <h6>4 Days after Interview</h6>
-        """)
+        default=_get_default_job_details)
 
     @api.onchange('website_published')
     def _onchange_website_published(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Add translation for the default content

Note: I tried adding `_()` within the field, but it didn't work, so I moved it to the default function `_get_default_job_details`



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
