### PR TITLE
[FIX] hr_holidays: add correct follower when importing leaves

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -903,7 +903,7 @@ class HolidaysRequest(models.Model):
                 # eg : holidays_user can create a leave request with validation_type = 'manager' for someone else
                 # but they can only write on it if they are leave_manager_id
                 holiday_sudo = holiday.sudo()
-                holiday_sudo.add_follower(employee_id)
+                holiday_sudo.add_follower(holiday.employee_id.id)
                 if holiday.validation_type == 'manager':
                     holiday_sudo.message_subscribe(partner_ids=holiday.employee_id.leave_manager_id.partner_id.ids)
                 if holiday.validation_type == 'no_validation':

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -110,7 +110,7 @@ class TestDiscussFullPerformance(TransactionCase):
             init_messaging = self.users[0].with_user(self.users[0])._init_messaging()
 
         self.assertEqual(init_messaging, {
-            'needaction_inbox_counter': 1,
+            'needaction_inbox_counter': 2,
             'starred_counter': 1,
             'channels': [
                 {


### PR DESCRIPTION
Before this commit, when importing multiple leaves for different employee, the last employee in the list will be set as a follower on all the created leaves.

This commit fixes this behavior by checking for the employee assigned to each leave and using its ID when adding the follower.

opw-4023073