### PR TITLE
[IMP] point_of_sale: order report with new fields for better sale analysis

### DIFF
--- a/addons/point_of_sale/views/pos_order_report_view.xml
+++ b/addons/point_of_sale/views/pos_order_report_view.xml
@@ -64,6 +64,7 @@
                         <filter string="Product" name="product" context="{'group_by':'product_id'}"/>
                         <filter string="Product Category" name="product_category" context="{'group_by':'product_categ_id'}"/>
                         <filter string="Payment Method" name="payment_method" context="{'group_by':'payment_method_id'}"/>
+                        <filter string="Point of Sale Category" name="pos_categ_id" context="{'group_by':'pos_categ_id'}"/>
                         <separator/>
                         <filter string="Order Date" name="order_month" context="{'group_by':'date:month'}"/>
                     </group>


### PR DESCRIPTION
In this commit:
================

Added a new fields `price_subtotal_excl` and `pos_categ_id` in `report_pos_order` to Improve our reporting model to ensure that the users have all the fields available to analyse their sales. 

task - 4123372

