### PR TITLE
[FIX] web: kanban quick create and config button position

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_header.xml
+++ b/addons/web/static/src/views/kanban/kanban_header.xml
@@ -9,7 +9,7 @@
                     <t t-esc="groupName + ' (' + group.count + ')'"/>
                 </div>
                 <div t-if="!group.isFolded"
-                    class="o_column_title min-w-0 mw-100 gap-1 d-flex fs-4 fw-bold align-top text-900"
+                    class="o_column_title flex-grow-1 min-w-0 mw-100 gap-1 d-flex fs-4 fw-bold align-top text-900"
                       t-on-mouseenter="onTitleMouseEnter" t-on-mouseleave="onTitleMouseLeave"
                 >
                     <span class="text-truncate" t-esc="groupName"/>


### PR DESCRIPTION
Since [1], the alignment of the quick create and config button in a kanban was not correct. It was aligned to the left.

Now, the alignment is correctly to the right of the kanban header.

[1] : https://github.com/odoo/odoo/commit/f486bca505cb6ef9bf477e5d02d06c420b27de56