### PR TITLE
[FIX] web: display small and SVG product images correctly

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -354,8 +354,9 @@
         margin-bottom: 10px;
 
         .img {
-            max-width: $o-form-picture-size;
-            max-height: $o-form-picture-size;
+            width: $o-form-picture-size;
+            height: $o-form-picture-size;
+            object-fit: contain;
             vertical-align: top;
             border: 1px solid $o-gray-300;
         }


### PR DESCRIPTION
Problem:
If the product image size is smaller than `$o-form-picture-size` or is an SVG without intrinsic size, it uses the original image size or displays as 0px in the case of SVGs without intrinsic size. The desired behavior is for the image to always display at `$o-form-picture-size`.

Steps to reproduce:

- Add a small or SVG image without intrinsic size to a product.
- The image will not display correctly.

opw-4119433

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
