### PR TITLE
[IMP] stock: allow route from another company

### DIFF
--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -555,7 +555,10 @@ class ProcurementGroup(models.Model):
         # ones of the company. This is not useful as a regular user since there is a record
         # rule to filter out the rules based on the company.
         if self.env.su and values.get('company_id'):
-            domain_company = ['|', ('company_id', '=', False), ('company_id', 'child_of', values['company_id'].ids)]
+            company_ids = set(values.get('company_id').ids)
+            if values.get('route_ids'):
+                company_ids |= set(values['route_ids'].company_id.ids)
+            domain_company = ['|', ('company_id', '=', False), ('company_id', 'child_of', list(company_ids))]
             domain = expression.AND([domain, domain_company])
         return domain
 


### PR DESCRIPTION
Sometimes we have to sudo the environement in order to find rules not in the current company (e.g. pull between companies). However during this sudo we add a domain to prevent taking too much rules.

But in a recent modification we want to allow route_ids in values from different compagnies. It doesn't work in a sudo env since the domain on the company will prevent the search on the rule in route_ids

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
