### PR TITLE
[FIX] point_of_sale: hide quantity for non tracked products

### DIFF
--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -107,7 +107,7 @@ class ProductProduct(models.Model):
     def _load_pos_data_fields(self, config_id):
         return [
             'id', 'display_name', 'lst_price', 'standard_price', 'categ_id', 'pos_categ_ids', 'taxes_id', 'barcode', 'name',
-            'default_code', 'to_weight', 'uom_id', 'description_sale', 'description', 'product_tmpl_id', 'tracking', 'type', 'service_tracking',
+            'default_code', 'to_weight', 'uom_id', 'description_sale', 'description', 'product_tmpl_id', 'tracking', 'type', 'service_tracking', 'is_storable',
             'write_date', 'available_in_pos', 'attribute_line_ids', 'active', 'image_128', 'combo_ids', 'product_template_variant_value_ids',
         ]
 

--- a/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.js
+++ b/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.js
@@ -55,7 +55,7 @@ export class ProductInfoBanner extends Component {
     }
 
     get bannerBackground() {
-        if (this.props.product.type === "service" || this.state.available_quantity > 10) {
+        if (!this.props.product.is_storable || this.state.available_quantity > 10) {
             return "bg-info";
         }
 

--- a/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.xml
+++ b/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.xml
@@ -5,7 +5,7 @@
             class="section-product-info-title d-flex text-info bg-opacity-25 mx-n3 mt-n3 px-3 pb-2 pt-3 mb-3">
             <div class="d-flex flex-column">
                 <span class="h4" t-esc="props.product.name"/>
-                <span t-if="this.props.product.type !== 'service'" class="h4">
+                <span t-if="this.props.product.is_storable" class="h4">
                     <span>On hand: </span>
                     <span t-if="this.fetchStock.status === 'success' || this.props.info"><t t-esc="this.state.available_quantity"/> Units</span>
                     <span t-elif="this.fetchStock.status === 'error'">N/A</span>

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -289,6 +289,10 @@ registry.category("web_tour.tours").add("CheckProductInformation", {
                 trigger: ".section-financials :contains('Margin')",
                 run: () => {},
             },
+            {
+                trigger: ".section-product-info-title:not(:contains('On hand:'))",
+                run: () => {},
+            },
         ].flat(),
 });
 

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -611,6 +611,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.pos_admin.write({
             'groups_id': [Command.link(self.env.ref('base.group_system').id)],
         })
+        self.assertFalse(self.product_a.is_storable)
         self.main_pos_config.with_user(self.pos_admin).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'CheckProductInformation', login="pos_admin")
 


### PR DESCRIPTION
Currently, when checking the information page of a product from the shop, the quantity will be shown, even though some products are not tracked in inventory.

Steps to reproduce:
-------------------
* Go to the **Point of sale** App
* Select a table
* We focus on the `Bacon Burger` for example
* Click on the information icon of the product
> Observation: The quantity on hand is shown with a zero qty

Why the fix:
------------
Currently, the on hand quantity is shown for all products except `service` products.

https://github.com/odoo/odoo/blob/82ef7426cf977b4d2c16c2f01d378b9beafca697/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.xml#L8

Since the refactoring on the products (https://github.com/odoo/odoo/commit/728d9f83f6d140b57b91000f683298f1f5bd43c9), there exists a checkbox field to say wheter or not we track the stock of product.

In the case where the product is of type `service`, `is_storable` is by default false.

In the case of the bacon burger, it was previously a 'consumable' product, now they are 'goods' that have `is_storable = False`.

opw-4148426