### PR TITLE
[FIX] mail: show list_activity widget in studio in debug mode

### DIFF
--- a/addons/mail/static/src/views/web/fields/list_activity/list_activity.js
+++ b/addons/mail/static/src/views/web/fields/list_activity/list_activity.js
@@ -37,6 +37,8 @@ export class ListActivity extends Component {
 export const listActivity = {
     component: ListActivity,
     fieldDependencies: ListActivity.fieldDependencies,
+    displayName: _t("List Activity"),
+    supportedTypes: ["one2many"],
 };
 
 registry.category("fields").add("list_activity", listActivity);


### PR DESCRIPTION
The list_activity widget did not set its web_studio related keys (displayName and supportedTypes) which caused it not to be shown in the widgets selection.

The widget can now be selected for one2many fields but only in debug mode.

Task: 4152399

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
