### PR TITLE
[IMP] mail: modify send email flow in form

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -645,6 +645,18 @@ class MailMail(models.Model):
                 if smtp_session:
                     smtp_session.quit()
 
+    def action_send_and_close(self):
+        """ An action sending the selected mail and redirecting to mail.mail list view. """
+        self.send()
+        return {
+            'name': _('Emails'),
+            'res_model': 'mail.mail',
+            'view_mode': 'list',
+            'views': [[False, 'list'], [False, 'form']],
+            'target': 'main',
+            'type': 'ir.actions.act_window',
+        }
+
     def _send(self, auto_commit=False, raise_exception=False, smtp_session=None, alias_domain_id=False,
               mail_server=False, post_send_callback=None):
         IrMailServer = self.env['ir.mail_server']

--- a/addons/mail/views/mail_mail_views.xml
+++ b/addons/mail/views/mail_mail_views.xml
@@ -8,7 +8,7 @@
                 <form string="Email message" duplicate="0">
                     <header>
                         <field name="message_type" invisible="1"/>
-                        <button name="send" string="Send Now" type="object" class="oe_highlight" invisible="state != 'outgoing' or message_type == 'user_notification'"/>
+                        <button name="action_send_and_close" string="Send &amp; Close" type="object" class="oe_highlight" invisible="state != 'outgoing' or message_type == 'user_notification'"/>
                         <button name="mark_outgoing" string="Retry" type="object" invisible="state not in ('exception', 'cancel')"/>
                         <button name="cancel" string="Cancel" type="object" invisible="state != 'outgoing'"/>
                         <field name="state" widget="statusbar" statusbar_visible="outgoing,sent,received,exception,cancel"/>


### PR DESCRIPTION
Purpose:
Currently, while sending an email from form view, pops a record not found warning, because after a successful sent, the system drops the mail record which is not reflected on UI.

Specifications:
Change the Send button flow. After sending the email, users will be redirected back to the tree view, which prevents the "record not found" warning from appearing. (Rename button with `Send & Close`).

Task-4143453