### PR TITLE
[FIX] account: Catching TaxClosingNonPostedDependingMovesError when p…

### DIFF
--- a/addons/account/models/exceptions.py
+++ b/addons/account/models/exceptions.py
@@ -1,0 +1,7 @@
+class TaxClosingNonPostedDependingMovesError(Exception):
+    """
+        This error contains an action that will be used in the case of a tax closing with branches or tax units where
+        the different companies have non-posted closing moves. The action will be a form view if there is only one dependent move
+        and a list view if there are more.
+    """
+    pass


### PR DESCRIPTION
…osting a batch of moves

When we tried to confirm a batch of moves during the tax closing in a multi company setup with branches, an error was raised because the dependant closing moves should be posted before the parent move.

This error was only catched in the `action_post` method but not on the modal that validates the batch.

Original Commit: https://github.com/odoo/enterprise/pull/65645

opw-4148070

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
