### PR TITLE
[FIX] account: traceback when loading foreign tax data

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -940,7 +940,7 @@ class AccountChartTemplate(models.AbstractModel):
         }
         # add the prefix to the "children_tax_ids" value for group-type taxes
         for tax_data in data['account.tax'].values():
-            if tax_data.get('amount_type') == 'group':
+            if tax_data.get('amount_type') == 'group' and 'children_tax_ids' in tax_data:
                 children_taxes = tax_data['children_tax_ids'].split(',')
                 for idx, child_tax in enumerate(children_taxes):
                     children_taxes[idx] = f"{chart_template_code}_{child_tax}"


### PR DESCRIPTION
Create a new Fiscal Position and set
Country: Austria
Foreign Tax ID: ATU79284409
Click "here" to create the taxes for this country.

Traceback will raise
"KeyError: 'children_tax_ids'"

This occurs because the system tries to load the children tax of a tax group with no child defined

opw-4134352