### PR TITLE
[FIX] point_of_sale: fix traceback when duplicating multi payment methods

### DIFF
--- a/addons/point_of_sale/models/pos_payment_method.py
+++ b/addons/point_of_sale/models/pos_payment_method.py
@@ -165,10 +165,13 @@ class PosPaymentMethod(models.Model):
 
     def copy_data(self, default=None):
         default = dict(default or {}, config_ids=[(5, 0, 0)])
-        if self.journal_id and self.journal_id.type == 'cash':
-            if ('journal_id' in default and default['journal_id'] == self.journal_id.id) or ('journal_id' not in default):
-                default.update({'journal_id': False})
-        return super().copy_data(default=default)
+        vals_list = super().copy_data(default=default)
+
+        for pm, vals in zip(self, vals_list):
+            if pm.journal_id and pm.journal_id.type == 'cash':
+                if ('journal_id' in default and default['journal_id'] == pm.journal_id.id) or ('journal_id' not in default):
+                    vals['journal_id'] = False
+        return vals_list
 
     @api.constrains('payment_method_type', 'journal_id', 'qr_code_method')
     def _check_payment_method(self):

--- a/addons/point_of_sale/tests/test_pos_basic_config.py
+++ b/addons/point_of_sale/tests/test_pos_basic_config.py
@@ -1081,3 +1081,19 @@ class TestPoSBasicConfig(TestPoSCommon):
             {'account_id': self.tax_received_account.id, 'balance': -9.72, 'reconciled': False},
             {'account_id': self.receivable_account.id, 'balance': 117.72, 'reconciled': True},
         ])
+
+    def test_pos_payment_method_copy(self):
+        """
+        Test POS payment method copy:
+            - Create two payment methods in which one of the payment method's journal type be cash
+            - Copy multiple payment methods
+            - Check the duplicated cash payment method journal should be empty
+        """
+        pm_1 = self.cash_pm1
+        pm_2 = self.bank_pm1
+        pm_3, pm_4 = (pm_1 + pm_2).copy()
+
+        self.assertTrue(pm_3)
+        self.assertFalse(pm_3.journal_id)
+        self.assertTrue(pm_4)
+        self.assertEqual(pm_4.journal_id.type, "bank")


### PR DESCRIPTION
Currently, a traceback occurs when the user tries to duplicate multiple pos payment methods.

To reproduce this issue:

1) Install Point of Sale
2) Try to duplicate multiple payment methods from the POS configuration

Error:- 
```
ValueError: Expected singleton: account.journal(14, 18)
```

This is because of the changes from the recent commit https://github.com/odoo/odoo/pull/175530/commits/0fbd47bdd2fe06feda7df747e8560b810a666386

In `copy` method, when multiple records are duplicated it executed the method at multiple times.
 so `self` should have a single record at a time.

From the `saas-17.2`, the `copy` method changes to `copy_data`, 
So it is executed at a time when the `self` having multiple recordsets.

This leads to a traceback as `self.journal_id.type` is used.

https://github.com/odoo/odoo/blob/88604332ae37d75c1435a298319a378841abf25a/addons/point_of_sale/models/pos_payment_method.py#L166-L168

sentry-5790593911
