### PR TITLE
[FIX] sale_project: search only service type product

### DIFF
--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -58,6 +58,7 @@ class SaleOrderLine(models.Model):
             if product_name := self.env.context.get('sol_product_name') or self.env.context.get('default_name'):
                 product = self.env['product.product'].search([
                     ('name', 'ilike', product_name),
+                    ('type', '=', 'service'),
                     ('company_id', 'in', [False, self.env.company.id]),
                 ], limit=1)
                 if product:


### PR DESCRIPTION
When a user creates a new sol, only service-type product should be searched. Before this commit, consumable and other types of product was being searched.

task-3972359