### PR TITLE
[FIX] website_slides: missing action on go to backend button

### DIFF
--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -631,7 +631,7 @@
             </t>
             <span t-if="channel.can_publish" class="d-none d-md-flex">
                 <a t-if="slide.slide_category == 'article'" class="mx-2 o_text_link text-primary o_not_editable" target="_blank" t-attf-href="/slides/slide/#{slug(slide)}?enable_editor=1" title="Edit"><span class="fa fa-pencil"/></a>
-                <a t-else="" class="mx-2 o_text_link text-primary o_not_editable" target="_blank" t-attf-href="/odoo/action-{{slide_action}}/{{slide.id}}" title="Edit in backend"><span class="fa fa-pencil"/></a>
+                <a t-else="" class="mx-2 o_text_link text-primary o_not_editable" target="_blank" t-attf-href="/odoo/slide.slide/{{slide.id}}" title="Edit in backend"><span class="fa fa-pencil"/></a>
                 <a href="#" t-att-data-slide-id="slide.id" class="o_text_link text-danger mx-2 o_wslides_js_slide_archive o_not_editable" title="Delete"><span class="fa fa-trash"/></a>
             </span>
         </div>


### PR DESCRIPTION
**Steps to reproduce**
1. Go on website_slides
2. Click on the "Edit in backend' button  ﻿﻿Reference video:  //nimb.ws/og8jBHb﻿﻿ 

**Technical**
The bug is coming after this commit: https://github.com/odoo/odoo/commit/df82fc83ce18dcb93dcc26e6c47094ee40a54829 
there is no action named slide_action and without #, we cannot get the slide.id

**After this PR**
Now the redirection will work properly.

Task-4149272