### PR TITLE
[IMP] account: Account unmerge tool

### DIFF
--- a/addons/account/views/account_account_views.xml
+++ b/addons/account/views/account_account_views.xml
@@ -195,5 +195,17 @@ if records:
     action = records.action_merge()
             </field>
         </record>
+        <record model="ir.actions.server" id="action_unmerge_accounts">
+            <field name="name">Unmerge account</field>
+            <field name="model_id" ref="model_account_account"/>
+            <field name="groups_id" eval="[(4, ref('account.group_account_manager'))]"/>
+            <field name="binding_model_id" ref="account.model_account_account" />
+            <field name="binding_view_types">form,tree</field>
+            <field name="state">code</field>
+            <field name="code">
+if record:
+    action = record.action_unmerge()
+            </field>
+        </record>
     </data>
 </odoo>


### PR DESCRIPTION
This lets you un-merge accounts that belong to multiple companies, e.g. those created using the merge tool.

Everything in the account configuration should be un-merged correctly. However, the account's chatter cannot be un-merged. As such, we put a message in the newly-created accounts that the user should refer to the old account for tracking values.

taskid: 4149795