### PR TITLE
[FIX] account_payment: only allow refunding payments if created by tx

### DIFF
--- a/addons/account_payment/models/account_payment.py
+++ b/addons/account_payment/models/account_payment.py
@@ -54,7 +54,8 @@ class AccountPayment(models.Model):
                 or tx_sudo.payment_method_id
             )
             if (
-                tx_sudo.provider_id.support_refund != 'none'
+                tx_sudo  # The payment was created by a transaction.
+                and tx_sudo.provider_id.support_refund != 'none'
                 and payment_method.support_refund != 'none'
                 and tx_sudo.operation != 'refund'
             ):

--- a/addons/account_payment/tests/test_account_payment.py
+++ b/addons/account_payment/tests/test_account_payment.py
@@ -11,6 +11,15 @@ from odoo.tests import tagged
 @tagged('-at_install', 'post_install')
 class TestAccountPayment(AccountPaymentCommon):
 
+    def test_no_amount_available_for_refund_when_no_tx(self):
+        payment = self.env['account.payment'].create({'amount': 10})
+        self.assertEqual(
+            payment.amount_available_for_refund,
+            0,
+            msg="The value of `amount_available_for_refund` should be 0 when the payment was not"
+                " created by a transaction."
+        )
+
     def test_no_amount_available_for_refund_when_not_supported(self):
         self.provider.support_refund = 'none'
         tx = self._create_transaction('redirect', state='done')


### PR DESCRIPTION
Commit 242b5219 made the computation for `amount_available_for_refund` take the payment method's support for refund into account but did not consider the case where payments are not created by transactions. In that case, the refundable amount was not set to zero, and users could see the refund button in form view.

opw-4148110