### PR TITLE
[FIX] web_editor: background color of banner in pdf

### DIFF
--- a/addons/web_editor/static/src/scss/bootstrap_overridden.scss
+++ b/addons/web_editor/static/src/scss/bootstrap_overridden.scss
@@ -97,3 +97,95 @@ $small-font-size: if(
     ($o-small-font-size / $font-size-base) * 1em,
     null
 ) !default;
+
+
+// We hardcode the styles of the alerts because wkhtmltopdf doesn't work
+// with css variables that we introduced while upgrading to bootstrap v 5.3 in
+// https://github.com/odoo/odoo/commit/058212e12b5079eba870bde9775fe98f27928935
+.alert {
+    position: relative;
+    padding: 1rem 1rem;
+    margin-bottom: 1rem;
+    border: 1px solid transparent;
+    border-radius: 0.25rem;
+}
+
+.alert-primary {
+    color: #084298;
+    background-color: #cfe2ff;
+    border-color: #b6d4fe;
+}
+
+.alert-primary .alert-link {
+    color: #06357a;
+}
+
+.alert-secondary {
+    color: #41464b;
+    background-color: #e2e3e5;
+    border-color: #d3d6d8;
+}
+
+.alert-secondary .alert-link {
+    color: #34383c;
+}
+
+.alert-success {
+    color: #0f5132;
+    background-color: #d1e7dd;
+    border-color: #badbcc;
+}
+
+.alert-success .alert-link {
+    color: #0c4128;
+}
+
+.alert-info {
+    color: #055160;
+    background-color: #cff4fc;
+    border-color: #b6effb;
+}
+
+.alert-info .alert-link {
+    color: #04414d;
+}
+
+.alert-warning {
+    color: #664d03;
+    background-color: #fff3cd;
+    border-color: #ffecb5;
+}
+
+.alert-warning .alert-link {
+    color: #523e02;
+}
+
+.alert-danger {
+    color: #842029;
+    background-color: #f8d7da;
+    border-color: #f5c2c7;
+}
+
+.alert-danger .alert-link {
+    color: #6a1a21;
+}
+
+.alert-light {
+    color: #636464;
+    background-color: #fefefe;
+    border-color: #fdfdfe;
+}
+
+.alert-light .alert-link {
+    color: #4f5050;
+}
+
+.alert-dark {
+    color: #141619;
+    background-color: #d3d3d4;
+    border-color: #bcbebf;
+}
+
+.alert-dark .alert-link {
+    color: #101214;
+}


### PR DESCRIPTION
Issue:
======
Downloaded pdfs doesn't have the background color of banners.

Steps to reproduce the issue:
=============================
- Go to any sale order
- Add a banner in terms and conditions
- Print PDF Quote
- No background color of the banner

Origin of the issue:
====================
After the upgrade of bootstrap to 5.3 in [1], we changed the hardcoded colors to css variables of the alers.

We use wkhtmltopdf to render the pdf files but it doesn't support the css variables so we loose all the stylnig that was using those variables.

Solution:
=========
Add an override for alert classes to keep the old colors and styles as hardcoded to make sure they appear in the generated pdf

opw-4143779

[1]: https://github.com/odoo/odoo/commit/058212e12b5079eba870bde9775fe98f27928935