### PR TITLE
[IMP] account: Fallback if account.code not set in active company

### DIFF
--- a/addons/account/static/src/components/char_with_placeholder_field/char_with_placeholder_field.js
+++ b/addons/account/static/src/components/char_with_placeholder_field/char_with_placeholder_field.js
@@ -1,0 +1,46 @@
+/** @odoo-module **/
+
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { CharField, charField } from "@web/views/fields/char/char_field";
+
+// Ensure that in Hoot tests, this module is loaded after `@mail/js/onchange_on_keydown`
+// (needed because that module patches `charField`).
+import "@mail/js/onchange_on_keydown";
+
+export class CharWithPlaceholderField extends CharField {
+    static template = "account.CharWithPlaceholderField";
+    static props = {
+        ...CharField.props,
+        placeholderField: { type: String },
+    };
+
+    /** Override **/
+    get formattedValue() {
+        return super.formattedValue || this.placeholder;
+    }
+
+    get placeholder() {
+        return this.props.record.data[this.props.placeholderField] || this.props.placeholder;
+    }
+}
+
+export const charWithPlaceholderField = {
+    ...charField,
+    component: CharWithPlaceholderField,
+    supportedOptions: [
+        ...charField.supportedOptions,
+        {
+            label: _t("Placeholder field"),
+            name: "placeholder_field",
+            type: "field",
+            availableTypes: ["char"],
+        },
+    ],
+    extractProps: ({ attrs, options }) => ({
+        ...charField.extractProps({ attrs, options }),
+        placeholderField: options.placeholder_field,
+    }),
+};
+
+registry.category("fields").add("char_with_placeholder_field", charWithPlaceholderField);

--- a/addons/account/static/src/components/char_with_placeholder_field/char_with_placeholder_field.xml
+++ b/addons/account/static/src/components/char_with_placeholder_field/char_with_placeholder_field.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="account.CharWithPlaceholderField" t-inherit="web.CharField">
+        <xpath expr="//span" position="attributes">
+            <attribute name="t-att-class">{'text-muted': !this.props.record.data[props.name]}</attribute>
+        </xpath>
+        <xpath expr="//input" position="attributes">
+            <attribute name="t-att-placeholder">placeholder</attribute>
+        </xpath>
+    </t>
+
+</templates>

--- a/addons/account/static/tests/char_with_placeholder_field.test.js
+++ b/addons/account/static/tests/char_with_placeholder_field.test.js
@@ -1,0 +1,99 @@
+import { defineAccountModels } from "./account_test_helpers";
+import { expect, test } from "@odoo/hoot";
+import { queryFirst } from "@odoo/hoot-dom";
+import {
+    contains,
+    defineModels,
+    fieldInput,
+    fields,
+    models,
+    mountView,
+} from "@web/../tests/web_test_helpers";
+
+class Account extends models.Model {
+    _name = "account.account";
+    _inherit = [];
+
+    code = fields.Char({
+        string: "Code",
+        trim: true,
+    });
+    placeholder_code = fields.Char();
+
+    _records = [
+        {
+            id: 1,
+            placeholder_code: "Placeholder Code",
+        },
+    ];
+
+    _views = {
+        form: /* xml */ `
+            <form>
+                <sheet>
+                    <group>
+                        <field name="placeholder_code" invisible="1" />
+                        <field name="code" widget="char_with_placeholder_field" options="{'placeholder_field': 'placeholder_code'}" />
+                    </group>
+                </sheet>
+            </form>
+        `,
+        list: /* xml */ `
+            <list editable="top" create="1" delete="1">
+                <field name="placeholder_code" column_invisible="1" />
+                <field name="code" widget="char_with_placeholder_field" options="{'placeholder_field': 'placeholder_code'}" />
+            </list>
+        `,
+    };
+}
+
+defineAccountModels();
+defineModels([Account]);
+
+test("Form: placeholder_field shows as placeholder", async () => {
+    await mountView({ type: "form", resModel: "account.account", resId: 1 });
+
+    expect("input").toHaveValue("", {
+        message: "should have no value in input",
+    });
+    expect("input").toHaveAttribute("placeholder", "Placeholder Code", {
+        message: "placeholder_field should be the placeholder",
+    });
+});
+
+test.tags("desktop")("List: placeholder_field shows as text/placeholder", async () => {
+    await mountView({
+        type: "list",
+        resModel: "account.account",
+    });
+
+    const firstCellSelector = "tbody td:not(.o_list_record_selector):first";
+
+    expect(`${firstCellSelector} span`).toHaveText("Placeholder Code", {
+        message: "placeholder_field should be the text value",
+    });
+
+    expect(`${firstCellSelector} span`).toHaveClass("text-muted", {
+        message: "placeholder_field should be greyed out",
+    });
+
+    await contains(firstCellSelector).click();
+    expect(queryFirst(firstCellSelector).parentElement).toHaveClass("o_selected_row", {
+        message: "should be set as edit mode",
+    });
+    expect(`${firstCellSelector} input`).toHaveValue("", {
+        message: "once in edit mode, should have no value in input",
+    });
+    expect(`${firstCellSelector} input`).toHaveAttribute("placeholder", "Placeholder Code", {
+        message: "once in edit mode, should have placeholder_field as placeholder",
+    });
+    await fieldInput("code").edit("100001", { confirm: false });
+
+    await contains(".o_list_button_save").click();
+    expect(firstCellSelector).toHaveText("100001", {
+        message: "entered value should be saved",
+    });
+    expect(firstCellSelector).not.toHaveClass("text-muted", {
+        message: "field should not be greyed out",
+    });
+});

--- a/addons/account/views/account_account_views.xml
+++ b/addons/account/views/account_account_views.xml
@@ -38,7 +38,9 @@
                                     <div class="col col-md-auto">
                                         <label for="code" string="Code"/>
                                         <div>
-                                            <field name="code" placeholder="e.g. 101000" class="oe_inline"/>
+                                            <field name="placeholder_code" invisible="1"/>
+                                            <field name="code" placeholder="e.g. 101000" class="oe_inline"
+                                                   widget="char_with_placeholder_field" options="{'placeholder_field': 'placeholder_code'}"/>
                                         </div>
                                     </div>
                                 </div>
@@ -93,7 +95,8 @@
             <field name="model">account.account</field>
             <field name="arch" type="xml">
                 <list editable="top" create="1" delete="1" multi_edit="1" string="Chart of accounts"  open_form_view="True">
-                    <field name="code"/>
+                    <field name="placeholder_code" column_invisible="1"/>
+                    <field name="code" string="Code" widget="char_with_placeholder_field" options="{'placeholder_field': 'placeholder_code'}"/>
                     <field name="name"/>
                     <field name="account_type" widget="account_type_selection"/>
                     <field name="group_id" optional="hide"/>


### PR DESCRIPTION
In the CoA view (both list + form), if account.code is False for the active company, we show its code in another company, in greyed-out, so that the user knows they need to change it.

taskid: 4150457