### PR TITLE
[FIX] base: properly display ir.asset target field

### DIFF
--- a/odoo/addons/base/views/ir_asset_views.xml
+++ b/odoo/addons/base/views/ir_asset_views.xml
@@ -14,7 +14,7 @@
                             <field name="active" widget="boolean_toggle"/>
                         </group>
                         <group>
-                            <field name="target" attrs="{ 'invisible': [('directive', '!=', 'replace')] }"/>
+                            <field name="target" attrs="{'invisible': [('directive', 'not in', ['after', 'before', 'replace'])]}"/>
                             <field name="path"/>
                         </group>
                     </group>


### PR DESCRIPTION
- Before this commit The ir.asset target field is only displayed when the directive is 'replace', but this field is required for 'after' and 'before' directives too.

- After this commit The form view is adapted to fix this issue.