### PR TITLE
[FIX] account: always handle all valid attachments when enhancing invoices

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3206,8 +3206,6 @@ class AccountMove(models.Model):
                             invoices |= invoice
                             current_invoice = self.env['account.move']
                             add_file_data_results(file_data, invoice)
-                        if extend_with_existing_lines:
-                            return attachments_by_invoice
 
                 except RedirectWarning:
                     raise


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting and l10n_mx_edi
- Switch to a Mexican company (e.g. ESCUELA KEMPER URGATE)
- Configure an email alias for "Vendor Bills" journal
- Send an email with 2 attachments (a PDF invoice and its associated CFDI XML) to the alias

**Issue:**
A vendor bill is created but only the XML file is in the list of attachments.

**Cause:**
A fix/improvement had been made to set the "Folio fiscal" and SAT information on an existing draft invoice from a CFDI XML attached on a message or a log note (see task-3731034).
If such a XML attachment is found, all the following attachments are ignored, breaking the multi-attachments behavior.

opw-4003766




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
