### PR TITLE
[IMP] web: enable login user switch if more than one

### DIFF
--- a/addons/auth_totp/static/tests/totp_flow.js
+++ b/addons/auth_totp/static/tests/totp_flow.js
@@ -219,9 +219,13 @@ registry.category("web_tour.tours").add('totp_login_device', {
     trigger: '.dropdown-item[data-menu=logout]',
     run: "click",
 }, {
-    content: "check that we're back on the quick login page",
-    trigger: ".o_user_switch .o_user_avatar",
-    run: "click",
+    content: "check that we're back on the login page or go to it",
+    trigger: 'input#login, a:contains(Log in)',
+    run: "edit Test",
+}, {
+    content: "input login again",
+    trigger: 'input#login',
+    run: "edit demo",
 }, {
     content: 'input password again',
     trigger: 'input#password',

--- a/addons/web/static/src/core/user_switch/user_switch.js
+++ b/addons/web/static/src/core/user_switch/user_switch.js
@@ -12,10 +12,10 @@ export class UserSwitch extends Component {
         this.root = useRef("root");
         this.state = useState({
             users,
-            displayUserChoice: users.length,
+            displayUserChoice: users.length > 1,
         });
         this.form = document.querySelector("form.oe_login_form");
-        this.form.classList.toggle("d-none", users.length);
+        this.form.classList.toggle("d-none", users.length > 1);
         this.form.querySelector(":placeholder-shown")?.focus();
         useEffect(
             (el) => el?.querySelector("button.list-group-item-action")?.focus(),

--- a/addons/web/static/tests/tours/user_switch_tour.js
+++ b/addons/web/static/tests/tours/user_switch_tour.js
@@ -21,6 +21,19 @@ registry.category("web_tour.tours").add("test_user_switch", {
     steps: () => [
         ...logout(),
         {
+            content: "check if the login input is empty",
+            trigger: "input#login:empty",
+        },
+        {
+            content: "check if the password input is empty",
+            trigger: "input#password:empty",
+        },
+        {
+            content: "Should contains the user switch button",
+            trigger: ".oe_login_form .o_user_switch_btn",
+            run: "click",
+        },
+        {
             content: "Click on Marc Demo on the quick login page",
             trigger:
                 ".o_user_switch:not(:has(.list-group-item:nth-child(2))) .list-group-item:contains('Marc Demo')",


### PR DESCRIPTION
If there is only one user in user switch, don't display it and propose the login form. If there is more than one user, display the user switch.

task-4160923

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
