### PR TITLE
[FIX] point_of_sale: apply rewards on gs1 barcode scan

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/components/product_screen/product_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/product_screen/product_screen.js
@@ -106,6 +106,11 @@ patch(ProductScreen.prototype, {
         await super._barcodeProductAction(code);
         this.currentOrder._updateRewards();
     },
+    async _barcodeGS1Action(code) {
+        await super._barcodeGS1Action(code);
+        this.currentOrder._updateRewards();
+    },
+
     async _showDecreaseQuantityPopup() {
         const result = await super._showDecreaseQuantityPopup();
         if (result) {

--- a/addons/pos_loyalty/static/tests/tours/PosLoyaltyTour.js
+++ b/addons/pos_loyalty/static/tests/tours/PosLoyaltyTour.js
@@ -4,6 +4,7 @@ import * as PosLoyalty from "@pos_loyalty/../tests/tours/PosLoyaltyTourMethods";
 import * as ProductScreen from "@point_of_sale/../tests/tours/helpers/ProductScreenTourMethods";
 import * as SelectionPopup from "@point_of_sale/../tests/tours/helpers/SelectionPopupTourMethods";
 import { registry } from "@web/core/registry";
+import { scan_barcode } from "@point_of_sale/../tests/tours/helpers/utils";
 
 registry.category("web_tour.tours").add("PosLoyaltyTour1", {
     test: true,
@@ -502,5 +503,30 @@ registry.category("web_tour.tours").add("PosLoyaltyArchivedRewardProductsActive"
             PosLoyalty.isRewardButtonHighlighted(true),
             ProductScreen.selectedOrderlineHas('Test Product A', '1.00', '100.00'),
             PosLoyalty.finalizeOrder("Cash", "100"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("PosRewardProductScan", {
+    test: true,
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            scan_barcode("95412427100283"),
+            ProductScreen.selectedOrderlineHas('product_a', '1.00', '1,150.00'),
+            PosLoyalty.hasRewardLine("50% on your order", "-575.00"),
+            PosLoyalty.orderTotalIs("575.00"),
+            PosLoyalty.finalizeOrder("Cash", "575.00"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("PosRewardProductScanGS1", {
+    test: true,
+    steps: () =>
+        [
+            scan_barcode("0195412427100283"),
+            ProductScreen.selectedOrderlineHas('product_a', '1.00', '1,150.00'),
+            PosLoyalty.hasRewardLine("50% on your order", "-575.00"),
+            PosLoyalty.orderTotalIs("575.00"),
+            PosLoyalty.finalizeOrder("Cash", "575.00"),
         ].flat(),
 });


### PR DESCRIPTION
### Steps to reproduce:

- In the settings:
  - Change the Barcode Nomenclature to Default gs1
  - Enable Promotions, Coupons, ... on Point of sale
- Create a prodcut with barcode 95412427100283
- Point of Sale > Product > Discount & Loyalty
- Create a new discount and change the conditional rule to set your product and a min purchase of 0
- Open a new pos session
- Scan the gs1 barcode 0195412427100283

#### > the product is found but the discount is not applied

### Expected behavior:

Just as if you scanned the barcode 95412427100283 directly the discount should be applied.

Cause of the issue:

When a barcode is scanned in the pos, the ` _scan` method is called to parse the barcode and to trigger the associated action:
https://github.com/odoo/odoo/blob/775827b8f7fa95f2afd77a9b42d6cd8e436ea690/addons/point_of_sale/static/src/app/barcode/barcode_reader_service.js#L69-L79
This flow use to not update the rewards after a product scanned and was fixed by commit 21392ab when the barcode associated action is `_barcodeProductAction` because fo these lines:
https://github.com/odoo/odoo/blob/775827b8f7fa95f2afd77a9b42d6cd8e436ea690/addons/pos_loyalty/static/src/overrides/components/product_screen/product_screen.js#L105-L107 however, if the code is identified to be gs1
Howecver, if the barcode is identified to be of the gs1 nomenclature it will trigger the `_barcodeGS1Action` which still does not update the rewards.

### Fix:

Inspired by commit 21392ab

opw-3813858
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
