### PR TITLE
[IMP] html_editor: make datetime field in dynamic placeholder acc to user's tz

### DIFF
--- a/addons/html_editor/static/tests/dynamic_placeholder.test.js
+++ b/addons/html_editor/static/tests/dynamic_placeholder.test.js
@@ -26,6 +26,7 @@ test("inserted value from dynamic placeholder should contain the data-oe-t-inlin
             dynamicPlaceholderResModel: "res.users",
         },
     });
+    onRpc("/web/dataset/call_kw/res.users/mail_get_partner_fields", () => ['partner_id']);
 
     await insertText(editor, "/dynamicplaceholder");
     await press("Enter");

--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -105,6 +105,9 @@ class Base(models.AbstractModel):
             ]
         return partner_fnames
 
+    def mail_get_partner_fields(self):
+        return self._mail_get_partner_fields()
+
     def _mail_get_partners(self, introspect_fields=False):
         """ Give the default partners (customers) associated to customers.
 

--- a/addons/mail/static/tests/tours/mail_template_dynamic_placeholder_tour.js
+++ b/addons/mail/static/tests/tours/mail_template_dynamic_placeholder_tour.js
@@ -155,7 +155,63 @@ registry.category("web_tour.tours").add("mail_template_dynamic_placeholder_tour"
         {
             content: "Ensure the editable contain the dynamic placeholder t tag",
             trigger: `.note-editable.odoo-editor-editable t[t-out="object.company_name"]:contains("defValue")`,
+        },
+        {
+            content: 'Type "Push Notification Device" model',
+            trigger: 'div[name="model_id"] input[type="text"]',
+            run: "edit Push Notification Device",
+        },
+        {
+            content: 'Select "Push Notification Device" model',
+            trigger: 'a.dropdown-item:contains("Push Notification Device")',
             run: "click",
+        },
+        {
+            content: "Insert text inside editable",
+            trigger: ".note-editable.odoo-editor-editable",
+            async run(actions) {
+                await actions.editor(`/`);
+                document.querySelector(".note-editable").dispatchEvent(
+                    new InputEvent("input", {
+                        inputType: "insertText",
+                        data: "/",
+                    })
+                );
+            },
+        },
+        {
+            content: "Click on the the dynamic placeholder powerBox options",
+            trigger: "div.o-we-powerbox .o-we-command:contains(Dynamic Placeholder)",
+            run: "click",
+        },
+        {
+            content: "Check if the dynamic placeholder popover is opened",
+            trigger: "div.o_model_field_selector_popover",
+            run: "click",
+        },
+        {
+            content: "filter the dph result",
+            trigger: "div.o_model_field_selector_popover_search input[type='text']",
+            run: "edit created on",
+        },
+        {
+            content: "Click on the first entry of the dynamic placeholder",
+            trigger: 'div.o_model_field_selector_popover li:first-child button:contains("Created on")',
+            run: "click",
+        },
+        {
+            content: "Enter a default value",
+            trigger: "div.o_model_field_selector_popover .o_model_field_selector_default_value_input input[type='text']",
+            run: "edit localTime",
+        },
+        {
+            content: "Click on the insert button",
+            trigger: "div.o_model_field_selector_popover button:first-child:contains('Insert)",
+            run: "click",
+        },
+        {
+            content: "Ensure the editable contain the dynamic placeholder t tag",
+            trigger: `.note-editable.odoo-editor-editable t[t-out="format_datetime(object.create_date, tz=object.partner_id.tz) or 'localTime'"]:contains("localTime")`,
         },
         {
             content: "Discard form changes",

--- a/addons/web/static/src/views/fields/dynamic_placeholder_popover.js
+++ b/addons/web/static/src/views/fields/dynamic_placeholder_popover.js
@@ -50,12 +50,13 @@ export class DynamicPlaceholderPopover extends Component {
     setPath(path, fieldInfo) {
         this.state.path = path;
         this.state.fieldName = fieldInfo?.string;
+        this.fieldType = fieldInfo?.type
     }
     setDefaultValue(value) {
         this.state.defaultValue = value;
     }
     validate() {
-        this.props.validate(this.state.path, this.state.defaultValue);
+        this.props.validate(this.state.path, this.state.defaultValue, this.fieldType);
         this.props.close();
     }
 


### PR DESCRIPTION
**How to reproduce:**
- Create an email template, add datetime field using /dynamic command
- Set the datetime on a record
- Send an email

**Specifications:**
Currently, datetime field in the email always display UTC.

**After this PR:**
When the user inputs a datetime field using the /dynamic command, it will now be displayed according to the recipient's or sender's timezone.

Task-4011120
