### PR TITLE
[FIX] website_payment: prevent error while donate amount with empty value

### DIFF
--- a/addons/website_payment/controllers/portal.py
+++ b/addons/website_payment/controllers/portal.py
@@ -48,6 +48,8 @@ class PaymentPortal(payment_portal.PaymentPortal):
 
     @http.route('/donation/transaction/<minimum_amount>', type='json', auth='public', website=True, sitemap=False)
     def donation_transaction(self, amount, currency_id, partner_id, access_token, minimum_amount=0, **kwargs):
+        if not amount:
+            raise ValidationError(_('Please select or enter an amount'))
         if float(amount) < float(minimum_amount):
             raise ValidationError(_('Donation amount must be at least %.2f.', float(minimum_amount)))
         use_public_partner = request.env.user._is_public() or not partner_id

--- a/addons/website_payment/i18n/website_payment.pot
+++ b/addons/website_payment/i18n/website_payment.pot
@@ -330,6 +330,7 @@ msgstr ""
 
 #. module: website_payment
 #. openerp-web
+#: code:addons/website_payment/controllers/portal.py:0
 #: code:addons/website_payment/static/src/snippets/s_donation/000.js:0
 #, python-format
 msgid "Please select or enter an amount"


### PR DESCRIPTION
Currently, An error occurs when paying a donation with an empty 'Custom Amount'.

Steps to produce:

- Installing the 'website_payment' module.
- Go to the website and add a 'Donation' block via drag and drop.
- Select or enter an amount and click on the 'Donate Now' button.
- in donation/pay, Choose the 'Custom Amount' option and click on the 'Custom Amount' input field.
- Without entering any value, click the 'Donate Now' button.

Stack Trace:

```
TypeError: float() argument must be a string or a real number, not 'NoneType'
  File "odoo/http.py", line 2383, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1913, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1976, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1943, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2187, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 227, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 757, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/website_payment/controllers/portal.py", line 38, in donation_transaction
    if float(amount) < float(minimum_amount):
```

An error occurs when the system tries to convert an empty amount into a float at [1], But it is not available.

To handle this issue, Raise a validation error if the donation amount is not provided or is empty.

Sentry-5794503324

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
