### PR TITLE
[FIX] spreadsheet_dashboard_stock_account: fix dashboard domain

### DIFF
--- a/addons/spreadsheet_dashboard_stock_account/data/files/inventory_on_hand_dashboard.json
+++ b/addons/spreadsheet_dashboard_stock_account/data/files/inventory_on_hand_dashboard.json
@@ -741,9 +741,9 @@
             "context": {},
             "domain": [
                 [
-                    "product_id.type",
+                    "product_id.is_storable",
                     "=",
-                    "product"
+                    true
                 ]
             ],
             "id": "1",


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/165372 , the type = 'product' was replaced by a boolean field `is_storable` but this was not reflected in the dashboard 'Inventory on hand'.

task-4154706

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
