### PR TITLE
[FIX] pos_self_order: broken language selection in self-order-kiosk

### DIFF
--- a/addons/point_of_sale/models/res_lang.py
+++ b/addons/point_of_sale/models/res_lang.py
@@ -7,4 +7,4 @@ class ResLang(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config_id):
-        return ['id', 'name', 'code']
+        return ['id', 'name', 'code', 'flag_image_url']

--- a/addons/pos_self_order/static/src/app/components/language_popup/language_popup.xml
+++ b/addons/pos_self_order/static/src/app/components/language_popup/language_popup.xml
@@ -11,7 +11,7 @@
                                     <t t-if="lang.id !== currentLanguage.id">
                                         <div class="btn btn-light d-flex flex-row align-items-center rounded border p-4" t-on-click="() => this.onClickLanguage(lang)">
                                             <img class="rounded-2" t-attf-src="{{lang.flag_image_url}}" />
-                                            <span class="fs-5 ms-4" t-esc="lang.display_name" />
+                                            <span class="fs-5 ms-4" t-esc="lang.name" />
                                         </div>
                                     </t>
                                 </t>

--- a/addons/pos_self_order/static/src/app/pages/landing_page/landing_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/landing_page/landing_page.xml
@@ -3,7 +3,7 @@
     <t t-name="pos_self_order.LandingPage">
         <div t-if="languages.length > 1" t-on-click="openLanguages" class="self_order_language_selector position-absolute top-0 end-0 m-4 rounded p-4 bg-white shadow-lg">
             <img class="rounded" t-attf-src="{{currentLanguage.flag_image_url}}" />
-            <span t-esc="currentLanguage.display_name" class="ms-3"></span>
+            <span t-esc="currentLanguage.name" class="ms-3"></span>
         </div>
         <div t-if="selfOrder.config._self_ordering_image_home_ids.length > 0" t-on-click="start" class="d-flex flex-column vh-100 align-items-center overflow-hidden">
             <div id="carouselAutoplaying" t-ref="carousel" class="carousel slide w-100 h-100" data-bs-ride="true">


### PR DESCRIPTION
Steps:
----------
Step 1: Set up the self-order (kiosk) configuration. Step 2: Select multiple languages in the self-order configuration. Step 3: Open the self-order UI page.
You'll see the broken language selection on the UI.

Issue:
----------
language selection on the self-order UI is broken.

Cause:
----------
Use `display_name` instead of `name` and
the field `flag_image_url` is not loaded in pos.

FIX:
---------
Replace "display_name" with "name" and load the "flag_image_url" field in the "pos".

task- 4153942
