### PR TITLE
[IMP] hr_timesheet,sale_timesheet: hide timesheets in portal

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -433,3 +433,10 @@ class AccountAnalyticLine(models.Model):
                 'res_id': uom_hours.id,
                 'noupdate': True,
             })
+
+    @api.model
+    def _show_portal_timesheets(self):
+        """
+        Determine if we show timesheet information in the portal. Meant to be overriden in website_timesheet.
+        """
+        return True

--- a/addons/hr_timesheet/views/project_task_portal_templates.xml
+++ b/addons/hr_timesheet/views/project_task_portal_templates.xml
@@ -2,26 +2,29 @@
 <odoo>
 
     <template id="portal_my_task" inherit_id="project.portal_my_task" name="Portal: My Task with Timesheets">
+        <xpath expr="//div[hasclass('o_project_portal_sidebar')]" position="before">
+            <t t-set="show_portal_timesheets" t-value="timesheets and timesheets[0].env['account.analytic.line']._show_portal_timesheets()"/>
+        </xpath>
         <xpath expr="//div[@id='task-nav']" position="before">
-            <div t-if="timesheets and allow_timesheets" class="d-grid flex-grow-1" id='nav-report'>
+            <div t-if="timesheets and allow_timesheets and show_portal_timesheets" class="d-grid flex-grow-1" id='nav-report'>
                 <a class="btn btn-light o_print_btn o_project_timesheet_print d-block" t-att-href="task.get_portal_url(report_type='pdf')" href="#" title="View Details" role="button" target="_blank"><i class="fa fa-print"/> View Details</a>
             </div>
         </xpath>
         <xpath expr="//li[@id='nav-header']" position="after">
-            <div t-if="timesheets and allow_timesheets" class="nav-item">
+            <div t-if="timesheets and allow_timesheets and show_portal_timesheets" class="nav-item">
                 <a class="nav-link p-0" href="#task_timesheets">
                     Timesheets
                 </a>
             </div>
         </xpath>
         <xpath expr="//div[@id='card_body']" position="inside">
-            <div class="container" t-if="timesheets and allow_timesheets">
+            <div class="container" t-if="timesheets and allow_timesheets and show_portal_timesheets">
                 <h5 id="task_timesheets" class="mt-2 mb-2" data-anchor="true">Timesheets</h5>
                 <t t-call="hr_timesheet.portal_timesheet_table"/>
             </div>
         </xpath>
         <xpath expr="//div[@name='portal_my_task_allocated_hours']" position="after">
-            <div t-if="task.allocated_hours > 0 and allow_timesheets"><strong>Progress:</strong> <span t-esc="task.progress * 100" t-options='{"widget": "float", "precision": 0}'/>%</div>
+            <div t-if="task.allocated_hours > 0 and allow_timesheets and show_portal_timesheets"><strong>Progress:</strong> <span t-esc="task.progress * 100" t-options='{"widget": "float", "precision": 0}'/>%</div>
         </xpath>
         <xpath expr="//div[@name='portal_my_task_allocated_hours']/t" position="replace">
             <t t-call="hr_timesheet.portal_my_task_allocated_hours_template"></t>
@@ -40,13 +43,14 @@
     <template id="portal_tasks_list_inherit" inherit_id="project.portal_tasks_list" name="Portal: My Tasks with Timesheets">
         <xpath expr="//thead" position="before">
             <t t-set="allow_timesheets" t-value="any(task.allow_timesheets for group in grouped_tasks for task in group)"/>
+            <t t-set="show_portal_timesheets" t-value="grouped_tasks[0][0].env['account.analytic.line']._show_portal_timesheets()"/>
         </xpath>
         <xpath expr="//t[@t-foreach='tasks']/tr" position="before">
             <t t-set="timesheet_ids" t-value="task.sudo().timesheet_ids"/>
             <t t-set="is_uom_day" t-value="timesheet_ids._is_timesheet_encode_uom_day()"/>
         </xpath>
         <xpath expr="//thead/tr/th[@name='project_portal_milestones']" position="after">
-            <t t-if="not project or project.allow_timesheets">
+            <t t-if="(not project or project.allow_timesheets) and show_portal_timesheets">
                 <th class="text-end">Time Spent</th>
             </t>
         </xpath>
@@ -75,7 +79,7 @@
             </th>
         </xpath>
         <xpath expr="//tbody/t/tr/td[@name='project_portal_milestones']" position="after">
-            <td t-if="not project or project.allow_timesheets" class="text-end">
+            <td t-if="(not project or project.allow_timesheets) and show_portal_timesheets" class="text-end">
                 <t t-if="task.allow_timesheets">
                     <t t-if="is_uom_day">
                         <t t-out="timesheet_ids._convert_hours_to_days(task.total_hours_spent)"/>

--- a/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
+++ b/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
@@ -3,7 +3,7 @@
 
     <template id="sale_order_portal_content_inherit" inherit_id="sale.sale_order_portal_template">
         <xpath expr="//t[@t-set='entries']/div/div/div[hasclass('o_download_pdf')]" position="inside">
-            <t t-if="sale_order.timesheet_count > 0 and sale_order.state == 'sale'">
+            <t t-if="sale_order.timesheet_count > 0 and sale_order.state == 'sale' and sale_order.env['account.analytic.line']._show_portal_timesheets()">
                 <a class="btn btn-light flex-grow-1" t-att-href="'/my/timesheets?search_in=so&amp;search=%s' % sale_order.name" title="View Timesheets" target="_blank" role="button">View Timesheets</a>
             </t>
         </xpath>
@@ -63,14 +63,14 @@
             <th t-if="not groupby == 'timesheet_invoice_id'">Invoice</th>
         </th>
         <xpath expr="//tbody//td[hasclass('text-end')]" position="before">
-            <td t-if="not groupby == 'so_line'"><span t-field="timesheet.so_line" t-att-title="timesheet.so_line.display_name"></span></td>
+            <td t-if="not groupby == 'so_line' and timesheets[0].env['account.analytic.line']._show_portal_timesheets()"><span t-field="timesheet.so_line" t-att-title="timesheet.so_line.display_name"></span></td>
             <td t-if="not groupby == 'timesheet_invoice_id'"><span t-field="timesheet.timesheet_invoice_id" t-att-title="timesheet.timesheet_invoice_id.display_name"></span></td>
         </xpath>
     </template>
 
     <template id="portal_invoice_page_inherit" inherit_id="account.portal_invoice_page">
         <xpath expr="//t[@t-set='entries']/div/div/div[hasclass('o_download_pdf')]" position="after">
-            <t t-if="invoice.timesheet_count > 0">
+            <t t-if="invoice.timesheet_count > 0 and invoice.env['account.analytic.line']._show_portal_timesheets()">
                 <t t-set="search_value" t-value="invoice.name"/>
                 <t t-if="invoice.state == 'draft'" t-set="search_value" t-value="invoice.id"/>
                 <a t-if="invoice.move_type == 'out_invoice' and invoice.state in ('draft', 'posted') and invoice.timesheet_count > 0"

--- a/addons/website_timesheet/__init__.py
+++ b/addons/website_timesheet/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/website_timesheet/__manifest__.py
+++ b/addons/website_timesheet/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    'name': 'Hide Portal Timesheet Information',
+    'category': 'Website/Website',
+    'summary': 'Allow hiding timesheet information in the portal',
+    'version': '1.0',
+    'description': """
+When hiding the timesheets in the portal, this module allows also hiding timesheet information on other records.
+    """,
+    'depends': ['website', 'hr_timesheet'],
+    'installable': True,
+    'auto_install': True,
+    'author': 'Odoo S.A.',
+    'license': 'LGPL-3',
+}

--- a/addons/website_timesheet/models/__init__.py
+++ b/addons/website_timesheet/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_analytic_line

--- a/addons/website_timesheet/models/account_analytic_line.py
+++ b/addons/website_timesheet/models/account_analytic_line.py
@@ -1,0 +1,13 @@
+from odoo import api, models
+
+
+class AccountAnalyticLine(models.Model):
+    _inherit = 'account.analytic.line'
+
+    @api.model
+    def _show_portal_timesheets(self):
+        """
+        Determine if we show timesheet information in the portal.
+        """
+        domain = [("key", "=", "hr_timesheet.portal_my_home_timesheet")]
+        return self.env["ir.ui.view"].sudo().with_context(active_test=False).search(domain).filter_duplicate().active


### PR DESCRIPTION
Some companies don't want their customers to see the detailed timesheets in the portal.
This PR therefore hides all timesheets in the portal if they are disabled through the website customization.

Task-3951054