### PR TITLE
[FIX] website: adapt `s_image_title` vertical align. option

### DIFF
--- a/addons/website/views/snippets/s_image_title.xml
+++ b/addons/website/views/snippets/s_image_title.xml
@@ -20,7 +20,7 @@
 <template id="s_image_title_options" inherit_id="website.snippet_options">
     <!--  Box Vertical Alignment -->
     <xpath expr="//div[@data-js='WebsiteAnimate']" position="after">
-        <div data-selector=".row > div" data-exclude=".o_grid_item_image">
+        <div data-selector=".s_image_title .row > div" data-exclude=".o_grid_item_image">
             <we-button-group string="Vert. Alignment" title="Vertical Alignment">
                 <we-button title="Align Top"
                         data-select-class=""


### PR DESCRIPTION
Prior to this commit, the selector for the vertical alignment option in `s_image_title` was too generic and displayed this option in other snippets and was therefore broken.

This commit adapts the selector to make it work correctly.

task-4105319
Part of task-4077427



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
