### PR TITLE
[PERF] web: fix issue in tree views with button

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -3,6 +3,7 @@
 
     <t t-name="web.ListRenderer">
         <t t-set="_canSelectRecord" t-value="canSelectRecord"/>
+        <t t-set="_editedRecord" t-value="props.list.editedRecord"/>
         <div
             class="o_list_renderer o_renderer table-responsive"
             t-att-class="uniqueRendererClass"
@@ -116,7 +117,7 @@
                             href="#"
                             role="button"
                             t-att-class="create_index !== 0 ? 'ml16' : ''"
-                            t-att-tabindex="props.list.editedRecord ? '-1' : '0'"
+                            t-att-tabindex="_editedRecord ? '-1' : '0'"
                             t-on-click.stop.prevent="() => this.add({ context: create.context })"
                         >
                             <t t-esc="create.string"/>
@@ -129,7 +130,7 @@
                             record="props.list"
                             string="create.string"
                             title="create.title"
-                            tabindex="props.list.editedRecord ? '-1' : '0'"
+                            tabindex="_editedRecord ? '-1' : '0'"
                         />
                     </t>
                 </td>
@@ -258,7 +259,7 @@
                                 record="record"
                                 string="button.string"
                                 title="button.title"
-                                tabindex="props.list.editedRecord ? '-1' : '0'"
+                                tabindex="_editedRecord ? '-1' : '0'"
                                 onClick="isX2Many and record.isNew ? displaySaveNotification.bind(this) : ''"
                             />
                         </t>


### PR DESCRIPTION
When tree views contain buttons, the editedRecord getter is called for each row, and it iterates over all records each time.

To address this, we can compute the value of editedRecord once and then pass it down to the child views.

## Benchmark

Using the default view from Inventory > Report > Locations

| Number of Products | Time Before Fix | Time After Fix |
|--------------------|-----------------|----------------|
| 80                 | 137ms           | 108ms          |
| 500                | 1.56s           | 0.5s           |
| 1000               | 5.8s            | 1s             |
| 3000               | 54s             | 3.1s           |
| 6000               | crash           | 6.65s          |

opw-4133250





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
