### PR TITLE
[FIX] {mass_mailing_}event: stop notifying draft registrations

### DIFF
--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -579,7 +579,7 @@ class EventEvent(models.Model):
         if first_ended_stage:
             self.write({'stage_id': first_ended_stage.id})
 
-    def mail_attendees(self, template_id, force_send=False, filter_func=lambda self: self.state != 'cancel'):
+    def mail_attendees(self, template_id, force_send=False, filter_func=lambda self: self.state not in ('cancel', 'draft')):
         for event in self:
             for attendee in event.registration_ids.filtered(filter_func):
                 self.env['mail.template'].browse(template_id).send_mail(attendee.id, force_send=force_send)

--- a/addons/event/models/event_mail.py
+++ b/addons/event/models/event_mail.py
@@ -184,10 +184,10 @@ class EventMailScheduler(models.Model):
                 # do not send emails if the mailing was scheduled before the event but the event is over
                 if scheduler.scheduled_date <= now and (scheduler.interval_type != 'before_event' or scheduler.event_id.date_end > now):
                     scheduler.event_id.mail_attendees(scheduler.template_ref.id)
-                    # Mail is sent to all attendees (unconfirmed as well), so count all attendees
+                    notified_registrations = scheduler.event_id.registration_ids.filtered(lambda r: r.state not in ('cancel', 'draft'))
                     scheduler.update({
                         'mail_done': True,
-                        'mail_count_done': scheduler.event_id.seats_expected,
+                        'mail_count_done': len(notified_registrations)
                     })
         return True
 

--- a/addons/event_sms/models/event_mail.py
+++ b/addons/event_sms/models/event_mail.py
@@ -54,7 +54,7 @@ class EventMailScheduler(models.Model):
                 if scheduler.scheduled_date <= now and (scheduler.interval_type != 'before_event' or scheduler.event_id.date_end > now):
                     self.env['event.registration']._message_sms_schedule_mass(
                         template=scheduler.template_ref,
-                        active_domain=[('event_id', '=', scheduler.event_id.id), ('state', '!=', 'cancel')],
+                        active_domain=[('event_id', '=', scheduler.event_id.id), ('state', 'not in', ('cancel', 'draft'))],
                         mass_keep_log=True
                     )
                     scheduler.update({

--- a/addons/mass_mailing_event/models/event_event.py
+++ b/addons/mass_mailing_event/models/event_event.py
@@ -16,7 +16,7 @@ class Event(models.Model):
             'target': 'current',
             'context': {
                 'default_mailing_model_id': self.env.ref('event.model_event_registration').id,
-                'default_mailing_domain': repr([('event_id', 'in', self.ids), ('state', '!=', 'cancel')])
+                'default_mailing_domain': repr([('event_id', 'in', self.ids), ('state', '!=', 'cancel'), ('state', '!=', 'draft')])
             },
         }
 

--- a/addons/mass_mailing_event/models/event_registration.py
+++ b/addons/mass_mailing_event/models/event_registration.py
@@ -9,4 +9,4 @@ class EventRegistration(models.Model):
     _mailing_enabled = True
 
     def _mailing_get_default_domain(self, mailing):
-        return [('state', '!=', 'cancel')]
+        return [('state', '!=', 'cancel'), ('state', '!=', 'draft')]

--- a/addons/test_event_full/tests/test_event_mail.py
+++ b/addons/test_event_full/tests/test_event_mail.py
@@ -91,8 +91,8 @@ class TestEventSmsMailSchedule(TestWEventCommon, MockEmail, MockSMS):
 
     @mute_logger('odoo.addons.base.models.ir_model', 'odoo.models')
     def test_event_mail_before_trigger_sent_count(self):
-        """ Emails are sent to both confirmed and unconfirmed attendees.
-        This test checks that the count of sent emails includes the emails sent to unconfirmed ones.
+        """ Emails are only sent to confirmed attendees.
+        This test checks that the count of sent emails does not include the emails sent to unconfirmed ones.
 
         Time in the test is frozen to simulate the following state:
 
@@ -155,7 +155,7 @@ class TestEventSmsMailSchedule(TestWEventCommon, MockEmail, MockSMS):
         with self.mock_mail_gateway(), self.mockSMSGateway():
             mail_scheduler.execute()
 
-        self.assertEqual(len(self._new_mails), 2, 'Mails were not created')
+        self.assertEqual(len(self._new_mails), 1, 'Mails were not created')
         self.assertEqual(len(self._new_sms), 2, 'SMS were not created')
 
         self.assertEqual(test_event.seats_expected, 2, 'Wrong number of expected seats (attendees)')


### PR DESCRIPTION
Draft registrations should not receive any periodic email until they confirm they will be attending.

This avoids awkward situations where the reminder contains a ticket, but their ticket isn't validated yet...

task-4104891

