### PR TITLE
[FIX] web: calendar view on time off dashboard

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_year/calendar_year_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_year/calendar_year_renderer.js
@@ -77,6 +77,7 @@ export class CalendarYearRenderer extends Component {
             windowResize: this.onWindowResizeDebounced,
             eventContent: this.onEventContent,
             viewDidMount: this.viewDidMount,
+            weekends: this.props.isWeekendVisible,
         };
     }
 

--- a/addons/web/static/src/views/calendar/hooks.js
+++ b/addons/web/static/src/views/calendar/hooks.js
@@ -8,7 +8,6 @@ import {
     onPatched,
     onWillStart,
     onWillUnmount,
-    onWillUpdateProps,
     useComponent,
     useExternalListener,
     useRef,
@@ -114,13 +113,13 @@ export function useFullCalendar(refName, params) {
         }
     });
 
-    let isWeekendVisible = params.isWeekendVisible;
-    onWillUpdateProps((np) => {
-        isWeekendVisible = np.isWeekendVisible;
-    });
     onPatched(() => {
         instance.refetchEvents();
-        instance.setOption("weekends", isWeekendVisible);
+        instance.setOption("weekends", component.props.isWeekendVisible);
+        if (params.weekNumbers && component.props.model.scale === "year") {
+            instance.destroy();
+            instance.render();
+        }
     });
     onWillUnmount(() => {
         instance.destroy();


### PR DESCRIPTION
Before this commit when the filter on the Time Off Dashboard 
is set to "Year" (which is default) and the "Show Weekends" 
filter is toggled, the entire calendar view of the dashboard 
becomes scrambled. It returns to its normal state when the 
page is refreshed.
Also when "Show Weekends" filter is in false state and we 
refresh the page we are getting weekends in calendar view 
of dashboard while the "Show Weekends" filter state remains 
false.

Steps to reproduce :
- Go to Time Off Module
- Click on scale selector and then click on "Show Weekends" filter
- The entire calendar view of the dashboard becomes scrambled

After this commit the calendar view of time off dashboard will 
not be scrambled when we toggle the "Show Weekends" filter. 
Also we will get weekdays in calendar view of dashboard when 
"Show Weekends" filter is in false state and we refresh the page.

Task-4072516

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
