### PR TITLE
[FIX] web: add minimum height to calendar events

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
@@ -100,6 +100,7 @@ export class CalendarCommonRenderer extends Component {
             slotLabelFormat: is24HourFormat() ? HOUR_FORMATS[24] : HOUR_FORMATS[12],
             snapDuration: { minutes: 15 },
             timeZone: luxon.Settings.defaultZone.name,
+            timeGridEventMinHeight : 15,
             unselectAuto: false,
             weekLabel:
                 this.props.model.scale === "month" && this.env.isSmall ? "" : this.env._t("Week"),


### PR DESCRIPTION
Issue
-----
1. Create a short meeting (e.g. 5 minutes), view it in the Calendar week view.
2. The text of the meeting is not visible.

Cause
-----
Before the refactor ed9a9d024adf9749ed5844ec3af35a0dae910828, the timeGridEventMinHeight had a value of 15, which allows short events to have a larger height when displayed.
https://github.com/odoo/odoo/blob/ebce7719b624136da2b26a73acf8930538c7a38c/addons/web/static/lib/fullcalendar/timegrid/main.js#L806

![image](https://github.com/user-attachments/assets/04ed0a9f-1a75-44a4-98d4-b101dd82fac7)

opw-4116031
