### PR TITLE
[FIX] l10n_it_edi: fix send & print if fallback pdf enabled

### DIFF
--- a/addons/l10n_it_edi/tests/test_edi_export.py
+++ b/addons/l10n_it_edi/tests/test_edi_export.py
@@ -389,3 +389,25 @@ class TestItEdiExport(TestItEdi):
         invoice.action_post()
 
         self._assert_export_invoice(invoice, 'invoice_decimal_precision_product.xml')
+
+    def test_send_and_print_invoice_with_fallback_pdf(self):
+        self.italian_partner_a.zip = False  # invalid configuration for partner -> proforma pdf
+        invoice = self.env['account.move'].with_company(self.company).create({
+            'partner_id': self.italian_partner_a.id,
+            'move_type': 'out_invoice',
+            'invoice_line_ids': [
+                Command.create({
+                    'name': 'Example Product',
+                    'price_unit': 500,
+                    'tax_ids': [Command.set(self.default_tax.ids)],
+                }),
+            ],
+        })
+        invoice.action_post()
+        template = self.env.ref(invoice._get_mail_template())
+        invoice._generate_pdf_and_send_invoice(template)
+        self.assertIn(
+            'INV_2024_00001_proforma.pdf',
+            invoice.attachment_ids.mapped('name'),
+            "The proforma PDF should have been generated.",
+        )

--- a/addons/l10n_it_edi/wizard/account_move_send.py
+++ b/addons/l10n_it_edi/wizard/account_move_send.py
@@ -121,7 +121,11 @@ class AccountMoveSend(models.TransientModel):
     def _hook_invoice_document_after_pdf_report_render(self, invoice, invoice_data):
         # EXTENDS 'account'
         super()._hook_invoice_document_after_pdf_report_render(invoice, invoice_data)
-        if invoice_data.get('l10n_it_edi_checkbox_xml_export') and invoice._l10n_it_edi_ready_for_xml_export():
+        if (
+            invoice_data.get('l10n_it_edi_checkbox_xml_export')
+            and invoice._l10n_it_edi_ready_for_xml_export()
+            and invoice_data.get('pdf_attachment_values')
+        ):
             invoice_data['l10n_it_edi_values'] = invoice._l10n_it_edi_get_attachment_values(
                 pdf_values=invoice_data['pdf_attachment_values'])
 


### PR DESCRIPTION
In some cases, the Send & Print wizard is used in a "headless" way. For
instance, when paying a sale order from the website, with the "automatic
invoicing" setting on, an invoice will be created and the legal
attachments will be generated and sent to the government.

Neverthless, if the attachments cannot be generated (in the case of
missing or invalid data on the partner or on the invoice), a proforma
pdf will be generated instead (`allow_fallback_pdf=True`).

In Italy, when generating an invoice with such an "headless" send &
print, for instance: from the website, with a missing zip, an error will
be raised: "Partner(s) should have a complete address, verify their
Street, City, Zipcode and Country.". This prevents the generation of the
PDF. Hence, a traceback will occur in
`_hook_invoice_document_after_pdf_report_render`: a KeyError is raised
by `invoice_data['pdf_attachment_values']`.

This commit fixes this and makes sure the proforma pdf is generated.

no task/ticket (internal feedback at task-3542881)
