### PR TITLE
[WIP][IMP] hr_holidays: clickable leave information

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -497,6 +497,7 @@ class HrLeaveType(models.Model):
                         'icon': leave_type.sudo().icon_id.url,
                         'allows_negative': leave_type.allows_negative,
                         'max_allowed_negative': leave_type.max_allowed_negative,
+                        'employee_company': employee.company_id.id,
                     },
                     leave_type.requires_allocation,
                     leave_type.id)

--- a/addons/hr_holidays/static/src/dashboard/time_off_card.scss
+++ b/addons/hr_holidays/static/src/dashboard/time_off_card.scss
@@ -22,6 +22,10 @@
         margin-bottom: 3px;
     }
 
+    .o_timeoff_name.btn-link:hover {
+        color: $btn-link-hover-color;
+    }
+
     .o_timeoff_duration {
         font-size: 30px;
         font-weight: bold;

--- a/addons/hr_holidays/static/src/dashboard/time_off_card.xml
+++ b/addons/hr_holidays/static/src/dashboard/time_off_card.xml
@@ -6,7 +6,7 @@
         <t t-set="parsed_duration" t-value="formatNumber(this.lang, duration)"/>
         <t t-set="show_popover" t-value="true"/>
 
-        <strong class="o_timeoff_name"><t t-esc="props.name"/></strong>
+        <strong class="o_timeoff_name cursor-pointer btn-link" t-on-click="navigateTimeOffType"><t t-esc="props.name"/></strong>
         <span class="o_timeoff_duration">
             <t t-if="data and data.icon">
                 <img t-att-src="data.icon" />
@@ -58,14 +58,14 @@
     <t t-name="hr_holidays.TimeOffCardPopover">
         <ul class="list-unstyled p-3 mb-0">
             <li class="d-flex justify-content-between">
-                <span>Allocated (<span class="btn-link p-0 cursor-pointer" t-on-click="props.onClickNewAllocationRequest">new request</span>):</span>
+                <span><span class="btn-link p-0 cursor-pointer" t-on-click="allocatedLeaves">Allocated</span> (<span class="btn-link p-0 cursor-pointer" t-on-click="props.onClickNewAllocationRequest">new request</span>):</span>
                 <span class="ps-1" t-esc="props.allocated"/>
             </li>
-            <li class="d-flex justify-content-between" t-if="props.accrual_bonus">
+            <li class="d-flex justify-content-between" t-if="props.accrual_bonus != 0">
                 Accrual (Future): <span class="ps-1" t-esc="props.accrual_bonus"/>
             </li>
-            <li class="d-flex justify-content-between">Approved: <span class="ps-1" t-esc="props.approved"/></li>
-            <li class="d-flex justify-content-between border-bottom">Planned: <span class="ps-1" t-esc="props.planned"/></li>
+            <li class="d-flex justify-content-between btn-link cursor-pointer" t-on-click="() => this.navigateInfo(['validate'])">Approved: <span class="ps-1" t-esc="props.approved"/></li>
+            <li class="d-flex justify-content-between border-bottom btn-link cursor-pointer" t-on-click="() => this.navigateInfo(['confirm','validate1'])">Planned: <span class="ps-1" t-esc="props.planned"/></li>
             <li class="d-flex justify-content-between">Available: <span class="ps-1" t-esc="props.left"/></li>
         </ul>
         <div t-if="props.warning" class="alert alert-warning mb-0 pb-0 o_time_off_card_popover_warning">

--- a/addons/hr_holidays/static/tests/tours/time_off_card_tour.js
+++ b/addons/hr_holidays/static/tests/tours/time_off_card_tour.js
@@ -1,0 +1,84 @@
+import { registry } from "@web/core/registry";
+import { stepUtils } from "@web_tour/tour_service/tour_utils";
+
+registry.category("web_tour.tours").add("time_off_card_tour", {
+    url: "/odoo",
+    steps: () => [
+        stepUtils.showAppsMenuItem(),
+        {
+            content: "Open Time Off app",
+            trigger: '.o_app[data-menu-xmlid="hr_holidays.menu_hr_holidays_root"]',
+            run: "click",
+        },
+        {
+            content: "Click on the Time Off name",
+            trigger: '.o_timeoff_name',
+            run: "click",
+        },
+        {
+            content: "Ensure the list view for Time Off requests is displayed",
+            trigger: '.o_list_view',
+        },
+        {
+            content: "Navigate back to the previous view",
+            trigger: ".o_back_button",
+            run: "click",
+        },
+        {
+            content: "Click on the time off card to open the detailed popover.",
+            trigger: ".o_timeoff_details",
+            run: "click",
+        },
+        {
+            content: "Verify that the popover is displayed after clicking on the time off details.",
+            trigger: ".o_popover",
+        },
+        {
+            content: "Click on the link containing 'Allocated'.",
+            trigger: ".o_popover .btn-link:contains('Allocated')",
+            run: "click",
+        },
+        {
+            content: "Ensure the list view for Time Off requests is displayed",
+            trigger: '.o_list_view',
+        },
+        {
+            content: "Navigate back to the previous view",
+            trigger: ".o_back_button",
+            run: "click",
+        },
+        {
+            content: "Click on the time off card to open the detailed popover.",
+            trigger: ".o_timeoff_details",
+            run: "click",
+        },
+        {
+            content: "Click on the link containing 'Approved'",
+            trigger: ".o_popover .btn-link:contains('Approved')",
+            run: "click",
+        },
+        {
+            content: "Ensure the list view for Time Off requests is displayed",
+            trigger: '.o_list_view',
+        },
+        {
+            content: "Navigate back to the previous view",
+            trigger: ".o_back_button",
+            run: "click",
+        },
+        {
+            content: "Click on the time off card to open the detailed popover.",
+            trigger: ".o_timeoff_details",
+            run: "click",
+        },
+        {
+            content: "Click on the link containing 'Planned'",
+            trigger: ".o_popover .btn-link:contains('Planned')",
+            run: "click",
+        },
+        {
+            content: "Ensure the list view for Time Off requests is displayed",
+            trigger: '.o_list_view',
+        },
+    ],
+});

--- a/addons/hr_holidays/tests/__init__.py
+++ b/addons/hr_holidays/tests/__init__.py
@@ -26,3 +26,4 @@ from . import test_working_hours
 from . import test_dashboard
 from . import test_expiring_leaves
 from . import test_hr_departure_wizard
+from . import test_time_off_card_tour

--- a/addons/hr_holidays/tests/test_time_off_card_tour.py
+++ b/addons/hr_holidays/tests/test_time_off_card_tour.py
@@ -1,0 +1,8 @@
+from odoo.tests import HttpCase, tagged, users
+
+@tagged('post_install', '-at_install')
+class TestTimeOffCardTour(HttpCase):
+
+    @users('admin')
+    def test_time_off_card_tour(self):
+        self.start_tour('/', 'time_off_card_tour', login='admin')


### PR DESCRIPTION
make the time off type information clickable on the dashboard.
Users can now click on time off types info in the dashboard to view the list of that time off type.
And in time off type info popover the Allocated, Approved and Planned state are also clickable

task-4115758