### PR TITLE
[FIX] web: list: misleading total of records in selection box

### DIFF
--- a/addons/web/i18n/web.pot
+++ b/addons/web/i18n/web.pot
@@ -3929,6 +3929,13 @@ msgstr ""
 #. openerp-web
 #: code:addons/web/static/src/legacy/xml/base.xml:0
 #, python-format
+msgid "Select all records matching the search"
+msgstr ""
+
+#. module: web
+#. openerp-web
+#: code:addons/web/static/src/legacy/xml/base.xml:0
+#, python-format
 msgid "Select field"
 msgstr ""
 

--- a/addons/web/static/src/legacy/js/views/list/list_controller.js
+++ b/addons/web/static/src/legacy/js/views/list/list_controller.js
@@ -726,6 +726,7 @@ var ListController = BasicController.extend({
                 isPageSelected: this.isPageSelected,
                 nbSelected: this.selectedRecords.length,
                 nbTotal: state.count,
+                isTotalTrustable: !state.groupedBy.length || state.groupsCount <= state.groupsLimit,
             }));
             this.$selectionBox.appendTo(this.$buttons);
         }

--- a/addons/web/static/src/legacy/xml/base.xml
+++ b/addons/web/static/src/legacy/xml/base.xml
@@ -600,11 +600,11 @@
 
 <t t-name="ListView.selection">
     <div class="o_list_selection_box alert alert-info d-inline-flex align-items-center pl-0 px-lg-2 py-0 mb-0 ml-2" role="alert">
-        <span t-if="isDomainSelected">All <span class="text-monospace" t-esc="nbTotal"/> selected</span>
+        <span t-if="isDomainSelected">All <t t-if="isTotalTrustable"><span class="text-monospace" t-esc="nbTotal"/> </t>selected</span>
         <t t-else="">
             <span class="text-monospace mr-1" t-esc="nbSelected"/> selected
-            <a t-if="isPageSelected and nbTotal > nbSelected" href="#" class="o_list_select_domain ml-2 btn btn-sm btn-info px-2 py-1 border-0 font-weight-normal">
-                <i class="fa fa-arrow-right"/> Select all <span class="text-monospace" t-esc="nbTotal"/>
+            <a t-if="isPageSelected and nbTotal > nbSelected" href="#" class="o_list_select_domain ml-2 btn btn-sm btn-info px-2 py-1 border-0 font-weight-normal" title="Select all records matching the search">
+                <i class="fa fa-arrow-right"/> Select all <span t-if="isTotalTrustable" class="text-monospace" t-esc="nbTotal"/>
             </a>
         </t>
     </div>

--- a/addons/web/static/tests/legacy/views/list_tests.js
+++ b/addons/web/static/tests/legacy/views/list_tests.js
@@ -2265,6 +2265,37 @@ QUnit.module('Views', {
         list.destroy();
     });
 
+    QUnit.test('selection box in grouped list, multi pages)', async function (assert) {
+        assert.expect(8);
+
+        var list = await createView({
+            View: ListView,
+            model: 'foo',
+            data: this.data,
+            groupBy: ['int_field'],
+            arch: '<tree groups_limit="2"><field name="foo"/><field name="bar"/></tree>',
+        });
+
+        assert.containsN(list, '.o_group_header', 2);
+        assert.containsNone(list.$('.o_cp_buttons'), '.o_list_selection_box');
+
+        // open first group and select all records of first page
+        await testUtils.dom.click(list.$('.o_group_header:first'));
+        assert.containsOnce(list, '.o_data_row');
+        await testUtils.dom.click(list.$('thead .o_list_record_selector input'));
+        assert.containsOnce(list.$('.o_cp_buttons'), '.o_list_selection_box');
+        assert.containsOnce(list.$('.o_list_selection_box'), '.o_list_select_domain');
+        assert.strictEqual(list.$('.o_list_selection_box').text().replace(/\s+/g, ' ').trim(),
+            '1 selected Select all'); // we don't know the total count, so we don't display it
+
+        // select all domain
+        await testUtils.dom.click(list.$('.o_list_selection_box .o_list_select_domain'));
+        assert.containsOnce(list.$('.o_cp_buttons'), '.o_list_selection_box');
+        assert.strictEqual(list.$('.o_list_selection_box').text().trim(), 'All selected');
+
+        list.destroy();
+    });
+
     QUnit.test('selection box is displayed after header buttons', async function (assert) {
         assert.expect(5);
 


### PR DESCRIPTION
Have a grouped list view with several several pages (more groups than the groups_limit). Open a group, and click on the record selector in the header, to select all records of the current page. The selection box is displayed in the control panel. It indicates the number of selected records (in the current page), and allows to select all records matching the domain ("Select n records"). Before this commit, n was wrong in the scenario described above. Indeed, we don't know in JS the total count of records as the information isn't returned by read_group. As we compute it by summing up the count of each group, it's only the number of records in groups of the first page. However, if the user performs an action after clicking "Select All", the action is indeed performed on **all** records, not those of the first page, which could lead to a surprising result.

We can't easily add the correct count without risking to impact the perf, so this commit is simply about not displaying a falsy information. When we can't trust the count, we simply display "Select All"/"All selected".

opw~4129944

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
