### PR TITLE
Fix datetime change

### DIFF
--- a/addons/web/static/src/core/datetime/datetime_hook.js
+++ b/addons/web/static/src/core/datetime/datetime_hook.js
@@ -18,13 +18,14 @@ export function useDateTimePicker(hookParams) {
         });
     }
     const inputRefs = [useRef("start-date"), useRef("end-date")];
+    const getInputs = () => inputRefs.map((ref) => ref?.el);
     const { computeBasePickerProps, state, open, focusIfNeeded, enable } = datetimePicker.create(
         hookParams,
-        () => inputRefs.map((ref) => ref?.el),
+        getInputs,
         usePopover
     );
     onWillRender(computeBasePickerProps);
-    useEffect(enable);
+    useEffect(enable, getInputs);
 
     // Note: this `onPatched` callback must be called after the `useEffect` since
     // the effect may change input values that will be selected by the patch callback.

--- a/addons/web/static/src/core/datetime/datetimepicker_service.js
+++ b/addons/web/static/src/core/datetime/datetimepicker_service.js
@@ -42,6 +42,8 @@ const formatters = {
     datetime: formatDateTime,
 };
 
+const listenedElements = new WeakSet();
+
 const parsers = {
     date: parseDate,
     datetime: parseDateTime,
@@ -430,16 +432,6 @@ export const datetimePickerService = {
                 let restoreTargetMargin = null;
                 let shouldFocus = false;
 
-                /**
-                 * @param {HTMLElement} el
-                 * @param {string} type
-                 * @param {(ev: Event) => any} listener
-                 */
-                const addListener = (el, type, listener) => {
-                    el.addEventListener(type, listener);
-                    return () => el.removeEventListener(type, listener);
-                };
-
                 return {
                     state: pickerProps,
                     open: openPicker,
@@ -451,39 +443,36 @@ export const datetimePickerService = {
                     },
                     enable() {
                         let editableInputs = 0;
-                        const cleanups = [];
                         for (const [el, value] of zip(
                             getInputs(),
                             ensureArray(pickerProps.value),
                             true
                         )) {
                             updateInput(el, value);
-                            if (el && !el.disabled && !el.readOnly) {
-                                cleanups.push(addListener(el, "change", onInputChange));
-                                cleanups.push(addListener(el, "click", onInputClick));
-                                cleanups.push(addListener(el, "focus", onInputFocus));
-                                cleanups.push(addListener(el, "keydown", onInputKeydown));
+                            if (el && !el.disabled && !el.readOnly && !listenedElements.has(el)) {
+                                listenedElements.add(el);
+                                el.addEventListener("change", onInputChange);
+                                el.addEventListener("click", onInputClick);
+                                el.addEventListener("focus", onInputFocus);
+                                el.addEventListener("keydown", onInputKeydown);
                                 editableInputs++;
                             }
                         }
                         const calendarIconGroupEl = getInput(0)?.parentElement.querySelector(
                             ".input-group-text .fa-calendar"
                         )?.parentElement;
-                        if (calendarIconGroupEl) {
+                        if (calendarIconGroupEl && !listenedElements.has(calendarIconGroupEl)) {
+                            listenedElements.add(calendarIconGroupEl);
                             // TODO: Remove this line and the `pe-none` class
                             // from templates in master
                             calendarIconGroupEl.classList.remove("pe-none");
                             calendarIconGroupEl.classList.add("cursor-pointer");
-                            cleanups.push(
-                                addListener(calendarIconGroupEl, "click", () => {
-                                    openPicker(0);
-                                })
-                            );
+                            calendarIconGroupEl.addEventListener("click", () => openPicker(0));
                         }
                         if (!editableInputs && popover.isOpen) {
                             saveAndClose();
                         }
-                        return () => cleanups.forEach((cleanup) => cleanup());
+                        return () => {};
                     },
                     get isOpen() {
                         return popover.isOpen;


### PR DESCRIPTION
Before this commit, event listeners set on inputs by the datetime picker
service would be removed in the callback of the `useEffect` hook,
meaning that these listeners could be unregistered before the actual
elements would be removed.

This is an issue in the specific case where the deletion of the element
occurs before the "change" event has been dispatched and after the
removal of the listeners. The thing is: the removal of the element also
triggers the "change" event (if it hasn't been triggered before), and
with the listener gone this means that the value is lost.

This commit deletes the removal of event listeners attached on inputs
by the hook. This has been done since using the datetime picker service
implies that the inputs affected by the feature will never be in an
interactive state without the datetime picker actively listening on
them.

Although a test case setup is easy to reproduce, this behavior is
unfortunately impossible to reproduce programmatically as the "change"
event dispatched by removing an element only works when a trusted
"input" event was triggered to change its value (setting the internal
browser "changed" value of the input).

Task [4104407](https://www.odoo.com/odoo/all-tasks/4104407)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
