### PR TITLE
[FIX] stock: select first warehouse on Forecast page when multiple are filtered

### DIFF
--- a/addons/purchase_mrp/report/mrp_report_mo_overview.py
+++ b/addons/purchase_mrp/report/mrp_report_mo_overview.py
@@ -11,7 +11,8 @@ class ReportMoOverview(models.AbstractModel):
         domain = [('state', 'in', ['draft', 'sent', 'to approve']), ('product_id', '=', product.id)]
         warehouse_id = self.env.context.get('warehouse', False)
         if warehouse_id:
-            domain += [('order_id.picking_type_id.warehouse_id', '=', warehouse_id)]
+            warehouse_id = warehouse_id if isinstance(warehouse_id, list) else [warehouse_id]
+            domain += [('order_id.picking_type_id.warehouse_id', 'in', warehouse_id)]
         po_lines = self.env['purchase.order.line'].search(domain, order='date_planned, id')
 
         for po_line in po_lines:

--- a/addons/purchase_stock/report/stock_forecasted.py
+++ b/addons/purchase_stock/report/stock_forecasted.py
@@ -13,7 +13,8 @@ class StockForecasted(models.AbstractModel):
         domain += self._product_purchase_domain(product_template_ids, product_ids)
         warehouse_id = self.env.context.get('warehouse', False)
         if warehouse_id:
-            domain += [('order_id.picking_type_id.warehouse_id', '=', warehouse_id)]
+            warehouse_id = warehouse_id if isinstance(warehouse_id, list) else [warehouse_id]
+            domain += [('order_id.picking_type_id.warehouse_id', 'in', warehouse_id)]
         po_lines = self.env['purchase.order.line'].search(domain)
         in_sum = sum(po_lines.mapped('product_uom_qty'))
         res['draft_purchase_qty'] = in_sum

--- a/addons/sale_stock/report/stock_forecasted.py
+++ b/addons/sale_stock/report/stock_forecasted.py
@@ -53,5 +53,6 @@ class StockForecasted(models.AbstractModel):
             domain += [('product_id', 'in', product_ids)]
         warehouse_id = self.env.context.get('warehouse', False)
         if warehouse_id:
-            domain += [('warehouse_id', '=', warehouse_id)]
+            warehouse_id = warehouse_id if isinstance(warehouse_id, list) else [warehouse_id]
+            domain += [('warehouse_id', 'in', warehouse_id)]
         return domain

--- a/addons/stock/static/src/stock_forecasted/forecasted_warehouse_filter.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_warehouse_filter.js
@@ -21,9 +21,15 @@ export class ForecastedWarehouseFilter extends Component {
         this.props.setWarehouseInContext(Number(id));
     }
 
-    get activeWarehouse(){
-        return this.context.warehouse ?
-            this.warehouses.find(w => w.id == this.context.warehouse) :
+    get activeWarehouse() {
+        let warehouseIds = null;
+        if (Array.isArray(this.context.warehouse)) {
+            warehouseIds = this.context.warehouse;
+        } else {
+            warehouseIds = [this.context.warehouse];
+        }
+        return warehouseIds ?
+            this.warehouses.find(w => warehouseIds.includes(w.id)) :
             this.warehouses[0];
     }
 }

--- a/addons/stock/static/src/stock_forecasted/stock_forecasted.js
+++ b/addons/stock/static/src/stock_forecasted/stock_forecasted.js
@@ -88,9 +88,10 @@ export class StockForecasted extends Component {
     }
 
     get graphDomain() {
+        const warehouseIds = Array.isArray(this.context.warehouse) ? this.context.warehouse : [this.context.warehouse];
         const domain = [
             ["state", "=", "forecast"],
-            ["warehouse_id", "=", this.context.warehouse],
+            ["warehouse_id", "in", warehouseIds],
         ];
         if (this.resModel === "product.template") {
             domain.push(["product_tmpl_id", "=", this.productId]);

--- a/addons/stock/static/tests/tours/stock_report_tests.js
+++ b/addons/stock/static/tests/tours/stock_report_tests.js
@@ -20,3 +20,60 @@
         isCheck: true,
     },
     ]});
+
+
+registry.category("web_tour.tours").add('test_multiple_warehouses_filter', {
+    test: true,
+    steps: () => [
+        // Add (Warehouse A or Warehouse B) to the filter
+        {
+            content: "click search",
+            trigger: '.o_searchview_input',
+            run: 'click',
+        },
+        {
+            trigger: '.o_searchview_input',
+            run: 'text warehouse',
+        },
+        {
+            trigger: '.o_menu_item.dropdown-item:contains("Warehouse") a.o_expand > i',
+            run: 'click',
+        },
+        {
+            trigger: '.o_menu_item.dropdown-item.o_indent:contains("Warehouse A") a',
+            run: 'click',
+        },
+        {
+            trigger: '.o_searchview_input',
+            run: 'text warehouse',
+        },
+        {
+            trigger: '.o_menu_item.dropdown-item:contains("Warehouse") a.o_expand > i',
+            run: 'click',
+        },
+        {
+            trigger: '.o_menu_item.dropdown-item.o_indent:contains("Warehouse B") a',
+            run: 'click',
+        },
+        // Go to product page
+        {
+            trigger: '.oe_kanban_card:has(.o_kanban_record_title span:contains("Product A"))',
+            run: 'click',
+        },
+        // Forecast page should load correctly
+        {
+            trigger: '.dropdown-toggle.o_button_more:contains("More")',
+            run: 'click',
+        },
+        {
+            trigger: 'button[name="action_product_tmpl_forecast_report"]',
+            run: 'click',
+        },
+        {
+            trigger: '.o_graph_view',
+            content: 'Wait for the Forecast page to load.',
+            extra_trigger: '.o_graph_view',
+            run: () => {},
+        },
+    ],
+});

--- a/addons/stock/tests/test_report_tours.py
+++ b/addons/stock/tests/test_report_tours.py
@@ -14,3 +14,27 @@ class TestStockReportTour(HttpCase):
         url = self._get_report_url()
 
         self.start_tour(url, 'test_stock_route_diagram_report', login='admin', timeout=180)
+
+    def test_multiple_warehouses_filter(self):
+
+        self.env['product.product'].create({
+            'name': 'Product A',
+            'default_code': 'PA',
+            'lst_price': 100.0,
+            'standard_price': 100.0,
+            'type': 'product'
+        })
+
+        self.env['stock.warehouse'].create({
+            'name': 'Warehouse A',
+            'code': 'WH-A',
+            'company_id': self.env.user.company_id.id,
+        })
+
+        self.env['stock.warehouse'].create({
+            'name': 'Warehouse B',
+            'code': 'WH-B',
+            'company_id': self.env.user.company_id.id,
+        })
+
+        self.start_tour(self._get_report_url(), 'test_multiple_warehouses_filter', login='admin', timeout=180)


### PR DESCRIPTION

Problem:
When multiple warehouses are selected in the products list page filter, clicking the Forecast button on the product page causes a traceback due to not handling multiple selected warehouses.

Steps to reproduce:

- Create two warehouses.
- Go to Inventory > Products.
- Add a filter for Warehouse 1 or Warehouse 2.
- Open a product page.
- Click the Forecast button.
- Traceback occurs.

opw-4149904

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
