### PR TITLE
[FIX] payment_aps: allow testing with a non-standard port

### DIFF
--- a/addons/payment_aps/tests/test_payment_transaction.py
+++ b/addons/payment_aps/tests/test_payment_transaction.py
@@ -19,6 +19,9 @@ class TestPaymentTransaction(APSCommon):
 
     def test_no_item_missing_from_rendering_values(self):
         """ Test that the rendered values are conform to the transaction fields. """
+        self.env['ir.config_parameter'].set_param('web.base.url', 'http://127.0.0.1:8069')
+        self.patch(self, 'base_url', lambda: 'http://127.0.0.1:8069')
+
         tx = self._create_transaction(flow='redirect')
 
         converted_amount = payment_utils.to_minor_currency_units(self.amount, self.currency)
@@ -35,7 +38,7 @@ class TestPaymentTransaction(APSCommon):
             'signature': '8f4e295359a578f05fdc6c275829128e7b93440e6c7d13179c1e16cc579c6111',
             'api_url': self.provider._aps_get_api_url(),
         }
-        self.assertDictEqual(tx._get_specific_rendering_values(None), expected_values)
+        self.assertEqual(tx._get_specific_rendering_values(None), expected_values)
 
     @mute_logger('odoo.addons.payment.models.payment_transaction')
     def test_no_input_missing_from_redirect_form(self):


### PR DESCRIPTION
Because the signature is precomputed and includes the server URL, when running with a non-standard port the test fails as the port does not match the original value used to precompute the signature.

- reset `web.base.url` to its default / precomputation value.
- patch `TestPaymentTransaction.base_url` to return the same, as that is what `PaymentHttpCommon._build_url` uses to... build the url.
