### PR TITLE
[FIX] l10n_es_pos: generate normal invoice in es PoS

### DIFF
--- a/addons/l10n_es_pos/models/account_move.py
+++ b/addons/l10n_es_pos/models/account_move.py
@@ -10,3 +10,8 @@ class AccountMove(models.Model):
         for move in self:
             if move.pos_order_ids:
                 move.l10n_es_is_simplified = move.pos_order_ids[0].is_l10n_es_simplified_invoice
+
+    def _generate_pdf_and_send_invoice(self, template, force_synchronous=True, allow_fallback_pdf=True, bypass_download=False, **kwargs):
+        if self.company_id.country_code == "ES" and not self.company_id.l10n_es_edi_facturae_certificate_id:
+            kwargs['l10n_es_edi_facturae_checkbox_xml'] = False
+        return super()._generate_pdf_and_send_invoice(template, force_synchronous, allow_fallback_pdf, bypass_download, **kwargs)

--- a/addons/l10n_es_pos/tests/test_frontend.py
+++ b/addons/l10n_es_pos/tests/test_frontend.py
@@ -3,6 +3,7 @@
 
 import odoo.tests
 from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
+from odoo import Command
 
 
 @odoo.tests.tagged('post_install_l10n', 'post_install', '-at_install')
@@ -10,6 +11,8 @@ class TestUi(TestPointOfSaleHttpCommon):
     @classmethod
     def _get_main_company(cls):
         cls.company_data["company"].country_id = cls.env.ref("base.es").id
+        cls.company_data["company"].currency_id = cls.env.ref("base.EUR").id
+        cls.company_data["company"].vat = "ESA12345674"
         return cls.company_data["company"]
 
     def test_spanish_pos(self):
@@ -37,3 +40,46 @@ class TestUi(TestPointOfSaleHttpCommon):
         num_of_regular_invoices = get_number_of_regular_invoices() - initial_number_of_regular_invoices
         self.assertEqual(num_of_simp_invoices, 3)
         self.assertEqual(num_of_regular_invoices, 1)
+
+    def test_spanish_pos_invoice_no_certificate(self):
+        """This test make sure that the invoice generated in spanish PoS are not proforma invoices"""
+        self.partner_a.write({
+            'vat': "ESA12345674",
+            'country_id': self.env.ref("base.es").id,
+            'email': "email@gmail.com"
+        })
+        self.main_pos_config.open_ui()
+        self.pos_order_pos0 = self.env['pos.order'].create({
+            'company_id': self._get_main_company().id,
+            'partner_id': self.partner_a.id,
+            'session_id': self.main_pos_config.current_session_id.id,
+            'pricelist_id': self.main_pos_config.pricelist_id.id,
+            'lines': [Command.create({
+                'product_id': self.product_a.id,
+                'price_unit': 100,
+                'qty': 1.0,
+                'price_subtotal': 100,
+                'price_subtotal_incl': 100,
+                'discount': 0,
+            })],
+            'amount_total': 100,
+            'amount_tax': 0,
+            'amount_paid': 0,
+            'amount_return': 0,
+            'to_invoice': True,
+        })
+
+        context_make_payment = {"active_ids": [self.pos_order_pos0.id], "active_id": self.pos_order_pos0.id}
+        self.pos_make_payment_0 = self.env['pos.make.payment'].with_context(context_make_payment).create({
+            'amount': 100.0,
+            'payment_method_id': self.main_pos_config.payment_method_ids[0].id,
+        })
+        context_payment = {'active_id': self.pos_order_pos0.id}
+        self.pos_make_payment_0.with_context(context_payment).check()
+
+        self.pos_order_pos0.action_pos_order_invoice()
+        attachment_proforma = self.pos_order_pos0.account_move.attachment_ids.filtered(lambda att: "proforma" in att.name)
+        self.assertFalse(attachment_proforma)
+        invoice_str = str(self.pos_order_pos0.account_move.get_invoice_pdf_report_attachment()[0])
+        self.assertTrue("invoice" in invoice_str)
+        self.assertTrue("proforma" not in invoice_str)


### PR DESCRIPTION
In a Spanish company if you don't have a certificate set on the company, the PoS would generate a proforma invoice instead of a normal invoice.

Steps to reproduce:
-------------------
* Install l10n_es_pos
* Remove the l10n_es_edi_facturae_certificate_id from the company
* Open PoS
* Make an order and invoice it
> Observation: The invoice generated is a proforma invoice instead of a
normal invoice

Why the fix:
------------
When generating the invoice data in `_generate_pdf_and_send_invoice` the wizard would have `l10n_es_edi_facturae_checkbox_xml` checked by default This leads to the generation of a specific invoice that will fail because there are no certificate setup on the company. This will then fallback to the proforma invoice.

opw-4074779
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
