### PR TITLE
[FIX] account: rename generic coa

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0\n"
+"Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-14 16:15+0000\n"
-"PO-Revision-Date: 2024-08-14 16:15+0000\n"
+"POT-Creation-Date: 2024-09-06 12:08+0000\n"
+"PO-Revision-Date: 2024-09-06 12:08+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -15078,6 +15078,13 @@ msgstr ""
 #: model:ir.model.fields,field_description:account.field_account_invoice_report__product_uom_id
 #: model:ir.model.fields,field_description:account.field_account_move_line__product_uom_id
 msgid "Unit of Measure"
+msgstr ""
+
+#. module: account
+#. odoo-python
+#: code:addons/account/models/template_generic_coa.py:0
+#, python-format
+msgid "United States of America (Generic)"
 msgstr ""
 
 #. module: account

--- a/addons/account/models/template_generic_coa.py
+++ b/addons/account/models/template_generic_coa.py
@@ -1,4 +1,4 @@
-from odoo import models
+from odoo import models, _
 from odoo.addons.account.models.chart_template import template
 
 
@@ -17,7 +17,7 @@ class AccountChartTemplate(models.AbstractModel):
         :rtype: dict
         """
         return {
-            'name': "Generic Chart Template",
+            'name': _("United States of America (Generic)"),
             'country': None,
             'property_account_receivable_id': 'receivable',
             'property_account_payable_id': 'payable',


### PR DESCRIPTION
It happens often enough that whenever someone wants to install The US Accounting localization they have a hard time finding it because they do not know that the "Generic Chart Template" is for the US.
This task will rename the template so that it's more clear for users.

task: 4146856




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
