### PR TITLE
[FIX] html_editor: restore selection not inEditable

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -413,14 +413,7 @@ export class SelectionPlugin extends Plugin {
         const selection = this.getEditableSelection();
         const anchor = { node: selection.anchorNode, offset: selection.anchorOffset };
         const focus = { node: selection.focusNode, offset: selection.focusOffset };
-
-        let externalRangeToRestore, documentSelection;
-        if (!selection.inEditable) {
-            documentSelection = this.document.getSelection();
-            if (documentSelection && documentSelection.rangeCount) {
-                externalRangeToRestore = documentSelection.getRangeAt(0);
-            }
-        }
+        const activeElement = this.document.activeElement;
         return {
             restore: () => {
                 if (selection.isDefault) {
@@ -437,15 +430,8 @@ export class SelectionPlugin extends Plugin {
                     { normalize: false }
                 );
 
-                if (!selection.inEditable && externalRangeToRestore) {
-                    const { startContainer, startOffset, endContainer, endOffset } =
-                        externalRangeToRestore;
-                    documentSelection.setBaseAndExtent(
-                        startContainer,
-                        startOffset,
-                        endContainer,
-                        endOffset
-                    );
+                if (!selection.inEditable && activeElement) {
+                    activeElement.focus();
                 }
             },
             update(callback) {

--- a/addons/html_editor/static/tests/selection.test.js
+++ b/addons/html_editor/static/tests/selection.test.js
@@ -164,6 +164,7 @@ test("press 'ctrl+a' in 'contenteditable' should only select his content", async
 test("restore a selection when you are not in the editable shouldn't move the focus", async () => {
     class TestInput extends Component {
         static template = xml`<input t-ref="input" t-att-value="'eee'" class="test"/>`;
+        static props = ["*"];
 
         setup() {
             useAutofocus({ refName: "input" });

--- a/addons/html_editor/static/tests/selection.test.js
+++ b/addons/html_editor/static/tests/selection.test.js
@@ -1,12 +1,14 @@
 import { describe, expect, test } from "@odoo/hoot";
-import { press, queryFirst } from "@odoo/hoot-dom";
+import { getActiveElement, press, queryFirst, queryOne } from "@odoo/hoot-dom";
 import { animationFrame, tick } from "@odoo/hoot-mock";
+import { Component, xml } from "@odoo/owl";
 import { patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { useAutofocus } from "@web/core/utils/hooks";
 import { Plugin } from "../src/plugin";
 import { MAIN_PLUGINS } from "../src/plugin_sets";
 import { setupEditor } from "./_helpers/editor";
 import { getContent } from "./_helpers/selection";
-import { tripleClick } from "./_helpers/user_actions";
+import { insertText, tripleClick } from "./_helpers/user_actions";
 
 test("getEditableSelection should work, even if getSelection returns null", async () => {
     const { editor } = await setupEditor("<p>a[b]</p>");
@@ -157,4 +159,53 @@ test("press 'ctrl+a' in 'contenteditable' should only select his content", async
     expect(getContent(el)).toBe(
         `<div contenteditable="false"><p contenteditable="true">[ab]</p><p contenteditable="true">cd</p></div>`
     );
+});
+
+test("restore a selection when you are not in the editable shouldn't move the focus", async () => {
+    class TestInput extends Component {
+        static template = xml`<input t-ref="input" t-att-value="'eee'" class="test"/>`;
+
+        setup() {
+            useAutofocus({ refName: "input" });
+        }
+    }
+
+    class TestPlugin extends Plugin {
+        static name = "test";
+        static dependencies = ["overlay"];
+        static resources = (p) => ({
+            powerboxItems: [
+                {
+                    category: "widget",
+                    name: "Test",
+                    action() {
+                        p.showOverlay();
+                    },
+                },
+            ],
+        });
+
+        setup() {
+            this.overlay = this.shared.createOverlay(TestInput);
+        }
+
+        showOverlay() {
+            this.overlay.open({
+                props: {},
+            });
+        }
+    }
+
+    const { editor } = await setupEditor("<p>te[]st</p>", {
+        config: { Plugins: [...MAIN_PLUGINS, TestPlugin] },
+    });
+    insertText(editor, "/test");
+    press("enter");
+    await animationFrame();
+    expect(getActiveElement()).toBe(queryOne("input.test"));
+
+    // Something trigger restore
+    const cursors = editor.shared.preserveSelection();
+    cursors.restore();
+    expect(getActiveElement()).toBe(queryOne("input.test"));
 });

--- a/addons/html_editor/static/tests/tags.test.js
+++ b/addons/html_editor/static/tests/tags.test.js
@@ -445,7 +445,7 @@ describe("to blockquote", () => {
         expect(getContent(el)).toBe("<p>abcd</p>");
 
         setTag("h1")(editor);
-        expect(getContent(el)).toBe("<h1>abcd</h1>");
+        expect(getContent(el)).toBe("<h1>ab[]cd</h1>");
     });
 
     test("triple click with setTag should only switch the tag on the selected line", async () => {


### PR DESCRIPTION
The aim of this commit is that when we are outside the editor (for example in the input of an overlay) and something executes preserveSelection + restore then the focus must not change. It must stay in the ovelay input.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
