### PR TITLE
[FIX] mail: prioritize alias over reply route, forwarded mail

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -868,6 +868,12 @@ class MailThread(models.AbstractModel):
         if alias:
             if thread_id:
                 obj = record_set[0]
+                if obj._name == 'mail.group':
+                    if obj.alias_id and obj.alias_id != alias:
+                        self._routing_warn(
+                            _('Detected message forward, reseting route for alias %(name)s', name=alias.alias_name), message_id, route, False)
+                        return ()
+
             elif alias.alias_parent_model_id and alias.alias_parent_thread_id:
                 obj = self.env[alias.alias_parent_model_id.model].browse(alias.alias_parent_thread_id)
             else:


### PR DESCRIPTION
When you forward a mail from odoo, odoo will use the reference to the existing message and append it to the message's thread. This is undesirable when forwarding mail group emails to different groups.

Reproduce
---
- install mail_group
- Add an alias "example.com" in settings
- Create two public mailing groups:
	- mga "Email Alias": mga@example.com
	- mgb "Email Alias": mgb@example.com
- Send 1st email  to mga (ref.1)
- Obtain Message-ID given to 1st message
- Use obtained id in reference header of 2nd message (ref.2) and send it to mgb
- BUG: email sent to mgb arrives at mga

(ref.1)
---
```eml
From: <member1@example.com>
Subject: sent to mga
To: <mga@example.com>
Initiall email sent to mga
```

(ref.2)
---
```eml
From: <member2@example.com>
Subject: sent to mgb
To: <mgb@example.com>
References: <1725354872.2640402@localhost>
Message to mgb with References added manually
```
Update References header value in the above eml

opw-3820925