### PR TITLE
[FIX] pos_loyalty: loyalty reward after less points than required points

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_order.js
@@ -1238,7 +1238,7 @@ patch(PosOrder.prototype, {
                 reward.program_id.applies_on !== "future"
             ) {
                 const line = this.get_orderlines().find(
-                    (line) => line._reward_product_id === product.id
+                    (line) => line._reward_product_id?.id === product.id
                 );
                 // Compute the correction points once even if there are multiple reward lines.
                 // This is because _getPointsCorrection is taking into account all the lines already.


### PR DESCRIPTION
Before this commit:
==========
- Loyalty rewards would apply even if the customer had fewer loyalty points than required.

After this commit:
==========
- If the customer has fewer loyalty points than required for the loyalty rewards, the loyalty button will become disabled.

task-4126886