### PR TITLE
[FIX] website: keep the correct ratio when adding a link on a Card image

### DIFF
--- a/addons/website/static/src/snippets/s_card/000.scss
+++ b/addons/website/static/src/snippets/s_card/000.scss
@@ -21,6 +21,10 @@
         }
     }
 
+    .o_card_img_wrapper.ratio > a > .o_card_img {
+        height: 100%;
+    }
+
     // Options
     &.o_card_img_top {
         .o_card_img_ratio_custom {


### PR DESCRIPTION
Since the redesign of the `s_card` snippet in commit [1], we can choose the ratio of the card image. However, this ratio is lost when adding a link on the image. This happens because the image does not have a height set in that case, which makes it keep its own height.

This commit fixes this by forcing the image height to 100% when a ratio and a link are set on the card image.

Steps to reproduce:
- Drop the "Card" snippet.
- Click on the card image and add a link on it.
- Try to change the "Ratio" option. => The image does not have the correct ratio.

[1]: https://github.com/odoo/odoo/commit/dd40e1e8d9026d189dc17134c85331711f50a470

Related to task-3674888
