### PR TITLE
[FIX] website: Resolve traceback and layout issues in image wall snippet

### DIFF
--- a/addons/website/static/src/snippets/s_image_gallery/000.js
+++ b/addons/website/static/src/snippets/s_image_gallery/000.js
@@ -60,7 +60,7 @@ const GalleryWidget = publicWidget.Widget.extend({
         };
 
         const milliseconds = this.el.dataset.interval || false;
-        this.$modal = $(renderToElement('website.gallery.slideshow.lightbox', {
+        this.$modal = $(renderToElement("website.s_image_gallery_mirror.lightbox", {
             images: imageEls,
             index: currentImageIndex,
             dim: dimensions,

--- a/addons/website/static/src/snippets/s_image_gallery/001.xml
+++ b/addons/website/static/src/snippets/s_image_gallery/001.xml
@@ -26,4 +26,28 @@
             </div>
         </div>
     </t>
+
+    <!--
+        ========================================================================
+        Gallery Slideshow LightBox
+
+        This template is used to display a lightbox with a slideshow.
+
+        This template wraps website.s_image_gallery_mirror in a bootstrap modal
+        dialog.
+        ========================================================================
+    -->
+    <t t-name="website.s_image_gallery_mirror.lightbox">
+        <div role="dialog" class="modal o_technical_modal fade s_gallery_lightbox p-0" aria-label="Image Gallery Dialog" tabindex="-1">
+            <div class="modal-dialog m-0" role="Picture Gallery"
+                t-attf-style="">
+                <div class="modal-content bg-transparent modal-fullscreen">
+                    <main class="modal-body o_slideshow bg-transparent">
+                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close" style="position: absolute; right: 10px; top: 10px;"></button>
+                        <t t-call="website.s_image_gallery_mirror"></t>
+                    </main>
+                </div>
+            </div>
+        </div>
+    </t>
 </templates>

--- a/addons/website/static/src/snippets/s_image_gallery/002.scss
+++ b/addons/website/static/src/snippets/s_image_gallery/002.scss
@@ -329,3 +329,61 @@
         }
     }
 }
+
+.s_gallery_lightbox {
+    .modal-dialog {
+        height: 100%;
+        background-color: rgba(0,0,0,0.7);
+    }
+    @include media-breakpoint-up(sm) {
+        .modal-dialog {
+            max-width: 100%;
+            padding: 0;
+        }
+    }
+    ul.carousel-indicators {
+        display: none;
+    }
+
+    .modal-body.o_slideshow {
+        @extend %image-gallery-slideshow-styles;
+    }
+}
+
+%image-gallery-slideshow-styles {
+    &:not(.s_image_gallery_cover) .carousel-item {
+        > a {
+            display: flex;
+            height: 100%;
+            width: 100%;
+        }
+        > a > img,
+        > img {
+            max-height: 100%;
+            max-width: 100%;
+            margin: auto;
+        }
+    }
+    .carousel {
+        height: 100%;
+
+        .carousel-inner {
+            height: 100%;
+        }
+        .carousel-item.active,
+        .carousel-item-next,
+        .carousel-item-prev,
+        .carousel-control-next,
+        .carousel-control-prev {
+            display: flex;
+            align-items: center;
+            height: 100%;
+        }
+        .carousel-control-next,
+        .carousel-control-prev {
+             .fa, .oi {
+                text-shadow: 0px 0px 3px $gray-800;
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Resolved traceback in frontend view caused when clicking an image from the image wall snippet, outside the editing mode due to related template not loading.
   - Moved the related template code from the old XML file (000.xml) to the current one (001.xml).

- Center-aligned images in the lightbox by updating the styling.

task-4160564