### PR TITLE
[FIX] point_of_sale, pos_*: Several fixes

### DIFF
--- a/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.js
+++ b/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.js
@@ -24,16 +24,24 @@ export class OrderTabs extends Component {
         this.pos.selectedTable = null;
         this.pos.add_new_order();
         this.pos.showScreen("ProductScreen");
-        if (this.env.inDialog) {
-            this.dialog.closeAll();
-        }
+        this.dialog.closeAll();
     }
     selectFloatingOrder(order) {
         this.pos.set_order(order);
         this.pos.selectedTable = null;
         this.pos.showScreen("ProductScreen");
-        if (this.env.inDialog) {
-            this.dialog.closeAll();
-        }
+        this.dialog.closeAll();
+    }
+    get orders() {
+        return this.props.orders.sort((a, b) => {
+            // Orders with a note should be displayed first and alphabetically ordered
+            if (a.note && !b.note) {
+                return -1;
+            } else if (!a.note && b.note) {
+                return 1;
+            } else if (a.note && b.note) {
+                return a.note.localeCompare(b.note);
+            }
+        });
     }
 }

--- a/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.xml
+++ b/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.OrderTabs">
-        <ListContainer items="props.orders"
+        <ListContainer items="orders"
             onClickPlus="() => this.newFloatingOrder()"
             t-slot-scope="scope"
             class="props.class"
@@ -10,7 +10,7 @@
             <t t-set="order" t-value="scope.item" />
             <button t-esc="order.getFloatingOrderName()"
                 t-attf-class="{{pos.get_order()?.id === order.id ? 'btn-secondary active' : ''}}"
-                class="btn btn-lg btn-secondary text-truncate"
+                class="btn btn-lg btn-secondary text-truncate mx-1"
                 style="min-width: 4rem;"
                 t-on-click="() => this.selectFloatingOrder(order)"
             />

--- a/addons/point_of_sale/static/src/app/generic_components/list_container/list_container.js
+++ b/addons/point_of_sale/static/src/app/generic_components/list_container/list_container.js
@@ -1,26 +1,26 @@
-import { Component, useRef, xml } from "@odoo/owl";
-import { useIsChildLarger, useReactivePopover } from "@point_of_sale/app/utils/hooks";
+import { Component, useEffect, useRef, xml } from "@odoo/owl";
+import { useIsChildLarger } from "@point_of_sale/app/utils/hooks";
 import { useService } from "@web/core/utils/hooks";
 import { Dialog } from "@web/core/dialog/dialog";
 
-class ListContainerPopover extends Component {
+class ListContainerDialog extends Component {
+    static components = { Dialog };
     static props = {
         items: Array,
         slots: { type: Object },
         close: Function,
     };
     static template = xml`
-        <div class="d-flex p-2 flex-wrap" style="gap: 0.5rem;">
-            <t t-foreach="props.items" t-as="item" t-key="item_index">
-                <t t-slot="default" item="item" t-on-click="props.close"/>
-            </t>
-        </div>
+        <Dialog title.translate="Choose an order" footer="false">
+            <div class="d-flex p-2 flex-wrap" style="gap: 0.5rem;">
+                <t t-foreach="props.items" t-as="item" t-key="item_index">
+                    <t t-slot="default" item="item" />
+                </t>
+            </div>
+        </Dialog>
     `;
 }
-class ListContainerDialog extends ListContainerPopover {
-    static components = { ListContainerPopover, Dialog };
-    static template = "point_of_sale.ListContainerDialog";
-}
+
 export class ListContainer extends Component {
     static props = {
         items: Array,
@@ -33,58 +33,39 @@ export class ListContainer extends Component {
         class: "",
     };
     static template = xml`
-        <div class="overflow-hidden d-flex" t-attf-class="{{props.class}}">
-            <!-- it's important that the parent of the 'container' div not be the parent of the 'view more' div -->
-            <!-- otherwise the appearance and disappearance of the 'view more' div will retrigger the resizeObserver, -->
-            <!-- which will cause a glitch-->
-            <div class="overflow-hidden">
-                <!-- the popover will position itself underneath the specified div, -->
-                <!-- but in this case we want it to be right on top of it; -->
-                <!-- in order to do this we set the height of our div to 0 for the -->
-                <!-- duration that the popover is shown. -->
-                <div t-ref="container" class="d-flex" t-attf-style="
-                    gap: 0.5rem;
-                    height: {{popover.isOpen ? '0' : 'auto'}};
-                ">
-                    <t t-if="!props.forceSmall" t-foreach="props.items" t-as="item" t-key="item_index">
+        <div class="overflow-hidden d-flex flex-grow-1" t-attf-class="{{props.class}}">
+            <button t-if="props.onClickPlus" class="btn btn-secondary btn-lg me-1" t-on-click="props.onClickPlus">
+                <i class="fa fa-fw fa-plus-circle" aria-hidden="true"/>
+            </button>
+            <button t-if="this.sizing.isLarger or props.forceSmall" t-on-click="toggle"
+                class="btn btn-secondary mx-1 fa fa-caret-down" />
+            <div class="overflow-hidden w-100 position-relative">
+                <div t-ref="container" class="d-flex w-100">
+                    <div t-if="!props.forceSmall" t-foreach="props.items" t-as="item" t-key="item_index" t-att-class="{'invisible': shouldBeInvisible(item_index)}">
                         <t t-slot="default" item="item"/>
-                    </t>
+                    </div>
                 </div>
             </div>
-            <button t-if="props.onClickPlus" class="btn btn-light btn-lg" t-on-click="props.onClickPlus">
-                <i class="fa fa-fw fa-lg fa-plus-circle" aria-hidden="true"/>
-            </button>
-            <button t-if="isLarger() or props.forceSmall" t-on-click="toggle"
-                class="btn btn-secondary ms-2"
-                t-attf-class="fa {{popover.isOpen ? 'fa-caret-up' : 'fa-caret-down'}}"/>
         </div>
     `;
     setup() {
         this.container = useRef("container");
-        this.isLarger = useIsChildLarger(this.container);
+        this.sizing = useIsChildLarger(this.container);
         this.ui = useService("ui");
         this.dialog = useService("dialog");
-        this.popover = useReactivePopover(ListContainerPopover, {
-            position: "bottom-fit",
-            arrow: false,
-            animation: false,
-            popoverClass: "mh-50 overflow-y-auto overflow-x-hidden",
-            closeOnClickAway: (target) => !target.classList.contains("fa-caret-up"),
-        });
+
+        useEffect(
+            () => {
+                this.sizing.reload();
+            },
+            () => [this.props.items]
+        );
+    }
+    shouldBeInvisible(itemIndex) {
+        return itemIndex >= this.sizing.maxItems;
     }
     toggle() {
-        if (this.ui.isSmall) {
-            this.dialog.add(ListContainerDialog, {
-                items: this.props.items,
-                slots: this.props.slots,
-            });
-            return;
-        }
-        if (this.popover.isOpen) {
-            this.popover.close();
-            return;
-        }
-        this.popover.open(this.container.el, {
+        this.dialog.add(ListContainerDialog, {
             items: this.props.items,
             slots: this.props.slots,
         });

--- a/addons/point_of_sale/static/src/app/generic_components/list_container/list_container_dialog.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/list_container/list_container_dialog.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0"?>
-<templates>
-    <t t-name="point_of_sale.ListContainerDialog">
-        <Dialog title.translate="Choose an order" footer="false">
-            <ListContainerPopover t-props="props" t-on-click="props.close"/>
-        </Dialog>
-    </t>
-</templates>

--- a/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.Orderline">
         <t t-set="line" t-value="props.line" />
-        <li class="orderline position-relative d-flex align-items-center p-2 lh-sm cursor-pointer" t-attf-class="{{ line.comboParent ? 'orderline-combo ms-2' : '' }}" t-att-class="props.class">
+        <li class="orderline position-relative d-flex align-items-center p-2 lh-sm cursor-pointer" t-attf-class="{{ line.comboParent ? 'orderline-combo ms-4 fst-italic' : '' }}" t-att-class="props.class">
             <div class="product-order"></div>
             <div t-if="line.imageSrc" class="o_line_container d-flex align-items-center justify-content-center">
                 <img t-attf-style="border-radius: 1rem;" t-att-src="line.imageSrc"/>

--- a/addons/point_of_sale/static/src/app/models/data_service_options.js
+++ b/addons/point_of_sale/static/src/app/models/data_service_options.js
@@ -2,33 +2,28 @@
 // We are now able to override options from others modules
 export class DataServiceOptions {
     get databaseTable() {
-        return [
-            {
-                name: "pos.order",
+        return {
+            "pos.order": {
                 key: "uuid",
                 condition: (record) => record.finalized && typeof record.id === "number",
             },
-            {
-                name: "pos.order.line",
+            "pos.order.line": {
                 key: "uuid",
                 condition: (record) =>
                     record.order_id?.finalized && typeof record.order_id.id === "number",
             },
-            {
-                name: "pos.payment",
+            "pos.payment": {
                 key: "uuid",
                 condition: (record) =>
                     record.pos_order_id?.finalized && typeof record.pos_order_id.id === "number",
             },
-            {
-                name: "pos.pack.operation.lot",
+            "pos.pack.operation.lot": {
                 key: "id",
                 condition: (record) =>
                     record.pos_order_line_id?.order_id?.finalized &&
                     typeof record.pos_order_line_id.order_id.id === "number",
             },
-            {
-                name: "product.product",
+            "product.product": {
                 key: "id",
                 condition: (record) => {
                     return record.models["pos.order.line"].find(
@@ -36,8 +31,7 @@ export class DataServiceOptions {
                     );
                 },
             },
-            {
-                name: "product.attribute.custom.value",
+            "product.attribute.custom.value": {
                 key: "id",
                 condition: (record) => {
                     return record.models["pos.order.line"].find((l) => {
@@ -46,7 +40,7 @@ export class DataServiceOptions {
                     });
                 },
             },
-        ];
+        };
     }
 
     get databaseIndex() {

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -86,6 +86,10 @@ export class PosOrder extends Base {
         return this.state !== "draft";
     }
 
+    getOrderName() {
+        return this.getFloatingOrderName() || "";
+    }
+
     getEmailItems() {
         return [_t("the receipt")].concat(this.is_to_invoice() ? [_t("the invoice")] : []);
     }
@@ -1060,7 +1064,7 @@ export class PosOrder extends Base {
         };
     }
     getFloatingOrderName() {
-        return this.note || this.tracking_number;
+        return this.note || this.tracking_number.toString() || "";
     }
 
     sortBySequenceAndCategory(a, b) {

--- a/addons/point_of_sale/static/src/app/navbar/navbar.xml
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.xml
@@ -3,13 +3,13 @@
 
     <t t-name="point_of_sale.Navbar">
         <div class="pos-topheader navbar-height d-flex align-items-center justify-content-between px-2 py-1 m-0 bg-white border-bottom">
-            <div class="pos-leftheader d-flex align-items-center">
+            <div class="pos-leftheader d-flex align-items-center overflow-hidden">
                 <OrderTabs orders="getOrderTabs()"/>
             </div>
-            <div t-if="!ui.isSmall"  class="pos-centerheader d-flex justify-content-center">
+            <div t-if="!ui.isSmall"  class="pos-centerheader d-flex justify-content-center overflow-hidden">
                 <img class="pos-logo pos-logo mw-100" height="42" t-on-click="() => debug.toggleWidget()" src="/web/static/img/logo.png" alt="Logo" />
             </div>
-            <div class="pos-rightheader d-flex justify-content-end"
+            <div class="pos-rightheader d-flex justify-content-end overflow-hidden"
                 t-att-class="{ 'ms-auto': !ui.isSmall, 'me-1 position-absolute end-0 width-100 pos-nav-small': ui.isSmall }"
             >
                 <div class="status-buttons d-flex flex-grow-1 align-items-center justify-content-end gap-1">

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -416,7 +416,9 @@ export class TicketScreen extends Component {
      * Hide the delete button if one of the payments is a 'done' electronic payment.
      */
     shouldHideDeleteButton(order) {
+        const orders = this.pos.models["pos.order"].filter((o) => !o.finalized);
         return (
+            (orders.length === 1 && orders[0].lines.length === 0) ||
             (this.ui.isSmall && order != this.state.selectedOrder) ||
             this.isDefaultOrderEmpty(order) ||
             order.payment_ids.some(

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -132,7 +132,7 @@
                             <Orderline line="line.getDisplayData()"
                                 class="{'selected': line.id === getSelectedOrderlineId()}"
                                 t-on-click="() => this.onClickOrderline(line)">
-                                <t t-set="toRefundDetail" t-value="line.order_id.uiState.lineToRefund[line.uuid]" />
+                                <t t-set="toRefundDetail" t-value="line.order_id?.uiState?.lineToRefund?.[line.uuid]" />
                                 <li t-if="!pos.isProductQtyZero(line.refunded_qty)"
                                     class="info refund-note mt-1">
                                     <strong t-esc="env.utils.formatProductQty(line.refunded_qty)" />

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -272,7 +272,7 @@ export class PosStore extends Reactive {
         for (const order of orders) {
             if (order && (await this._onBeforeDeleteOrder(order))) {
                 if (Object.keys(order.last_order_preparation_change).length > 0) {
-                    await this.sendOrderInPreparationUpdateLastChange(order, true);
+                    await this.sendOrderInPreparation(order, true);
                 }
 
                 const cancelled = this.removeOrder(order, true);
@@ -1019,7 +1019,7 @@ export class PosStore extends Reactive {
             const modelToAdd = {};
             const newData = {};
             for (const [model, records] of Object.entries(data)) {
-                const modelKey = this.data.opts.databaseTable.find((dt) => dt.name === model)?.key;
+                const modelKey = this.data.opts.databaseTable[model]?.key;
 
                 if (!modelKey) {
                     modelToAdd[model] = records;

--- a/addons/pos_event/static/src/app/models/data_service_options.js
+++ b/addons/pos_event/static/src/app/models/data_service_options.js
@@ -3,10 +3,9 @@ import { patch } from "@web/core/utils/patch";
 
 patch(DataServiceOptions.prototype, {
     get databaseTable() {
-        return [
+        return {
             ...super.databaseTable,
-            {
-                name: "event.registration",
+            "event.registration": {
                 key: "id",
                 condition: (record) => {
                     return (
@@ -14,8 +13,7 @@ patch(DataServiceOptions.prototype, {
                     );
                 },
             },
-            {
-                name: "event.registration.answer",
+            "event.registration.answer": {
                 key: "id",
                 condition: (record) => {
                     return (
@@ -24,6 +22,6 @@ patch(DataServiceOptions.prototype, {
                     );
                 },
             },
-        ];
+        };
     },
 });

--- a/addons/pos_loyalty/static/src/overrides/models/data_service_options.js
+++ b/addons/pos_loyalty/static/src/overrides/models/data_service_options.js
@@ -3,14 +3,16 @@ import { patch } from "@web/core/utils/patch";
 
 patch(DataServiceOptions.prototype, {
     get databaseTable() {
-        const data = super.databaseTable;
-        data.push({
-            name: "loyalty.card",
-            key: "id",
-            condition: (record) => {
-                return record.models["pos.order.line"].find((l) => l.coupon_id?.id === record.id);
+        return {
+            ...super.databaseTable,
+            "loyalty.card": {
+                key: "id",
+                condition: (record) => {
+                    return record.models["pos.order.line"].find(
+                        (l) => l.coupon_id?.id === record.id
+                    );
+                },
             },
-        });
-        return data;
+        };
     },
 });

--- a/addons/pos_restaurant/models/pos_order.py
+++ b/addons/pos_restaurant/models/pos_order.py
@@ -54,3 +54,9 @@ class PosOrder(models.Model):
                 messages.append(('TABLE_ORDER_COUNT', order_count))
         if messages:
             a_config._notify(*messages, private=False)
+
+    def action_pos_order_cancel(self):
+        res = super().action_pos_order_cancel()
+        if self.table_id:
+            self.send_table_count_notification(self.table_id)
+        return res

--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
@@ -380,8 +380,8 @@ export class FloorScreen extends Component {
 
             tableByIds[table.id].uiState.orderCount = tableOrders.length;
             tableByIds[table.id].uiState.changeCount = qtyChange.changed;
+            await this.pos.unsetTable();
         }
-        await this.pos.unsetTable();
     }
     get floorBackround() {
         return this.activeFloor.floor_background_image

--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
@@ -100,7 +100,7 @@
                         </div>
                         <div t-else="" t-ref="map" t-att-class="{'floor-kanban d-grid gap-3 p-3': pos.floorPlanStyle == 'kanban'}">
                            <t t-foreach="activeTables.sort((a,b)=>a.id-b.id)" t-as="table" t-key="table.id" >
-                                <t t-set="isOccupied" t-value="table.getOrder() || table.uiState.orderCount > 0"/>
+                                <t t-set="isOccupied" t-value="table.hasOrder || table.uiState.orderCount > 0"/>
                                 <t t-set="isIntersecting" t-value="state.potentialLink?.child?.id === table.id"/>
                                 <t t-set="isIntersected" t-value="state.potentialLink?.parent?.id === table.id"/>
                                 <div

--- a/addons/pos_restaurant/static/src/app/models/restaurant_table.js
+++ b/addons/pos_restaurant/static/src/app/models/restaurant_table.js
@@ -65,6 +65,10 @@ export class RestaurantTable extends Base {
     getOrder() {
         return this.parent_id?.getOrder?.() || this["<-pos.order.table_id"][0];
     }
+    get hasOrder() {
+        const order = this.getOrder();
+        return order && !order.finalized;
+    }
     setPositionAsIfLinked(parent, side) {
         // console.log("132")
         this.parent_id = parent;

--- a/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
+++ b/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
@@ -56,8 +56,9 @@ export class SplitBillScreen extends Component {
         const curOrderUuid = this.currentOrder.uuid;
         const originalOrder = this.pos.models["pos.order"].find((o) => o.uuid === curOrderUuid);
         this.pos.selectedTable = null;
-        const newOrder = this.pos.add_new_order();
-        newOrder.note = `${newOrder.tracking_number} Split from ${originalOrder.table_id.table_number}`;
+        const newOrder = this.pos.createNewOrder();
+        const originalOrderName = originalOrder.getOrderName();
+        newOrder.note = `${newOrder.tracking_number} Split from ${originalOrderName}`;
         newOrder.uiState.splittedOrderUuid = curOrderUuid;
         newOrder.originalSplittedOrder = originalOrder;
 
@@ -65,9 +66,11 @@ export class SplitBillScreen extends Component {
         const lineToDel = [];
         for (const line of originalOrder.lines) {
             if (this.qtyTracker[line.uuid]) {
+                const data = line.serialize();
+                delete data.uuid;
                 this.pos.models["pos.order.line"].create(
                     {
-                        ...line.serialize(),
+                        ...data,
                         qty: this.qtyTracker[line.uuid],
                         order_id: newOrder.id,
                     },

--- a/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
@@ -95,10 +95,6 @@ patch(Navbar.prototype, {
         });
         return currentOrder || orderToTransfer;
     },
-    getOrderName() {
-        const order = this.getOrderToDisplay();
-        return order.table_id?.table_number || order.getFloatingOrderName();
-    },
     onClickPlanButton() {
         this.pos.orderToTransferUuid = null;
         this.pos.showScreen("FloorScreen", { floor: this.floor });

--- a/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.xml
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.xml
@@ -23,14 +23,14 @@
                         <img t-else="" src="/pos_restaurant/static/img/plan.svg" class="navbar-icon" alt="Floor Plan"/>
                     </button>
                     <button class="table-free-order-label btn btn-lg lh-lg" t-att-class="{'btn-primary': screen === 'ProductScreen' or pos.orderToTransferUuid}" t-on-click="() => this.onClickTableTab()">
-                        <span t-if="getOrderToDisplay()" t-esc="getOrderName()"/>
+                        <span t-if="getOrderToDisplay()" t-esc="getOrderToDisplay()?.getOrderName().slice(0, 7)"/>
                         <span t-elif="!ui.isSmall">Table</span>
                         <img t-else="" src="/pos_restaurant/static/img/table.svg" class="navbar-icon" alt="Table Selector"/>
                     </button>
                 </div>
                 <div t-if="!ui.isSmall" class="ms-1 me-2 my-2 border-start border"/>
                 <div class="d-flex align-items-center" t-if="pos.orderToTransferUuid">
-                    <strong class="ms-2">
+                    <strong class="mx-2 text-warning">
                         Select table to transfer order
                     </strong>
                 </div>

--- a/addons/pos_restaurant/static/src/overrides/models/pos_order.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_order.js
@@ -35,4 +35,7 @@ patch(PosOrder.prototype, {
     setBooked(booked) {
         this.uiState.booked = booked;
     },
+    getOrderName() {
+        return this.table_id?.table_number.toString() || this.getFloatingOrderName() || "";
+    },
 });

--- a/addons/pos_sale/static/src/overrides/models/data_service_options.js
+++ b/addons/pos_sale/static/src/overrides/models/data_service_options.js
@@ -3,25 +3,24 @@ import { patch } from "@web/core/utils/patch";
 
 patch(DataServiceOptions.prototype, {
     get databaseTable() {
-        const data = super.databaseTable;
-        data.push({
-            name: "sale.order",
-            key: "id",
-            condition: (record) => {
-                return record.models["pos.order.line"].find(
-                    (l) => l.sale_order_origin_id?.id === record.id
-                );
+        return {
+            ...super.databaseTable,
+            "sale.order": {
+                key: "id",
+                condition: (record) => {
+                    return record.models["pos.order.line"].find(
+                        (l) => l.sale_order_origin_id?.id === record.id
+                    );
+                },
             },
-        });
-        data.push({
-            name: "sale.order.line",
-            key: "id",
-            condition: (record) => {
-                return record.models["pos.order.line"].find(
-                    (l) => l.sale_order_line_id?.id === record.id
-                );
+            "sale.order.line": {
+                key: "id",
+                condition: (record) => {
+                    return record.models["pos.order.line"].find(
+                        (l) => l.sale_order_line_id?.id === record.id
+                    );
+                },
             },
-        });
-        return data;
+        };
     },
 });

--- a/addons/pos_self_order/static/src/app/data_service_options.js
+++ b/addons/pos_self_order/static/src/app/data_service_options.js
@@ -3,17 +3,15 @@ import { patch } from "@web/core/utils/patch";
 
 patch(DataServiceOptions.prototype, {
     get databaseTable() {
-        return [
-            {
-                name: "pos.order",
+        return {
+            "pos.order": {
                 key: "uuid",
                 condition: (record) => false,
             },
-            {
-                name: "pos.order.line",
+            "pos.order.line": {
                 key: "uuid",
                 condition: (record) => false,
             },
-        ];
+        };
     },
 });


### PR DESCRIPTION
*: pos_event, pos_loyalty, pos_restaurant, pos_sale, pos_self_order

- Tables remain full despite the fact that they are empty and not booked
- Delete btn on the last order should not be displayed on ticket_screen
- When retourning on the floor_plan just after creating a floating order
should not delete it.
- The message `Select table to transfer order` is now in yellow.

---

Before in related models we were using set to manage relation between
records, but this set was referring to the references of the records$
instead of the ids or indexes, so when we were trying to remove a
record from the set, we were not able to do it because sometime the
record was replaced by a new one with a different reference.

Now we are using the indexes or the ids to manage the relations, so we
can remove the records from the set.

---

Before this commit the floating order layout was not correctly displayed
when there were too many orders, the last one was cut off and not fully
displayed. If only one order was displayed, the popover was much too
narrow.

This commit fixes the issue.

---

point_of_sale: style of combo line:
- ms-2 to ms-4
- adding fst-italic

taskId: 4154787