### PR TITLE
[FIX] mrp: document.document not created from bom

### DIFF
--- a/addons/product/models/ir_attachment.py
+++ b/addons/product/models/ir_attachment.py
@@ -9,6 +9,7 @@ class IrAttachment(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         """Create product.document for attachments added in products chatters"""
+        vals_list = self._pre_create_check(vals_list)
         attachments = super().create(vals_list)
         if not self.env.context.get('disable_product_documents_creation'):
             product_attachments = attachments.filtered(
@@ -17,9 +18,17 @@ class IrAttachment(models.Model):
                     and not attachment.res_field
             )
             if product_attachments:
-                self.env['product.document'].sudo().create(
+                self._create_product_document(product_attachments)
+        return attachments
+
+    def _pre_create_check(self, vals_list):
+        # To be overrided
+        return vals_list
+
+    def _create_product_document(self, product_attachments):
+        # To be overrided
+        self.env['product.document'].sudo().create(
                     {
                         'ir_attachment_id': attachment.id
                     } for attachment in product_attachments
                 )
-        return attachments


### PR DESCRIPTION
Since the document refactor https://github.com/odoo/odoo/pull/152286, adding an attachment to the BoM chatter did not add it to the document app.

It needed to create a document.document which was handled in the create method of ir_attachment if the model was correct. However, the model was changed after the create method, which lead to the document.document not being created.

task-id: 4164386

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
