### PR TITLE
[REF] mail, im_livechat: rename attachment accessToken

### DIFF
--- a/addons/im_livechat/static/src/embed/cors/attachment_model_patch.js
+++ b/addons/im_livechat/static/src/embed/cors/attachment_model_patch.js
@@ -9,7 +9,7 @@ patch(Attachment.prototype, {
         };
     },
     get urlRoute() {
-        if (!this.accessToken && this.thread?.model === "discuss.channel") {
+        if (!this.access_token && this.thread?.model === "discuss.channel") {
             return this.isImage
                 ? `/im_livechat/cors/channel/${this.thread.id}/image/${this.id}`
                 : `/im_livechat/cors/channel/${this.thread.id}/attachment/${this.id}`;

--- a/addons/mail/controllers/attachment.py
+++ b/addons/mail/controllers/attachment.py
@@ -75,7 +75,7 @@ class AttachmentController(http.Controller):
             # sudo: ir.attachment - posting a new attachment on an accessible thread
             attachment = request.env["ir.attachment"].sudo().create(vals)
             attachment._post_add_create(**kwargs)
-            res = {"data": Store(attachment, access_token=True).get_result()}
+            res = {"data": Store(attachment, extra_fields=["access_token"]).get_result()}
         except AccessError:
             res = {"error": _("You are not allowed to upload an attachment here.")}
         return request.make_json_response(res)

--- a/addons/mail/models/ir_attachment.py
+++ b/addons/mail/models/ir_attachment.py
@@ -77,7 +77,7 @@ class IrAttachment(models.Model):
             )
         self.unlink()
 
-    def _to_store(self, store: Store, /, *, fields=None, access_token=False):
+    def _to_store(self, store: Store, /, *, fields=None, extra_fields=None):
         if fields is None:
             fields = [
                 "checksum",
@@ -89,6 +89,8 @@ class IrAttachment(models.Model):
                 "size",
                 "thread",
             ]
+        if extra_fields:
+            fields.extend(extra_fields)
         safari = (
             request
             and request.httprequest.user_agent
@@ -120,6 +122,4 @@ class IrAttachment(models.Model):
                     if attachment.res_model != "mail.compose.message" and attachment.res_id
                     else False
                 )
-            if access_token:
-                data["accessToken"] = attachment.access_token
             store.add(attachment, data)

--- a/addons/mail/static/src/core/common/attachment_model.js
+++ b/addons/mail/static/src/core/common/attachment_model.js
@@ -64,7 +64,7 @@ export class Attachment extends FileModelMixin(Record) {
         if (this.id > 0) {
             await rpc(
                 "/mail/attachment/delete",
-                assignDefined({ attachment_id: this.id }, { access_token: this.accessToken })
+                assignDefined({ attachment_id: this.id }, { access_token: this.access_token })
             );
         }
         this.delete();

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -394,7 +394,7 @@ export class Message extends Record {
             attachment_ids: attachments.concat(this.attachments).map((attachment) => attachment.id),
             attachment_tokens: attachments
                 .concat(this.attachments)
-                .map((attachment) => attachment.accessToken),
+                .map((attachment) => attachment.access_token),
             body: await prettifyMessageContent(body, validMentions),
             message_id: this.id,
             partner_ids: validMentions?.partners?.map((partner) => partner.id),

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -542,7 +542,7 @@ export class Store extends BaseStore {
                 mail_post_autofollow: !isNote && thread.hasWriteAccess,
             },
             post_data: postData,
-            attachment_tokens: attachments.map((attachment) => attachment.accessToken),
+            attachment_tokens: attachments.map((attachment) => attachment.access_token),
             canned_response_ids: cannedResponseIds,
             partner_emails: recipientEmails,
             partner_additional_values: recipientAdditionalValues,

--- a/addons/mail/static/src/discuss/core/common/attachment_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/attachment_model_patch.js
@@ -10,7 +10,7 @@ patch(Attachment.prototype, {
         return super.isDeletable;
     },
     get urlRoute() {
-        if (!this.accessToken && this.thread?.model === "discuss.channel") {
+        if (!this.access_token && this.thread?.model === "discuss.channel") {
             return this.isImage
                 ? `/discuss/channel/${this.thread.id}/image/${this.id}`
                 : `/discuss/channel/${this.thread.id}/attachment/${this.id}`;


### PR DESCRIPTION
Use the same name as the python field to avoid rename and confusion.

Part of task-3605717