### PR TITLE
[IMP] l10n_in: gst number based State Auto-population and Mismatch Warning

### DIFF
--- a/addons/l10n_in/models/company.py
+++ b/addons/l10n_in/models/company.py
@@ -5,6 +5,7 @@ class ResCompany(models.Model):
     _inherit = 'res.company'
 
     l10n_in_upi_id = fields.Char(string="UPI Id")
+    l10n_in_gst_state_warning = fields.Char(related="partner_id.l10n_in_gst_state_warning")
 
     def create(self, vals):
         res = super().create(vals)
@@ -25,3 +26,7 @@ class ResCompany(models.Model):
             ChartTemplate = self.env['account.chart.template'].with_company(company)
             fiscal_position_data = ChartTemplate._get_in_account_fiscal_position()
             ChartTemplate._load_data({'account.fiscal.position': fiscal_position_data})
+
+    def action_update_state_as_per_gstin(self):
+        self.ensure_one()
+        self.partner_id.action_update_state_as_per_gstin()

--- a/addons/l10n_in/models/res_partner.py
+++ b/addons/l10n_in/models/res_partner.py
@@ -28,6 +28,29 @@ class ResPartner(models.Model):
     )
 
     display_pan_warning = fields.Boolean(string="Display pan warning", compute="_compute_display_pan_warning")
+    l10n_in_gst_state_warning = fields.Char(compute="_compute_l10n_in_gst_state_warning")
+
+    @api.depends('vat', 'state_id', 'country_id', 'fiscal_country_codes')
+    def _compute_l10n_in_gst_state_warning(self):
+        for partner in self:
+            if (
+                "IN" in partner.fiscal_country_codes
+                and partner.check_vat_in(partner.vat)
+            ):
+                if partner.vat[:2] == "99":
+                    partner.l10n_in_gst_state_warning = _(
+                        "As per GSTN the country should be other than India, so it's recommended to update it."
+                    )
+                else:
+                    state_id = self.env['res.country.state'].search([('l10n_in_tin', '=', partner.vat[:2])])
+                    if state_id and state_id != partner.state_id:
+                        partner.l10n_in_gst_state_warning = _(
+                            "As per GSTN the state should be %s, so it's recommended to update it.", state_id.name
+                        )
+                    else:
+                        partner.l10n_in_gst_state_warning = False
+            else:
+                partner.l10n_in_gst_state_warning = False
 
     @api.depends('l10n_in_pan')
     def _compute_display_pan_warning(self):
@@ -72,3 +95,8 @@ class ResPartner(models.Model):
         if vat == TEST_GST_NUMBER:
             return True
         return super().check_vat_in(vat)
+
+    def action_update_state_as_per_gstin(self):
+        self.ensure_one()
+        state_id = self.env['res.country.state'].search([('l10n_in_tin', '=', self.vat[:2])], limit=1)
+        self.state_id = state_id

--- a/addons/l10n_in/views/res_company_views.xml
+++ b/addons/l10n_in/views/res_company_views.xml
@@ -8,6 +8,16 @@
             <xpath expr="//field[@name='currency_id']" position="after">
                 <field name="l10n_in_upi_id" invisible="country_code != 'IN'"/>
             </xpath>
+            <xpath expr="//sheet" position="before">
+                <div class="alert alert-warning mt-1 mb-1" role="alert" invisible="not l10n_in_gst_state_warning or country_code != 'IN'">
+                    <field name="l10n_in_gst_state_warning"/>
+                    <button name="action_update_state_as_per_gstin"
+                            string="Update it"
+                            class="oe_link"
+                            invisible="country_code != 'IN'"
+                            type="object"/>
+                </div>
+            </xpath>
         </field>
     </record>
 </odoo>

--- a/addons/l10n_in/views/res_partner_views.xml
+++ b/addons/l10n_in/views/res_partner_views.xml
@@ -17,6 +17,14 @@
                 <field name="l10n_in_pan" placeholder="e.g. ABCTY1234D" invisible="'IN' not in fiscal_country_codes" readonly="parent_id"/>
             </xpath>
             <xpath expr="//sheet" position="before">
+                <div class="alert alert-warning mt-1 mb-1" role="alert" invisible="not l10n_in_gst_state_warning or country_code != 'IN'">
+                    <field name="l10n_in_gst_state_warning"/>
+                    <button name="action_update_state_as_per_gstin"
+                            string="Update it"
+                            class="oe_link"
+                            invisible="country_code != 'IN'"
+                            type="object"/>
+                </div>
                 <field name="display_pan_warning" invisible="1"/>
                 <div class="alert alert-warning" role="alert"
                         invisible="not display_pan_warning">


### PR DESCRIPTION
Before this PR:
- The state field on the res_company form is not automatically populated based on the entered GST number
- On the res_company and res_partner, even if there is a mismatch between the GST number and state no warning is shown

After this PR:
- The state field on the res_company form now automatically populates based on the entered GST number
- A validation check is implemented for both res_company and res_partner forms. Users will receive a warning if there's a discrepancy between the GST number and the corresponding state.

Task ID - 4055948