### PR TITLE
 [FIX] web_editor: pasting within blockquote and pre tags

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -4634,12 +4634,13 @@ export class OdooEditor extends EventTarget {
         } else {
             const text = ev.clipboardData.getData('text/plain');
             const selectionIsInsideALink = !!closestElement(sel.anchorNode, 'a');
+            const isSelectionInsidePre = !!closestElement(sel.anchorNode, 'pre');
             let splitAroundUrl = [text];
             // Avoid transforming dynamic placeholder pattern to url.
             if(!text.match(/\${.*}/gi)) {
                 splitAroundUrl = text.split(URL_REGEX);
             }
-            if (splitAroundUrl.length === 3 && !splitAroundUrl[0] && !splitAroundUrl[2]) {
+            if (splitAroundUrl.length === 3 && !splitAroundUrl[0] && !splitAroundUrl[2] && !isSelectionInsidePre) {
                 // Pasted content is a single URL.
                 const url = /^https?:\/\//i.test(text) ? text : 'https://' + text;
                 const youtubeUrl = this.options.allowCommandVideo && YOUTUBE_URL_GET_VIDEO_ID.exec(url);
@@ -4738,7 +4739,7 @@ export class OdooEditor extends EventTarget {
                         : 'https://' + splitAroundUrl[i];
                     // Even indexes will always be plain text, and odd indexes will always be URL.
                     // A url cannot be transformed inside an existing link.
-                    if (i % 2 && !selectionIsInsideALink) {
+                    if (i % 2 && !selectionIsInsideALink && !isSelectionInsidePre) {
                         this._applyCommand('insert', this._createLink(splitAroundUrl[i], url));
                     } else if (splitAroundUrl[i] !== '') {
                         const textFragments = splitAroundUrl[i].split(/\r?\n/);

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -4758,7 +4758,10 @@ export class OdooEditor extends EventTarget {
                                 // Break line by inserting new paragraph and
                                 // remove current paragraph's bottom margin.
                                 const p = closestElement(sel.anchorNode, 'p');
-                                if (isUnbreakable(closestBlock(sel.anchorNode))) {
+                                if (
+                                    isUnbreakable(closestBlock(sel.anchorNode)) ||
+                                    closestElement(sel.anchorNode).nodeName === 'PRE'
+                                ) {
                                     this._applyCommand('oShiftEnter');
                                 } else {
                                     this._applyCommand('oEnter');

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -204,7 +204,7 @@ export const editorCommands = {
             block.textContent !== "" && node.textContent !== "" &&
             (
                 block.nodeName === node.nodeName ||
-                ['BLOCKQUOTE', 'PRE', 'DIV'].includes(block.nodeName)
+                block.nodeName === 'DIV'
             )
         );
 
@@ -356,12 +356,6 @@ export const editorCommands = {
                 insertBefore = false;
             } else {
                 currentNode.after(nodeToInsert);
-            }
-            if (
-                ['BLOCKQUOTE', 'PRE'].includes(block.nodeName) &&
-                paragraphRelatedElements.includes(nodeToInsert.nodeName)
-            ) {
-                nodeToInsert = setTagName(nodeToInsert, block.nodeName);
             }
             let convertedList;
             if (

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/enter.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/enter.js
@@ -37,6 +37,19 @@ HTMLElement.prototype.oEnter = function (offset, firstSplit = true) {
     if (isUnbreakable(this)) {
         throw UNBREAKABLE_ROLLBACK_CODE;
     }
+    if (
+        !this.textContent &&
+        ['BLOCKQUOTE', 'PRE'].includes(this.parentElement.nodeName) &&
+        !this.nextSibling
+    ) {
+        const parent = this.parentElement;
+        const index = childNodeIndex(this);
+        if (this.previousElementSibling) {
+            this.remove();
+            return parent.oEnter(index, !didSplit);
+        }
+        return parent.oEnter(index + 1, !didSplit);
+    }
     let restore;
     if (firstSplit) {
         restore = prepareUpdate(this, offset);
@@ -92,7 +105,7 @@ HTMLElement.prototype.oEnter = function (offset, firstSplit = true) {
  */
 HTMLHeadingElement.prototype.oEnter = function () {
     const newEl = HTMLElement.prototype.oEnter.call(this, ...arguments);
-    if ([...newEl.textContent].every(char => char === '\u200B')) { // empty or all invisible
+    if (newEl && [...newEl.textContent].every(char => char === '\u200B')) { // empty or all invisible
         const node = setTagName(newEl, 'P');
         node.replaceChildren(document.createElement('br'));
         setCursorStart(node);

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -1755,7 +1755,7 @@ export const paragraphRelatedElements = [
  * @returns {boolean}
  */
 export function allowsParagraphRelatedElements(node) {
-    return isBlock(node) && !paragraphRelatedElements.includes(node.nodeName);
+    return isBlock(node) && !['P', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6'].includes(node.nodeName);
 }
 
 /**

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
@@ -1136,28 +1136,28 @@ describe('Paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
                     },
-                    contentAfter: '<blockquote>abc</blockquote><blockquote>def</blockquote><blockquote>ghi[]</blockquote>',
+                    contentAfter: '<blockquote><h1>abc</h1><h2>def</h2><h3>ghi[]</h3></blockquote>',
                 });
                 await testEditor(BasicEditor, {
                     contentBefore: '<blockquote>x[]</blockquote>',
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
                     },
-                    contentAfter: '<blockquote>xabc</blockquote><blockquote>def</blockquote><blockquote>ghi[]</blockquote>',
+                    contentAfter: '<blockquote>x<h1>abc</h1><h2>def</h2><h3>ghi[]</h3></blockquote>',
                 });
                 await testEditor(BasicEditor, {
                     contentBefore: '<blockquote>[]x</blockquote>',
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
                     },
-                    contentAfter: '<blockquote>abc</blockquote><blockquote>def</blockquote><blockquote>ghi[]x</blockquote>',
+                    contentAfter: '<blockquote><h1>abc</h1><h2>def</h2><h3>ghi[]</h3>x</blockquote>',
                 });
                 await testEditor(BasicEditor, {
                     contentBefore: '<blockquote>x[]y</blockquote>',
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
                     },
-                    contentAfter: '<blockquote>xabc</blockquote><blockquote>def</blockquote><blockquote>ghi[]y</blockquote>',
+                    contentAfter: '<blockquote>x<h1>abc</h1><h2>def</h2><h3>ghi[]</h3>y</blockquote>',
                 });
             });
             it('should paste all nodes as pre when pasting in pre', async () => {
@@ -1166,28 +1166,28 @@ describe('Paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
                     },
-                    contentAfter: '<pre>abc</pre><pre>def</pre><pre>ghi[]</pre>',
+                    contentAfter: '<pre><h1>abc</h1><h2>def</h2><h3>ghi[]</h3></pre>',
                 });
                 await testEditor(BasicEditor, {
                     contentBefore: '<pre>x[]</pre>',
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
                     },
-                    contentAfter: '<pre>xabc</pre><pre>def</pre><pre>ghi[]</pre>',
+                    contentAfter: '<pre>x<h1>abc</h1><h2>def</h2><h3>ghi[]</h3></pre>',
                 });
                 await testEditor(BasicEditor, {
                     contentBefore: '<pre>[]x</pre>',
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
                     },
-                    contentAfter: '<pre>abc</pre><pre>def</pre><pre>ghi[]x</pre>',
+                    contentAfter: '<pre><h1>abc</h1><h2>def</h2><h3>ghi[]</h3>x</pre>',
                 });
                 await testEditor(BasicEditor, {
                     contentBefore: '<pre>x[]y</pre>',
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
                     },
-                    contentAfter: '<pre>xabc</pre><pre>def</pre><pre>ghi[]y</pre>',
+                    contentAfter: '<pre>x<h1>abc</h1><h2>def</h2><h3>ghi[]</h3>y</pre>',
                 });
             });
             it('should not unwrap empty block nodes even when pasting on same node', async () => {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
@@ -451,6 +451,15 @@ describe('Paste', () => {
                     contentAfter: '<div><span style="font-size: 9px;">ab<br>c<br>d[]</span></div>',
                 });
             });
+            it('should paste text and understand \\n newlines within PRE element', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<pre>[]<br></div>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'a\nb\nc');
+                    },
+                    contentAfter: '<pre>a<br>b<br>c[]</pre>',
+                });
+            });
         });
         describe('range not collapsed', async () => {
             it('should paste a text in a p', async () => {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
@@ -2514,6 +2514,15 @@ describe('Paste', () => {
                     contentAfter: '<p><a href="#">a123[]b</a></p>',
                 });
             });
+            it('should paste and not transform an URL in a pre tag', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<pre>[]<br></pre>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'http://www.xyz.com');
+                    },
+                    contentAfter: '<pre>http://www.xyz.com[]</pre>',
+                });
+            });
         });
         describe('range not collapsed', async () => {
             it('should paste and transform an URL in a p', async () => {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
@@ -3636,7 +3636,37 @@ X[]
                         contentAfter: '<pre>abc</pre><p>[]<br></p>',
                     });
                 });
+                it('should insert a new line within the pre', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<pre><p>abc</p><p>def[]</p></pre>',
+                        stepFunction: insertParagraphBreak,
+                        contentAfter: '<pre><p>abc</p><p>def</p><p>[]<br></p></pre>',
+                    });
+                });
+                it('should insert a new line after pre', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<pre><p>abc</p><p>def</p><p>[]<br></p></pre>',
+                        stepFunction: insertParagraphBreak,
+                        contentAfter: '<pre><p>abc</p><p>def</p></pre><p>[]<br></p>',
+                    });
+                });
             });
+            describe('Blockquote', () => {
+                it('should insert a new line within the blockquote', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<blockquote><h1>abc</h1><h2>def[]</h2></blockquote>',
+                        stepFunction: insertParagraphBreak,
+                        contentAfter: '<blockquote><h1>abc</h1><h2>def</h2><p>[]<br></p></blockquote>',
+                    });
+                });
+                it('should insert a new line after blockquote', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<blockquote><h1>abc</h1><h2>def</h2><p>[]<br></p></blockquote>',
+                        stepFunction: insertParagraphBreak,
+                        contentAfter: '<blockquote><h1>abc</h1><h2>def</h2></blockquote><p>[]<br></p>',
+                    });
+                });
+            })
             describe('Consecutive', () => {
                 it('should duplicate an empty paragraph twice', async () => {
                     await testEditor(BasicEditor, {

--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -646,6 +646,10 @@ blockquote {
     font-style: italic;
 }
 
+pre {
+    white-space: pre-wrap;
+}
+
 // Extend bootstrap to create background and text utilities for some colors
 // outside of the $theme-colors too (but not btn-, alert-, etc).
 @for $index from 1 through 5 {


### PR DESCRIPTION
Description of the issue this PR addresses:

Current behavior before PR:

I. Pasting content within `blockquote` and `pre` elements resulted in each node being converted into separate `blockquote` or `pre` elements.
II. When pasting the clipboard content as plain text (CTRL+SHIFT+V) inside a `PRE` element would convert each line break into a new paragraph.
III. When text with a url is pasted within a pre tag the text is converted to a link.

Desired behavior after PR is merged:

I. `blockquote` and `pre` should be considered like wrappers, allowing paragraph-related elements to be pasted inside them.
II. When pasting the clipboard content as plain text within `pre`, every new line should be pasted within the `pre` tag.
III. When text with a url is pasted within a pre tag it should not convert it to a link.
IV. The `pre` tag does not have automatic word-wrapping or line-breaks as it is intended to keep the formatting of the text. This commit ensures that long text within `pre` tags does not overflow.

task-4154465

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
