### PR TITLE
[FIX] point_of_sale: enable loading partners by barcode in search

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
@@ -190,7 +190,7 @@ export class PartnerListScreen extends Component {
         let domain = [];
         const limit = 30;
         if (this.state.query) {
-            const search_fields = ["name", "parent_name", "phone_mobile_search", "email"];
+            const search_fields = ["name", "parent_name", "phone_mobile_search", "email", "barcode"];
             domain = [
                 ...Array(search_fields.length - 1).fill('|'),
                 ...search_fields.map(field => [field, "ilike", this.state.query + "%"])


### PR DESCRIPTION
Before this commit, searching for a missing partner using their barcode via the 'search more' button did not yield any results.

opw-4154847

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
