### PR TITLE
[FIX] website_sale: _prepare_values overriden twice

### DIFF
--- a/addons/website_sale/models/website_snippet_filter.py
+++ b/addons/website_sale/models/website_snippet_filter.py
@@ -19,8 +19,16 @@ class WebsiteSnippetFilter(models.Model):
         website = self.env['website'].get_current_website()
         if self.model_name == 'product.product' and not website.has_ecommerce_access():
             return []
-
-        return super()._prepare_values(**kwargs)
+        hide_variants = False
+        search_domain = kwargs.get('search_domain')
+        if self.filter_id and search_domain and 'hide_variants' in search_domain:
+            hide_variants = True
+            search_domain.remove('hide_variants')
+            kwargs['search_domain'] = search_domain
+        return super(
+            WebsiteSnippetFilter,
+            self.with_context(hide_variants=hide_variants),
+        )._prepare_values(**kwargs)
 
     @api.model
     def _get_website_currency(self):
@@ -223,13 +231,3 @@ class WebsiteSnippetFilter(models.Model):
                 ).search(domain, limit=limit)
         return products
 
-    def _prepare_values(self, limit=None, search_domain=None):
-        hide_variants = False
-        if self.filter_id and search_domain and 'hide_variants' in search_domain:
-            hide_variants = True
-            search_domain.remove('hide_variants')
-            search_domain = search_domain or None
-        return super(
-            WebsiteSnippetFilter,
-            self.with_context(hide_variants=hide_variants)
-        )._prepare_values(limit, search_domain)


### PR DESCRIPTION
A previous oversight lead to _prepare_values to be overridden twice for 2 separate tasks 
The task that was merged last was functioning while the other one wasn't 
This commit merges the 2 functions together

commit 1: 5bde2e42c8ec5e943a779ad4b3e1b7142f2d2fcf
commit 2: 4ac43fbafc2899e296bf0593dcaef0c3b914928c

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
