### PR TITLE
[IMP] l10n_in_edi: restrict E-Invoicing based on date

### DIFF
--- a/addons/l10n_in_edi/models/account_edi_format.py
+++ b/addons/l10n_in_edi/models/account_edi_format.py
@@ -47,7 +47,8 @@ class AccountEdiFormat(models.Model):
     def _get_move_applicability(self, move):
         # EXTENDS account_edi
         self.ensure_one()
-        if self.code != 'in_einvoice_1_03':
+        einvoice_sending_start_date = move.company_id.l10n_in_edi_start_date
+        if self.code != 'in_einvoice_1_03' or (einvoice_sending_start_date and move.invoice_date < einvoice_sending_start_date):
             return super()._get_move_applicability(move)
         is_under_gst = any(move_line_tag.id in self._get_l10n_in_gst_tags() for move_line_tag in move.line_ids.tax_tag_ids)
         if move.is_sale_document(include_receipts=True) and move.country_code == 'IN' and is_under_gst and move.l10n_in_gst_treatment in (

--- a/addons/l10n_in_edi/models/res_company.py
+++ b/addons/l10n_in_edi/models/res_company.py
@@ -11,6 +11,7 @@ class ResCompany(models.Model):
     l10n_in_edi_password = fields.Char("E-invoice (IN) Password", groups="base.group_system")
     l10n_in_edi_token = fields.Char("E-invoice (IN) Token", groups="base.group_system")
     l10n_in_edi_token_validity = fields.Datetime("E-invoice (IN) Valid Until", groups="base.group_system")
+    l10n_in_edi_start_date = fields.Date("Sending E-Invoice from this date")
 
     def _l10n_in_edi_token_is_valid(self):
         self.ensure_one()

--- a/addons/l10n_in_edi/models/res_config_settings.py
+++ b/addons/l10n_in_edi/models/res_config_settings.py
@@ -10,6 +10,7 @@ class ResConfigSettings(models.TransientModel):
 
     l10n_in_edi_username = fields.Char("Indian EDI username", related="company_id.l10n_in_edi_username", readonly=False)
     l10n_in_edi_password = fields.Char("Indian EDI password", related="company_id.l10n_in_edi_password", readonly=False)
+    l10n_in_edi_start_date = fields.Date("Sending E-Invoice from this date", related="company_id.l10n_in_edi_start_date", readonly=False)
 
     def l10n_in_check_gst_number(self):
         if not self.company_id.vat:

--- a/addons/l10n_in_edi/views/res_config_settings_views.xml
+++ b/addons/l10n_in_edi/views/res_config_settings_views.xml
@@ -7,7 +7,11 @@
         <field name="arch" type="xml">
             <xpath expr="//setting[@name='electronic_invoices_in']" position="inside">
                     <div class="content-group" invisible="not module_l10n_in_edi">
-                        <div class="mt16 row">
+                        <div class="mt16 row" title="If a date is selected, then only invoices starting from that day will be send for E-Invoicing.">
+                            <label for="l10n_in_edi_start_date" string="Start Date" class="col-3 col-lg-3 o_light_label"/>
+                            <field name="l10n_in_edi_start_date"/>
+                        </div>
+                        <div class="row">
                             <label for="l10n_in_edi_username" string="Username" class="col-3 col-lg-3 o_light_label"/>
                             <field name="l10n_in_edi_username" nolabel="1"/>
                         </div>


### PR DESCRIPTION
This PR introduces a new field in the settings to specify a starting date for E-Invoicing. If this date is set and E-Invoicing is activated, invoices dated before the specified date will be excluded from E-Invoicing.

This feature is necessary to address scenarios where users have older invoices before E-Invoicing was activated. If users later enable E-Invoicing and import or reset old records to draft state, these invoices will inadvertently trigger E-Invoicing upon confirmation. This safeguard prevents that from happening.

Task [link](https://www.odoo.com/odoo/project/967/tasks/4149649)
task-4149649