### PR TITLE
[FIX] point_of_sale: automatic printed receipt show correct change

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -104,7 +104,7 @@ export class PosOrder extends Base {
             total_discount: this.get_total_discount(),
             rounding_applied: this.get_rounding_applied(),
             tax_details: this.get_tax_details(),
-            change: this.uiState.locked ? this.amount_return : this.get_change(),
+            change: this.amount_return,
             name: this.name,
             invoice_id: null, //TODO
             cashier: this.employee_id?.name || this.user_id?.name,


### PR DESCRIPTION
When activating the automatic receipt printing option, the receipt would not show the change amount.

Steps to reproduce:
-------------------
* Turn on automatic receipt printing
* Open PoS, add some product and go to the payment page
* Click on cash, and change the amount so that there is some change
> Observation: The change doesn't appear on the receipt

Why the fix:
------------
When computing the change to display on the receipt, we were using the
`get_change` function that was not returning the right value in this
context. Instead we will always use the `amount_return` that is correct

opw-4141904
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
