### PR TITLE
[FIX] point_of_sale: account move shouldn't be mapped with fp

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -802,9 +802,8 @@ class PosSession(models.Model):
                         .filtered(lambda m: not bool(m.origin_returned_move_id and sum(m.stock_valuation_layer_ids.mapped('quantity')) >= 0))\
                         .mapped('stock_valuation_layer_ids')
                     for move in stock_moves_batch.with_context(candidates_prefetch_ids=candidates._prefetch_ids):
-                        fpos = order_line.order_id.fiscal_position_id
-                        exp_key = fpos.map_account(move.product_id._get_product_accounts()['expense'])
-                        out_key = fpos.map_account(move.product_id.categ_id.property_stock_account_output_categ_id)
+                        exp_key = move.product_id._get_product_accounts()['expense']
+                        out_key = move.product_id.categ_id.property_stock_account_output_categ_id
                         signed_product_qty = move.product_qty
                         if move._is_in():
                             signed_product_qty *= -1


### PR DESCRIPTION
Account moves are created for the whole session and are not specific to a pos order. So we shouldn't map the accounts used.

This reverts commit 595561fd9b48b5a71bf709b018d25006deb9f12c.

opw-4086609
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
