### PR TITLE
[FIX] web: Hide label from percentpie widget in list view

### DIFF
--- a/addons/web/static/src/views/fields/percent_pie/percent_pie_field.scss
+++ b/addons/web/static/src/views/fields/percent_pie/percent_pie_field.scss
@@ -9,6 +9,12 @@
     }
 }
 
+.o_list_renderer .o_list_table .o_list_number{
+    .o_pie, .o_field_percent_pie .o_pie_text {
+        display: none !important;
+    }
+}
+
 .o_field_percent_pie .o_pie_text {
     display: none;
 }


### PR DESCRIPTION
Specification:
When creating a percent pie widget in the list view using Studio, the field's name has been added after percent pie, which is not user-friendly.

Expected behavior:
The duplicate label should not be visible in the list view.

Task-3942207
