### PR TITLE
[FIX] website_sale_picking: unable to edit warehouse address

### DIFF
--- a/addons/website_sale_picking/controllers/main.py
+++ b/addons/website_sale_picking/controllers/main.py
@@ -1,10 +1,10 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import _
-from odoo.addons.website_sale.controllers.main import PaymentPortal
 from odoo.exceptions import ValidationError
 from odoo.http import request
+
+from odoo.addons.website_sale.controllers.main import PaymentPortal, WebsiteSale
 
 
 class PaymentPortalOnsite(PaymentPortal):
@@ -26,3 +26,14 @@ class PaymentPortalOnsite(PaymentPortal):
 
         if sale_order.carrier_id.delivery_type == 'onsite' and sale_order.carrier_id.warehouse_id:
             sale_order.warehouse_id = sale_order.carrier_id.warehouse_id
+
+
+class WebsiteSalePicking(WebsiteSale):
+
+    def _check_shipping_partner_mandatory_fields(self, partner_id):
+        order_sudo = request.website.sale_get_order()
+        carrier_sudo = order_sudo.carrier_id
+        if carrier_sudo.delivery_type == 'onsite' and partner_id == carrier_sudo.warehouse_id.partner_id:
+            return True
+
+        return super()._check_shipping_partner_mandatory_fields(partner_id)


### PR DESCRIPTION
Some fixes already landed with 7cbf7f94263a31d316b9c5a0efad57ad357aa5a0,
but if the address is incomplete, the user would still be redirected
to a 403 page because he cannot update the warehouse address to fill
the missing fields.

This commit makes sure that for onsite flows, the warehouse address
is considered complete.

opw-4126140
opw-4114139
opw-4115510
opw-4117520
opw-4109625
opw-4115415
opw-4143237
opw-4123382
opw-4136888
opw-4125807