### PR TITLE
[FIX] website{_hr_recruitment}: don't log warning message in recruitment

### DIFF
--- a/addons/website/controllers/form.py
+++ b/addons/website/controllers/form.py
@@ -273,10 +273,10 @@ class WebsiteForm(http.Controller):
                 if user_email != form_email:
                     authenticate_message = _("This %(model_name)s was submitted by %(user_name)s (%(user_email)s) on behalf of %(form_email)s",
                         model_name=model.name, user_name=request.env.user.name, user_email=user_email, form_email=form_email)
-            else:
+            elif self._should_log_authenticate_message(record):
                 warning_icon = "/!\\ "
                 authenticate_message = _("EXTERNAL SUBMISSION - Customer not verified")
-            if authenticate_message and self._should_log_authenticate_message(record):
+            if authenticate_message:
                 record._message_log(
                     body=Markup('<div class="alert alert-info" role="alert">{warning_icon}{message}</div>').format(warning_icon=warning_icon, message=authenticate_message),
                 )

--- a/addons/website_hr_recruitment/controllers/main.py
+++ b/addons/website_hr_recruitment/controllers/main.py
@@ -351,13 +351,3 @@ class WebsiteHrRecruitment(WebsiteForm):
         if record._name == "hr.applicant" and not request.session.uid:
             return False
         return super()._should_log_authenticate_message(record)
-
-    def insert_record(self, request, model, values, custom, meta=None):
-        record_id = super().insert_record(request, model, values, custom, meta=meta)
-        model_name = model.sudo().model
-        default_field = model.website_form_default_field_id
-        if model_name == 'hr.applicant' and default_field:
-            # remove custom and authenticate message (warnings) from the description
-            applicant = request.env[model_name].sudo().browse(record_id)
-            applicant[default_field.name] = values.get(default_field.name, '')
-        return record_id

--- a/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
+++ b/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
@@ -72,3 +72,33 @@ class TestWebsiteHrRecruitmentForm(odoo.tests.HttpCase):
         with MockRequest(self.env, website=self.env['website'].browse(1)):
             response = WebsiteHrRecruitmentController.jobs()
         self.assertEqual(response.status, '200 OK')
+
+    def test_apply_job(self):
+        """ Test a user can apply to a job via the website form and add extra information inside custom field """
+        research_and_development_department = self.env['hr.department'].create({
+            'name': 'R&D',
+        })
+        developer_job = self.env['hr.job'].create({
+            'name': 'Developer',
+            'is_published': True,
+            'department_id': research_and_development_department.id
+        })
+        applicant_data = {
+            'partner_name': 'Georges',
+            'email_from': 'georges@test.com',
+            'partner_phone': '12345678',
+            'job_id': developer_job.id,
+            'department_id': research_and_development_department.id,
+            'description': 'This is a short introduction',
+            'Additional info': 'Test',
+        }
+        self.authenticate(None, None)
+        response = self.url_open('/website/form/hr.applicant', data=applicant_data)
+        applicant = self.env['hr.applicant'].browse(response.json().get('id'))
+        self.assertTrue(applicant.exists())
+        self.assertEqual(applicant.job_id, developer_job)
+        self.assertEqual(applicant.department_id, research_and_development_department)
+        self.assertEqual(applicant.partner_name, 'Georges')
+        self.assertEqual(applicant.email_from, 'georges@test.com')
+        self.assertEqual(applicant.partner_phone, '12345678')
+        self.assertEqual(html2plaintext(applicant.description), 'This is a short introduction\n\n\nOther Information:\n___________\n\nAdditional info : Test')


### PR DESCRIPTION
Before this commit, the commit 5045bd712f21e2f92e97ab9cb8a7221e0340ca54 avoid displayed the warning message in the chatter and alters the description field of applicant model to remove the warning message as well. The problem is the update on the description field does not take into account the custom fields added to the website form and also remove them.

This commit makes sure the warning message is not added in the chatter and description instead of letting the warning message in the description and erased it afterwards.
