### PR TITLE
[FIX] web: emojis not loading in different lang

### DIFF
--- a/addons/mail/static/tests/emoji/emoji.test.js
+++ b/addons/mail/static/tests/emoji/emoji.test.js
@@ -1,3 +1,5 @@
+import { patchTranslations } from "@web/../tests/web_test_helpers";
+
 import {
     click,
     contains,
@@ -14,6 +16,19 @@ import { EMOJI_PER_ROW } from "@web/core/emoji_picker/emoji_picker";
 
 describe.current.tags("desktop");
 defineMailModels();
+
+test("emoji picker works well with translation with double quotes", async () => {
+    patchTranslations({
+        "Japanese “here” button": `Bouton "ici" japonais`,
+    });
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "" });
+    await start();
+    await openDiscuss(channelId);
+    await click("button[aria-label='Emojis']");
+    await insertText("input[placeholder='Search for an emoji']", "ici");
+    await contains(`.o-Emoji[title='Bouton "ici" japonais']`);
+});
 
 test("search emoji from keywords", async () => {
     const pyEnv = await startServer();

--- a/addons/web/static/src/core/emoji_picker/emoji_data.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_data.js
@@ -53,7 +53,10 @@
 // Since JSON grammar is way simpler than JavaScript's grammar, it is actually
 // faster to parse the data as a JSON object than as a JavaScript object.
 
-import { _t } from "@web/core/l10n/translation";
+import { _t as realT } from "@web/core/l10n/translation";
+
+// replace all double quotes with escaped double quotes
+const _t = (str) => realT(str).replace(/"/g, '\\"')
 
 const _getCategories = () => `[
     {


### PR DESCRIPTION
BUG: emojis were not loading in some non-English languages

The issue was that the emojis were not escaped when translated, and in some languages, the translated emojis contained double quotes inside, which was originally curly quotes.

FIX: escape the translated emoji names to avoid the double quotes breaking the JSON parsing.

task-4139904
task-4143513


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
