### PR TITLE
[IMP] base_partner_merge: Raise exception instead of deleting records on merge partners

### DIFF
--- a/odoo/addons/base/wizard/base_partner_merge.py
+++ b/odoo/addons/base/wizard/base_partner_merge.py
@@ -154,11 +154,10 @@ class MergePartnerAutomatic(models.TransientModel):
                     with mute_logger('odoo.sql_db'), self._cr.savepoint():
                         query = 'UPDATE "%(table)s" SET "%(column)s" = %%s WHERE "%(column)s" IN %%s' % query_dic
                         self._cr.execute(query, (dst_partner.id, tuple(src_partners.ids),))
-                except psycopg2.Error:
+                except psycopg2.Error as e:
                     # updating fails, most likely due to a violated unique constraint
                     # keeping record with nonexistent partner_id is useless, better delete it
-                    query = 'DELETE FROM "%(table)s" WHERE "%(column)s" IN %%s' % query_dic
-                    self._cr.execute(query, (tuple(src_partners.ids),))
+                    raise UserError('Error updating the record. A unique constraint may have been violated.\n\nError details: %s' % str(e))
 
     @api.model
     def _update_reference_fields(self, src_partners, dst_partner):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR addresses the issue encountered when merging contacts. During the merge process, if a unique constraint violation occurs in certain tables, the system was automatically deleting records associated with the contacts instead of handling the error gracefully.

Current behavior before PR:
When merging contacts, if an update operation triggers a unique constraint error in specific tables, the system responds by deleting the conflicting records. This can lead to unintended data loss without any notification to the user.

Desired behavior after PR is merged:
After merging this PR, instead of deleting records when a unique constraint violation occurs during a contact merge, the system will raise a UserError to inform the user of the issue. This ensures that users are aware of the error and can take corrective action without losing any data.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
