### PR TITLE
[FIX] payment_razorpay: prevent exception while processing instance refund

### DIFF
--- a/addons/payment_razorpay/models/payment_transaction.py
+++ b/addons/payment_razorpay/models/payment_transaction.py
@@ -203,7 +203,8 @@ class PaymentTransaction(models.Model):
                 raise ValidationError("Razorpay: " + _("Received data with missing reference."))
             tx = self.search([('reference', '=', reference), ('provider_code', '=', 'razorpay')])
         else:  # 'refund'
-            reference = notification_data.get('notes', {}).get('reference')
+            notes = notification_data.get('notes')
+            reference = isinstance(notes, dict) and notes.get('reference')
             if reference:  # The refund was initiated from Odoo.
                 tx = self.search([('reference', '=', reference), ('provider_code', '=', 'razorpay')])
             else:  # The refund was initiated from Razorpay.


### PR DESCRIPTION
Currently an exception was generated when the user processed an instance refund from
Razorpay, and we get notes as a list in notification data (see  response here [Ref](https://github.com/razorpay/razorpay-python/blob/master/documents/refund.md#create-an-instant-refund)).

error: 
```
AttributeError: 'list' object has no attribute 'get'
  File "odoo/http.py", line 2383, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1913, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1976, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1943, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2100, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 227, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 757, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/payment_razorpay/controllers/main.py", line 41, in razorpay_webhook
    tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
  File "addons/payment_razorpay/models/payment_transaction.py", line 328, in _get_tx_from_notification_data
    reference = notification_data.get('notes', {}).get('reference')
```

This commit will fix the above issue by preventing getting the dict data if `notes` in notification data is list type.



sentry-5793000218

