### PR TITLE
[IMP] pos_loyalty: physical gift card in PoS terminal

### DIFF
--- a/addons/pos_loyalty/static/src/app/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/app/models/pos_order.js
@@ -3,6 +3,7 @@ import { patch } from "@web/core/utils/patch";
 import { _t } from "@web/core/l10n/translation";
 import { loyaltyIdsGenerator } from "@pos_loyalty/app/services/pos_store";
 import { computePriceForcePriceInclude } from "@point_of_sale/app/models/utils/tax_utils";
+import { serializeDate } from "@web/core/l10n/dates";
 const { DateTime } = luxon;
 
 function _newRandomRewardCode() {
@@ -635,7 +636,7 @@ patch(PosOrder.prototype, {
                                 (rule.reward_point_amount * line.getPriceWithTax()) /
                                     line.getQuantity()
                             );
-                            if (pointsPerUnit > 0) {
+                            if (pointsPerUnit >= 0) {
                                 splitPoints.push(
                                     ...Array.apply(null, Array(line.getQuantity())).map(() => {
                                         if (line._gift_barcode && line.getQuantity() == 1) {
@@ -643,6 +644,18 @@ patch(PosOrder.prototype, {
                                                 points: pointsPerUnit,
                                                 barcode: line._gift_barcode,
                                                 giftCardId: line._gift_card_id.id,
+                                            };
+                                        } else if (program.program_type === "gift_card") {
+                                            return {
+                                                points: pointsPerUnit,
+                                                barcode: null,
+                                                code: line.uiState.gift_code,
+                                                expiration_date:
+                                                    line.uiState.gift_card_expiration_date ||
+                                                    serializeDate(
+                                                        luxon.DateTime.now().plus({ year: 1 })
+                                                    ),
+                                                partner_id: this.partner_id?.id || false,
                                             };
                                         }
                                         return { points: pointsPerUnit };

--- a/addons/pos_loyalty/static/src/app/models/pos_order_line.js
+++ b/addons/pos_loyalty/static/src/app/models/pos_order_line.js
@@ -12,12 +12,6 @@ patch(PosOrderline, {
             type: "many2one",
             local: true,
         },
-        gift_code: {
-            model: "pos.order.line",
-            name: "gift_code",
-            type: "char",
-            local: true,
-        },
         _gift_barcode: {
             model: "pos.order.line",
             name: "_gift_barcode",
@@ -42,9 +36,21 @@ patch(PosOrderline, {
 });
 
 patch(PosOrderline.prototype, {
+    initState() {
+        super.initState();
+        this.uiState = {
+            ...this.uiState,
+            program_type: null,
+            gift_code: null,
+            e_wallet_id: null,
+            gift_card_expiration_date: null,
+        };
+    },
     setOptions(options) {
         if (options.eWalletGiftCardProgram) {
             this._e_wallet_program_id = options.eWalletGiftCardProgram;
+            this.uiState.program_type = options.eWalletGiftCardProgram.program_type;
+            this.uiState.e_wallet_id = options.eWalletGiftCardProgram.id;
         }
         if (options.giftBarcode) {
             this._gift_barcode = options.giftBarcode;
@@ -55,12 +61,16 @@ patch(PosOrderline.prototype, {
         return super.setOptions(...arguments);
     },
     getEWalletGiftCardProgramType() {
-        return this._e_wallet_program_id && this._e_wallet_program_id.program_type;
+        return (
+            (this._e_wallet_program_id && this._e_wallet_program_id.program_type) ||
+            this.uiState.program_type
+        );
     },
     ignoreLoyaltyPoints({ program }) {
         return (
             (["gift_card", "ewallet"].includes(program.program_type) &&
-                this._e_wallet_program_id?.id !== program.id) ||
+                (this._e_wallet_program_id?.id !== program.id ||
+                    this.uiState.e_wallet_id !== program.id)) ||
             this.settled_invoice_id ||
             this.settled_order_id
         );
@@ -81,5 +91,12 @@ patch(PosOrderline.prototype, {
             ...super.getDisplayClasses(),
             "fst-italic": this.is_reward_line,
         };
+    },
+    canBeMergedWith(orderline) {
+        const res = super.canBeMergedWith(...arguments);
+        if (!this._e_wallet_program_id || this.uiState.gift_code === orderline.uiState.gift_code) {
+            return res;
+        }
+        return false;
     },
 });

--- a/addons/pos_loyalty/static/src/app/screens/product_screen/order_summary/order_summary.xml
+++ b/addons/pos_loyalty/static/src/app/screens/product_screen/order_summary/order_summary.xml
@@ -6,8 +6,8 @@
                 Current Balance: <t t-esc="line.getGiftCardOrEWalletBalance()"/>
             </li>
             <t t-if="!line.isGiftCardOrEWalletReward() and line.getEWalletGiftCardProgramType() === 'gift_card'">
-                <a t-if="!line.gift_code" class="text-wrap text-action" t-on-click="manageGiftCard">Sell physical gift card?</a>
-                <div t-if="line.gift_code" class="text-wrap" t-esc="line.gift_code"/>
+                <a t-if="!line.uiState.gift_code" class="text-wrap text-action" t-on-click="manageGiftCard">Sell physical gift card?</a>
+                <div t-if="line.uiState.gift_code" class="text-wrap" t-esc="line.uiState.gift_code"/>
             </t>
         </xpath>
         <xpath expr="//OrderDisplay/t[@t-set-slot='details']" position="inside">


### PR DESCRIPTION
Before this commit:
==========
- Users could update the quantity of physical gift cards using the Numpad.
- Users could apply discounts to a gift card, which reduced their value in the backend.
- The code for physical gift cards was not visible after transitioning from the floor screen to the product screen.
- If the user updates the price value of the physical gift card from numpad then it is not reflected in the backend.
- When the quantity of gift cards was reduced from Numpad, gift cards were not generated.

After this commit:
==========
- Users will no longer be able to update the quantity of physical gift cards.
- Users will also be unable to add discounts to the gift card order line.
- The code for physical gift cards is now properly visible after transitioning from the floor screen to the product screen.
- If the user updates the price value of the physical gift card from numpad then it will reflect the backend.
- After reducing the quantity of gift cards from Numpad, generation will be seamless.

task-4114112