### PR TITLE
[FIX] web: make destroy of non-fully initialized widget possible

### DIFF
--- a/addons/web/static/src/legacy/js/public/public_widget.js
+++ b/addons/web/static/src/legacy/js/public/public_widget.js
@@ -196,11 +196,14 @@ export const PublicWidget = Class.extend(mixins.PropertiesMixin, ServicesMixin, 
      */
     destroy: function () {
         mixins.PropertiesMixin.destroy.call(this);
-        this._undelegateEvents();
-        // If not done with a selector, then
-        // remove the elements added to the DOM.
-        if (!this.selector && this.$el) {
-            this.$el.remove();
+        if (this.$el) {
+            this._undelegateEvents();
+
+            // If not done with a selector (attached to existing DOM), then
+            // remove the elements added to the DOM.
+            if (!this.selector) {
+                this.$el.remove();
+            }
         }
     },
 


### PR DESCRIPTION
When a widget is destroyed before it is fully initialized, it should not crash. When the widget implementation was merged into the public widget one at [1], that bug was created for public widgets.

No existing flow was found to be broken because of this but it would not be a surprise if this actually fixes issues.

[1]: https://github.com/odoo/odoo/commit/51b1808ebedf9b810f83d264bb7e9204cab45e4a

Found while working on task-3930204
