### PR TITLE
[FIX] account: fix traceback when send and print invoice

### DIFF
--- a/addons/account/models/ir_actions_report.py
+++ b/addons/account/models/ir_actions_report.py
@@ -50,7 +50,8 @@ class IrActionsReport(models.Model):
         return collected_streams
 
     def _is_invoice_report(self, report_ref):
-        return self._get_report(report_ref).is_invoice_report
+        report = self._get_report(report_ref)
+        return report.is_invoice_report or report.model == 'account.move'
 
     def _pre_render_qweb_pdf(self, report_ref, res_ids=None, data=None):
         # Check for reports only available for invoices.


### PR DESCRIPTION
Currently, a traceback is occurring when the user disabled the `is_invoice_report` 
for an invoice report and try to send and print an invoice.

To reproduce this issue:

1) Install `Accounting` and enable debug mode
2) Open the `report_invoice_with_payments` report from
    `settings/technical/actions/report`
3) Disable the `Invoice Report`
4) Now create a customer invoice and try to send and print

Error:- 
```
TypeError: a bytes-like object is required, not 'dict'
```

When the user disabled the invoice report it directly returns content as a dict, eventually the raw values will be

```
raw: {
attachment: None,
stream: <_io.BytesIO object at 0x7fd38f10e3e0>
}
```

This leads to a traceback when `io.BytesIO(pdf_values['raw'])` is used to
on raw value

https://github.com/odoo/odoo/blob/330a3efbd09ea84ab44c64751087afcc19cee9d6/addons/account/models/ir_actions_report.py#L66-L68

https://github.com/odoo/odoo/blob/330a3efbd09ea84ab44c64751087afcc19cee9d6/addons/account/wizard/account_move_send.py#L417-L422

when the user disabled the is_invoice, and has the model `account.move`
We can consider that an invoice report. By doing this we can resolve this issue

sentry-5762537325

