### PR TITLE
[FIX] l10n_sa_edi: fix tax retention with down payment

### DIFF
--- a/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
+++ b/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
@@ -371,10 +371,10 @@ class AccountEdiXmlUBL21Zatca(models.AbstractModel):
 
         def grouping_key_generator(base_line, tax_values):
             tax = tax_values['tax_repartition_line'].tax_id
-            tax_category_vals = self._get_tax_category_list(line.move_id, tax)[0]
+            tax_category_vals = next(iter(self._get_tax_category_list(line.move_id, tax)), {})
             grouping_key = {
-                'tax_category_id': tax_category_vals['id'],
-                'tax_category_percent': tax_category_vals['percent'],
+                'tax_category_id': tax_category_vals.get('id'),
+                'tax_category_percent': tax_category_vals.get('percent'),
                 '_tax_category_vals_': tax_category_vals,
                 'tax_amount_type': tax.amount_type,
             }


### PR DESCRIPTION
Steps:

- Create a negative retention tax `T`
- Create, confirm and receive a SO
- Create and confirm a downpayment
- Create a regular draft invoice for the rest, and
  add tax `T` to the product line, confirm and process edi
-> Traceback: list index out of range

This is because we override `_get_tax_category_list` to filter
the retention taxes that have no list of categories, therefore
we try to access an empty dict.

Ticket [link](https://www.odoo.com/odoo/project/967/tasks/4139894)
opw-4139894
