### PR TITLE
[17.0] Fix fullcalendar TypeError: offsetTracker is undefined

### DIFF
--- a/addons/web/static/lib/fullcalendar/interaction/main.js
+++ b/addons/web/static/lib/fullcalendar/interaction/main.js
@@ -1071,7 +1071,9 @@ Docs & License: https://fullcalendar.io/
             for (var id in droppableStore) {
                 var component = droppableStore[id].component;
                 var offsetTracker = offsetTrackers[id];
-                if (offsetTracker.isWithinClipping(offsetLeft, offsetTop)) {
+                if (offsetTracker && // Odoo patch - backport fix
+                    offsetTracker.isWithinClipping(offsetLeft, offsetTop)
+                ) {
                     var originLeft = offsetTracker.computeLeft();
                     var originTop = offsetTracker.computeTop();
                     var positionLeft = offsetLeft - originLeft;

--- a/doc/cla/corporate/novacode.md
+++ b/doc/cla/corporate/novacode.md
@@ -1,0 +1,15 @@
+Netherlands, 2024-09-03
+
+Nova Code agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Bob Leers bob@novacode.nl https://github.com/bobslee
+
+List of contributors:
+
+Bob Leers bob@novacode.nl https://github.com/bobslee


### PR DESCRIPTION
In very rare occasions, when dragging (moving an event) in the calendar view, the following TypeError can occur. This could be related to custom computations (fields, other actions) when the ORM is updating a the related record. Perhaps this slows down the UI/frontend and triggers the error.

The change just adds a JS undefined check, to addres the error below. It seems really cumbersome to add unittest and even reproduction isn't repeatable.

TypeError: offsetTracker is undefined
    HitDragging.prototype.queryHitForOffset@https://.../web/static/lib/fullcalendar/interaction/main.js:1074:21
    HitDragging.prototype.handleMove@https://.../web/static/lib/fullcalendar/interaction/main.js:1049:28
    HitDragging/this.handleDragMove@https://.../web/static/lib/fullcalendar/interaction/main.js:1000:23
    applyAll@https://.../web/static/lib/fullcalendar/core/main.js:988:36
    EmitterMixin.prototype.triggerWith@https://.../web/static/lib/fullcalendar/core/main.js:3582:25
    EmitterMixin.prototype.trigger@https://.../web/static/lib/fullcalendar/core/main.js:3577:18
    FeaturefulElementDragging/_this.onPointerMove@https://.../web/static/lib/fullcalendar/interaction/main.js:809:39
    applyAll@https://.../web/static/lib/fullcalendar/core/main.js:988:36
    EmitterMixin.prototype.triggerWith@https://.../web/static/lib/fullcalendar/core/main.js:3582:25
    EmitterMixin.prototype.trigger@https://.../web/static/lib/fullcalendar/core/main.js:3577:18
    PointerDragging/this.handleMouseMove@https://.../web/static/lib/fullcalendar/interaction/main.js:102:31

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
