### PR TITLE
[FIX] website: fix font style of snippet headers

### DIFF
--- a/addons/website/views/new_page_template_templates.xml
+++ b/addons/website/views/new_page_template_templates.xml
@@ -546,14 +546,14 @@ overridden by modules), because:
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="pt0 o_cc3 o_colored_level" remove="o_cc1 pt80" separator=" "/>
     </xpath>
-    <xpath expr="//h6" position="replace">
-        <h6 class="lead" style="text-align: center;">Clients</h6>
+    <xpath expr="//span[hasclass('h5-fs')]" position="replace" mode="inner">
+        Clients
     </xpath>
-    <xpath expr="(//h6)[2]" position="replace">
-        <h6 class="lead" style="text-align: center;">Amazing Pages</h6>
+    <xpath expr="(//span[hasclass('h5-fs')])[2]" position="replace" mode="inner">
+        Growth Rate
     </xpath>
-    <xpath expr="(//h6)[3]" position="replace">
-        <h6 class="lead" style="text-align: center;">Websites</h6>
+    <xpath expr="(//span[hasclass('h5-fs')])[3]" position="replace" mode="inner">
+        Websites
     </xpath>
 </template>
 

--- a/addons/website/views/snippets/s_carousel.xml
+++ b/addons/website/views/snippets/s_carousel.xml
@@ -13,7 +13,7 @@
                     <div class="container oe_unremovable">
                         <div class="row">
                             <div class="carousel-content col-lg-6">
-                                <h2><span class="display-3-fs">Slide Title</span></h2>
+                                <h2 class="display-3-fs">Slide Title</h2>
                                 <p class="lead">Use this snippet to presents your content in a slideshow-like format. Don't write about products or services here, write about solutions.</p>
                                 <p>
                                     <a href="/contactus" class="btn btn-primary">Contact us</a>
@@ -27,7 +27,7 @@
                     <div class="container oe_unremovable">
                         <div class="row">
                             <div class="carousel-content col-lg-8 offset-lg-2 text-center pt48 pb40">
-                                <h2><span class="display-3-fs">Clever Slogan</span></h2>
+                                <h2 class="display-3-fs">Clever Slogan</h2>
                                 <div class="s_hr pt8 pb24" data-snippet="s_hr" data-name="Separator">
                                     <hr class="w-25 mx-auto"/>
                                 </div>

--- a/addons/website/views/snippets/s_key_benefits.xml
+++ b/addons/website/views/snippets/s_key_benefits.xml
@@ -11,10 +11,10 @@
                     </p>
                 </div>
                 <div class="o_grid_item g-col-lg-12 g-height-3 col-lg-12 pb96" style="--grid-item-padding-x: 16px; --grid-item-padding-y: 0px; grid-area: 2 / 1 / 5 / 13; z-index: 2;">
-                    <h2 class="display-3">Discover our<br/>main three benefits</h2>
+                    <h2 class="display-3-fs">Discover our<br/>main three benefits</h2>
                 </div>
                 <div class="o_grid_item g-col-lg-4 g-height-7 col-lg-4 pt48 pb24" style="--grid-item-padding-x: 16px; grid-area: 6 / 1 / 12 / 5; z-index: 3;">
-                    <span class="display-3 text-o-color-1">1</span>
+                    <span class="display-3-fs text-o-color-1">1</span>
                     <div class="s_hr pt8 pb24" data-snippet="s_hr" data-name="Separator">
                         <hr class="w-100 mx-auto"/>
                     </div>
@@ -22,7 +22,7 @@
                     <p>We provide transparent pricing that offers great value, ensuring you always get the best deal without hidden costs.</p>
                 </div>
                 <div class="o_grid_item g-col-lg-4 g-height-7 col-lg-4 pt48 pb24" style="--grid-item-padding-x: 16px; grid-area: 6 / 5 / 12 / 9; z-index: 4;">
-                    <span class="display-3 text-o-color-1">2</span>
+                    <span class="display-3-fs text-o-color-1">2</span>
                     <div class="s_hr pt8 pb24" data-snippet="s_hr" data-name="Separator">
                         <hr class="w-100 mx-auto"/>
                     </div>
@@ -30,7 +30,7 @@
                     <p>Our support team is available 24/7 to assist with any inquiries or issues, ensuring you get help whenever you need it.</p>
                 </div>
                 <div class="o_grid_item g-col-lg-4 g-height-7 col-lg-4 pt48 pb24" style="--grid-item-padding-x: 16px; grid-area: 6 / 9 / 12 / 13; z-index: 5;">
-                    <span class="display-3 text-o-color-1">3</span>
+                    <span class="display-3-fs text-o-color-1">3</span>
                     <div class="s_hr pt8 pb24" data-snippet="s_hr" data-name="Separator">
                         <hr class="w-100 mx-auto"/>
                     </div>

--- a/addons/website/views/snippets/s_masonry_block.xml
+++ b/addons/website/views/snippets/s_masonry_block.xml
@@ -67,12 +67,12 @@
     <div class="row o_grid_mode" data-row-count="8" style="gap: 16px;">
         <div class="o_grid_item o_cc o_cc5 g-height-8 g-col-lg-6 col-lg-6 justify-content-start shadow rounded-3 oe_img_bg o_bg_img_center" data-name="Block" style="z-index: 1; grid-area: 1 / 1 / 9 / 7; background-image: url(/web/image/website.s_masonry_block_default_image_2); --grid-item-padding-y: 30px; --grid-item-padding-x: 30px;">
             <div class="o_we_bg_filter bg-black-50"/>
-            <h3 class="display-4">Key <br class="d-none d-lg-inline"/>Milestone</h3>
+            <h3 class="display-4-fs">Key <br class="d-none d-lg-inline"/>Milestone</h3>
             <p class="lead">Reaching new heights together</p>
         </div>
         <div class="o_grid_item o_cc o_cc5 g-height-8 g-col-lg-6 col-lg-6 justify-content-start shadow rounded-3 oe_img_bg o_bg_img_center" data-name="Block" style="z-index: 2; grid-area: 1 / 7 / 9 / 13; background-image: url(/web/image/website.s_masonry_block_default_image_1); --grid-item-padding-y: 30px; --grid-item-padding-x: 30px;">
             <div class="o_we_bg_filter bg-black-50"/>
-            <h3 class="display-4">Innovation <br class="d-none d-lg-inline"/>Hub</h3>
+            <h3 class="display-4-fs">Innovation <br class="d-none d-lg-inline"/>Hub</h3>
             <p class="lead">Where ideas come to life</p>
         </div>
     </div>
@@ -120,11 +120,11 @@
             <img src="/web/image/website.s_masonry_block_default_image_1" class="img img-fluid mx-auto" alt=""/>
         </div>
         <div class="o_grid_item o_cc o_cc2 g-height-3 g-col-lg-3 col-lg-3 justify-content-center text-center order-lg-0 rounded-3" data-name="Block" style="order: 4; z-index: 5; --grid-item-padding-y: 20px; --grid-item-padding-x: 20px; grid-area: 8 / 7 / 11 / 10;">
-            <h3><span class="display-1">22%</span></h3>
+            <h3 class="display-1-fs">22%</h3>
             <p>Reaching new heights</p>
         </div>
         <div class="o_grid_item o_cc o_cc4 g-height-3 g-col-lg-3 col-lg-3 justify-content-center text-center order-lg-0 rounded-3" data-name="Block" style="order: 5; z-index: 6; --grid-item-padding-y: 20px; --grid-item-padding-x: 20px; grid-area: 8 / 10 / 11 / 13; linear-gradient(135deg, var(--o-color-4) -400%, var(--o-color-1) 100%);">
-            <h3><span class="display-1">+12</span><br/></h3>
+            <h3 class="display-1-fs">+12</h3>
             <p>Mark the difference</p>
         </div>
     </div>

--- a/addons/website/views/snippets/s_numbers.xml
+++ b/addons/website/views/snippets/s_numbers.xml
@@ -12,16 +12,22 @@
                 <div class="col-lg-7 offset-lg-1">
                     <div class="row">
                         <div class="col-lg-4 pt24 pb24 text-center" data-name="Number Box">
-                            <span class="s_number h1 display-1">12k</span>
-                            <h6 class="lead">Useful options</h6>
+                            <p class="lead">
+                                <span class="s_number display-1-fs">12k</span><br/>
+                                <span class="h5-fs">Useful options</span>
+                            </p>
                         </div>
                         <div class="col-lg-4 pt24 pb24 text-center" data-name="Number Box">
-                            <span class="s_number h1 display-1">45%</span>
-                            <h6 class="lead">More leads</h6>
+                            <p class="lead">
+                                <span class="s_number display-1-fs">45%</span><br/>
+                                <span class="h5-fs">More leads</span>
+                            </p>
                         </div>
                         <div class="col-lg-4 pt24 pb24 text-center" data-name="Number Box">
-                            <span class="s_number h1 display-1">8+</span>
-                            <h6 class="lead">Amazing pages</h6>
+                            <p class="lead">
+                                <span class="s_number display-1-fs">8+</span><br/>
+                                <span class="h5-fs">Amazing pages</span>
+                            </p>
                         </div>
                     </div>
                 </div>

--- a/addons/website/views/snippets/s_numbers_showcase.xml
+++ b/addons/website/views/snippets/s_numbers_showcase.xml
@@ -12,19 +12,19 @@
                     <p><a href="#" class="btn btn-primary" role="button">More details</a></p>
                 </div>
                 <div class="o_grid_item g-height-4 g-col-lg-4 col-lg-4 o_cc o_cc3" style="--grid-item-padding-y: 32px; --grid-item-padding-x: 32px; grid-area: 1 / 5 / 5 / 9; z-index: 2;">
-                    <h3 class="display-3">12k</h3>
+                    <h3 class="display-3-fs">12k</h3>
                     <p><br/></p>
                     <h4>Useful options</h4>
                     <p>Explore a vast array of practical and beneficial choices.</p>
                 </div>
                 <div class="o_grid_item g-height-4 g-col-lg-4 col-lg-4 o_cc o_cc5" style="--grid-item-padding-y: 32px; --grid-item-padding-x: 32px; grid-area: 1 / 9 / 5 / 13; z-index: 3;">
-                    <h3 class="display-3">45%</h3>
+                    <h3 class="display-3-fs">45%</h3>
                     <p><br/></p>
                     <h4>More leads</h4>
                     <p>Boost your pipeline with an increase in potential leads.</p>
                 </div>
                 <div class="o_grid_item g-height-4 g-col-lg-8 col-lg-8 o_cc o_cc4" style="--grid-item-padding-y: 32px; --grid-item-padding-x: 32px; grid-area: 5 / 5 / 9 / 13; z-index: 4;">
-                    <h3 class="display-3">8+</h3>
+                    <h3 class="display-3-fs">8+</h3>
                     <p><br/></p>
                     <h4>Amazing pages</h4>
                     <p>Discover outstanding and highly engaging web pages.</p>


### PR DESCRIPTION
Some snippets contain incorrect font style that are not achievable using the editor (for example: `<h2 class="display-3">` in the "Key benefits" snippet).

This commit adapts these snippets to align with what the editor would generate if we recreated them from scratch.

task-4148057