### PR TITLE
[FIX] tests: fix test_freeze_time

### DIFF
--- a/odoo/addons/test_testing_utilities/tests/test_freeze_time.py
+++ b/odoo/addons/test_testing_utilities/tests/test_freeze_time.py
@@ -2,8 +2,6 @@
 from datetime import date, datetime
 from odoo.tests.common import tagged, TransactionCase, HttpCase, freeze_time
 
-REFERENCE_NOW = datetime.now()
-
 
 @freeze_time('2021-01-01')
 @tagged('post_install', '-at_install')
@@ -41,7 +39,7 @@ class TestHttpCaseFreezeTimeClassDecorator(HttpCase):
 class TestFreezeTimeContextManager(TransactionCase):
 
     def test_freeze_time_context_manager(self):
-        self.assertEqual(datetime.now().strftime('%Y-%m-%d'), REFERENCE_NOW.strftime('%Y-%m-%d'))
+        self.assertNotEqual(datetime.now().strftime('%Y-%m-%d %H:%M:%S'), '2024-04-04 04:04:00', "The datetime should not be altered by a freeze_time from the previous class")
         with freeze_time('2025-05-05 05:05') as frozen_time:
             self.assertEqual(datetime.now().strftime('%Y-%m-%d %H:%M:%S'), '2025-05-05 05:05:00')
             frozen_time.move_to('2026-06-06 06:06')


### PR DESCRIPTION
When the test_freeze_time test starts a few minutes after midnight it may fail because the reference time date used in test is computed at the module import time and compared with the date computed at the test time.

The best fix is to remove this assertion as the reference time was used to ensure that the datetime in the test is not affected by the freezetime used all allong the tests in the file. So fixing the test by moving the reference time computation inside a setUpClass or a setUp would make the assertion useless.

As a close colleague said to me, it's always a bad idea to put your fingers in frozen time ...

