### PR TITLE
[IMP] l10n_in: pan field after vat field for indian company

### DIFF
--- a/addons/l10n_in/views/res_company_views.xml
+++ b/addons/l10n_in/views/res_company_views.xml
@@ -14,7 +14,7 @@
             <xpath expr="//label[@for='name']" position="before">
                <field class="o_form_label mb-0" name="l10n_in_pan_type" invisible="not l10n_in_pan_type"/>
             </xpath>
-            <xpath expr="//field[@name='vat']" position="before">
+            <xpath expr="//field[@name='vat']" position="after">
                 <field name="l10n_in_pan" invisible="country_code != 'IN'"/>
             </xpath>
         </field>


### PR DESCRIPTION
Position for `l10n_in_pan` is changed from above `vat` field to below it, as for indian company when user enters `GSTIN` number, PAN is computed from it,

Task [link](https://www.odoo.com/odoo/project/967/tasks/4153417)
task-4153417

