### PR TITLE
[FIX] mail: livechat conversation name is only operator name

### DIFF
--- a/addons/im_livechat/static/src/embed/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/thread_model_patch.js
@@ -48,7 +48,12 @@ patch(Thread.prototype, {
         }
         return super.avatarUrl;
     },
-
+    get displayName() {
+        if (this.channel_type === "livechat" && this.operator) {
+            return this.operator.user_livechat_username || this.operator.name;
+        }
+        return super.displayName;
+    },
     get hasWelcomeMessage() {
         return this.channel_type === "livechat" && !this.chatbot && !this.requested_by_operator;
     },

--- a/addons/im_livechat/static/tests/embed/chat_window.test.js
+++ b/addons/im_livechat/static/tests/embed/chat_window.test.js
@@ -73,3 +73,13 @@ test("internal users can upload file to temporary thread", async () => {
     await triggerHotkey("Enter");
     await contains(".o-mail-Message .o-mail-AttachmentCard", { text: "text.txt" });
 });
+
+test("Conversation name is operator livechat user name", async () => {
+    const pyEnv = await startServer();
+    await loadDefaultEmbedConfig();
+    pyEnv["res.partner"].write(serverState.partnerId, { user_livechat_username: "MitchellOp" });
+    await start({ authenticateAs: false });
+    await mountWithCleanup(LivechatButton);
+    await click(".o-livechat-LivechatButton");
+    await contains(".o-mail-ChatWindow-header", { text: "MitchellOp" });
+});

--- a/addons/im_livechat/static/tests/embed/livechat_session.test.js
+++ b/addons/im_livechat/static/tests/embed/livechat_session.test.js
@@ -36,7 +36,7 @@ test("Session is reset after failing to persist the channel", async () => {
             return false;
         }
     });
-    await start({ authenticateAs: false, env: { zzz: true } });
+    await start({ authenticateAs: false });
     await mountWithCleanup(LivechatButton);
     await click(".o-livechat-LivechatButton");
     await insertText(".o-mail-Composer-input", "Hello World!");


### PR DESCRIPTION
Before this commit, the name of livechat conversation from visitor PoV was something like `Visitor https://github.com/odoo/odoo/pull/12345 Mitchell Op`, that is the technical name of visitor followed by the operator livechat name.

The technical visitor name should not leak to the visitor, which is what this commit fixes by only showing the operator livechat user name in livechat header.

Before / After
<img width="363" alt="Screenshot 2024-09-02 at 12 06 30" src="https://github.com/user-attachments/assets/4454d636-51e3-4407-9968-d269e676473e"> <img width="367" alt="Screenshot 2024-09-02 at 12 05 40" src="https://github.com/user-attachments/assets/0416a477-ed49-4f85-9c20-719cae8db86d">

