### PR TITLE
[IMP] web: list: select all domain when all groups are folded

### DIFF
--- a/addons/web/static/src/model/relational_model/dynamic_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_list.js
@@ -187,7 +187,9 @@ export class DynamicList extends DataPoint {
 
     toggleSelection() {
         return this.model.mutex.exec(() => {
-            if (this.selection.length === this.records.length) {
+            if (!this.records.length) {
+                this.isDomainSelected = !this.isDomainSelected;
+            } else if (this.selection.length === this.records.length) {
                 this.records.forEach((record) => {
                     record._toggleSelection(false);
                 });

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -433,6 +433,10 @@ export class ListController extends Component {
         return this.props.className;
     }
 
+    get hasSelectedRecords() {
+        return this.nbSelected || this.isDomainSelected;
+    }
+
     get nbSelected() {
         return this.model.root.selection.length;
     }
@@ -470,7 +474,7 @@ export class ListController extends Component {
             ...this.props.display,
             controlPanel: {
                 ...controlPanel,
-                layoutActions: !this.nbSelected,
+                layoutActions: !this.hasSelectedRecords,
             },
         };
     }

--- a/addons/web/static/src/views/list/list_controller.xml
+++ b/addons/web/static/src/views/list/list_controller.xml
@@ -43,7 +43,7 @@
                     <CogMenu t-if="!nbSelected"/>
                 </t>
                 <t t-set-slot="control-panel-selection-actions">
-                    <div t-if="nbSelected" class="d-flex gap-1">
+                    <div t-if="hasSelectedRecords" class="d-flex gap-1">
                         <t t-call="web.ListView.Selection"/>
                         <t t-foreach="archInfo.headerButtons" t-as="button" t-key="button.id" t-if="!evalViewModifier(button.invisible)">
                             <MultiRecordViewButton

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -3260,6 +3260,39 @@ test(`selection box is properly displayed (group list)`, async () => {
     });
 });
 
+test(`selection box: grouped list, all groups folded`, async () => {
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `<tree><field name="foo"/><field name="bar"/></tree>`,
+        groupBy: ["foo"],
+    });
+    expect(`.o_group_header`).toHaveCount(3);
+    expect(`.o_data_row`).toHaveCount(0);
+    expect(`.o_searchview`).toHaveCount(1);
+    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(0);
+
+    // click on the checkbox in the thead
+    await contains(`thead .o_list_record_selector input`).click();
+    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(1);
+    expect(`.o_searchview`).toHaveCount(0);
+    expect(`.o_list_selection_box`).toHaveText("All 4 selected");
+
+    // remove selection by clicking on the cross in the selection box
+    await contains(`.o_list_unselect_all`).click();
+    expect(`.o_list_selection_box`).toHaveCount(0);
+
+    // click again on the checkbox in the thead
+    await contains(`thead .o_list_record_selector input`).click();
+    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(1);
+    expect(`.o_list_selection_box`).toHaveText("All 4 selected");
+
+    // remove selection by clicking on the checkbox in the thead
+    await contains(`thead .o_list_record_selector input`).click();
+    expect(`.o_searchview`).toHaveCount(1);
+    expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(0);
+});
+
 test(`selection box is displayed as first action button`, async () => {
     await mountView({
         resModel: "foo",


### PR DESCRIPTION
Have a grouped list view with all groups folded. Click on the checkbox in the thead. Before this commit, this had no effect, apart from toggling the checkbox itself, because there was no visible record to select.

With this commit, we now directly select all records matching the domain, i.e. like when the user select all visible records and then clicks in the selection box on "Select All".

This allows to perform an action on all records matching the domain without opening a random group first.

Task~4150362

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
