### PR TITLE
[FIX] hw_drivers: avoid xrandr if no display is connected

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
@@ -115,6 +115,10 @@ class DisplayDriver(Driver):
             self.browser.refresh()
 
     def set_orientation(self, orientation=Orientation.NORMAL):
+        if self.device_identifier == 'distant_display':
+            # Avoid calling xrandr if no display is connected
+            return
+
         if type(orientation) is not Orientation:
             raise TypeError("orientation must be of type Orientation")
         subprocess.run(['xrandr', '-o', orientation.value], check=True)


### PR DESCRIPTION
We called `set_orientation` method which calls `xrandr` package even if no display was connected, leading to a traceback. We now check whether the display is `distant_display` to avoid that behaviour.