### PR TITLE
[FIX] account - Remove inverse from price_include

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -126,7 +126,6 @@ class AccountTax(models.Model):
     invoice_label = fields.Char(string='Label on Invoices', translate=True)
     price_include = fields.Boolean(
         compute='_compute_price_include',
-        inverse='_inverse_price_include',
         search='_search_price_include',
         help="Determines whether the price you use on the product and invoices includes this tax.")
     company_price_include = fields.Selection(related="company_id.account_price_include")
@@ -259,14 +258,6 @@ class AccountTax(models.Model):
                 or (tax.company_price_include == 'tax_included'
                     and not tax.price_include_override)
             )
-
-    def _inverse_price_include(self):
-        for tax in self:
-            new_value = 'tax_included' if tax.price_include else 'tax_excluded'
-            if tax.company_price_include == new_value:
-                tax.price_include_override = False
-            else:
-                tax.price_include_override = new_value
 
     def _search_price_include(self, operator, value):
         if isinstance(value, bool):

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -351,7 +351,7 @@ class AccountTestInvoicingCommon(ProductCommon):
                     'amount': 20.0,
                     'type_tax_use': type_tax_use,
                     'country_id': company_data['company'].account_fiscal_country_id.id,
-                    'price_include': True,
+                    'price_include_override': 'tax_included',
                     'include_base_amount': True,
                     'tax_exigibility': 'on_invoice',
                     'invoice_repartition_line_ids': [

--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -442,7 +442,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
             'name': 'included_tax_line',
             'amount_type': 'percent',
             'amount': 20,
-            'price_include': True,
+            'price_include_override': 'tax_included',
             'include_base_amount': False,
         })
         self.account = self.company_data['default_account_revenue']

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -223,7 +223,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             'type_tax_use': 'purchase',
             'amount_type': 'percent',
             'amount': 10,
-            'price_include': True,
+            'price_include_override': 'tax_included',
             'include_base_amount': True,
         })
         tax_price_exclude = self.env['account.tax'].create({
@@ -366,7 +366,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             'type_tax_use': 'purchase',
             'amount_type': 'percent',
             'amount': 10,
-            'price_include': True,
+            'price_include_override': 'tax_included',
             'include_base_amount': True,
         })
         tax_price_include_2 = self.env['account.tax'].create({
@@ -374,7 +374,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             'type_tax_use': 'purchase',
             'amount_type': 'percent',
             'amount': 20,
-            'price_include': True,
+            'price_include_override': 'tax_included',
             'include_base_amount': True,
         })
 

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -209,7 +209,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             'type_tax_use': 'sale',
             'amount_type': 'percent',
             'amount': 10,
-            'price_include': True,
+            'price_include_override': 'tax_included',
             'include_base_amount': True,
         })
         tax_price_exclude = self.env['account.tax'].create({
@@ -379,7 +379,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             'type_tax_use': 'sale',
             'amount_type': 'percent',
             'amount': 10,
-            'price_include': True,
+            'price_include_override': 'tax_included',
             'include_base_amount': True,
         })
         tax_price_include_2 = self.env['account.tax'].create({
@@ -387,7 +387,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             'type_tax_use': 'sale',
             'amount_type': 'percent',
             'amount': 20,
-            'price_include': True,
+            'price_include_override': 'tax_included',
             'include_base_amount': True,
         })
 
@@ -879,7 +879,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         tax = self.env['account.tax'].create({
             'name': '21%',
             'amount': 21.0,
-            'price_include': True,
+            'price_include_override': 'tax_included',
             'include_base_amount': True,
         })
 
@@ -959,7 +959,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             'name': 'Tax 5.5% price included',
             'amount': 5.5,
             'amount_type': 'percent',
-            'price_include': True,
+            'price_include_override': 'tax_included',
         })
 
         # == Single-currency ==
@@ -1710,7 +1710,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             'type_tax_use': 'sale',
             'amount_type': 'fixed',
             'amount': 0.05,
-            'price_include': True,
+            'price_include_override': 'tax_included',
             'include_base_amount': True,
         })
         invoice = self.env['account.move'].create({
@@ -1757,7 +1757,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             'type_tax_use': 'sale',
             'amount_type': 'fixed',
             'amount': 0.05,
-            'price_include': True,
+            'price_include_override': 'tax_included',
             'include_base_amount': True,
         })
         fixed_tax_price_include_2 = self.env['account.tax'].create({
@@ -1765,7 +1765,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             'type_tax_use': 'sale',
             'amount_type': 'fixed',
             'amount': 0.25,
-            'price_include': True,
+            'price_include_override': 'tax_included',
             'include_base_amount': True,
         })
         invoice = self.env['account.move'].create({

--- a/addons/account/tests/test_account_tax.py
+++ b/addons/account/tests/test_account_tax.py
@@ -84,7 +84,7 @@ class TestAccountTax(AccountTestInvoicingCommon):
             'amount': 21,
             'amount_type': 'fixed',
             'type_tax_use': 'purchase',
-            'price_include': True,
+            'price_include_override': 'tax_included',
             'include_base_amount': True,
             'is_base_affected': False,
         })

--- a/addons/account/tests/test_early_payment_discount.py
+++ b/addons/account/tests/test_early_payment_discount.py
@@ -632,7 +632,7 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
         tax = self.env['account.tax'].create({
             'name': 'Tax 21% included',
             'amount': 21,
-            'price_include': True,
+            'price_include_override': 'tax_included',
         })
 
         with Form(self.env['account.move'].with_context(default_move_type='out_invoice')) as invoice:

--- a/addons/account/tests/test_invoice_tax_totals.py
+++ b/addons/account/tests/test_invoice_tax_totals.py
@@ -226,7 +226,7 @@ class TestTaxTotals(AccountTestInvoicingCommon):
             'amount_type': 'percent',
             'amount': 10.0,
             'tax_group_id': self.tax_group1.id,
-            'price_include': True,
+            'price_include_override': 'tax_included',
             'include_base_amount': True,
         })
 
@@ -784,14 +784,14 @@ class TestTaxTotals(AccountTestInvoicingCommon):
             'tax_group_id': self.tax_group1.id,
             'amount': 1.0,
             'include_base_amount': True,
-            'price_include': True,
+            'price_include_override': 'tax_included',
         })
         tax_21 = self.env['account.tax'].create({
             'name': "tax_21",
             'amount_type': 'percent',
             'tax_group_id': self.tax_group2.id,
             'amount': 21.0,
-            'price_include': True,
+            'price_include_override': 'tax_included',
         })
         invoice = self.env['account.move'].create({
             'move_type': 'out_invoice',
@@ -1073,7 +1073,7 @@ class TestTaxTotals(AccountTestInvoicingCommon):
             })
 
         # == Tax-included ==
-        taxes.write({'price_include': True})
+        taxes.write({'price_include_override': 'tax_included'})
         document = self._create_document_for_tax_totals_test([(48.0, taxes)])
 
         # Multiple tax groups.

--- a/addons/account/tests/test_invoice_taxes.py
+++ b/addons/account/tests/test_invoice_taxes.py
@@ -23,7 +23,7 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
             'name': '21% incl',
             'amount_type': 'percent',
             'amount': 21,
-            'price_include': True,
+            'price_include_override': 'tax_included',
             'include_base_amount': True,
             'sequence': 20,
         })
@@ -37,7 +37,7 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
             'name': '5% incl',
             'amount_type': 'percent',
             'amount': 5,
-            'price_include': True,
+            'price_include_override': 'tax_included',
             'include_base_amount': True,
             'sequence': 40,
         })
@@ -318,7 +318,7 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
             'type_tax_use': 'sale',
             'amount_type': 'division',
             'amount': 100,
-            'price_include': True,
+            'price_include_override': 'tax_included',
             'include_base_amount': True,
         })
         invoice = self._create_invoice([(100, sale_tax)])

--- a/addons/account/tests/test_tax.py
+++ b/addons/account/tests/test_tax.py
@@ -34,7 +34,7 @@ class TestTax(TestTaxCommon):
 
     def test_forced_price_exclude_context_key(self):
         """ Test the 'force_price_include' context key that force all taxes to act as price excluded taxes. """
-        taxes = (self.percent_tax(10.0, price_include=True) + self.percent_tax(10.0, price_include=True))\
+        taxes = (self.percent_tax(10.0, price_include_override='tax_included') + self.percent_tax(10.0, price_include_override='tax_included'))\
             .with_context({'force_price_include': False})
         self._check_compute_all_results(
             taxes,
@@ -64,11 +64,11 @@ class TestTax(TestTaxCommon):
             ],
         }
         tax_price_excluded = self.percent_tax(21.0, **common_values)
-        tax_price_included = self.percent_tax(21.0, price_include=True, **common_values)
+        tax_price_included = self.percent_tax(21.0, price_include_override='tax_included', **common_values)
 
         for tax, price_unit in ((tax_price_included, 121.0), (tax_price_excluded, 100.0)):
             for sign in (1, -1):
-                with self.subTest(sign=sign, price_include=tax.price_include):
+                with self.subTest(sign=sign, price_include_override=tax.price_include_override):
                     self._check_compute_all_results(
                         tax,
                         {

--- a/addons/account/tests/test_taxes_computation.py
+++ b/addons/account/tests/test_taxes_computation.py
@@ -26,8 +26,8 @@ class TestTaxesComputation(TestTaxCommon):
             },
         )
 
-        tax_percent1 = self.percent_tax(0.0, price_include=True)
-        tax_percent2 = self.percent_tax(8.0, price_include=True)
+        tax_percent1 = self.percent_tax(0.0, price_include_override='tax_included')
+        tax_percent2 = self.percent_tax(8.0, price_include_override='tax_included')
         tax_group1 = self.group_of_taxes(tax_percent1, sequence=5)
         tax_group2 = self.group_of_taxes(tax_percent2, sequence=6)
         self.assert_taxes_computation(
@@ -45,8 +45,8 @@ class TestTaxesComputation(TestTaxCommon):
         self._run_js_tests()
 
     def test_random_case_1(self):
-        tax_percent_8_price_included = self.percent_tax(8.0, price_include=True)
-        tax_percent_0_price_included = self.percent_tax(0.0, price_include=True)
+        tax_percent_8_price_included = self.percent_tax(8.0, price_include_override='tax_included')
+        tax_percent_0_price_included = self.percent_tax(0.0, price_include_override='tax_included')
 
         self.assert_taxes_computation(
             tax_percent_8_price_included + tax_percent_0_price_included,
@@ -77,7 +77,7 @@ class TestTaxesComputation(TestTaxCommon):
         self._run_js_tests()
 
     def test_random_case_2(self):
-        tax_percent_5_price_included = self.percent_tax(5.0, price_include=True)
+        tax_percent_5_price_included = self.percent_tax(5.0, price_include_override='tax_included')
         currency_dp_half = 0.05
 
         self.assert_taxes_computation(
@@ -159,7 +159,7 @@ class TestTaxesComputation(TestTaxCommon):
 
     def test_random_case_3(self):
         tax_percent_15_price_excluded = self.percent_tax(15.0)
-        tax_percent_5_5_price_included = self.percent_tax(5.5, price_include=True)
+        tax_percent_5_5_price_included = self.percent_tax(5.5, price_include_override='tax_included')
 
         self.assert_taxes_computation(
             tax_percent_15_price_excluded + tax_percent_5_5_price_included,
@@ -190,7 +190,7 @@ class TestTaxesComputation(TestTaxCommon):
         self._run_js_tests()
 
     def test_random_case_4(self):
-        tax_percent_12_price_included = self.percent_tax(12.0, price_include=True)
+        tax_percent_12_price_included = self.percent_tax(12.0, price_include_override='tax_included')
 
         self.assert_taxes_computation(
             tax_percent_12_price_included,
@@ -220,7 +220,7 @@ class TestTaxesComputation(TestTaxCommon):
 
     def test_random_case_5(self):
         tax_percent_19 = self.percent_tax(19.0)
-        tax_percent_19_price_included = self.percent_tax(19.0, price_include=True)
+        tax_percent_19_price_included = self.percent_tax(19.0, price_include_override='tax_included')
         currency_dp_0 = 1.0
 
         self.assert_taxes_computation(
@@ -326,7 +326,7 @@ class TestTaxesComputation(TestTaxCommon):
         self._run_js_tests()
 
     def test_random_case_6(self):
-        tax_percent_20_price_included = self.percent_tax(20.0, price_include=True)
+        tax_percent_20_price_included = self.percent_tax(20.0, price_include_override='tax_included')
         currency_dp_6 = 0.000001
 
         self.assert_taxes_computation(
@@ -359,7 +359,7 @@ class TestTaxesComputation(TestTaxCommon):
         self._run_js_tests()
 
     def test_random_case_7(self):
-        tax_percent_21_price_included = self.percent_tax(21.0, price_include=True)
+        tax_percent_21_price_included = self.percent_tax(21.0, price_include_override='tax_included')
         currency_dp_6 = 0.000001
 
         self.assert_taxes_computation(
@@ -459,7 +459,7 @@ class TestTaxesComputation(TestTaxCommon):
         self._run_js_tests()
 
     def test_random_case_9(self):
-        tax_division_100 = self.division_tax(100.0, price_include=True)
+        tax_division_100 = self.division_tax(100.0, price_include_override='tax_included')
 
         self.assert_taxes_computation(
             tax_division_100,
@@ -475,7 +475,7 @@ class TestTaxesComputation(TestTaxCommon):
         self._run_js_tests()
 
     def test_fixed_tax_price_included_affect_base_on_0(self):
-        tax = self.fixed_tax(0.05, price_include=True, include_base_amount=True)
+        tax = self.fixed_tax(0.05, price_include_override='tax_included', include_base_amount=True)
         self.assert_taxes_computation(
             tax,
             0.0,
@@ -578,8 +578,8 @@ class TestTaxesComputation(TestTaxCommon):
         # tax1      T               T                   T
         # tax2      T               T
         # tax3                                          T
-        tax1.price_include = True
-        tax2.price_include = True
+        tax1.price_include_override = 'tax_included'
+        tax2.price_include_override = 'tax_included'
         self.assert_taxes_computation(
             tax1 + tax2 + tax3,
             112.0,
@@ -635,7 +635,7 @@ class TestTaxesComputation(TestTaxCommon):
             rounding_method='round_globally',
         )
 
-        (tax1 + tax2 + tax3 + tax4 + tax5).price_include = True
+        (tax1 + tax2 + tax3 + tax4 + tax5).price_include_override = 'tax_included'
         self.assert_taxes_computation(
             tax1 + tax2 + tax3 + tax4 + tax5,
             48.0,
@@ -657,7 +657,7 @@ class TestTaxesComputation(TestTaxCommon):
     def test_division_taxes_for_l10n_au_differed_gst(self):
         tax = self.division_tax(
             amount=100,
-            price_include=True,
+            price_include_override='tax_included',
             invoice_repartition_line_ids=[
                 Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
                 Command.create({'repartition_type': 'tax', 'factor_percent': 100.0}),
@@ -730,7 +730,7 @@ class TestTaxesComputation(TestTaxCommon):
         # tax1                      T
         # tax2      T
         # tax3
-        tax2.price_include = True
+        tax2.price_include_override = 'tax_included'
         self.assert_taxes_computation(
             tax1 + tax2 + tax3,
             120.0,
@@ -793,7 +793,7 @@ class TestTaxesComputation(TestTaxCommon):
         # tax1
         # tax2                      T
         # tax3
-        tax2.price_include = False
+        tax2.price_include_override = 'tax_excluded'
         self.assert_taxes_computation(
             tax1 + tax2 + tax3,
             100.0,
@@ -814,8 +814,8 @@ class TestTaxesComputation(TestTaxCommon):
         # tax1      T
         # tax2      T               T
         # tax3
-        tax1.price_include = True
-        tax2.price_include = True
+        tax1.price_include_override = 'tax_included'
+        tax2.price_include_override = 'tax_included'
         self.assert_taxes_computation(
             tax1 + tax2 + tax3,
             122.0,
@@ -876,12 +876,12 @@ class TestTaxesComputation(TestTaxCommon):
         self._run_js_tests()
 
     def test_adapt_price_unit_to_another_taxes(self):
-        tax_fixed_incl = self.fixed_tax(10, price_include=True)
-        tax_fixed_excl = self.fixed_tax(10)
-        tax_include_src = self.percent_tax(21, price_include=True)
-        tax_include_dst = self.percent_tax(6, price_include=True)
-        tax_exclude_src = self.percent_tax(15)
-        tax_exclude_dst = self.percent_tax(21)
+        tax_fixed_incl = self.fixed_tax(10, price_include_override='tax_included')
+        tax_fixed_excl = self.fixed_tax(10, price_include_override='tax_excluded')
+        tax_include_src = self.percent_tax(21, price_include_override='tax_included')
+        tax_include_dst = self.percent_tax(6, price_include_override='tax_included')
+        tax_exclude_src = self.percent_tax(15, price_include_override='tax_excluded')
+        tax_exclude_dst = self.percent_tax(21, price_include_override='tax_excluded')
 
         self.assert_adapt_price_unit_to_another_taxes(
             121.0,

--- a/addons/account_tax_python/tests/test_taxes_computation.py
+++ b/addons/account_tax_python/tests/test_taxes_computation.py
@@ -8,13 +8,20 @@ class TestTaxesComputation(TestTaxCommon):
 
     def python_tax(self, formula, **kwargs):
         self.number += 1
-        return self.env['account.tax'].create({
+        vals = {
             **kwargs,
             'name': f"code_({self.number})",
             'amount_type': 'code',
             'amount': 0.0,
             'formula': formula,
-        })
+        }
+        if 'price_include' in vals:
+            price_include = vals.pop('price_include')
+            if self.env.company.account_price_include != price_include:
+                vals['price_include_override'] = price_include
+            else:
+                vals['price_include_override'] = False
+        return self.env['account.tax'].create(vals)
 
     def _jsonify_tax(self, tax):
         values = super()._jsonify_tax(tax)
@@ -27,7 +34,7 @@ class TestTaxesComputation(TestTaxCommon):
         price_unit,
         expected_values,
         product_values=None,
-        price_include=False,
+        price_include='tax_excluded',
     ):
         tax = self.python_tax(formula, price_include=price_include)
         if product_values:
@@ -61,7 +68,7 @@ class TestTaxesComputation(TestTaxCommon):
                     (102.7, 27.3),
                 ),
             },
-            price_include=True,
+            price_include='tax_included',
         )
         self.assert_python_taxes_computation(
             "product.volume * quantity * 0.35",

--- a/addons/delivery/tests/test_delivery_cost.py
+++ b/addons/delivery/tests/test_delivery_cost.py
@@ -227,7 +227,7 @@ class TestDeliveryCost(DeliveryCommon, SaleCommon):
             'type_tax_use': 'sale',
             'amount_type': 'percent',
             'amount': 10,
-            'price_include': True,
+            'price_include_override': 'tax_included',
             'include_base_amount': True,
         }, {
             'name': '15% exc',

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_cii_fr.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_cii_fr.py
@@ -94,7 +94,7 @@ class TestCIIFR(TestUBLCommon):
             'amount_type': 'percent',
             'amount': 5,
             'type_tax_use': 'sale',
-            'price_include': True,
+            'price_include_override': 'tax_included',
         })
 
     @classmethod
@@ -330,8 +330,8 @@ class TestCIIFR(TestUBLCommon):
 
     def test_export_with_fixed_taxes_case3(self):
         # CASE 3: same as Case 1 but taxes are Price Included
-        self.recupel.price_include = True
-        self.tax_21.price_include = True
+        self.recupel.price_include_override = 'tax_included'
+        self.tax_21.price_include_override = 'tax_included'
 
         # Price TTC = 121 = (99 + 1 ) * 1.21
         invoice = self._generate_move(

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
@@ -367,8 +367,8 @@ class TestUBLBE(TestUBLCommon, TestAccountMoveSendCommon):
 
     def test_export_with_fixed_taxes_case3(self):
         # CASE 3: same as Case 1 but taxes are Price Included
-        self.recupel.price_include = True
-        self.tax_21.price_include = True
+        self.recupel.price_include_override = 'tax_included'
+        self.tax_21.price_include_override = 'tax_included'
 
         # Price TTC = 121 = (99 + 1 ) * 1.21
         invoice = self._generate_move(

--- a/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
@@ -114,13 +114,13 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
                 'name': "IVA 21% (Bienes)",
                 'company_id': cls.company_data['company'].id,
                 'amount': 21.0,
-                'price_include': False,
+                'price_include_override': 'tax_excluded',
                 'l10n_es_edi_facturae_tax_type': '01'
             }, {
                 'name': "IVA 21% (Bienes) Included",
                 'company_id': cls.company_data['company'].id,
                 'amount': 21.0,
-                'price_include': True,
+                'price_include_override': 'tax_included',
                 'l10n_es_edi_facturae_tax_type': '01'
         }
         ])
@@ -203,13 +203,13 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
                 'name': "IVA 21%",
                 'company_id': self.company_data['company'].id,
                 'amount': 21.0,
-                'price_include': False,
+                'price_include_override': 'tax_excluded',
                 'l10n_es_edi_facturae_tax_type': '01'
             }, {
                 'name': "IVA 21% withholding",
                 'company_id': self.company_data['company'].id,
                 'amount': -21.0,
-                'price_include': False,
+                'price_include_override': 'tax_excluded',
                 'l10n_es_edi_facturae_tax_type': '01'
             }])
 

--- a/addons/l10n_hu_edi/tests/common.py
+++ b/addons/l10n_hu_edi/tests/common.py
@@ -103,7 +103,7 @@ class L10nHuEdiTestCommon(AccountTestInvoicingCommon):
             'amount': 30.0,
             'country_id': company.account_fiscal_country_id.id,
             'tax_exigibility': 'on_invoice',
-            'price_include': True,
+            'price_include_override': 'tax_included',
             'include_base_amount': True,
             'invoice_repartition_line_ids': [
                 Command.create({'repartition_type': 'base'}),

--- a/addons/l10n_id_efaktur/tests/test_l10n_id_efaktur.py
+++ b/addons/l10n_id_efaktur/tests/test_l10n_id_efaktur.py
@@ -21,7 +21,7 @@ class TestIndonesianEfaktur(AccountTestInvoicingCommon):
         })
         cls.partner_id = cls.env['res.partner'].create({"name": "l10ntest", "l10n_id_pkp": True, "l10n_id_kode_transaksi": "01", "l10n_id_nik": "12345", "vat": "000000000000000"})
         cls.partner_id_vat = cls.env['res.partner'].create({"name": "l10ntest3", "l10n_id_pkp": True, "l10n_id_kode_transaksi": "01", "l10n_id_nik": "67890", "vat": "010000000000000"})
-        cls.tax_id = cls.env['account.tax'].create({"name": "test tax", "type_tax_use": "sale", "amount": 10.0, "price_include": True})
+        cls.tax_id = cls.env['account.tax'].create({"name": "test tax", "type_tax_use": "sale", "amount": 10.0, "price_include_override": "tax_included"})
 
         cls.efaktur = cls.env['l10n_id_efaktur.efaktur.range'].create({'min': '0000000000001', 'max': '0000000000010'})
         cls.maxDiff = None
@@ -201,7 +201,7 @@ class TestIndonesianEfaktur(AccountTestInvoicingCommon):
         """
         # Prepare the test invoice.
         tax_id = self.env["account.tax"].create(
-            {"name": "test tax 11", "type_tax_use": "sale", "amount": 11.0, "price_include": True}
+            {"name": "test tax 11", "type_tax_use": "sale", "amount": 11.0, "price_include_override": "tax_included"}
         )
         invoice = self.env['account.move'].create({
             'move_type': 'out_invoice',

--- a/addons/l10n_it_edi/tests/test_edi_export.py
+++ b/addons/l10n_it_edi/tests/test_edi_export.py
@@ -72,7 +72,7 @@ class TestItEdiExport(TestItEdi):
             'name': "22% price included tax",
             'amount': 22.0,
             'amount_type': 'percent',
-            'price_include': True,
+            'price_include_override': 'tax_included',
         })
 
         invoice = self.env['account.move'].with_company(self.company).create({

--- a/addons/point_of_sale/tests/common.py
+++ b/addons/point_of_sale/tests/common.py
@@ -100,7 +100,7 @@ class TestPointOfSaleCommon(ValuationReconciliationTestCommon):
             'name': 'VAT 10 perc Incl',
             'amount_type': 'percent',
             'amount': 10.0,
-            'price_include': True,
+            'price_include_override': 'tax_included',
         })
 
         # assign this 10 percent tax on the [PCSC234] PC Assemble SC234 product
@@ -112,7 +112,7 @@ class TestPointOfSaleCommon(ValuationReconciliationTestCommon):
             'name': 'VAT 5 perc Incl',
             'amount_type': 'percent',
             'amount': 5.0,
-            'price_include': False,
+            'price_include_override': 'tax_excluded',
         })
 
         # create a second VAT tax of 5% but this time for a child company, to
@@ -122,7 +122,7 @@ class TestPointOfSaleCommon(ValuationReconciliationTestCommon):
             'name': 'VAT 05 perc Excl (US)',
             'amount_type': 'percent',
             'amount': 5.0,
-            'price_include': False,
+            'price_include_override': 'tax_excluded',
             'company_id': cls.company_data_2['company'].id,
         })
 
@@ -379,11 +379,11 @@ class TestPoSCommon(ValuationReconciliationTestCommon):
         cls.tax_tag_refund_base = create_tag('Refund Base tag')
         cls.tax_tag_refund_tax = create_tag('Refund Tax tag')
 
-        def create_tax(percentage, price_include=False, include_base_amount=False):
+        def create_tax(percentage, price_include_override='tax_excluded', include_base_amount=False):
             return cls.env['account.tax'].create({
                 'name': f'Tax {percentage}%',
                 'amount': percentage,
-                'price_include': price_include,
+                'price_include_override': price_include_override,
                 'amount_type': 'percent',
                 'include_base_amount': include_base_amount,
                 'invoice_repartition_line_ids': [
@@ -409,12 +409,13 @@ class TestPoSCommon(ValuationReconciliationTestCommon):
                     }),
                 ],
             })
-        def create_tax_fixed(amount, price_include=False):
+
+        def create_tax_fixed(amount, price_include_override='tax_excluded', include_base_amount=False):
             return cls.env['account.tax'].create({
                 'name': f'Tax fixed amount {amount}',
                 'amount': amount,
-                'price_include': price_include,
-                'include_base_amount': price_include,
+                'price_include_override': price_include_override,
+                'include_base_amount': include_base_amount,
                 'amount_type': 'fixed',
                 'invoice_repartition_line_ids': [
                     (0, 0, {
@@ -440,13 +441,13 @@ class TestPoSCommon(ValuationReconciliationTestCommon):
                 ],
             })
 
-        tax_fixed006 = create_tax_fixed(0.06, price_include=True)
-        tax_fixed012 = create_tax_fixed(0.12, price_include=True)
-        tax7 = create_tax(7, price_include=False)
+        tax_fixed006 = create_tax_fixed(0.06, price_include_override='tax_included', include_base_amount=True)
+        tax_fixed012 = create_tax_fixed(0.12, price_include_override='tax_included', include_base_amount=True)
+        tax7 = create_tax(7, price_include_override='tax_excluded')
         tax8 = create_tax(8, include_base_amount=True)
         tax9 = create_tax(9)
-        tax10 = create_tax(10, price_include=True)
-        tax21 = create_tax(21, price_include=True)
+        tax10 = create_tax(10, price_include_override='tax_included')
+        tax21 = create_tax(21, price_include_override='tax_included')
 
 
         tax_group_7_10 = tax7.copy()

--- a/addons/point_of_sale/tests/common_setup_methods.py
+++ b/addons/point_of_sale/tests/common_setup_methods.py
@@ -16,7 +16,7 @@ def setup_product_combo_items(self):
             "amount": 20,
             "amount_type": "percent",
             "type_tax_use": "sale",
-            "price_include": True,
+            "price_include_override": "tax_included",
             "include_base_amount": True,
         }
     )

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -642,6 +642,7 @@ class TestUi(TestPointOfSaleHttpCommon):
                     'account_id': tax_received_account.id,
                 }),
             ],
+            'price_include_override': 'tax_excluded',
         })
         zero_amount_product = self.env['product.product'].create({
             'name': 'Zero Amount Product',
@@ -833,7 +834,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         tax = self.env['account.tax'].create({
             'name': 'Tax 15%',
             'amount': 15,
-            'price_include': True,
+            'price_include_override': 'tax_included',
             'amount_type': 'percent',
             'type_tax_use': 'sale',
         })
@@ -874,26 +875,28 @@ class TestUi(TestPointOfSaleHttpCommon):
         tax_inclusive_1 = self.env['account.tax'].create({
             'name': 'Tax incl.20%',
             'amount': 20,
-            'price_include': True,
+            'price_include_override': 'tax_included',
             'amount_type': 'percent',
             'type_tax_use': 'sale',
         })
         tax_exclusive_1 = self.env['account.tax'].create({
             'name': 'Tax excl.20%',
             'amount': 20,
+            'price_include_override': 'tax_excluded',
             'amount_type': 'percent',
             'type_tax_use': 'sale',
         })
         tax_inclusive_2 = self.env['account.tax'].create({
             'name': 'Tax incl.10%',
             'amount': 10,
-            'price_include': True,
+            'price_include_override': 'tax_included',
             'amount_type': 'percent',
             'type_tax_use': 'sale',
         })
         tax_exclusive_2 = self.env['account.tax'].create({
             'name': 'Tax excl.10%',
             'amount': 10,
+            'price_include_override': 'tax_excluded',
             'amount_type': 'percent',
             'type_tax_use': 'sale',
         })
@@ -1026,7 +1029,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'name': 'Tax 10% Included',
             'amount_type': 'percent',
             'amount': 10,
-            'price_include': True,
+            'price_include_override': 'tax_included',
         })
 
         # define a product record with the tax
@@ -1116,7 +1119,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'amount': 15,
             'amount_type': 'percent',
             'type_tax_use': 'sale',
-            'price_include': True,
+            'price_include_override': 'tax_included',
         })
         #create a tax of 0%
         self.tax2 = self.env['account.tax'].create({
@@ -1124,6 +1127,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'amount': 0,
             'amount_type': 'percent',
             'type_tax_use': 'sale',
+            'price_include_override': 'tax_included',
         })
         #create a fiscal position with the two taxes
         self.fiscal_position = self.env['account.fiscal.position'].create({
@@ -1431,7 +1435,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         tax_1 = self.env['account.tax'].create({
             'name': 'Tax 10%',
             'amount': 10,
-            'price_include': True,
+            'price_include_override': 'tax_included',
             'amount_type': 'percent',
             'type_tax_use': 'sale',
         })
@@ -1439,7 +1443,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         tax_2 = self.env['account.tax'].create({
             'name': 'Tax 5%',
             'amount': 5,
-            'price_include': True,
+            'price_include_override': 'tax_included',
             'amount_type': 'percent',
             'type_tax_use': 'sale',
         })

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -1167,7 +1167,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'name': 'Tax 50%',
             'amount_type': 'percent',
             'amount': 50.0,
-            'price_include': 0
+            'price_include_override': 'tax_excluded',
         })
 
         # set tax to product

--- a/addons/point_of_sale/tests/test_report_session.py
+++ b/addons/point_of_sale/tests/test_report_session.py
@@ -15,7 +15,7 @@ class TestReportSession(TestPoSCommon):
         self.tax1 = self.env['account.tax'].create({
             'name': 'Tax 1',
             'amount': 10,
-            'price_include': True,
+            'price_include_override': 'tax_included',
         })
         self.product1 = self.create_product('Product A', self.categ_basic, 110, self.tax1.id)
 

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -599,7 +599,7 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         tax_2 = self.env['account.tax'].create({
             'name': '5 incl',
             'amount': 5,
-            'price_include': True,
+            'price_include_override': 'tax_included',
         })
 
         product_a = self.env['product.product'].create({

--- a/addons/project_purchase/tests/test_project_profitability.py
+++ b/addons/project_purchase/tests/test_project_profitability.py
@@ -571,7 +571,7 @@ class TestProjectPurchaseProfitability(TestProjectProfitabilityCommon, TestPurch
             'amount': '15.0',
             'amount_type': 'percent',
             'type_tax_use': 'purchase',
-            'price_include': True
+            'price_include_override': 'tax_included',
         })
 
         # create a purchase.order with the project account in analytic_distribution

--- a/addons/purchase/tests/test_accrued_purchase_orders.py
+++ b/addons/purchase/tests/test_accrued_purchase_orders.py
@@ -128,7 +128,7 @@ class TestAccruedPurchaseOrders(AccountTestInvoicingCommon):
             'name': 'Tax 10% included',
             'amount': 10.0,
             'type_tax_use': 'purchase',
-            'price_include': True,
+            'price_include_override': 'tax_included',
         })
         self.purchase_order.order_line.taxes_id = tax_10_included
         self.purchase_order.order_line.qty_received = 5

--- a/addons/purchase_stock/tests/test_average_price.py
+++ b/addons/purchase_stock/tests/test_average_price.py
@@ -261,7 +261,7 @@ class TestAveragePrice(ValuationReconciliationTestCommon):
             'type_tax_use': 'purchase',
             'amount_type': 'percent',
             'amount': 10,
-            'price_include': True,
+            'price_include_override': 'tax_included',
             'invoice_repartition_line_ids': [
                 (0, 0, {'repartition_type': 'base'}),
                 (0, 0, {

--- a/addons/purchase_stock/tests/test_onchange_product.py
+++ b/addons/purchase_stock/tests/test_onchange_product.py
@@ -40,7 +40,7 @@ class TestOnchangeProductId(TransactionCase):
         partner_id = self.res_partner_model.create(dict(name="George"))
         tax_include_id = self.tax_model.create(dict(name="Include tax",
                                                     amount='21.00',
-                                                    price_include=True,
+                                                    price_include_override='tax_included',
                                                     type_tax_use='purchase'))
         tax_exclude_id = self.tax_model.create(dict(name="Exclude tax",
                                                     amount='0.00',

--- a/addons/purchase_stock/tests/test_stockvaluation.py
+++ b/addons/purchase_stock/tests/test_stockvaluation.py
@@ -944,7 +944,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
             "name": "Tax with no account",
             "amount_type": "percent",
             "amount": 5,
-            "price_include": True,
+            "price_include_override": "tax_included",
             "invoice_repartition_line_ids": repartition_line_vals,
             "refund_repartition_line_ids": repartition_line_vals,
         })
@@ -1032,7 +1032,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
             "name": "Tax with no account",
             "amount_type": "fixed",
             "amount": 5,
-            "price_include": 5,
+            "price_include_override": "tax_included",
         })
 
         # Create PO

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -396,7 +396,7 @@ class TestSaleOrder(SaleCommon):
         tax_a = self.env['account.tax'].create({
             'name': 'Test tax',
             'type_tax_use': 'sale',
-            'price_include': False,
+            'price_include_override': 'tax_excluded',
             'amount_type': 'percent',
             'amount': 15.0,
         })
@@ -888,7 +888,7 @@ class TestSalesTeam(SaleCommon):
             'amount_type': 'percent',
             'amount': 25.0,
             'include_base_amount': True,
-            'price_include': True,
+            'price_include_override': 'tax_included',
         })
 
         mapped_tax_a = self.env['account.tax'].create({
@@ -896,7 +896,7 @@ class TestSalesTeam(SaleCommon):
             'amount_type': 'percent',
             'amount': 12.5,
             'include_base_amount': True,
-            'price_include': True,
+            'price_include_override': 'tax_included',
         })
 
         mapped_tax_b = self.env['account.tax'].create({
@@ -904,14 +904,14 @@ class TestSalesTeam(SaleCommon):
             'amount_type': 'percent',
             'amount': 5.0,
             'include_base_amount': True,
-            'price_include': True,
+            'price_include_override': 'tax_included',
         })
 
         sales_tax = self.env['account.tax'].create({
             'name': "VAT 20%",
             'amount_type': 'percent',
             'amount': 20.0,
-            'price_include': True,
+            'price_include_override': 'tax_included',
         })
 
         mapping_a = self.env['account.fiscal.position'].create({

--- a/addons/sale/tests/test_sale_order_down_payment.py
+++ b/addons/sale/tests/test_sale_order_down_payment.py
@@ -264,7 +264,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self._assert_invoice_lines_values(invoice.line_ids, expected)
 
     def test_tax_price_include_breakdown(self):
-        tax_10_incl = self.create_tax(10, {'price_include': True})
+        tax_10_incl = self.create_tax(10, {'price_include_override': 'tax_included'})
         self.sale_order.order_line[0].tax_id = tax_10_incl + self.tax_10
         self.sale_order.order_line[1].tax_id = self.tax_10
         self.sale_order.order_line[2].tax_id = self.tax_10
@@ -288,7 +288,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self._assert_invoice_lines_values(invoice.line_ids, expected)
 
     def test_tax_price_include_include_base_amount_breakdown(self):
-        tax_10_pi_ba = self.create_tax(10, {'price_include': True, 'include_base_amount': True})
+        tax_10_pi_ba = self.create_tax(10, {'price_include_override': 'tax_included', 'include_base_amount': True})
         self.tax_10.sequence = 2
         self.sale_order.order_line[0].tax_id = tax_10_pi_ba + self.tax_10
         self.sale_order.order_line[1].tax_id = self.tax_10
@@ -337,7 +337,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self._assert_invoice_lines_values(invoice.line_ids, expected)
 
     def test_tax_price_include_include_base_amount_breakdown_with_discount(self):
-        tax_10_pi_ba = self.create_tax(10, {'price_include': True, 'include_base_amount': True})
+        tax_10_pi_ba = self.create_tax(10, {'price_include_override': 'tax_included', 'include_base_amount': True})
         self.tax_10.sequence = 2
         self.sale_order.order_line[0].tax_id = tax_10_pi_ba + self.tax_10
         self.sale_order.order_line[0].discount = 25.0
@@ -410,8 +410,8 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self._assert_invoice_lines_values(invoice.line_ids, expected)
 
     def test_tax_fixed_amount_price_include(self):
-        tax_fix = self.create_tax(5, {'amount_type': 'fixed', 'include_base_amount': True, 'price_include': True})
-        tax_percentage = self.create_tax(21, {'amount_type': 'percent', 'price_include': True})
+        tax_fix = self.create_tax(5, {'amount_type': 'fixed', 'include_base_amount': True, 'price_include_override': 'tax_included'})
+        tax_percentage = self.create_tax(21, {'amount_type': 'percent', 'price_include_override': 'tax_included'})
         sale_order = self.env['sale.order'].create({
             'partner_id': self.partner_a.id,
             'partner_invoice_id': self.partner_a.id,

--- a/addons/sale/tests/test_sale_prices.py
+++ b/addons/sale/tests/test_sale_prices.py
@@ -547,7 +547,7 @@ class TestSalePrices(SaleCommon):
         tax_a, tax_b = self.env['account.tax'].create([{
             'name': 'Test tax A',
             'type_tax_use': 'sale',
-            'price_include': True,
+            'price_include_override': 'tax_included',
             'amount': 15.0,
         }, {
             'name': 'Test tax B',
@@ -635,32 +635,32 @@ class TestSalePrices(SaleCommon):
             'name': "fixed include",
             'amount': 10.00,
             'amount_type': 'fixed',
-            'price_include': True,
+            'price_include_override': 'tax_included',
         }, {
             'name': "fixed exclude",
             'amount': 10.00,
             'amount_type': 'fixed',
-            'price_include': False,
+            'price_include_override': 'tax_excluded',
         }, {
             'name': "Include 21%",
             'amount': 21.00,
             'amount_type': 'percent',
-            'price_include': True,
+            'price_include_override': 'tax_included',
         }, {
             'name': "Include 6%",
             'amount': 6.00,
             'amount_type': 'percent',
-            'price_include': True,
+            'price_include_override': 'tax_included',
         }, {
             'name': "Exclude 15%",
             'amount': 15.00,
             'amount_type': 'percent',
-            'price_include': False,
+            'price_include_override': 'tax_excluded',
         }, {
             'name': "Exclude 21%",
             'amount': 21.00,
             'amount_type': 'percent',
-            'price_include': False,
+            'price_include_override': 'tax_excluded',
         }])
 
         (
@@ -804,7 +804,7 @@ class TestSalePrices(SaleCommon):
         tax_include, tax_exclude = self.env['account.tax'].create([{
             'name': 'Include Tax',
             'amount': '21.00',
-            'price_include': True,
+            'price_include_override': 'tax_included',
             'type_tax_use': 'sale',
         }, {
             'name': 'Exclude Tax',
@@ -845,14 +845,14 @@ class TestSalePrices(SaleCommon):
             'type_tax_use': 'sale',
             'amount_type': 'fixed',
             'amount': 0.05,
-            'price_include': True,
+            'price_include_override': 'tax_included',
             'include_base_amount': True,
         }, {
             'name': 'Recupel 0.25',
             'type_tax_use': 'sale',
             'amount_type': 'fixed',
             'amount': 0.25,
-            'price_include': True,
+            'price_include_override': 'tax_included',
             'include_base_amount': True,
         }])
         order = self.empty_order
@@ -881,7 +881,7 @@ class TestSalePrices(SaleCommon):
         tax_include, tax_exclude = self.env['account.tax'].create([{
             'name': 'Tax with price include',
             'amount': 10,
-            'price_include': True
+            'price_include_override': 'tax_included',
         }, {
             'name': 'Tax with no price include',
             'amount': 10,
@@ -932,7 +932,7 @@ class TestSalePrices(SaleCommon):
             'name': 'Super Tax',
             'amount_type': 'percent',
             'amount': 15.0,
-            'price_include': True,
+            'price_include_override': 'tax_included',
         })]
         order.action_confirm()
         self.assertEqual(line.untaxed_amount_to_invoice, 0)
@@ -983,7 +983,7 @@ class TestSalePrices(SaleCommon):
             'name': 'Super Tax',
             'amount_type': 'percent',
             'amount': 10.0,
-            'price_include': True,
+            'price_include_override': 'tax_included',
         })]
         line.discount = 50.0
         order.action_confirm()

--- a/addons/sale/tests/test_sale_to_invoice.py
+++ b/addons/sale/tests/test_sale_to_invoice.py
@@ -272,7 +272,7 @@ class TestSaleToInvoice(TestSaleCommon):
         self.sale_order.action_confirm()
         tax_downpayment = self.company_data['default_tax_sale'].copy({
             'name': 'default price included',
-            'price_include': True,
+            'price_include_override': 'tax_included',
         })
         # Let's do an invoice for a deposit of 100
         payment = self.env['sale.advance.payment.inv'].with_context(self.context).create({

--- a/addons/sale_loyalty/tests/common.py
+++ b/addons/sale_loyalty/tests/common.py
@@ -32,14 +32,14 @@ class TestSaleCouponCommon(SaleCommon):
             'name': "10% Tax incl",
             'amount_type': 'percent',
             'amount': 10,
-            'price_include': True,
+            'price_include_override': 'tax_included',
         })
 
         cls.tax_10pc_base_incl = cls.env['account.tax'].create({
             'name': "10% Tax incl base amount",
             'amount_type': 'percent',
             'amount': 10,
-            'price_include': True,
+            'price_include_override': 'tax_included',
             'include_base_amount': True,
         })
 
@@ -47,14 +47,14 @@ class TestSaleCouponCommon(SaleCommon):
             'name': "10% Tax excl",
             'amount_type': 'percent',
             'amount': 10,
-            'price_include': False,
+            'price_include_override': 'tax_excluded',
         })
 
         cls.tax_20pc_excl = cls.env['account.tax'].create({
             'name': "20% Tax excl",
             'amount_type': 'percent',
             'amount': 20,
-            'price_include': False,
+            'price_include_override': 'tax_excluded',
         })
 
         cls.tax_group = cls.env['account.tax'].create({

--- a/addons/sale_loyalty/tests/test_program_numbers.py
+++ b/addons/sale_loyalty/tests/test_program_numbers.py
@@ -93,7 +93,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
             'name': "15% Tax",
             'amount_type': 'percent',
             'amount': 15,
-            'price_include': True,
+            'price_include_override': 'tax_included',
         })
         p_specific_product = self.env['loyalty.program'].create({
             'name': '20% reduction on Large Cabinet in cart',
@@ -126,10 +126,9 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
 
         self._auto_rewards(order, self.all_programs)
         self.assertEqual(len(order.order_line.ids), 1, "We should not get the reduction line since we dont have 320$ tax excluded (cabinet is 320$ tax included)")
-        sol1.tax_id.price_include = False
+        sol1.tax_id.price_include_override = 'tax_excluded'
         sol1._compute_tax_id()
         self.env.flush_all()
-        self.env['account.tax'].invalidate_model(['price_include'])
         self._auto_rewards(order, self.all_programs)
         self.assertEqual(len(order.order_line.ids), 2, "We should now get the reduction line since we have 320$ tax included (cabinet is 320$ tax included)")
         # Name                 | Qty | price_unit |  Tax     |  HTVA   |   TVAC  |  TVA  |
@@ -217,7 +216,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
             'name': "35% Tax incl",
             'amount_type': 'percent',
             'amount': 35,
-            'price_include': True,
+            'price_include_override': 'tax_included',
         })
 
         # Set tax and prices on products as neeed for the test
@@ -909,7 +908,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
             'name': "30% Tax",
             'amount_type': 'percent',
             'amount': 30,
-            'price_include': True,
+            'price_include_override': 'tax_included',
         })
         sol2.tax_id = percent_tax
 

--- a/addons/website_sale/tests/test_address.py
+++ b/addons/website_sale/tests/test_address.py
@@ -283,9 +283,9 @@ class TestCheckoutAddress(BaseUsersCommon, WebsiteSaleCommon):
         ]
 
         tax_10_incl, tax_20_excl, tax_15_incl = self.env['account.tax'].create([
-            {'name': 'Tax 10% incl', 'amount': 10, 'price_include': True},
-            {'name': 'Tax 20% excl', 'amount': 20, 'price_include': False},
-            {'name': 'Tax 15% incl', 'amount': 15, 'price_include': True},
+            {'name': 'Tax 10% incl', 'amount': 10, 'price_include_override': 'tax_included'},
+            {'name': 'Tax 20% excl', 'amount': 20, 'price_include_override': 'tax_excluded'},
+            {'name': 'Tax 15% incl', 'amount': 15, 'price_include_override': 'tax_included'},
         ])
         fpos_be, fpos_nl = self.env['account.fiscal.position'].create([
             {

--- a/addons/website_sale/tests/test_website_sale_cart.py
+++ b/addons/website_sale/tests/test_website_sale_cart.py
@@ -184,8 +184,8 @@ class TestWebsiteSaleCart(BaseUsersCommon, ProductAttributesCommon, WebsiteSaleC
         pricelist = self.pricelist
         # Add 10% tax on product
         tax10, tax6 = self.env['account.tax'].create([
-            {'name': "Test tax 10", 'amount': 10, 'price_include': True, 'amount_type': 'percent'},
-            {'name': "Test tax 6", 'amount': 6, 'price_include': True, 'amount_type': 'percent'},
+            {'name': "Test tax 10", 'amount': 10, 'price_include_override': 'tax_included', 'amount_type': 'percent'},
+            {'name': "Test tax 6", 'amount': 6, 'price_include_override': 'tax_included', 'amount_type': 'percent'},
         ])
 
         test_product = self.env['product.product'].create({
@@ -236,8 +236,8 @@ class TestWebsiteSaleCart(BaseUsersCommon, ProductAttributesCommon, WebsiteSaleC
         # We will test that the mapping of an 10% included tax by a 0% by a fiscal position is taken into account when updating the cart for no_variant product
         # Add 10% tax on product
         tax10, tax0 = self.env['account.tax'].create([
-            {'name': "Test tax 10", 'amount': 10, 'price_include': True, 'amount_type': 'percent'},
-            {'name': "Test tax 0", 'amount': 0, 'price_include': True, 'amount_type': 'percent'},
+            {'name': "Test tax 10", 'amount': 10, 'price_include_override': 'tax_included', 'amount_type': 'percent'},
+            {'name': "Test tax 0", 'amount': 0, 'price_include_override': 'tax_included', 'amount_type': 'percent'},
         ])
 
         # Create fiscal position mapping taxes 10% -> 0%

--- a/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
+++ b/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
@@ -140,7 +140,7 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
         self.assertEqual(combination_info['price_extra'], 200, "200% + 0% tax (mapped from fp 15% -> 0%)")
 
         # Try same flow with tax included
-        self.company_data['default_tax_sale'].price_include = True
+        self.company_data['default_tax_sale'].price_include_override = 'tax_included'
 
         # Reset / Safety check
         self.env.user.partner_id.country_id = None
@@ -159,7 +159,7 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
         self.assertEqual(combination_info['price_extra'], 173.91, "173.91$ + 0% tax (mapped from fp 15% -> 0%)")
 
         # Try same flow with tax included for apply tax
-        tax0.write({'name': "Test tax 5", 'amount': 5, 'price_include': True})
+        tax0.write({'name': "Test tax 5", 'amount': 5, 'price_include_override': 'tax_included'})
         combination_info = product._get_combination_info()
         self.assertEqual(round(combination_info['price'], 2), 456.52, "434.78$ + 5% tax (mapped from fp 15% -> 5% for BE)")
         self.assertEqual(round(combination_info['list_price'], 2), 2008.7, "434.78$ + 5% tax (mapped from fp 15% -> 5% for BE)")


### PR DESCRIPTION
As users can not modify directly the `price_include` field, there is no need for an inverse.

Also doing a reverse of that field does not make much sense as it is the combination of the `company_price_include` and `price_include_override`.

Enterprise PR: odoo/enterprise#69909

task-4144792

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
