### PR TITLE
[FIX] l10n_cl: display discount correctly on invoice

### DIFF
--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -166,7 +166,7 @@
             <attribute name="t-options">{"widget": "float", "precision": 2}</attribute>
         </xpath>
 
-        <th name="th_priceunit" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}" position="after">
+        <th name="th_discount" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}" position="after">
             <th name="th_discount_currency" t-if="display_discount" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
                 <span>Disc.</span>
             </th>


### PR DESCRIPTION
Steps to reproduce:
1. In the Chilean localization, create a new invoice with a discount.
2. Confirm and send.

The behavior:
The Discount Amount is displayed under the Discount Percentage, and vice versa.

Why this was the case:
The Discount table header was placed after the Price Unit header (`th_priceunit`), and its data was displayed after the Discount Percentage (`th_discount`).

OPW-4112378