### PR TITLE
[FIX] mrp: fix display issue with MO quantities when exceeding 3 digits

### DIFF
--- a/addons/mrp/static/src/scss/mrp_fields.scss
+++ b/addons/mrp/static/src/scss/mrp_fields.scss
@@ -1,3 +1,7 @@
 .o_field_widget.o_embed_url_viewer iframe {
     aspect-ratio: 3/2;
 }
+
+.o_form_view .o_form_editable .o_row .qty_producing_field {
+    width: auto !important;
+}

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -248,8 +248,8 @@
                             <field name="product_description_variants" invisible="product_description_variants in (False, '')" readonly="state != 'draft'"/>
                             <label for="product_qty" string="Quantity"/>
                             <div class="o_row g-0 d-flex">
-                                <div invisible="state == 'draft'" class="o_row flex-grow-0">
-                                    <field name="qty_producing" class="text-start" readonly="state == 'cancel' or (state == 'done' and is_locked)"/>
+                                <div invisible="state == 'draft'" class="o_row flex-grow-0 qty_producing_field">
+                                    <field name="qty_producing" class="text-start qty_producing_field" readonly="state == 'cancel' or (state == 'done' and is_locked)"/>
                                     /
                                 </div>
                                 <field name="product_qty" class="oe_inline text-start" invisible="state not in ('draft', 'done')" readonly="state != 'draft'"/>


### PR DESCRIPTION
When the quantity number in an MO exceeds 3 digits in the integral part (e.g., 1000), an overlapping issue occurs on the display between the "Quantity Done" and "Quantity Produced" fields.


Steps to reproduce the issue:

1- Navigate to Manufacturing.
2- Go to Operations -> Manufacturing Orders.
3- Create a new Manufacturing Order.
4- Choose a quantity number exceeding three digits.
5- Confirm the MO.
6- Click on "Produce All". The overlapping should appear in the quantity field.

OPW-4144956

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
