### PR TITLE
[FIX] mail: insert()  multiple PY records sharing the same JS model

### DIFF
--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -364,7 +364,13 @@ export class Store extends BaseStore {
                         insertData.push(vals);
                     }
                 }
-                res[modelName] = store[modelName].insert(insertData, options);
+                const records = store[modelName].insert(insertData, options);
+                if (!res[modelName]) {
+                    res[modelName] = records;
+                } else {
+                    const knownRecordIds = new Set(res[modelName].map((r) => r.localId));
+                    res[modelName].push(...records.filter((r) => !knownRecordIds.has(r.localId)));
+                }
             }
             // Delete after all inserts to make sure a relation potentially registered before the
             // delete doesn't re-add the deleted record by mistake.

--- a/addons/mail/static/tests/core/common/store_service.test.js
+++ b/addons/mail/static/tests/core/common/store_service.test.js
@@ -52,3 +52,27 @@ test("store.insert deletes record after relation created it", async () => {
     await assertSteps(["new-1"]);
     expect(store.Message.get({ id: 1 })?.id).toBe(undefined);
 });
+
+test("store.insert different PY model having same JS model", async () => {
+    await start();
+    const store = getService("mail.store");
+    const data = {
+        "discuss.channel": [
+            { id: 1, name: "General" },
+            { id: 2, name: "Sales" },
+        ],
+        "mail.thread": [
+            { id: 1, model: "discuss.channel" },
+            { id: 3, name: "R&D", model: "discuss.channel" },
+        ],
+    };
+
+    const { Thread: threads } = store.insert(data);
+    expect(threads).toHaveLength(3);
+    const general = store.Thread.get({ id: 1, model: "discuss.channel" });
+    const sales = store.Thread.get({ id: 2, model: "discuss.channel" });
+    const rd = store.Thread.get({ id: 3, model: "discuss.channel" });
+    expect(general.in(threads)).toBe(true);
+    expect(sales.in(threads)).toBe(true);
+    expect(rd.in(threads)).toBe(true);
+});


### PR DESCRIPTION
Before this PR, inserting data related to two Python models that
shared the same JavaScript model would return only the records
associated with the last inserted model, instead of returning all
inserted records. This issue could arise when inserting both
"discuss.channel" and "mail.thread" records, for instance.

The root cause of this problem was in the `storeService.insert`
method, which stored the result in a dictionary keyed by the JS model.
When two Python models shared the same JS model, the records for the
earlier model would be overwritten by those of the later one.

This PR ensures that the `storeService.insert` method properly handles
this scenario, allowing it to return records from all inserted models,
even if they share the same JS model.