### PR TITLE
[FIX] stock_barcode_mrp: not redirect to backend from barcode backorder

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -2151,13 +2151,18 @@ class MrpProduction(models.Model):
                 return self.with_context(always_backorder_mo_ids=mo_ids_always)._action_generate_backorder_wizard(mos_ask)
             elif mo_ids_always:
                 # we have to pass all the MOs that the nevers/no issue MOs are also passed to be "mark done" without a backorder
-                return self.with_context(skip_backorder=True, mo_ids_to_backorder=mo_ids_always).button_mark_done()
+                res = self.with_context(skip_backorder=True, mo_ids_to_backorder=mo_ids_always).button_mark_done()
+                return res if self._should_return_records() else True
         return True
 
     def _button_mark_done_sanity_checks(self):
         self._check_company()
         for order in self:
             order._check_sn_uniqueness()
+
+    def _should_return_records(self):
+        # Meant to be overriden for flows that don't want to be redirected to the backend e.g. barcode
+        return True
 
     def do_unreserve(self):
         (self.move_finished_ids | self.move_raw_ids).filtered(lambda x: x.state not in ('done', 'cancel'))._do_unreserve()


### PR DESCRIPTION
### Steps to reproduce:

- Enable multi-step routes in the settings
- Inventory > Configuration > Warehouse Management > Operations types
- Click on Manufacturing and put "Always" on create a backorder
- Create a product P (no need for a bom)
- Create and confirm a manufacturing order for 2 units of the product
- Go to the barcode module > operations > manufacturing > the MO
- Register only one unit of P and produce
#### > A backorder is automatically created but you are redirected to the backend.

#### Note:

If you were in "ask" on create backorder or if your product had a bom and you did not register the quantities of consumed components, a pop up would appear and resolving the pop up would redirect you to the kanban view of mrp.production in the barcode module.

### Cause of the issue:

The issue was originally solved by commit d90acab by overriding the `action_backorder` however, since commit 1e5c82f the action_backorder is no more part of the flow in "always" backorder.

opw-3890886
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
