### PR TITLE
[FIX] mail: remove eager: true on Message computed fields

### DIFF
--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -223,9 +223,6 @@ export class Message extends Record {
             }
             return this.author.eq(this.store.self);
         },
-        // FIXME necessary to not trigger double-rendering of messages
-        // lazy-compute on-the-fly notifies the current reactive again
-        eager: true,
     });
 
     isPending = false;

--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -2,7 +2,7 @@ import { busModels } from "@bus/../tests/bus_test_helpers";
 import { mailGlobal } from "@mail/utils/common/misc";
 import { after, before, getFixture } from "@odoo/hoot";
 import { hover as hootHover, resize } from "@odoo/hoot-dom";
-import { Component, onRendered, onWillDestroy, status } from "@odoo/owl";
+import { Component, onMounted, onPatched, onWillDestroy, status } from "@odoo/owl";
 import {
     MockServer,
     authenticate,
@@ -25,7 +25,11 @@ import { MEDIAS_BREAKPOINTS, utils as uiUtils } from "@web/core/ui/ui_service";
 import { useServiceProtectMethodHandling } from "@web/core/utils/hooks";
 import { session } from "@web/session";
 import { WebClient } from "@web/webclient/webclient";
-import { DISCUSS_ACTION_ID, authenticateGuest, mailDataHelpers } from "./mock_server/mail_mock_server";
+import {
+    DISCUSS_ACTION_ID,
+    authenticateGuest,
+    mailDataHelpers,
+} from "./mock_server/mail_mock_server";
 import { Base } from "./mock_server/mock_models/base";
 import { DEFAULT_MAIL_VIEW_ID } from "./mock_server/mock_models/constants";
 
@@ -540,14 +544,16 @@ let nextObserveRenderResults = 0;
 export function prepareObserveRenders() {
     patchWithCleanup(Component.prototype, {
         setup(...args) {
-            onRendered(() => {
+            const cb = () => {
                 for (const result of observeRenderResults.values()) {
                     if (!result.has(this.constructor)) {
                         result.set(this.constructor, 0);
                     }
                     result.set(this.constructor, result.get(this.constructor) + 1);
                 }
-            });
+            };
+            onMounted(cb);
+            onPatched(cb);
             onWillDestroy(() => {
                 for (const result of observeRenderResults.values()) {
                     // owl could invoke onrendered and cancel immediately to re-render, so should compensate


### PR DESCRIPTION
They were put to prevent some re-render of message. However the problem was the test helpers that rely on hooks that were triggered more than once per actual render.

This commit fixes the issue by using `onMounted()`/`onPatched` rather than `onRendered`. This allows the remove the `eager: true` on `Message` model computed fields.

Also, test `"posting new message should only render relevant part"` has been adapted to be simpler to what's actually being tested.
