### PR TITLE
[FIX] mail: show all record when grouping by activity state

### DIFF
--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -289,7 +289,7 @@ class MailActivityMixin(models.AbstractModel):
             today_utc=pytz.utc.localize(datetime.utcnow()),
             tz=tz,
         )
-        alias = query.join(self._table, "id", sql_join, "res_id", "last_activity_state")
+        alias = query.left_join(self._table, "id", sql_join, "res_id", "last_activity_state")
 
         return SQL.identifier(alias, 'activity_state'), ['activity_state']
 


### PR DESCRIPTION
Before this commit:
-------------------

If you want to group by records that inherit from mail.activity.mixin like crm.lead for example, only records with an activity will show up in the result, record without activity won't show up.

After this commit:
------------------

Read group is not expected to filter record. Record without activity shows up under the group None since the value for activity state is None



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
