### PR TITLE
[FIX] mail: Crash from backbutton after 'Open in Discuss'

### DIFF
--- a/addons/mail/static/src/discuss/core/web/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/web/thread_actions.js
@@ -23,13 +23,15 @@ threadActionsRegistry.add("expand-discuss", {
         return false;
     },
     open(component) {
-        component.thread.setAsDiscussThread();
         component.actionService.doAction(
             {
                 type: "ir.actions.client",
                 tag: "mail.action_discuss",
             },
-            { clearBreadcrumbs: this.shouldClearBreadcrumbs(component) }
+            {
+                clearBreadcrumbs: this.shouldClearBreadcrumbs(component),
+                additionalContext: { active_id: component.thread.id },
+            }
         );
     },
     sequence: 15,


### PR DESCRIPTION
Before this PR, open in discuss would push an active_id in the browser history before calling doAction. This creates an unnecessary url inside the history that could crash when using the back button.

This PR removes the call to setAsDiscussThread and adds the active_id inside the doAction call.

Task-4105649