### PR TITLE
[FIX] html_editor: wysiwyg in iframe with contentClass

### DIFF
--- a/addons/html_editor/static/src/wysiwyg.js
+++ b/addons/html_editor/static/src/wysiwyg.js
@@ -75,7 +75,7 @@ export class Wysiwyg extends Component {
                         if (this.props.copyCss) {
                             copyCssRules(document, el.contentDocument);
                         }
-                        const additionalClasses = el.dataset.class?.split(" ");
+                        const additionalClasses = el.dataset.class?.trim().split(" ");
                         if (additionalClasses) {
                             for (const c of additionalClasses) {
                                 el.contentDocument.body.classList.add(c);

--- a/addons/html_editor/static/tests/_helpers/editor.js
+++ b/addons/html_editor/static/tests/_helpers/editor.js
@@ -191,7 +191,9 @@ export async function setupWysiwyg(props = {}) {
     const content = props.content;
     delete props.content;
     const wysiwyg = await mountWithCleanup(Wysiwyg, { props });
-    const el = /** @type {HTMLElement} **/ (queryOne(".odoo-editor-editable"));
+    const el = /** @type {HTMLElement} **/ (
+        queryOne(`${props.iframe ? ":iframe " : ""}.odoo-editor-editable`)
+    );
     if (content) {
         // force selection to be put properly
         setContent(el, content);

--- a/addons/html_editor/static/tests/wysiwyg.test.js
+++ b/addons/html_editor/static/tests/wysiwyg.test.js
@@ -95,4 +95,12 @@ describe("Wysiwyg Component", () => {
         expect(getContent(el)).toBe("<p>test <strong>[some]</strong> text</p>");
         await waitFor(".o-we-toolbar .btn[name='bold'].active");
     });
+
+    test("Wysiwyg in iframe with a contentClass that need to be trim", async () => {
+        await setupWysiwyg({
+            iframe: true,
+            contentClass: "test ",
+        });
+        expect(":iframe .test.odoo-editor-editable").toHaveCount(1);
+    });
 });


### PR DESCRIPTION
Before this commit, if we have a Wysiwyg component in iframe mode that receives contentClass props with an extra space at the end, then the component crashes because it doesn't trim contentClass.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
