### PR TITLE
[IMP] core: deprecate odoo.registry()

### DIFF
--- a/addons/auth_ldap/models/res_users.py
+++ b/addons/auth_ldap/models/res_users.py
@@ -3,7 +3,8 @@
 
 from odoo.exceptions import AccessDenied
 
-from odoo import api, models, registry, SUPERUSER_ID
+from odoo import api, models, SUPERUSER_ID
+from odoo.modules.registry import Registry
 
 
 class Users(models.Model):
@@ -14,7 +15,7 @@ class Users(models.Model):
         try:
             return super()._login(db, credential, user_agent_env=user_agent_env)
         except AccessDenied as e:
-            with registry(db).cursor() as cr:
+            with Registry(db).cursor() as cr:
                 login = credential['login']
                 cr.execute("SELECT id FROM res_users WHERE lower(login)=%s", (login,))
                 res = cr.fetchone()

--- a/addons/auth_ldap/tests/test_auth_ldap.py
+++ b/addons/auth_ldap/tests/test_auth_ldap.py
@@ -13,7 +13,7 @@ class TestAuthLDAP(BaseCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.registry = odoo.registry(get_db_name())
+        cls.registry = Registry(get_db_name())
 
     def setUp(self):
         super().setUp()

--- a/addons/auth_passkey/models/res_users.py
+++ b/addons/auth_passkey/models/res_users.py
@@ -1,8 +1,9 @@
 import json
 
-from odoo import fields, models, registry, _
+from odoo import fields, models, _
 from odoo.tools import SQL
 from odoo.exceptions import AccessDenied
+from odoo.modules.registry import Registry
 
 from odoo.addons.base.models.res_users import check_identity
 from .._vendor.webauthn.helpers.exceptions import InvalidAuthenticationResponse
@@ -35,7 +36,7 @@ class UsersPasskey(models.Model):
     def _login(cls, db, credential, user_agent_env):
         if credential['type'] == 'webauthn':
             webauthn = json.loads(credential['webauthn_response'])
-            with registry(db).cursor() as cr:
+            with Registry(db).cursor() as cr:
                 cr.execute(SQL("""
                     SELECT login
                       FROM auth_passkey_key key

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -44,7 +44,7 @@ def acquire_cursor(db):
     """ Try to acquire a cursor up to `MAX_TRY_ON_POOL_ERROR` """
     for tryno in range(1, MAX_TRY_ON_POOL_ERROR + 1):
         with suppress(PoolError):
-            return odoo.registry(db).cursor()
+            return Registry(db).cursor()
         time.sleep(random.uniform(DELAY_ON_POOL_ERROR, DELAY_ON_POOL_ERROR * tryno))
     raise PoolError('Failed to acquire cursor after %s retries' % MAX_TRY_ON_POOL_ERROR)
 

--- a/addons/delivery/models/delivery_carrier.py
+++ b/addons/delivery/models/delivery_carrier.py
@@ -3,8 +3,9 @@
 import psycopg2
 import re
 
-from odoo import _, api, fields, models, registry, Command, SUPERUSER_ID
+from odoo import _, api, fields, models, Command, SUPERUSER_ID
 from odoo.exceptions import UserError
+from odoo.modules.registry import Registry
 from odoo.tools.safe_eval import safe_eval
 
 
@@ -299,7 +300,7 @@ class DeliveryCarrier(models.Model):
 
             # Use a new cursor to avoid rollback that could be caused by an upper method
             try:
-                db_registry = registry(db_name)
+                db_registry = Registry(db_name)
                 with db_registry.cursor() as cr:
                     env = api.Environment(cr, SUPERUSER_ID, {})
                     IrLogging = env['ir.logging']

--- a/addons/google_calendar/models/google_sync.py
+++ b/addons/google_calendar/models/google_sync.py
@@ -9,7 +9,8 @@ import pytz
 from dateutil.parser import parse
 from markupsafe import Markup
 
-from odoo import api, fields, models, registry, _
+from odoo import api, fields, models, _
+from odoo.modules.registry import Registry
 from odoo.tools import ormcache_context, email_normalize
 from odoo.osv import expression
 
@@ -36,7 +37,7 @@ def after_commit(func):
 
         @self.env.cr.postcommit.add
         def called_after():
-            db_registry = registry(dbname)
+            db_registry = Registry(dbname)
             with db_registry.cursor() as cr:
                 env = api.Environment(cr, uid, context)
                 try:

--- a/addons/hr_presence/models/ir_websocket.py
+++ b/addons/hr_presence/models/ir_websocket.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from odoo import models, registry
+from odoo import models
 from odoo.api import Environment
 from odoo.fields import Datetime
 from odoo.http import request
+from odoo.modules.registry import Registry
 from odoo.addons.bus.websocket import wsrequest
 
 class IrWebsocket(models.AbstractModel):
@@ -23,6 +24,6 @@ class IrWebsocket(models.AbstractModel):
                 ('ip', '=', ip_address),
                 ('create_date', '>=', Datetime.to_string(Datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)))])
             if not users_log:
-                with registry(req.env.cr.dbname).cursor() as cr:
+                with Registry(req.env.cr.dbname).cursor() as cr:
                     env = Environment(cr, req.env.user.id, {})
                     env['res.users.log'].sudo().create({'ip': ip_address})

--- a/addons/l10n_ch/migrations/9.0.9.0/pre-set_tags_and_taxes_updatable.py
+++ b/addons/l10n_ch/migrations/9.0.9.0/pre-set_tags_and_taxes_updatable.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import odoo
+from odoo.modules.registry import Registry
 
 def migrate(cr, version):
-    registry = odoo.registry(cr.dbname)
+    registry = Registry(cr.dbname)
     from odoo.addons.account.models.chart_template import migrate_set_tags_and_taxes_updatable
     migrate_set_tags_and_taxes_updatable(cr, registry, 'l10n_ch')
 

--- a/addons/l10n_in/migrations/9.0.2.0/pre-set_tags_and_taxes_updatable.py
+++ b/addons/l10n_in/migrations/9.0.2.0/pre-set_tags_and_taxes_updatable.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import odoo
+from odoo.modules.registry import Registry
 
 def migrate(cr, version):
-    registry = odoo.registry(cr.dbname)
+    registry = Registry(cr.dbname)
     from odoo.addons.account.models.chart_template import migrate_set_tags_and_taxes_updatable
     migrate_set_tags_and_taxes_updatable(cr, registry, 'l10n_in')

--- a/addons/l10n_nl/migrations/9.0.2.0/pre-set_tags_and_taxes_updatable.py
+++ b/addons/l10n_nl/migrations/9.0.2.0/pre-set_tags_and_taxes_updatable.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import odoo
+from odoo.modules.registry import Registry
 
 def migrate(cr, version):
-    registry = odoo.registry(cr.dbname)
+    registry = Registry(cr.dbname)
     from odoo.addons.account.models.chart_template import migrate_set_tags_and_taxes_updatable
     migrate_set_tags_and_taxes_updatable(cr, registry, 'l10n_nl')

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -14,8 +14,9 @@ from collections import defaultdict
 
 from dateutil.parser import parse
 
-from odoo import _, api, fields, models, modules, registry, SUPERUSER_ID, tools
+from odoo import _, api, fields, models, modules, SUPERUSER_ID, tools
 from odoo.addons.base.models.ir_mail_server import MailDeliveryException
+from odoo.modules.registry import Registry
 
 _logger = logging.getLogger(__name__)
 _UNFOLLOW_REGEX = re.compile(r'<span id="mail_unfollow".*?<\/span>', re.DOTALL)
@@ -591,7 +592,7 @@ class MailMail(models.Model):
 
         @self.env.cr.postcommit.add
         def send_emails_with_new_cursor():
-            db_registry = registry(dbname)
+            db_registry = Registry(dbname)
             with db_registry.cursor() as cr:
                 env = api.Environment(cr, SUPERUSER_ID, _context)
                 env['mail.mail'].browse(email_ids).send()

--- a/addons/microsoft_calendar/models/microsoft_sync.py
+++ b/addons/microsoft_calendar/models/microsoft_sync.py
@@ -8,8 +8,8 @@ import pytz
 from dateutil.parser import parse
 from datetime import timedelta
 
-from odoo import api, fields, models, registry
-from odoo.exceptions import UserError
+from odoo import api, fields, models
+from odoo.modules.registry import Registry
 from odoo.osv import expression
 
 from odoo.addons.microsoft_calendar.utils.microsoft_event import MicrosoftEvent
@@ -36,7 +36,7 @@ def after_commit(func):
 
         @self.env.cr.postcommit.add
         def called_after():
-            db_registry = registry(dbname)
+            db_registry = Registry(dbname)
             with db_registry.cursor() as cr:
                 env = api.Environment(cr, uid, context)
                 try:

--- a/addons/onboarding/tests/test_onboarding_concurrency.py
+++ b/addons/onboarding/tests/test_onboarding_concurrency.py
@@ -7,6 +7,7 @@ from concurrent.futures import ThreadPoolExecutor
 import psycopg2.errors
 
 import odoo
+from odoo.modules.registry import Registry
 from odoo.tests.common import get_db_name, tagged, BaseCase
 from odoo.tools import mute_logger
 
@@ -17,7 +18,7 @@ class TestOnboardingConcurrency(BaseCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.registry = odoo.registry(get_db_name())
+        cls.registry = Registry(get_db_name())
         cls.addClassCleanup(cls.cleanUpClass)
 
         with cls.registry.cursor() as cr:

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -8,9 +8,10 @@ from datetime import datetime, time
 from dateutil import relativedelta
 from psycopg2 import OperationalError
 
-from odoo import SUPERUSER_ID, _, api, fields, models, registry
+from odoo import SUPERUSER_ID, _, api, fields, models
 from odoo.addons.stock.models.stock_rule import ProcurementException
 from odoo.exceptions import RedirectWarning, UserError, ValidationError
+from odoo.modules.registry import Registry
 from odoo.osv import expression
 from odoo.tools import float_compare, float_is_zero, frozendict, split_every
 
@@ -598,7 +599,7 @@ class StockWarehouseOrderpoint(models.Model):
 
         for orderpoints_batch_ids in split_every(1000, self.ids):
             if use_new_cursor:
-                cr = registry(self._cr.dbname).cursor()
+                cr = Registry(self._cr.dbname).cursor()
                 self = self.with_env(self.env(cr=cr))
             try:
                 orderpoints_batch = self.env['stock.warehouse.orderpoint'].browse(orderpoints_batch_ids)

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -5,8 +5,9 @@ import logging
 from collections import defaultdict, namedtuple
 from dateutil.relativedelta import relativedelta
 
-from odoo import SUPERUSER_ID, _, api, fields, models, registry
+from odoo import SUPERUSER_ID, _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
+from odoo.modules.registry import Registry
 from odoo.osv import expression
 from odoo.tools import float_compare, float_is_zero
 from odoo.tools.misc import split_every
@@ -603,7 +604,7 @@ class ProcurementGroup(models.Model):
         we run functions as SUPERUSER to avoid intercompanies and access rights issues. """
         try:
             if use_new_cursor:
-                cr = registry(self._cr.dbname).cursor()
+                cr = Registry(self._cr.dbname).cursor()
                 self = self.with_env(self.env(cr=cr))  # TDE FIXME
 
             self._run_scheduler_tasks(use_new_cursor=use_new_cursor, company_id=company_id)

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -14,7 +14,7 @@ from lxml import etree, html
 from werkzeug import urls
 from werkzeug.exceptions import NotFound
 
-from odoo import api, fields, models, tools, release, registry
+from odoo import api, fields, models, tools, release
 from odoo.addons.website.models.ir_http import sitemap_qs2dom
 from odoo.addons.website.tools import similarity_score, text_from_html, get_base_domain
 from odoo.addons.portal.controllers.portal import pager
@@ -507,9 +507,6 @@ class Website(models.Model):
         theme = self.env['ir.module.module'].search([('name', '=', theme_name)])
         redirect_url = theme.button_choose_theme()
 
-        # Force to refresh env after install of module
-        assert self.env.registry is registry()
-
         website.configurator_done = True
 
         # Enable tour
@@ -621,7 +618,6 @@ class Website(models.Model):
 
         if modules:
             modules.button_immediate_install()
-            assert self.env.registry is registry()
 
         self.env['website'].browse(website.id).configurator_set_menu_links(menu_company, module_data)
 

--- a/odoo/__init__.py
+++ b/odoo/__init__.py
@@ -33,6 +33,8 @@ def registry(database_name=None):
     on the current thread. If the registry does not exist yet, it is created on
     the fly.
     """
+    import warnings  # noqa: PLC0415
+    warnings.warn("Use directly odoo.modules.registry.Registry", DeprecationWarning, 2)
     if database_name is None:
         import threading
         database_name = threading.current_thread().dbname

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -12,6 +12,7 @@ from dateutil.relativedelta import relativedelta
 import odoo
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
+from odoo.modules.registry import Registry
 from odoo.tools import SQL
 
 _logger = logging.getLogger(__name__)
@@ -147,7 +148,7 @@ class ir_cron(models.Model):
                         continue
                     _logger.debug("job %s acquired", job_id)
                     # take into account overridings of _process_job() on that database
-                    registry = odoo.registry(db_name)
+                    registry = Registry(db_name)
                     registry[cls._name]._process_job(db, cron_cr, job)
                     _logger.debug("job %s updated and released", job_id)
 

--- a/odoo/addons/base/tests/test_db_cursor.py
+++ b/odoo/addons/base/tests/test_db_cursor.py
@@ -9,6 +9,7 @@ import psycopg2
 from psycopg2.extensions import ISOLATION_LEVEL_REPEATABLE_READ
 
 import odoo
+from odoo.modules.registry import Registry
 from odoo.sql_db import db_connect, TestCursor
 from odoo.tests import common
 from odoo.tests.common import BaseCase, HttpCase
@@ -16,8 +17,9 @@ from odoo.tools.misc import config
 
 ADMIN_USER_ID = common.ADMIN_USER_ID
 
+
 def registry():
-    return odoo.registry(common.get_db_name())
+    return Registry(common.get_db_name())
 
 
 class TestRealCursor(BaseCase):

--- a/odoo/addons/base/tests/test_ir_sequence.py
+++ b/odoo/addons/base/tests/test_ir_sequence.py
@@ -8,18 +8,20 @@ import psycopg2.errors
 
 import odoo
 from odoo.exceptions import UserError
+from odoo.modules.registry import Registry
 from odoo.tests import common
 from odoo.tests.common import BaseCase
 from odoo.tools.misc import mute_logger
 
 ADMIN_USER_ID = common.ADMIN_USER_ID
 
+
 @contextmanager
 def environment():
     """ Return an environment with a new cursor for the current database; the
         cursor is committed and closed after the context block.
     """
-    registry = odoo.registry(common.get_db_name())
+    registry = Registry(common.get_db_name())
     with registry.cursor() as cr:
         yield odoo.api.Environment(cr, ADMIN_USER_ID, {})
 

--- a/odoo/addons/base/tests/test_uninstall.py
+++ b/odoo/addons/base/tests/test_uninstall.py
@@ -6,7 +6,7 @@
 from contextlib import contextmanager
 import unittest
 
-from odoo import api, registry, SUPERUSER_ID
+from odoo import api, SUPERUSER_ID
 from odoo.tests import common
 from odoo.tests.common import BaseCase
 
@@ -18,7 +18,7 @@ def environment():
     """ Return an environment with a new cursor for the current database; the
         cursor is committed and closed after the context block.
     """
-    reg = registry(common.get_db_name())
+    reg = Registry(common.get_db_name())
     with reg.cursor() as cr:
         yield api.Environment(cr, SUPERUSER_ID, {})
 

--- a/odoo/addons/test_http/tests/test_registry.py
+++ b/odoo/addons/test_http/tests/test_registry.py
@@ -95,7 +95,7 @@ class TestHttpRegistry(BaseCase):
         self.assertEqual(res.status_code, 200)
 
         # invalidate the registry of the current db
-        with odoo.registry(get_db_name()).cursor() as cr:
+        with Registry(get_db_name()).cursor() as cr:
             cr.execute("select nextval('base_registry_signaling')")
 
         # the registry should rebuild itself just fine

--- a/odoo/addons/test_lint/tests/test_override_signatures.py
+++ b/odoo/addons/test_lint/tests/test_override_signatures.py
@@ -3,6 +3,7 @@ import inspect
 import itertools
 
 import odoo
+from odoo.modules.registry import Registry
 from odoo.tests.common import get_db_name, tagged
 from .lint_case import LintCase
 
@@ -114,7 +115,7 @@ def assert_valid_override(parent_signature, child_signature):
 class TestLintOverrideSignatures(LintCase):
     def test_lint_override_signature(self):
         self.failureException = TypeError
-        registry = odoo.registry(get_db_name())
+        registry = Registry(get_db_name())
         for model_name, model_cls in registry.items():
             for method_name, _ in inspect.getmembers(model_cls, inspect.isroutine):
                 if method_name not in methods_to_sanitize:

--- a/odoo/cli/obfuscate.py
+++ b/odoo/cli/obfuscate.py
@@ -7,6 +7,7 @@ import logging
 from collections import defaultdict
 
 from . import Command
+from odoo.modules.registry import Registry
 from odoo.tools import SQL
 
 _logger = logging.getLogger(__name__)
@@ -156,7 +157,7 @@ class Obfuscate(Command):
                 _logger.error("--allfields can only be used in unobfuscate mode")
                 sys.exit("ERROR: --allfields can only be used in unobfuscate mode")
             self.dbname = odoo.tools.config['db_name']
-            self.registry = odoo.registry(self.dbname)
+            self.registry = Registry(self.dbname)
             with self.registry.cursor() as cr:
                 self.cr = cr
                 self.begin()

--- a/odoo/cli/populate.py
+++ b/odoo/cli/populate.py
@@ -10,6 +10,8 @@ from unittest.mock import patch
 import odoo
 
 from . import Command
+from odoo.modules.registry import Registry
+
 _logger = logging.getLogger(__name__)
 
 
@@ -38,7 +40,7 @@ class Populate(Command):
         opt = odoo.tools.config.parse_config(cmdargs)
         populate_models = opt.populate_models and set(opt.populate_models.split(','))
         dbname = odoo.tools.config['db_name']
-        registry = odoo.registry(dbname)
+        registry = Registry(dbname)
         with registry.cursor() as cr:
             env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
             self.populate(

--- a/odoo/cli/shell.py
+++ b/odoo/cli/shell.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 
 import odoo
+from odoo.modules.registry import Registry
 from odoo.tools import config
 from . import Command
 
@@ -106,7 +107,7 @@ class Shell(Command):
             'odoo': odoo,
         }
         if dbname:
-            registry = odoo.registry(dbname)
+            registry = Registry(dbname)
             with registry.cursor() as cr:
                 uid = odoo.SUPERUSER_ID
                 ctx = odoo.api.Environment(cr, uid, {})['res.users'].context_get()

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -97,6 +97,7 @@ class Registry(Mapping):
 
     def __new__(cls, db_name):
         """ Return the registry for the given database name."""
+        assert db_name, "Missing database name"
         with cls._lock:
             try:
                 return cls.registries[db_name]

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -748,7 +748,7 @@ def get_unaccent_wrapper(cr):
         "Since 18.0, deprecated method, use env.registry.unaccent instead",
         DeprecationWarning, 2,
     )
-    return odoo.registry(cr.dbname).unaccent
+    return odoo.modules.registry.Registry(cr.dbname).unaccent
 
 
 class expression(object):

--- a/odoo/service/common.py
+++ b/odoo/service/common.py
@@ -5,6 +5,7 @@ import logging
 import odoo.release
 import odoo.tools
 from odoo.exceptions import AccessDenied
+from odoo.modules.registry import Registry
 from odoo.tools.translate import _
 
 _logger = logging.getLogger(__name__)
@@ -22,7 +23,7 @@ def exp_login(db, login, password):
 def exp_authenticate(db, login, password, user_agent_env):
     if not user_agent_env:
         user_agent_env = {}
-    res_users = odoo.registry(db)['res.users']
+    res_users = Registry(db)['res.users']
     try:
         credential = {'login': login, 'password': password, 'type': 'password'}
         return res_users.authenticate(db, credential, {**user_agent_env, 'interactive': False})['uid']

--- a/odoo/service/model.py
+++ b/odoo/service/model.py
@@ -12,6 +12,7 @@ import odoo
 from odoo.exceptions import UserError, ValidationError
 from odoo.http import request
 from odoo.models import check_method_name
+from odoo.modules.registry import Registry
 from odoo.tools import DotDict
 from odoo.tools.translate import _, translate_sql_constraint
 from . import security
@@ -30,7 +31,7 @@ def dispatch(method, params):
 
     threading.current_thread().dbname = db
     threading.current_thread().uid = uid
-    registry = odoo.registry(db).check_signaling()
+    registry = Registry(db).check_signaling()
     with registry.manage_changes():
         if method == 'execute':
             res = execute(db, uid, *params[3:])
@@ -62,7 +63,7 @@ def execute_kw(db, uid, obj, method, args, kw=None):
 
 def execute(db, uid, obj, method, *args, **kw):
     # TODO could be conditionnaly readonly as in _call_kw_readonly
-    with odoo.registry(db).cursor() as cr:
+    with Registry(db).cursor() as cr:
         check_method_name(method)
         res = execute_cr(cr, uid, obj, method, *args, **kw)
         if res is None:

--- a/odoo/service/security.py
+++ b/odoo/service/security.py
@@ -3,9 +3,11 @@
 
 import odoo
 import odoo.exceptions
+from odoo.modules.registry import Registry
+
 
 def check(db, uid, passwd):
-    res_users = odoo.registry(db)['res.users']
+    res_users = Registry(db)['res.users']
     return res_users.check(db, uid, passwd)
 
 def compute_session_token(session, env):

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -804,7 +804,7 @@ class TransactionCase(BaseCase):
         # they can addup during test and take some disc space.
         # since cron are not running during tests, we need to gc manually
         # We need to check the status of the file system outside of the test cursor
-        with odoo.registry(get_db_name()).cursor() as cr:
+        with Registry(get_db_name()).cursor() as cr:
             gc_env = api.Environment(cr, odoo.SUPERUSER_ID, {})
             gc_env['ir.attachment']._gc_file_store_unsafe()
 
@@ -812,7 +812,7 @@ class TransactionCase(BaseCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.addClassCleanup(cls._gc_filestore)
-        cls.registry = odoo.registry(get_db_name())
+        cls.registry = Registry(get_db_name())
         cls.registry_start_invalidated = cls.registry.registry_invalidated
         cls.registry_start_sequence = cls.registry.registry_sequence
 
@@ -917,7 +917,7 @@ class SingleTransactionCase(BaseCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.registry = odoo.registry(get_db_name())
+        cls.registry = Registry(get_db_name())
         cls.addClassCleanup(cls.registry.reset_changes)
         cls.addClassCleanup(cls.registry.clear_all_caches)
 

--- a/odoo/tests/test_module_operations.py
+++ b/odoo/tests/test_module_operations.py
@@ -9,6 +9,7 @@ sys.path.append(os.path.abspath(os.path.join(__file__,'../../../')))
 
 import odoo
 from odoo.tools import config, topological_sort, unique
+from odoo.modules.registry import Registry
 from odoo.netsvc import init_logger
 from odoo.tests import standalone_tests
 import odoo.tests.loader
@@ -25,8 +26,9 @@ INSTALL_BLACKLIST = {
     'payment_alipay', 'payment_ogone', 'payment_payulatam', 'payment_payumoney',
 }  # deprecated modules (cannot be installed manually through button_install anymore)
 
+
 def install(db_name, module_id, module_name):
-    with odoo.registry(db_name).cursor() as cr:
+    with Registry(db_name).cursor() as cr:
         env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
         module = env['ir.module.module'].browse(module_id)
         module.button_immediate_install()
@@ -34,7 +36,7 @@ def install(db_name, module_id, module_name):
 
 
 def uninstall(db_name, module_id, module_name):
-    with odoo.registry(db_name).cursor() as cr:
+    with Registry(db_name).cursor() as cr:
         env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
         module = env['ir.module.module'].browse(module_id)
         module.button_immediate_uninstall()
@@ -123,7 +125,7 @@ class StandaloneAction(argparse.Action):
 
 def test_cycle(args):
     """ Test full install/uninstall/reinstall cycle for all modules """
-    with odoo.registry(args.database).cursor() as cr:
+    with Registry(args.database).cursor() as cr:
         env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
 
         def valid(module):
@@ -158,7 +160,7 @@ def test_cycle(args):
 def test_uninstall(args):
     """ Tries to uninstall/reinstall one ore more modules"""
     for module_name in args.uninstall.split(','):
-        with odoo.registry(args.database).cursor() as cr:
+        with Registry(args.database).cursor() as cr:
             env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
             module = env['ir.module.module'].search([('name', '=', module_name)])
             module_id, module_state = module.id, module.state
@@ -176,7 +178,7 @@ def test_uninstall(args):
 def test_standalone(args):
     """ Tries to launch standalone scripts tagged with @post_testing """
     # load the registry once for script discovery
-    registry = odoo.registry(args.database)
+    registry = Registry(args.database)
     for module_name in registry._init_modules:
         # import tests for loaded modules
         odoo.tests.loader.get_test_modules(module_name)
@@ -190,7 +192,7 @@ def test_standalone(args):
 
     start_time = time.time()
     for index, func in enumerate(funcs, start=1):
-        with odoo.registry(args.database).cursor() as cr:
+        with Registry(args.database).cursor() as cr:
             env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
             _logger.info("Executing standalone script: %s (%d / %d)",
                          func.__name__, index, len(funcs))

--- a/odoo/tools/cloc.py
+++ b/odoo/tools/cloc.py
@@ -287,7 +287,7 @@ class Cloc(object):
         self.count_customization(env)
 
     def count_database(self, database):
-        registry = odoo.registry(config['db_name'])
+        registry = odoo.modules.registry.Registry(config['db_name'])
         with registry.cursor() as cr:
             uid = odoo.SUPERUSER_ID
             env = odoo.api.Environment(cr, uid, {})

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -1708,7 +1708,8 @@ def _get_translation_upgrade_queries(cr, field):
     field's column, while the queries in ``cleanup_queries`` remove the corresponding data from
     table ``_ir_translation``.
     """
-    Model = odoo.registry(cr.dbname)[field.model_name]
+    from odoo.modules.registry import Registry  # noqa: PLC0415
+    Model = Registry(cr.dbname)[field.model_name]
     translation_name = f"{field.model_name},{field.name}"
     migrate_queries = []
     cleanup_queries = []


### PR DESCRIPTION
You can use directly `odoo.modules.registry.Registry` when needed and cases where you need to do it are rare. At the same time, this allows to remove a function from the `odoo` package.

Related PRs:
Enterprise: odoo/enterprise#69269
Upgrade: odoo/upgrade-util#132

Task [link](https://www.odoo.com/odoo/project/1364/tasks/4069446)
task-4069446


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
