### PR TITLE
[IMP] account: dashboard links

### DIFF
--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -346,12 +346,12 @@
                             <div class="row" t-if="dashboard.number_waiting">
                                 <div class="col overflow-hidden text-start">
                                     <span t-if="journal_type == 'sale'">
-                                        <a type="object" name="open_action" context="{'action_name': 'action_amounts_to_settle', 'search_default_invoices': '1', 'journal_type': type}">
+                                        <a type="object" name="open_action" context="{'search_default_open': '1', 'search_default_posted': '1', 'journal_type': type}">
                                             <t t-out="dashboard.number_waiting"/> Unpaid
                                         </a>
                                     </span>
                                     <span t-if="journal_type == 'purchase'">
-                                        <a type="object" name="open_action" context="{'action_name': 'action_amounts_to_settle', 'search_default_bills': '1', 'journal_type': type}">
+                                        <a type="object" name="open_action" context="{'search_default_open': '1', 'search_default_posted': '1', 'journal_type': type}">
                                             <t t-out="dashboard.number_waiting"/> To Pay
                                         </a>
                                     </span>
@@ -363,12 +363,12 @@
                             <div class="row" t-if="dashboard.number_late">
                                 <div class="col overflow-hidden text-start">
                                     <span t-if="journal_type == 'sale'">
-                                        <a type="object" name="open_action" context="{'action_name': 'action_amounts_to_settle', 'search_default_invoices': '1', 'search_default_late': '1', 'journal_type': type}">
+                                        <a type="object" name="open_action" context="{'search_default_late': '1', 'search_default_posted': '1', 'journal_type': type}">
                                             <t t-out="dashboard.number_late"/> Late
                                         </a>
                                     </span>
                                     <span t-if="journal_type == 'purchase'">
-                                        <a type="object" name="open_action" context="{'action_name': 'action_amounts_to_settle', 'search_default_bills': '1', 'search_default_late': '1', 'journal_type': type}">
+                                        <a type="object" name="open_action" context="{'search_default_late': '1', 'search_default_posted': '1', 'journal_type': type}">
                                             <t t-out="dashboard.number_late"/> Late
                                         </a>
                                     </span>


### PR DESCRIPTION
Before this commit, some links of the dashboard on sale and purchase journal were linked to account.move.line which was not consistent with the rest of the actions.
We change that to target account.move instead.

To do that we will use the same actions as when going on the tree view of invoices or bills. But in the context we will pass some new default_search and the 'show_amount_due' key to change the view so that we can have the column amount due is optional show.

task: 4156150




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
