### PR TITLE
 [FIX] pos_loyalty: loyalty reward product quantity and loyalty points

### DIFF
--- a/addons/pos_loyalty/static/src/css/Loyalty.scss
+++ b/addons/pos_loyalty/static/src/css/Loyalty.scss
@@ -98,9 +98,12 @@
             font-size: small;
         }
 
+        .loyalty-points-balance {
+            color: #714B67;
+        }
+
         .loyalty-points-spent {
             color: #C86E6E;
-            background: rgba(200, 110, 110, 0.17);
         }
 
         .loyalty-points-total {

--- a/addons/pos_loyalty/static/src/tours/PosLoyaltyLoyaltyProgramTour.js
+++ b/addons/pos_loyalty/static/src/tours/PosLoyaltyLoyaltyProgramTour.js
@@ -156,7 +156,7 @@ ProductScreen.do.clickCustomer('Test Partner AAA');
 PosLoyalty.check.isRewardButtonHighlighted(true);
 
 PosLoyalty.do.clickRewardButton();
-PosLoyalty.check.hasRewardLine('Free Product - Whiteboard Pen', '0.0', '2.00');
+PosLoyalty.check.hasRewardLine('Free Product - Whiteboard Pen', '0.0', '1.00');
 
 PosLoyalty.check.orderTotalIs('10.2');
 PosLoyalty.exec.finalizeOrder('Cash');

--- a/addons/pos_loyalty/static/src/tours/PosLoyaltyTourMethods.js
+++ b/addons/pos_loyalty/static/src/tours/PosLoyaltyTourMethods.js
@@ -174,7 +174,7 @@ odoo.define('pos_loyalty.tour.PosCouponTourMethods', function (require) {
             return [
                 {
                     content: 'loyalty points awarded ' + points_str,
-                    trigger: '.loyalty-points-won .value:contains("' + points_str + '")',
+                    trigger: '.loyalty-points-won.value:contains("' + points_str + '")',
                     run: function () {}, // it's a check
                 },
             ];

--- a/addons/pos_loyalty/static/src/xml/OrderSummary.xml
+++ b/addons/pos_loyalty/static/src/xml/OrderSummary.xml
@@ -10,16 +10,19 @@
                             <div class='loyalty-points-title'>
                                 <t t-esc="_loyaltyStat.points.name"/>
                             </div>
-                            <t t-if='_loyaltyStat.points.won'>
-                                <div class="loyalty-points-won">
-                                    <span class='value'>+<t t-esc='_loyaltyStat.points.won'/></span>
+                            <t t-if='_loyaltyStat.points.balance'>
+                                <div class="loyalty-points-balance">
+                                    <span class='value'><t t-esc='_loyaltyStat.points.balance'/></span>
                                 </div>
                             </t>
-                            <t t-if='_loyaltyStat.points.spent'>
-                                <div class="loyalty-points-spent">
-                                    <span class='value'>-<t t-esc='_loyaltyStat.points.spent'/></span>
-                                </div>
-                            </t>
+                            <div>
+                                <t t-if='_loyaltyStat.points.won'>
+                                    <span class="value loyalty-points-won">+<t t-esc='_loyaltyStat.points.won'/></span>
+                                </t>
+                                <t t-if='_loyaltyStat.points.spent'>
+                                    <span class="value loyalty-points-spent">-<t t-esc='_loyaltyStat.points.spent'/></span>
+                                </t>
+                            </div>
                             <div class='loyalty-points-total'>
                                 <span class='value'><t t-esc='_loyaltyStat.points.total'/></span>
                             </div>

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -394,7 +394,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         aaa_loyalty_card = loyalty_program.coupon_ids.filtered(lambda coupon: coupon.partner_id.id == partner_aaa.id)
 
         self.assertEqual(loyalty_program.pos_order_count, 1)
-        self.assertAlmostEqual(aaa_loyalty_card.points, 0.2)
+        self.assertAlmostEqual(aaa_loyalty_card.points, 5.2)
 
     def test_pos_loyalty_tour_max_amount(self):
         """Test the loyalty program with a maximum amount and product with different taxe."""


### PR DESCRIPTION
Before this commit:
==========
- An issue existed with the quantity of reward products where there were more
  reward products applied than configured in the backend.
- Rewards were being applied even when loyalty points were insufficient for the
  redemption of loyalty rewards.
- In a loyalty program configuration with a reward point mode per order, loyalty
  points were consistently decreasing.
- We were not showing a balance of loyalty points for the customers.

After this commit:
==========
- The quantity of the applied reward product will now match the configuration
  set in the backend.
- Reward products will not be applied if the customer's loyalty points are
  insufficient for the specific reward product.
- Loyalty points will be computed correctly in the case of the reward point mode
  per order.
- We will show a balance of loyalty points for the customers.

task-4126886