### PR TITLE
[FIX] website: adapt carousel indicator selectors

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -2073,7 +2073,7 @@ options.registry.Carousel = options.registry.CarouselHandler.extend({
     cleanForSave: function () {
         const $items = this.$target.find('.carousel-item');
         $items.removeClass('next prev left right active').first().addClass('active');
-        this.$indicators.find('li').removeClass('active').empty().first().addClass('active');
+        this.$indicators.find('button').removeClass('active').empty().first().addClass('active');
     },
     /**
      * @override
@@ -2128,7 +2128,7 @@ options.registry.Carousel = options.registry.CarouselHandler.extend({
         const $items = this.$target.find('.carousel-item');
         this.$controls.removeClass('d-none');
         const $active = $items.filter('.active');
-        this.$indicators.append($('<li>', {
+        this.$indicators.append($('<button>', {
             'data-bs-target': '#' + this.$target.attr('id'),
             'data-bs-slide-to': $items.length,
         }));
@@ -2234,7 +2234,7 @@ options.registry.CarouselItem = options.Class.extend({
                 $toDelete.remove();
                 // To ensure the proper functioning of the indicators, their
                 // attributes must reflect the position of the slides.
-                const indicatorsEls = this.$indicators[0].querySelectorAll('li');
+                const indicatorsEls = this.$indicators[0].querySelectorAll('button');
                 for (let i = 0; i < indicatorsEls.length; i++) {
                     indicatorsEls[i].setAttribute('data-bs-slide-to', i);
                 }


### PR DESCRIPTION
Since the introduction of the new carousel design in 3deb8050831c69ca1e32039622b322ffa38cc497, some selectors still target the old tags. This creates an error when the user tries to add or delete a slide using the WE.

This commit updates the selectors to fix the issue.

task-4153956
Part of task-3619705


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
