### PR TITLE
[IMP] html_editor: rm MERGE_ADJACENT_NODES and CLEAN on save

### DIFF
--- a/addons/html_editor/static/src/core/protected_node_plugin.js
+++ b/addons/html_editor/static/src/core/protected_node_plugin.js
@@ -12,6 +12,7 @@ export class ProtectedNodePlugin extends Plugin {
         return {
             is_mutation_record_savable: p.isMutationRecordSavable.bind(p),
             filter_descendants_to_remove: p.filterDescendantsToRemove.bind(p),
+            isUnsplittable: isProtecting, // avoid merge
         };
     }
     static shared = ["setProtectingNode"];

--- a/addons/html_editor/static/src/editor.js
+++ b/addons/html_editor/static/src/editor.js
@@ -215,8 +215,6 @@ export class Editor {
 
     getElContent() {
         const el = this.editable.cloneNode(true);
-        this.dispatch("CLEAN", { root: el });
-        this.dispatch("MERGE_ADJACENT_NODE", { node: el });
         this.dispatch("CLEAN_FOR_SAVE", { root: el });
         return el;
     }

--- a/addons/html_editor/static/src/main/hint_plugin.js
+++ b/addons/html_editor/static/src/main/hint_plugin.js
@@ -55,7 +55,7 @@ export class HintPlugin extends Plugin {
                 break;
             }
             case "CLEAN":
-                // TODO @phoenix: evaluate if this should be cleanforsave instead
+            case "CLEAN_FOR_SAVE":
                 this.clearHints(payload.root);
                 break;
         }

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -206,8 +206,7 @@ export class LinkPlugin extends Plugin {
             case "NORMALIZE":
                 this.normalizeLink();
                 break;
-            case "CLEAN":
-                // TODO @phoenix: evaluate if this should be cleanforsave instead
+            case "CLEAN_FOR_SAVE":
                 this.removeEmptyLinks(payload.root);
                 break;
             case "REMOVE_LINK_FROM_SELECTION":
@@ -476,7 +475,7 @@ export class LinkPlugin extends Plugin {
 
     removeEmptyLinks(root) {
         // @todo: check for unremovables
-        // @todo: preserve cursor and spaces
+        // @todo: preserve spaces
         for (const link of root.querySelectorAll("a")) {
             if ([...link.childNodes].some(isVisible)) {
                 continue;

--- a/addons/html_editor/static/src/main/link/link_selection_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_selection_plugin.js
@@ -65,9 +65,8 @@ export class LinkSelectionPlugin extends Plugin {
             case "NORMALIZE":
                 this.normalize(payload.node || this.editable);
                 break;
-            case "CLEAN":
-                // TODO @phoenix: evaluate if this should be cleanforsave instead
-                this.clean(payload.root);
+            case "CLEAN_FOR_SAVE":
+                this.cleanForSave(payload.root);
                 break;
         }
     }
@@ -83,7 +82,7 @@ export class LinkSelectionPlugin extends Plugin {
     /**
      * @param {Element} root
      */
-    clean(root) {
+    cleanForSave(root) {
         this.removeFEFFs(root);
         this.clearLinkInSelectionClass(root);
     }

--- a/addons/html_editor/static/src/main/list/utils.js
+++ b/addons/html_editor/static/src/main/list/utils.js
@@ -50,16 +50,6 @@ export function compareListTypes(a, b) {
     return true;
 }
 
-export function applyToTree(root, func) {
-    const modifiedRoot = func(root);
-    let next = modifiedRoot.firstElementChild;
-    while (next) {
-        const modifiedNext = applyToTree(next, func);
-        next = modifiedNext.nextElementSibling;
-    }
-    return modifiedRoot;
-}
-
 export function isListItem(node) {
     return node.nodeName === "LI" && !node.classList.contains("nav-item");
 }

--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -76,7 +76,6 @@ export class MediaPlugin extends Plugin {
                 this.normalizeMedia(payload.node);
                 break;
             case "CLEAN":
-                // TODO @phoenix: evaluate if this should be cleanforsave instead
                 this.clean(payload.root);
                 break;
             case "CLEAN_FOR_SAVE":
@@ -123,6 +122,9 @@ export class MediaPlugin extends Plugin {
 
     cleanForSave(root) {
         for (const el of root.querySelectorAll(MEDIA_SELECTOR)) {
+            if (isIconElement(el)) {
+                el.textContent = "";
+            }
             el.removeAttribute("contenteditable");
         }
     }

--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -62,6 +62,7 @@ export class MediaPlugin extends Plugin {
                     text: "Replace",
                 },
             ],
+            isUnsplittable: isIconElement, // avoid merge
         };
         return resources;
     };

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -71,7 +71,7 @@ export class TablePlugin extends Plugin {
                 this.deleteTable(payload);
                 break;
             case "CLEAN":
-                // TODO @phoenix: evaluate if this should be cleanforsave instead
+            case "CLEAN_FOR_SAVE":
                 this.deselectTable(payload.root);
                 break;
         }

--- a/addons/html_editor/static/src/main/tabulation_plugin.js
+++ b/addons/html_editor/static/src/main/tabulation_plugin.js
@@ -34,6 +34,7 @@ export class TabulationPlugin extends Plugin {
             { hotkey: "tab", command: "TAB" },
             { hotkey: "shift+tab", command: "SHIFT_TAB" },
         ],
+        isUnsplittable: isEditorTab, // avoid merge
     });
 
     setup() {

--- a/addons/html_editor/static/src/others/qweb_plugin.js
+++ b/addons/html_editor/static/src/others/qweb_plugin.js
@@ -47,17 +47,10 @@ export class QWebPlugin extends Plugin {
                 this.normalize(payload.node);
                 break;
             case "CLEAN":
-                // TODO @phoenix: evaluate if this should be cleanforsave instead
-                for (const node of payload.root.querySelectorAll(
-                    "[data-oe-t-group], [data-oe-t-inline], [data-oe-t-selectable], [data-oe-t-group-active]"
-                )) {
-                    node.removeAttribute("data-oe-t-group-active");
-                    node.removeAttribute("data-oe-t-group");
-                    node.removeAttribute("data-oe-t-inline");
-                    node.removeAttribute("data-oe-t-selectable");
-                }
+                this.clearDataAttributes(payload.root);
                 break;
             case "CLEAN_FOR_SAVE":
+                this.clearDataAttributes(payload.root);
                 for (const element of payload.root.querySelectorAll(
                     "[t-esc], [t-raw], [t-out], [t-field]"
                 )) {
@@ -203,5 +196,16 @@ export class QWebPlugin extends Plugin {
         this.selectedNode = node;
         this.picker.close();
         this.selectNode(node);
+    }
+
+    clearDataAttributes(root) {
+        for (const node of root.querySelectorAll(
+            "[data-oe-t-group], [data-oe-t-inline], [data-oe-t-selectable], [data-oe-t-group-active]"
+        )) {
+            node.removeAttribute("data-oe-t-group-active");
+            node.removeAttribute("data-oe-t-group");
+            node.removeAttribute("data-oe-t-inline");
+            node.removeAttribute("data-oe-t-selectable");
+        }
     }
 }

--- a/addons/html_editor/static/src/utils/dom.js
+++ b/addons/html_editor/static/src/utils/dom.js
@@ -218,12 +218,12 @@ export function toggleClass(node, className) {
 }
 
 /**
- * Remove all occurrences of a character from a text node and update cursors for
- * for later selection restore.
+ * Remove all occurrences of a character from a text node and optionally update
+ * cursors for later selection restore.
  *
  * @param {Node} node text node
  * @param {String} char character to remove (string of length 1)
- * @param {Cursors} cursors
+ * @param {Cursors} [cursors]
  */
 export function cleanTextNode(node, char, cursors) {
     const removedIndexes = [];
@@ -231,7 +231,7 @@ export function cleanTextNode(node, char, cursors) {
         removedIndexes.push(offset);
         return "";
     });
-    cursors.update((cursor) => {
+    cursors?.update((cursor) => {
         if (cursor.node === node) {
             cursor.offset -= removedIndexes.filter((index) => cursor.offset > index).length;
         }

--- a/addons/html_editor/static/src/utils/dom.js
+++ b/addons/html_editor/static/src/utils/dom.js
@@ -148,7 +148,7 @@ export function removeClass(element, ...classNames) {
 /**
  * Add a BR in the given node if its closest ancestor block has nothing to make
  * it visible, and/or add a zero-width space in the given node if it's an empty
- * inline unremovable so the cursor can stay in it.
+ * inline so the cursor can stay in it.
  *
  * @param {HTMLElement} el
  * @returns {Object} { br: the inserted <br> if any,
@@ -157,9 +157,7 @@ export function removeClass(element, ...classNames) {
 export function fillEmpty(el) {
     const document = el.ownerDocument;
     const fillers = { ...fillShrunkPhrasingParent(el) };
-    if (!isVisible(el) && !el.hasAttribute("data-oe-zws-empty-inline")) {
-        // As soon as there is actual content in the node, the zero-width space
-        // is removed by the sanitize function.
+    if (!isBlock(el) && !isVisible(el) && !el.hasAttribute("data-oe-zws-empty-inline")) {
         const zws = document.createTextNode("\u200B");
         el.appendChild(zws);
         el.setAttribute("data-oe-zws-empty-inline", "");

--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -609,8 +609,6 @@ export function areSimilarElements(node, node2) {
     if (node.nodeName !== node2.nodeName) {
         return false; // The nodes aren't the same type of element.
     }
-    const nodeName = node.nodeName;
-
     for (const name of new Set([...node.getAttributeNames(), ...node2.getAttributeNames()])) {
         if (node.getAttribute(name) !== node2.getAttribute(name)) {
             return false; // The nodes don't have the same attributes.
@@ -623,14 +621,8 @@ export function areSimilarElements(node, node2) {
     ) {
         return false; // The nodes have pseudo elements with content.
     }
-    if (isIconElement(node) || isIconElement(node2)) {
+    if (isBlock(node)) {
         return false;
-    }
-    if (["UL", "OL"].includes(nodeName)) {
-        return !isSelfClosingElement(node) && !isSelfClosingElement(node2); // The nodes are non-empty lists. TODO: this doesn't check that and it will always be true!
-    }
-    if (isBlock(node) || isSelfClosingElement(node) || isSelfClosingElement(node2)) {
-        return false; // The nodes are blocks or are empty but visible. TODO: Not sure this was what we wanted to check (see just above).
     }
     const nodeStyle = getComputedStyle(node);
     const node2Style = getComputedStyle(node2);

--- a/addons/html_editor/static/src/utils/selection.js
+++ b/addons/html_editor/static/src/utils/selection.js
@@ -197,6 +197,21 @@ function updateCursorBeforeUnwrap(node, cursor) {
     }
 }
 
+function updateCursorBeforeMergeIntoPreviousSibling(node, cursor) {
+    if (cursor.node === node) {
+        cursor.node = node.previousSibling;
+        cursor.offset += node.previousSibling.childNodes.length;
+    } else if (cursor.node === node.parentNode) {
+        const childIndex = childNodeIndex(node);
+        if (cursor.offset === childIndex) {
+            cursor.node = node.previousSibling;
+            cursor.offset = node.previousSibling.childNodes.length;
+        } else if (cursor.offset > childIndex) {
+            cursor.offset--;
+        }
+    }
+}
+
 /** @typedef {import("@html_editor/core/selection_plugin").Cursor} Cursor */
 
 export const callbacksForCursorUpdate = {
@@ -215,6 +230,8 @@ export const callbacksForCursorUpdate = {
     prepend: (to, node) => (cursor) => updateCursorBeforeMove(to, 0, node, cursor),
     /** @type {(node: HTMLElement) => (cursor: Cursor) => void} */
     unwrap: (node) => (cursor) => updateCursorBeforeUnwrap(node, cursor),
+    /** @type {(node: HTMLElement) => (cursor: Cursor) => void} */
+    merge: (node) => (cursor) => updateCursorBeforeMergeIntoPreviousSibling(node, cursor),
 };
 
 /**

--- a/addons/html_editor/static/tests/_helpers/editor.js
+++ b/addons/html_editor/static/tests/_helpers/editor.js
@@ -174,9 +174,7 @@ export async function testEditor(config) {
     }
     if (contentAfter) {
         const content = editor.getContent();
-        editor.dispatch("CLEAN", { root: el });
         editor.dispatch("CLEAN_FOR_SAVE", { root: el });
-        editor.dispatch("MERGE_ADJACENT_NODE", { node: el });
         compareFunction(getContent(el), contentAfter, "Editor content, after clean");
         compareFunction(content, el.innerHTML, "Value from editor.getContent()");
     }

--- a/addons/html_editor/static/tests/_helpers/editor.js
+++ b/addons/html_editor/static/tests/_helpers/editor.js
@@ -174,7 +174,7 @@ export async function testEditor(config) {
     }
     if (contentAfter) {
         const content = editor.getContent();
-        editor.dispatch("CLEAN_FOR_SAVE", { root: el });
+        editor.dispatch("CLEAN_FOR_SAVE", { root: el, preserveSelection: true });
         compareFunction(getContent(el), contentAfter, "Editor content, after clean");
         compareFunction(content, el.innerHTML, "Value from editor.getContent()");
     }

--- a/addons/html_editor/static/tests/format/underline.test.js
+++ b/addons/html_editor/static/tests/format/underline.test.js
@@ -163,7 +163,7 @@ describe("with strikeThrough", () => {
                 underline(editor);
                 insertText(editor, "C");
             },
-            contentAfterEdit: `<p>ab<u><s>cd</s></u><s>A<u>B</u></s><s>C[]</s><u><s>ef</s></u></p>`,
+            contentAfterEdit: `<p>ab<u><s>cd</s></u><s>A<u>B</u>C[]</s><u><s>ef</s></u></p>`,
         });
     });
 

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -168,7 +168,7 @@ describe("popover should edit,copy,remove the link", () => {
         await contains(".o-we-linkpopover input.o_we_href_input_link").clear();
         // ZWNBSPs make space at the end of the paragraph to be visible
         expect(getContent(el)).toBe("<p>this is a \ufeff[]\ufeff</p>");
-        editor.dispatch("CLEAN", { root: el });
+        editor.dispatch("CLEAN_FOR_SAVE", { root: el });
         expect(getContent(el)).toBe("<p>this is a&nbsp;[]</p>");
     });
 });

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -1509,7 +1509,7 @@ describe("Complex html p+i", () => {
                     pasteHtml(editor, complexHtmlData);
                 },
                 contentAfter:
-                    '<p>a<span class="a">b12</span></p><p><span class="a"><i>ii[]</i>e</span>f</p>',
+                    '<p>a<span class="a">b12</span></p><p><span class="a"><i>ii</i>[]e</span>f</p>',
             });
         });
 

--- a/addons/html_editor/static/tests/utils/dom.test.js
+++ b/addons/html_editor/static/tests/utils/dom.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "@odoo/hoot";
 import { setupEditor } from "../_helpers/editor";
-import { cleanTextNode, wrapInlinesInBlocks } from "@html_editor/utils/dom";
+import { cleanTextNode, fillEmpty, wrapInlinesInBlocks } from "@html_editor/utils/dom";
 import { getContent } from "../_helpers/selection";
 import { parseHTML } from "@html_editor/utils/html";
 import { unformat } from "../_helpers/format";
@@ -268,5 +268,15 @@ describe("wrapInlinesInBlocks", () => {
                 <p style="margin-bottom: 0px;"><span class="a">span</span></p>
             `)
         );
+    });
+});
+
+describe("fillEmpty", () => {
+    test("should not add fill a shrunk protected block, nor add a ZWS to it", async () => {
+        const { el } = await setupEditor('<div data-oe-protected="true"></div>');
+        expect(el.innerHTML).toBe('<div data-oe-protected="true" contenteditable="false"></div>');
+        const div = el.firstChild;
+        fillEmpty(div);
+        expect(el.innerHTML).toBe('<div data-oe-protected="true" contenteditable="false"></div>');
     });
 });


### PR DESCRIPTION
**[FIX] html_editor: fillEmpty on protected nodes** -> fixes a bug that would impact tests on the following commit

**[IMP] html_editor: rm MERGE_ADJACENT_NODES and CLEAN on save** -> the commit that really matters

**[REF] html_editor: merge adjacent nodes** -> as the commit above moves this method from the dom plugin to the format plugin (and the code is weird), this seemed a good moment to refactor it.

**[REF] html_editor: list normalization** -> as the commit above creates a new helper function for selection preservation when merging siblings, this helper could be used in list normalization too (which involves merging siblings)

**[IMP] html_editor: skip preserve selection on cleanForSave** 