### PR TITLE
[FIX] account_edi_ubl_cii: use ubl namespace for partner vals

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from odoo import models, _
+from odoo.addons.account_edi_ubl_cii.models.account_edi_xml_ubl_20 import UBL_NAMESPACES
 
 from stdnum.no import mva
 
@@ -433,8 +434,7 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
     def _import_retrieve_partner_vals(self, tree, role):
         # EXTENDS account.edi.xml.ubl_20
         partner_vals = super()._import_retrieve_partner_vals(tree, role)
-        nsmap = {k: v for k, v in tree.nsmap.items() if k is not None}
-        endpoint_node = tree.find(f'.//cac:Accounting{role}Party/cac:Party/cbc:EndpointID', nsmap)
+        endpoint_node = tree.find(f'.//cac:Accounting{role}Party/cac:Party/cbc:EndpointID', UBL_NAMESPACES)
         if endpoint_node is not None:
             peppol_eas = endpoint_node.attrib.get('schemeID')
             peppol_endpoint = endpoint_node.text


### PR DESCRIPTION
When importing a UBL file, we get an error `SyntaxError: prefix 'cac'
not found in prefix map`
When importing a UBL file Odoo expects the UBL specific namespaces to be
in the root element of the file. This is not always the case as these
namespaces could exist in every element in the file. When a file is
formatted this way, Odoo cannot extract the necessary data from it
because it is missing the necessary namespaces.
We fix it by using the ubl namespace as nsmap (see
https://github.com/odoo-dev/odoo/commit/1e24b151c6ad0023769b5a561690cb62bcda1d8a)

opw-4142421
