### PR TITLE
[IMP] * : use fa-clipboard icon for copy-to-clipboard buttons

### DIFF
--- a/addons/account/static/src/components/document_state/document_state_field.xml
+++ b/addons/account/static/src/components/document_state/document_state_field.xml
@@ -4,7 +4,7 @@
         <div class="row m-2 mt-4 justify-content-between account_document_state_popover">
             <span class="col-10" t-out="props.message" style="white-space: pre-wrap;"/>
             <button class="col-2 btn p-0 account_document_state_popover_clone" t-on-click="() => props.copyText()">
-                <i class="fa fa-clone"/>
+                <i class="fa fa-clipboard"/>
             </button>
         </div>
     </t>

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -72,7 +72,7 @@
                                     <t t-esc="state.urlTitle"/>
                                 </a>
                                 <a href="#" class="mx-1 o_we_copy_link text-dark" t-on-click="onClickCopy" title="Copy Link">
-                                    <i class="fa fa-clone"></i>
+                                    <i class="fa fa-clipboard"></i>
                                 </a>
                                 <a href="#" class="mx-1 o_we_edit_link text-dark" t-on-click="onClickEdit" title="Edit Link">
                                     <i class="fa fa-edit"></i>

--- a/addons/spreadsheet/static/src/components/share_button/share_button.xml
+++ b/addons/spreadsheet/static/src/components/share_button/share_button.xml
@@ -26,7 +26,7 @@
           <div class=" px-3 o_field_widget o_readonly_modifier o_field_CopyClipboardChar">
             <div class="d-grid rounded-2 overflow-hidden">
               <span t-out="state.url"/>
-              <CopyButton className="'o_btn_char_copy btn-sm'" content="state.url" successText="copiedText" icon="'fa-clone'"/>
+              <CopyButton className="'o_btn_char_copy btn-sm'" content="state.url" successText="copiedText" icon="'fa-clipboard'"/>
             </div>
           </div>
         </t>

--- a/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action.test.js
+++ b/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action.test.js
@@ -294,7 +294,7 @@ test("share dashboard from dashboard view", async function () {
     expect(target.querySelector(".o_field_CopyClipboardChar").innerText).toBe(
         "localhost:8069/share/url/132465"
     );
-    await contains(".fa-clone").click();
+    await contains(".fa-clipboard").click();
     expect.verifySteps(["share url copied"]);
 });
 

--- a/addons/web/static/src/core/errors/error_dialogs.xml
+++ b/addons/web/static/src/core/errors/error_dialogs.xml
@@ -59,7 +59,7 @@
                 <button class="btn btn-link p-0" t-on-click="() => { state.showTraceback = !state.showTraceback }" t-esc="state.showTraceback ? this.constructor.hideTracebackButtonText : this.constructor.showTracebackButtonText"/>
                 <div t-if="state.showTraceback" class="bg-100 mb-0 clearfix mt-3 position-relative o_error_detail">
                     <button class="btn position-absolute bg-100" t-ref="copyButton" t-on-click="onClickClipboard">
-                        <span class="fa fa-clone"/>
+                        <span class="fa fa-clipboard"/>
                     </button>
                     <div class="ps-3 pt-3">
                         <p class="m-0"><b t-esc="title or this.constructor.title"></b></p>

--- a/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.js
+++ b/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.js
@@ -55,7 +55,7 @@ export class CopyClipboardCharField extends CopyClipboardField {
     static components = { Field: CharField, CopyButton };
 
     get copyButtonIcon() {
-        return "fa-clone";
+        return "fa-clipboard";
     }
 }
 

--- a/addons/web/static/tests/core/errors/error_dialogs.test.js
+++ b/addons/web/static/tests/core/errors/error_dialogs.test.js
@@ -109,7 +109,7 @@ test("button clipboard copy error traceback", async () => {
     });
     await click("main button");
     await animationFrame();
-    await click(".fa-clone");
+    await click(".fa-clipboard");
     await tick();
 });
 
@@ -134,7 +134,7 @@ test("Display a tooltip on clicking copy button", async () => {
     });
     await click("main button");
     await animationFrame();
-    await click(".fa-clone");
+    await click(".fa-clipboard");
 });
 
 test("WarningDialog", async () => {

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
@@ -25,7 +25,7 @@ export class LinkPopoverWidget {
                 <div class="d-flex">
                     <a href="#" target="_blank" class="o_we_url_link fw-bold flex-grow-1 text-truncate" title="${_t('Open in a new tab')}"></a>
                     <a href="#" class="mx-1 o_we_copy_link text-dark" data-bs-toggle="tooltip" data-bs-placement="top" title="${_t('Copy Link')}">
-                        <i class="fa fa-clone"></i>
+                        <i class="fa fa-clipboard"></i>
                     </a>
                     <a href="#" class="mx-1 o_we_edit_link text-dark" data-bs-toggle="tooltip" data-bs-placement="top" title="${_t('Edit Link')}">
                         <i class="fa fa-edit"></i>


### PR DESCRIPTION
* = account, html_editor, spreadsheet, spreadsheet_dashboard, web, web_editor

Buttons that copy text to the clipboard were previously using the
fa-clone icon, which was incorrect. Updated these icons to fa-clipboard.

task-3181092
