### PR TITLE
[FIX] html_editor: test inde show default custom color

### DIFF
--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -147,7 +147,7 @@ test("select hex color and apply it", async () => {
 });
 
 test("always show the current custom color", async () => {
-    await setupEditor(`<p>[test]</p>`);
+    const { el } = await setupEditor(`<p>[test]</p>`);
     await waitFor(".o-we-toolbar");
     click(".o-we-toolbar .o-select-color-foreground");
     await animationFrame();
@@ -157,8 +157,9 @@ test("always show the current custom color", async () => {
     click(".o_hex_input");
     await animationFrame();
     expect(".o_colorpicker_section:nth-of-type(1) button").toHaveCount(1);
+    const defaultTextColor = getComputedStyle(el.querySelector("p")).color;
     expect(queryOne(".o_colorpicker_section:nth-of-type(1) button").style.backgroundColor).toBe(
-        "rgb(55, 65, 81)",
+        defaultTextColor,
         { message: "backgroundColor is the default black" }
     );
 


### PR DESCRIPTION
The purpose of this commit is to fix a bug probably linked to the runbot's configuration. This does not ensure that the default text color is always the same.

Build that failed: https://runbot.odoo.com/runbot/build/67519465

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
