### PR TITLE
[REF] mail, *: rename attachment on message (js)

### DIFF
--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -91,7 +91,7 @@ class TestImLivechatMessage(HttpCase, MailCommon):
             {
                 "mail.message": self._filter_messages_fields(
                     {
-                        "attachments": [],
+                        "attachment_ids": [],
                         "author": {"id": self.users[1].partner_id.id, "type": "partner"},
                         "body": message.body,
                         "date": fields.Datetime.to_string(message.date),
@@ -194,7 +194,7 @@ class TestImLivechatMessage(HttpCase, MailCommon):
                             "data": {
                                 "mail.message": self._filter_messages_fields(
                                     {
-                                        "attachments": [],
+                                        "attachment_ids": [],
                                         "author": {
                                             "id": self.env.user.partner_id.id,
                                             "type": "partner",

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1019,7 +1019,7 @@ class Message(models.Model):
             data["default_subject"] = default_subject
             vals = {
                 # sudo: mail.message - reading attachments on accessible message is allowed
-                "attachments": Store.many(message.sudo().attachment_ids.sorted("id")),
+                "attachment_ids": Store.many(message.sudo().attachment_ids.sorted("id")),
                 # sudo: mail.message - reading link preview on accessible message is allowed
                 "linkPreviews": Store.many(
                     message.sudo().link_preview_ids.filtered(lambda l: not l.is_hidden)

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4542,7 +4542,7 @@ class MailThread(models.AbstractModel):
         empty_messages._cleanup_side_records()
         empty_messages.write({'pinned_at': None})
         res = {
-            "attachments": Store.many(message.attachment_ids.sorted("id")),
+            "attachment_ids": Store.many(message.attachment_ids.sorted("id")),
             "body": message.body,
             "pinned_at": message.pinned_at,
             "recipients": Store.many(message.partner_ids, fields=["name", "write_date"]),

--- a/addons/mail/static/src/core/common/attachment_model.js
+++ b/addons/mail/static/src/core/common/attachment_model.js
@@ -29,7 +29,7 @@ export class Attachment extends FileModelMixin(Record) {
 
     thread = Record.one("Thread", { inverse: "attachments" });
     res_name;
-    message = Record.one("Message");
+    message = Record.one("Message", { inverse: "attachment_ids" });
     /** @type {luxon.DateTime} */
     create_date = Record.attr(undefined, { type: "datetime" });
 

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -584,7 +584,7 @@ export class Composer extends Component {
         } else if (
             this.props.composer.text.trim() ||
             attachments.length > 0 ||
-            (this.message && this.message.attachments.length > 0)
+            (this.message && this.message.attachment_ids.length > 0)
         ) {
             if (!this.state.active) {
                 return;
@@ -652,7 +652,7 @@ export class Composer extends Component {
 
     async editMessage() {
         const composer = toRaw(this.props.composer);
-        if (composer.text || composer.message.attachments.length > 0) {
+        if (composer.text || composer.message.attachment_ids.length > 0) {
             await this.processMessage(async (value) =>
                 composer.message.edit(value, composer.attachments, {
                     mentionedChannels: composer.mentionedChannels,

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -114,10 +114,10 @@
                                     <t t-if="!message.is_note and !message.isPending and message.hasTextContent and !env.inChatWindow" t-call="mail.Message.actions"/>
                                 </div>
                                 <AttachmentList
-                                    t-if="message.attachments.length > 0"
-                                    attachments="message.attachments.map((a) => a)"
+                                    t-if="message.attachment_ids.length > 0"
+                                    attachments="message.attachment_ids.map((a) => a)"
                                     unlinkAttachment.bind="onClickAttachmentUnlink"
-                                    imagesHeight="message.attachments.length === 1 ? 300 : 75"
+                                    imagesHeight="message.attachment_ids.length === 1 ? 300 : 75"
                                     messageSearch="props.messageSearch"/>
                                 <LinkPreviewList t-if="message.linkPreviews.length > 0 and store.hasLinkPreviewFeature and !message.linkPreviewSquash" linkPreviews="message.linkPreviews" deletable="props.message.editable"/>
                             </div>

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -175,13 +175,13 @@ messageActionsRegistry
         sequence: 90,
     })
     .add("download_files", {
-        condition: (component) => component.message.attachments.length > 1,
+        condition: (component) => component.message.attachment_ids.length > 1,
         icon: "fa-download",
         title: _t("Download Files"),
         onClick: (component) =>
             download({
                 data: {
-                    file_ids: component.message.attachments.map((rec) => rec.id),
+                    file_ids: component.message.attachment_ids.map((rec) => rec.id),
                     zip_name: `attachments_${DateTime.local().toFormat("HHmmddMMyyyy")}.zip`,
                 },
                 url: "/mail/attachment/zip",

--- a/addons/mail/static/src/core/common/message_in_reply.xml
+++ b/addons/mail/static/src/core/common/message_in_reply.xml
@@ -15,7 +15,7 @@
                             <t t-if="!props.message.parentMessage.isBodyEmpty">
                                 <t t-out="props.message.parentMessage.body"/>
                             </t>
-                            <t t-elif="props.message.parentMessage.attachments.length > 0">
+                            <t t-elif="props.message.parentMessage.attachment_ids.length > 0">
                                 <span class="me-2 fst-italic">Click to see the attachments</span>
                                 <i class="fa fa-image"/>
                             </t>

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -40,7 +40,7 @@ export class Message extends Record {
         }
     }
 
-    attachments = Record.many("Attachment", { inverse: "message" });
+    attachment_ids = Record.many("Attachment", { inverse: "message" });
     author = Record.one("Persona");
     body = Record.attr("", { html: true });
     composer = Record.one("Composer", { inverse: "message", onDelete: (r) => r.delete() });
@@ -286,7 +286,7 @@ export class Message extends Record {
     }
 
     get hasTextContent() {
-        return /*(this.editDate && this.attachments.length) || */ !this.isBodyEmpty;
+        return /*(this.editDate && this.attachment_ids.length) || */ !this.isBodyEmpty;
     }
 
     isEmpty = Record.attr(false, {
@@ -294,7 +294,7 @@ export class Message extends Record {
         compute() {
             return (
                 this.isBodyEmpty &&
-                this.attachments.length === 0 &&
+                this.attachment_ids.length === 0 &&
                 this.trackingValues.length === 0 &&
                 !this.subtype_description
             );
@@ -404,9 +404,11 @@ export class Message extends Record {
             mentionedPartners,
         });
         const data = await rpc("/mail/message/update_content", {
-            attachment_ids: attachments.concat(this.attachments).map((attachment) => attachment.id),
+            attachment_ids: attachments
+                .concat(this.attachment_ids)
+                .map((attachment) => attachment.id),
             attachment_tokens: attachments
-                .concat(this.attachments)
+                .concat(this.attachment_ids)
                 .map((attachment) => attachment.access_token),
             body: await prettifyMessageContent(body, validMentions),
             message_id: this.id,
@@ -438,7 +440,7 @@ export class Message extends Record {
             message_id: this.id,
         });
         this.body = "";
-        this.attachments = [];
+        this.attachment_ids = [];
     }
 
     async setDone() {

--- a/addons/mail/static/tests/core/message_model.test.js
+++ b/addons/mail/static/tests/core/message_model.test.js
@@ -9,23 +9,23 @@ defineMailModels();
 
 test("Message model properties", async () => {
     await start();
-    getService("mail.store").Store.insert({
+    const store = getService("mail.store");
+    store.Store.insert({
         self: { id: serverState.partnerId, type: "partner" },
     });
-    getService("mail.store").Thread.insert({
+    store.Thread.insert({
         id: serverState.partnerId,
         model: "res.partner",
         name: "general",
     });
-    const message = getService("mail.store").Message.insert({
-        attachments: [
-            {
-                filename: "test.txt",
-                id: 750,
-                mimetype: "text/plain",
-                name: "test.txt",
-            },
-        ],
+    store.Attachment.insert({
+        filename: "test.txt",
+        id: 750,
+        mimetype: "text/plain",
+        name: "test.txt",
+    });
+    const message = store.Message.insert({
+        attachment_ids: 750,
         author: { id: 5, displayName: "Demo" },
         body: "<p>Test</p>",
         date: deserializeDateTime("2019-05-05 10:00:00"),
@@ -38,7 +38,7 @@ test("Message model properties", async () => {
     expect(message.body).toBe("<p>Test</p>");
     expect(serializeDateTime(message.date)).toBe("2019-05-05 10:00:00");
     expect(message.id).toBe(4000);
-    expect(message.attachments[0].name).toBe("test.txt");
+    expect(message.attachment_ids[0].name).toBe("test.txt");
     expect(message.thread.id).toBe(serverState.partnerId);
     expect(message.thread.name).toBe("general");
     expect(message.author.id).toBe(5);

--- a/addons/mail/static/tests/legacy/helpers/mock_server/controllers/discuss.js
+++ b/addons/mail/static/tests/legacy/helpers/mock_server/controllers/discuss.js
@@ -140,7 +140,9 @@ patch(MockServer.prototype, {
                     "mail.message": {
                         id: args.message_id,
                         body: args.body,
-                        attachments: this._mockIrAttachment_attachmentFormat(args.attachment_ids),
+                        attachment_ids: this._mockIrAttachment_attachmentFormat(
+                            args.attachment_ids
+                        ),
                     },
                 }
             );

--- a/addons/mail/static/tests/legacy/helpers/mock_server/models/mail_message.js
+++ b/addons/mail/static/tests/legacy/helpers/mock_server/models/mail_message.js
@@ -281,7 +281,7 @@ patch(MockServer.prototype, {
                 });
             }
             const response = Object.assign({}, message, {
-                attachments: formattedAttachments,
+                attachment_ids: formattedAttachments,
                 author,
                 default_subject:
                     message.model &&

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -681,7 +681,7 @@ async function mail_message_update_content(request) {
         MailMessage._bus_notification_target(message.id),
         "mail.record/insert",
         new mailDataHelpers.Store(MailMessage.browse(message.id), {
-            attachments: mailDataHelpers.Store.many(IrAttachment.browse(message.attachment_ids)),
+            attachment_ids: mailDataHelpers.Store.many(IrAttachment.browse(message.attachment_ids)),
             body: message.body,
             pinned_at: message.pinned_at,
             recipients: mailDataHelpers.Store.many(

--- a/addons/mail/static/tests/mock_server/mock_models/mail_message.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_message.js
@@ -145,7 +145,7 @@ export class MailMessage extends models.ServerModel {
                 );
             }
             Object.assign(data, {
-                attachments: mailDataHelpers.Store.many(
+                attachment_ids: mailDataHelpers.Store.many(
                     IrAttachment.browse(message.attachment_ids).sort((a1, a2) => a1.id - a2.id)
                 ),
                 default_subject:

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -85,7 +85,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                             "data": {
                                 "mail.message": self._filter_messages_fields(
                                     {
-                                        "attachments": [],
+                                        "attachment_ids": [],
                                         "author": {
                                             "id": self.env.user.partner_id.id,
                                             "type": "partner",

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -1206,7 +1206,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         guest = member_g.guest_id
         if channel == self.channel_general:
             return {
-                "attachments": [],
+                "attachment_ids": [],
                 "author": {"id": user_0.partner_id.id, "type": "partner"},
                 "body": "<p>test</p>",
                 "create_date": create_date,
@@ -1242,7 +1242,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_channel_public_1:
             return {
-                "attachments": [],
+                "attachment_ids": [],
                 "author": {"id": user_2.partner_id.id, "type": "partner"},
                 "body": "<p>test</p>",
                 "create_date": create_date,
@@ -1278,7 +1278,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_channel_public_2:
             return {
-                "attachments": [],
+                "attachment_ids": [],
                 "author": {"id": user_0.partner_id.id, "type": "partner"},
                 "body": f'<div class="o_mail_notification">invited <a href="#" data-oe-model="res.partner" data-oe-id="{user_9.partner_id.id}">@test9</a> to the channel</div>',
                 "create_date": create_date,
@@ -1310,7 +1310,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_channel_group_1:
             return {
-                "attachments": [],
+                "attachment_ids": [],
                 "author": {"id": user_0.partner_id.id, "type": "partner"},
                 "body": f'<div class="o_mail_notification">invited <a href="#" data-oe-model="res.partner" data-oe-id="{user_12.partner_id.id}">@test12</a> to the channel</div>',
                 "create_date": create_date,
@@ -1342,7 +1342,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_channel_group_2:
             return {
-                "attachments": [],
+                "attachment_ids": [],
                 "author": {"id": user_0.partner_id.id, "type": "partner"},
                 "body": f'<div class="o_mail_notification">invited <a href="#" data-oe-model="res.partner" data-oe-id="{user_13.partner_id.id}">@test13</a> to the channel</div>',
                 "create_date": create_date,
@@ -1374,7 +1374,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_livechat_1:
             return {
-                "attachments": [],
+                "attachment_ids": [],
                 "author": {"id": user_1.partner_id.id, "type": "partner"},
                 "body": "<p>test</p>",
                 "create_date": create_date,
@@ -1405,7 +1405,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_livechat_2:
             return {
-                "attachments": [],
+                "attachment_ids": [],
                 "author": {"id": guest.id, "type": "guest"},
                 "body": "<p>test</p>",
                 "create_date": create_date,

--- a/addons/test_mail/tests/test_mail_followers.py
+++ b/addons/test_mail/tests/test_mail_followers.py
@@ -884,7 +884,7 @@ class UnfollowFromInboxTest(MailCommon, HttpCase):
         expected = {
             "mail.message": self._filter_messages_fields(
                 {
-                    "attachments": [],
+                    "attachment_ids": [],
                     "author": {"id": self.user_admin.partner_id.id, "type": "partner"},
                     "body": "<p>test message</p>",
                     "create_date": fields.Datetime.to_string(message.create_date),

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1287,7 +1287,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
 
         self.assertEqual(len(res["mail.message"]), 2 * 2)
         for message in res["mail.message"]:
-            self.assertEqual(len(message['attachments']), 2)
+            self.assertEqual(len(message["attachment_ids"]), 2)
 
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
     @users('employee')
@@ -1299,7 +1299,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
             res = Store(message, for_current_user=True).get_result()
 
         self.assertEqual(len(res["mail.message"]), 1)
-        self.assertEqual(len(res["mail.message"][0]["attachments"]), 2)
+        self.assertEqual(len(res["mail.message"][0]["attachment_ids"]), 2)
 
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
     @users('employee')
@@ -1369,7 +1369,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                             ],
                             "mail.message": self._filter_messages_fields(
                                 {
-                                    "attachments": [],
+                                    "attachment_ids": [],
                                     "author": {
                                         "id": self.env.user.partner_id.id,
                                         "type": "partner",
@@ -1472,7 +1472,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                             ],
                             "mail.message": self._filter_messages_fields(
                                 {
-                                    "attachments": [],
+                                    "attachment_ids": [],
                                     "author": {
                                         "id": self.env.user.partner_id.id,
                                         "type": "partner",


### PR DESCRIPTION
Rename attachment to attachment_ids to match python field name.

Part of task-3605717

https://github.com/odoo/enterprise/pull/69374