### PR TITLE
[FIX] web: Hide label from percentpie widget in list view

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -305,6 +305,12 @@
                 white-space: nowrap;
                 .o_field_widget:not(.o_row_handle):not(.o_field_handle):not(.o_field_badge) {
                     display: inline;
+                    &.o_field_percent_pie{
+                        @include o-text-overflow(inline-flex);
+                        span.o_pie_text{
+                            @include o-text-overflow(none);
+                        }
+                    }
                     span:not(.o_m2o_avatar) {
                         @include o-text-overflow(inline);
                     }


### PR DESCRIPTION
Specification:
When creating a percent pie widget in the list view using Studio, the field's name has been added after percent pie, which is not user-friendly.

Expected behavior:
The duplicate label should not be visible in the list view.

Task-3942207

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
