### PR TITLE
[FIX] account: prevent setting wrong partner_id.payment_term

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -790,6 +790,7 @@ class AccountMove(models.Model):
     @api.depends('partner_id')
     def _compute_invoice_payment_term_id(self):
         for move in self:
+            move = move.with_company(move.company_id)
             if move.is_sale_document(include_receipts=True) and move.partner_id.property_payment_term_id:
                 move.invoice_payment_term_id = move.partner_id.property_payment_term_id
             elif move.is_purchase_document(include_receipts=True) and move.partner_id.property_supplier_payment_term_id:

--- a/addons/account/tests/test_payment_term.py
+++ b/addons/account/tests/test_payment_term.py
@@ -397,3 +397,25 @@ class TestAccountPaymentTerms(AccountTestInvoicingCommon):
                     'discount_amount_currency': 362.30,
                 },
             ])
+
+    def test_payment_term_multi_company(self):
+        """
+        Ensure that the payment term is determined by `move.company_id` rather than `user.company_id`.
+        OdooBot has `res.company(1)` set as the default company. The test checks that the payment term correctly reflects
+        the company associated with the move, independent of the user's default company.
+        """
+        user_company, other_company = self.company_data_2.get('company'), self.company_data.get('company')
+        self.env.user.write({
+            'company_ids': [user_company.id, other_company.id],
+            'company_id': user_company.id,
+        })
+        self.pay_terms_a.company_id = user_company
+        self.partner_a.with_company(user_company).property_payment_term_id = self.pay_terms_a
+        self.partner_a.with_company(other_company).property_payment_term_id = False
+
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'company_id': other_company.id
+        })
+        self.assertFalse(invoice.invoice_payment_term_id)


### PR DESCRIPTION
Steps to reproduce:
- have two companies A and B
- create a new partner
- create a new payment term for Company A
- In Company A, set the customer's payment term the newly created one
- Configure aliases for invoice in company A and B
- Make sure the default company for OdooBot is COmpany A
- Send an email to company B

Issue:
Access Error

Cause:
payment_term is pre-compute and the company context is the one of OdooBot

opw-4103229