### PR TITLE
[FIX] base: allow importing translation files

### DIFF
--- a/odoo/addons/base/wizard/base_import_language_views.xml
+++ b/odoo/addons/base/wizard/base_import_language_views.xml
@@ -11,6 +11,7 @@
                         <field name="name" placeholder="e.g. English"/>
                         <field name="code" string="Code" placeholder="e.g. en_US"/>
                         <field name="data" filename="filename" options="{'accepted_file_extensions': '.csv,.po'}"/>
+                        <field name="filename" invisible="1"/> <!-- The name is needed in the BinaryField component used to upload the file -->
                         <field name="overwrite" groups="base.group_no_one"/>
                     </group>
                     <footer>


### PR DESCRIPTION
Same missing required invisible field issue as mentioned in odoo/odoo#178175

opw-4139872

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
