### PR TITLE
[FIX] pos_loyalty: update reward line when changing quantity

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/loyalty.js
+++ b/addons/pos_loyalty/static/src/overrides/models/loyalty.js
@@ -1542,9 +1542,15 @@ patch(Order.prototype, {
                   Math.ceil(unclaimedQty / reward.reward_product_qty),
                   Math.floor(points / reward.required_points)
               );
-        const cost = reward.clear_wallet ? points : claimable_count * reward.required_points;
+        const cost = reward.clear_wallet
+            ? points
+            : Math.min(claimable_count * reward.required_points, args["cost"] || Infinity);
         // In case the reward is the product multiple times, give it as many times as possible
-        const freeQuantity = Math.min(unclaimedQty, reward.reward_product_qty * claimable_count);
+        const freeQuantity = Math.min(
+            unclaimedQty,
+            reward.reward_product_qty * claimable_count,
+            args["quantity"] || Infinity
+        );
         return [
             {
                 product: reward.discount_line_product_id,
@@ -1553,12 +1559,12 @@ patch(Order.prototype, {
                     this.pos.currency.decimal_places
                 ),
                 tax_ids: product.taxes_id,
-                quantity: args["quantity"] || freeQuantity,
+                quantity: freeQuantity,
                 reward_id: reward.id,
                 is_reward_line: true,
                 reward_product_id: product.id,
                 coupon_id: args["coupon_id"],
-                points_cost: args["cost"] || cost,
+                points_cost: cost,
                 reward_identifier_code: _newRandomRewardCode(),
                 merge: false,
             },

--- a/addons/pos_loyalty/static/tests/tours/PosLoyaltyLoyaltyProgramTour.js
+++ b/addons/pos_loyalty/static/tests/tours/PosLoyaltyLoyaltyProgramTour.js
@@ -146,6 +146,23 @@ registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram2", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("PosLoyaltyChangeRewardQty", {
+    test: true,
+    url: "/pos/web",
+    steps: () =>
+        [
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("Test Partner DDD"),
+            ProductScreen.addOrderline("Desk Organizer", "1"),
+            PosLoyalty.isRewardButtonHighlighted(true),
+            PosLoyalty.claimReward("Free Product - Whiteboard Pen"),
+            PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "-80", "25.00"),
+            ProductScreen.pressNumpad("Qty"),
+            ProductScreen.pressNumpad("1"),
+            PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "-3.20", "1"),
+        ].flat(),
+    });
+
 registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram3", {
     test: true,
     url: "/pos/web",

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -377,6 +377,20 @@ class TestUi(TestPointOfSaleHttpCommon):
         reward_orderline = self.main_pos_config.current_session_id.order_ids[-1].lines.filtered(lambda line: line.is_reward_line)
         self.assertEqual(len(reward_orderline.ids), 0, msg='Reference: Order4_no_reward. Last order should have no reward line.')
 
+        # Part 3
+        partner_ddd = self.env['res.partner'].create({'name': 'Test Partner DDD'})
+        self.env['loyalty.card'].create({
+            'partner_id': partner_ddd.id,
+            'program_id': loyalty_program.id,
+            'points': 100,
+        })
+
+        self.start_tour(
+            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "PosLoyaltyChangeRewardQty",
+            login="pos_user",
+        )
+
     def test_loyalty_free_product_zero_sale_price_loyalty_program(self):
         # In this program, each $ spent gives 1 point.
         # 5 points can be used to get a free whiteboard pen.


### PR DESCRIPTION
Currently, when adding product rewards to an order, you are rewarded with the maximum amount of products you can get with you current points. If you change the quantity of the reward product, the reward lines does not update.

Steps to reproduce:
-------------------
* Go to the **Point of sale** App
* Open Shop session
* Select a customer that has plenty of loyalty points
* Put any product in the order
* Add the reward `Simple pen` (you'll havelike 230 of them)
* Try changing the reward quantity to 1
> Observation: The quantity of the simple pen changes to 1 but the negative reward line still shows 230. Thus, the order can have a negative amount since 229 pens are still being deducted from the order even though they are not present.

Why the fix:
------------
This commit https://github.com/odoo/odoo/commit/de45ff3c9f23decdab176bc1511b3356d19844a8 passes the quantity and cost (in points) to the `_applyReward` function. This was done because when recomputing reward lines, if two lines came from the same reward, the quantity would be merged even though they would not apply on the same product.

In our case, this causes problems as we are using the function `_getRewardLineValuesProduct` to update the reward quantity but the quantity (230) is given as an argument and is then used as the quantity to set.
https://github.com/odoo/odoo/blob/775827b8f7fa95f2afd77a9b42d6cd8e436ea690/addons/pos_loyalty/static/src/overrides/models/loyalty.js#L1548-L1566

`args["quantity"] || freeQuantity` will always use `args["quantity"]` if given, bypassing the maximum quantity that is available to give.

`freeQuantity || args["quantity"]` will never use `args["quantity"]`.

Since we do not want to reward more than what is available, we add the arguments inside the `Math.min` function.

opw-4103833
