### PR TITLE
[FIX] l10n_mx: restrict account codes to coa sat

### DIFF
--- a/addons/l10n_mx/i18n/l10n_mx.pot
+++ b/addons/l10n_mx/i18n/l10n_mx.pot
@@ -15,6 +15,12 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
+
+#. module: l10n_mx
+#: code:addons/l10n_mx/models/account_account.py:0
+msgid "\t- %(name)s"
+msgstr ""
+
 #. module: l10n_mx
 #: model:ir.model.fields,field_description:l10n_mx.field_res_bank__l10n_mx_edi_code
 msgid "ABM Code"
@@ -78,6 +84,11 @@ msgid "Effectively Paid"
 msgstr ""
 
 #. module: l10n_mx
+#: code:addons/l10n_mx/models/account_account.py:0
+msgid "Go to documentation"
+msgstr ""
+
+#. module: l10n_mx
 #: model:account.tax.group,name:l10n_mx.tax_group_isr_ret_10
 msgid "ISR Retencion 10%"
 msgstr ""
@@ -125,6 +136,11 @@ msgstr ""
 #. module: l10n_mx
 #: model:ir.model.fields,field_description:l10n_mx.field_account_account_tag__nature
 msgid "Nature"
+msgstr ""
+
+#. module: l10n_mx
+#: code:addons/l10n_mx/models/account_account.py:0
+msgid "Some of your accounts do not respect the SAT code regulation.\n\n%(names_list)s"
 msgstr ""
 
 #. module: l10n_mx

--- a/addons/l10n_mx/models/account_account.py
+++ b/addons/l10n_mx/models/account_account.py
@@ -1,4 +1,13 @@
-from odoo import api, Command, models
+import re
+from odoo import _, api, Command, models
+from odoo.exceptions import RedirectWarning
+from odoo.tools import file_open
+from odoo.tools.pycompat import csv_reader
+
+with file_open('l10n_mx/data/account.group.template.csv', 'rb') as group_template_csv:
+    reader = csv_reader(group_template_csv, delimiter=',', quotechar='"')
+    SAT_GROUPS_CODES = {row[3] for row in reader}  # Getting every value from "code_prefix_start" column and removing quotes
+ACCOUNT_ID_PATTERN = re.compile(r'\.\d{1,2}[1-9]')  # A dot, two or three digits, last digit cannot be 0
 
 
 class AccountAccount(models.Model):
@@ -17,3 +26,23 @@ class AccountAccount(models.Model):
             tag_id = debit_tag.id if account.code[0] in DEBIT_CODES else credit_tag.id
             account.tag_ids = [Command.link(tag_id)]
         return accounts
+
+    @api.constrains('code', 'group_id')
+    def ensure_code_conforms_coa_sat(self):
+        # filtering accounts used in Mexican reports that do not respect the regulation of the SAT (see documentation for more explanation)
+        # six first characters correspond to the group provided, a list is provided by the SAT
+        # last part is up to the user but should match ACCOUNT_ID_PATTERN which is detailed in the header
+        incorrect_accounts = self.filtered(
+            lambda a: a.group_id and a.account_type != 'equity_unaffected' and a.company_id.country_code == 'MX'
+            and (a.code[:6] not in SAT_GROUPS_CODES or not ACCOUNT_ID_PATTERN.fullmatch(a.code[6:]))
+        )
+        if incorrect_accounts:
+            account_names = '\n'.join(_('\t- %(name)s', name=account.name) for account in incorrect_accounts)
+            raise RedirectWarning(
+                _("Some of your accounts do not respect the SAT code regulation.\n\n%(account_names)s", account_names=account_names),
+                {
+                    'type': 'ir.actions.act_url',
+                    'url': 'https://www.odoo.com/documentation/16.0/applications/finance/fiscal_localizations/mexico.html#chart-of-accounts'
+                },
+                _("Go to documentation")
+            )


### PR DESCRIPTION
### Steps to reproduce the issue:

1. Activate the Odoo Mexican Localization Reports module
2. In a Mexican company, create a new Account with 1 as code
3. Go to Trial Balance and download COA SAT (XML)
5. In the General Settings with developer mode active, Download XSD files
6. Go to Trial Balance and download COA SAT (XML) again
7. You get a UserError with an unclear message

### Explanation:

The Mexican Chart of Accounts have clear rules regarding `account.account.code`. The only way to verify those accounts is through the XSD files check, but they are not automatically downloaded and the error received with those files downloaded is not user friendly.

### Fix reasoning:

Instead of regulating the code when downloading the XML, we will do so on creation or update of `account.account`.
The SAT codes are storred in an array to avoid fetch requests on every module update or installation.

opw-4103681