### PR TITLE
[FIX] web: tests: don't forget to rollback visibilityState mock

### DIFF
--- a/addons/web/static/tests/views/form/auto_save.test.js
+++ b/addons/web/static/tests/views/form/auto_save.test.js
@@ -18,12 +18,16 @@ import {
 
 import { WebClient } from "@web/webclient/webclient";
 
-const hideTab = () => {
+const hideTab = async () => {
+    const prop = Object.getOwnPropertyDescriptor(Document.prototype, "visibilityState")
     Object.defineProperty(document, "visibilityState", {
         value: "hidden",
+        configurable: true,
+        writable: true,
     });
     document.dispatchEvent(new Event("visibilitychange"));
-    return tick();
+    await tick();
+    Object.defineProperty(document, "visibilityState", prop);
 };
 
 onRpc("has_group", () => true);


### PR DESCRIPTION
Before this commit, the tests of the
feature introduced at odoo/odoo@544da24ebc6359895a548c79b3bca4164dcee45c did not clean their mock overrides. NAmely the visibility state of the document.

This could be problematic if other test were to do the same thing.

After this commit, we revert the mock overrides to make sure we don't alter the test infrastructure.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
