### PR TITLE
[FIX] html_editor: keep wysiwyg when saving content with JSON attrs

### DIFF
--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -3,6 +3,7 @@ import {
     MAIN_PLUGINS,
     DYNAMIC_PLACEHOLDER_PLUGINS,
 } from "@html_editor/plugin_sets";
+import { decodeHTMLEntities } from "@html_editor/utils/html";
 import { Wysiwyg } from "@html_editor/wysiwyg";
 import { Component, status, useRef, useState } from "@odoo/owl";
 import { localization } from "@web/core/l10n/localization";
@@ -137,12 +138,11 @@ export class HtmlField extends Component {
                 await this.updateValue(this.codeViewRef.el.value);
                 return;
             }
-
             if (urgent) {
-                await this.updateValue(this.editor.getContent());
+                await this.updateValue(decodeHTMLEntities(this.editor.getContent()));
             }
             const el = await this.getEditorContent();
-            const content = el.innerHTML;
+            const content = decodeHTMLEntities(el.innerHTML);
             if (!urgent || (urgent && this.lastValue !== content)) {
                 await this.updateValue(content);
             }

--- a/addons/html_editor/static/src/utils/html.js
+++ b/addons/html_editor/static/src/utils/html.js
@@ -10,3 +10,18 @@ export function parseHTML(document, html) {
     fragment.replaceChildren(...parsedDocument.body.childNodes);
     return fragment;
 }
+
+/**
+ * Server-side, HTML is stored as a string without HTML entities. This
+ * function can be used to convert strings with HTML entities to strings
+ * comparable to the format stored server-side (i.e. to determine if a record
+ * HTML value has changed compared with its value in the Form view).
+ *
+ * @param { string } string i.e. innerHTML or outerHTML
+ * @returns { string } without HTML entities (i.e. &quot;)
+ */
+export function decodeHTMLEntities(string) {
+    const textarea = document.createElement("textarea");
+    textarea.innerHTML = string;
+    return textarea.value;
+}

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -1,6 +1,7 @@
 import { HtmlField } from "@html_editor/fields/html_field";
 import { MediaDialog } from "@html_editor/main/media/media_dialog/media_dialog";
 import { parseHTML } from "@html_editor/utils/html";
+import { Wysiwyg } from "@html_editor/wysiwyg";
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import {
     click,
@@ -13,6 +14,7 @@ import {
 } from "@odoo/hoot-dom";
 import { Deferred, animationFrame, mockSendBeacon, tick } from "@odoo/hoot-mock";
 import {
+    clickSave,
     contains,
     defineModels,
     defineParams,
@@ -28,7 +30,7 @@ import { assets } from "@web/core/assets";
 import { browser } from "@web/core/browser/browser";
 import { FormController } from "@web/views/form/form_controller";
 import { moveSelectionOutsideEditor, setSelection } from "./_helpers/selection";
-import { insertText, pasteText, undo } from "./_helpers/user_actions";
+import { insertText, pasteOdooEditorHtml, pasteText, undo } from "./_helpers/user_actions";
 
 class Partner extends models.Model {
     txt = fields.Html({ trim: true });
@@ -229,6 +231,43 @@ test("edit and save a html field", async () => {
     expect.verifySteps(["web_save"]);
     expect(".odoo-editor-editable p").toHaveText("testfirst");
     expect(`.o_form_button_save`).not.toBeVisible();
+});
+
+test("edit and save a html field containing JSON as some attribute values should keep the same wysiwyg", async () => {
+    patchWithCleanup(Wysiwyg.prototype, {
+        setup() {
+            super.setup();
+            expect.step("Setup Wysiwyg");
+        },
+    });
+    onRpc("partner", "web_save", ({ args }) => {
+        expect.step("web_save");
+        // server representation does not have HTML entities
+        args[1].txt = `<div data-value="{"myString":"myString"}"><p>content</p></div><p>first</p>`;
+    });
+
+    await mountView({
+        type: "form",
+        resId: 1,
+        resModel: "partner",
+        arch: `
+            <form>
+                <field name="txt" widget="html"/>
+            </form>`,
+    });
+    setSelectionInHtmlField();
+    const value = JSON.stringify({
+        myString: "myString",
+    });
+    pasteOdooEditorHtml(htmlEditor, `<div data-value=${value}><p>content</p></div>`);
+    const txtField = queryOne('.o_field_html[name="txt"] .odoo-editor-editable');
+    expect(txtField).toHaveInnerHTML(
+        `<div data-value="{&quot;myString&quot;:&quot;myString&quot;}"><p>content</p></div><p>first</p>`
+    );
+    expect.verifySteps(["Setup Wysiwyg"]);
+
+    await clickSave();
+    expect.verifySteps(["web_save"]);
 });
 
 test("edit a html field in new form view dialog and close the dialog with 'escape'", async () => {


### PR DESCRIPTION
Before this commit, editing an html field containing at least one element with one attribute with a JSON string as its value and then saving caused a rebuild of the Wysiwyg and therefore the creation of a new editor, inducing flickering and multiple reloadings (i.e. embedded components).

Reason:
Server side, the html string value is stored without html entities. In frontend, the html string value extracted from the editor is done through `innerHTML`, and therefore contains html entities. In `_commitChanges`, two values with different formats could be compared and were therefore always different if at least one HTML entity was present.

Solution:
Add a `decodeHTMLEntities` util which should be used when comparing values extracted from the DOM through `innerHTML` and html values coming from the server.