### PR TITLE
[FIX] pos_restaurant: order cancel trackeback

### DIFF
--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -35,14 +35,14 @@ patch(PosStore.prototype, {
             this.getTableOrderCount();
         }
     },
-    afterOrderDeletion() {
+    async onDeleteOrder(order) {
         if (
             this.config.module_pos_restaurant &&
             this.mainScreen.component.name !== "TicketScreen"
         ) {
-            return this.showScreen("FloorScreen");
+            this.showScreen("FloorScreen");
         }
-        return super.afterOrderDeletion();
+        return super.onDeleteOrder(...arguments);
     },
     async getTableOrderCount() {
         const result = await this.data.call(


### PR DESCRIPTION
Steps to reproduce:
1. open table. add items.
2. go back to floor plan.
3. Open table again.
4. cancel order. -> Blank screen.

Reason:
After removing the order we switch to the FloorScreen, but in between the time when the order is removed and screen switches to the FloorScreen, a rerender of the ProductScreen occurs. A error is encountered because there is no selected order.

The fix is to switch to the FloorScreen before removing the order.

Task: 4155617

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
