### PR TITLE
[FIX] website: remove unnecessary scss in `s_numbers_showcase`

### DIFF
--- a/addons/website/static/src/snippets/s_numbers_showcase/000.scss
+++ b/addons/website/static/src/snippets/s_numbers_showcase/000.scss
@@ -1,6 +1,0 @@
-.s_numbers_showcase {
-    .o_grid_item {
-        display: flex;
-        flex-direction: column;
-    }
-}

--- a/addons/website/views/snippets/s_numbers_showcase.xml
+++ b/addons/website/views/snippets/s_numbers_showcase.xml
@@ -34,11 +34,4 @@
     </section>
 </template>
 
-<!-- Assets -->
-<record id="website.s_numbers_showcase_000_scss" model="ir.asset">
-    <field name="name">Numbers Showcase 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_numbers_showcase/000.scss</field>
-</record>
-
 </odoo>


### PR DESCRIPTION
Commit c4a28f1258962198a0ca4a95a2a9abe08d6b718d introduced the new `s_numbers_showcase` snippet but also some unnecessary scss with it. This commit removes this scss and its record.

task-4094383
Part of task-4077427


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
