### PR TITLE
[IMP] mail: ignore odoo internal URL when creating link preview

### DIFF
--- a/addons/mail/controllers/link_preview.py
+++ b/addons/mail/controllers/link_preview.py
@@ -17,7 +17,9 @@ class LinkPreviewController(http.Controller):
             return
         if not message.is_current_user_or_guest_author and not guest.env.user._is_admin():
             return
-        guest.env["mail.link.preview"].sudo()._create_from_message_and_notify(message)
+        guest.env["mail.link.preview"].sudo()._create_from_message_and_notify(
+            message, request_url=request.httprequest.url_root
+        )
 
     @http.route("/mail/link_preview/hide", methods=["POST"], type="json", auth="public")
     @add_guest_to_context

--- a/addons/mail/models/mail_link_preview.py
+++ b/addons/mail/models/mail_link_preview.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import re
 import requests
 
 from datetime import timedelta
@@ -28,7 +29,7 @@ class LinkPreview(models.Model):
     create_date = fields.Datetime(index=True)
 
     @api.model
-    def _create_from_message_and_notify(self, message):
+    def _create_from_message_and_notify(self, message, request_url=None):
         if tools.is_html_empty(message.body):
             return self
         urls = OrderedSet(html.fromstring(message.body).xpath('//a[not(@data-oe-model)]/@href'))
@@ -38,7 +39,12 @@ class LinkPreview(models.Model):
         link_previews_by_url = {
             preview.source_url: preview for preview in message.sudo().link_preview_ids
         }
+        ignore_pattern = (
+            re.compile(f"{re.escape(request_url)}(odoo|web)(/|$|#|\\?)") if request_url else None
+        )
         for url in urls:
+            if ignore_pattern and ignore_pattern.match(url):
+                continue
             if url in link_previews_by_url:
                 preview = link_previews_by_url.pop(url)
                 if not preview.is_hidden:

--- a/addons/mail/tests/test_link_preview.py
+++ b/addons/mail/tests/test_link_preview.py
@@ -170,3 +170,38 @@ class TestLinkPreview(MailCommon):
             url = self.source_url
             session = requests.Session()
             link_preview.get_link_preview_from_url(url, session)
+
+    def test_link_preview_ignore_internal_link(self):
+        """Test internal links are properly ignored from link preview."""
+        with patch.object(requests.Session, "get", self._patch_with_og_properties), patch.object(
+            requests.Session, "head", self._patch_head_html
+        ):
+            urls = [
+                ("http://localhost:8069/", "http://localhost:8069/odoo", 0),
+                ("http://localhost:8069/", "http://localhost:8069/odoo/test", 0),
+                ("http://localhost:8069/", "http://localhost:8069/web/test", 0),
+                ("http://localhost:8069/", "http://localhost:8069/", 1),
+                ("http://localhost:8069/", "http://localhost:8069/odoo-experience", 1),
+                ("https://www.odoo.com/", "https://www.odoo.com/web", 0),
+                ("https://www.odoo.com/", "https://www.odoo.com/odoo", 0),
+                ("https://www.odoo.com/", "https://www.odoo.com/odoo/", 0),
+                ("https://www.odoo.com/", "https://www.odoo.com/odoo?debug=assets", 0),
+                ("https://www.odoo.com/", "https://www.odoo.com/odoo#anchor", 0),
+                ("https://www.odoo.com/", "https://www.odoo.com/odoo-experience", 1),
+                ("https://www.odoo.com/", "https://www.odoo.com/odoo/1519/tasks/4102866", 0),
+                ("http://www.odoo.com/", "https://www.odoo.com/odoo/1519/tasks/4102866", 1),
+                ("https://clients.odoo.com/", "https://www.odoo.com/odoo/1519/tasks/4102866", 1),
+                ("https://www.odoo.com/", "https://wwwaodoo.com/odoo/", 1),
+            ]
+            for request_url, url, counter in urls:
+                with self.subTest(request_url=request_url, url=url, counter=counter):
+                    message = self.test_partner.message_post(
+                        body=Markup(f'<a href="{url}">Nothing link</a>'),
+                    )
+                    self.env["mail.link.preview"]._create_from_message_and_notify(
+                        message, request_url
+                    )
+                    link_preview_count = self.env["mail.link.preview"].search_count(
+                        [("message_id", "=", message.id)]
+                    )
+                    self.assertEqual(link_preview_count, counter)


### PR DESCRIPTION
This PR will limit the generation of link previews inside the chatter and discuss for the internal links (/web|/odoo).

task-4102866