### PR TITLE
[IMP] Stock: Add yearly order for stock replenishment info wizard sal…

### DIFF
--- a/addons/stock/models/res_company.py
+++ b/addons/stock/models/res_company.py
@@ -42,6 +42,12 @@ class Company(models.Model):
         string='Day of the month', default=31,
         help="""Day of the month when the annual inventory should occur. If zero or negative, then the first day of the month will be selected instead.
         If greater than the last day of a month, then the last day of the month will be selected instead.""")
+    stock_replenishment_info_periods = fields.Selection([
+        ('month', 'Monthly'),
+        ('year', 'Yearly'),
+    ], string='Stock Replenishment Info Periods',
+        default='year',
+        help="The stock replenishment info can be either ordered yearly or monthly")
 
     def _create_transit_location(self):
         '''Create a transit location with company_id being the given company_id. This is needed

--- a/addons/stock/models/res_config_settings.py
+++ b/addons/stock/models/res_config_settings.py
@@ -50,6 +50,7 @@ class ResConfigSettings(models.TransientModel):
     annual_inventory_day = fields.Integer(related='company_id.annual_inventory_day', readonly=False)
     group_stock_reception_report = fields.Boolean("Reception Report", implied_group='stock.group_reception_report')
     module_stock_dropshipping = fields.Boolean("Dropshipping")
+    stock_replenishment_info_periods = fields.Selection(related='company_id.stock_replenishment_info_periods', readonly=False)
 
     @api.onchange('group_stock_multi_locations')
     def _onchange_group_stock_multi_locations(self):

--- a/addons/stock/views/res_config_settings_views.xml
+++ b/addons/stock/views/res_config_settings_views.xml
@@ -49,6 +49,9 @@
                             <setting id="reception_report" help="View and allocate received quantities.">
                                 <field name="group_stock_reception_report"/>
                             </setting>
+                            <setting id="stock.replenishment_info_period" help="Modify the way stocks are grouped in the stock replenishment info wizard.">
+                                <field name="stock_replenishment_info_periods" class="o_light_label" widget="selection"/>
+                            </setting>
                         </block>
                         <block title="Barcode" name="barcode_setting_container">
                             <setting id="process_operations_barcodes" help="Process operations faster with barcodes" company_dependent="1" documentation="/applications/inventory_and_mrp/inventory/barcode/setup/software.html">

--- a/addons/stock/wizard/stock_replenishment_info.py
+++ b/addons/stock/wizard/stock_replenishment_info.py
@@ -8,7 +8,7 @@ from datetime import datetime, time
 
 from odoo import api, fields, models, SUPERUSER_ID, _
 from odoo.osv.expression import AND
-from odoo.tools import get_month, subtract, format_date
+from odoo.tools import get_month, subtract, format_date, get_fiscal_year
 from odoo.tools.misc import get_lang
 
 
@@ -22,6 +22,12 @@ class StockReplenishmentInfo(models.TransientModel):
     qty_to_order = fields.Float(related='orderpoint_id.qty_to_order')
     json_lead_days = fields.Char(compute='_compute_json_lead_days')
     json_replenishment_history = fields.Char(compute='_compute_json_replenishment_history')
+    periods = fields.Selection([
+        ('year', 'Yearly'),
+        ('month', 'Monthly'),
+    ], string='Stock replenishment info period',
+        default='year',
+        help="The stock replenishments infos can be either ordered monthly or yearly.")
 
     warehouseinfo_ids = fields.One2many(related='orderpoint_id.warehouse_id.resupply_route_ids')
     wh_replenishment_option_ids = fields.One2many('stock.replenishment.option', 'replenishment_info_id', compute='_compute_wh_replenishment_options')
@@ -59,12 +65,16 @@ class StockReplenishmentInfo(models.TransientModel):
 
     @api.depends('orderpoint_id')
     def _compute_json_replenishment_history(self):
+        period_setting = self.orderpoint_id.company_id.stock_replenishment_info_periods
+        today = fields.Datetime.now()
+        get_period = get_fiscal_year if period_setting == 'year' else get_month
+        group_period = "date:year" if period_setting == 'year' else "date:month"
+        start_period = subtract(today, year=2) if period_setting == 'year' else subtract(today, months=2)
         for replenishment_report in self:
             replenishment_history = []
             today = fields.Datetime.now()
-            first_month = subtract(today, months=2)
-            date_from, dummy = get_month(first_month)
-            dummy, date_to = get_month(today)
+            date_from = get_period(start_period)[0]
+            date_to = get_period(today)[1]
             domain = [
                 ('product_id', '=', replenishment_report.product_id.id),
                 ('date', '>=', date_from),
@@ -72,18 +82,18 @@ class StockReplenishmentInfo(models.TransientModel):
                 ('state', '=', 'done'),
                 ('company_id', '=', replenishment_report.orderpoint_id.company_id.id)
             ]
-            quantity_by_month_out = self.env['stock.move']._read_group(
+            quantity_by_period_out = self.env['stock.move']._read_group(
                 AND([domain, [('location_dest_id.usage', '=', 'customer')]]),
-                ['date:month'], ['product_qty:sum'])
-            quantity_by_month_returned = dict(self.env['stock.move']._read_group(
+                [group_period], ['product_qty:sum'])
+            quantity_by_period_returned = dict(self.env['stock.move']._read_group(
                 AND([domain, [('location_id.usage', '=', 'customer')]]),
-                ['date:month'], ['product_qty:sum']))
+                [group_period], ['product_qty:sum']))
             locale = get_lang(self.env).code
-            fmt = models.READ_GROUP_DISPLAY_FORMAT['month']
-            for month, product_qty_sum in quantity_by_month_out:
+            fmt = models.READ_GROUP_DISPLAY_FORMAT[period_setting]
+            for period, product_qty_sum in quantity_by_period_out:
                 replenishment_history.append({
-                    'name': babel.dates.format_datetime(month, format=fmt, locale=locale),
-                    'quantity': product_qty_sum - quantity_by_month_returned.get(month, 0),
+                    'name': babel.dates.format_datetime(period, format=fmt, locale=locale),
+                    'quantity': product_qty_sum - quantity_by_period_returned.get(period, 0),
                     'uom_name': replenishment_report.product_id.uom_id.display_name,
                 })
             replenishment_report.json_replenishment_history = dumps({

--- a/doc/cla/corporate/camptocamp.md
+++ b/doc/cla/corporate/camptocamp.md
@@ -50,7 +50,7 @@ Ricardo Almeida Soares ricardo.almeidasoares@camptocamp.com https://github.com/R
 Juan Miguel Sánchez Arce juan.sanchez@camptocamp.com https://github.com/JuMiSanAr
 Maksym Yankin maksym.yankin@camptocamp.com https://github.com/yankinmax
 Vincent Van Rossem vincent.vanrossem@camptocamp.com https://github.com/vvrossem
-Victor Vermot-Petit-Outhenin victor.vermot@camptocamp.com https://github.com/victorvermot
+Victor Vermot-Petit-Outhenin victorvermot@gmail.com https://github.com/victorvermot
 Sarah Jallon sarah.jallon@camptocamp.com https://github.com/sarsurgithub
 Ricardo Almeida Soares ricardo.almeidasoares@camptocamp.com https://github.com/ricardoalso
 Italo Lopes italo.lopes@camptocamp.com https://github.com/imlopes


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

# BEFORE MERGE
- The stock replenishment info wizard contains a sale history ordered by months only: (up to 3 months)

![Screenshot from 2023-07-04 17-00-23](https://github.com/odoo/odoo/assets/48206917/742ed001-ddd0-4deb-bfaf-b23db201b7f0)


# AFTER MERGE
- The stock replenishment info wizard sale history can now be ordered by years based on a res config setting: (up to 3 years)

![Screenshot from 2023-07-04 16-43-54](https://github.com/odoo/odoo/assets/48206917/a1886ec3-43e8-40ff-b46e-29511f97bec7)

