### PR TITLE
[REF] web_tour: macroEngine only in tour_automatic

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_automatic.js
@@ -1,13 +1,17 @@
 import { tourState } from "./tour_state";
 import { config as transitionConfig } from "@web/core/transition";
 import { TourStepAutomatic } from "./tour_step_automatic";
+import { MacroEngine } from "@web/core/macro";
 
 export class TourAutomatic {
     mode = "auto";
-    constructor(data, macroEngine) {
+    constructor(data) {
         Object.assign(this, data);
         this.steps = this.steps.map((step, index) => new TourStepAutomatic(step, this, index));
-        this.macroEngine = macroEngine;
+        this.macroEngine = new MacroEngine({
+            target: document,
+            defaultCheckDelay: 500,
+        });
         this.stepDelay = +tourState.get(this.name, "stepDelay") || 0;
     }
 
@@ -37,6 +41,7 @@ export class TourAutomatic {
 
         pointer.start();
         transitionConfig.disabled = true;
+        //Activate macro in exclusive mode (only one macro per MacroEngine)
         this.macroEngine.activate(macro, true);
     }
 }

--- a/addons/web_tour/static/src/tour_service/tour_service.js
+++ b/addons/web_tour/static/src/tour_service/tour_service.js
@@ -3,7 +3,6 @@
 import { EventBus, markup, whenReady, reactive, validate } from "@odoo/owl";
 import { browser } from "@web/core/browser/browser";
 import { _t } from "@web/core/l10n/translation";
-import { MacroEngine } from "@web/core/macro";
 import { registry } from "@web/core/registry";
 import { session } from "@web/session";
 import { TourPointer } from "../tour_pointer/tour_pointer";
@@ -127,7 +126,6 @@ export const tourService = {
         });
 
         const bus = new EventBus();
-        const macroEngine = new MacroEngine({ target: document });
 
         const pointers = reactive({});
         /** @type {Set<string>} */
@@ -265,7 +263,7 @@ export const tourService = {
 
             if (!willUnload) {
                 if (options.mode === "auto") {
-                    new TourAutomatic(tour, macroEngine).start(pointer, () => {
+                    new TourAutomatic(tour).start(pointer, () => {
                         pointer.stop();
                         endTour(tour);
                     });
@@ -292,7 +290,7 @@ export const tourService = {
                 bounce: !(mode === "auto" && keepWatchBrowser),
             });
             if (mode === "auto") {
-                new TourAutomatic(tour, macroEngine).start(pointer, () => {
+                new TourAutomatic(tour).start(pointer, () => {
                     pointer.stop();
                     endTour(tour);
                 });

--- a/addons/web_tour/static/tests/tour_service.test.js
+++ b/addons/web_tour/static/tests/tour_service.test.js
@@ -254,7 +254,7 @@ test("next step with new anchor at same position", async () => {
 
 test("a failing tour logs the step that failed in run", async () => {
     patchWithCleanup(browser.console, {
-        log: (s) => expect.step(`log: ${s}`),
+        groupCollapsed: (s) => expect.step(`log: ${s}`),
         warn: (s) => {},
         error: (s) => expect.step(`error: ${s}`),
     });
@@ -364,7 +364,7 @@ test("a failing tour with disabled element", async () => {
 test("a failing tour logs the step that failed", async () => {
     patchWithCleanup(browser.console, {
         dir: (s) => expect.step(`runbot: ${s.replace(/[\s-]*/g, "")}`),
-        log: (s) => expect.step(`log: ${s}`),
+        groupCollapsed: (s) => expect.step(`log: ${s}`),
         warn: (s) => expect.step(`warn: ${s.replace(/[\s-]*/gi, "")}`),
         error: (s) => expect.step(`error: ${s}`),
     });
@@ -1047,10 +1047,11 @@ test("manual tour with inactive steps", async () => {
 
 test("automatic tour with alternative trigger", async () => {
     patchWithCleanup(browser.console, {
+        groupCollapsed: (s) => {
+            expect.step("on step");
+        },
         log: (s) => {
-            if (s.includes("→ Step")) {
-                expect.step("on step");
-            } else if (s.toLowerCase().includes("tour tour_des_flandres succeeded")) {
+            if (s.toLowerCase().includes("tour tour_des_flandres succeeded")) {
                 expect.step("succeeded");
             }
         },


### PR DESCRIPTION
In this commit, we move macroEngine from tour_service to put it in tour_automatic. Indeed, only tour_automatic is concerned by the macroEngine. What's more, it is useless to create a single macroEngine for the tours because, in any case, they are launched one by one (in exclusive mode).
We take advantage of this PR and this refactoring to improve the console log in debugMode (to have more information on the current step in the debugger)