### PR TITLE
[FIX] point_of_sale: mobile receipt background color

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.scss
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.scss
@@ -12,7 +12,7 @@
 
 @media print {
     body {
-        background: white;
+        background-color: transparent;
     }
     body * {
         visibility: hidden;
@@ -22,7 +22,7 @@
     }
     .render-container .pos-receipt * {
         visibility: visible;
-        background: white !important;
+        background-color: transparent !important;
         color: black !important;
     }
     .render-container .pos-receipt {


### PR DESCRIPTION
When trying to print the receipt on the Odoo app on a mobile device, the background color of the receipt would be different than the background color of the text

Steps to reproduce:
-------------------
* Open PoS on the Odoo app
* Print receipt
> Observation: On the preview the receipt looks like this

![Screenshot_20240902-141836](https://github.com/user-attachments/assets/f7426653-7e68-4565-9bf4-a90d3f2fae1b)

Why the fix:
------------
By making the background color transparent we ensure that it will always be the same for the text and the general background color

opw-4094591
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
