### PR TITLE
[FIX] web_editor: remove dark mode style from convert inline

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -426,7 +426,7 @@ function classToStyle($editable, cssRules) {
 
     for (const node of nodeToRules.keys()) {
         const nodeRules = nodeToRules.get(node);
-        const css = nodeRules ? _getMatchedCSSRules(node, nodeRules) : {};
+        const css = nodeRules ? _getMatchedCSSRules(node, nodeRules, true) : {};
         // Flexbox
         for (const styleName of node.style) {
             if (styleName.includes('flex') || `${node.style[styleName]}`.includes('flex')) {
@@ -1464,6 +1464,29 @@ function _getColumnOffsetSize(column) {
     const offsetSize = offsetOptions && (offsetOptions.length === 2 ? +offsetOptions[1] : +offsetOptions[0]) || 0;
     return offsetSize;
 }
+
+
+function isBlacklistedStyle(node, selector, key) {
+    return (
+        node.matches("table, thead, tbody, tfoot, tr, td, th") &&
+        ["table", "thead", "tbody", "tfoot", "tr", "td", "th"].some((elName) => selector.includes(elName)) &&
+        key.includes("color")
+    );
+}
+
+function removeBlacklistedStyles(rule, node, checkBlacklisted) {
+    if (!checkBlacklisted || !rule.style) {
+        return rule.style;
+    }
+    const styles = {};
+    for (const [key, value] of Object.entries(rule.style)) {
+        if (isBlacklistedStyle(node, rule.selector, key)) {
+            continue;
+        }
+        styles[key] = value;
+    }
+    return styles;
+}
 /**
  * Return the CSS rules which applies on an element, tweaked so that they are
  * browser/mail client ok.
@@ -1474,9 +1497,11 @@ function _getColumnOffsetSize(column) {
  *                          specificity: number;}>
  * @returns {Object} {[styleName]: string}
  */
-function _getMatchedCSSRules(node, cssRules) {
+function _getMatchedCSSRules(node, cssRules, checkBlacklisted = false) {
     node.matches = node.matches || node.webkitMatchesSelector || node.mozMatchesSelector || node.msMatchesSelector || node.oMatchesSelector;
-    const styles = cssRules.map((rule) => rule.style).filter(Boolean);
+    const styles = cssRules
+        .map((rule) => removeBlacklistedStyles(rule, node, checkBlacklisted))
+        .filter(Boolean);
 
     // Add inline styles at the highest specificity.
     if (node.style.length) {


### PR DESCRIPTION
Steps to reproduce the issue:
=============================
- Switch to dark mode
- Go to any record with a chatter
- Open mail composer in log note
- Add a table
- Save
- Switch to light mode
- The table is still dark

Origin of the issue:
====================
Since in dark mode we add some styles to improve the display, those
styles are getting applied in convert_inline.

Solution:
=========
Skip the stylesheets for table that have color only for now since
skipping all styles can produce more issues.

We skip also the background-color and border color for light mode too
because they will not display the same in dark mode.

Before:
======
![before_light](https://github.com/user-attachments/assets/c566c92e-ace9-4fc0-a123-b91563ee85a7)

![before_dark](https://github.com/user-attachments/assets/f6addda2-81f3-4bae-b90c-0696f48056fc)

After:
=====
![after_light](https://github.com/user-attachments/assets/a2fd629b-6a71-4fa9-b03a-8f940198e9e0)
![after-dark](https://github.com/user-attachments/assets/402d58ec-60f0-4088-abd2-2bae21964ca7)




opw-4137267