### PR TITLE
[FIX] hw_posbox_homepage: replace unlink_file by update_conf

### DIFF
--- a/addons/hw_posbox_homepage/controllers/main.py
+++ b/addons/hw_posbox_homepage/controllers/main.py
@@ -237,7 +237,7 @@ class IoTboxHomepage(Home):
 
     @http.route('/wifi_clear', type='http', auth='none', cors='*', csrf=False)
     def clear_wifi_configuration(self):
-        helpers.unlink_file('wifi_network.txt')
+        helpers.update_conf({'wifi_ssid': '', 'wifi_password': ''})
         return "<meta http-equiv='refresh' content='0; url=http://" + helpers.get_ip() + ":8069'>"
 
     @http.route('/server_clear', type='http', auth='none', cors='*', csrf=False)


### PR DESCRIPTION
We still disconnected from wifi unlinking the old file, despite that we moved this configuration to `odoo.conf`. We replaced that.