### PR TITLE
Hoot element(s)FromPoint

### DIFF
--- a/addons/web/static/lib/hoot/mock/window.js
+++ b/addons/web/static/lib/hoot/mock/window.js
@@ -117,6 +117,22 @@ const findPropertyOwner = (object, property) => {
     return object;
 };
 
+function mockedElementFromPoint() {
+    return mockedElementsFromPoint.call(this, ...arguments)[0];
+}
+
+function mockedElementsFromPoint() {
+    const { value: elementsFromPoint } = findOriginalDescriptor(document, "elementsFromPoint");
+    const elements = elementsFromPoint
+        .call(this, ...arguments)
+        .filter(
+            (el) =>
+                !el.tagName.startsWith("HOOT") && el !== this.body && el !== this.documentElement
+        );
+    elements.push(this.body, this.documentElement);
+    return elements;
+}
+
 const EVENT_TARGET_PROTOTYPES = new Map(
     [
         // Top level objects
@@ -149,6 +165,8 @@ const DOCUMENT_MOCK_DESCRIPTORS = {
         get: () => mockCookie.get(),
         set: (value) => mockCookie.set(value),
     },
+    elementFromPoint: { value: mockedElementFromPoint },
+    elementsFromPoint: { value: mockedElementsFromPoint },
     title: {
         get: () => mockTitle,
         set: (value) => (mockTitle = value),

--- a/addons/web/static/lib/hoot/tests/index.js
+++ b/addons/web/static/lib/hoot/tests/index.js
@@ -11,6 +11,7 @@ import "./hoot-dom/events.test.js";
 import "./hoot_utils.test.js";
 import "./mock/navigator.test.js";
 import "./mock/network.test.js";
+import "./mock/window.test.js";
 import "./ui/hoot_technical_value.test.js";
 
 whenReady(() => start());

--- a/addons/web/static/lib/hoot/tests/mock/window.test.js
+++ b/addons/web/static/lib/hoot/tests/mock/window.test.js
@@ -1,0 +1,33 @@
+/** @odoo-module */
+
+import { describe, expect, mountOnFixture, test } from "@odoo/hoot";
+import { queryOne } from "@odoo/hoot-dom";
+import { parseUrl } from "../local_helpers";
+
+describe(parseUrl(import.meta.url), () => {
+    test("elementFromPoint and elementsFromPoint should be mocked", async () => {
+        await mountOnFixture(/* xml */ `
+            <div class="oui" style="position: absolute; left: 10px; top: 10px; width: 250px; height: 250px;">
+                Oui
+            </div>
+        `);
+
+        expect(".oui").toHaveRect({
+            x: 10,
+            y: 10,
+            width: 250,
+            height: 250,
+        });
+
+        const div = queryOne(".oui");
+        expect(document.elementFromPoint(11, 11)).toBe(div);
+        expect(document.elementsFromPoint(11, 11)).toEqual([
+            div,
+            document.body,
+            document.documentElement,
+        ]);
+
+        expect(document.elementFromPoint(9, 9)).toBe(document.body);
+        expect(document.elementsFromPoint(9, 9)).toEqual([document.body, document.documentElement]);
+    });
+});


### PR DESCRIPTION
This commit introduces a global mock for the document `elementFromPoint` and `elementsFromPoint` methods, so that it ignores both Hoot's fixture and UI container.

This has been done since when not debugging a test, the fixture is z-indexed behind the body and both of these methods would consider them accordingly, meaning that production code relying on these methods would consistently get the Hoot UI or the body instead of the desired element.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
