### PR TITLE
[IMP] base: add expiration date on API keys

### DIFF
--- a/addons/auth_totp/controllers/home.py
+++ b/addons/auth_totp/controllers/home.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import re
 
+from datetime import datetime, timedelta
+
 from odoo import http, _
 from odoo.exceptions import AccessDenied
 from odoo.http import request
@@ -58,7 +60,11 @@ class Home(web_home.Home):
                     if request.geoip.city.name:
                         name += f" ({request.geoip.city.name}, {request.geoip.country_name})"
 
-                    key = request.env['auth_totp.device']._generate("browser", name)
+                    key = request.env['auth_totp.device'].sudo()._generate(
+                        "browser",
+                        name,
+                        datetime.now() + timedelta(seconds=TRUSTED_DEVICE_AGE)
+                    )
                     response.set_cookie(
                         key=TRUSTED_DEVICE_COOKIE,
                         value=key,

--- a/addons/auth_totp/models/auth_totp.py
+++ b/addons/auth_totp/models/auth_totp.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-from odoo import api, models
-from odoo.addons.auth_totp.controllers.home import TRUSTED_DEVICE_AGE
+from odoo import models
 
 import logging
 _logger = logging.getLogger(__name__)
@@ -21,11 +20,3 @@ class AuthTotpDevice(models.Model):
         """Return True if device key matches given `scope` for user ID `uid`"""
         assert uid, "uid is required"
         return self._check_credentials(scope=scope, key=key) == uid
-
-    @api.autovacuum
-    def _gc_device(self):
-        self._cr.execute("""
-            DELETE FROM auth_totp_device
-            WHERE create_date < (NOW() AT TIME ZONE 'UTC' - INTERVAL '%s SECONDS')
-        """, [TRUSTED_DEVICE_AGE])
-        _logger.info("GC'd %d totp devices entries", self._cr.rowcount)

--- a/addons/auth_totp_mail/models/auth_totp_device.py
+++ b/addons/auth_totp_mail/models/auth_totp_device.py
@@ -22,12 +22,12 @@ class AuthTotpDevice(models.Model):
 
         return super().unlink()
 
-    def _generate(self, scope, name):
+    def _generate(self, scope, name, expiration_date):
         """ Notify users when trusted devices are added onto their account.
         We override this method instead of 'create' as those records are inserted directly into the
         database using raw SQL. """
 
-        res = super()._generate(scope, name)
+        res = super()._generate(scope, name, expiration_date)
 
         self.env.user._notify_security_setting_update(
             _("Security Update: Device Added"),

--- a/addons/auth_totp_mail/tests/test_notify_security_update_totp.py
+++ b/addons/auth_totp_mail/tests/test_notify_security_update_totp.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import datetime, timedelta
+
+from odoo.addons.auth_totp.controllers.home import TRUSTED_DEVICE_AGE
 from odoo.addons.mail.tests.test_res_users import TestNotifySecurityUpdate
 from odoo.tests import users
 
@@ -28,7 +31,11 @@ class TestNotifySecurityUpdateTotp(TestNotifySecurityUpdate):
         """ Make sure we notify the user when TOTP trusted devices are added/removed on his account. """
         recipients = [self.env.user.email_formatted]
         with self.mock_mail_gateway():
-            self.env['auth_totp.device']._generate('trusted_device_chrome', 'Chrome on Windows')
+            self.env['auth_totp.device'].sudo()._generate(
+                'trusted_device_chrome',
+                'Chrome on Windows',
+                datetime.now() + timedelta(seconds=TRUSTED_DEVICE_AGE)
+            )
 
         self.assertMailMailWEmails(recipients, 'outgoing', fields_values={
             'subject': 'Security Update: Device Added',
@@ -36,7 +43,11 @@ class TestNotifySecurityUpdateTotp(TestNotifySecurityUpdate):
 
         # generating a key outside of the 'auth_totp.device' model should however not notify
         with self.mock_mail_gateway():
-            self.env['res.users.apikeys']._generate('new_api_key', 'New Key')
+            self.env['res.users.apikeys']._generate(
+                'new_api_key',
+                'New Key',
+                datetime.now() + timedelta(days=1)
+            )
         self.assertNotSentEmail(recipients)
 
         # now remove the key using the user's relationship

--- a/addons/mail_plugin/controllers/authenticate.py
+++ b/addons/mail_plugin/controllers/authenticate.py
@@ -73,7 +73,11 @@ class Authenticate(http.Controller):
             return {"error": "Invalid code"}
         request.update_env(user=auth_message['uid'])
         scope = 'odoo.plugin.' + auth_message.get('scope', '')
-        api_key = request.env['res.users.apikeys']._generate(scope, auth_message['name'])
+        api_key = request.env['res.users.apikeys']._generate(
+            scope,
+            auth_message['name'],
+            datetime.datetime.now() + datetime.timedelta(days=1)
+        )
         return {'access_token': api_key}
 
     def _get_auth_code_data(self, auth_code):

--- a/addons/portal/tests/test_portal.py
+++ b/addons/portal/tests/test_portal.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta
+
 from odoo import Command
 from odoo.http import Request
 from odoo.tests.common import HttpCase, tagged
@@ -15,7 +17,11 @@ class TestUsersHttp(HttpCase):
             'password': login,
             'groups_id': [Command.set([self.env.ref('base.group_portal').id])],
         })
-        self.env['res.users.apikeys'].with_user(portal_user)._generate(None, 'Portal API Key')
+        self.env['res.users.apikeys'].with_user(portal_user)._generate(
+            None,
+            'Portal API Key',
+            datetime.now() + timedelta(days=1)
+        )
         self.assertTrue(portal_user.api_key_ids)
 
         # Request the deactivation of the portal account as portal through the route meant for this purpose

--- a/odoo/addons/base/security/base_groups.xml
+++ b/odoo/addons/base/security/base_groups.xml
@@ -24,6 +24,7 @@
 
         <record model="res.groups" id="group_user">
             <field name="name">Internal User</field>
+            <field name="api_key_duration">90.0</field>
         </record>
 
         <record id="default_user" model="res.users">

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -75,6 +75,7 @@
                         <field name="category_id"/>
                         <field name="name"/>
                         <field name="share"/>
+                        <field name="api_key_duration" groups="base.group_no_one"/>
                     </group>
                     <notebook>
                         <page string="Users" name="users">
@@ -371,6 +372,14 @@
                         and complete, <strong>it will be the only way to
                         identify the key once created</strong>.
                     </p>
+                    <h3 class="fw-bold">
+                        Give a duration for the key's validity
+                    </h3>
+                    <field name="duration"/>
+                    <field name="expiration_date" invisible="duration != '-1'"/>
+                    <p>
+                        The key will be deleted once this period has elapsed.
+                    </p>
                     <footer>
                         <button name="make_key" type="object" string="Generate key" class="btn-primary" data-hotkey="q"/>
                         <button special="cancel" data-hotkey="x" string="Cancel" class="btn-secondary"/>
@@ -471,6 +480,7 @@
                                             <field name="name"/>
                                             <field name="scope"/>
                                             <field name="create_date"/>
+                                            <field name="expiration_date"/>
                                             <button type="object" name="remove"
                                                     string="Delete API key." icon="fa-trash"/>
                                         </list>


### PR DESCRIPTION
From a security point of view, API keys must have an expiration date
(only administrators can create persistent keys).

The expiration date of an API key is determined when it is created
and cannot be changed afterwards.

The maximum duration (a number of days) of an API key depends
on the privileges of the user creating the key.
This duration is determined according to the the groups
to which the user belongs.
Each group contains a maximum duration for api keys
(administrator can change this).

An API key whose expiration date has passed will be unusable
and will be deleted during the next garbage collector.

task-4143574