### PR TITLE
[FIX] website_sale_delivery: Check order state before deleting carrier_id

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -738,9 +738,6 @@ class WebsiteSale(http.Controller):
         revive: Revival method when abandoned cart. Can be 'merge' or 'squash'
         """
         order = request.website.sale_get_order()
-        if order and order.state != 'draft':
-            request.session['sale_order_id'] = None
-            order = request.website.sale_get_order()
 
         request.session['website_sale_cart_quantity'] = order.cart_quantity
 

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -333,9 +333,9 @@ class Website(models.Model):
 
         # Ignore the current order if a payment has been initiated. We don't want to retrieve the
         # cart and allow the user to update it when the payment is about to confirm it.
-        if sale_order_sudo and sale_order_sudo.get_portal_last_transaction().state in (
+        if sale_order_sudo and (sale_order_sudo.get_portal_last_transaction().state in (
             'pending', 'authorized', 'done'
-        ):
+        ) or sale_order_sudo.state != 'draft'):
             sale_order_sudo = None
 
         if not (sale_order_sudo or force_create):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This happens when, during a payment process, when the order is confirmed from the backend and in Website the cart icon is clicked. What causes the error is that the request is still pinned in the session, so it identifies that certain values ​​should not be loaded and deletes them.
With this modification, the cart() method at website_sale_delivery will check if it's a draft order or not, and discriminates with that if it should delete the carrier_id information.

This error was detected because the carrier_id was eliminated when following the aforementioned flow. The problem is that clicking on the cart retrieves the order that is in the session, but if it has been confirmed from the backend it should not collect it since at that moment it is not a "cart".

A way to see this clearly is with the 'delivery_auto_refresh' module. This module shows the carrier_id field in sale order view (that exists but is not visible), which is collected at website. The flow that exists nowadays remove this value when we follow this steps:

[358524955-9ec82b67-3e73-4083-b65b-be8d59db6a5a.webm](https://github.com/user-attachments/assets/9f89b818-1232-4ebd-b5cc-4a583dfbe761)

In this video:

1. Customer starts an order
2. An user confirms the order at backend
3. Customer acceses to /shop/cart
4. Some fields of the sale order can be deleted, such as the delivery carrier

If we confirm the order at backend and then follow the flow shown, the value of this field will dissapear. This happens because, as I said before, clicking the cart icon recovers the confirmed sale order (which is no longer a 'cart') and deletes many values of it.

Current behavior before PR:

If you confirm an order in process from website at backend and then click on the cart icon, the carrier_id field is eliminated.

Desired behavior after PR is merged:

The cart() method checks if the sale order is in draft state, and if it's not it avoids to delete the carrier_id information.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
