### PR TITLE
[FIX] mrp: document in bom chatter not showing

### DIFF
--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -170,7 +170,7 @@
                         </page>
                     </notebook>
                     </sheet>
-                    <chatter/>
+                    <chatter reload_on_attachment="True" open_attachments="True"/>
                 </form>
             </field>
         </record>


### PR DESCRIPTION
In https://github.com/odoo/odoo/pull/152286, we changed the documents that are added to the chatter of a BoM to be added to the product_product directly (or the template if there are no product on the BoM).

However, some changes in mail made the just-added document not appear untill reload. This commit fixes it by reloading the chatter when adding an attachment.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
