### PR TITLE
[FIX] payment_(adyen,stripe): map the Cash App Pay PM to the correct code

### DIFF
--- a/addons/payment_adyen/const.py
+++ b/addons/payment_adyen/const.py
@@ -41,6 +41,7 @@ PAYMENT_METHODS_MAPPING = {
     'bacs_direct_debit': 'directdebit_GB',
     'bancontact_card': 'bcmc',
     'bancontact': 'bcmc_mobile',
+    'cash_app_pay': 'cashapp',
     'gopay': 'gopay_wallet',
     'becs_direct_debit': 'au_becs_debit',
     'afterpay': 'afterpaytouch',

--- a/addons/payment_stripe/const.py
+++ b/addons/payment_stripe/const.py
@@ -29,6 +29,7 @@ PAYMENT_METHODS_MAPPING = {
     'sepa_direct_debit': 'sepa_debit',
     'afterpay': 'afterpay_clearpay',
     'clearpay': 'afterpay_clearpay',
+    'cash_app_pay': 'cashapp',
     'mobile_pay': 'mobilepay',
     'unknown': 'card',  # For express checkout.
 }


### PR DESCRIPTION
Version : 17

Steps to Reproduce:

Install the Stripe or Adyen Payment Provider.
Activate the CashApp payment method.
Attempt to make a payment using CashApp at checkout.

Issue:
Users encounter an error when selecting the CashApp payment method during
payment. The error is caused by the use  incorrect code of Cash App Pay
payment method, resulting in a traceback.

Cause:
The error occurs because Cash App Pay payment method not mapped with
correct code.

Fix:
Add the correct code 'cashapp' to the 'PAYMENT_METHODS_MAPPING' variable of
stripe and ayden.

opw-4132745