### PR TITLE
[FIX] account: quick search by code prefix

### DIFF
--- a/addons/account/views/account_account_views.xml
+++ b/addons/account/views/account_account_views.xml
@@ -141,7 +141,7 @@
             <field name="model">account.account</field>
             <field name="arch" type="xml">
                 <search string="Accounts">
-                    <field name="name" filter_domain="['|', ('name','ilike',self), ('code','ilike',self)]" string="Account"/>
+                    <field name="name" filter_domain="['|', ('name', 'ilike', self), ('code', '=ilike', self + '%')]" string="Account"/>
                     <filter string="Receivable" name="receivableacc" domain="[('account_type','=','asset_receivable')]"/>
                     <filter string="Payable" name="payableacc" domain="[('account_type','=','liability_payable')]"/>
                     <filter string="Equity" name="equityacc" domain="[('internal_group','=', 'equity')]"/>


### PR DESCRIPTION
We should only see the accounts matching the code prefix, just like done in `_name_search`.
It was the expected result before this fix[^1] but the solution was to remove the feature instead of fix the traceback without explanation.

[^1]: 8852ff2767eef111807a3f6efc7cc5376656f45f
