### PR TITLE
[FIX] base: fix the synchronization of selection translations

### DIFF
--- a/odoo/addons/base/tests/test_translate.py
+++ b/odoo/addons/base/tests/test_translate.py
@@ -975,6 +975,73 @@ class TestXMLTranslation(TransactionCase):
         self.assertEqual(view.with_env(env_fr).arch_db, archf % new_terms_fr)
         self.assertEqual(view.with_env(env_nl).arch_db, archf % terms_nl)
 
+    def test_sync_selection(self):
+        """ Check the `<select/>` translations after source terms changes."""
+        archf = '<form>%s</form>'
+        env_en = self.env(context={'lang': 'en_US'})
+        env_fr = self.env(context={'lang': 'fr_FR'})
+
+        # The selection terms should be long enough to consider an option
+        # removal/addition a "minor change".
+        terms_en = ("""<select>
+            <option/>
+            <option value="option-1">Option 1</option>
+            <option value="option-2">Opti 2</option>
+            <option value="option-3">Option 3</option>
+            <option value="option-4">Option 4</option>
+            <option value="option-5">Option 5</option>
+            <option value="option-6">Option 6</option>
+            <option value="option-7">Option 7</option>
+        </select>""",)
+        terms_fr = ("""<select>
+            <option/>
+            <option value="option-1">Choix 1</option>
+            <option value="option-2">Choix 2</option>
+            <option value="option-3">Choix 3</option>
+            <option value="option-4">Choix 4</option>
+            <option value="option-5">Choix 5</option>
+            <option value="option-6">Choix 6</option>
+            <option value="option-7">Choix 7</option>
+        </select>""",)
+        view = self.create_view(archf, terms_en, en_US=terms_en, fr_FR=terms_fr)
+
+        # Check that terms were translated correctly.
+        self.assertEqual(view.with_env(env_en).arch_db, archf % terms_en)
+        self.assertEqual(view.with_env(env_fr).arch_db, archf % terms_fr)
+
+        # Update the source term: fix a typo in "Option 2".
+        terms_en = ("""<select>
+            <option/>
+            <option value="option-1">Option 1</option>
+            <option value="option-2">Option 2</option>
+            <option value="option-3">Option 3</option>
+            <option value="option-4">Option 4</option>
+            <option value="option-5">Option 5</option>
+            <option value="option-6">Option 6</option>
+            <option value="option-7">Option 7</option>
+        </select>""",)
+        view.with_env(env_en).write({'arch_db': archf % terms_en})
+
+        # Check whether translations have been synchronized.
+        self.assertEqual(view.with_env(env_en).arch_db, archf % terms_en)
+        self.assertEqual(view.with_env(env_fr).arch_db, archf % terms_fr)
+
+        # Update the source term: remove an option from the `<select/>`.
+        terms_en = ("""<select>
+            <option/>
+            <option value="option-1">Option 1</option>
+            <option value="option-3">Option 3</option>
+            <option value="option-4">Option 4</option>
+            <option value="option-5">Option 5</option>
+            <option value="option-6">Option 6</option>
+            <option value="option-7">Option 7</option>
+        </select>""",)
+        view.with_env(env_en).write({'arch_db': archf % terms_en})
+
+        # Check that translations have not been synchronized (different options).
+        self.assertEqual(view.with_env(env_en).arch_db, archf % terms_en)
+        self.assertEqual(view.with_env(env_fr).arch_db, archf % terms_en)
+
     def test_sync_xml(self):
         """ Check translations of 'arch' after xml tags changes in source terms. """
         archf = '<form string="X">%s<div>%s</div></form>'


### PR DESCRIPTION
Steps to reproduce:

1. Activate an additional language on the website (e.g., German).

2. Create a page with a form and select the action: "Create an
   Opportunity" for it.

3. Add the existing field "Country" to the form.

4. Remove a country from the "Country" field options and save.

5. Switch to the other language (e.g., German) on the website and
   translate any country value in the selection (e.g., translate
   "Germany" to "Deutschland").

6. Save the page and switch back to English.

7. Edit the page again and add back the removed country as an additional
   option for the "Country" field.

8. Save the page.

9. Switch to the other language (e.g., German) on the website > The
   added country option is not visible and cannot be translated.

When the form selection is updated in the editor, the code from
`_sync_terms_translations()` tries to match the current selection term
with other terms translations. And since minor changes (such as option
removal) won't affect the matching score, the code will always use the
first translation even when an option is added in the original language.

The goal of this commit is to prevent this inconsistency (that cannot
unfortunately be fixed in translation mode: the `<select>` cannot be
edited...), by considering a selection term as a match of another only
if they have the same options.

Remark: Translating the `<option/>`s of a `<select>` as a whole can
theoretically solve the issue here, but since translation `<span/>`s
cannot be added around these options in the DOM, this implementation
won't work unfortunately (see [1]).

[1]: https://github.com/odoo/odoo/commit/57d7e75b030ed34992865170ce349442fb3c1d03

opw-4013362