### PR TITLE
[IMP] hw_drivers: protect public routes with payload signature

### DIFF
--- a/addons/hw_drivers/controllers/driver.py
+++ b/addons/hw_drivers/controllers/driver.py
@@ -17,11 +17,13 @@ from odoo import http, tools
 from odoo.addons.hw_drivers.event_manager import event_manager
 from odoo.addons.hw_drivers.main import iot_devices, manager
 from odoo.addons.hw_drivers.tools import helpers
+from odoo.addons.hw_drivers.tools import route
 
 _logger = logging.getLogger(__name__)
 
 
 class DriverController(http.Controller):
+    @route.protect
     @http.route('/hw_drivers/action', type='jsonrpc', auth='none', cors='*', csrf=False, save_session=False)
     def action(self, session_id, device_identifier, data):
         """
@@ -55,6 +57,7 @@ class DriverController(http.Controller):
         """
         helpers.get_certificate_status()
 
+    @route.protect
     @http.route('/hw_drivers/event', type='jsonrpc', auth='none', cors='*', csrf=False, save_session=False)
     def event(self, listener):
         """

--- a/addons/hw_drivers/http.py
+++ b/addons/hw_drivers/http.py
@@ -1,10 +1,39 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import collections
 import odoo.http
+
+from odoo.http import JsonRPCDispatcher, serialize_exception
+from werkzeug.exceptions import Forbidden
+
+
+class JsonRPCDispatcherPatch(JsonRPCDispatcher):
+    def handle_error(self, exc: Exception) -> collections.abc.Callable:
+        """Monkey patch the handle_error method to add HTTP 403 Forbidden
+        error handling.
+
+        :param exc: the exception that occurred.
+        :returns: a WSGI application
+        """
+        error = {
+            'code': 200,  # this code is the JSON-RPC level code, it is
+            # distinct from the HTTP status code. This
+            # code is ignored and the value 200 (while
+            # misleading) is totally arbitrary.
+            'message': "Odoo Server Error",
+            'data': serialize_exception(exc),
+        }
+        if isinstance(exc, Forbidden):
+            error['code'] = 403
+            error['message'] = "403: Forbidden"
+            error['data'] = {"message": error['data']["message"]}  # only keep the message, not the traceback
+
+        return self._response(error=error)
 
 
 def db_list(force=False, host=None):
     return []
+
 
 odoo.http.db_list = db_list

--- a/addons/hw_drivers/tools/route.py
+++ b/addons/hw_drivers/tools/route.py
@@ -1,0 +1,87 @@
+import functools
+import hashlib
+import hmac
+import json
+import logging
+import time
+from urllib.parse import urlparse, parse_qsl
+
+from odoo import tools
+from odoo.addons.hw_drivers.tools import helpers
+from odoo.http import request
+from werkzeug.exceptions import Forbidden
+
+_logger = logging.getLogger(__name__)
+WINDOW = 5
+
+
+def protect(endpoint):
+    """Decorate a route to protect it with a hmac signature. If the IoT Box is not connected
+    to a db, the route will not be protected.
+    """
+    fname = f"<function {endpoint.__module__}.{endpoint.__qualname__}>"
+
+    @functools.wraps(endpoint)
+    def protect_wrapper(*args, **kwargs):
+        # If no db connected, we don't protect the endpoint
+        if not helpers.get_odoo_server_url():
+            return endpoint(*args, **kwargs)
+
+        signature = request.httprequest.headers.get('Authorization')
+        url = request.httprequest.url
+        payload = dict(kwargs)
+        if not signature or not verify_hmac_signature(url, payload, signature):
+            _logger.error('%s: Authentication failed.', fname)
+            return Forbidden('Authentication failed.')
+
+        return endpoint(*args, **kwargs)
+    return protect_wrapper
+
+
+def hmac_sign(url, payload, t=None):
+    """Compute HMAC signature for the url and the payload of a request with
+    the IoT Box `token` as key.
+
+    :param url: url of the request
+    :param payload: payload of the request
+    :param float t: timestamp to use for the signature, if not provided, the current
+        time is used
+    :return: HMAC signature of the timestamp, url and payload
+    """
+    if not t:
+        t = time.time()
+
+    parsed_url = urlparse(url)
+    query_params = dict(parse_qsl(parsed_url.query, keep_blank_values=True))
+
+    payload = "%s|%s|%s|%s" % (
+        int(t),
+        parsed_url.path,
+        json.dumps(query_params, sort_keys=True),
+        json.dumps(payload, sort_keys=True),
+    )
+    return hmac.new(helpers.get_token().encode(), payload.encode(), hashlib.sha256).hexdigest()
+
+
+def verify_hmac_signature(url, payload, signature, t=None, window=WINDOW):
+    """Verify the signature of a payload.
+
+    :param url: url of the request
+    :param payload: payload of the request
+    :param signature: signature to verify
+    :param float t: timestamp to use for the signature, if not provided, the
+        current time is used
+    :param int window: fuzz window to account for slow fingers, network
+        latency, desynchronised clocks, ..., every signature valid between
+        t-window and t+window is considered valid
+    """
+    if not t:
+        t = time.time()
+
+    low = int(t - window)
+    high = int(t + window)
+
+    return next((
+        counter for counter in range(low, high)
+        if tools.consteq(signature, hmac_sign(url, payload, counter))
+    ), None)


### PR DESCRIPTION
Most routes on the IoT Box are public. We implemented a decorator to require a payload signature based on the token shared on connection between IoT Box and DB.
We updated this token to be a 16 bytes hex token as well.

As Odoo's hmac methods are meant to use the `database.secret` from `ir.config_parameter`, we had to re implement those methods to use our token.

The signatures are time based and have a window of 5 seconds to be validated.

Enterprise PR: [https://github.com/odoo/enterprise/pull/69426](https://github.com/odoo/enterprise/pull/69426)
Task: 3082226