### PR TITLE
[IMP] various: improve user error wording

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2433,10 +2433,9 @@ class AccountMove(models.Model):
                 move = self.browse(move_id)
                 error_msg += _(
                     "\n\n"
-                    "The move (%(move)s) is not balanced.\n"
-                    "The total of debits equals %(debit_total)s and the total of credits equals %(credit_total)s.\n"
-                    "You might want to specify a default account on journal \"%(journal)s\" to automatically balance each move.",
-                    move=move.display_name,
+                    "The journal entry is not balanced,"
+                    "with %(debit_total)s on the debit side and %(credit_total)s on the credit side, there needs to be an equilibrium!\n\n"
+                    "Consider adding a default account on the journal \"%(journal)s\" to automatically balance each journal entry and restore order to the accounting universe!",
                     debit_total=format_amount(self.env, sum_debit, move.company_id.currency_id),
                     credit_total=format_amount(self.env, sum_credit, move.company_id.currency_id),
                     journal=move.journal_id.name)
@@ -5118,7 +5117,10 @@ class AccountMove(models.Model):
 
             if not invoice.partner_id:
                 if invoice.is_sale_document():
-                    validation_msgs.add(_("The field 'Customer' is required, please complete it to validate the Customer Invoice."))
+                    validation_msgs.add(_(
+                        "The 'Customer' field is required to validate the invoice.\n"
+                        "You probably don't want to explain to your auditor that you invoiced an invisible man :)"
+                    ))
                 elif invoice.is_purchase_document():
                     validation_msgs.add(_("The field 'Vendor' is required, please complete it to validate the Vendor Bill."))
 
@@ -5131,7 +5133,7 @@ class AccountMove(models.Model):
             if move.state in ['posted', 'cancel']:
                 validation_msgs.add(_('The entry %(name)s (id %(id)s) must be in draft.', name=move.name, id=move.id))
             if not move.line_ids.filtered(lambda line: line.display_type not in ('line_section', 'line_note')):
-                validation_msgs.add(_('You need to add a line before posting.'))
+                validation_msgs.add(_("Even magicians can't post nothing!"))
             if not soft and move.auto_post != 'no' and move.date > fields.Date.context_today(self):
                 date_msg = move.date.strftime(get_lang(self.env).date_format)
                 validation_msgs.add(_("This move is configured to be auto-posted on %(date)s", date=date_msg))
@@ -5414,7 +5416,7 @@ class AccountMove(models.Model):
 
     def action_switch_move_type(self):
         if any(move.posted_before for move in self):
-            raise ValidationError(_("You cannot switch the type of a document which has been posted once."))
+            raise ValidationError(_("Once a document has been posted once, its type is set in stone and you can't change it anymore."))
         if any(move.move_type == "entry" for move in self):
             raise ValidationError(_("This action isn't available for this document."))
 

--- a/addons/account/models/account_payment_term.py
+++ b/addons/account/models/account_payment_term.py
@@ -251,7 +251,7 @@ class AccountPaymentTerm(models.Model):
     @api.ondelete(at_uninstall=False)
     def _unlink_except_referenced_terms(self):
         if self.env['account.move'].search_count([('invoice_payment_term_id', 'in', self.ids)], limit=1):
-            raise UserError(_('You can not delete payment terms as other records still reference it. However, you can archive it.'))
+            raise UserError(_("Uh-oh! Those payment terms are quite popular and can't be deleted since there are still some records referencing them. How about archiving them instead?"))
 
     def _get_last_discount_date(self, date_ref):
         self.ensure_one()

--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -745,7 +745,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
         tax_line.unlink()
 
         # But creating unbalanced misc entry shouldn't be allowed otherwise
-        with self.assertRaisesRegex(UserError, r"The move \(.*\) is not balanced\."):
+        with self.assertRaisesRegex(UserError, r"The journal entry is not balanced"):
             self.env["account.move"].create({
                 "move_type": "entry",
                 "line_ids": [

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -1570,7 +1570,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         self.assertFalse(move.payment_ids)  # don't auto reconcile payments
 
         # If the move is already fully paid, we should alert the user
-        with self.assertRaisesRegex(UserError, r"You can't register a payment because there is nothing left"):
+        with self.assertRaisesRegex(UserError, r"There's nothing left to pay for the selected journal items, so no payment registration is necessary. You've got your finances under control like a boss!"):
             action_register_payment = move.action_force_register_payment()
             self.env[action_register_payment['res_model']].with_context(action_register_payment['context']).create({})
 

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -4127,12 +4127,17 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         self.assertEqual(invalid_invoice_1.state, 'draft')
 
         self.assertTrue(any(
-            message.body == "<p>The move could not be posted for the following reason: The field 'Customer' is required, please complete it to validate the Customer Invoice.</p>"
+            message.body == (
+                "<p>The move could not be posted for the following reason: The 'Customer' field is required to validate the invoice.\n"
+                "You probably don't want to explain to your auditor that you invoiced an invisible man :)</p>"
+            )
             for message in invalid_invoice_1.message_ids))
 
         self.assertEqual(invalid_invoice_2.state, 'draft')
         self.assertTrue(any(
-            message.body == "<p>The move could not be posted for the following reason: You need to add a line before posting.</p>"
+            message.body == (
+                "<p>The move could not be posted for the following reason: Even magicians can't post nothing!</p>"
+            )
             for message in invalid_invoice_2.message_ids))
 
     def test_no_taxes_on_payment_term_line(self):

--- a/addons/account/wizard/account_automatic_entry_wizard.py
+++ b/addons/account/wizard/account_automatic_entry_wizard.py
@@ -145,9 +145,9 @@ class AccountAutomaticEntryWizard(models.TransientModel):
         res['move_line_ids'] = [(6, 0, move_line_ids.ids)]
 
         if any(move.state != 'posted' for move in move_line_ids.mapped('move_id')):
-            raise UserError(_('You can only change the period/account for posted journal items.'))
+            raise UserError(_("Oops! You can only change the period or account for posted entries! Other ones aren't up for an adventure like that!"))
         if any(move_line.reconciled for move_line in move_line_ids):
-            raise UserError(_('You can only change the period/account for items that are not yet reconciled.'))
+            raise UserError(_("Oops! You can only change the period or account for posted entries! Other ones aren't up for an adventure like that!"))
         if any(line.company_id.root_id != move_line_ids[0].company_id.root_id for line in move_line_ids):
             raise UserError(_('You cannot use this wizard on journal entries belonging to different companies.'))
         res['company_id'] = move_line_ids[0].company_id.root_id.id

--- a/addons/account/wizard/account_move_reversal.py
+++ b/addons/account/wizard/account_move_reversal.py
@@ -72,7 +72,9 @@ class AccountMoveReversal(models.TransientModel):
             raise UserError(_("All selected moves for reversal must belong to the same company."))
 
         if any(move.state != "posted" for move in move_ids):
-            raise UserError(_('You can only reverse posted moves.'))
+            raise UserError(_(
+                'To reverse a journal entry, it has to be posted first.'
+            ))
         if 'company_id' in fields:
             res['company_id'] = move_ids.company_id.id or self.env.company.id
         if 'move_ids' in fields:

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -948,7 +948,7 @@ class AccountPaymentRegister(models.TransientModel):
 
             # Check.
             if not available_lines:
-                raise UserError(_("You can't register a payment because there is nothing left to pay on the selected journal items."))
+                raise UserError(_("There's nothing left to pay for the selected journal items, so no payment registration is necessary. You've got your finances under control like a boss!"))
             if len(lines.company_id.root_id) > 1:
                 raise UserError(_("You can't create payments for entries belonging to different companies."))
             if len(lines.company_id.filtered(lambda c: c.root_id not in lines.company_id)) > 1:

--- a/addons/analytic/models/analytic_account.py
+++ b/addons/analytic/models/analytic_account.py
@@ -99,7 +99,7 @@ class AccountAnalyticAccount(models.Model):
                 ('auto_account_id', 'in', [account.id for account in accounts]),
                 '!', ('company_id', 'child_of', company.id),
             ], limit=1):
-                raise UserError(_("You can't set a different company on your analytic account since there are some analytic items linked to it."))
+                raise UserError(_("You can't change the company of an analytic account that already has analytic items! It's a recipe for an analytical disaster!"))
 
     @api.depends('code', 'partner_id')
     def _compute_display_name(self):

--- a/addons/hr_contract/models/hr_contract.py
+++ b/addons/hr_contract/models/hr_contract.py
@@ -163,7 +163,7 @@ class HrContract(models.Model):
             if self.search_count(domain):
                 raise ValidationError(
                     _(
-                        'An employee can only have one contract at the same time. (Excluding Draft and Cancelled contracts).\n\nEmployee: %(employee_name)s',
+                        "No matter how stellar %(employee_name)s might be, you are limited to one contract per company at a time.",
                         employee_name=contract.employee_id.name
                     )
                 )

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -501,7 +501,10 @@ class HrExpense(models.Model):
     def _inverse_total_amount_currency(self):
         for expense in self:
             if not expense.is_editable:
-                raise UserError(_('You are not authorized to edit this expense.'))
+                raise UserError(_(
+                    "Uh-oh! You can’t edit this expense.\n\n"
+                    "Reach out to the administrators, flash your best smile, and see if they'll grant you the magical access you seek."
+                ))
             expense.price_unit = (expense.total_amount / expense.quantity) if expense.quantity != 0 else 0.
 
     @api.depends(
@@ -807,7 +810,10 @@ class HrExpense(models.Model):
 
         if any(field in vals for field in {'tax_ids', 'analytic_distribution', 'account_id', 'manager_id'}):
             if any((not expense.is_editable and not self.env.su) for expense in self):
-                raise UserError(_('You are not authorized to edit this expense.'))
+                raise UserError(_(
+                    "Uh-oh! You can’t edit this expense.\n\n"
+                    "Reach out to the administrators, flash your best smile, and see if they'll grant you the magical access you seek."
+                ))
 
         res = super().write(vals)
 

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -836,7 +836,7 @@ class HrLeave(models.Model):
                 if hol.state not in ['confirm', 'validate1', 'cancel']:
                     raise UserError(error_message % {'state': state_description_values.get(self[:1].state)})
                 if hol.date_from.date() < now:
-                    raise UserError(_('You cannot delete a time off which is in the past'))
+                    raise UserError(_("You can't delete a time off request that is in the past."))
         elif not self.env.user.has_group('hr_holidays.group_hr_holidays_manager'):
             for holiday in self.filtered(lambda holiday: holiday.state not in ['cancel', 'confirm']):
                 error_message = self.env._('Oops! %(state)s Time-Off requests can only be deleted by Administrators.')

--- a/addons/hr_timesheet/models/project_task.py
+++ b/addons/hr_timesheet/models/project_task.py
@@ -264,9 +264,9 @@ class ProjectTask(models.Model):
                 "and then you’ll be able to delete the task.")
             )
         if len(task_with_timesheets_ids) > 1:
-            warning_msg = _("These tasks have some timesheet entries referencing them. Before removing these tasks, you have to remove these timesheet entries.")
+            warning_msg = _("Some timesheet entries are weighing down these tasks! Remove them first, then you’ll be able to delete the tasks!")
         else:
-            warning_msg = _("This task has some timesheet entries referencing it. Before removing this task, you have to remove these timesheet entries.")
+            warning_msg = _("Some timesheet entries are weighing down these tasks! Remove them first, then you’ll be able to delete the tasks!")
         raise RedirectWarning(
             warning_msg, self.env.ref('hr_timesheet.timesheet_action_task').id,
             _('See timesheet entries'), {'active_ids': task_with_timesheets_ids})

--- a/addons/hr_timesheet/wizard/hr_employee_delete_wizard_views.xml
+++ b/addons/hr_timesheet/wizard/hr_employee_delete_wizard_views.xml
@@ -9,9 +9,9 @@
                     <field name="has_timesheet" invisible="1"/>
                     <field name="has_active_employee" invisible="1"/>
                     <span invisible="not has_timesheet">
-                        You cannot delete employees who have timesheets.
+                        Uh-oh! The employee you’re trying to delete still has some timesheets hanging around and can’t be deleted.
                         <span invisible="not has_active_employee">
-                            You can either archive these employees or first delete all of their timesheets.
+                            So here are your two options: either delete those timesheets or consider archiving the employee instead.
                         </span>
                         <span invisible="has_active_employee" groups="hr_timesheet.group_hr_timesheet_approver">
                             Please first delete all of their timesheets.

--- a/addons/lunch/models/lunch_order.py
+++ b/addons/lunch/models/lunch_order.py
@@ -252,7 +252,7 @@ class LunchOrder(models.Model):
         self.env.flush_all()
         for line in self:
             if self.env['lunch.cashmove'].get_wallet_balance(line.user_id) < 0:
-                raise ValidationError(_('Your wallet does not contain enough money to order that. To add some money to your wallet, please contact your lunch manager.'))
+                raise ValidationError(_('Oh no! You don’t have enough money in your wallet to order your selected lunch! Contact your lunch manager to add some money to your wallet.'))
 
     def action_order(self):
         for order in self:

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -763,11 +763,8 @@ export class Composer extends Component {
         } else {
             this.env.services.dialog.add(MessageConfirmDialog, {
                 message: composer.message,
-                onConfirm: () => {
-                    this.message.remove();
-                    this.props.onDiscardCallback?.();
-                },
-                prompt: _t("Are you sure you want to delete this message?"),
+                onConfirm: () => this.message.remove(),
+                prompt: _t("Are you sure you want to bid farewell to this message forever?"),
             });
         }
         this.suggestion?.clearRawMentions();

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -117,7 +117,7 @@ messageActionsRegistry
                 discussComponentRegistry.get("MessageConfirmDialog"),
                 {
                     message,
-                    prompt: _t("Are you sure you want to delete this message?"),
+                    prompt: _t("Are you sure you want to bid farewell to this message forever?"),
                     onConfirm: () => {
                         def.resolve(true);
                         message.remove();

--- a/addons/mail/static/src/core/common/message_confirm_dialog.js
+++ b/addons/mail/static/src/core/common/message_confirm_dialog.js
@@ -18,9 +18,9 @@ export class MessageConfirmDialog extends Component {
     ];
     static defaultProps = {
         confirmColor: "btn-primary",
-        confirmText: _t("Confirm"),
+        confirmText: _t("Delete"),
         size: "xl",
-        title: _t("Confirmation"),
+        title: _t("Send this message to the great trash can in the sky?"),
     };
     static template = "mail.MessageConfirmDialog";
 

--- a/addons/mail/static/tests/core/new_message_separator.test.js
+++ b/addons/mail/static/tests/core/new_message_separator.test.js
@@ -56,7 +56,7 @@ test("keep new message separator when message is deleted", async () => {
         parent: [".o-mail-Message", { text: "message 0" }],
     });
     await click(".o-mail-Message-moreMenu [title='Delete']");
-    await click("button", { text: "Confirm" });
+    await click("button", { text: "Delete" });
     await contains(".o-mail-Message", { text: "message 0", count: 0 });
     await contains(".o-mail-Thread-newMessage ~ .o-mail-Message", { text: "message 1" });
 });

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -588,7 +588,7 @@ test("Deleting parent message of a reply should adapt reply visual", async () =>
     triggerHotkey("Enter", false);
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message-moreMenu [title='Delete']");
-    await click("button", { text: "Confirm" });
+    await click("button", { text: "Delete" });
     await contains(".o-mail-MessageInReply", { text: "Original message was deleted" });
 });
 
@@ -1138,7 +1138,9 @@ test("Editing a message to clear its composer opens message delete dialog.", asy
     await insertText(".o-mail-Message.o-editing .o-mail-Composer-input", "", { replace: true });
     triggerHotkey("Enter");
     await contains(".o-mail-Message", { text: "not empty" });
-    await contains(".modal-body p", { text: "Are you sure you want to delete this message?" });
+    await contains(".modal-body p", {
+        text: "Are you sure you want to bid farewell to this message forever?",
+    });
 });
 
 test("Clear message body should not open message delete dialog if it has attachments", async () => {
@@ -1165,7 +1167,7 @@ test("Clear message body should not open message delete dialog if it has attachm
     await contains(".o-mail-Message-textContent", { text: "" });
     // weak test, no guarantee that we waited long enough for the potential dialog to show
     await contains(".modal-body p", {
-        text: "Are you sure you want to delete this message?",
+        text: "Are you sure you want to bid farewell to this message forever?",
         count: 0,
     });
 });
@@ -1545,7 +1547,7 @@ test("delete all attachments of message without content should mark message as d
     await contains(".o-mail-Message");
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message-moreMenu [title='Delete']");
-    await click("button", { text: "Confirm" });
+    await click("button", { text: "Delete" });
     await contains(".o-mail-Message", { text: "This message has been removed" });
 });
 
@@ -1986,7 +1988,7 @@ test("deleted message should not have translate feature", async () => {
     await contains(".dropdown-menu");
     await contains(".dropdown-item:contains('Translate')");
     await click(".dropdown-item:contains('Delete')");
-    await click("button:contains('Confirm')");
+    await click("button:contains('Delete')");
     await contains(".o-mail-Message:contains('This message has been removed')");
     await contains(".o-mail-Message [title='Add a Reaction']");
     await contains(".o-mail-Message [title='Mark as Todo']");

--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -63,7 +63,7 @@ class MaintenanceEquipmentCategory(models.Model):
     def _unlink_except_contains_maintenance_requests(self):
         for category in self:
             if category.equipment_ids or category.maintenance_ids:
-                raise UserError(_("You cannot delete an equipment category containing equipment or maintenance requests."))
+                raise UserError(_("You can’t delete an equipment category if some equipment or maintenance requests are linked to it."))
 
 
 class MaintenanceMixin(models.AbstractModel):

--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -186,12 +186,16 @@ class MrpUnbuild(models.Model):
 
         finished_moves = consume_moves.filtered(lambda m: m.product_id == self.product_id)
         consume_moves -= finished_moves
+        error_message = _(
+            "Please specify a manufacturing order.\n"
+            "It will allow us to retrieve the lots/serial numbers of the correct components and/or byproducts."
+        )
 
         if any(produce_move.has_tracking != 'none' and not self.mo_id for produce_move in produce_moves):
-            raise UserError(_('Some of your components are tracked, you have to specify a manufacturing order in order to retrieve the correct components.'))
+            raise UserError(error_message)
 
         if any(consume_move.has_tracking != 'none' and not self.mo_id for consume_move in consume_moves):
-            raise UserError(_('Some of your byproducts are tracked, you have to specify a manufacturing order in order to retrieve the correct byproducts.'))
+            raise UserError(error_message)
 
         for finished_move in finished_moves:
             finished_move_line_vals = self._prepare_finished_move_line_vals(finished_move)

--- a/addons/mrp/wizard/mrp_production_backorder.xml
+++ b/addons/mrp/wizard/mrp_production_backorder.xml
@@ -33,7 +33,7 @@
         </record>
 
         <record id="action_mrp_production_backorder" model="ir.actions.act_window">
-            <field name="name">You produced less than initial demand</field>
+            <field name="name">You produced less than the initial demand</field>
             <field name="res_model">mrp.production.backorder</field>
             <field name="view_mode">form</field>
             <field name="target">new</field>

--- a/addons/phone_validation/tools/phone_validation.py
+++ b/addons/phone_validation/tools/phone_validation.py
@@ -52,7 +52,7 @@ try:
                 else:
                     raise UserError(_lt('Impossible number %s: too many digits.', number))
             else:
-                raise UserError(_lt('Impossible number %s: probably invalid number of digits.', number))
+                raise UserError(_lt("The phone number %s is invalid! Let's fix it - you are not dialing aliens.", number))
         if not phonenumbers.is_valid_number(phone_nbr):
             raise UserError(_lt('Invalid number %s: probably incorrect prefix.', number))
 

--- a/addons/project/models/account_analytic_account.py
+++ b/addons/project/models/account_analytic_account.py
@@ -26,7 +26,7 @@ class AccountAnalyticAccount(models.Model):
             limit=1,
         )
         if has_tasks:
-            raise UserError(_('Please remove existing tasks in the project linked to the accounts you want to delete.'))
+            raise UserError(_("Before we can bid farewell to these accounts, you need to tidy up the projects linked to them by removing their existing tasks!"))
 
     def action_view_projects(self):
         kanban_view_id = self.env.ref('project.view_project_kanban').id

--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -161,8 +161,10 @@ class PurchaseOrderLine(models.Model):
                 rounding = line.product_uom_id.rounding
                 # Prevent decreasing below received quantity
                 if float_compare(line.product_qty, line.qty_received, precision_rounding=rounding) < 0:
-                    raise UserError(_('You cannot decrease the ordered quantity below the received quantity.\n'
-                                      'Create a return first.'))
+                    raise UserError(_(
+                        "You're trying to decrease the ordered quantity below the received quantity, you goofball.\n\n"
+                        "Try creating a return first silly billy!"
+                    ))
 
                 if float_compare(line.product_qty, line.qty_invoiced, precision_rounding=rounding) < 0 and line.invoice_lines:
                     # If the quantity is now below the invoiced quantity, create an activity on the vendor bill

--- a/addons/repair/wizard/stock_warn_insufficient_qty_views.xml
+++ b/addons/repair/wizard/stock_warn_insufficient_qty_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="stock.stock_warn_insufficient_qty_form_view"/>
         <field name="arch" type="xml">
             <xpath expr="//div[@name='description']" position="after">
-                Do you confirm you want to repair <strong><field name="quantity" readonly="True"/></strong><field name="product_uom_name" readonly="True" class="mx-1"/>from location <strong><field name="location_id" readonly="True"/></strong>? This may lead to inconsistencies in your inventory.
+                <br/>You can still confirm the repair of <strong><field name="quantity" readonly="True"/></strong><field name="product_uom_name" readonly="True" class="mx-1"/>from location <strong><field name="location_id" readonly="True"/></strong>? , but get ready to have fun taking inventory to fix the negative stock quantity!
             </xpath>
         </field>
     </record>

--- a/addons/sale/wizard/mass_cancel_orders_views.xml
+++ b/addons/sale/wizard/mass_cancel_orders_views.xml
@@ -19,8 +19,7 @@
                     Are you sure you want to cancel the selected item?
                 </div>
                 <div invisible="sale_orders_count == 1">
-                    Are you sure you want to cancel the <field name="sale_orders_count"/> selected
-                    items?
+                    So, are you sure you want to cancel these <field name="sale_orders_count"/> items?
                 </div>
                 <footer>
                     <button class="btn-primary"

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -557,7 +557,11 @@ class StockMoveLine(models.Model):
     def _unlink_except_done_or_cancel(self):
         for ml in self:
             if ml.state in ('done', 'cancel'):
-                raise UserError(_('You can not delete product moves if the picking is done. You can only correct the done quantities.'))
+                raise UserError(_(
+                    "Deleting product moves after the transfer is done?\n\n"
+                    "That would be like going back in time to revert all operations triggered after this move. Who knows what the end result would be, So let's not do it.\n\n"
+                    "Try changing the “done” quantity to 0 instead."
+                ))
 
     def unlink(self):
         precision = self.env['decimal.precision'].precision_get('Product Unit')

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1517,8 +1517,8 @@ class StockPicking(models.Model):
         :rtype: str
         """
         return _(
-            'You cannot validate a transfer if no quantities are reserved. '
-            'To force the transfer, encode quantities.'
+            "Transfer trouble alert! Validating a zero quantity transfer? You're not moving invisible goods around are you?\n"
+            "Set some quantities and let's get moving!"
         )
 
     def _action_generate_backorder_wizard(self, show_transfers=False):

--- a/addons/stock/wizard/stock_backorder_confirmation_views.xml
+++ b/addons/stock/wizard/stock_backorder_confirmation_views.xml
@@ -5,21 +5,14 @@
         <field name="model">stock.backorder.confirmation</field>
         <field name="arch" type="xml">
             <form string="Backorder creation">
-                <group>
-                    <group>
-                        <div colspan="2"><p name="explanation-text">
-                            You have processed less products than the initial demand.
-                        </p></div>
-                    </group>
-                    <group>
-                        <div colspan="2" class="text-muted">
-                            Create a backorder if you expect to process the remaining
-                            products later. Do not create a backorder if you will not
-                            process the remaining products.
-                        </div>
-                    </group>
-                </group>
-
+                <p name="explanation-text">
+                    You have processed less products than the initial demand.
+                </p>
+                <p class="text-muted">
+                    Create a backorder if you expect to process the remaining
+                    products later. Do not create a backorder if you will not
+                    process the remaining products.
+                </p>
                 <!-- Added to ensure a correct default_get behavior
 
                 The wizard is always opened with default_pick_ids values in context,

--- a/addons/web/static/src/views/list/list_confirmation_dialog.js
+++ b/addons/web/static/src/views/list/list_confirmation_dialog.js
@@ -35,6 +35,22 @@ export class ListConfirmationDialog extends Component {
         useAutofocus();
     }
 
+    get validRecordsText() {
+        return _t(
+            "Among the %(total)s selected records, %(valid_count)s are valid for this update.",
+            {
+                total: this.props.nbRecords,
+                valid_count: this.props.nbValidRecords,
+            }
+        );
+    }
+
+    get updateConfirmationText() {
+        return _t("Are you sure you want to update %(count)s records?", {
+            count: this.props.nbValidRecords,
+        });
+    }
+
     _cancel() {
         if (this.props.cancel) {
             this.props.cancel();

--- a/addons/web/static/src/views/list/list_confirmation_dialog.xml
+++ b/addons/web/static/src/views/list/list_confirmation_dialog.xml
@@ -7,10 +7,10 @@
                 <p>
                     <t t-if="props.isDomainSelected">This update will only consider the records of the current page.<br/><br/></t>
                     <t t-if="props.nbRecords != props.nbValidRecords">
-                        Among the <t t-esc="props.nbRecords"/> selected records,
-                        <t t-esc="props.nbValidRecords"/> are valid for this update.<br/>
+                        <t t-esc="validRecordsText"/>
+                        <br/>
                     </t>
-                    Are you sure you want to perform the following update on those <t t-esc="props.nbValidRecords"/> records?
+                    <t t-esc="updateConfirmationText"/>
                 </p>
                 <div class="table-responsive">
                     <table class="o_modal_changes">
@@ -34,7 +34,7 @@
             </main>
             <t t-set-slot="footer">
                 <button class="btn btn-primary" t-on-click="_confirm" t-ref="autofocus">
-                Confirm
+                Update
                 </button>
                 <button t-if="props.cancel" class="btn btn-secondary" t-on-click="_cancel">
                 Cancel

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -10824,7 +10824,7 @@ test(`editable list view: multi edition`, async () => {
 
     await contains(`.o_data_row:eq(0) .o_data_cell:eq(1)`).click();
     await contains(`.o_data_row [name=int_field] input`).edit("666");
-    expect(queryOne(".modal-body").innerText.includes("those 2 records")).toBe(true, {
+    expect(queryOne(".modal-body").innerText.includes("update 2 records")).toBe(true, {
         message: "the number of records should be correctly displayed",
     });
 
@@ -11407,7 +11407,7 @@ test(`editable list view: multi edition with readonly modifiers`, async () => {
     await contains(`.o_data_row [name=int_field] input`).edit("666");
 
     expect(`.modal-body`).toHaveText(`Among the 4 selected records, 2 are valid for this update.
-Are you sure you want to perform the following update on those 2 records?
+Are you sure you want to update 2 records?
 
 Field: Int field
 Update to: 666`);
@@ -11768,7 +11768,7 @@ test(`non editable list view: multi edition`, async () => {
     await contains(`.o_data_row:eq(0) .o_data_cell:eq(1)`).click();
     await contains(`.o_data_row [name=int_field] input`).edit("666");
     expect(`.modal`).toHaveCount(1);
-    expect(queryOne(".modal").innerText.includes("those 2 records")).toBe(true, {
+    expect(queryOne(".modal").innerText.includes("update 2 records")).toBe(true, {
         message: "the number of records should be correctly displayed",
     });
 

--- a/addons/website/static/src/components/dialog/page_properties.xml
+++ b/addons/website/static/src/components/dialog/page_properties.xml
@@ -25,7 +25,7 @@
             </div>
         </t>
         <t t-else="">
-            <p class="text-warning">We found these ones:</p>
+            <p class="text-warning">We found these links:</p>
             <div t-foreach="state.dependencies" t-as="dependency" t-key="dependency" class="ml16 mb16">
                 <a class="collapsed" data-bs-toggle="collapse"
                 t-attf-aria-controls="collapseDependencies{{ dependency_index }}"
@@ -65,13 +65,12 @@
 
 <t t-name="website.DeletePageDialog">
     <WebsiteDialog title.translate="Delete Page" close="props.close">
-        <p t-if="props.resIds.length > 1">Are you sure you want to delete those pages?</p>
-        <p t-else="">Are you sure you want to delete this page?</p>
-        <p t-if="props.hasNewPageTemplate" class="text-warning">
-            <t t-if="props.resIds.length > 1">Some of these pages are used as new page templates.</t>
-            <t t-else="">This page is used as a new page template.</t>
+        <p t-if="props.resIds.length > 1">Ready to make these web pages disappear into thin air? Are you sure?\n They will be gone forever!\n
+            <span class="text-warning">But before deleting, make sure you update all links referring to them. That way, your customers won't bump into the not-so-famous 404 error page.</span>
         </p>
-        <p class="text-warning">Don't forget to update all links referring to it.</p>
+        <p t-else="">Ready to make this web page disappear into thin air? Are you sure?\n It will be gone forever!\n
+            <span class="text-warning">But before deleting, make sure you update all links referring to it. That way, your customers won't bump into the not-so-famous 404 error page.</span>
+        </p>  
         <PageDependencies resIds="props.resIds" resModel="props.resModel" mode="'collapse'"/>
         <CheckBox value="state.confirm" onChange.bind="onConfirmCheckboxChange">
             <p class="text-warning">I am sure about this.</p>
@@ -79,10 +78,10 @@
 
         <t t-set-slot="footer">
             <button class="btn btn-primary" t-on-click="() => this.onClickDelete()"  t-att-disabled="!this.state.confirm">
-                Ok
+                Delete
             </button>
             <button class="btn btn-secondary" t-on-click="() => this.props.close()">
-                Cancel
+                No, keep it
             </button>
         </t>
     </WebsiteDialog>

--- a/addons/website_slides_survey/models/survey_survey.py
+++ b/addons/website_slides_survey/models/survey_survey.py
@@ -40,7 +40,8 @@ class SurveySurvey(models.Model):
                 for certi in certifications
             ]
             raise ValidationError(_(
-                'Any Survey listed below is currently used as a Course Certification and cannot be deleted:\n%s',
+                'Uh-oh! You can’t delete surveys used as a Course Certification! Otherwise, students might think diplomas just grow on trees.\n'
+                'The courses that need them are:\n%s',
                 '\n'.join(certifications_course_mapping)))
 
     # ---------------------------------------------------------

--- a/odoo/addons/test_rpc/tests/test_error.py
+++ b/odoo/addons/test_rpc/tests/test_error.py
@@ -54,11 +54,11 @@ class TestError(common.HttpCase):
         e = ctx.exception
         self.assertIn("The operation cannot be completed:", e.faultString)
         self.assertIn(
-            "Another model requires the record being deleted, if possible, archive it instead",
+            "Another model is using the record you are trying to delete",
             e.faultString,
         )
-        self.assertIn("Model: 'Model A' (test_rpc.model_a)", e.faultString)
-        self.assertIn("Foreign key: 'required field'", e.faultString)
+        self.assertIn("The troublemaker is: 'Model A' (test_rpc.model_a)", e.faultString)
+        self.assertIn("Thanks to the following constraint: 'required field'", e.faultString)
 
         # Unlink b2 => ON DELETE RESTRICT constraint raises
         with self.assertRaises(Fault) as ctx, mute_logger("odoo.sql_db", "odoo.http"):
@@ -67,11 +67,11 @@ class TestError(common.HttpCase):
         e = ctx.exception
         self.assertIn("The operation cannot be completed:", e.faultString)
         self.assertIn(
-            "Another model requires the record being deleted, if possible, archive it instead",
+            "Another model is using the record you are trying to delete",
             e.faultString,
         )
-        self.assertIn("Model: 'Model A' (test_rpc.model_a)", e.faultString)
-        self.assertIn("Foreign key: 'restricted field'", e.faultString)
+        self.assertIn("The troublemaker is: 'Model A' (test_rpc.model_a)", e.faultString)
+        self.assertIn("Thanks to the following constraint: 'restricted field'", e.faultString)
 
     def test_03_sql_constraint(self):
         with mute_logger("odoo.sql_db"), self.assertLogs("odoo.http", level="WARNING") as capture:

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -3013,9 +3013,10 @@ class BaseModel(metaclass=MetaModel):
             if len(columns) != 1:
                 info['field_display'] = info['constraint_name']
             return self.env._(
-                "Another model requires the record being deleted, if possible, archive it instead.\n\n"
-                "Model: %(model_display)s\n"
-                "Foreign key: %(field_display)s\n",
+                "Another model is using the record you are trying to delete.\n\n"
+                "The troublemaker is: %(model_display)s\n"
+                "Thanks to the following constraint: %(field_display)s\n"
+                "How about archiving the record instead?",
                 **info,
             )
 
@@ -3732,9 +3733,9 @@ class BaseModel(metaclass=MetaModel):
                         inconsistencies.append((record, name, corecords))
 
         if inconsistencies:
-            lines = [_("Incompatible companies on records:")]
-            company_msg = _lt("- Record is company “%(company)s” and “%(field)s” (%(fname)s: %(values)s) belongs to another company.")
-            record_msg = _lt("- “%(record)s” belongs to company “%(company)s” and “%(field)s” (%(fname)s: %(values)s) belongs to another company.")
+            lines = [_("Uh-oh! You’ve got some company inconsistencies here:")]
+            company_msg = _lt("- Record is company “%(company)s” while “%(field)s” (%(fname)s: %(values)s) belongs to another company.")
+            record_msg = _lt("- “%(record)s” belongs to company “%(company)s” while “%(field)s” (%(fname)s: %(values)s) belongs to another company.")
             root_company_msg = _lt("- Only a root company can be set on “%(record)s”. Currently set to “%(company)s”")
             for record, name, corecords in inconsistencies[:5]:
                 if record._name == 'res.company':
@@ -3751,6 +3752,7 @@ class BaseModel(metaclass=MetaModel):
                     'fname': field.name,
                     'values': ", ".join(repr(rec.display_name) for rec in corecords),
                 })
+            lines.append(_("To avoid a mess, no company crossover is allowed!"))
             raise UserError("\n".join(lines))
 
     @api.private  # use has_access


### PR DESCRIPTION
Before this commit error messages in odoo are boring and not much attractive to user. Those were like odoo is preventing them from doing something user want to do.

In this commit, we have modified the message to be a more friendly and humorous tone, making it less tedious and more enjoyable. It aims to enhance the user experience and ensure that interactions with any application are both pleasant and informative. As a result, the messages have been clear, short, easy to understand and informative.

Task [link](https://www.odoo.com/odoo/project/967/tasks/3422664)
task-3422664
