### PR TITLE
[FIX] mrp, stock: correct typo in warehouse in/out steps

### DIFF
--- a/addons/mrp/models/stock_warehouse.py
+++ b/addons/mrp/models/stock_warehouse.py
@@ -29,13 +29,12 @@ class StockWarehouse(models.Model):
 
     manufacture_steps = fields.Selection([
         ('mrp_one_step', 'Manufacture (1 step)'),
-        ('pbm', 'Pick components, then manufacture (2 steps)'),
+        ('pbm', 'Pick components then manufacture (2 steps)'),
         ('pbm_sam', 'Pick components, manufacture, then store products (3 steps)')],
         'Manufacture', default='mrp_one_step', required=True,
-        help="Produce: Move the components to the production location\
-        directly and start the manufacturing process.\nPick / Produce: Unload\
-        the components from the Stock to Input location first, and then\
-        transfer it to the Production location.")
+        help="1 Step: Consume components from stock and produce.\n\
+              2 Steps: Pick components from stock and then produce.\n\
+              3 Steps: Pick components from stock, produce, and then move final product(s) from production area to stock.")
 
     pbm_route_id = fields.Many2one('stock.route', 'Picking Before Manufacturing Route', ondelete='restrict', copy=False)
 

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -56,15 +56,15 @@ class Warehouse(models.Model):
         domain="[('warehouse_selectable', '=', True), '|', ('company_id', '=', False), ('company_id', '=', company_id)]",
         help='Defaults routes through the warehouse', check_company=True, copy=False)
     reception_steps = fields.Selection([
-        ('one_step', 'Receive & Store (1 step)'),
-        ('two_steps', 'Receive , then Store (2 steps)'),
-        ('three_steps', 'Receive , Quality, Store (3 steps)')],
+        ('one_step', 'Receive and Store (1 step)'),
+        ('two_steps', 'Receive then Store (2 steps)'),
+        ('three_steps', 'Receive, Quality Control, then Store (3 steps)')],
         'Incoming Shipments', default='one_step', required=True,
         help="Default incoming route to follow")
     delivery_steps = fields.Selection([
         ('ship_only', 'Deliver (1 step)'),
-        ('pick_ship', 'Pick, then Deliver (2 steps)'),
-        ('pick_pack_ship', 'Pick, Pack, Deliver (3 steps)')],
+        ('pick_ship', 'Pick then Deliver (2 steps)'),
+        ('pick_pack_ship', 'Pick, Pack, then Deliver (3 steps)')],
         'Outgoing Shipments', default='ship_only', required=True,
         help="Default outgoing route to follow")
     wh_input_stock_loc_id = fields.Many2one('stock.location', 'Input Location', check_company=True)


### PR DESCRIPTION
Follow-up of #172457
Updates the wording of the Incoming/Outgoing Shipments & Manufacturing steps.

Before:
![image](https://github.com/user-attachments/assets/f0324ec2-e968-4955-aa74-e519ae3a9149)

After:
![image](https://github.com/user-attachments/assets/295705b9-aa55-4390-aa07-34a643c1e0a1)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
