### PR TITLE
[FIX] website_payment: fix test_01_donation test

### DIFF
--- a/addons/website_payment/tests/test_snippets.py
+++ b/addons/website_payment/tests/test_snippets.py
@@ -6,6 +6,9 @@ import odoo.tests
 class TestSnippets(odoo.tests.HttpCase):
 
     def test_01_donation(self):
+        if self.env['ir.module.module']._get('payment_demo').state != 'installed':
+            self.skipTest("Payment Provider: Demo module is not installed")
+
         demo_provider = self.env['payment.provider'].search([('code', '=', "demo")])
         demo_provider.write({'state': 'test'})
 


### PR DESCRIPTION
demo_provider does not always have code defined, which causes issues in multiple Single app nightly builds. This commit fixes the issue by searching with name instead of code.

Runbot build errors https://runbot.odoo.com/web#id=76977&menu_id=424&cids=1&action=573&model=runbot.build.error&view_type=form

pr introducing issue: https://github.com/odoo/odoo/pull/178565


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
