### PR TITLE
[FIX] website_sale: ecommerce categories margin behavior on hover

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -97,8 +97,15 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, cartHandlerM
         });
 
         // This allows conditional styling for the filmstrip
-        if (isBrowserFirefox() || hasTouch()) {
-            this.el.querySelector('.o_wsale_filmstip_container')?.classList.add('o_wsale_filmstip_fancy_disabled');
+        const filmstripContainer = this.el.querySelector('.o_wsale_filmstip_container');
+        const filmstripContainerWidth = filmstripContainer
+            ? filmstripContainer.getBoundingClientRect().width : 0;
+        const filmstripWrapper = this.el.querySelector('.o_wsale_filmstip_wrapper');
+        const filmstripWrapperWidth = filmstripWrapper
+            ? filmstripWrapper.getBoundingClientRect().width : 0;
+        const isFilmstripScrollable = filmstripWrapperWidth < filmstripContainerWidth
+        if (isBrowserFirefox() || hasTouch() || isFilmstripScrollable) {
+            filmstripContainer?.classList.add('o_wsale_filmstip_fancy_disabled');
         }
 
         this.getRedirectOption();


### PR DESCRIPTION
**Steps:**
- Create a few products and e-commerce categories
- Go to the shop page
- Hover on the eCommerce categories created
- A bit displacement is seen in the margin

**Issue:**
- The margin is given to adjust the height of the scrollbar on hover but it's applied even when scrollbar is not present (when handful of categories are there) resulting in a displacement.

**Fix:**
- Disabling the margin on hover when there are less categories that is when scrollbar is not present

**Affected version:** 17.0~master
opw-4088697