### PR TITLE
[IMP] web: display view type when breadcrumb is hovered

### DIFF
--- a/addons/web/static/src/search/breadcrumbs/breadcrumbs.xml
+++ b/addons/web/static/src/search/breadcrumbs/breadcrumbs.xml
@@ -23,7 +23,7 @@
                             </button>
                             <t t-set-slot="content">
                                 <t t-foreach="collapsedBreadcrumbs" t-as="breadcrumb" t-key="breadcrumb.jsId">
-                                    <DropdownItem onSelected="breadcrumb.onSelected" attrs="{ href: breadcrumb.url}">
+                                    <DropdownItem onSelected="breadcrumb.onSelected" attrs="{ href: breadcrumb.url, 'data-tooltip': 'Back to &quot;' + breadcrumb.name + '&quot; ' + breadcrumb.viewType}">
                                         <t t-call="web.Breadcrumb.Name"/>
                                     </DropdownItem>
                                 </t>
@@ -32,7 +32,7 @@
                     </li>
                     <t t-foreach="visiblePathBreadcrumbs" t-as="breadcrumb" t-key="breadcrumb.jsId">
                         <li class="breadcrumb-item d-inline-flex min-w-0" t-att-class="{ o_back_button: breadcrumb_last }" t-att-data-hotkey="breadcrumb_last and 'b'" t-on-click.prevent="breadcrumb.onSelected">
-                            <a t-att-href="breadcrumb.url" class="fw-bold text-truncate" t-att-data-tooltip="'Back to &quot;' + breadcrumb.name + '&quot;'"><t t-call="web.Breadcrumb.Name"/></a>
+                            <a t-att-href="breadcrumb.url" class="fw-bold text-truncate" t-att-data-tooltip="'Back to &quot;' + breadcrumb.name + '&quot; ' + breadcrumb.viewType"><t t-call="web.Breadcrumb.Name"/></a>
                         </li>
                     </t>
                 </ol>

--- a/addons/web/static/tests/_framework/mock_server/mock_server.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_server.js
@@ -932,13 +932,25 @@ export class MockServer {
             if (actionId) {
                 const action = this.getAction(actionId);
                 if (resId) {
-                    return this.env[action.res_model].read([resId], ["display_name"])[0]
-                        .display_name;
+                    return {
+                        display_name: this.env[action.res_model].read([resId], ["display_name"])[0]
+                            .display_name,
+                        view_type: "form",
+                    };
                 }
-                return action.name;
+                const res = {};
+                res.display_name = action.name;
+                if (action.views) {
+                    res.view_type = action.views[0][1];
+                }
+                return res;
             } else if (model) {
                 if (resId) {
-                    return this.env[model].read([resId], ["display_name"])[0].display_name;
+                    return {
+                        display_name: this.env[model].read([resId], ["display_name"])[0]
+                            .display_name,
+                        view_type: "form",
+                    };
                 }
                 throw new Error("Actions with a model should also have a resId");
             }

--- a/addons/web/static/tests/legacy/helpers/mock_server.js
+++ b/addons/web/static/tests/legacy/helpers/mock_server.js
@@ -789,13 +789,24 @@ export class MockServer {
             if (action_id) {
                 const act = this.mockLoadAction({ action_id });
                 if (resId) {
-                    return this.mockRead(act.res_model, [[resId], ["display_name"]])[0]
-                        .display_name;
+                    return {
+                        display_name: this.mockRead(act.res_model, [[resId], ["display_name"]])[0]
+                            .display_name,
+                        view_type: "form",
+                    };
                 }
-                return act.name;
+                const res = {};
+                res.display_name = act.name;
+                if (act.views) {
+                    res.view_type = act.views[0][1];
+                }
+                return res;
             } else if (model) {
                 if (resId) {
-                    return this.models[model].records[resId].display_name;
+                    return {
+                        display_name: this.models[model].records[resId].display_name,
+                        view_type: "form",
+                    };
                 }
                 throw new Error("Actions with a model should also have a resId");
             }

--- a/addons/web/static/tests/search/control_panel.test.js
+++ b/addons/web/static/tests/search/control_panel.test.js
@@ -41,8 +41,18 @@ test.tags`desktop`("breadcrumbs", async () => {
         { resModel: "foo" },
         {
             breadcrumbs: [
-                { jsId: "controller_7", name: "Previous", onSelected: () => expect.step("controller_7") },
-                { jsId: "controller_9", name: "Current", onSelected: () => expect.step("controller_9") },
+                {
+                    jsId: "controller_7",
+                    name: "Previous",
+                    onSelected: () => expect.step("controller_7"),
+                    viewType: "kanban",
+                },
+                {
+                    jsId: "controller_9",
+                    name: "Current",
+                    onSelected: () => expect.step("controller_9"),
+                    viewType: "form",
+                },
             ],
         }
     );
@@ -52,6 +62,10 @@ test.tags`desktop`("breadcrumbs", async () => {
     expect(breadcrumbItems[0]).toHaveText("Previous");
     expect(breadcrumbItems[1]).toHaveText("Current");
     expect(breadcrumbItems[1]).toHaveClass("active");
+    expect(breadcrumbItems[0].children[0]).toHaveAttribute(
+        "data-tooltip",
+        'Back to "Previous" kanban'
+    );
 
     click(breadcrumbItems[0]);
     expect.verifySteps(["controller_7"]);

--- a/addons/web/static/tests/webclient/actions/load_state.test.js
+++ b/addons/web/static/tests/webclient/actions/load_state.test.js
@@ -27,7 +27,7 @@ import { redirect } from "@web/core/utils/urls";
 import { ControlPanel } from "@web/search/control_panel/control_panel";
 import { _t } from "@web/core/l10n/translation";
 import { user } from "@web/core/user";
-import { queryAllTexts, queryFirst } from "@odoo/hoot-dom";
+import { queryAllAttributes, queryAllTexts, queryFirst } from "@odoo/hoot-dom";
 
 describe.current.tags("desktop");
 
@@ -748,6 +748,10 @@ describe(`new urls`, () => {
         expect(browser.location.href).toBe("http://example.com/odoo/action-3/new", {
             message: "the url did not change",
         });
+        expect(`.o_breadcrumb li.breadcrumb-item a`).toHaveAttribute(
+            "data-tooltip",
+            'Back to "Partners" list'
+        );
         expect.verifySteps([
             "/web/webclient/translations",
             "/web/webclient/load_menus",
@@ -793,6 +797,10 @@ describe(`new urls`, () => {
             "Partners",
             "Second record",
         ]);
+        expect(`.o_breadcrumb li.breadcrumb-item a`).toHaveAttribute(
+            "data-tooltip",
+            'Back to "Partners" list'
+        );
         expect(browser.location.href).toBe("http://example.com/odoo/action-3/2", {
             message: "the url did not change",
         });
@@ -986,6 +994,10 @@ describe(`new urls`, () => {
         await mountWebClient();
         expect(`.o_form_view`).toHaveCount(1);
         expect(queryAllTexts`.breadcrumb-item, .o_breadcrumb .active`).toEqual(["Partner", "New"]);
+        expect(`.o_breadcrumb li.breadcrumb-item a`).toHaveAttribute(
+            "data-tooltip",
+            'Back to "Partner" list'
+        );
         expect.verifySteps([
             "/web/webclient/translations",
             "/web/webclient/load_menus",
@@ -1228,11 +1240,19 @@ describe(`new urls`, () => {
 
         await contains(`.breadcrumb .dropdown-toggle`).click();
         expect(`.o-overlay-container .dropdown-menu`).toHaveText("Partners Action 27");
+        expect(`.o-overlay-container .dropdown-menu a`).toHaveAttribute(
+            "data-tooltip",
+            'Back to "Partners Action 27" list'
+        );
         expect(queryAllTexts`.breadcrumb-item, .o_breadcrumb .active`).toEqual([
             "",
             "Second record",
             "Partners Action 28",
             "First record",
+        ]);
+        expect(queryAllAttributes(".o_breadcrumb li.breadcrumb-item a", "data-tooltip")).toEqual([
+            'Back to "Second record" form',
+            'Back to "Partners Action 28" kanban',
         ]);
     });
 
@@ -1257,6 +1277,10 @@ describe(`new urls`, () => {
             "Partners",
             "Second record",
         ]);
+        expect(`.o_breadcrumb li.breadcrumb-item a`).toHaveAttribute(
+            "data-tooltip",
+            'Back to "Partners" list'
+        );
         expect.verifySteps([
             "/web/webclient/translations",
             "/web/webclient/load_menus",


### PR DESCRIPTION
This commit, will add the view type to the tooltip when the breadcrumb is hovered. Note that, this commit will also add a tooltip on the collapsed breadcrumb items.

task-id: 4070508
