### PR TITLE
[FIX] account: Allow users to edit subview list with studio

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
@@ -185,7 +185,7 @@ export class ProductLabelSectionAndNoteField extends Many2OneField {
     }
 
     get isProductClickable() {
-        return this.props.record.model.root.data.state !== "draft";
+        return this.props.record.evalContext.parent.state !== "draft";
     }
 
     get isSectionOrNote() {


### PR DESCRIPTION
Steps to reproduce:

* Install `web_studio` and `account`
* Open customers/invoices
* Edit view form with studio
* click on subview list
* click edit
* traceback

```
TypeError: Cannot read properties of undefined (reading 'state')
    get isProductClickable()
    /account/static/src/components/product_label_section_and_note_field/
        product_label_section_and_note_field.js:188
```

To get fields from the parent view, we need to use evalContext instead
of `model.root`.

Ticket [link](https://www.odoo.com/odoo/project/967/tasks/4148174)
opw-4148174
