### PR TITLE
[FIX] website: Correct scroll behaviour for #top and #bottom anchors

### DIFF
--- a/addons/website/static/src/js/content/snippets.animation.js
+++ b/addons/website/static/src/js/content/snippets.animation.js
@@ -1064,10 +1064,13 @@ registry.anchorSlide = publicWidget.Widget.extend({
             // parameter, the "scrollTo" function handles the scroll to the top
             // or to the bottom of the document even if the header or the
             // footer is removed from the DOM.
-            scrollTo(hash, {
-                behavior: "smooth",
-                offset: this._computeExtraOffset(),
-            });
+            const element = document.querySelector(hash);
+            if (element) {
+                scrollTo(element, {
+                    behavior: "smooth",
+                    offset: this._computeExtraOffset(),
+                });
+            }
         } else {
             this._scrollTo($anchor, scrollValue);
         }


### PR DESCRIPTION
Fixed a bug where the scroll action to the top or bottom of the page failed.

Issue: The scroll function requires the element to scroll to, but we were passing the ID (a string) instead of the element.

Fix: Ensured that the element is retrieved from the ID, and passed the element instead of the ID to the scroll function.

task-4074921