### PR TITLE
[FIX] mail, web: rename accessToken to access_token in FileModelMixin

### DIFF
--- a/addons/mail/static/tests/tours/discuss_channel_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_public_tour.js
@@ -39,7 +39,7 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
             run: "edit cheese",
         },
         {
-            content: "Add one file in composer",
+            content: "Add a text file in composer",
             trigger: ".o-mail-Composer button[aria-label='Attach files']",
             async run() {
                 await inputFiles(".o-mail-Composer-coreMain .o_input_file", [
@@ -55,8 +55,46 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
             trigger: ".o-mail-AttachmentCard:not(.o-isUploading)", // waiting the attachment to be uploaded
         },
         {
-            content: "Check the earlier provided attachment is listed",
+            content: "Check the text attachment is listed",
             trigger: '.o-mail-AttachmentCard[title="text.txt"]',
+        },
+        {
+            content: "Add an image file in composer",
+            trigger: ".o-mail-Composer button[aria-label='Attach files']",
+            async run() {
+                await inputFiles(".o-mail-Composer-coreMain .o_input_file", [
+                    new File(
+                        [
+                            await (
+                                await fetch(
+                                    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2P4v5ThPwAG7wKklwQ/bwAAAABJRU5ErkJggg=="
+                                )
+                            ).blob(),
+                        ],
+                        "image.png",
+                        { type: "image/png" }
+                    ),
+                ]);
+            },
+        },
+        {
+            trigger: ".o-mail-AttachmentImage:not(.o-isUploading)",
+        },
+        {
+            content: "Check the image attachment is listed",
+            trigger: '.o-mail-AttachmentImage[title="image.png"]',
+            async run() {
+                const store = odoo.__WOWL_DEBUG__.root.env.services["mail.store"];
+                if (store.self.type === "guest") {
+                    const src = this.anchor.querySelector("img").src;
+                    const token = store.Attachment.get(
+                        (src.match("/web/image/([0-9]+)") || []).at(-1)
+                    )?.access_token;
+                    if (!(token && src.includes(`access_token=${token}`))) {
+                        throw new Error("Access token of the attachment isn't correct.");
+                    }
+                }
+            },
         },
         {
             content: "Send message",

--- a/addons/web/static/src/core/file_viewer/file_model.js
+++ b/addons/web/static/src/core/file_viewer/file_model.js
@@ -1,7 +1,7 @@
 import { url } from "@web/core/utils/urls";
 
 export const FileModelMixin = T => class extends T {
-    accessToken;
+    access_token;
     checksum;
     extension;
     filename;
@@ -102,7 +102,7 @@ export const FileModelMixin = T => class extends T {
             return {};
         }
         const params = {
-            access_token: this.accessToken,
+            access_token: this.access_token,
             filename: this.name,
             unique: this.checksum,
         };

--- a/addons/web/static/tests/core/file_model.test.js
+++ b/addons/web/static/tests/core/file_model.test.js
@@ -1,0 +1,20 @@
+import { expect, test } from "@odoo/hoot";
+
+import { FileModel } from "@web/core/file_viewer/file_model";
+
+test("url query params of FileModel returns proper params", () => {
+    const attachmentData = {
+        access_token: "4b52e31e-a155-4598-8d15-538f64f0fb7b",
+        checksum: "f6a9d2bcbb34ce90a73785d8c8d1b82e5cdf0b5b",
+        extension: "jpg",
+        name: "test.jpg",
+        mimetype: "image/jpeg",
+    };
+    const expectedQueryParams = {
+        access_token: "4b52e31e-a155-4598-8d15-538f64f0fb7b",
+        filename: "test.jpg",
+        unique: "f6a9d2bcbb34ce90a73785d8c8d1b82e5cdf0b5b",
+    };
+    const fileModel = Object.assign(new FileModel(), attachmentData);
+    expect(fileModel.urlQueryParams).toEqual(expectedQueryParams);
+});


### PR DESCRIPTION
Since odoo/odoo#178523, `accessToken` of the attachment is renamed to
`access_token`. We also need to make the same change in `FileModelMixin` so the
access token would be returned properly by `urlQueryParams`in this mixin.

Steps to reproduce:
- Open a public channel as a guest
- Send an attachment
- The attachment is not visible either in the attachment preview or in the
posted message.

![image](https://github.com/user-attachments/assets/7db7821a-1e41-4750-b524-2be681c09821)


