### PR TITLE
[FIX] mrp: fix _split_productions set consumed_qty 2

### DIFF
--- a/addons/mrp/wizard/stock_assign_serial_numbers.py
+++ b/addons/mrp/wizard/stock_assign_serial_numbers.py
@@ -64,6 +64,7 @@ class StockAssignSerialNumbers(models.TransientModel):
 
     def _assign_serial_numbers(self, cancel_remaining_quantity=False):
         serial_numbers = self._get_serial_numbers()
+        self._reset_production_qties()
         productions = self.production_id._split_productions(
             {self.production_id: [1] * len(serial_numbers)}, cancel_remaining_quantity, set_consumed_qty=True)
         production_lots_vals = []
@@ -91,3 +92,9 @@ class StockAssignSerialNumbers(models.TransientModel):
 
     def no_backorder(self):
         self._assign_serial_numbers(True)
+
+    def _reset_production_qties(self):
+        if self.production_id.qty_producing:
+            self.production_id.qty_producing = 0.0
+            self.production_id.move_raw_ids.picked = False
+            self.production_id.move_raw_ids.quantity = 0.0


### PR DESCRIPTION
### Steps to reproduce:
- Create a product P tracked by serial number with a BOM: - 1 x COMP (a storable prodcut that you do not have in stock)
- Create and confirm an MO for 10 units of P
- Click on the [+] button to generate one serial number of P
> This steps updates the qty_producting to 1 and the set the
consumed_qty of the raw move to 1.
- Click on `Mass Produce` > `Generate` > Apply (to generate the remaining SN)
> This generates 9 backorders each for 1 unit of P with a set SN
#### > However raw moves are **picked with a consumed_qty of 0**

### Cause of the issue:

Since the stockpocalypse commit 7dda6bb the `_split_productions` did not consume quantities anymore. This behavior was fixed by commit 4be8cac for mass production notably by the addittion of these lines: https://github.com/odoo/odoo/blob/6995d65437ba6b2cd0df7503d589260bedcce67d/addons/mrp/models/mrp_production.py#L1879-L1887 However, in our flow, when we assigned the firt serial number by clicking on the [+] button we had set the quantity of the `initial_move` to 1 and associated a `move_line` with the corresponding quantity to it. As such, none of the move line of the raw moves of the back order is going to be created and the issue remains.

opw-4119702
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
