### PR TITLE
[FIX] website_event: sanitize event tags for mobile compatibility

### DIFF
--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -91,13 +91,13 @@
                                     <button class="accordion-button collapsed"
                                         type="button"
                                         data-bs-toggle="collapse"
-                                        t-attf-aria-controls="o_wevent_offcanvas_cat_#{category.name}"
-                                        t-att-data-bs-target="'.o_wevent_offcanvas_cat_%s' % category.name"
+                                        t-attf-aria-controls="o_wevent_offcanvas_cat_#{category.id}"
+                                        t-att-data-bs-target="'.o_wevent_offcanvas_cat_%s' % category.id"
                                         aria-expanded="false">
                                         <t t-out="category.name"/>
                                     </button>
                                 </h2>
-                                <div t-attf-id="o_wevent_offcanvas_cat_#{category.name}" t-attf-class="o_wevent_offcanvas_cat_#{category.name} accordion-collapse collapse">
+                                <div t-attf-id="o_wevent_offcanvas_cat_#{category.id}" t-attf-class="o_wevent_offcanvas_cat_#{category.id} accordion-collapse collapse">
                                     <div class="accordion-body pt-0">
                                         <ul class="list-group list-group-flush">
                                             <t t-if="category.is_published and category.tag_ids and any(tag.color for tag in category.tag_ids)" t-foreach="category.tag_ids" t-as="tag">


### PR DESCRIPTION
Category tags names are used directly as selectors. Adding spaces to the names leads to tracebacks.

Reproduce
---
- Install website_event
- Create new event category with spaces in it
- Open mobile view of all events
- Select the category collapsible -> BUG

opw-4009122
