### PR TITLE
[REF] point_of_sale: remove jquery

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -156,7 +156,6 @@
             # tour system FIXME: can this be added only in test mode? Are there any onboarding tours in PoS?
             "web_tour/static/src/tour_pointer/**/*",
             ("include", "point_of_sale.base_tests"),
-            'web/static/src/legacy/js/libs/jquery.js',
             # account
             'account/static/src/helpers/*.js',
             'account/static/src/services/account_move_service.js',
@@ -170,10 +169,8 @@
             ('remove', 'web/static/src/webclient/actions/reports/layout_assets/**/*'),
             ('remove', 'web/static/src/webclient/actions/**/*css'),
             'web/static/src/webclient/company_service.js',
-            "web/static/lib/jquery/jquery.js",
         ],
         'point_of_sale.base_tests': [
-            "web/static/lib/jquery/jquery.js",
             "web/static/lib/hoot-dom/**/*",
             "web_tour/static/src/tour_pointer/**/*.xml",
             "web_tour/static/src/tour_pointer/**/*.js",

--- a/addons/point_of_sale/static/tests/tours/utils/product_configurator_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/product_configurator_util.js
@@ -40,7 +40,7 @@ export function numberRadioOptions(number) {
         {
             trigger: `.attribute-name-cell`,
             run: () => {
-                const radio_options = $(".attribute-name-cell").length;
+                const radio_options = document.querySelectorAll(".attribute-name-cell").length;
                 if (radio_options !== number) {
                     throw new Error(`Expected ${number} radio options, got ${radio_options}`);
                 }


### PR DESCRIPTION
    In this commit we remove jquery from the pos assets.

    Task: 4156023



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
