### PR TITLE
[IMP] mrp: prevent merging of post-pickings across backorders

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -492,6 +492,18 @@ class MrpProduction(models.Model):
                 ('group_id', '=', order.procurement_group_id.id), ('group_id', '!=', False),
             ])
             order.picking_ids |= order.move_raw_ids.move_orig_ids.picking_id
+            # Count only those deliveries related to the current MO in a 2-step or 3-step MRP process.
+            if order.warehouse_id.manufacture_steps in ['pbm_sam', 'pbm']:
+                filtered_picking_ids = order.picking_ids.filtered(
+                    lambda picking: picking.origin == order.name or any(
+                        order in move.move_dest_ids.raw_material_production_id or
+                        order in move.move_orig_ids.production_id or
+                        order in move.production_ids
+                        for move in picking.move_ids
+                    )
+                )
+                # Unlink unrelated pickings from current MO after split.
+                order.picking_ids = [(3, picking.id, False) for picking in (order.picking_ids - filtered_picking_ids)]
             order.delivery_count = len(order.picking_ids)
 
     @api.depends('product_uom_id', 'product_qty', 'product_id.uom_id')
@@ -1824,7 +1836,8 @@ class MrpProduction(models.Model):
             backorder_qtys = amounts[production][1:]
             production.with_context(skip_compute_move_raw_ids=True).product_qty = amounts[production][0]
 
-            next_seq = max(production.procurement_group_id.mrp_production_ids.mapped("backorder_sequence"), default=1)
+            next_seq = 1 if self.env.context.get('is_split_production') and production.backorder_sequence == 1 else \
+                    max(production.procurement_group_id.mrp_production_ids.mapped("backorder_sequence"), default=1)
 
             for qty_to_backorder in backorder_qtys:
                 next_seq += 1
@@ -1980,6 +1993,22 @@ class MrpProduction(models.Model):
         self.env['stock.move.line'].browse(move_lines_to_unlink).unlink()
 
         moves_to_consume.write({'picked': True})
+
+        # Create the pre-production picking/transfer for each backorder in 2-step or 3-step MRP process if MO is split.
+        if self.env.context.get('is_split_production') and len(production.picking_ids) == 1:
+            for production in self:
+                if production.picking_ids.state != "done":
+                    # Cancel the pre-picking of this production if picking is not done because new tranfer is created based on new product_qty of production.
+                    production.picking_ids.action_cancel()
+                    production.picking_ids.group_id = False
+
+                    productions = self.env['mrp.production'].browse(list(production_ids))
+                    for production in productions:
+                        production.move_raw_ids.write({'move_orig_ids': False, 'state': 'draft'})
+                        production.write({'state': 'draft'})
+                        production.action_confirm()
+                else:
+                    production.picking_ids.move_ids.production_ids = production.picking_ids.move_ids.move_dest_ids.raw_material_production_id
 
         workorders_to_cancel = self.env['mrp.workorder']
         for production in self:

--- a/addons/mrp/models/stock_picking.py
+++ b/addons/mrp/models/stock_picking.py
@@ -140,8 +140,15 @@ class StockPicking(models.Model):
     def _compute_mrp_production_ids(self):
         for picking in self:
             production_ids = picking.group_id.mrp_production_ids | picking.move_ids.move_dest_ids.raw_material_production_id
-            # Filter out unwanted MO types
-            picking.production_ids = production_ids.filtered(lambda p: p.picking_type_id.active)
+            # Count only those MO related to the current picking for a 2-step or 3-step MRP process.
+            if picking.picking_type_id.warehouse_id.manufacture_steps in ['pbm_sam', 'pbm']:
+                picking.production_ids = production_ids.filtered(lambda p: p.picking_type_id.active and (
+                    any(p in move.raw_material_production_id or p in move.production_id for move in picking.move_ids)
+                    or p.name == picking.origin)
+                )
+            else:
+                # Filter out unwanted MO types
+                picking.production_ids = production_ids.filtered(lambda p: p.picking_type_id.active)
             picking.production_count = len(picking.production_ids)
 
     def action_detailed_operations(self):

--- a/addons/mrp/tests/test_backorder.py
+++ b/addons/mrp/tests/test_backorder.py
@@ -163,7 +163,7 @@ class TestMrpProductionBackorder(TestMrpCommon):
         self.assertEqual(sum(sam_move.mapped("product_qty")), 1)
 
         mo_backorder = production.procurement_group_id.mrp_production_ids[-1]
-        self.assertEqual(mo_backorder.delivery_count, 2)
+        self.assertEqual(mo_backorder.delivery_count, 1)
 
         pbm_move |= mo_backorder.move_raw_ids.move_orig_ids
         self.assertEqual(sum(pbm_move.filtered(lambda m: m.product_id.id == product_to_use_1.id).mapped("product_qty")), 16)
@@ -174,7 +174,7 @@ class TestMrpProductionBackorder(TestMrpCommon):
 
         mo_backorder.button_mark_done()
         self.assertEqual(len(sam_move), 1.0)
-        self.assertEqual(sam_move.product_qty, 4.0)
+        self.assertEqual(sam_move.product_qty, 1.0)
 
     def test_tracking_backorder_series_lot_1(self):
         """ Create a MO of 4 tracked products. all component is tracked by lots
@@ -859,6 +859,74 @@ class TestMrpProductionBackorder(TestMrpCommon):
         self.assertRecordValues(mo_all_produced, [{'state': 'done', 'qty_produced': product_qty, 'mrp_production_backorder_count': 1, 'priority': '0'}])
         self.assertRecordValues(mo_ask, [{'state': 'done', 'qty_produced': qty_produced, 'mrp_production_backorder_count': 1, 'priority': '0'}])
         self.assertRecordValues(mo_never, [{'state': 'done', 'qty_produced': qty_produced, 'mrp_production_backorder_count': 1, 'priority': '0'}])
+
+    def test_split_pre_post_pickings_when_mo_is_split(self):
+        """
+        Test that when the Manufacturing Order (MO) is split, a new split pre-picking/transfer of components will be created for each generated backorder MO,
+        ensuring that all backorders are processed independently.
+        """
+        self.env.user.groups_id += self.env.ref("stock.group_adv_location")
+        location = self.env.ref('stock.stock_location_stock')
+        with Form(self.warehouse) as warehouse:
+            warehouse.manufacture_steps = 'pbm_sam'
+
+        Product = self.env['product.product']
+        product_finish = Product.create({
+            'name': 'product1',
+            'is_storable': True,
+            'tracking': 'none',
+        })
+        component1 = Product.create({
+            'name': 'product2',
+            'is_storable': True,
+            'tracking': 'none',
+        })
+        component2 = Product.create({
+            'name': 'product3',
+            'is_storable': True,
+            'tracking': 'none',
+        })
+        self.env['stock.quant']._update_available_quantity(component1, location, 50)
+        self.env['stock.quant']._update_available_quantity(component2, location, 50)
+
+        bom = self.env['mrp.bom'].create({
+            'product_id': product_finish.id,
+            'product_tmpl_id': product_finish.product_tmpl_id.id,
+            'product_qty': 1,
+            'type': 'normal',
+            'bom_line_ids': [
+                (0, 0, {'product_id': component1.id, 'product_qty': 2}),
+                (0, 0, {'product_id': component2.id, 'product_qty': 2}),
+            ],
+        })
+
+        mo_form = Form(self.env['mrp.production'])
+        mo_form.product_id = product_finish
+        mo_form.picking_type_id = self.warehouse.manu_type_id
+        mo_form.bom_id = bom
+        mo_form.product_qty = 2
+        mo = mo_form.save()
+        mo.action_confirm()
+
+        action = mo.action_split()
+        wizard = Form.from_action(self.env, action)
+        wizard.counter = 2
+        action = wizard.save().action_split()
+
+        # check that the MO is split in 2.
+        self.assertEqual(len(mo.procurement_group_id.mrp_production_ids), 2)
+
+        for backorder in mo.procurement_group_id.mrp_production_ids:
+            # Verify that there is only one picking for each backorder before the MO is completed.
+            # Verify the quantity for each move in the backorder's pickings.
+            self.assertEqual(len(backorder.picking_ids), 1)
+            self.assertEqual(backorder.picking_ids.move_ids.mapped('product_uom_qty'), [2, 2])
+
+            # After the MO is done, confirm that there are two pickings for each backorder.
+            # Also, ensure that each picking's origin matches the MO name.
+            backorder.button_mark_done()
+            self.assertEqual(len(backorder.picking_ids), 2)
+            self.assertTrue(all(picking.origin == backorder.name for picking in backorder.picking_ids))
 
 
 class TestMrpWorkorderBackorder(TransactionCase):

--- a/addons/mrp/wizard/mrp_production_split.py
+++ b/addons/mrp/wizard/mrp_production_split.py
@@ -66,7 +66,7 @@ class MrpProductionSplit(models.TransientModel):
                 wizard.valid_details = float_compare(wizard.product_qty, sum(wizard.production_detailed_vals_ids.mapped('quantity')), precision_rounding=wizard.product_uom_id.rounding) == 0
 
     def action_split(self):
-        productions = self.production_id._split_productions({self.production_id: [detail.quantity for detail in self.production_detailed_vals_ids]})
+        productions = self.production_id.with_context(is_split_production=True)._split_productions({self.production_id: [detail.quantity for detail in self.production_detailed_vals_ids]})
         for production, detail in zip(productions, self.production_detailed_vals_ids):
             production.user_id = detail.user_id
             production.date_start = detail.date


### PR DESCRIPTION
Before this commit:
======================
- When splitting a Manufacturing Order (MO) into multiple backorders,
  it did not split the pre-pickings/transfers, causing all backorders
  to rely on a single picking, which prevented independent processing.

- If a picking was not completed, all post-pickings of backorders were merged.
  This caused issues where cancelling a picking or MO in one backorder
  could impact post-pickings across all backorders.

After this commit:
======================
- Now, each backorder has a separate pre-picking/transfer created
  during the MO split, allowing each split MO to process independently.

- Each backorder now displays only its associated pickings
  (preventing merge of pickings), ensuring that
  actions on one post-picking do not impact others.

Task Id's - 4065843, 4095552
