### PR TITLE
[FIX] web: action service tests: wait for error to be thrown

### DIFF
--- a/addons/web/static/tests/legacy/webclient/actions/misc_tests.js
+++ b/addons/web/static/tests/legacy/webclient/actions/misc_tests.js
@@ -106,6 +106,7 @@ QUnit.module("ActionManager", (hooks) => {
         const webClient = await createWebClient({ serverData });
         doAction(webClient, 4448);
         await nextTick();
+        await nextTick(); // wait for the unhandledrejection error to be thrown/caught
         assert.containsOnce(target, ".o_error_dialog");
         assert.strictEqual(
             document.querySelector(".o_error_dialog .modal-body").innerText,
@@ -122,6 +123,7 @@ QUnit.module("ActionManager", (hooks) => {
         const webClient = await createWebClient({ serverData });
         doAction(webClient, "plop");
         await nextTick();
+        await nextTick(); // wait for the unhandledrejection error to be thrown/caught
         assert.containsOnce(target, ".o_error_dialog");
         assert.strictEqual(
             document.querySelector(".o_error_dialog .modal-body").innerText,
@@ -138,6 +140,7 @@ QUnit.module("ActionManager", (hooks) => {
         const webClient = await createWebClient({ serverData });
         doAction(webClient, "not.found.action");
         await nextTick();
+        await nextTick(); // wait for the unhandledrejection error to be thrown/caught
         assert.containsOnce(target, ".o_error_dialog");
         assert.strictEqual(
             document.querySelector(".o_error_dialog .modal-body").innerText,


### PR DESCRIPTION
Before this commit, some tests might randomly fail because we didn't wait enough before checking the presence of an error dialog in the DOM, `unhandledrejection` errors being thrown asynchrosnouly

Runbot error `66438`

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
