### PR TITLE
[FIX] bus: adapt test to custom imbus & cron_trigger notifications

### DIFF
--- a/addons/bus/tests/test_notify.py
+++ b/addons/bus/tests/test_notify.py
@@ -7,7 +7,7 @@ import threading
 import odoo
 from odoo.tests import TransactionCase
 
-from ..models.bus import json_dump, get_notify_payloads, NOTIFY_PAYLOAD_MAX_LENGTH
+from ..models.bus import json_dump, get_notify_payloads, NOTIFY_PAYLOAD_MAX_LENGTH, ODOO_NOTIFY_FUNCTION
 
 
 class NotifyTests(TransactionCase):
@@ -55,6 +55,8 @@ class NotifyTests(TransactionCase):
 
     def test_postcommit(self):
         """Asserts all ``postcommit`` channels are fetched with a single listen."""
+        if ODOO_NOTIFY_FUNCTION != 'pg_notify':
+            return
         channels = []
         stop_event = threading.Event()
 


### PR DESCRIPTION
When a custom postgresql function is used (`ODOO_NOTIFY_FUNCTION` environment variable is set), testing to listen to imbus should be skipped

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
