### PR TITLE
[FIX] point_of_sale: broken reciept format

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.xml
@@ -19,7 +19,7 @@
                     </div>
                     <div t-if="props.showTaxGroupLabels" t-esc="line.taxGroupLabels" class="text-end" style="width: 2rem"/>
                 </div>
-                <ul class="info-list small d-flex flex-column small">
+                <ul class="info-list d-flex flex-column">
                     <li class="price-per-unit">
                         <span class="qty px-1 border rounded text-bg-view fw-bolder me-1" t-esc="line.qty"/>
                         x

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
@@ -22,7 +22,7 @@
                     <div t-esc="props.data.cashier" />
                 </div>
                 <div t-if="props.data.trackingNumber and !props.data.bigTrackingNumber">
-                    <span class="fs-2" t-esc="props.data.trackingNumber" />
+                    <span class="tracking-number fs-1" t-esc="props.data.trackingNumber" />
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Steps to reproduce :
---------------------------
- Install pos & open session.
- Order something and pay for it.
- Print reciept.

Issue :
--------
Tracking number as well as quantity,price of orderline comes too small in reciept printed.

Cause :
----------
There was a small class applied which was causing it to be printed very small.

Fix :
-----
Written the styles appropriately.

Related PR: https://github.com/odoo/enterprise/pull/69314

task: 4147609