### PR TITLE
Master sms query count fix jmak

### DIFF
--- a/addons/sms/tests/common.py
+++ b/addons/sms/tests/common.py
@@ -113,6 +113,12 @@ class SMSCase(MockSMS):
     """ Main test class to use when testing SMS integrations. Contains helpers and tools related
     to notification sent by SMS. """
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # This is called to make sure that an iap_account for sms already exists or if not is created.
+        cls.env['iap.account'].get('sms')
+
     def _find_sms_sent(self, partner, number):
         if number is None and partner:
             number = partner._phone_format()

--- a/addons/sms/tests/common.py
+++ b/addons/sms/tests/common.py
@@ -10,7 +10,7 @@ from odoo.addons.sms.models.sms_sms import SmsApi, SmsSms
 from odoo.tests import common
 
 
-class MockSMS(common.BaseCase):
+class MockSMS(common.TransactionCase):
 
     def tearDown(self):
         super(MockSMS, self).tearDown()


### PR DESCRIPTION
[IMP] sms: change MockSms to TransactionCase

Change MockSms to inherit from TransactionCase and not BaseCase, so that
the env would be available.


[FIX] sms: create iap_account for tests

Since https://github.com/odoo/odoo/commit/e57d2c7437fcde59b05e317be8e863aabd42e2d7 some test were failing due to an iap_account for sms
already existing and sometimes it had to be created. To keep it
consistent, it is checked, using the get function on iap_account model,
if an sms account already exists, if not it is created.