### PR TITLE
[FIX] website_blog: tag caching issue.

### DIFF
--- a/addons/website_blog/tests/test_performance.py
+++ b/addons/website_blog/tests/test_performance.py
@@ -35,7 +35,7 @@ class TestBlogPerformance(UtilPerf):
         } for blog in blogs])
 
     def test_10_perf_sql_blog_standard_data(self):
-        self.assertLessEqual(self._get_url_hot_query('/blog'), 11)
+        self.assertLessEqual(self._get_url_hot_query('/blog'), 12)
 
     def test_20_perf_sql_blog_bigger_data_scaling(self):
         BlogPost = self.env['blog.post']
@@ -47,7 +47,7 @@ class TestBlogPerformance(UtilPerf):
         for blog_post in blog_posts:
             blog_post.tag_ids += blog_tags
             blog_tags = blog_tags[:-1]
-        self.assertEqual(self._get_url_hot_query('/blog'), 10)
+        self.assertEqual(self._get_url_hot_query('/blog'), 12)
         self.assertLessEqual(self._get_url_hot_query('/blog', cache=False), 33)
         self.assertLessEqual(self._get_url_hot_query(blog_post[0].website_url), 16)
         self.assertLessEqual(self._get_url_hot_query(blog_post[0].website_url, cache=False), 20)

--- a/addons/website_blog/views/website_blog_posts_loop.xml
+++ b/addons/website_blog/views/website_blog_posts_loop.xml
@@ -98,7 +98,7 @@ according to the enabled options.
             <!-- Loop through posts: exclude the first one if already displayed as top banner -->
             <t t-foreach="posts" t-as="blog_post">
                 <!-- Assign 'colWidth': 'col-12' is default for List-View and mobile -->
-                <div t-attf-class="pb-4 col-12 #{colWidth}" t-cache="blog_post,opt_blog_list_view,opt_blog_readable,active_tag_ids">
+                <div t-attf-class="pb-4 col-12 #{colWidth}" t-cache="blog_post,opt_blog_list_view,opt_blog_readable,active_tag_ids,blog_post.tag_ids">
                     <article t-attf-class="o_wblog_post position-relative #{'card h-100' if opt_blog_cards_design else ''}" name="blog_post">
                         <!-- List-View Design -->
                         <t t-if="opt_blog_list_view">
@@ -201,7 +201,7 @@ according to the enabled options.
 
 <!-- ======   Sub-Template: Posts list : Posts Teaser + Tags  ============= -->
 <template id="post_teaser">
-    <t t-cache="blog_post,str(active_tag_ids)">
+    <t t-cache="blog_post,str(active_tag_ids),blog_post.tag_ids">
     <a t-attf-href="/blog/#{slug(blog_post.blog_id)}/#{slug(blog_post)}" class="text-reset text-decoration-none">
         <div t-if="opt_blog_list_view" t-field="blog_post.teaser" class="mt-2 o_wblog_read_text"/>
         <div t-else="" t-field="blog_post.teaser" t-attf-class="mt-2 #{opt_blog_readable and 'o_wblog_normalize_font'}"/>


### PR DESCRIPTION
Steps to reproduce the issue:

1. Create a new website blog tag.
2. Apply that tag to a particular post.
3. Check the website blog page to see the newly added tags.
4. Modify the tag's name and color.
5. Recheck the website blog page changes will not be reflected.

Before this commit, Changes made to a blog's tags were not being
updated in real-time on the website. This issue was `tag_ids` field of
`blog_post` was not cached.

After this commit: The issue has been fixed by including the necessary
fields in the template's caching mechanism, ensuring that changes to
tags are reflected correctly on the website. Additionally, the query
count has been incremented to account for the improved tag caching
behavior.

task-4045724