### PR TITLE
[FIX] point_of_sale: fix line saving in pos_order

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -110,6 +110,13 @@ class PosOrder(models.Model):
             pos_order = pos_order.with_company(pos_order.company_id)
         else:
             pos_order = self.env['pos.order'].browse(order.get('id'))
+
+            # Save line before to avoid exception if a line is deleted
+            # when vals change the state to 'paid'
+            if order.get('lines'):
+                pos_order.write({'lines': order.get('lines')})
+                order['lines'] = []
+
             pos_order.write(order)
 
         pos_order._link_combo_items(combo_child_uuids_by_parent_uuid)


### PR DESCRIPTION
When saving an order with a deleted line just after paying it, an error was raised because we cannot remove line from paid order.

Now the line is saved before mark the order as paid.

taskId: 4137889

