### PR TITLE
[FIX] crm: contact created without name

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1875,7 +1875,7 @@ class Lead(models.Model):
 
         for record in self.filtered('email_normalized'):
             values = email_normalized_to_values.setdefault(record.email_normalized, {})
-            contact_name = record.contact_name or record.partner_name or parse_contact_from_email(record.email_from)[0]
+            contact_name = record.contact_name or record.partner_name or parse_contact_from_email(record.email_from)[0] or record.email_from
             # Note that we don't attempt to create the parent company even if partner name is set
             values.update(record._prepare_customer_values(contact_name, is_company=False))
             values['company_name'] = record.partner_name

--- a/addons/crm/tests/test_crm_lead_notification.py
+++ b/addons/crm/tests/test_crm_lead_notification.py
@@ -174,6 +174,7 @@ class NewLeadNotification(TestCrmCommon):
             (False, 'Test', 'test_default_create@example.com'),
             ('Delivery Boy company', 'Test With Company', 'default_create_with_partner@example.com'),
             ('Delivery Boy company', '', 'default_create_with_partner_no_name@example.com'),
+            ('', '', 'lenny.bar@gmail.com'),
         ]:
             formatted_email = formataddr((name, email)) if name else formataddr((partner_name, email))
             with self.subTest(partner_name=partner_name):
@@ -197,7 +198,7 @@ class NewLeadNotification(TestCrmCommon):
                 self.assertEqual(create_vals, lead1._get_customer_information().get(email, {}))
                 for field, value in lead_details_for_contact.items():
                     self.assertEqual(create_vals.get(field), value)
-                expected_name = partner_name if partner_name and not name else name
+                expected_name = name or partner_name or email
                 self.assertEqual(create_vals['name'], expected_name)
                 self.assertEqual(create_vals['comment'], description)  # description -> comment
                 # Parent company not created even if partner_name is set

--- a/addons/mail/tests/test_res_partner.py
+++ b/addons/mail/tests/test_res_partner.py
@@ -485,6 +485,8 @@ class TestPartner(MailCommon):
             'False',
             # (simili) void values
             '', ' ', False, None,
+            # email only
+            'lenny.bar@gmail.com',
         ]
         expected = [
             ('Raoul', 'raoul@grosbedon.fr'),
@@ -493,6 +495,8 @@ class TestPartner(MailCommon):
             ('False', False),
             # (simili) void values: always False
             ('', False), ('', False), ('', False), ('', False),
+            # email only: email used as both name and email
+            ('lenny.bar@gmail.com', 'lenny.bar@gmail.com')
         ]
         for (expected_name, expected_email), sample in zip(expected, samples):
             with self.subTest(sample=sample):


### PR DESCRIPTION
Steps to reproduce
===================
1. Create a new lead in CRM with only an email address.
2. Send a message to the email through the chatter. 
-> The contact is created but it has no name.

Issue
=================
The issue was in _get_customer_information() for CRM. The function uses
parse_contact_from_email which returns an empty name for a simple email.

After this commit
=================
Email will serve as a name for the contact created through the chatter in CRM.

Task-4129454