### PR TITLE
[FIX] l10n_ar: Traceback when sending einvoice from branch

### DIFF
--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -300,7 +300,7 @@ class AccountMove(models.Model):
             if any(tax.tax_group_id.l10n_ar_vat_afip_code and tax.tax_group_id.l10n_ar_vat_afip_code not in ['0', '1', '2'] for tax in line.tax_ids):
                 vat_taxable |= line
 
-        profits_tax_group = self.env.ref(f'account.{self.company_id.id}_tax_group_percepcion_ganancias')
+        profits_tax_group = self.env['account.chart.template'].with_company(self.company_id).ref('tax_group_percepcion_ganancias')
         return {'vat_amount': sign * sum(vat_taxes.mapped(amount_field)),
                 # For invoices of letter C should not pass VAT
                 'vat_taxable_amount': sign * sum(vat_taxable.mapped(amount_field)) if self.l10n_latam_document_type_id.l10n_ar_letter != 'C' else self.amount_untaxed,


### PR DESCRIPTION
With an AR setup
Create a branch company with:
- Tax ID: same as in the parent company
- Address: same as in the parent company
- Certificate/Private key: same as parent company Create an invoice in Journal "Factura electrónica (FE)" Set customer "ADHOC SA"
Confirm

When the system attempt to send the e-invoice raceback pops up "ValueError: External ID not found in the system: account.5_tax_group_percepcion_ganancias"

This occurs because the sytem looks for an xmlid which is only present in the parent company

opw-4151003
