### PR TITLE
[FIX] website_slides: prevent traceback when clicking add tag button

### DIFF
--- a/addons/website_slides/static/src/js/slides_course_tag_add.js
+++ b/addons/website_slides/static/src/js/slides_course_tag_add.js
@@ -19,9 +19,10 @@ publicWidget.registry.websiteSlidesTag = publicWidget.Widget.extend({
      */
     _onAddTagClick: function (ev) {
         ev.preventDefault();
+        const channelTagIds = ev.currentTarget.dataset.channelTagIds;
         this.call("dialog", "add", CourseTagAddDialog, {
             channelId: parseInt(ev.currentTarget.dataset.channelId, 10),
-            tagIds: JSON.parse(ev.currentTarget.dataset.channelTagIds),
+            tagIds: channelTagIds ? JSON.parse(channelTagIds) : [],
         });
     },
 });


### PR DESCRIPTION
Steps to reproduce:
1. Create a new course
2. Go to front-end.
3. Click on the "Add tag" button.
4. Throws a traceback

Technical Reason:
When creating a website slide for the first time, channelTagIds are undefined, causing JSON.parse to throw an error.

After this Commit:
No traceback will occur.

Task-4154899
