### PR TITLE
[IMP] website: review snippets modal

### DIFF
--- a/addons/web_editor/static/src/js/editor/add_snippet_dialog.js
+++ b/addons/web_editor/static/src/js/editor/add_snippet_dialog.js
@@ -143,7 +143,7 @@ export class AddSnippetDialog extends Component {
         this.iframeDocumentEl.body.scrollTop = 0;
         this.iframeDocumentEl.body.innerHTML = "";
         const rowEl = document.createElement("div");
-        rowEl.classList.add("row", "g-0", "o_snippets_preview_row", "p-5");
+        rowEl.classList.add("row", "g-0", "o_snippets_preview_row");
         const leftColEl = document.createElement("div");
         leftColEl.classList.add("col-lg-6");
         rowEl.appendChild(leftColEl);
@@ -174,7 +174,7 @@ export class AddSnippetDialog extends Component {
             }
             clonedSnippetEl.classList.remove("oe_snippet_body");
             const snippetPreviewWrapEl = document.createElement("div");
-            snippetPreviewWrapEl.classList.add("o_snippet_preview_wrap", "m-5", "position-relative", "fade");
+            snippetPreviewWrapEl.classList.add("o_snippet_preview_wrap", "position-relative", "fade");
             snippetPreviewWrapEl.dataset.snippetId = snippet.name;
             snippetPreviewWrapEl.dataset.snippetKey = snippet.key;
             snippetPreviewWrapEl.appendChild(clonedSnippetEl);
@@ -194,6 +194,8 @@ export class AddSnippetDialog extends Component {
             // Replace the snippet with an image preview if one exists.
             const imagePreview = snippet.imagePreview || originalSnippet?.imagePreview;
             if (imagePreview) {
+                // Enforce no-padding for image previews
+                clonedSnippetEl.style.setProperty("padding", "0", "important");
                 const previewImgDivEl = document.createElement("div");
                 previewImgDivEl.classList.add("s_dialog_preview", "s_dialog_preview_image");
                 const previewImgEl = document.createElement("img");

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -2811,7 +2811,29 @@ we-select.o_grid we-toggler {
         display: flex;
         padding: 0;
 
+        aside {
+            input[type="search"] {
+                // Chromium-based browsers render a "cancel" button by default.
+                // When visible, adapt its position in order to visually
+                // "replace" the magnify icon.
+                &::-webkit-search-cancel-button {
+                    transform: translateX(map-get($spacers, 3));
+                }
+
+                &:not(:placeholder-shown) + .input-group-text {
+                    display: none;
+
+                    // Preserve Firefox from chromium adaptations
+                    @media screen and (min--moz-device-pixel-ratio:0) {
+                        display: block;
+                    }
+                }
+            }
+        }
+
         .list-group {
+            --list-group-border-radius: 0;
+
             min-width: 200px;
             max-width: 250px;
 
@@ -2829,6 +2851,7 @@ we-select.o_grid we-toggler {
     width: 30%;
     height: 30%;
     background-color: unset;
+    scrollbar-gutter: stable both-edges;
 
     .o_snippets_preview_row {
         transform: scale(0.3);
@@ -2838,10 +2861,10 @@ we-select.o_grid we-toggler {
 
         .o_snippet_preview_wrap {
             min-height: 100px;
-            transition: all 150ms cubic-bezier(0.65, 0.05, 0.36, 1);
-            box-shadow: 0 0.5rem 6rem rgba(0, 0, 0, 0.2);
-            margin-bottom: 96px !important;
+            box-shadow: 0 0 6rem rgba(0, 0, 0, 0.16);
+            margin: map-get($spacers, 5) (map-get($spacers, 5) * .5) (map-get($spacers, 3) * 4);
             background-color: var(--body-bg);
+            transform: scale(.98);
             cursor: pointer;
 
             [data-snippet="s_carousel"],
@@ -2862,13 +2885,14 @@ we-select.o_grid we-toggler {
             .o_half_screen_height {
                 aspect-ratio: 8 / 3;
             }
-            [data-snippet="s_map"], [data-snippet="s_google_map"] {
-                padding: 0 !important;
-            }
             > [data-snippet] {
                 isolation: isolate;
                 pointer-events: none;
                 user-select: none;
+
+                &[data-snippet="s_text_block"] {
+                    font-size: 1.6rem;
+                }
 
                 &.s_popup {
                     min-height: 660px;
@@ -2892,11 +2916,10 @@ we-select.o_grid we-toggler {
                 content: "";
                 @include o-position-absolute(0, 0, 0, 0);
                 outline: 6px solid transparent;
-                transition: all 150ms;
                 z-index: 1;
             }
             &:hover {
-                box-shadow: 0 1rem 6rem rgba(0, 0, 0, 0.25);
+                box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.2);
                 &::after {
                     outline: 6px solid $o-we-handles-accent-color;
                 }

--- a/addons/web_editor/static/src/xml/add_snippet_dialog.xml
+++ b/addons/web_editor/static/src/xml/add_snippet_dialog.xml
@@ -9,15 +9,15 @@
         size="'xl'">
         <div class="overflow-hidden w-100">
             <div class="d-flex w-100 h-100 vertical flex-row">
-                <div class="border-end overflow-auto">
-                    <div class="input-group p-2 bg-100">
-                        <input type="search" class="form-control bg-white" placeholder="Search for a block"
+                <aside class="border-end overflow-auto">
+                    <div class="d-block position-relative p-2 bg-100 border-bottom">
+                        <input type="search" class="form-control bg-white pe-4" placeholder="Search for a block"
                             aria-label="Search for a block" t-model="state.search" t-ref="search-input"/>
-                        <span class="input-group-text border-0">
-                            <i class="fa fa-search" aria-hidden="true"></i>
+                        <span class="input-group-text position-absolute top-50 end-0 translate-middle-y me-2 border-0 bg-transparent text-muted">
+                            <i class="oi oi-search" aria-hidden="true"></i>
                         </span>
                     </div>
-                    <div class="list-group flex-column flex-nowrap overflow-y-auto" role="tablist">
+                    <div class="list-group list-group-flush flex-column flex-nowrap overflow-y-auto" role="tablist">
                         <t t-if="!state.search" t-foreach="snippetGroups" t-as="snippetGroup" t-key="snippetGroup.name">
                             <button class="list-group-item list-group-item-light list-group-item-action p-3" role="tab"
                                 t-att-class="{ 'active': this.state.groupSelected === snippetGroup.name}"
@@ -26,9 +26,12 @@
                             </button>
                         </t>
                     </div>
-                </div>
+                </aside>
                 <div class="position-relative flex-grow-1 flex-shrink-1">
-                    <iframe class="border-0 fade bg-200 o_add_snippet_iframe" tabindex="-1" t-ref="iframe" src="about:blank" height="333%" width="333%"/>
+                    <div class="spinner-grow position-absolute top-50 start-50 translate-middle" role="status">
+                        <span class="visually-hidden">Loading...</span>
+                    </div>
+                    <iframe class="border-0 fade bg-200 position-relative o_add_snippet_iframe" tabindex="-1" t-ref="iframe" src="about:blank" height="333%" width="333%"/>
                 </div>
             </div>
         </div>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -117,8 +117,6 @@
                 <t t-snippet="website.s_countdown" string="Countdown" t-thumbnail="/website/static/src/img/snippets_thumbs/s_countdown.svg" group="content">
                     <keywords>celebration, launch</keywords>
                 </t>
-                <t t-snippet="website.s_embed_code" string="Embed Code" t-forbid-sanitize="true"
-                    t-image-preview="/website/static/src/img/snippets_previews/s_embed_code_preview.png" t-thumbnail="/website/static/src/img/snippets_thumbs/s_embed_code.svg" group="content"/>
                 <t t-snippet="website.s_numbers" string="Numbers" group="content">
                     <keywords>statistics, stats, KPI</keywords>
                 </t>
@@ -144,6 +142,11 @@
                 <t t-snippet="website.s_accordion_image" string="Accordion Image" group="content">
                     <keywords>common answers, common questions, faq, QA, collapse, expandable, toggle, collapsible, hide-show, movement, information, image, picture, photo, illustration, media, visual</keywords>
                 </t>
+
+                <!-- Keep `s_embed_code` snippet at the very end of the "Content" group -->
+                <t t-snippet="website.s_embed_code" string="Embed Code" t-forbid-sanitize="true"
+                    t-image-preview="/website/static/src/img/snippets_previews/s_embed_code_preview.png" t-thumbnail="/website/static/src/img/snippets_thumbs/s_embed_code.svg" group="content"/>
+
 
                 <!-- Images group -->
                 <t t-snippet="website.s_picture" string="Title - Image" group="images">


### PR DESCRIPTION
Refined `AddSnippetDialog` to improve UX and visual clarity. Addressed design inconsistencies, improved snippet previews, enhanced search usability, and provided better feedback for slow connections.
Overall, these changes aim to create a smoother and more appealing experience.

Screenshoot in the task. In detail:

- Solve a miscalculation on containers sizes => Ensure that snippets are rendered at their natural size
- ~~Prompt the snippet's name on `:hover` =>  `title`​ attribute~~ (see [discussion](https://github.com/odoo/odoo/pull/178975/files#r1743651140))
- Avoid unwanted padding on `s_dialog_preview​`  previews
- Slightly improve search field design and UX
- Groups: remove double horizontal border
- Groups: remove unwanted border-radius
- Provide a "Loading" visual feedback for slow connections ( prior iframe loading)
- Increase visibility for snippets using a light gray backgrounds
- Improve `s_text_block​ preview` => previously hardly distinguishable, make it clear that's a block of text
- Avoid flickering on snippets loading due to scrollbars appearing
- Keep the `s_embed_code`​ snippet at the very end of the "Content" group
- Reduce transitions => Provide immediate feedback (eg. on hover), make the UI feel faster 


task-4160243





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
