### PR TITLE
[16.0][FIX] stock_dropshipping: Do not use the purchase description in dropshipping pickings

### DIFF
--- a/addons/stock_dropshipping/models/purchase.py
+++ b/addons/stock_dropshipping/models/purchase.py
@@ -31,6 +31,13 @@ class PurchaseOrderLine(models.Model):
         res = super(PurchaseOrderLine, self)._prepare_stock_moves(picking)
         for re in res:
             re['sale_line_id'] = self.sale_line_id.id
+            if self.order_id.dest_address_id:
+                # In a dropshipping context we do not need the description of the purchase order or it will be displayed
+                # in Delivery slip report and it may be confusing for the customer to see several times the same text (product name + description_picking).
+                product = self.product_id.with_context(lang=self.order_id.dest_address_id.lang or self.env.user.lang)
+                re['description_picking'] = product._get_description(
+                    self.env['stock.picking.type'].browse(re['picking_type_id'])
+                )
         return res
 
     def _find_candidate(self, product_id, product_qty, product_uom, location_id, name, origin, company_id, values):

--- a/addons/stock_dropshipping/tests/test_dropship.py
+++ b/addons/stock_dropshipping/tests/test_dropship.py
@@ -90,6 +90,7 @@ class TestDropship(common.TransactionCase):
         self.assertAlmostEqual(pol2.product_qty, sol2.product_uom_qty)
 
     def test_00_dropship(self):
+        self.dropship_product.description_purchase = "description_purchase"
         # Required for `route_id` to be visible in the view
         self.env.user.groups_id += self.env.ref('stock.group_adv_location')
 
@@ -116,6 +117,7 @@ class TestDropship(common.TransactionCase):
         # Check a quotation was created to a certain vendor and confirm so it becomes a confirmed purchase order
         purchase = self.env['purchase.order'].search([('partner_id', '=', self.supplier.id)])
         self.assertTrue(purchase, "an RFQ should have been created by the scheduler")
+        self.assertIn("description_purchase", purchase.order_line.name)
         purchase.button_confirm()
         self.assertEqual(purchase.state, 'purchase', 'Purchase order should be in the approved state')
 
@@ -126,6 +128,7 @@ class TestDropship(common.TransactionCase):
         self.assertEqual(purchase.dropship_picking_count, 1)
 
         # Send the 200 pieces
+        self.assertNotIn("description_purchase", purchase.picking_ids.move_ids.description_picking)
         purchase.picking_ids.move_ids.quantity_done = purchase.picking_ids.move_ids.product_qty
         purchase.picking_ids.button_validate()
 


### PR DESCRIPTION
Do not use the purchase description in dropshipping pickings

Example use case:
- Create a dropshipping product and set a purchase description
- Create a sales order with the product and confirm
- Purchase order will have the purchase description
- Confirm the purchase order
- Go to dropshipping picking
- Print Delivery slip

Current behavior:
- Product name and purchase description is displayed

Expected behavior:
- Purchase description should not be displayed

@Tecnativa TT50677

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr