### PR TITLE
[IMP] mail: disable activity creation in kanban view

### DIFF
--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -349,7 +349,7 @@
         <field name="name">mail.activity.view.kanban.open.target</field>
         <field name="model">mail.activity</field>
         <field name="arch" type="xml">
-            <kanban string="Activity" action="action_open_document" type="object">
+            <kanban string="Activity" action="action_open_document" type="object" create="false">
                 <templates>
                     <field name="active" invisible="1"/>
                     <t t-name="kanban-card">


### PR DESCRIPTION
**Purpose:**
An activity needs a parent record, and thus cannot be created directly from 'My Activities' page.

**Specifications:**
Disable activity creation from kanban view as its done in the list view.

Task-4161331