### PR TITLE
[REV] website_sale_picking: adjust fpos based on warehouse location

### DIFF
--- a/addons/website_sale_picking/__manifest__.py
+++ b/addons/website_sale_picking/__manifest__.py
@@ -21,11 +21,6 @@ Allows customers to pay for their orders at a shop, instead of paying online.
     'demo': [
         'data/demo.xml',
     ],
-    'assets': {
-        'web.assets_tests': [
-            'website_sale_picking/static/tests/tours/**/*.js'
-        ]
-    },
     'uninstall_hook': 'uninstall_hook',
     'license': 'LGPL-3',
 }

--- a/addons/website_sale_picking/models/sale_order.py
+++ b/addons/website_sale_picking/models/sale_order.py
@@ -1,22 +1,10 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from odoo import models
 
 
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
-
-    def _set_delivery_method(self, *args, **kwargs):
-        carrier_before = self.carrier_id
-        fpos_before = self.fiscal_position_id
-        super()._set_delivery_method(*args, **kwargs)
-        if self.carrier_id.delivery_type == 'onsite' and self.carrier_id.warehouse_id:
-            self.partner_shipping_id = self.carrier_id.warehouse_id.partner_id
-        elif carrier_before.delivery_type == 'onsite':
-            # setting partner_shipping_id as the carrier pickup location
-            # overwrites the original partner shipping address
-            # so it needs to be recomputed if the delivery method is not onsite picking
-            self._compute_partner_shipping_id()
-        if self.fiscal_position_id != fpos_before:
-            self._recompute_taxes()
 
     def _remove_delivery_line(self):
         if self.carrier_id.delivery_type == 'onsite' and self.carrier_id.warehouse_id:

--- a/addons/website_sale_picking/tests/test_payment.py
+++ b/addons/website_sale_picking/tests/test_payment.py
@@ -1,6 +1,8 @@
-from odoo import Command
-from odoo.addons.website_sale_picking.tests.common import OnsiteCommon
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from odoo.tests import HttpCase, tagged
+
+from odoo.addons.website_sale_picking.tests.common import OnsiteCommon
 
 
 @tagged('post_install', '-at_install')
@@ -24,86 +26,3 @@ class TestOnsitePayment(HttpCase, OnsiteCommon):
         self.assertTrue(not any(
             p.code == 'custom' and p.custom_mode == 'onsite' for p in compatible_providers
         ))
-
-    def test_onsite_payment_fiscal_change_tour(self):
-        # Setup fiscal position
-        (
-            tax_5,
-            tax_10,
-            tax_15,
-        ) = self.env['account.tax'].create([
-            {
-                'name': '5% Tax',
-                'amount_type': 'percent',
-                'amount': 5,
-                'price_include': False,
-                'include_base_amount': False,
-                'type_tax_use': 'sale',
-            },
-            {
-                'name': '10% Tax',
-                'amount_type': 'percent',
-                'amount': 10,
-                'price_include': False,
-                'include_base_amount': False,
-                'type_tax_use': 'sale',
-            },
-            {
-                'name': '15% Tax',
-                'amount_type': 'percent',
-                'amount': 15,
-                'price_include': False,
-                'include_base_amount': False,
-                'type_tax_use': 'sale',
-            },
-        ])
-        warehouse_fiscal_country = self.env['res.country'].create({
-            'name': "Dummy Country",
-            'code': 'DC',
-        })
-        # wsTourUtils.fillAdressForm() selects first country as address country
-        client_fiscal_country = self.env['res.country'].search([('code', '=', 'AF')])
-
-        self.env['product.product'].create({
-            'name': 'Super Product',
-            'list_price': 100.0,
-            'type': 'consu',
-            'website_published': True,
-            'taxes_id': [Command.link(tax_15.id)],
-        })
-
-        self.env['account.fiscal.position'].create([
-            {
-                'name': 'Super Fiscal Position',
-                'auto_apply': True,
-                'country_id': warehouse_fiscal_country.id,
-                'tax_ids': [
-                    Command.create({
-                        'tax_src_id': tax_15.id,
-                        'tax_dest_id': tax_5.id,
-                    })
-                ],
-            },
-            {
-                'name': 'Super Fiscal Position',
-                'auto_apply': True,
-                'country_id': client_fiscal_country.id,
-                'tax_ids': [
-                    Command.create({
-                        'tax_src_id': tax_15.id,
-                        'tax_dest_id': tax_10.id,
-                    }),
-                ],
-            },
-        ])
-        self.env.user.company_id.partner_id.country_id = warehouse_fiscal_country
-        # Setup onsite picking with fiscal position different than user
-        warehouse = self.env['stock.warehouse'].create({
-            'name': "Warehouse",
-            'partner_id': self.env.user.company_id.partner_id.id,
-            'code': "WH01",
-        })
-        self.carrier.update({
-            'warehouse_id': warehouse.id,
-        })
-        self.start_tour('/shop', 'onsite_payment_fiscal_change_tour')


### PR DESCRIPTION
This commit reverts dd331e7bb27c533808a01b53f80e0ee7f1dfed7f

This change has caused a lot of issues recently, and despite some other fixes, we believe it's safer to revert it for now.

opw-4126140
opw-4114139
opw-4115510
opw-4117520
opw-4109625
opw-4115415
opw-4143237
opw-4123382
opw-4136888
opw-4125807

X-original-commit: e18831c3a0364894227bb87d12815baee6915242


Manual forward-port of #178693 for 17.4

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
