### PR TITLE
[FIX] account: Write onboarding step with sudo

### DIFF
--- a/addons/account/wizard/setup_wizards.py
+++ b/addons/account/wizard/setup_wizards.py
@@ -151,7 +151,9 @@ class SetupBarBankConfigWizard(models.TransientModel):
         """Called by the validation button of this wizard. Serves as an
         extension hook in account_bank_statement_import.
         """
-        self.env["onboarding.onboarding.step"].action_validate_step("account.onboarding_onboarding_step_bank_account")
+        self.env["onboarding.onboarding.step"].sudo().action_validate_step(
+            "account.onboarding_onboarding_step_bank_account"
+        )
         return {'type': 'ir.actions.client', 'tag': 'soft_reload'}
 
     def _compute_company_id(self):


### PR DESCRIPTION
Steps to reproduce:

1. Login with a user with invoicing manager permission, but not settings one.
2. Go to Settings > Add a Bank account.
3. Fill the data, and click on "Create".

Current behavior: Access Error, due to the lack of the Administration/Settings permission

Expected behavior: No error

The solution is to put sudo on the operation.

@Tecnativa TT50693