### PR TITLE
[FIX] analytic: Remove account dependencies from analytic tests

### DIFF
--- a/addons/analytic/tests/test_analytic_mixin.py
+++ b/addons/analytic/tests/test_analytic_mixin.py
@@ -8,9 +8,7 @@ class TestAnalyticMixin(TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.analytic_plan = cls.env['account.analytic.plan'].create({
-            'name': 'Plan',
-        })
+        cls.analytic_plan = cls.env['account.analytic.plan'].create({'name': 'Plan'})
 
         cls.sales_aa = cls.env['account.analytic.account'].create({'name': 'Sales', 'plan_id': cls.analytic_plan.id})
         cls.administrative_aa = cls.env['account.analytic.account'].create({'name': 'Administrative', 'plan_id': cls.analytic_plan.id})
@@ -18,11 +16,6 @@ class TestAnalyticMixin(TransactionCase):
         cls.commercial_aa = cls.env['account.analytic.account'].create({'name': 'Commercial', 'plan_id': cls.analytic_plan.id})
         cls.marketing_aa = cls.env['account.analytic.account'].create({'name': 'Marketing', 'plan_id': cls.analytic_plan.id})
         cls.com_marketing_aa = cls.env['account.analytic.account'].create({'name': 'Commercial & Marketing', 'plan_id': cls.analytic_plan.id})
-
-        cls.product_a = cls.env['product.product'].create({
-            'name': 'product_a',
-            'lst_price': 1000.0,
-        })
 
     def test_filtered_domain(self):
         """
@@ -36,81 +29,46 @@ class TestAnalyticMixin(TransactionCase):
             and the "in" operator used to directly indicate a tuple/list of analytic account ids.
             This test verifies that the public method handles all these operators.
         """
-        self.move = self.env['account.move'].create({
-            'move_type': 'out_invoice',
-            'date': '2023-02-01',
-            'invoice_date': '2023-02-01',
-            'invoice_line_ids': []
-        })
 
-        self.aml_sales_admin_ad = self.env['account.move.line'].create({
-            'product_id': self.product_a.id,
-            'price_unit': 1000.0,
+        self.adm_sales_admin_ad = self.env['account.analytic.distribution.model'].create({
             'analytic_distribution': {
                 self.sales_aa.id: 50,
-                self.administrative_aa.id: 50
-            },
-            'move_id': self.move.id
+                self.administrative_aa.id: 50,
+            }
         })
+        self.adm_rd_ad = self.env['account.analytic.distribution.model'].create({
+            'analytic_distribution': {self.rd_aa.id: 100},
+        })
+        self.adm_commercial_ad = self.env['account.analytic.distribution.model'].create({
+            'analytic_distribution': {self.commercial_aa.id: 100},
+        })
+        self.adm_com_marketing_ad = self.env['account.analytic.distribution.model'].create({
+            'analytic_distribution': {self.com_marketing_aa.id: 100},
+        })
+        self.adm_without_ad = self.env['account.analytic.distribution.model'].create({})
+        self.adm_without_ad_1 = self.env['account.analytic.distribution.model'].create({})
 
-        self.aml_rd_ad = self.env['account.move.line'].create({
-            'product_id': self.product_a.id,
-            'price_unit': 1000.0,
-            'analytic_distribution': {
-                self.rd_aa.id: 100,
-            },
-            'move_id': self.move.id
-        })
-
-        self.aml_commercial_ad = self.env['account.move.line'].create({
-            'product_id': self.product_a.id,
-            'price_unit': 1000.0,
-            'analytic_distribution': {
-                self.commercial_aa.id: 100,
-            },
-            'move_id': self.move.id
-        })
-
-        self.aml_com_marketing_ad = self.env['account.move.line'].create({
-            'product_id': self.product_a.id,
-            'price_unit': 1000.0,
-            'analytic_distribution': {
-                self.com_marketing_aa.id: 100,
-            },
-            'move_id': self.move.id
-        })
-
-        self.aml_without_ad = self.env['account.move.line'].create({
-            'product_id': self.product_a.id,
-            'price_unit': 100.0,
-            'move_id': self.move.id
-        })
-
-        self.aml_without_ad_1 = self.env['account.move.line'].create({
-            'product_id': self.product_a.id,
-            'price_unit': 100.0,
-            'move_id': self.move.id
-        })
+        adm_ids = self.env['account.analytic.distribution.model'].search([])
 
         def filter_domain(comparator, value):
-            return self.move.invoice_line_ids.filtered_domain([('analytic_distribution', comparator, value)])
+            return adm_ids.filtered_domain([('analytic_distribution', comparator, value)])
 
-        self.assertEqual(filter_domain('=', 'Research & Development'), self.aml_rd_ad)
-        self.assertEqual(filter_domain('=', 'Sales'), self.aml_sales_admin_ad)
-        self.assertEqual(filter_domain('=', 'Administrative'), self.aml_sales_admin_ad)
-        self.assertEqual(filter_domain('=', 'Commercial'), self.aml_commercial_ad)
+        self.assertEqual(filter_domain('=', 'Research & Development'), self.adm_rd_ad)
+        self.assertEqual(filter_domain('=', 'Sales'), self.adm_sales_admin_ad)
+        self.assertEqual(filter_domain('=', 'Administrative'), self.adm_sales_admin_ad)
+        self.assertEqual(filter_domain('=', 'Commercial'), self.adm_commercial_ad)
         self.assertFalse(filter_domain('=', ''))  # Should returns an empty recordset
-        self.assertEqual(filter_domain('=', self.commercial_aa.id), self.aml_commercial_ad)
+        self.assertEqual(filter_domain('=', self.commercial_aa.id), self.adm_commercial_ad)
 
-        self.assertEqual(filter_domain('ilike', 'Commercial'), self.aml_commercial_ad | self.aml_com_marketing_ad)
-        self.assertEqual(filter_domain('ilike', ''), self.move.invoice_line_ids - self.aml_without_ad - self.aml_without_ad_1)
+        self.assertEqual(filter_domain('ilike', 'Commercial'), self.adm_commercial_ad | self.adm_com_marketing_ad)
+        self.assertEqual(filter_domain('ilike', ''), adm_ids - self.adm_without_ad - self.adm_without_ad_1)
 
-        self.assertEqual(filter_domain('not ilike', 'Commercial'), self.move.invoice_line_ids - self.aml_com_marketing_ad - self.aml_commercial_ad)
-        self.assertEqual(filter_domain('not ilike', ''), self.aml_without_ad + self.aml_without_ad_1)  # Should returns an AML without analytic_distribution
+        self.assertEqual(filter_domain('not ilike', 'Commercial'), adm_ids - self.adm_com_marketing_ad - self.adm_commercial_ad)
+        self.assertEqual(filter_domain('not ilike', ''), self.adm_without_ad + self.adm_without_ad_1)  # Should returns an AML without analytic_distribution
 
-        self.assertEqual(filter_domain('!=', 'Commercial & Marketing'), self.move.invoice_line_ids - self.aml_com_marketing_ad)
-        self.assertEqual(filter_domain('!=', ''), self.move.invoice_line_ids)  # Should returns an every AML
-        self.assertEqual(filter_domain('!=', self.commercial_aa.id), self.move.invoice_line_ids - self.aml_commercial_ad)
+        self.assertEqual(filter_domain('!=', 'Commercial & Marketing'), adm_ids - self.adm_com_marketing_ad)
+        self.assertEqual(filter_domain('!=', ''), adm_ids)  # Should returns an every ADM
+        self.assertEqual(filter_domain('!=', self.commercial_aa.id), adm_ids - self.adm_commercial_ad)
 
-        self.assertEqual(filter_domain('in', [self.commercial_aa.id]), self.aml_commercial_ad)
-        self.assertEqual(filter_domain('in', (self.sales_aa + self.rd_aa).ids), self.aml_sales_admin_ad + self.aml_rd_ad)
+        self.assertEqual(filter_domain('in', [self.commercial_aa.id]), self.adm_commercial_ad)
+        self.assertEqual(filter_domain('in', (self.sales_aa + self.rd_aa).ids), self.adm_sales_admin_ad + self.adm_rd_ad)


### PR DESCRIPTION
Before this fix `TestAnalyticMixin` used `product.product`, `account.move`
and `account.move.line`, but `analytic` does not have these models in its
dependencies.

So this test causes `Single App` tests (when tests are run with just
concerned modules and its dependencies) to fail.

This commit adapts the tests so that they only use
`account.analytic.*` models.

original fix: https://github.com/odoo/odoo/commit/9d51fa9daee09e5467d38c5a890be7c0392d93f4

runbot error logs: https://runbot.odoo.com/web#id=74493&menu_id=405&cids=1&model=runbot.build.error&view_type=form