### PR TITLE
[FIX] point_of_sale: prevent error when clicking on order

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -90,6 +90,9 @@ class PosOrder(models.Model):
         """
         draft = True if order.get('state') == 'draft' else False
         pos_session = self.env['pos.session'].browse(order['session_id'])
+        if not pos_session and existing_order:
+            order['session_id'] = existing_order.session_id.id
+
         if pos_session.state == 'closing_control' or pos_session.state == 'closed':
             order['session_id'] = self._get_valid_session(order).id
 


### PR DESCRIPTION
When we try to add any product for order in the first browser and simultaneously close the session in the second browser, the error will occur in the first browser when we click on order.

Steps to reproduce:
- Install the ``point_of_sale`` module(without demo data)
- Open the ``Bar``, copy the URL, and Open a POS session on 2 different browsers
- Now go to the second browser and then close the session there
- Now come to the first browser and add any product
- Click on ``Order``

Traceback: 
``ValueError: Expected singleton: pos.config()``

This error occurred at [1] where we didn't find ``config_id`` in order.

This commit will fix the error by passing the session ID of the existing session into the order if ``pos_session`` does not have any session ID, especially in the case of a rescue session.

[1]- https://github.com/odoo/odoo/blob/42acdb4bffa5295ec834fc9d6258540683ab90ce/addons/pos_online_payment/models/pos_order.py#L16

sentry-5699019259

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
