### PR TITLE
[FIX] stock: orderpoint: don't always set qty_to_order_manual at create

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -188,7 +188,7 @@ class StockWarehouseOrderpoint(models.Model):
     def create(self, vals_list):
         if any(val.get('snoozed_until', False) and val.get('trigger', self.default_get(['trigger'])['trigger']) == 'auto' for val in vals_list):
             raise UserError(_("You can not create a snoozed orderpoint that is not manually triggered."))
-        return super().create(vals_list)
+        return super(StockWarehouseOrderpoint, self.with_context(no_set_qty_to_order=True)).create(vals_list)
 
     def write(self, vals):
         if 'company_id' in vals:
@@ -290,6 +290,8 @@ class StockWarehouseOrderpoint(models.Model):
             orderpoint.qty_to_order = orderpoint.qty_to_order_manual if orderpoint.qty_to_order_manual else orderpoint.qty_to_order_computed
 
     def _inverse_qty_to_order(self):
+        if self.env.context.get('no_set_qty_to_order'):
+            return
         for orderpoint in self:
             orderpoint.qty_to_order_manual = orderpoint.qty_to_order
 

--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -59,7 +59,7 @@
                 <field name="product_min_qty" string="Min" optional="show"/>
                 <field name="product_max_qty" string="Max" optional="show"/>
                 <field name="qty_multiple" optional="hide"/>
-                <field name="qty_to_order"/>
+                <field name="qty_to_order" readonly="not id"/>
                 <field name="qty_to_order_manual" column_invisible="True"/>
                 <button name="action_remove_manual_qty_to_order" type="object" icon="fa-undo" title="Remove manually entered value and replace by the quantity to order based on the forecasted quantities" invisible="not qty_to_order_manual"/>
                 <button name="action_remove_manual_qty_to_order" type="object" icon="fa-undo" title="-" class="disabled opacity-0" invisible="qty_to_order_manual"/>


### PR DESCRIPTION
Steps
---
* create a product P with inventory tracked by quantity
* create a 1, 10 reordering rule for it
* save 
  * => the `action_remove_manual_qty_to_order` arrow button appears but we did not set the `qty_to_order`
* create a delivery order for 1 P and mark it as todo 
  * => a RFQ for 10 (instead of 11) P is generated

Cause
---
When we recieve a `qty_to_order` from a `web_save` we assume the user wants to set it, but if we are creating the rr, all the fields will be sent.

Fix
---
Never set the `qty_to_order_manual` at create time.
\+ optional xml-side fix make `qty_to_order` readonly when a rr has not been saved yet. This avoids the user inputting a value that will get ignored.

opw-4150572