### PR TITLE
[FIX] point_of_sale: correct partner creation event for mobile

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.xml
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.xml
@@ -47,7 +47,7 @@
             <t t-set-slot="footer">
                 <div class="d-flex justify-content-start flex-wrap gap-2 w-100">
                     <button t-if="ui.isSmall" class="btn btn-primary" role="img" aria-label="Add a customer"
-                        t-on-click="createPartner"
+                        t-on-click="() => this.pos.editPartner()"
                         title="Add a customer">
                     New 
                     </button>


### PR DESCRIPTION
Before this commit, attempting to create a new contact on a mobile device would result in an error due to an incorrect partner creation event being triggered.

opw-4152438

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
