### PR TITLE
[FIX] mail: no jump to present when emptying inbox

### DIFF
--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -206,7 +206,7 @@ export function useVisible(refName, cb, { ready = true } = {}) {
             if (el && ready) {
                 observer.observe(el);
                 return () => {
-                    setValue(false);
+                    setValue(undefined);
                     observer.unobserve(el);
                 };
             }

--- a/addons/mail/static/tests/discuss_app/inbox.test.js
+++ b/addons/mail/static/tests/discuss_app/inbox.test.js
@@ -6,6 +6,7 @@ import {
     insertText,
     onRpcBefore,
     openDiscuss,
+    scroll,
     start,
     startServer,
     step,
@@ -415,6 +416,44 @@ test("inbox: mark all messages as read", async () => {
     });
     await contains(".o-mail-Message", { count: 0 });
     await contains("button:disabled", { text: "Mark all read" });
+});
+
+test("inbox: mark as read should not display jump to present", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    const msgIds = pyEnv["mail.message"].create(
+        Array(30)
+            .keys()
+            .map((i) => ({
+                body: "not empty".repeat(100),
+                model: "discuss.channel",
+                needaction: true,
+                res_id: channelId,
+            }))
+    );
+    pyEnv["mail.notification"].create(
+        Array(30)
+            .keys()
+            .map((i) => ({
+                mail_message_id: msgIds[i],
+                notification_type: "inbox",
+                res_partner_id: serverState.partnerId,
+            }))
+    );
+    await start();
+    await openDiscuss();
+    // scroll up so that there's the "Jump to Present".
+    // So that assertion of negative matches the positive assertion
+    await contains(".o-mail-Message", { count: 30 });
+    await scroll(".o-mail-Thread", 0);
+    await contains(".o-mail-Thread-banner", {
+        text: "You're viewing older messagesJump to Present",
+    });
+    await click(".o-mail-Discuss-header button:enabled", { text: "Mark all read" });
+    await contains(".o-mail-Thread-banner", {
+        count: 0,
+        text: "You're viewing older messagesJump to Present",
+    });
 });
 
 test("click on (non-channel/non-partner) origin thread link should redirect to form view", async () => {


### PR DESCRIPTION
Before this commit, when emptying inbox e.g. with "mark all as read" button, Inbox was showing the "Jump to present" at bottom of thread.

Steps to reproduce:
- With Mitchell Admin: set user preferences of notification to "Handle in Odoo"
- With Marc Demo: send logged note in contact form view with `@Mitchell Admin` mentions
- With Mitchell Admin: open Discuss app inbox then mark all messages as read => There's "Jump to present" at bottom of thread view of inbox

This happens because when inbox is empty, it uses a special branching in template to display "Inbox is empty". In this branching, the invisible `span` "present-treshold" is not present, so by it being considered not visible it shows the bar.

The `useVisible()` hook was resetting the value of `isVisible` to `false` when the ref.el changes, but it should actually be `undefined`. Which is what this commit fixes.

This fixes the issue because condition to show "Jump to Present" relies on specific value `isVisible: false`, therefore `undefined` does not show the "Jump to Present" visual.

<img width="982" alt="Screenshot 2024-09-02 at 16 03 08" src="https://github.com/user-attachments/assets/7dcc0e57-1b49-4d95-9dbd-24e76d7733f0">
