### PR TITLE
[DRAFT][FIX] l10n_cl: fixe the incorrect positioning of discount-related fie…

### DIFF
--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -166,7 +166,7 @@
             <attribute name="t-options">{"widget": "float", "precision": 2}</attribute>
         </xpath>
 
-        <th name="th_priceunit" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}" position="after">
+        <th name="th_discount" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}" position="after">
             <th name="th_discount_currency" t-if="display_discount" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
                 <span>Disc.</span>
             </th>


### PR DESCRIPTION

The discount percentage and discount amount values were not in the correct positions. 
To fix this, I placed the Discount Amount after the Discount Percentage ("td_discount") to make the table header and table data consistent. OWP-4112378
         -->

Description of the issue/feature this PR addresses:

The Discount Percentage value and the Discount Amount value are not in the correct positions. The Discount Amount was placed after the unit price ("td_priceunit"), and its value was displayed after the Discount Percentage ("td_discount"). As a result, the values were swapped.

Current behavior before PR:
The Discount Amount and Percentage are mixed up.
![image](https://github.com/user-attachments/assets/855ec66f-9826-4354-9c69-4eb04da29ca5)

Desired behavior after PR is merged:
The Discount Amount data should appear under the "Discount Amount" table header, and the Discount Percentage data should appear under the "Discount Percentage" header.
![image](https://github.com/user-attachments/assets/cfed20c3-e0ac-4f67-9c67-0525d34cf69d)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
