### PR TITLE
[FIX] payment: set company for post-processing

### DIFF
--- a/addons/payment/controllers/post_processing.py
+++ b/addons/payment/controllers/post_processing.py
@@ -47,6 +47,9 @@ class PaymentPostProcessing(http.Controller):
         if not monitored_tx:  # The session might have expired, or the tx has never existed.
             raise Exception('tx_not_found')
 
+        if request.env.user._is_public():
+            monitored_tx = monitored_tx.with_company(monitored_tx.company_id)
+
         # Finalize the post-processing of the transaction before redirecting the user to the landing
         # route and its document.
         if monitored_tx.state == 'done' and not monitored_tx.is_post_processed:


### PR DESCRIPTION
Steps to reproduce:
- Install Subscription, Stripe and Intercompany rules (to have multiple company)
- Set the company of the first website to Chicago
- Setup stripe for the provider
- Make a new subscription with Monthly template for "Joel Willis"
- Generate a payment link

Issues:
"Expected a singleton error" in the `ensure_one` this is due to us having the wrong company during the `post_processing`.

Fix is to set the right company during the creation of the `monitored_tx` if we have a public user.

Local solution is to just set the with_company lower in the stack however it's the second time since this problem was met so a general solution might be more appropriate.

Link to the commit that fixed the first issue: 7c35302bf61b429e52989df6f5eb9d0401433f74

opw-3999546