### PR TITLE
[FIX] hr_attendance: fix the kiosk layout in attendance

### DIFF
--- a/addons/hr_attendance/static/src/components/barcode_dialog/kiosk_barcode_dialog.js
+++ b/addons/hr_attendance/static/src/components/barcode_dialog/kiosk_barcode_dialog.js
@@ -16,7 +16,7 @@ export class AttendanceBarcodeDialog extends BarcodeDialog {
      */
     setup() {
         super.setup();
-        this.state = useState({
+        this.barcodeState = useState({
             barcode: false,
         });
         this.notification = useService("notification");
@@ -33,7 +33,7 @@ export class AttendanceBarcodeDialog extends BarcodeDialog {
     }
 
     async setBadgeID() {
-        let barcode = this.state.barcode;
+        let barcode = this.barcodeState.barcode;
         if (barcode) {
             const result = await rpc("/hr_attendance/set_user_barcode", { token: this.props.token, barcode, });
             if (result) {

--- a/addons/hr_attendance/static/src/scss/kiosk/hr_attendance.scss
+++ b/addons/hr_attendance/static/src/scss/kiosk/hr_attendance.scss
@@ -83,3 +83,7 @@
         image: var(--homeMenu-bg-image, url("/hr_attendance/static/img/background-light.svg"));
     }
 }
+
+.o_hr_attendance_kiosk_body {
+    height: 100vh;
+}


### PR DESCRIPTION
before this commit, the scan badge button shows an error message in kiosk mode Steps:
1) install hr_attendance application
2) open kiosk mode and click on the scan badge
3) it will give an error and the layout is broken

Cause:
the child component overrides the state variable

Fix:
- Changing the variable name resolves the issue
- Setting the body of the kiosk page to 100vh
