### PR TITLE
[FIX] account: report field availability_condition should be set to country only if country_id is set

### DIFF
--- a/addons/account/data/account_reports_data.xml
+++ b/addons/account/data/account_reports_data.xml
@@ -24,6 +24,7 @@
         <record id="generic_tax_report_account_tax" model="account.report">
             <field name="name">Group by: Account &gt; Tax </field>
             <field name="root_report_id" ref="generic_tax_report"/>
+            <field name="availability_condition">always</field>
             <field name="column_ids">
                 <record id="generic_tax_report_account_tax_column_net" model="account.report.column">
                     <field name="name">NET</field>
@@ -39,6 +40,7 @@
         <record id="generic_tax_report_tax_account" model="account.report">
             <field name="name">Group by: Tax &gt; Account </field>
             <field name="root_report_id" ref="generic_tax_report"/>
+            <field name="availability_condition">always</field>
             <field name="column_ids">
                 <record id="generic_tax_report_tax_account_column_net" model="account.report.column">
                     <field name="name">NET</field>

--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -127,10 +127,10 @@ class AccountReport(models.Model):
             else:
                 report[field_name] = default_value
 
-    @api.depends('root_report_id')
+    @api.depends('root_report_id', 'country_id')
     def _compute_default_availability_condition(self):
         for report in self:
-            if report.root_report_id:
+            if report.root_report_id and report.country_id:
                 report.availability_condition = 'country'
             else:
                 report.availability_condition = 'always'


### PR DESCRIPTION

The base two variants of the generic_tax_report : (generic_tax_report_tax_account, generic_tax_report_account_tax) had the availability_condition set to country with no country_id.

The expected result was to have the availability_condition set to always as no country_id is set.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
