### PR TITLE
[IMP] point_of_sale: remove selectedOrder

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1164,10 +1164,6 @@ export class PosStore extends Reactive {
 
         return this.models["pos.order"].getBy("uuid", this.selectedOrderUuid);
     }
-    get selectedOrder() {
-        return this.get_order();
-    }
-
     // change the current order
     set_order(order, options) {
         if (this.get_order()) {


### PR DESCRIPTION
Remove `selectedOrder` getter to use `get_order()` instead.

taskId: 4141914

