### PR TITLE
[FIX] point_of_sale: use correct field for product name on invoice

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -8,7 +8,6 @@ from collections import defaultdict
 
 import psycopg2
 import pytz
-import re
 
 from odoo import api, fields, models, tools, _
 from odoo.tools import float_is_zero, float_round, float_repr, float_compare
@@ -1492,10 +1491,7 @@ class PosOrderLine(models.Model):
             product_name = line.product_id\
                 .with_context(lang=line.order_id.partner_id.lang or self.env.user.lang)\
                 .get_product_multiline_description_sale()
-            if line.product_id.display_name:
-                product_name = re.sub(re.escape(line.product_id.display_name), '', product_name)
-                product_name = re.sub(r'^\n', '', product_name)
-                product_name = re.sub(r'(?<=\n) ', '', product_name)
+
             base_line_vals_list.append(
                 {
                     **self.env['account.tax']._convert_to_tax_base_line_dict(


### PR DESCRIPTION
Problem:
The wrong field was used for the product name on the invoice, causing some or all product names to be missing in the generated PDF.

Steps to reproduce:

- Go to PoS.
- Add some products.
- Generate an invoice for a customer during checkout.
- The invoice (PDF) is missing some or all product names.

opw-4140603

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
