### PR TITLE
[FIX] mail: Fallback to mail.thread for _process_attachments_for_post

### DIFF
--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -1050,7 +1050,8 @@ class MailComposer(models.TransientModel):
             ]
             # email_mode: prepare processed attachments as commands for mail.mail
             if email_mode:
-                mail_values['attachment_ids'] = record._process_attachments_for_post(
+                process_record = record if hasattr(record, "_process_attachments_for_post") else record.env["mail.thread"]
+                mail_values['attachment_ids'] = process_record._process_attachments_for_post(
                     decoded_attachments,
                     attachment_ids,
                     {'model': 'mail.message', 'res_id': 0}


### PR DESCRIPTION
Using composer in the mass mail mode is allowed on non `mail.thread` models. 
This fix covers the case where one of the required methods isn't available on the model that we try to send mail on.

Reproduce
---
- install website_slides
- "Add Context Action" on the "Elearning: Add Attendees to Course" template
- open an eLearning course -> Attendees list view, select one, click on Send Mail action
- fill required replyto -> send -> BUG: traceback

opw-4062613