### PR TITLE
FIX] html_editor: properly reset the snapshots in resetFromSteps 

### DIFF
--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -184,7 +184,6 @@ export class HistoryPlugin extends Plugin {
         for (const step of steps) {
             this.applyMutations(step.mutations);
         }
-        this.snapshots = [{ step: steps[0] }];
         this.steps = steps;
         // todo: to test
         this.resources.historyResetFromSteps?.forEach((cb) => cb());

--- a/addons/html_editor/static/src/editor.js
+++ b/addons/html_editor/static/src/editor.js
@@ -17,9 +17,7 @@ import { initElementForEdition } from "./utils/sanitize";
  * @property { String } collaboration.collaborationChannel.collaborationFieldName
  * @property { Number } collaboration.collaborationChannel.collaborationResId
  * @property { 'start' | 'focus' } [collaboration.collaborativeTrigger]
-/**
 
-/**
  * @typedef { Object } EditorConfig
  * @property { string } [content]
  * @property { boolean } [allowInlineAtRoot]

--- a/addons/html_editor/static/src/others/collaboration/collaboration_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_plugin.js
@@ -281,6 +281,7 @@ export class CollaborationPlugin extends Plugin {
     resetFromSteps(steps, branchStepIds) {
         this.shared.resetSelection();
         this.shared.historyResetFromSteps(steps);
+        this.snapshots = [{ step: steps[0] }];
         this.branchStepIds = branchStepIds;
         this.postProcessExternalSteps();
         this.shared.enableObserver();

--- a/addons/html_editor/static/tests/odoo_collaboration.test.js
+++ b/addons/html_editor/static/tests/odoo_collaboration.test.js
@@ -1062,8 +1062,8 @@ describe("Disconnect & reconnect", () => {
     });
 });
 
-describe("Destroy odoo collaboration plugin", () => {
-    test("should destroy snapshot interval", async () => {
+describe("Snapshot", () => {
+    test("should destroy snapshot interval when the editor is destroyed", async () => {
         const pool = await createPeers(["p1"]);
         const peers = pool.peers;
         const editor = peers.p1.editor;
@@ -1072,6 +1072,27 @@ describe("Destroy odoo collaboration plugin", () => {
         editor.destroy();
         await advanceTime(2 * HISTORY_SNAPSHOT_INTERVAL);
         expect(peers.p1.plugins.collaboration._snapshotInterval).toBe(false);
+    });
+    test("should get the steps from the first made snapshot of a reseted peer", async () => {
+        const pool = await createPeers(["p1", "p2", "p3"]);
+        const peers = pool.peers;
+
+        await peers.p1.focus();
+        await peers.p2.focus();
+        await peers.p3.focus();
+
+        await peers.p1.openDataChannel(peers.p2);
+
+        insertEditorText(peers.p1.editor, "b");
+        await animationFrame();
+
+        await advanceTime(HISTORY_SNAPSHOT_INTERVAL);
+
+        await peers.p2.openDataChannel(peers.p3);
+
+        expect(peers.p3.getValue()).toBe(`<p>[]ab</p>`, {
+            message: "p3 should have the steps from the first snapshot of p2",
+        });
     });
 });
 


### PR DESCRIPTION
[FIX] html_editor: properly reset the snapshots in resetFromSteps

Before this commit, a traceback could arises reseting from a peer that
is itself reseted from another peer under a specific timiming
condition.

To reproduce:
- open 2 tabs (tab A then tab B) in the same todo record to be in
  collaboration
- close tab A then open a new tab (tab C) (the problem only arises
  when tab B is reset from tab A then tab C reset from B)
- wait 60 seconds for the method makeSnapshot to be called by the
  interval (HISTORY_SNAPSHOT_INTERVAL is 60seconds). Or call it
  manually if you're debugging.
- refresh tab C before 10 seconds have elapsed (because
  HISTORY_SNAPSHOT_BUFFER_TIME is 10seconds)

=> Traceback in tab B. And as a consequence tab C does not have the
same history as tab B so there is a network partition.

task-4160230



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
