### PR TITLE
[FIX] account: fix default_account_id for misc journal

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -399,9 +399,14 @@ class AccountJournal(models.Model):
                 journal.suspense_account_id = False
 
     def _inverse_type(self):
-        if not self._context.get('account_journal_skip_alias_sync'):
-            for record in self:
-                record._update_mail_alias()
+        update_alias = not self._context.get('account_journal_skip_alias_sync')
+        for journal in self:
+            if update_alias:
+                journal._update_mail_alias()
+            # Since 'default_account_id' is not visible on MISC ('general') journals,
+            # any existing value should be cleared to avoid undesired side effects.
+            if journal.type == 'general':
+                journal.default_account_id = False
 
     @api.depends('name')
     def _compute_alias_domain(self):


### PR DESCRIPTION
**Steps to reproduce:**
- Install account_accountant.
- Create a journal with a type other than miscellaneous. 
- For the created journal, select a default account
- Now change the journal type to Miscellaneous.

**Issue :**
- When changing the journal type to Miscellaneous from any other type, the default_account_id remains unchanged in the database. Functionally, the default_account_id should be removed for Miscellaneous journals, as this field isn't visible in the front-end, so customers aren't aware if it still contains data.
- I have faced one issue where customer changed journal type to miscellaneous and after upgrade he faced some issue related to cash flow statement which is accuring because there is default_account_id set for it.
- Before fix : https://drive.google.com/file/d/1OL19m14RIz44gAtsZyu866OjRv4xGOoO/view?usp=sharing
- After fix : https://drive.google.com/file/d/1u89YTUIrRGvZgI-5afG26sR00fcbHWT2/view?usp=sharing
opw-4072696
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
