### PR TITLE
[IMP] account: Enhance multi-ledger with cross-company support

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -18,9 +18,12 @@ class AccountJournalGroup(models.Model):
     _check_company_domain = models.check_company_domain_parent_of
 
     name = fields.Char("Ledger group", required=True, translate=True)
-    company_id = fields.Many2one('res.company', required=True, default=lambda self: self.env.company)
-    excluded_journal_ids = fields.Many2many('account.journal', string="Excluded Journals",
-        check_company=True)
+    company_id = fields.Many2one(
+        comodel_name='res.company',
+        help="Define which company can select the multi-ledger in report filters. If none is provided, available for all companies",
+        default=lambda self: self.env.company,
+    )
+    excluded_journal_ids = fields.Many2many('account.journal', string="Excluded Journals")
     sequence = fields.Integer(default=10)
 
     _sql_constraints = [

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -173,6 +173,12 @@ class AccountMove(models.Model):
         check_company=True,
         domain="[('id', 'in', suitable_journal_ids)]",
     )
+    journal_group_id = fields.Many2one(
+        'account.journal.group',
+        string='Ledger',
+        store=False,
+        search='_search_journal_group_id',
+    )
     company_id = fields.Many2one(
         comodel_name='res.company',
         string='Company',
@@ -1886,6 +1892,14 @@ class AccountMove(models.Model):
                 if not is_html_empty(tax.invoice_legal_notes)
             )
 
+    # -------------------------------------------------------------------------
+    # SEARCH METHODS
+    # -------------------------------------------------------------------------
+
+    def _search_journal_group_id(self, operator, value):
+        field = 'name' if 'like' in operator else 'id'
+        journal_groups = self.env['account.journal.group'].search([(field, operator, value)])
+        return [('journal_id', 'not in', journal_groups.excluded_journal_ids.ids)]
     # -------------------------------------------------------------------------
     # INVERSE METHODS
     # -------------------------------------------------------------------------

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1834,7 +1834,7 @@ class AccountMoveLine(models.Model):
             return {}
 
         # Override in order to not read the complete move line table and use the index instead
-        query_account = self.env['account.account']._search([('company_ids', 'in', self.env.companies.ids)])
+        query_account = self.env['account.account']._search([('company_ids', 'in', self.env.companies.ids), ('code', '!=', False)])
         account_code_alias = self.env['account.account']._field_to_sql('account_account', 'code', query_account)
 
         query_line = self._search(domain, limit=1)

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -45,6 +45,14 @@ class AccountMoveLine(models.Model):
         index=True,
         copy=False,
     )
+
+    journal_group_id = fields.Many2one(
+        string='Ledger',
+        comodel_name='account.journal.group',
+        store=False,
+        search='_search_journal_group_id',
+    )
+
     company_id = fields.Many2one(
         related='move_id.company_id', store=True, readonly=True, precompute=True,
         index=True,
@@ -1204,6 +1212,15 @@ class AccountMoveLine(models.Model):
             'target': 'new',
             'type': 'ir.actions.act_window',
         }
+
+    # -------------------------------------------------------------------------
+    # SEARCH METHODS
+    # -------------------------------------------------------------------------
+
+    def _search_journal_group_id(self, operator, value):
+        field = 'name' if 'like' in operator else 'id'
+        journal_groups = self.env['account.journal.group'].search([(field, operator, value)])
+        return [('journal_id', 'not in', journal_groups.excluded_journal_ids.ids)]
 
     # -------------------------------------------------------------------------
     # INVERSE METHODS

--- a/addons/account/security/account_security.xml
+++ b/addons/account/security/account_security.xml
@@ -149,7 +149,7 @@
     <record id="journal_group_comp_rule" model="ir.rule">
         <field name="name">Multi-ledger multi-company</field>
         <field name="model_id" ref="model_account_journal_group"/>
-        <field name="domain_force">[('company_id', 'parent_of', company_ids)]</field>
+        <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'parent_of', company_ids)]</field>
     </record>
 
     <record id="journal_comp_rule" model="ir.rule">

--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -11,7 +11,7 @@
                     <field name='sequence' widget='handle'/>
                     <field name="name"/>
                     <field name="type"/>
-                    <field name="journal_group_ids" widget="many2many_tags" readonly="1" optional="show"/>
+                    <field name="journal_group_ids" widget="many2many_tags" readonly="1" optional="hide"/>
                     <field name="currency_id" groups="base.group_multi_currency" optional="hide"/>
                     <field name="code" optional="show"/>
                     <field name="default_account_id" optional="show"/>
@@ -273,9 +273,9 @@
                 <list editable="bottom">
                     <field name="company_id" column_invisible="True"/>
                     <field name="sequence"  widget="handle"/>
-                    <field name="name"/>
+                    <field name="name" placeholder="e.g. GAAP, IFRS, ..."/>
                     <field name="excluded_journal_ids" widget="many2many_tags" options="{'no_create': True}"/>
-                    <field name="company_id" groups="base.group_multi_company"/>
+                    <field name="company_id" groups="base.group_multi_company" placeholder="All Companies" options="{'no_create': True}"/>
                 </list>
             </field>
         </record>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -319,6 +319,7 @@
                     <field name="account_type"/>
                     <field name="partner_id"/>
                     <field name="journal_id"/>
+                    <field name="journal_group_id"/>
                     <field name="product_id"/>
                     <field name="product_category_id"/>
                     <field name="move_id" string="Journal Entry" filter_domain="[
@@ -346,6 +347,7 @@
                     <filter string="Purchases" name="purchases" domain="[('journal_id.type', '=', 'purchase')]" context="{'default_journal_type': 'purchase'}"/>
                     <filter string="Bank" name="bank" domain="[('journal_id.type', '=', 'bank')]" context="{'default_journal_type': 'bank'}"/>
                     <filter string="Cash" name="cash" domain="[('journal_id.type', '=', 'cash')]" context="{'default_journal_type': 'cash'}"/>
+                    <filter string="Credit" name="credit" domain="[('journal_id.type', '=', 'credit')]" context="{'default_journal_type': 'credit'}"/>
                     <filter string="Miscellaneous" domain="[('journal_id.type', '=', 'general')]" name="misc_filter" context="{'default_journal_type': 'general'}"/>
                     <separator/>
                     <filter string="Payable" domain="[('account_id.account_type', '=', 'liability_payable'), ('account_id.non_trade', '=', False)]" help="From Trade Payable accounts" name="trade_payable"/>
@@ -1495,6 +1497,7 @@
                     <filter string="Purchases" name="purchases" domain="[('journal_id.type', '=', 'purchase')]" context="{'default_journal_type': 'purchase'}"/>
                     <filter string="Bank" name="bankoperations" domain="[('journal_id.type', '=', 'bank')]" context="{'default_journal_type': 'bank'}"/>
                     <filter string="Cash" name="cashoperations" domain="[('journal_id.type', '=', 'cash')]" context="{'default_journal_type': 'cash'}"/>
+                    <filter string="Credit" name="credit" domain="[('journal_id.type', '=', 'credit')]" context="{'default_journal_type': 'credit'}"/>
                     <filter string="Miscellaneous" name="misc_filter" domain="[('journal_id.type', '=', 'general')]" context="{'default_journal_type': 'general'}"/>
                     <separator/>
                     <filter string="Date" name="date" date="date"/>
@@ -1532,6 +1535,7 @@
                     <field name="ref"/>
                     <field name="payment_reference"/>
                     <field name="journal_id"/>
+                    <field name="journal_group_id"/>
                     <field name="partner_id" operator="child_of"/>
                     <field name="invoice_user_id" string="Salesperson" domain="[('share', '=', False)]"/>
                     <field name="date" string="Period"/>
@@ -1554,6 +1558,15 @@
                             string="Not Sent"
                             domain="[('is_move_sent', '=', False)]"
                             invisible="context.get('default_move_type') in ('in_invoice', 'in_refund', 'in_receipt')"
+                    />
+                    <separator/>
+                    <filter name="out_invoice"
+                            string="Invoices"
+                            domain="[('move_type', '=', 'out_invoice')]"
+                    />
+                    <filter name="out_refund"
+                            string="Credit Notes"
+                            domain="[('move_type', '=', 'out_refund')]"
                     />
                     <separator/>
                     <filter string="To Check" name="to_check" domain="[('checked', '=', False), ('state', '!=', 'draft')]"/>
@@ -1619,6 +1632,18 @@
                 <filter name="salesperson" position="replace"/>
                 <filter name="invoicedate" position="attributes">
                     <attribute name="string">Bill Date</attribute>
+                </filter>
+                <filter name="out_invoice" position="replace">
+                    <filter name="in_invoice"
+                            string="Bills"
+                            domain="[('move_type', '=', 'in_invoice')]"
+                    />
+                </filter>
+                <filter name="out_refund" position="replace">
+                    <filter name="in_refund"
+                            string="Refunds"
+                            domain="[('move_type', '=', 'in_refund')]"
+                    />
                 </filter>
             </field>
         </record>
@@ -1771,8 +1796,8 @@
             <field name="view_mode">list,kanban,form,activity</field>
             <field name="view_id" ref="view_out_invoice_tree"/>
             <field name="search_view_id" ref="view_account_invoice_filter"/>
-            <field name="domain">[('move_type', '=', 'out_invoice')]</field>
-            <field name="context">{'default_move_type': 'out_invoice'}</field>
+            <field name="domain">[('move_type', 'in', ['out_invoice', 'out_refund'])]</field>
+            <field name="context">{'search_default_out_invoice': 1, 'default_move_type': 'out_invoice'}</field>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">
                 Create a customer invoice
@@ -1789,8 +1814,8 @@
             <field name="view_mode">list,kanban,form,activity</field>
             <field name="view_id" ref="view_out_credit_note_tree"/>
             <field name="search_view_id" ref="view_account_invoice_filter"/>
-            <field name="domain">[('move_type', '=', 'out_refund')]</field>
-            <field name="context">{'default_move_type': 'out_refund', 'display_account_trust': True}</field>
+            <field name="domain">[('move_type', 'in', ['out_invoice', 'out_refund'])]</field>
+            <field name="context">{'search_default_out_refund': 1, 'default_move_type': 'out_refund', 'display_account_trust': True}</field>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">
                 Create a credit note
@@ -1808,8 +1833,8 @@
             <field name="view_mode">list,kanban,form,activity</field>
             <field name="view_id" ref="view_in_invoice_bill_tree"/>
             <field name="search_view_id" ref="view_account_bill_filter"/>
-            <field name="domain">[('move_type', '=', 'in_invoice')]</field>
-            <field name="context">{'default_move_type': 'in_invoice', 'display_account_trust': True}</field>
+            <field name="domain">[('move_type', 'in', ['in_invoice', 'in_refund'])]</field>
+            <field name="context">{'search_default_in_invoice': 1, 'default_move_type': 'in_invoice', 'display_account_trust': True}</field>
             <field name="help" type="html">
                 <!-- An owl component should be displayed instead -->
                 <p class="o_view_nocontent_smiling_face">
@@ -1826,8 +1851,8 @@
             <field name="view_mode">list,kanban,form,activity</field>
             <field name="view_id" ref="view_in_invoice_refund_tree"/>
             <field name="search_view_id" ref="view_account_bill_filter"/>
-            <field name="domain">[('move_type', '=', 'in_refund')]</field>
-            <field name="context">{'default_move_type': 'in_refund'}</field>
+            <field name="domain">[('move_type', 'in', ['in_invoice', 'in_refund'])]</field>
+            <field name="context">{'search_default_in_refund': 1, 'default_move_type': 'in_refund'}</field>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">
                 Create a vendor credit note

--- a/addons/account_debit_note/views/account_move_view.xml
+++ b/addons/account_debit_note/views/account_move_view.xml
@@ -49,8 +49,8 @@ if records:
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_account_invoice_filter" />
         <field name="arch" type="xml">
-            <filter name="to_check" position="before">
-                <filter string="Debit Note" name="debit_note_filter"
+            <filter name="out_refund" position="after">
+                <filter string="Debit Notes" name="debit_note_filter"
                     domain="[('debit_origin_id', '!=', False)]" />
                 <separator />
             </filter>


### PR DESCRIPTION
Improve the multi-ledger feature (journal groups) by allowing them to be visible across multiple companies. The company_id field does no longer impacts the excluded journals, allowing a ledger to exclude journals from all companies, provided the user has access.

This commit also enables filtering of journal entries and journal items based on a ledger. This filtering will exclude moves (or move lines) that belong to journals listed in the excluded journals of the journal group.

Task-4141521



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
