### PR TITLE
[IMP] pos*: remove start category feature from point_of_sale

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -107,8 +107,6 @@ class PosConfig(models.Model):
     iface_print_skip_screen = fields.Boolean(string='Skip Preview Screen', default=True,
         help='The receipt screen will be skipped if the receipt can be printed automatically.')
     iface_tax_included = fields.Selection([('subtotal', 'Tax-Excluded Price'), ('total', 'Tax-Included Price')], string="Tax Display", default='total', required=True)
-    iface_start_categ_id = fields.Many2one('pos.category', string='Initial Category',
-        help='The point of sale will display this product category by default. If no category is specified, all available products will be shown.')
     iface_available_categ_ids = fields.Many2many('pos.category', string='Available PoS Product Categories',
         help='The point of sale will only display products which are within one of the selected category trees. If no category is specified, all available products will be shown')
     customer_display_type = fields.Selection(selection=lambda self: self._get_customer_display_types(), string='Customer Facing Display', help="Show checkout to customers.", default='local')
@@ -158,7 +156,6 @@ class PosConfig(models.Model):
     default_bill_ids = fields.Many2many('pos.bill', string="Coins/Bills")
     use_pricelist = fields.Boolean("Use a pricelist.")
     tax_regime_selection = fields.Boolean("Tax Regime Selection value")
-    start_category = fields.Boolean("Start Category", default=False)
     limit_categories = fields.Boolean("Restrict Categories")
     module_pos_restaurant = fields.Boolean("Is a Bar/Restaurant")
     module_pos_discount = fields.Boolean("Global Discounts")
@@ -333,13 +330,6 @@ class PosConfig(models.Model):
                                         " the Accounting application."))
             if config.invoice_journal_id.currency_id and config.invoice_journal_id.currency_id != config.currency_id:
                 raise ValidationError(_("The invoice journal must be in the same currency as the Sales Journal or the company currency if that is not set."))
-
-    @api.constrains('iface_start_categ_id', 'iface_available_categ_ids')
-    def _check_start_categ(self):
-        for config in self:
-            allowed_categ_ids = config.iface_available_categ_ids or self.env['pos.category'].search([])
-            if config.iface_start_categ_id and config.iface_start_categ_id not in allowed_categ_ids:
-                raise ValidationError(_("Start category should belong in the available categories."))
 
     def _check_payment_method_ids(self):
         self.ensure_one()

--- a/addons/point_of_sale/models/res_config_settings.py
+++ b/addons/point_of_sale/models/res_config_settings.py
@@ -73,7 +73,6 @@ class ResConfigSettings(models.TransientModel):
     pos_iface_print_skip_screen = fields.Boolean(related='pos_config_id.iface_print_skip_screen', readonly=False)
     pos_iface_print_via_proxy = fields.Boolean(string='Print via Proxy', compute='_compute_pos_iface_print_via_proxy', readonly=False, store=True)
     pos_iface_scan_via_proxy = fields.Boolean(string='Scan via Proxy', compute='_compute_pos_iface_scan_via_proxy', readonly=False, store=True)
-    pos_iface_start_categ_id = fields.Many2one('pos.category', string='Initial Category', compute='_compute_pos_iface_start_categ_id', readonly=False, store=True)
     pos_iface_tax_included = fields.Selection(related='pos_config_id.iface_tax_included', readonly=False)
     pos_iface_tipproduct = fields.Boolean(related='pos_config_id.iface_tipproduct', readonly=False)
     pos_invoice_journal_id = fields.Many2one(related='pos_config_id.invoice_journal_id', readonly=False)
@@ -99,7 +98,6 @@ class ResConfigSettings(models.TransientModel):
     pos_sequence_id = fields.Many2one(related='pos_config_id.sequence_id')
     pos_set_maximum_difference = fields.Boolean(related='pos_config_id.set_maximum_difference', readonly=False)
     pos_ship_later = fields.Boolean(related='pos_config_id.ship_later', readonly=False)
-    pos_start_category = fields.Boolean(related='pos_config_id.start_category', readonly=False)
     pos_tax_regime_selection = fields.Boolean(related='pos_config_id.tax_regime_selection', readonly=False)
     pos_tip_product_id = fields.Many2one('product.product', string='Tip Product', compute='_compute_pos_tip_product_id', readonly=False, store=True)
     pos_use_pricelist = fields.Boolean(related='pos_config_id.use_pricelist', readonly=False)
@@ -211,14 +209,6 @@ class ResConfigSettings(models.TransientModel):
                 res_config.pos_iface_available_categ_ids = False
             else:
                 res_config.pos_iface_available_categ_ids = res_config.pos_config_id.iface_available_categ_ids
-
-    @api.depends('pos_start_category', 'pos_config_id')
-    def _compute_pos_iface_start_categ_id(self):
-        for res_config in self:
-            if not res_config.pos_start_category:
-                res_config.pos_iface_start_categ_id = False
-            else:
-                res_config.pos_iface_start_categ_id = res_config.pos_config_id.iface_start_categ_id
 
     @api.depends('pos_iface_available_categ_ids')
     def _compute_pos_selectable_categ_ids(self):

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -57,10 +57,6 @@ export class ProductScreen extends Component {
         onMounted(() => {
             this.pos.openCashControl();
 
-            if (this.pos.config.iface_start_categ_id) {
-                this.pos.setSelectedCategory(this.pos.config.iface_start_categ_id.id);
-            }
-
             // Call `reset` when the `onMounted` callback in `numberBuffer.use` is done.
             // We don't do this in the `mounted` lifecycle method because it is called before
             // the callbacks in `onMounted` hook.

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -79,7 +79,7 @@ export class ReceiptScreen extends Component {
         this.currentOrder.uiState.screen_data.value = "";
         this.currentOrder.uiState.locked = true;
         this._addNewOrder();
-        this.pos.resetProductScreenSearch();
+        this.pos.searchProductWord = "";
         const { name, props } = this.nextScreen;
         this.pos.showScreen(name, props);
     }

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1715,12 +1715,6 @@ export class PosStore extends Reactive {
     getDisplayDeviceIP() {
         return this.config.proxy_ip;
     }
-
-    resetProductScreenSearch() {
-        this.searchProductWord = "";
-        const { start_category, iface_start_categ_id } = this.config;
-        this.setSelectedCategory((start_category && iface_start_categ_id?.[0]) || 0);
-    }
 }
 
 PosStore.prototype.electronic_payment_interfaces = {};

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -139,12 +139,6 @@
                             </setting>
                         </block>
                         <block id="product_and_category_block" title="Product &amp; PoS categories">
-                            <setting help="Start selling from a default product PoS category">
-                                <field name="pos_start_category"/>
-                                <div class="content-group mt16" invisible="not pos_start_category">
-                                    <field name="pos_iface_start_categ_id" domain="[('id', 'in', pos_selectable_categ_ids)]"/>
-                                </div>
-                            </setting>
                             <setting help="Pick which product PoS categories are available">
                                 <field name="pos_limit_categories" readonly="pos_has_active_session"/>
                                 <div class="content-group mt16" invisible="not pos_limit_categories">

--- a/addons/pos_event/tests/test_frontend.py
+++ b/addons/pos_event/tests/test_frontend.py
@@ -64,10 +64,6 @@ class TestUi(TestPointOfSaleHttpCommon):
             ]
         })
 
-        cls.main_pos_config.write({
-            'iface_start_categ_id': cls.event_category.id,
-        })
-
     def test_selling_event_in_pos(self):
         self.pos_user.write({
             'groups_id': [

--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -129,9 +129,6 @@ patch(PosStore.prototype, {
                 // We check that it's in ReceiptScreen because we want to keep the order if it's in a tipping state
                 this.removeOrder(order);
             }
-            this.setSelectedCategory(
-                (this.config.start_category && this.config.iface_start_categ_id?.[0]) || 0
-            );
             this.showScreen("FloorScreen", { floor: table?.floor });
         }
     },

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -41,7 +41,6 @@ class TestFrontend(TestPointOfSaleHttpCommon):
             'module_pos_restaurant': True,
             'iface_splitbill': True,
             'iface_printbill': True,
-            'start_category': True,
             'is_order_printer': True,
             'printer_ids': [(4, printer.id)],
             'iface_tipproduct': False,

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -19,7 +19,6 @@ import {
     getTaxesAfterFiscalPosition,
     getTaxesValues,
 } from "@point_of_sale/app/models/utils/tax_utils";
-import { categorySorter } from "./utils";
 
 export class SelfOrder extends Reactive {
     constructor(...args) {
@@ -185,9 +184,8 @@ export class SelfOrder extends Reactive {
         now = now.hour + now.minute / 60;
         const prodByCategIds = this.productByCategIds;
         const availableCategories = this.productCategories
-            .sort((a, b) => a.sequence - b.sequence)
             .filter((c) => prodByCategIds[c.id])
-            .sort((a, b) => categorySorter(a, b, this.config.iface_start_categ_id));
+            .sort((a, b) => a.sequence - b.sequence);
 
         this.categoryList = new Set(availableCategories);
         this.availableCategories = availableCategories.filter((c) => {

--- a/addons/pos_self_order/static/src/app/utils.js
+++ b/addons/pos_self_order/static/src/app/utils.js
@@ -1,16 +1,3 @@
-export const categorySorter = (a, b, start_categ_id) => {
-    if (a.id === start_categ_id && b.id !== start_categ_id) {
-        return -1; // 'a' should come before 'b'
-    }
-    if (a.id !== start_categ_id && b.id === start_categ_id) {
-        return 1; // 'b' should come before 'a'
-    }
-    if (a.sequence !== b.sequence) {
-        return a.sequence - b.sequence; // sort by sequence
-    }
-    return a.id - b.id; // sort by id if sequences are the same
-};
-
 export const attributeFormatter = (attrById, values, customValues = []) => {
     if (!values) {
         return [];


### PR DESCRIPTION
pos*: point_of_sale, pos_restuarant, pos_self_order

In this commit:
==============
The "Start Category" feature has been removed from the Point of Sale.
This feature is now redundant due to the existing "Restrict Category" feature,
which provides similar functionality by limiting the available categories in POS

Details:
- Removed the "Start Category" feature and its associated code.
- The "Restrict Category" feature now effectively replaces the "Start Category"
  by limiting the selectable categories in POS, making the latter unnecessary.

task-4147445

Related Upgrade PR: https://github.com/odoo/upgrade/pull/6449