### PR TITLE
[FIX] l10n_fr_invoice_addr: format fr localized invoice

### DIFF
--- a/addons/l10n_fr_invoice_addr/views/report_invoice.xml
+++ b/addons/l10n_fr_invoice_addr/views/report_invoice.xml
@@ -20,7 +20,7 @@
         <xpath expr="//div[@id='informations']" position="inside">
             <t t-if="o.l10n_fr_is_company_french and o.partner_id.commercial_partner_id != o.partner_id and o.move_type.startswith('out_')">
                 <t t-set="partner" t-value="o.partner_id.commercial_partner_id"/>
-                <div class="col mb-2" name="customer_address">
+                <div class="col col-3 mw-100 mb-2" name="customer_address">
                     <strong>Customer Address:</strong>
                     <br/>
                     <address t-field="partner.self" class="m-0" t-options="{'widget': 'contact', 'fields': ['address'], 'no_marker': True}"/>


### PR DESCRIPTION
Steps to reproduce:
- Download french accounting localization module
- Switch company to 'FR Company'
- Accounting > Customers > Invoice > New
- Pick a customer with a parent company
- Confirm > Gear > Print > Invoice

Results in a formatting error that prints jumbled text in one column.
This happens because of a conditional field that did not receive the
update last time in 9674b4eeb26bfb7dd09d48b81bb8c27601e6990a.

opw-3865644

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
