### PR TITLE
[IMP] l10n_ar: remove dead code

### DIFF
--- a/addons/l10n_ar/__init__.py
+++ b/addons/l10n_ar/__init__.py
@@ -3,8 +3,3 @@
 from . import models
 from . import report
 from . import demo
-from odoo import api, SUPERUSER_ID
-
-def load_translations(cr, registry):
-    env = api.Environment(cr, SUPERUSER_ID, {})
-    env.ref('l10n_ar.l10nar_ri_chart_template').process_coa_translations()


### PR DESCRIPTION
Before 17 process_coa_translations might have been needed
in multi_lang localizations, but it is no longer needed.

It is also not called.

No task linked.  Just saw it checking other stuff.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
