### PR TITLE
[IMP] event_sale: allow only confirmed orders for sale stat button

### DIFF
--- a/addons/event_sale/tests/test_event_sale.py
+++ b/addons/event_sale/tests/test_event_sale.py
@@ -366,7 +366,7 @@ class TestEventSale(TestEventSaleCommon):
             editor.action_make_registration()
 
     def test_event_sale_price_total(self):
-        """ Test that the `sale_amount_total` matches the total amount of all concerned orders.
+        """ Test that the `sale_amount_total` matches the total amount of all confirmed orders.
         """
         self.env['sale.order.line'].create({
             'product_id': self.event_product.id,
@@ -374,6 +374,7 @@ class TestEventSale(TestEventSaleCommon):
             'event_id': self.event_0.id,
             'event_ticket_id': self.ticket.id,
         })
+        self.sale_order.action_confirm()
         expected_price = sum(self.event_0.sale_order_lines_ids.mapped('price_total'))
         self.assertEqual(self.event_0.sale_price_total, expected_price)
 


### PR DESCRIPTION
**Purpose:**
Users can review the specific details of the items or benefits they obtained from a particular event.
And helping them keep track of their acquisitions.

**Specifications:**
-The amount displayed on the sale stat button should reflect the total price of
 only the confirmed orders.
-Clicking the stat button should show only the confirmed orders.

Task-4137378