### PR TITLE
[FIX] mail: check access if modify model or res_id on mail message

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1460,7 +1460,7 @@ class Lead(models.Model):
                     subject = _("From %(source_name)s : %(source_subject)s", source_name=opportunity.name, source_subject=message.subject)
                 else:
                     subject = _("From %(source_name)s", source_name=opportunity.name)
-                message.write({
+                message.sudo().write({
                     'res_id': self.id,
                     'subject': subject,
                 })

--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -4967,6 +4967,12 @@ msgid "Only administrators are allowed to use grouped read on message model"
 msgstr ""
 
 #. module: mail
+#: code:addons/mail/models/mail_message.py:0
+#, python-format
+msgid "Only administrators can modify 'model' and 'res_id' fields."
+msgstr ""
+
+#. module: mail
 #: code:addons/mail/models/ir_model.py:0
 #, python-format
 msgid "Only custom models can be modified."

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -636,6 +636,8 @@ class Message(models.Model):
 
     def write(self, vals):
         record_changed = 'model' in vals or 'res_id' in vals
+        if record_changed and not self.env.is_system():
+            raise AccessError(_("Only administrators can modify 'model' and 'res_id' fields."))
         if record_changed or 'message_type' in vals:
             self._invalidate_documents()
         res = super(Message, self).write(vals)

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -491,11 +491,11 @@ class MailThread(models.AbstractModel):
         msg_vals = {"res_id": new_thread.id, "model": new_thread._name}
         if new_parent_message:
             msg_vals["parent_id"] = new_parent_message.id
-        msg_comment.write(msg_vals)
+        msg_comment.sudo().write(msg_vals)
 
         # other than comment: reset subtype
         msg_vals["subtype_id"] = None
-        msg_not_comment.write(msg_vals)
+        msg_not_comment.sudo().write(msg_vals)
         return True
 
     # ------------------------------------------------------


### PR DESCRIPTION
It is necessary to be an administrator to modify `model` or `res_id` field.

task-4122628