### PR TITLE
[FIX] portal, portal_rating: restore rating filtering

### DIFF
--- a/addons/portal/controllers/mail.py
+++ b/addons/portal/controllers/mail.py
@@ -174,6 +174,7 @@ class PortalChatter(http.Controller):
         field = model._fields['website_message_ids']
         field_domain = field.get_domain_list(model)
         domain = expression.AND([
+            self._setup_portal_message_fetch_extra_domain(kw),
             field_domain,
             [('res_id', '=', res_id), '|', ('body', '!=', ''), ('attachment_ids', '!=', False)]
         ])
@@ -192,6 +193,9 @@ class PortalChatter(http.Controller):
             'messages': Message.search(domain, limit=limit, offset=offset).portal_message_format(),
             'message_count': Message.search_count(domain)
         }
+
+    def _setup_portal_message_fetch_extra_domain(self, data):
+        return []
 
     @http.route(['/mail/update_is_internal'], type='json', auth="user", website=True)
     def portal_message_update_is_internal(self, message_id, is_internal):

--- a/addons/portal_rating/controllers/portal_chatter.py
+++ b/addons/portal_rating/controllers/portal_chatter.py
@@ -3,6 +3,7 @@
 
 from odoo import http
 from odoo.http import request
+from odoo.osv import expression
 
 from odoo.addons.portal.controllers import mail
 
@@ -44,3 +45,9 @@ class PortalChatter(mail.PortalChatter):
         result = super(PortalChatter, self).portal_message_fetch(res_model, res_id, domain=domain, limit=limit, offset=offset, **kw)
         result.update(self._portal_rating_stats(res_model, res_id, **kw))
         return result
+
+    def _setup_portal_message_fetch_extra_domain(self, data):
+        domains = [super()._setup_portal_message_fetch_extra_domain(data)]
+        if data.get('rating_value', False) is not False:
+            domains.append([('rating_value', '=', float(data['rating_value']))])
+        return expression.AND(domains)

--- a/addons/portal_rating/static/src/js/portal_chatter.js
+++ b/addons/portal_rating/static/src/js/portal_chatter.js
@@ -157,6 +157,11 @@ PortalChatter.include({
         var params = this._super.apply(this, arguments);
         if (this.options['display_rating']) {
             params['rating_include'] = true;
+
+            const ratingValue = this.get('rating_value');
+            if (ratingValue !== false) {
+                params['rating_value'] = ratingValue;
+            }
         }
         return params;
     },
@@ -377,6 +382,7 @@ PortalChatter.include({
     _onChangeRatingDomain: function () {
         var domain = [];
         if (this.get('rating_value')) {
+            // TODO dead code: remove in master
             domain = [['rating_value', '=', this.get('rating_value')]];
         }
         this._changeCurrentPage(1, domain);


### PR DESCRIPTION
Steps to reproduce:
- Go to a product page
- Enable "Discussions and rating" in the eCommerce
- Add some comments and ratings on the product
- Use the filtering tool on the left => It does not work anymore

task-4149745
