### PR TITLE
[FIX] website, *: restore proper colorpicker behavior (o_cc tab first)

### DIFF
--- a/addons/mass_mailing/static/tests/tours/mailing_editor_theme.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_editor_theme.js
@@ -103,10 +103,6 @@ registry.category("web_tour.tours").add('mailing_editor_theme', {
             trigger: '#toolbar #oe-text-color',
         },
         {
-            content: "Switch back to solid tab from custom tab",
-            trigger: '.colorpicker button[data-target="theme-colors"]',// Switch back to solid tab
-        },
-        {
             content: "Pick a color",
             trigger: '#toolbar button[data-color="o-color-1"]',
         },

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
@@ -119,13 +119,7 @@ export class ColorPalette extends Component {
         });
         onWillUpdateProps((newProps) => {
             this._updateColorToColornames();
-            // check if the color is selected from theme tab or common grays.
-            // if true, then select the default tab.
-            const selectedSolidColor = ['theme', 'common', 'common_grays'].every(picker =>
-                this.pickers[picker]?.querySelector('button.selected')
-            );
-
-            if (this.props.resetTabCount !== newProps.resetTabCount && selectedSolidColor) {
+            if (this.props.resetTabCount !== newProps.resetTabCount) {
                 this._selectDefaultTab();
             }
             if (this.props.selectedCC !== newProps.selectedCC || this.props.selectedColor !== newProps.selectedColor) {
@@ -334,15 +328,6 @@ export class ColorPalette extends Component {
                 defaultColor = 'rgba(0, 0, 0, ' + this.props.opacity + ')';
             }
             this.state.customDefaultColor = defaultColor;
-        }
-        // check if the color is not selected from theme tab or common grays.
-        // if true, then switch tab from solid or theme to custom-colors tab.
-        const notSelectedSolidColor = ['theme', 'common', 'common_grays'].every(picker =>
-            !this.pickers[picker]?.querySelector('button.selected')
-        );
-
-        if (notSelectedSolidColor) {
-            this._selectTabFromButton(this.el.querySelectorAll('button')[1]);
         }
     }
     //--------------------------------------------------------------------------

--- a/addons/website/static/tests/tours/snippet_background_edition.js
+++ b/addons/website/static/tests/tours/snippet_background_edition.js
@@ -60,10 +60,6 @@ function checkAndUpdateBackgroundColor({
 }) {
     const steps = [
         wTourUtils.changeBackgroundColor(),
-        {
-            content: "Switch back to theme tab from custom tab",
-            trigger: ".colorpicker button[data-target='color-combinations']", // Switch back to theme tab
-        },
     ];
 
     addCheck(steps, checkCC, checkNoCC, 'cc', true);


### PR DESCRIPTION
*: web_editor, mass_mailing

This purely reverts [1] which, while implementing a minor feature for the mass_mailing editor, broke a major feature of the website builder. This went unnoticed because the test tours were also adapted to account for the change.

Once the time is right, the minor feature will be re-implemented although it probably will be done another way. Also, the functional need should be rediscussed as I don't see the point in showing the "solid" tab at all if it is to show it only when such a color was previously selected. Just removing that tab seems to improve the UI and would be a one-line-code feature instead of this. To re-discuss.

[1]: https://github.com/odoo/odoo/commit/8594fa708c06232cde5743be2b66f551ff5a4589
