### PR TITLE
[IMP] product: add specific security group for product models

### DIFF
--- a/addons/product/security/ir.model.access.csv
+++ b/addons/product/security/ir.model.access.csv
@@ -16,21 +16,21 @@ access_product_template_attribute_line,product.template.attribute line,model_pro
 access_product_tag_user,product.tag.user,model_product_tag,base.group_user,1,0,0,0
 access_product_combo_user,product.combo.user,model_product_combo,base.group_user,1,0,0,0
 access_product_combo_item_user,product.combo.item.user,model_product_combo_item,base.group_user,1,0,0,0
-access_product_category_manager,product.category.manager,model_product_category,base.group_system,1,1,1,1
-access_product_template_manager,product.template.manager,model_product_template,base.group_system,1,1,1,1
-access_product_packaging_manager,product.packaging.manager,model_product_packaging,base.group_system,1,1,1,1
-access_product_supplierinfo_manager,product.supplierinfo.manager,model_product_supplierinfo,base.group_system,1,1,1,1
-access_product_pricelist_manager,product.pricelist.manager,model_product_pricelist,base.group_system,1,1,1,1
-access_product_pricelist_item_manager,product.pricelist.item.manager,model_product_pricelist_item,base.group_system,1,1,1,1
-access_product_product_manager,product.product manager,model_product_product,base.group_system,1,1,1,1
-access_product_attribute_manager,product.attribute manager,model_product_attribute,base.group_system,1,1,1,1
-access_product_attribute_value_manager,product.attribute value manager,model_product_attribute_value,base.group_system,1,1,1,1
-access_product_attribute_custom_value_manager,product.attribute.custom value manager,model_product_attribute_custom_value,base.group_system,1,1,1,1
-access_product_product_attribute_manager,product.template.attribute value manager,model_product_template_attribute_value,base.group_system,1,1,1,1
-access_product_template_attribute_exclusion_manager,product.template.attribute exclusion manager,model_product_template_attribute_exclusion,base.group_system,1,1,1,1
-access_product_template_attribute_line_manager,product.template.attribute line manager,model_product_template_attribute_line,base.group_system,1,1,1,1
+access_product_category_manager,product.category.manager,model_product_category,group_product_manager,1,1,1,1
+access_product_template_manager,product.template.manager,model_product_template,group_product_manager,1,1,1,1
+access_product_packaging_manager,product.packaging.manager,model_product_packaging,group_product_manager,1,1,1,1
+access_product_supplierinfo_manager,product.supplierinfo.manager,model_product_supplierinfo,group_product_manager,1,1,1,1
+access_product_pricelist_manager,product.pricelist.manager,model_product_pricelist,group_product_manager,1,1,1,1
+access_product_pricelist_item_manager,product.pricelist.item.manager,model_product_pricelist_item,group_product_manager,1,1,1,1
+access_product_product_manager,product.product manager,model_product_product,group_product_manager,1,1,1,1
+access_product_attribute_manager,product.attribute manager,model_product_attribute,group_product_manager,1,1,1,1
+access_product_attribute_value_manager,product.attribute value manager,model_product_attribute_value,group_product_manager,1,1,1,1
+access_product_attribute_custom_value_manager,product.attribute.custom value manager,model_product_attribute_custom_value,group_product_manager,1,1,1,1
+access_product_product_attribute_manager,product.template.attribute value manager,model_product_template_attribute_value,group_product_manager,1,1,1,1
+access_product_template_attribute_exclusion_manager,product.template.attribute exclusion manager,model_product_template_attribute_exclusion,group_product_manager,1,1,1,1
+access_product_template_attribute_line_manager,product.template.attribute line manager,model_product_template_attribute_line,group_product_manager,1,1,1,1
 access_product_label_layout_user,product.label.layout.user,model_product_label_layout,base.group_user,1,1,1,1
-access_product_tag_manager,product.tag.manager,model_product_tag,base.group_system,1,1,1,1
-access_product_combo_manager,product.combo.manager,model_product_combo,base.group_system,1,1,1,1
-access_product_combo_item_manager,product.combo.item.manager,model_product_combo_item,base.group_system,1,1,1,1
+access_product_tag_manager,product.tag.manager,model_product_tag,group_product_manager,1,1,1,1
+access_product_combo_manager,product.combo.manager,model_product_combo,group_product_manager,1,1,1,1
+access_product_combo_item_manager,product.combo.item.manager,model_product_combo_item,group_product_manager,1,1,1,1
 access_product_document_user,access_product_document_user,model_product_document,base.group_user,1,1,1,1

--- a/addons/product/security/product_security.xml
+++ b/addons/product/security/product_security.xml
@@ -16,6 +16,19 @@
         <field name="category_id" ref="base.module_category_hidden"/>
     </record>
 
+    <record id="group_product_manager" model="res.groups">
+        <field name="name">Product Creation</field>
+        <field name="users" eval="[Command.link(ref('base.user_root')), Command.link(ref('base.user_admin'))]"/>
+        <field name="category_id" ref="base.module_category_usability"/>
+    </record>
+
+    <record id="base.default_user" model="res.users">
+        <field name="groups_id" eval="[Command.link(ref('group_product_manager'))]"/>
+    </record>
+    <record id="base.group_system" model="res.groups">
+        <field name="implied_ids" eval="[Command.link(ref('group_product_manager'))]"/>
+    </record>
+
 <data noupdate="1">
 
     <record id="product_comp_rule" model="ir.rule">


### PR DESCRIPTION
By default, an internal user cannot create products (expect when point_of_sale is installed, because this module makes, by default, all users pos manager). As we did for contacts, create a separate security group for product models.

task-4094988