### PR TITLE
[FIX] base_import: fix date field when using openpyxl

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -483,7 +483,11 @@ class Import(models.TransientModel):
                     else:
                         values.append(str(cell.value))
                 elif isinstance(cell.value, datetime.datetime):
-                    values.append(cell.value.strftime(DEFAULT_SERVER_DATETIME_FORMAT))
+                    value = cell.value
+                    if value.hour == 0 and value.minute == 0 and value.second == 0 and value.microsecond == 0:
+                        values.append(value.strftime(DEFAULT_SERVER_DATE_FORMAT))
+                    else:
+                        values.append(value.strftime(DEFAULT_SERVER_DATETIME_FORMAT))
                 elif isinstance(cell.value, datetime.date):
                     values.append(cell.value.strftime(DEFAULT_SERVER_DATE_FORMAT))
                 else:


### PR DESCRIPTION
In Python 3.12, openpyxl is used to import xlsx file instead of xlsx (See https://github.com/odoo/odoo/pull/169614). But the fallback implementation doesn't manage correctly the Date type field, it was handle as datetime instead. Then it was not possible to import date field.

Fix it with something similar done by `_read_xls_book` for date.