### PR TITLE
[IMP] website_event_track: talks page enhancement

### DIFF
--- a/addons/website_event/static/src/scss/event_templates_common.scss
+++ b/addons/website_event/static/src/scss/event_templates_common.scss
@@ -18,6 +18,9 @@ $o-wevent-color: $body-color;
         border: $border-width solid var(--o-border-color);
         border-left: $border-width * 3 solid var(--badge-border-color);
     }
+    a.o_wesession_list_item:hover {
+        background-color: #e9e9e9;
+    }
 
     /*
      * COMMON MENU STYLING
@@ -75,6 +78,11 @@ $o-wevent-color: $body-color;
             outline: 0;
             box-shadow: 0 0 0 0.25rem rgba(134, 102, 126, 0.5);
         }
+    }
+
+    input[type="search"]::-webkit-search-cancel-button {
+        display: block;
+        opacity: 1;
     }
 }
 

--- a/addons/website_event_track/controllers/event_track.py
+++ b/addons/website_event_track/controllers/event_track.py
@@ -14,7 +14,7 @@ import json
 import operator
 import pytz
 
-from odoo import exceptions, http, fields, tools, _
+from odoo import http, fields, tools, _
 from odoo.http import request
 from odoo.osv import expression
 from odoo.tools import is_html_empty, plaintext2html
@@ -150,12 +150,13 @@ class EventTrackController(http.Controller):
         if tracks_announced:
             tracks_announced = tracks_announced.sorted('wishlisted_by_default', reverse=True)
             tracks_by_day.append({'date': False, 'name': _('Coming soon'), 'tracks': tracks_announced})
+        # Check if there are any ongoing or upcoming tracks
+        has_upcoming_or_ongoing = any(track for track in tracks_sudo if not track.is_track_done)
 
         for tracks_group in tracks_by_day:
-            # the tracks group is folded if all tracks are done (and if it's not "today")
-            tracks_group['default_collapsed'] = (today_tz != tracks_group['date']) and all(
-                track.is_track_done and not track.is_track_live
-                for track in tracks_group['tracks']
+           tracks_group['default_collapsed'] = (
+                has_upcoming_or_ongoing and
+                tracks_group['date'] and all(track.is_track_done for track in tracks_group['tracks'])
             )
 
         # return rendering values

--- a/addons/website_event_track/views/event_track_templates_list.xml
+++ b/addons/website_event_track/views/event_track_templates_list.xml
@@ -80,41 +80,29 @@
             </div>
             <div class="offcanvas-body p-0">
                 <div class="accordion accordion-flush">
-                    <div t-if="option_track_wishlist" class="accordion-item">
-                        <h2 class="accordion-header">
-                            <button class="accordion-button collapsed"
-                                type="button"
-                                data-bs-toggle="collapse"
-                                data-bs-target=".o_wevent_offcanvas_fav"
-                                aria-expanded="false"
-                                aria-controls="o_wevent_offcanvas_fav">
-                                Favorites
-                            </button>
-                        </h2>
-                        <div class="o_wevent_offcanvas_fav accordion-collapse collapse">
-                            <div class="accordion-body pt-0">
-                                <ul class="list-group list-group-flush">
-                                    <!-- Optional wishlist filter -->
-                                    <li class="list-group-item border-0 px-0">
-                                        <a t-att-href="'/event/%s/track?%s' % (
-                                                slug(event),
-                                                keep_query('*', search_wishlist='')
-                                            )"
-                                            class="d-flex align-items-center justify-content-between text-reset">
-                                            All Talks
-                                        </a>
-                                    </li>
-                                    <li class="list-group-item border-0 px-0">
-                                        <a t-att-href="'/event/%s/track?%s' % (
-                                                slug(event),
-                                                keep_query('*', search_wishlist='1')
-                                            )"
-                                            t-attf-class="d-flex align-items-center justify-content-between text-reset #{'active' if search_wishlist else ''}">
-                                            Favorites
-                                        </a>
-                                    </li>
-                                </ul>
-                            </div>
+                    <div class="o_wevent_offcanvas_fav accordion">
+                        <div class="accordion-body pt-0">
+                            <ul class="list-group list-group-flush">
+                                <!-- Optional wishlist filter -->
+                                <li class="list-group-item border-0 px-0">
+                                    <a t-att-href="'/event/%s/track?%s' % (
+                                            slug(event),
+                                            keep_query('*', search_wishlist='')
+                                        )"
+                                        class="d-flex align-items-center justify-content-between text-reset">
+                                        All Talks
+                                    </a>
+                                </li>
+                                <li class="list-group-item border-0 px-0">
+                                    <a t-att-href="'/event/%s/track?%s' % (
+                                            slug(event),
+                                            keep_query('*', search_wishlist='1')
+                                        )"
+                                        t-attf-class="d-flex align-items-center justify-content-between text-reset #{'active' if search_wishlist else ''}">
+                                        Favorites
+                                    </a>
+                                </li>
+                            </ul>
                         </div>
                     </div>
                     <t t-foreach="tag_categories" t-as="tag_category">
@@ -273,79 +261,16 @@
                 <!-- DAY TRACKS LIST -->
                 <div t-attf-class="collapse {{ '' if tracks_info['default_collapsed'] else 'show' }}"
                     t-attf-id="collapse_session_list_{{ tracks_info_index }}">
-                    <div t-foreach="tracks" t-as="track"
-                        t-att-class="'o_wesession_list_item p-3 o_color_%d' % (track.color)">
-                        <div class="row g-0">
-                            <div class="col-12 d-flex justify-content-between">
-                                <!-- Hour: Live > Remaining > Hour: desktop only -->
-                                <div class="d-flex align-items-center gap-1 flex-wrap">
-                                    <div t-if="tracks_date and today_tz &lt;= tracks_date"
-                                        >
-                                        <span t-if="track.is_track_live and not track.is_track_done"
-                                            class="alert alert-danger px-2 py-1">Live</span>
-                                        <span class="fw-bold" t-elif="not track.is_track_done and track.is_track_soon">
-                                            <span t-out="track.track_start_remaining"
-                                                t-options="{'widget': 'duration', 'digital': False, 'format': 'narrow',
-                                                            'add_direction': True, 'unit': 'second', 'round': 'minute'}"/>
-                                        </span>
-                                        <span class="fw-bold" t-elif="not track.is_track_done and not track.is_track_soon"
-                                            t-out="track.date"
-                                            t-options="{'widget': 'datetime', 'time_only': True, 'format': 'short', 'tz_name': event.date_tz}"/>
-                                        <span t-else="" class="alert alert-dark px-2 py-1 small">Finished</span>
-                                    </div>
-                                    <span t-if="tracks_date and today_tz &lt;= tracks_date and track.location_id">-</span>
-                                    <div t-if="track.location_id">
-                                        <i class="fa fa-map-marker" role="img"/> <span t-field="track.location_id"/>
-                                    </div>
-                                </div>
-                                <!-- reminder -->
-                                <div t-if="not event.is_done and (not track.date or today_tz &lt;= tracks_date) and option_track_wishlist"
-                                    class="d-none d-md-block py-1">
-                                    <t t-call="website_event_track.track_widget_reminder">
-                                        <t t-set="reminder_small" t-value="False"/>
-                                        <t t-set="reminder_light" t-value="False"/>
-                                    </t>
-                                </div>
-                            </div>
-                            <!-- Main column: name, speaker -->
-                            <div class="col-12">
-                                <span class="fw-bold mb0">
-                                    <a t-if="track.website_published or is_event_user"
-                                        class="text-reset me-2"
-                                        t-att-href="track.website_url">
-                                        <span t-field="track.name"/>
-                                    </a>
-                                    <t t-else="">
-                                        <span class="text-reset me-2" t-field="track.name"/>
-                                    </t>
-                                </span>
-                                <span t-if="not track.website_published and is_event_user" class="alert alert-danger px-2 py-1 align-top small">
-                                    Unpublished
-                                </span>
-                            </div>
-
-                            <div class="col-12 d-flex justify-content-between align-items-end">
-                                <div class="d-flex align-items-center w-100 gap-2 text-muted">
-                                    <span class="text-muted" t-out="track.partner_tag_line"/>
-                                    <t t-if="tracks_date and today_tz &lt;= tracks_date">
-                                        <t t-if="track.duration and not track.is_track_done and not track.is_track_done">
-                                            <span class="d-none d-md-block">&amp;bull;</span>
-                                            <span class="d-none d-md-block"
-                                                t-out="track.duration"
-                                                t-options="{'widget': 'duration', 'digital': False, 'format': 'short', 'unit': 'hour', 'round': 'minute'}"/>
-                                        </t>
-                                    </t>
-                                </div>
-                                <!-- Aside column: tags -->
-                                <div class="d-none d-md-flex justify-content-end align-items-center w-auto gap-2">
-                                    <!-- Tags: desktop only -->
-                                    <t t-foreach="track.tag_ids" t-as="tag">
-                                        <t t-if="tag.color" t-call="website_event_track.track_tag_badge_link"/>
-                                    </t>
-                                </div>
-                            </div>
+                    <t t-foreach="tracks" t-as="track">
+                        <a t-if="track.website_published or is_event_user"
+                            t-att-href="track.website_url"
+                            t-att-class="'o_wesession_list_item o_color_%d d-block text-decoration-none' % (track.color)">
+                            <t t-call="website_event_track.track_list_item"/>
+                        </a>
+                        <div t-else="" t-att-class="'o_wesession_list_item o_color_%d' % (track.color)">
+                            <t t-call="website_event_track.track_list_item"/>
                         </div>
-                    </div>
+                    </t>
                 </div>
             </li>
         </ul>
@@ -433,6 +358,69 @@
             </footer>
         </div>
     </article>
+</template>
+
+<template id="track_list_item" name="Track List Item">
+    <div class="row p-3 g-0">
+        <div class="col-12 d-flex justify-content-between">
+            <!-- Hour: Live > Remaining > Hour: desktop only -->
+            <div class="d-flex align-items-center gap-1 flex-wrap">
+                <div t-if="tracks_date and today_tz &lt;= tracks_date">
+                    <span t-if="track.is_track_live and not track.is_track_done"
+                        class="alert alert-danger px-2 py-1">Live</span>
+                    <span class="fw-bold" t-elif="not track.is_track_done and track.is_track_soon">
+                        <span t-out="track.track_start_remaining"
+                            t-options="{'widget': 'duration', 'digital': False, 'format': 'narrow',
+                                        'add_direction': True, 'unit': 'second', 'round': 'minute'}"/>
+                    </span>
+                    <span class="fw-bold" t-elif="not track.is_track_done and not track.is_track_soon"
+                        t-out="track.date"
+                        t-options="{'widget': 'datetime', 'time_only': True, 'format': 'short', 'tz_name': event.date_tz}"/>
+                    <span t-else="" class="alert alert-dark px-2 py-1 small">Finished</span>
+                </div>
+                <span t-if="tracks_date and today_tz &lt;= tracks_date and track.location_id">-</span>
+                <div t-if="track.location_id">
+                    <i class="fa fa-map-marker" role="img"/> <span t-field="track.location_id"/>
+                </div>
+            </div>
+            <!-- reminder -->
+            <div t-if="not event.is_done and (not track.date or today_tz &lt;= tracks_date) and option_track_wishlist"
+                class="d-none d-md-block py-1">
+                <t t-call="website_event_track.track_widget_reminder">
+                    <t t-set="reminder_small" t-value="False"/>
+                    <t t-set="reminder_light" t-value="False"/>
+                </t>
+            </div>
+        </div>
+        <!-- Main column: name, speaker -->
+        <div class="col-12">
+            <span class="o_wesession_list_item_title fw-bold" t-field="track.name"/>
+            <span t-if="not track.website_published and is_event_user" class="alert alert-danger px-2 py-1 align-top small">
+                Unpublished
+            </span>
+        </div>
+
+        <div class="col-12 d-flex justify-content-between align-items-end">
+            <div class="d-flex align-items-center w-100 gap-2 text-muted">
+                <span class="text-muted" t-out="track.partner_tag_line"/>
+                <t t-if="tracks_date and today_tz &lt;= tracks_date">
+                    <t t-if="track.duration and not track.is_track_done and not track.is_track_done">
+                        <span class="d-none d-md-block">&amp;bull;</span>
+                        <span class="d-none d-md-block"
+                            t-out="track.duration"
+                            t-options="{'widget': 'duration', 'digital': False, 'format': 'short', 'unit': 'hour', 'round': 'minute'}"/>
+                    </t>
+                </t>
+            </div>
+            <!-- Aside column: tags -->
+            <div class="d-none d-md-flex justify-content-end align-items-center w-auto gap-2">
+                <!-- Tags: desktop only -->
+                <t t-foreach="track.tag_ids" t-as="tag">
+                    <t t-if="tag.color" t-call="website_event_track.track_tag_badge_link"/>
+                </t>
+            </div>
+        </div>
+    </div>
 </template>
 
 <!-- Searched tags -->

--- a/addons/website_event_track/views/event_track_templates_page.xml
+++ b/addons/website_event_track/views/event_track_templates_page.xml
@@ -6,6 +6,9 @@
         <t t-set="navbar__back_url" t-value="'/event/%s/track' % (slug(event))"/>
         <t t-set="navbar__back_title">Back to All Talks</t>
         <t t-set="navbar__back_text">All Talks</t>
+        <!-- Set aside block only if there are filtered tracks -->
+        <t t-set="has_ongoing_or_upcoming" t-value="any(track.is_track_live or track.track_start_remaining for track in tracks_other)"/>
+        <t t-set="filtered_tracks_other" t-value="tracks_other.filtered(lambda track: not (has_ongoing_or_upcoming and track.is_track_done))"/>
 
         <div class="o_wevent_online o_wesession_index">
             <!-- Options -->
@@ -15,15 +18,16 @@
             <div id="oe_structure_wesession_track_index_1" class="oe_structure"/>
             <!-- Content -->
             <div t-att-class="'o_wevent_online_page_container py-3 %s' % ('container' if not option_widescreen else 'container-fluid')">
-                <div t-att-class="'row mb-5 mx-0 %s' % ('justify-content-center' if not tracks_other else '')">
-                    <t t-if="tracks_other">
-                        <t t-call="website_event_track.event_track_aside"/>
-                    </t>
+                <div t-att-class="'row mb-5 mx-0 %s' % ('justify-content-center' if not filtered_tracks_other else '')">
+                        <t t-call="website_event_track.event_track_aside">
+                            <t t-set="tracks_other" t-value="filtered_tracks_other"/>
+                        </t>
+                    <!-- Main content -->
                     <t t-call="website_event_track.event_track_content"/>
                 </div>
+                <!-- Drag/Drop Area -->
+                <div id="oe_structure_wesession_track_index_2" class="oe_structure"/>
             </div>
-            <!-- Drag/Drop Area -->
-            <div id="oe_structure_wesession_track_index_2" class="oe_structure"/>
         </div>
     </t>
 </template>

--- a/addons/website_event_track_live/views/event_track_templates_list.xml
+++ b/addons/website_event_track_live/views/event_track_templates_list.xml
@@ -1,19 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-<template id="tracks_display_list" inherit_id="website_event_track.tracks_display_list">
+<template id="track_list_item" inherit_id="website_event_track.track_list_item">
     <!-- TRACK LIST: ADD REPLAY TAG FOR FINISHED TRACKS -->
-    <xpath expr="//div[@t-foreach='tracks']//div[hasclass('col-12')]//span[@t-elif='not track.is_track_done and not track.is_track_soon']" position="after">
-        <a t-elif="track.youtube_video_url and (track.is_published or is_event_user)"
-            t-att-href="track.website_url" class="badge text-bg-danger">Replay
-        </a>
+    <xpath expr="//div[hasclass('col-12')]//span[@t-elif='not track.is_track_done and not track.is_track_soon']" position="after">
+        <span t-elif="track.youtube_video_url and (track.is_published or is_event_user)"
+            class="badge text-bg-danger">Replay
+        </span>
     </xpath>
     <!-- ADD YOUTUBE ICON -->
-    <xpath expr="//div[@t-foreach='tracks']//div[hasclass('col-12')]//a/span[@t-field='track.name']" position="before">
-        <i t-if="track.date and track.youtube_video_url and (track.is_track_soon or track.is_track_live or track.is_youtube_replay)"
-            class="fa fa-youtube-play text-danger me-1"/>
-    </xpath>
-    <xpath expr="//div[@t-foreach='tracks']//div[hasclass('col-12')]//t/span[@t-field='track.name']" position="before">
+    <xpath expr="//div[hasclass('col-12')]//span[@t-field='track.name']" position="before">
         <i t-if="track.date and track.youtube_video_url and (track.is_track_soon or track.is_track_live or track.is_youtube_replay)"
             class="fa fa-youtube-play text-danger me-1"/>
     </xpath>


### PR DESCRIPTION
This PR focuses on the following improvements:
- Sidebar now hides completed talks if ongoing or upcoming talks are available.
- Automatically expand past days when filters return results in those days for quick access to past talk details.
- Expose 'All Talks' and 'Favorites' shortcuts directly.
- Keep search filter cross visible at all times.
- Make the entire talk tile clickable, not just the title.

Task-4102026