### PR TITLE
[FIX] website: Calling _manageIframeSrc after assigning the iframeEl

### DIFF
--- a/addons/website/static/src/snippets/s_map/000.js
+++ b/addons/website/static/src/snippets/s_map/000.js
@@ -19,8 +19,8 @@ publicWidget.registry.Map = publicWidget.Widget.extend(ObservingCookieWidgetMixi
             const dataset = this.el.dataset;
             if (dataset.mapAddress) {
                 const iframeEl = generateGMapIframe();
-                this._manageIframeSrc(this.el, generateGMapLink(dataset));
                 this.el.querySelector('.s_map_color_filter').before(iframeEl);
+                this._manageIframeSrc(this.el, generateGMapLink(dataset));
             }
         }
         return this._super(...arguments);


### PR DESCRIPTION
In the register page of the events, when you add a map block, and save it, you'll get an UncaughtPromiseError.

To Reproduce on Runbot:
1. Go to the events page.
2. Click on one of the events.
3. Go to /register page
4. Go to Editor and add a map block
5. Save it Upon saving, you'll encounter the error, and further cannot make any edits.

The issue is due to calling _manageIframeSrc on the element where there is no iframeEl defined yet. So, we'll add the iframeEl first and call _manageIframeSrc.

opw-4104300