### PR TITLE
[IMP] calendar: remove redundant start time in UI

### DIFF
--- a/addons/calendar/static/src/views/attendee_calendar/common/attendee_calendar_common_renderer.xml
+++ b/addons/calendar/static/src/views/attendee_calendar/common/attendee_calendar_common_renderer.xml
@@ -15,7 +15,6 @@
                         </t>
                     </t>
             </div>
-            <span t-if="!isTimeHidden and !isMonth" class="fc-time" t-esc="startTime" />
         </div>
     </t>
 </templates>


### PR DESCRIPTION
When in daily and weekly calendar views, the start time of events are shown twice in the event card, poluting the user interface.

This commit removes the isolated start time for making the event card cleaner.

task-4161302
