### PR TITLE
[FIX] spreadsheet: prevent crash from SpreadsheetShareButton

### DIFF
--- a/addons/spreadsheet/static/src/components/share_button/share_button.js
+++ b/addons/spreadsheet/static/src/components/share_button/share_button.js
@@ -41,7 +41,11 @@ export class SpreadsheetShareButton extends Component {
         const url = await this.props.onSpreadsheetShared(data, model.exportXLSX());
         this.state.url = url;
         setTimeout(async () => {
-            await browser.navigator.clipboard.writeText(url);
+            try {
+                await browser.navigator.clipboard.writeText(url);
+            } catch(error) {
+                browser.console.warn(error);
+            }
         })
     }
 


### PR DESCRIPTION
Steps to reproduce
==================

- Use Epiphany (a webkit based browser, like Safari)
- Add `time.sleep(3)` inside `action_get_share_url` to simulate a slow network as it isn't possible inside the epiphany devtools
- Go to dashboard
- Click on Share

=> NotAllowedError: The request is not allowed by the user agent
   or the platform in the current context, possibly because the
   user denied permission.

Cause of the issue
==================

The delay between the user click and the actual copy is to slow for the trused event to be recognized as the origin of the copy. It is thus not allowed.

Note that it also fails in Chrome if the document is out of focus in the meantime.

Solution
========

Wrap the copy in a try catch. If it fails, the user can always use the copy button.

opw-4144551