### PR TITLE
[IMP] core: deprecate api.model_create_single

### DIFF
--- a/addons/l10n_in/models/company.py
+++ b/addons/l10n_in/models/company.py
@@ -53,8 +53,9 @@ class ResCompany(models.Model):
             else:
                 record.l10n_in_pan_type = False
 
-    def create(self, vals):
-        res = super().create(vals)
+    @api.model_create_multi
+    def create(self, vals_list):
+        res = super().create(vals_list)
         # Update Fiscal Positions for new branch
         res._update_l10n_in_fiscal_position()
         return res

--- a/odoo/addons/base/tests/test_ir_filters.py
+++ b/odoo/addons/base/tests/test_ir_filters.py
@@ -27,8 +27,7 @@ class FiltersCase(TransactionCaseWithUserDemo):
 
     def build(self, model, *args):
         Model = self.env[model].with_user(ADMIN_USER_ID)
-        for vals in args:
-            Model.create(vals)
+        Model.create(args)
 
 
 class TestGetFilters(FiltersCase):

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -16,6 +16,7 @@ __all__ = [
 ]
 
 import logging
+import warnings
 from collections import defaultdict
 from collections.abc import Mapping
 from contextlib import contextmanager
@@ -408,7 +409,10 @@ def model_create_single(method):
             record = model.create(vals)
             records = model.create([vals, ...])
     """
-    _create_logger.warning("The model %s is not overriding the create method in batch", method.__module__)
+    warnings.warn(
+        f"The model {method.__module__} is not overriding the create method in batch",
+        DeprecationWarning
+    )
     wrapper = _model_create_single(method) # pylint: disable=no-value-for-parameter
     wrapper._api = 'model_create'
     return wrapper


### PR DESCRIPTION
Log Deprecation warnings so that model_create_single can be removed in a future version.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
