### PR TITLE
[REV] website_sale_picking: adjust fpos based on warehouse location

### DIFF
--- a/addons/website_sale_picking/models/sale_order.py
+++ b/addons/website_sale_picking/models/sale_order.py
@@ -1,27 +1,10 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from odoo import models
 
 
 class SaleOrder(models.Model):
     _inherit = "sale.order"
-
-    def _check_carrier_quotation(self, force_carrier_id=None, keep_carrier=False):
-        carrier_before = self.carrier_id
-        res = super()._check_carrier_quotation(
-            force_carrier_id=force_carrier_id,
-            keep_carrier=keep_carrier,
-        )
-        if res:
-            fpos_before = self.fiscal_position_id
-            if self.carrier_id.delivery_type == 'onsite' and self.carrier_id.warehouse_id:
-                self.partner_shipping_id = self.carrier_id.warehouse_id.partner_id
-            elif carrier_before.delivery_type == 'onsite':
-                # setting partner_shipping_id as the carrier pickup location
-                # overwrites the original partner shipping address
-                # so it needs to be recomputed if the delivery method is not onsite picking
-                self._compute_partner_shipping_id()
-            if self.fiscal_position_id != fpos_before:
-                self._recompute_taxes()
-        return res
 
     def _remove_delivery_line(self):
         if self.carrier_id.delivery_type == 'onsite' and self.carrier_id.warehouse_id:

--- a/addons/website_sale_picking/static/tests/tours/onsite_payment_tour.js
+++ b/addons/website_sale_picking/static/tests/tours/onsite_payment_tour.js
@@ -52,37 +52,3 @@ registry.category("web_tour.tours").add('onsite_payment_tour', {
         },
     ]
 });
-
-registry.category("web_tour.tours").add('onsite_payment_fiscal_change_tour', {
-    test: true,
-    url: '/shop',
-    steps: () => [
-        ...wsTourUtils.addToCart({ productName: 'Super Product' }),
-        wsTourUtils.goToCart(),
-        wsTourUtils.goToCheckout(),
-        ...wsTourUtils.fillAdressForm(),
-        ...wsTourUtils.assertCartAmounts({
-            taxes: '10.00',
-            untaxed: '100.00',
-            total: '110.00',
-        }),
-        wTourUtils.clickOnElement(
-            'Example shipping On Site',
-            '.o_delivery_carrier_select:contains("Example shipping On Site")',
-        ),
-        ...wsTourUtils.assertCartAmounts({
-            taxes: '5.00',
-            untaxed: '100.00',
-            total: '105.00',
-        }),
-        wTourUtils.clickOnElement(
-            '"Standard delivery"',
-            '.o_delivery_carrier_select:contains("Standard delivery")',
-        ),
-        ...wsTourUtils.assertCartAmounts({
-            taxes: '10.00',
-            untaxed: '100.00',
-            total: '110.00',
-        }),
-    ]
-});

--- a/addons/website_sale_picking/tests/test_ui.py
+++ b/addons/website_sale_picking/tests/test_ui.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
 
-from odoo.fields import Command
-from odoo.tests import HttpCase, tagged, loaded_demo_data
+from odoo.tests import HttpCase, loaded_demo_data, tagged
 
 _logger = logging.getLogger(__name__)
 
@@ -52,93 +50,3 @@ class TestUi(HttpCase):
         self.env.ref("website_sale_picking.payment_provider_onsite").is_published = True
 
         self.start_tour('/shop', 'onsite_payment_tour')
-
-    def test_onsite_payment_fiscal_change_tour(self):
-        # Setup fiscal position
-        (
-            tax_5,
-            tax_10,
-            tax_15,
-        ) = self.env['account.tax'].create([
-            {
-                'name': '5% Tax',
-                'amount_type': 'percent',
-                'amount': 5,
-                'price_include': False,
-                'include_base_amount': False,
-                'type_tax_use': 'sale',
-            },
-            {
-                'name': '10% Tax',
-                'amount_type': 'percent',
-                'amount': 10,
-                'price_include': False,
-                'include_base_amount': False,
-                'type_tax_use': 'sale',
-            },
-            {
-                'name': '15% Tax',
-                'amount_type': 'percent',
-                'amount': 15,
-                'price_include': False,
-                'include_base_amount': False,
-                'type_tax_use': 'sale',
-            },
-        ])
-        warehouse_fiscal_country = self.env['res.country'].create({
-            'name': "Dummy Country",
-            'code': 'DC',
-        })
-        # wsTourUtils.fillAdressForm() selects first country as address country
-        client_fiscal_country = self.env['res.country'].search([('code', '=', 'AF')])
-
-        self.env['product.product'].create({
-            'name': 'Super Product',
-            'list_price': 100.0,
-            'type': 'consu',
-            'website_published': True,
-            'taxes_id': [Command.link(tax_15.id)]
-        })
-
-        self.env['account.fiscal.position'].create([
-            {
-                'name': 'Super Fiscal Position',
-                'auto_apply': True,
-                'country_id': warehouse_fiscal_country.id,
-                'tax_ids': [
-                    Command.create({
-                        'tax_src_id': tax_15.id,
-                        'tax_dest_id': tax_5.id,
-                    })
-                ]
-            },
-            {
-                'name': 'Super Fiscal Position',
-                'auto_apply': True,
-                'country_id': client_fiscal_country.id,
-                'tax_ids': [
-                    Command.create({
-                        'tax_src_id': tax_15.id,
-                        'tax_dest_id': tax_10.id,
-                    })
-                ]
-            },
-        ])
-        self.env.user.company_id.partner_id.country_id = warehouse_fiscal_country
-        # Setup onsite picking with fiscal position different than user
-        warehouse = self.env['stock.warehouse'].create({
-            'name': "Warehouse",
-            'partner_id': self.env.user.company_id.partner_id.id,
-            'code': "WH01"
-        })
-        self.env['delivery.carrier'].create({
-            'delivery_type': 'onsite',
-            'is_published': True,
-            'website_published': True,
-            'name': 'Example shipping On Site',
-            'product_id': self.env.ref('website_sale_picking.onsite_delivery_product').id,
-            'warehouse_id': warehouse.id,
-        })
-        self.env.ref("website_sale_picking.payment_provider_onsite").state = 'enabled'
-        self.env.ref("website_sale_picking.payment_provider_onsite").is_published = True
-        self.start_tour('/shop', 'onsite_payment_fiscal_change_tour')


### PR DESCRIPTION
This commit reverts dd331e7bb27c533808a01b53f80e0ee7f1dfed7f

This change has caused a lot of issues recently, and despite some other fixes, we believe it's safer to revert it for now.

opw-4126140
opw-4114139
opw-4115510
opw-4117520
opw-4109625
opw-4115415
opw-4143237
opw-4123382
opw-4136888
opw-4125807

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
