### PR TITLE
[FIX] website_event_booth[_sale]: find proper partner

### DIFF
--- a/addons/website_event_booth/i18n/website_event_booth.pot
+++ b/addons/website_event_booth/i18n/website_event_booth.pot
@@ -150,6 +150,13 @@ msgid "Get A Booth"
 msgstr ""
 
 #. module: website_event_booth
+#. odoo-javascript
+#: code:addons/website_event_booth/static/src/js/booth_register.js:0
+#, python-format
+msgid "It looks like your email is linked to an existing account."
+msgstr ""
+
+#. module: website_event_booth
 #: model:ir.model.fields,field_description:website_event_booth.field_website_event_menu__menu_type
 msgid "Menu Type"
 msgstr ""
@@ -162,6 +169,11 @@ msgstr ""
 #. module: website_event_booth
 #: model_terms:ir.ui.view,arch_db:website_event_booth.event_booth_registration_details
 msgid "Phone"
+msgstr ""
+
+#. module: website_event_booth
+#: model_terms:ir.ui.view,arch_db:website_event_booth.event_booth_registration_details
+msgid "Please Sign In."
 msgstr ""
 
 #. module: website_event_booth

--- a/addons/website_event_booth/static/src/js/booth_register.js
+++ b/addons/website_event_booth/static/src/js/booth_register.js
@@ -106,6 +106,7 @@ publicWidget.registry.boothRegistration = publicWidget.Widget.extend({
      */
     _updateErrorDisplay(errors) {
         this.$('.o_wbooth_registration_error_section').toggleClass('d-none', !errors.length);
+        this.$('.o_wbooth_registration_error_signin').addClass('d-none');
 
         let errorMessages = [];
         let $errorMessage = this.$('.o_wbooth_registration_error_message');
@@ -120,6 +121,11 @@ publicWidget.registry.boothRegistration = publicWidget.Widget.extend({
 
         if (errors.includes('boothCategoryError')) {
             errorMessages.push(_t("The booth category doesn't exist."));
+        }
+
+        if (errors.includes('existingPartnerError')) {
+            errorMessages.push(_t("It looks like your email is linked to an existing account."));
+            this.$('.o_wbooth_registration_error_signin').removeClass('d-none');
         }
 
         $errorMessage.text(errorMessages.join(' ')).change();

--- a/addons/website_event_booth/views/event_booth_registration_templates.xml
+++ b/addons/website_event_booth/views/event_booth_registration_templates.xml
@@ -52,6 +52,10 @@
                 <div class="o_wbooth_registration_error_section alert alert-danger d-none mt-4" role="alert">
                     <i class="fa fa-exclamation-triangle me-2" role="img" aria-label="Error" title="Error"/>
                     <span class="o_wbooth_registration_error_message"/>
+                    <a class="o_wbooth_registration_error_signin d-none"
+                        t-attf-href="/web/login?redirect={{redirect_url}}">
+                        Please Sign In.
+                    </a>
                 </div>
                 <div class="mb-3">
                     <div class="d-grid col-sm-6 offset-sm-3 mt-5">

--- a/addons/website_event_booth_sale/controllers/event_booth.py
+++ b/addons/website_event_booth_sale/controllers/event_booth.py
@@ -21,12 +21,13 @@ class WebsiteEventBoothController(WebsiteEventController):
         """Override: Doesn't call the parent method because we go through the checkout
         process which will confirm the booths when receiving the payment."""
         booths = self._get_requested_booths(event, event_booth_ids)
-        if not booths:
-            return json.dumps({'error': 'boothError'})
-
         booth_category = request.env['event.booth.category'].sudo().browse(int(booth_category_id))
-        if not booth_category.exists():
-            return json.dumps({'error': 'boothCategoryError'})
+        error_code = self._check_booth_registration_values(
+            booths,
+            kwargs['contact_email'],
+            booth_category=booth_category)
+        if error_code:
+            return json.dumps({'error': error_code})
 
         booth_values = self._prepare_booth_registration_values(event, kwargs)
         order_sudo = request.website.sale_get_order(force_create=True)


### PR DESCRIPTION
This commit fixes an issue where the partner assigned to a booth could be incorrect based on the provided email.

Indeed, we don't want to assign an existing partner when non-logged, as it could conflict when trying to checkout the order and providing another one. In addition, it just does not make much sense.

Instead we now suggest to login before booking your booths.

Task-4163951

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
