### PR TITLE
[IMP] website_sale: mega menu for ecommerce categories

### DIFF
--- a/addons/website_sale/__manifest__.py
+++ b/addons/website_sale/__manifest__.py
@@ -60,6 +60,15 @@
         'views/snippets/s_dynamic_snippet_products.xml',
         'views/snippets/s_dynamic_snippet_products_preview_data.xml',
         'views/snippets/s_popup.xml',
+        'views/snippets/s_mega_menu/big_icons_subtitles.xml',
+        'views/snippets/s_mega_menu/cards.xml',
+        'views/snippets/s_mega_menu/image_menu.xml',
+        'views/snippets/s_mega_menu/images_subtitles.xml',
+        'views/snippets/s_mega_menu/little_icons.xml',
+        'views/snippets/s_mega_menu/logos.xml',
+        'views/snippets/s_mega_menu/multi_menus.xml',
+        'views/snippets/s_mega_menu/odoo_menu.xml',
+        'views/snippets/s_mega_menu/thumbnails.xml',
     ],
     'demo': [
         'data/demo.xml',
@@ -147,6 +156,7 @@
             'website_sale/static/src/snippets/s_add_to_cart/options.js',
             'website_sale/static/src/js/website_sale.editor.js',
             'website_sale/static/src/js/website_sale_form_editor.js',
+            'website_sale/static/src/js/editor/snippets.options.js',
         ],
         'website.assets_editor': [
             'website_sale/static/src/js/systray_items/*.js',

--- a/addons/website_sale/data/demo.xml
+++ b/addons/website_sale/data/demo.xml
@@ -124,51 +124,266 @@
         </record>
         <record id="public_category_furnitures" model="product.public.category">
           <field name="name">Furnitures</field>
-          <field name="sequence">17</field>
+          <field name="sequence">22</field>
           <field name="image_1920" type="base64" file="website_sale/static/src/img/categories/furnitures.jpg"/>
         </record>
         <record id="public_category_boxes" model="product.public.category">
             <field name="name">Boxes</field>
-            <field name="sequence">20</field>
+            <field name="sequence">29</field>
             <field name="image_1920" type="base64" file="website_sale/static/src/img/categories/boxes.jpg"/>
         </record>
         <record id="public_category_drawers" model="product.public.category">
           <field name="name">Drawers</field>
-          <field name="sequence">21</field>
+          <field name="sequence">35</field>
           <field name="image_1920" type="base64" file="website_sale/static/src/img/categories/drawers.jpg"/>
         </record>
         <record id="public_category_cabinets" model="product.public.category">
           <field name="name">Cabinets</field>
-          <field name="sequence">22</field>
+          <field name="sequence">40</field>
           <field name="image_1920" type="base64" file="website_sale/static/src/img/categories/cabinets.jpg"/>
         </record>
         <record id="public_category_bins" model="product.public.category">
           <field name="name">Bins</field>
-          <field name="sequence">23</field>
+          <field name="sequence">45</field>
           <field name="image_1920" type="base64" file="website_sale/static/src/img/categories/bins.jpg"/>
         </record>
         <record id="public_category_lamps" model="product.public.category">
           <field name="name">Lamps</field>
-          <field name="sequence">24</field>
+          <field name="sequence">49</field>
           <field name="image_1920" type="base64" file="website_sale/static/src/img/categories/lamps.jpg"/>
         </record>
-        <record id="services" model="product.public.category">
+        <record id="public_category_services" model="product.public.category">
           <field name="name">Services</field>
-          <field name="sequence">25</field>
+          <field name="sequence">55</field>
           <field name="image_1920" type="base64" file="website_sale/static/src/img/warranty.jpg"/>
         </record>
         <record id="public_category_multimedia" model="product.public.category">
           <field name="name">Multimedia</field>
-          <field name="sequence">26</field>
+          <field name="sequence">59</field>
           <field name="image_1920" type="base64" file="product/static/img/product_product_43-image.jpg"/>
         </record>
 
         <!-- subcategories -->
+
+        <!-- subcategories for desks -->
         <record id="public_category_desks_components" model="product.public.category">
           <field name="parent_id" eval="ref('public_category_desks')"/>
           <field name="name">Components</field>
           <field name="sequence">16</field>
           <field name="image_1920" type="base64" file="website_sale/static/src/img/categories/desk_components.jpg"/>
+        </record>
+        <record id="public_category_desks_office" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_desks')"/>
+          <field name="name">Office Desks</field>
+          <field name="sequence">17</field>
+        </record>
+        <record id="public_category_desks_gaming" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_desks')"/>
+          <field name="name">Gaming Desks</field>
+          <field name="sequence">18</field>
+        </record>
+        <record id="public_category_desks_glass" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_desks')"/>
+          <field name="name">Glass Desks</field>
+          <field name="sequence">19</field>
+        </record>
+        <record id="public_category_desks_standing" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_desks')"/>
+          <field name="name">Standing Desks</field>
+          <field name="sequence">20</field>
+        </record>
+        <record id="public_category_desks_foldable" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_desks')"/>
+          <field name="name">Foldable Desks</field>
+          <field name="sequence">21</field>
+        </record>
+
+        <!-- subcategories for furnitures -->
+        <record id="public_category_furnitures_sofas" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_furnitures')"/>
+          <field name="name">Sofas</field>
+          <field name="sequence">23</field>
+        </record>
+        <record id="public_category_furnitures_chairs" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_furnitures')"/>
+          <field name="name">Chairs</field>
+          <field name="sequence">24</field>
+        </record>
+        <record id="public_category_furnitures_couches" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_furnitures')"/>
+          <field name="name">Couches</field>
+          <field name="sequence">25</field>
+        </record>
+        <record id="public_category_furnitures_recliners" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_furnitures')"/>
+          <field name="name">Recliners</field>
+          <field name="sequence">26</field>
+        </record>
+        <record id="public_category_furnitures_beds" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_furnitures')"/>
+          <field name="name">Beds</field>
+          <field name="sequence">27</field>
+        </record>
+        <record id="public_category_furnitures_wardrobes" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_furnitures')"/>
+          <field name="name">Wardrobes</field>
+          <field name="sequence">28</field>
+        </record>
+
+        <!-- subcategories for boxes -->
+        <record id="public_category_boxes_vintage" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_boxes')"/>
+          <field name="name">Vintage Boxes</field>
+          <field name="sequence">30</field>
+        </record>
+        <record id="public_category_boxes_rustic" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_boxes')"/>
+          <field name="name">Rustic Boxes</field>
+          <field name="sequence">31</field>
+        </record>
+        <record id="public_category_boxes_luxury" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_boxes')"/>
+          <field name="name">Luxury Boxes</field>
+          <field name="sequence">32</field>
+        </record>
+        <record id="public_category_boxes_stackable" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_boxes')"/>
+          <field name="name">Stackable Boxes</field>
+          <field name="sequence">33</field>
+        </record>
+        <record id="public_category_boxes_collapsible" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_boxes')"/>
+          <field name="name">Collapsible Boxes</field>
+          <field name="sequence">34</field>
+        </record>
+
+        <!-- subcategories for drawers -->
+        <record id="public_category_drawers_nightstand" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_drawers')"/>
+          <field name="name">Nightstand Drawers</field>
+          <field name="sequence">36</field>
+        </record>
+        <record id="public_category_drawers_underbed" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_drawers')"/>
+          <field name="name">Under-bed Drawers</field>
+          <field name="sequence">37</field>
+        </record>
+        <record id="public_category_drawers_file" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_drawers')"/>
+          <field name="name">File Drawers</field>
+          <field name="sequence">38</field>
+        </record>
+        <record id="public_category_drawers_kitchen" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_drawers')"/>
+          <field name="name">Kitchen Drawer Units</field>
+          <field name="sequence">39</field>
+        </record>
+
+        <!-- subcategories for cabinets -->
+        <record id="public_category_cabinets_kitchen" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_cabinets')"/>
+          <field name="name">Kitchen Cabinets</field>
+          <field name="sequence">41</field>
+        </record>
+        <record id="public_category_cabinets_bathroom" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_cabinets')"/>
+          <field name="name">Bathroom Cabinets</field>
+          <field name="sequence">42</field>
+        </record>
+        <record id="public_category_cabinets_storage" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_cabinets')"/>
+          <field name="name">Storage Cabinets</field>
+          <field name="sequence">43</field>
+        </record>
+        <record id="public_category_cabinets_medicine" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_cabinets')"/>
+          <field name="name">Medicine Cabinets</field>
+          <field name="sequence">44</field>
+        </record>
+
+        <!-- subcategories for bins -->
+        <record id="public_category_bins_laundry" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_bins')"/>
+          <field name="name">Laundry Bins</field>
+          <field name="sequence">46</field>
+        </record>
+        <record id="public_category_bins_toy" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_bins')"/>
+          <field name="name">Toy Bins</field>
+          <field name="sequence">47</field>
+        </record>
+        <record id="public_category_bins_storage" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_bins')"/>
+          <field name="name">Food Storage Bins</field>
+          <field name="sequence">48</field>
+        </record>
+
+        <!-- subcategories for lamps -->
+        <record id="public_category_lamps_desk" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_lamps')"/>
+          <field name="name">Desk Lamps</field>
+          <field name="sequence">50</field>
+        </record>
+        <record id="public_category_lamps_ceiling" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_lamps')"/>
+          <field name="name">Ceiling Lamps</field>
+          <field name="sequence">51</field>
+        </record>
+        <record id="public_category_lamps_chandelier" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_lamps')"/>
+          <field name="name">Chandeliers</field>
+          <field name="sequence">52</field>
+        </record>
+        <record id="public_category_lamps_touch" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_lamps')"/>
+          <field name="name">Touch Lamps</field>
+          <field name="sequence">53</field>
+        </record>
+
+        <!-- subcategories for services -->
+        <record id="public_category_services_design_and_planning" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_services')"/>
+          <field name="name">Design and Planning</field>
+          <field name="sequence">55</field>
+        </record>
+        <record id="public_category_services_delivery_and_installation" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_services')"/>
+          <field name="name">Delivery and Installation</field>
+          <field name="sequence">56</field>
+        </record>
+        <record id="public_category_services_repair_and_maintenance" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_services')"/>
+          <field name="name">Repair and Maintenance</field>
+          <field name="sequence">57</field>
+        </record>
+        <record id="public_category_services_relocation_and_moving" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_services')"/>
+          <field name="name">Relocation and Moving</field>
+          <field name="sequence">58</field>
+        </record>
+
+        <!-- subcategories for lamps -->
+        <record id="public_category_multimedia_virtual_design" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_multimedia')"/>
+          <field name="name">Virtual Design Tools</field>
+          <field name="sequence">60</field>
+        </record>
+        <record id="public_category_multimedia_augmented_reality" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_multimedia')"/>
+          <field name="name">Augmented Reality Tools</field>
+          <field name="sequence">61</field>
+        </record>
+        <record id="public_category_multimedia_education" model="product.public.category">
+          <field name="parent_id" eval="ref('public_category_multimedia')"/>
+          <field name="name">Education Tools</field>
+          <field name="sequence">62</field>
+        </record>
+
+        <record id="product.product_product_1_product_template" model="product.template">
+            <field name="public_categ_ids" eval="[(6,0,[ref('public_category_services')])]"/>
+        </record>
+        <record id="product.product_product_2_product_template" model="product.template">
+            <field name="public_categ_ids" eval="[(6,0,[ref('public_category_services')])]"/>
         </record>
         <record id="public_category_furnitures_chairs" model="product.public.category">
           <field name="parent_id" eval="ref('public_category_furnitures')"/>
@@ -182,10 +397,10 @@
         </record>
 
         <record id="product.product_product_1_product_template" model="product.template">
-            <field name="public_categ_ids" eval="[(6,0,[ref('services')])]"/>
+            <field name="public_categ_ids" eval="[(6,0,[ref('public_category_services')])]"/>
         </record>
         <record id="product.product_product_2_product_template" model="product.template">
-            <field name="public_categ_ids" eval="[(6,0,[ref('services')])]"/>
+            <field name="public_categ_ids" eval="[(6,0,[ref('public_category_services')])]"/>
         </record>
         <record id="product.product_product_3_product_template" model="product.template">
             <field name="public_categ_ids" eval="[(6,0,[ref('public_category_desks_components')])]"/>
@@ -624,7 +839,7 @@
             <field name="description_sale">Warranty, issued to the purchaser of an article by its manufacturer, promising to repair or replace it if necessary within a specified period of time.</field>
             <field name="categ_id" ref="product.product_category_3"/>
             <field name="invoice_policy">delivery</field>
-            <field name="public_categ_ids" eval="[(6, 0, [ref('website_sale.services')])]"/>
+            <field name="public_categ_ids" eval="[(6, 0, [ref('website_sale.public_category_services')])]"/>
             <field name="image_1920" type="base64" file="website_sale/static/src/img/warranty.jpg"/>
         </record>
 

--- a/addons/website_sale/static/src/js/editor/snippets.options.js
+++ b/addons/website_sale/static/src/js/editor/snippets.options.js
@@ -1,0 +1,38 @@
+import options from "@web_editor/js/editor/snippets.options";
+
+options.registry.MegaMenuLayout = options.registry.MegaMenuLayout.extend({
+    _fetchEcommerceCategories() {
+        return this.containerEl.classList.contains('fetchEcomCategories');
+    },
+
+    /**
+     * Override of `website` to get the e-commerce templates instead of the website's ones.
+     *
+     * @private
+     * @returns {string} xmlid of the current template.
+     */
+    _getCurrentTemplateXMLID: function () {
+        let currentTemplateXMLID = this._super();
+        if (this._fetchEcommerceCategories()) {
+            currentTemplateXMLID = currentTemplateXMLID.replace('website.', 'website_sale.');
+        }
+        return currentTemplateXMLID;
+    },
+
+    /**
+     * Refresh the current mega menu template.
+     *
+     * @private
+     * @returns {void} xmlid of the current template.
+     */
+    async refreshMegaMenuTemplate() {
+        const xmlid = this._getCurrentTemplateXMLID();
+        /*
+         * As `selectTemplate` fetch templates from the cache, `_getTemplate` is called first to
+         * ensure that the template is in the cache in case users did not open the select before
+         * clicking on the checkbox.
+         */
+        await this._getTemplate(xmlid);
+        await this.selectTemplate(true, xmlid);
+    },
+});

--- a/addons/website_sale/views/snippets/s_mega_menu/big_icons_subtitles.xml
+++ b/addons/website_sale/views/snippets/s_mega_menu/big_icons_subtitles.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template
+        id="website_sale.s_mega_menu_big_icons_subtitles"
+        name="eCommerce: Menu - Big icons &amp; subtitles"
+        groups="base.group_user"
+    >
+        <section
+            class="s_mega_menu_big_icons_subtitles pt24 pb24 o_colored_level o_cc o_cc1"
+            data-oe-shape-data="{'shape':'web_editor/Zigs/03','flip':[]}"
+        >
+            <div class="o_we_shape o_web_editor_Zigs_03"/>
+            <div class="container">
+                <div class="row">
+                    <t
+                        t-set="categories"
+                        t-value="request.env['product.public.category'].search([
+                            ('parent_id', '=', False)
+                        ])[:9]"
+                    />
+                    <t t-foreach="categories" t-as="category">
+                        <div class="col-12 col-lg-4">
+                            <nav class="nav flex-column w-100">
+                                <a
+                                    t-att-href="'/shop/category/%s' % category.id"
+                                    class="col-lg-4 nav-link o_default_snippet_text px-2 my-2 rounded text-wrap"
+                                >
+                                    <div class="d-flex align-items-center">
+                                        <img
+                                            t-att-src="image_data_uri(category.image_1920)"
+                                            class="fa rounded rounded-circle shadow me-3"
+                                            alt=""
+                                        />
+                                        <div class="flex-grow-1">
+                                            <h4 class="mt-0 mb-0" t-esc="category.name"/>
+                                        </div>
+                                    </div>
+                                </a>
+                            </nav>
+                        </div>
+                    </t>
+                </div>
+            </div>
+        </section>
+    </template>
+
+</odoo>

--- a/addons/website_sale/views/snippets/s_mega_menu/cards.xml
+++ b/addons/website_sale/views/snippets/s_mega_menu/cards.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template
+        id="website_sale.s_mega_menu_cards"
+        name="eCommerce: Menu - Cards"
+        groups="base.group_user"
+    >
+        <section class="s_mega_menu_cards pt16 pb16 o_colored_level o_cc o_cc1">
+            <div class="container">
+                <nav class="row">
+                    <t
+                        t-set="categories"
+                        t-value="request.env['product.public.category'].search([
+                            ('parent_id', '=', False)
+                        ])[:8]"
+                    />
+                    <t t-foreach="categories" t-as="category">
+                        <div class="col-12 col-lg-3">
+                            <a
+                                t-att-href="'/shop/category/%s' % category.id"
+                                class="nav-link o_default_snippet_text rounded text-wrap text-center p-3"
+                            >
+                                <div class="mb-3 rounded shadow" style="height:80px">
+                                    <img
+                                        t-att-src="image_data_uri(category.image_1920)"
+                                        class="img-fluid w-100 h-100 object-fit-cover"
+                                        alt=""
+                                    />
+                                </div>
+                                <h4 t-esc="category.name"/>
+                            </a>
+                        </div>
+                    </t>
+                </nav>
+            </div>
+        </section>
+    </template>
+
+</odoo>

--- a/addons/website_sale/views/snippets/s_mega_menu/image_menu.xml
+++ b/addons/website_sale/views/snippets/s_mega_menu/image_menu.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template
+        id="website_sale.s_mega_menu_menu_image_menu"
+        name="eCommerce: Menu - Image - Menu"
+        groups="base.group_user"
+    >
+        <section class="s_mega_menu_menu_image_menu py-4 o_colored_level o_cc o_cc1">
+            <div class="container">
+                <div class="row align-items-center">
+                    <t
+                        t-set="categories"
+                        t-value="request.env['product.public.category'].search([
+                            ('parent_id', '=', False)
+                        ])[:1]"
+                    />
+                    <t t-foreach="categories" t-as="category">
+                        <div class="col-12 col-lg-4 py-2 text-center">
+                            <h4 class="o_default_snippet_text">
+                                <a
+                                    t-att-href="'/shop/category/%s' % category.id"
+                                    class="nav-link o_default_snippet_text p-0 text-black"
+                                    t-esc="category.name"
+                                />
+                            </h4>
+                            <nav class="nav flex-column">
+                                <t t-foreach="category.child_id" t-as="sub_category">
+                                    <a
+                                        t-att-href="'/shop/category/%s' % sub_category.id"
+                                        class="nav-link o_default_snippet_text"
+                                        t-esc="sub_category.name"
+                                    />
+                                </t>
+                            </nav>
+                        </div>
+                    </t>
+                    <div class="col-12 col-lg-4 py-2 text-center">
+                        <img
+                            class="img-fluid"
+                            src="/web/image/website.s_mega_menu_menu_image_menu_default_image"
+                            alt="Mega menu default image"
+                        />
+                    </div>
+                    <t
+                        t-set="categories"
+                        t-value="request.env['product.public.category'].search([
+                            ('parent_id', '=', False)
+                        ])[1:2]"
+                    />
+                    <t t-foreach="categories" t-as="category">
+                        <div class="col-12 col-lg-4 py-2 text-center">
+                            <h4 class="o_default_snippet_text">
+                                <a
+                                    t-att-href="'/shop/category/%s' % category.id"
+                                    class="nav-link o_default_snippet_text p-0 text-black"
+                                    t-esc="category.name"
+                                />
+                            </h4>
+                            <nav class="nav flex-column">
+                                <t t-foreach="category.child_id" t-as="sub_category">
+                                    <a
+                                        t-att-href="'/shop/category/%s' % sub_category.id"
+                                        class="nav-link o_default_snippet_text"
+                                        t-esc="sub_category.name"
+                                    />
+                                </t>
+                            </nav>
+                        </div>
+                    </t>
+                </div>
+            </div>
+        </section>
+    </template>
+
+</odoo>

--- a/addons/website_sale/views/snippets/s_mega_menu/images_subtitles.xml
+++ b/addons/website_sale/views/snippets/s_mega_menu/images_subtitles.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template
+        id="website_sale.s_mega_menu_images_subtitles"
+        name="eCommerce: Menu - images &amp; subtitles"
+        groups="base.group_user"
+    >
+        <section class="s_mega_menu_images_subtitles pt16 pb16 o_colored_level o_cc o_cc1">
+            <div class="container">
+                <div class="row">
+                    <div class="col-12 col-lg-8">
+                        <nav class="nav d-flex">
+                            <t
+                                t-set="categories"
+                                t-value="request.env['product.public.category'].search([
+                                    ('parent_id', '=', False)
+                                ])[:8]"
+                            />
+                            <t t-foreach="categories" t-as="category">
+                                <a
+                                    t-att-href="'/shop/category/%s' % category.id"
+                                    class="col-lg-6 nav-link o_default_snippet_text px-2 rounded text-wrap"
+                                >
+                                    <div class="d-flex">
+                                        <img
+                                            t-att-src="image_data_uri(category.image_1920)"
+                                            class="me-3 rounded shadow"
+                                            alt=""
+                                        />
+                                        <div class="flex-grow-1 align-content-center">
+                                            <h4 class="mt-0 mb-0" t-esc="category.name"/>
+                                        </div>
+                                    </div>
+                                </a>
+                            </t>
+                        </nav>
+                    </div>
+                    <div class="col-12 col-lg-4 py-2">
+                        <img src="/web/image/website.s_mega_menu_images_subtitles_default_image_7" class="mb-3 rounded shadow img-fluid" alt=""/>
+                        <h4 class="o_default_snippet_text">The team</h4>
+                        <p class="text-muted o_default_snippet_text small">
+                            Created in 2021, the company is young and dynamic. Discover the composition of the team and their skills.
+                        </p>
+                        <a href="#" class="btn btn-primary o_default_snippet_text">Discover our team</a>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </template>
+
+</odoo>

--- a/addons/website_sale/views/snippets/s_mega_menu/little_icons.xml
+++ b/addons/website_sale/views/snippets/s_mega_menu/little_icons.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template
+        id="website_sale.s_mega_menu_little_icons"
+        name="eCommerce: Menu - Little icons"
+        groups="base.group_user"
+    >
+        <section class="s_mega_menu_little_icons overflow-hidden o_colored_level o_cc o_cc1">
+            <div class="container">
+                <div class="row">
+                    <div class="col-lg-9 py-2 align-content-center">
+                        <nav class="nav col-12 d-flex">
+                            <t
+                                t-set="categories"
+                                t-value="request.env['product.public.category'].search([
+                                    ('parent_id', '=', False)
+                                ])[:9]"
+                            />
+                            <t t-foreach="categories" t-as="category">
+                                <a
+                                    t-att-href="'/shop/category/%s' % category.id"
+                                    class="col-lg-4 nav-link o_default_snippet_text px-2 rounded text-wrap"
+                                >
+                                    <img
+                                        t-att-src="image_data_uri(category.image_1920)"
+                                        class="fa fa-fw me-2"
+                                        alt=""
+                                    />
+                                    <b t-esc="category.name"/>
+                                </a>
+                            </t>
+                        </nav>
+                    </div>
+                    <div class="col-lg-3 p-4 s_mega_menu_gray_area">
+                        <h4 class="o_default_snippet_text">The team</h4>
+                        <p class="text-muted o_default_snippet_text small">
+                            Created in 2021, the company is young and dynamic. Discover the composition of the team and their skills.
+                        </p>
+                        <a href="#" class="btn btn-primary o_default_snippet_text">Discover our team</a>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </template>
+
+
+</odoo>

--- a/addons/website_sale/views/snippets/s_mega_menu/logos.xml
+++ b/addons/website_sale/views/snippets/s_mega_menu/logos.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template
+        id="website_sale.s_mega_menu_menus_logos"
+        name="eCommerce: Menus &amp; logos"
+        groups="base.group_user"
+    >
+        <section class="s_mega_menu_menus_logos overflow-hidden o_colored_level o_cc o_cc1">
+            <div class="container">
+                <div class="row">
+                    <div class="col-12 col-lg-8">
+                        <div class="row py-3 h-100">
+                            <t
+                                t-set="categories"
+                                t-value="request.env['product.public.category'].search([
+                                    ('parent_id', '=', False)
+                                ])[:6]"
+                            />
+                            <t t-foreach="categories" t-as="category">
+                                <div class="col-12 col-lg-4 py-2">
+                                    <h4 class="o_default_snippet_text">
+                                        <a
+                                            t-att-href="'/shop/category/%s' % category.id"
+                                            class="col-lg-4 nav-link text-black p-0"
+                                            t-esc="category.name"
+                                        />
+                                    </h4>
+                                    <nav class="nav flex-column">
+                                        <t t-foreach="category.child_id" t-as="sub_category">
+                                            <a
+                                                t-if="sub_category_index &lt; 3"
+                                                t-att-href="'/shop/category/%s' % sub_category.id"
+                                                class="nav-link o_default_snippet_text px-0"
+                                                t-esc="sub_category.name"
+                                            />
+                                        </t>
+                                    </nav>
+                                </div>
+                            </t>
+                        </div>
+                    </div>
+                    <div class="col-12 col-lg-4 py-4 d-flex align-items-center justify-content-center s_mega_menu_gray_area">
+                        <a href="#" class="nav-link o_default_snippet_text text-center px-0" data-name="Menu Item">
+                            <img src="/web/image/website.s_mega_menu_menus_logos_default_image" class="mb-3 rounded shadow img-fluid" alt=""/>
+                            <h4 class="o_default_snippet_text">Spring collection has arrived!</h4>
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div class="s_mega_menu_menus_logos_wrapper border-top">
+            <div class="container">
+                <div class="row py-3">
+                    <div class="col-4 col-lg-2">
+                        <img
+                            src="/web/image/website.s_mega_menu_menus_logos_default_logo_1"
+                            class="img-fluid"
+                            alt=""/>
+                    </div>
+                    <div class="col-4 col-lg-2">
+                        <img
+                            src="/web/image/website.s_mega_menu_menus_logos_default_logo_2"
+                            class="img-fluid"
+                            alt=""/>
+                    </div>
+                    <div class="col-4 col-lg-2">
+                        <img
+                            src="/web/image/website.s_mega_menu_menus_logos_default_logo_3"
+                            class="img-fluid"
+                            alt=""/>
+                    </div>
+                    <div class="col-4 col-lg-2">
+                        <img
+                            src="/web/image/website.s_mega_menu_menus_logos_default_logo_4"
+                            class="img-fluid"
+                            alt=""/>
+                    </div>
+                    <div class="col-4 col-lg-2">
+                        <img
+                            src="/web/image/website.s_mega_menu_menus_logos_default_logo_5"
+                            class="img-fluid"
+                            alt=""/>
+                    </div>
+                    <div class="col-4 col-lg-2">
+                        <img
+                            src="/web/image/website.s_mega_menu_menus_logos_default_logo_6"
+                            class="img-fluid"
+                            alt=""/>
+                    </div>
+                </div>
+            </div>
+        </div>
+        </section>
+    </template>
+
+</odoo>

--- a/addons/website_sale/views/snippets/s_mega_menu/multi_menus.xml
+++ b/addons/website_sale/views/snippets/s_mega_menu/multi_menus.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template
+        id="website_sale.s_mega_menu_multi_menus"
+        name="eCommerce: Multi-Menus"
+        groups="base.group_user"
+    >
+        <section class="s_mega_menu_multi_menus py-4 o_colored_level o_cc o_cc1">
+            <div class="container">
+                <div class="row">
+                    <t
+                        t-set="categories"
+                        t-value="request.env['product.public.category'].search([
+                            ('parent_id', '=', False)
+                        ])[:4]"
+                    />
+                    <t t-foreach="categories" t-as="category">
+                        <div class="col-12 col-sm py-2 text-center">
+                            <h4 class="o_default_snippet_text">
+                                <a
+                                    t-att-href="'/shop/category/%s' % category.id"
+                                    class="nav-link o_default_snippet_text p-0 text-black"
+                                    t-esc="category.name"
+                                />
+                            </h4>
+                            <nav class="nav flex-column">
+                                <t t-foreach="category.child_id" t-as="sub_category">
+                                    <a
+                                        t-att-href="'/shop/category/%s' % sub_category.id"
+                                        class="nav-link o_default_snippet_text"
+                                        t-esc="sub_category.name"
+                                    />
+                                </t>
+                            </nav>
+                        </div>
+                    </t>
+                </div>
+            </div>
+        </section>
+    </template>
+
+</odoo>

--- a/addons/website_sale/views/snippets/s_mega_menu/odoo_menu.xml
+++ b/addons/website_sale/views/snippets/s_mega_menu/odoo_menu.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template
+        id="website_sale.s_mega_menu_odoo_menu"
+        name="eCommerce: Odoo Menu"
+        groups="base.group_user"
+    >
+        <section class="s_mega_menu_odoo_menu pt16 o_colored_level o_cc o_cc1">
+            <div class="container">
+                <div class="row">
+                    <t
+                        t-set="categories"
+                        t-value="request.env['product.public.category'].search([
+                            ('parent_id', '=', False)
+                        ])[:4]"
+                    />
+                    <t t-foreach="categories" t-as="category">
+                        <div class="col-12 col-lg-3 pt16 pb24">
+                            <h4 class="o_default_snippet_text text-uppercase h5 fw-bold mt-0">
+                                <a
+                                    t-att-href="'/shop/category/%s' % category.id"
+                                    class="nav-link o_default_snippet_text p-0 text-black"
+                                    t-esc="category.name"
+                                />
+                            </h4>
+                            <div class="s_hr pt4 pb16">
+                                <hr class="w-100 mx-auto"
+                                    style="border-top-width: 2px; border-top-color: var(--primary);"
+                                />
+                            </div>
+                            <nav class="nav flex-column">
+                                <t t-foreach="category.child_id" t-as="sub_category">
+                                    <a t-att-href="'/shop/category/%s' % sub_category.id"
+                                        class="nav-link o_default_snippet_text px-0"
+                                        t-esc="sub_category.name"/>
+                                </t>
+                            </nav>
+                        </div>
+                    </t>
+                </div>
+            </div>
+        </section>
+    </template>
+
+</odoo>

--- a/addons/website_sale/views/snippets/s_mega_menu/thumbnails.xml
+++ b/addons/website_sale/views/snippets/s_mega_menu/thumbnails.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template
+        id="website_sale.s_mega_menu_thumbnails"
+        name="eCommerce: Menu - Thumbnails"
+        groups="base.group_user"
+    >
+        <section class="s_mega_menu_thumbnails pt24 o_colored_level o_cc o_cc1">
+            <div class="container">
+                <div class="row ustify-content-center">
+                    <t
+                        t-set="categories"
+                        t-value="request.env['product.public.category'].search([
+                            ('parent_id', '=', False)
+                        ])[:10]"
+                    />
+                    <t t-set="counter" t-value="0"/>
+                    <t t-foreach="categories" t-as="category">
+                        <t t-set="counter" t-value="counter + 1"/>
+                        <t t-if="(counter - 1) % 5 == 0 and counter != 1">
+                            <div class="w-100 d-none d-lg-block"></div>
+                        </t>
+                        <div class="col-6 col-lg-2 text-center py-2">
+                            <a
+                                t-att-href="'/shop/category/%s' % category.id"
+                                class="nav-link o_default_snippet_text p-0"
+                            >
+                                <img
+                                    t-att-src="image_data_uri(category.image_1920)"
+                                    class="img-fluid rounded shadow"
+                                    alt=""
+                                />
+                                <br/>
+                                <span class="d-block p-2 small">
+                                    <b>
+                                        <t t-esc="category.name"/>
+                                    </b>
+                                </span>
+                            </a>
+                        </div>
+                    </t>
+                </div>
+            </div>
+        </section>
+    </template>
+
+</odoo>

--- a/addons/website_sale/views/snippets/snippets.xml
+++ b/addons/website_sale/views/snippets/snippets.xml
@@ -389,6 +389,160 @@
                          data-reload="/"/>
         </div>
     </xpath>
+    <xpath expr="//div[@data-js='MegaMenuLayout']" position="inside">
+        <we-row>
+            <we-title class="o_long_title">eCommerce Categories</we-title>
+            <div class="o_switch ms-4">
+                <we-checkbox
+                    class="o_mega_menu"
+                    data-name="fetch_ecom_categories_opt"
+                    data-select-class="fetchEcomCategories"
+                    data-refresh-mega-menu-template=""
+                    data-no-preview="true"
+                />
+            </div>
+            <we-button
+                type="button"
+                title="Reset Categories"
+                data-refresh-mega-menu-template=""
+                data-no-preview="true"
+                class="ms-4"
+            >
+                <i class="fa fa-refresh"/>
+            </we-button>
+        </we-row>
+    </xpath>
+    <xpath
+        expr="//div[@data-js='MegaMenuLayout']/we-select[@data-name='mega_menu_template_opt']/we-button[@data-select-template='website.s_mega_menu_multi_menus']"
+        position="attributes"
+    >
+        <attribute name="data-dependencies">!fetch_ecom_categories_opt</attribute>
+    </xpath>
+    <xpath
+        expr="//div[@data-js='MegaMenuLayout']/we-select[@data-name='mega_menu_template_opt']/we-button[@data-select-template='website.s_mega_menu_menu_image_menu']"
+        position="attributes"
+    >
+        <attribute name="data-dependencies">!fetch_ecom_categories_opt</attribute>
+    </xpath>
+    <xpath
+        expr="//div[@data-js='MegaMenuLayout']/we-select[@data-name='mega_menu_template_opt']/we-button[@data-select-template='website.s_mega_menu_odoo_menu']"
+        position="attributes"
+    >
+        <attribute name="data-dependencies">!fetch_ecom_categories_opt</attribute>
+    </xpath>
+    <xpath
+        expr="//div[@data-js='MegaMenuLayout']/we-select[@data-name='mega_menu_template_opt']/we-button[@data-select-template='website.s_mega_menu_little_icons']"
+        position="attributes"
+    >
+        <attribute name="data-dependencies">!fetch_ecom_categories_opt</attribute>
+    </xpath>
+    <xpath
+        expr="//div[@data-js='MegaMenuLayout']/we-select[@data-name='mega_menu_template_opt']/we-button[@data-select-template='website.s_mega_menu_big_icons_subtitles']"
+        position="attributes"
+    >
+        <attribute name="data-dependencies">!fetch_ecom_categories_opt</attribute>
+    </xpath>
+    <xpath
+        expr="//div[@data-js='MegaMenuLayout']/we-select[@data-name='mega_menu_template_opt']/we-button[@data-select-template='website.s_mega_menu_images_subtitles']"
+        position="attributes"
+    >
+        <attribute name="data-dependencies">!fetch_ecom_categories_opt</attribute>
+    </xpath>
+    <xpath
+        expr="//div[@data-js='MegaMenuLayout']/we-select[@data-name='mega_menu_template_opt']/we-button[@data-select-template='website.s_mega_menu_menus_logos']"
+        position="attributes"
+    >
+        <attribute name="data-dependencies">!fetch_ecom_categories_opt</attribute>
+    </xpath>
+    <xpath
+        expr="//div[@data-js='MegaMenuLayout']/we-select[@data-name='mega_menu_template_opt']/we-button[@data-select-template='website.s_mega_menu_thumbnails']"
+        position="attributes"
+    >
+        <attribute name="data-dependencies">!fetch_ecom_categories_opt</attribute>
+    </xpath>
+    <xpath
+        expr="//div[@data-js='MegaMenuLayout']/we-select[@data-name='mega_menu_template_opt']/we-button[@data-select-template='website.s_mega_menu_cards']"
+        position="attributes"
+    >
+        <attribute name="data-dependencies">!fetch_ecom_categories_opt</attribute>
+    </xpath>
+    <xpath
+        expr="//div[@data-js='MegaMenuLayout']/we-select[@data-name='mega_menu_template_opt']"
+        position="inside"
+    >
+        <t t-set="_label">Multi Menus</t>
+        <we-button
+            t-att-data-select-label="_label"
+            data-dependencies="fetch_ecom_categories_opt"
+            data-select-template="website_sale.s_mega_menu_multi_menus"
+            data-img="/website/static/src/img/snippets_thumbs/s_mega_menu_multi_menus.svg"
+            t-out="_label"
+        />
+        <t t-set="_label">Image Menu</t>
+        <we-button
+            t-att-data-select-label="_label"
+            data-dependencies="fetch_ecom_categories_opt"
+            data-select-template="website_sale.s_mega_menu_menu_image_menu"
+            data-img="/website/static/src/img/snippets_thumbs/s_mega_menu_menu_image_menu.svg"
+            t-out="_label"
+        />
+        <t t-set="_label">Odoo Menu</t>
+        <we-button
+            t-att-data-select-label="_label"
+            data-dependencies="fetch_ecom_categories_opt"
+            data-select-template="website_sale.s_mega_menu_odoo_menu"
+            data-img="/website/static/src/img/snippets_thumbs/s_mega_menu_odoo_menu.svg"
+            t-out="_label"
+        />
+        <t t-set="_label">Little Icons</t>
+        <we-button
+            t-att-data-select-label="_label"
+            data-dependencies="fetch_ecom_categories_opt"
+            data-select-template="website_sale.s_mega_menu_little_icons"
+            data-img="/website/static/src/img/snippets_thumbs/s_mega_menu_little_icons.svg"
+            t-out="_label"
+        />
+        <t t-set="_label">Big Icons Subtitles</t>
+        <we-button
+            t-att-data-select-label="_label"
+            data-dependencies="fetch_ecom_categories_opt"
+            data-select-template="website_sale.s_mega_menu_big_icons_subtitles"
+            data-img="/website/static/src/img/snippets_thumbs/s_mega_menu_big_icons_subtitles.svg"
+            t-out="_label"
+        />
+        <t t-set="_label">Images Subtitles</t>
+        <we-button
+            t-att-data-select-label="_label"
+            data-dependencies="fetch_ecom_categories_opt"
+            data-select-template="website_sale.s_mega_menu_images_subtitles"
+            data-img="/website/static/src/img/snippets_thumbs/s_mega_menu_images_subtitles.svg"
+            t-out="_label"
+         />
+        <t t-set="_label">Logos</t>
+        <we-button
+            t-att-data-select-label="_label"
+            data-dependencies="fetch_ecom_categories_opt"
+            data-select-template="website_sale.s_mega_menu_menus_logos"
+            data-img="/website/static/src/img/snippets_thumbs/s_mega_menu_menus_logos.svg"
+            t-out="_label"
+        />
+        <t t-set="_label">Thumbnails</t>
+        <we-button
+            t-att-data-select-label="_label"
+            data-dependencies="fetch_ecom_categories_opt"
+            data-select-template="website_sale.s_mega_menu_thumbnails"
+            data-img="/website/static/src/img/snippets_thumbs/s_mega_menu_thumbnails.svg"
+            t-out="_label"
+        />
+        <t t-set="_label">Cards</t>
+        <we-button
+            t-att-data-select-label="_label"
+            data-dependencies="fetch_ecom_categories_opt"
+            data-select-template="website_sale.s_mega_menu_cards"
+            data-img="/website/static/src/img/snippets_thumbs/s_mega_menu_cards.svg"
+            t-out="_label"
+        />
+    </xpath>
 </template>
 
 <template id="snippets_options_web_editor" inherit_id="web_editor.snippet_options" name="e-commerce base snippet options">


### PR DESCRIPTION
**Prior this commit:**
- There was no mega menu based on ecommerce categories. Hence, if a user wanted
one, he had to create it from scratch by typing in the name of each category
and copy/pasting each URL linked to it.

**Post this commit:**
- The user can now easily get the mega menu of Ecommerce categories for all the
possible templates by clicking on a button corresponding to the template.

**Affected version**-master
**Task**-3718978