### PR TITLE
[16.0][IMP] mrp: getBomData extend existing context

### DIFF
--- a/addons/mrp/static/src/components/bom_overview/mrp_bom_overview.js
+++ b/addons/mrp/static/src/components/bom_overview/mrp_bom_overview.js
@@ -10,6 +10,7 @@ const { Component, EventBus, onWillStart, useSubEnv, useState } = owl;
 export class BomOverviewComponent extends Component {
     setup() {
         this.orm = useService("orm");
+        this.context = this.props.action.context;
         this.actionService = useService("action");
 
         this.variants = [];
@@ -66,7 +67,10 @@ export class BomOverviewComponent extends Component {
             this.state.bomQuantity,
             this.state.currentVariantId,
         ];
-        const context = this.state.currentWarehouse ? { warehouse: this.state.currentWarehouse.id } : {};
+        const context = { ...this.context};
+        if (this.state.currentWarehouse) {
+            context.warehouse = this.state.currentWarehouse.id;
+        }
         const bomData = await this.orm.call(
             "report.mrp.report_bom_structure",
             "get_html",

--- a/doc/cla/corporate/forgeflow.md
+++ b/doc/cla/corporate/forgeflow.md
@@ -21,3 +21,4 @@ Hector Villarreal hector.villarreal@forgeflow.com https://github.com/HviorForgeF
 Bernat Puig bernat.puig@forgeflow.com https://github.com/BernatPForgeFlow
 Joan Sisquella joan.sisquella@forgeflow.com https://github.com/JoanSForgeFlow
 Laura Cazorla laura.cazorla@forgeflow.com https://github.com/LauraCForgeFlow
+Arnau Cruz arnau.cruz@forgeflow.com https://github.com/ArnauCForgeFlow


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Updated the code to make sure that the context object includes the current context. This change makes it easier to use all the relevant context-specific info in the process.

Current behavior before PR:

Currently, it only adds the warehouse information to the context variable.

Desired behavior after PR is merged:

The context object will include the warehouse information and the current context, ensuring that all necessary context data is properly included when making the call.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
