### PR TITLE
[FIX] mail: more realistic populate of group_chat size

### DIFF
--- a/addons/mail/populate/discuss/discuss_channel_member.py
+++ b/addons/mail/populate/discuss/discuss_channel_member.py
@@ -25,15 +25,20 @@ class ChannelMember(models.Model):
         big_done = 0
         big = min(300, len(users))
         chat_with_admin = 0
+        group_with_admin = 0
         admin_dm_size = {"small": 25, "medium": 100, "large": 500}[size]
+        admin_group_size = {"small": 5, "medium": 50, "large": 100}[size]
         for channel in channels:
             allowed_users = users
             if channel.channel_type == "channel" and channel.group_public_id:
                 if random.randint(1, 2) == 1 and channel.group_public_id in admin.groups_id:
                     users_by_channel[channel].append(admin)
                 allowed_users = users.filtered(lambda user: channel.group_public_id in user.groups_id)
-            elif random.randint(1, 2) == 1 and channel.channel_type in ["channel", "group"]:
+            elif random.randint(1, 2) == 1 and channel.channel_type == "channel":
                 users_by_channel[channel].append(admin)
+            elif group_with_admin < admin_group_size and random.randint(1, 2) == 1 and channel.channel_type == "group":
+                users_by_channel[channel].append(admin)
+                group_with_admin += 1
             if allowed_users:
                 # arbitrary limit of 20 for non-channel type to have a functionally significant number
                 max_users = len(allowed_users) if channel.channel_type == "channel" else min(20, len(allowed_users))


### PR DESCRIPTION
Before this commit, populate of Discuss gave around this amount of group chat for Admin:

```
small      12
medium     75
large     850
```

This is unrealistic of having this amount of group chats. Due to implementation details, data of group requires fetching all channel members, which lead to around 15k channel members being processed, which is far above the nominal amount of JS models. As a reminder, group chat needs to get channel members data because this is used to compute the conversation name. This made performance very slow during the initial page loading.

This commit fixes the issue by reducing the amount of group chats that admin is member of in the populate script:

```
small      5
medium    50
large    100
```

This reduces the amount of channel member data to process, thus making initializing messaging faster on populate scripts including in `--size=large`.

Installing contacts with `--side=large` took around 6.2sec to process `init_messaging`. It now takes 1.8sec.
