### PR TITLE
[FIX] l10n_ca: update the taxes and fiscal positions 2024

### DIFF
--- a/addons/l10n_ca/__manifest__.py
+++ b/addons/l10n_ca/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'Canada - Accounting',
-    'version': '1.1',
+    'version': '1.2',
     'author': 'Savoir-faire Linux',
     'website': 'https://www.savoirfairelinux.com',
     'category': 'Accounting/Localizations/Account Charts',

--- a/addons/l10n_ca/data/account_tax_data.xml
+++ b/addons/l10n_ca/data/account_tax_data.xml
@@ -36,7 +36,7 @@
             <field name="amount">7</field>
             <field name="amount_type">percent</field>
             <field name="sequence">2</field>
-            <field name="tax_group_id" ref="tax_group_gst_7"/>
+            <field name="tax_group_id" ref="tax_group_pst_7"/>
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {'repartition_type': 'base'}),
             (0,0, {
@@ -90,13 +90,13 @@
         </record>
         <record id="pst_mb_sale_en" model="account.tax.template">
             <field name="chart_template_id" ref="ca_en_chart_template_en"/>
-            <field name="name">PST for sales - 8% (MB)</field>
-            <field name="description">PST 8%</field>
+            <field name="name">PST for sales - 7% (MB)</field>
+            <field name="description">PST 7%</field>
             <field name="type_tax_use">none</field>
-            <field name="amount">8</field>
+            <field name="amount">7</field>
             <field name="amount_type">percent</field>
             <field name="sequence">2</field>
-            <field name="tax_group_id" ref="tax_group_gst_8"/>
+            <field name="tax_group_id" ref="tax_group_pst_7"/>
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {'repartition_type': 'base'}),
             (0,0, {
@@ -209,13 +209,13 @@
         </record>
         <record id="pst_sk_sale_en" model="account.tax.template">
             <field name="chart_template_id" ref="ca_en_chart_template_en"/>
-            <field name="name">PST for sales - 5% (SK)</field>
-            <field name="description">PST 5%</field>
+            <field name="name">PST for sales - 6% (SK)</field>
+            <field name="description">PST 6%</field>
             <field name="type_tax_use">none</field>
-            <field name="amount">5</field>
+            <field name="amount">6</field>
             <field name="amount_type">percent</field>
             <field name="sequence">2</field>
-            <field name="tax_group_id" ref="tax_group_pst_5"/>
+            <field name="tax_group_id" ref="tax_group_pst_6"/>
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {'repartition_type': 'base'}),
             (0,0, {
@@ -401,13 +401,13 @@
         </record>
         <record id="pst_mb_purc_en" model="account.tax.template">
             <field name="chart_template_id" ref="ca_en_chart_template_en"/>
-            <field name="name">PST for purchases - 8% (MB)</field>
-            <field name="description">PST 8%</field>
+            <field name="name">PST for purchases - 7% (MB)</field>
+            <field name="description">PST 7%</field>
             <field name="type_tax_use">none</field>
-            <field name="amount">8</field>
+            <field name="amount">7</field>
             <field name="amount_type">percent</field>
             <field name="sequence">2</field>
-            <field name="tax_group_id" ref="tax_group_pst_8"/>
+            <field name="tax_group_id" ref="tax_group_pst_7"/>
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {'repartition_type': 'base'}),
             (0,0, {
@@ -520,10 +520,10 @@
         </record>
         <record id="pst_sk_purc_en" model="account.tax.template">
             <field name="chart_template_id" ref="ca_en_chart_template_en"/>
-            <field name="name">PST for purchases - 5% (SK)</field>
-            <field name="description">PST 5%</field>
+            <field name="name">PST for purchases - 6% (SK)</field>
+            <field name="description">PST 6%</field>
             <field name="type_tax_use">none</field>
-            <field name="amount">5</field>
+            <field name="amount">6</field>
             <field name="amount_type">percent</field>
             <field name="sequence">2</field>
             <field name="tax_group_id" ref="tax_group_pst_5"/>

--- a/addons/l10n_ca/data/account_tax_group_data.xml
+++ b/addons/l10n_ca/data/account_tax_group_data.xml
@@ -13,6 +13,14 @@
             <field name="name">PST 5%</field>
             <field name="country_id" ref="base.ca"/>
         </record>
+        <record id="tax_group_pst_6" model="account.tax.group">
+            <field name="name">PST 6%</field>
+            <field name="country_id" ref="base.ca"/>
+        </record>
+        <record id="tax_group_pst_7" model="account.tax.group">
+            <field name="name">PST 7%</field>
+            <field name="country_id" ref="base.ca"/>
+        </record>
         <record id="tax_group_gst_7" model="account.tax.group">
             <field name="name">GST 7%</field>
             <field name="country_id" ref="base.ca"/>

--- a/addons/l10n_ca/data/fiscal_templates_data.xml
+++ b/addons/l10n_ca/data/fiscal_templates_data.xml
@@ -118,13 +118,13 @@
     <record id="fiscal_position_tax_template_ab2nb_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nb_en"/>
         <field name="tax_src_id" ref="gst_sale_en"/>
-        <field name="tax_dest_id" ref="hst13_sale_en"/>
+        <field name="tax_dest_id" ref="hst15_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_ab2nl_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nl_en"/>
         <field name="tax_src_id" ref="gst_sale_en"/>
-        <field name="tax_dest_id" ref="hst13_sale_en"/>
+        <field name="tax_dest_id" ref="hst15_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_ab2ns_sale_en" model="account.fiscal.position.tax.template">
@@ -170,19 +170,19 @@
     <record id="fiscal_position_tax_template_bc2mb_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_mb_en"/>
         <field name="tax_src_id" ref="gstpst_bc_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_dest_id" ref="gstpst_mb_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_bc2nb_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nb_en"/>
         <field name="tax_src_id" ref="gstpst_bc_sale_en"/>
-        <field name="tax_dest_id" ref="hst13_sale_en"/>
+        <field name="tax_dest_id" ref="hst15_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_bc2nl_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nl_en"/>
         <field name="tax_src_id" ref="gstpst_bc_sale_en"/>
-        <field name="tax_dest_id" ref="hst13_sale_en"/>
+        <field name="tax_dest_id" ref="hst15_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_bc2ns_sale_en" model="account.fiscal.position.tax.template">
@@ -218,13 +218,13 @@
     <record id="fiscal_position_tax_template_bc2qc_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_qc_en"/>
         <field name="tax_src_id" ref="gstpst_bc_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_dest_id" ref="gstqst_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_bc2sk_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_sk_en"/>
         <field name="tax_src_id" ref="gstpst_bc_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_dest_id" ref="gstpst_sk_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_bc2yt_sale_en" model="account.fiscal.position.tax.template">
@@ -249,25 +249,25 @@
     <record id="fiscal_position_tax_template_mb2bc_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_mb_en"/>
         <field name="tax_src_id" ref="gstpst_bc_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="gstpst_mb_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_nb2bc_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nb_en"/>
         <field name="tax_src_id" ref="gstpst_bc_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="hst15_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_nl2bc_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nl_en"/>
         <field name="tax_src_id" ref="gstpst_bc_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="hst15_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_ns2bc_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_ns_en"/>
         <field name="tax_src_id" ref="gstpst_bc_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="hst15_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_nt2bc_purc_en" model="account.fiscal.position.tax.template">
@@ -285,25 +285,25 @@
     <record id="fiscal_position_tax_template_on2bc_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_on_en"/>
         <field name="tax_src_id" ref="gstpst_bc_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="hst13_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_pe2bc_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_pe_en"/>
         <field name="tax_src_id" ref="gstpst_bc_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="hst15_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_qc2bc_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_qc_en"/>
         <field name="tax_src_id" ref="gstpst_bc_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="gstqst_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_sk2bc_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_sk_en"/>
         <field name="tax_src_id" ref="gstpst_bc_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="gstpst_sk_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_yt2bc_purc_en" model="account.fiscal.position.tax.template">
@@ -330,19 +330,19 @@
     <record id="fiscal_position_tax_template_mb2bc_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_bc_en"/>
         <field name="tax_src_id" ref="gstpst_mb_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_dest_id" ref="gstpst_bc_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_mb2nb_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nb_en"/>
         <field name="tax_src_id" ref="gstpst_mb_sale_en"/>
-        <field name="tax_dest_id" ref="hst13_sale_en"/>
+        <field name="tax_dest_id" ref="hst15_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_mb2nl_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nl_en"/>
         <field name="tax_src_id" ref="gstpst_mb_sale_en"/>
-        <field name="tax_dest_id" ref="hst13_sale_en"/>
+        <field name="tax_dest_id" ref="hst15_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_mb2ns_sale_en" model="account.fiscal.position.tax.template">
@@ -378,13 +378,13 @@
     <record id="fiscal_position_tax_template_mb2qc_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_qc_en"/>
         <field name="tax_src_id" ref="gstpst_mb_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_dest_id" ref="gstqst_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_mb2sk_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_sk_en"/>
         <field name="tax_src_id" ref="gstpst_mb_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_dest_id" ref="gstpst_sk_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_mb2yt_sale_en" model="account.fiscal.position.tax.template">
@@ -409,25 +409,25 @@
     <record id="fiscal_position_tax_template_bc2mb_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_bc_en"/>
         <field name="tax_src_id" ref="gstpst_mb_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="gstpst_bc_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_nb2mb_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nb_en"/>
         <field name="tax_src_id" ref="gstpst_mb_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="hst15_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_nl2mb_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nl_en"/>
         <field name="tax_src_id" ref="gstpst_mb_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="hst15_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_ns2mb_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_ns_en"/>
         <field name="tax_src_id" ref="gstpst_mb_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="hst15_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_nt2mb_purc_en" model="account.fiscal.position.tax.template">
@@ -445,25 +445,25 @@
     <record id="fiscal_position_tax_template_on2mb_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_on_en"/>
         <field name="tax_src_id" ref="gstpst_mb_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="hst13_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_pe2mb_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_pe_en"/>
         <field name="tax_src_id" ref="gstpst_mb_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="hst15_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_qc2mb_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_qc_en"/>
         <field name="tax_src_id" ref="gstpst_mb_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="gstqst_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_sk2mb_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_sk_en"/>
         <field name="tax_src_id" ref="gstpst_mb_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="gstpst_sk_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_yt2mb_purc_en" model="account.fiscal.position.tax.template">
@@ -477,162 +477,150 @@
         <field name="tax_src_id" ref="gstpst_mb_purc_en"/>
     </record>
 
-    <!--  Company is in New Brunswick (default is hst13) -->
+    <!--  Company is in New Brunswick (default is hst15) -->
 
     <record id="fiscal_position_tax_template_nb2ab_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_ab_en"/>
-        <field name="tax_src_id" ref="hst13_sale_en"/>
+        <field name="tax_src_id" ref="hst15_sale_en"/>
         <field name="tax_dest_id" ref="gst_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_nb2bc_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_bc_en"/>
-        <field name="tax_src_id" ref="hst13_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_src_id" ref="hst15_sale_en"/>
+        <field name="tax_dest_id" ref="gstpst_bc_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_nb2mb_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_mb_en"/>
-        <field name="tax_src_id" ref="hst13_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
-    </record>
-
-    <record id="fiscal_position_tax_template_nb2nl_sale_en" model="account.fiscal.position.tax.template">
-        <field name="position_id" ref="fiscal_position_template_nl_en"/>
-        <field name="tax_src_id" ref="hst13_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
-    </record>
-
-    <record id="fiscal_position_tax_template_nb2ns_sale_en" model="account.fiscal.position.tax.template">
-        <field name="position_id" ref="fiscal_position_template_ns_en"/>
-        <field name="tax_src_id" ref="hst13_sale_en"/>
-        <field name="tax_dest_id" ref="hst15_sale_en"/>
+        <field name="tax_src_id" ref="hst15_sale_en"/>
+        <field name="tax_dest_id" ref="gstpst_mb_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_nb2nt_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nt_en"/>
-        <field name="tax_src_id" ref="hst13_sale_en"/>
+        <field name="tax_src_id" ref="hst15_sale_en"/>
         <field name="tax_dest_id" ref="gst_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_nb2nu_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nu_en"/>
-        <field name="tax_src_id" ref="hst13_sale_en"/>
+        <field name="tax_src_id" ref="hst15_sale_en"/>
         <field name="tax_dest_id" ref="gst_sale_en"/>
     </record>
 
-    <record id="fiscal_position_tax_template_nb2pe_sale_en" model="account.fiscal.position.tax.template">
-        <field name="position_id" ref="fiscal_position_template_pe_en"/>
-        <field name="tax_src_id" ref="hst13_sale_en"/>
-        <field name="tax_dest_id" ref="hst15_sale_en"/>
+    <record id="fiscal_position_tax_template_nb2on_sale_en" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_on_en"/>
+        <field name="tax_src_id" ref="hst15_sale_en"/>
+        <field name="tax_dest_id" ref="hst13_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_nb2qc_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_qc_en"/>
-        <field name="tax_src_id" ref="hst13_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_src_id" ref="hst15_sale_en"/>
+        <field name="tax_dest_id" ref="gstqst_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_nb2sk_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_sk_en"/>
-        <field name="tax_src_id" ref="hst13_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_src_id" ref="hst15_sale_en"/>
+        <field name="tax_dest_id" ref="gstpst_sk_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_nb2yt_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_yt_en"/>
-        <field name="tax_src_id" ref="hst13_sale_en"/>
+        <field name="tax_src_id" ref="hst15_sale_en"/>
         <field name="tax_dest_id" ref="gst_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_nb2intl_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_intl_en"/>
-        <field name="tax_src_id" ref="hst13_sale_en"/>
+        <field name="tax_src_id" ref="hst15_sale_en"/>
     </record>
 
     <!-- Purchases -->
 
     <record id="fiscal_position_tax_template_intl2nb_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_intl_en"/>
-        <field name="tax_src_id" ref="hst13_purc_en"/>
+        <field name="tax_src_id" ref="hst15_purc_en"/>
     </record>
 
-    <!--  Company is in Newfoundland and Labrador (default is hst13) -->
-    
+    <!--  Company is in Newfoundland and Labrador (default is hst15) -->
+
     <!-- Already created by nb2ab_sale
     <record id="fiscal_position_tax_template_nl2ab_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_ab_en"/>
-        <field name="tax_src_id" ref="hst13_sale_en"/>
+        <field name="tax_src_id" ref="hst15_sale_en"/>
         <field name="tax_dest_id" ref="gst_sale_en"/>
     </record>
 
     Already created by nb2bc_sale
     <record id="fiscal_position_tax_template_nl2bc_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_bc_en"/>
-        <field name="tax_src_id" ref="hst13_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_src_id" ref="hst15_sale_en"/>
+        <field name="tax_dest_id" ref="gstpst_bc_sale_en"/>
     </record>
 
     Already created by nb2mb_sale
     <record id="fiscal_position_tax_template_nl2mb_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_mb_en"/>
-        <field name="tax_src_id" ref="hst13_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_src_id" ref="hst15_sale_en"/>
+        <field name="tax_dest_id" ref="gstpst_mb_sale_en"/>
     </record>
 
     Already creted by nb2ns_sale
     <record id="fiscal_position_tax_template_nl2ns_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_ns_en"/>
-        <field name="tax_src_id" ref="hst13_sale_en"/>
+        <field name="tax_src_id" ref="hst15_sale_en"/>
         <field name="tax_dest_id" ref="hst15_sale_en"/>
     </record>
 
     Already creted by nb2nt_sale
     <record id="fiscal_position_tax_template_nl2nt_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nt_en"/>
-        <field name="tax_src_id" ref="hst13_sale_en"/>
+        <field name="tax_src_id" ref="hst15_sale_en"/>
         <field name="tax_dest_id" ref="gst_sale_en"/>
     </record>
 
     Already created nb2nu_sale
     <record id="fiscal_position_tax_template_nl2nu_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nu_en"/>
-        <field name="tax_src_id" ref="hst13_sale_en"/>
+        <field name="tax_src_id" ref="hst15_sale_en"/>
         <field name="tax_dest_id" ref="gst_sale_en"/>
     </record>
 
     Already created by nb2pe_sale
     <record id="fiscal_position_tax_template_nl2pe_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_pe_en"/>
-        <field name="tax_src_id" ref="hst13_sale_en"/>
+        <field name="tax_src_id" ref="hst15_sale_en"/>
         <field name="tax_dest_id" ref="hst15_sale_en"/>
     </record>
 
     Already created by nb2qc_sale
     <record id="fiscal_position_tax_template_nl2qc_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_qc_en"/>
-        <field name="tax_src_id" ref="hst13_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_src_id" ref="hst15_sale_en"/>
+        <field name="tax_dest_id" ref="gstqst_sale_en"/>
     </record>
 
     Already created by nb2sk_sale
     <record id="fiscal_position_tax_template_nl2sk_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_sk_en"/>
-        <field name="tax_src_id" ref="hst13_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_src_id" ref="hst15_sale_en"/>
+        <field name="tax_dest_id" ref="gstpst_sk_sale_en"/>
     </record>
 
     Already created by nb2yt_sale
     <record id="fiscal_position_tax_template_nl2yt_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_yt_en"/>
-        <field name="tax_src_id" ref="hst13_sale_en"/>
+        <field name="tax_src_id" ref="hst15_sale_en"/>
         <field name="tax_dest_id" ref="gst_sale_en"/>
     </record>
 
     Already created by nb2intl_sale
     <record id="fiscal_position_tax_template_nl2intl_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_intl_en"/>
-        <field name="tax_src_id" ref="hst13_sale_en"/>
+        <field name="tax_src_id" ref="hst15_sale_en"/>
     </record>
     -->
 
@@ -641,12 +629,13 @@
     <!-- Already created by intl2nb_purc
     <record id="fiscal_position_tax_template_intl2nl_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_intl_en"/>
-        <field name="tax_src_id" ref="hst13_purc_en"/>
+        <field name="tax_src_id" ref="hst15_purc_en"/>
     </record>
     -->
 
     <!--  Company is in Nova Scotia (default is hst15) -->
 
+    <!-- Already created by nb2*_sale
     <record id="fiscal_position_tax_template_ns2ab_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_ab_en"/>
         <field name="tax_src_id" ref="hst15_sale_en"/>
@@ -656,25 +645,25 @@
     <record id="fiscal_position_tax_template_ns2bc_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_bc_en"/>
         <field name="tax_src_id" ref="hst15_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_dest_id" ref="gstpst_bc_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_ns2mb_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_mb_en"/>
         <field name="tax_src_id" ref="hst15_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_dest_id" ref="gstpst_mb_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_ns2nb_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nb_en"/>
         <field name="tax_src_id" ref="hst15_sale_en"/>
-        <field name="tax_dest_id" ref="hst13_sale_en"/>
+        <field name="tax_dest_id" ref="hst15_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_ns2nl_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nl_en"/>
         <field name="tax_src_id" ref="hst15_sale_en"/>
-        <field name="tax_dest_id" ref="hst13_sale_en"/>
+        <field name="tax_dest_id" ref="hst15_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_ns2nt_sale_en" model="account.fiscal.position.tax.template">
@@ -698,13 +687,13 @@
     <record id="fiscal_position_tax_template_ns2qc_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_qc_en"/>
         <field name="tax_src_id" ref="hst15_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_dest_id" ref="gstqst_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_ns2sk_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_sk_en"/>
         <field name="tax_src_id" ref="hst15_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_dest_id" ref="gstpst_sk_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_ns2yt_sale_en" model="account.fiscal.position.tax.template">
@@ -717,13 +706,16 @@
         <field name="position_id" ref="fiscal_position_template_intl_en"/>
         <field name="tax_src_id" ref="hst15_sale_en"/>
     </record>
+    -->
 
     <!-- Purchases -->
 
+    <!-- Already created by intl2nb_purc
     <record id="fiscal_position_tax_template_intl2ns_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_intl_en"/>
         <field name="tax_src_id" ref="hst15_purc_en"/>
     </record>
+    -->
 
     <!--  Company is in Northwest Territories (default is gst) -->
 
@@ -731,14 +723,14 @@
     <record id="fiscal_position_tax_template_nt2nb_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nb_en"/>
         <field name="tax_src_id" ref="gst_sale_en"/>
-        <field name="tax_dest_id" ref="hst13_sale_en"/>
+        <field name="tax_dest_id" ref="hst15_sale_en"/>
     </record>
 
     Already created by ab2nl_sale
     <record id="fiscal_position_tax_template_nt2nl_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nl_en"/>
         <field name="tax_src_id" ref="gst_sale_en"/>
-        <field name="tax_dest_id" ref="hst13_sale_en"/>
+        <field name="tax_dest_id" ref="hst15_sale_en"/>
     </record>
 
     Already created by ab2ns_sale
@@ -784,14 +776,14 @@
     <record id="fiscal_position_tax_template_nu2nb_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nb_en"/>
         <field name="tax_src_id" ref="gst_sale_en"/>
-        <field name="tax_dest_id" ref="hst13_sale_en"/>
+        <field name="tax_dest_id" ref="hst15_sale_en"/>
     </record>
 
     Already created by ab2nl_sale
     <record id="fiscal_position_tax_template_nu2nl_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nl_en"/>
         <field name="tax_src_id" ref="gst_sale_en"/>
-        <field name="tax_dest_id" ref="hst13_sale_en"/>
+        <field name="tax_dest_id" ref="hst15_sale_en"/>
     </record>
 
     Already created by ab2ns_sale
@@ -833,91 +825,89 @@
 
     <!--  Company is in Ontario (default is hst13) -->
 
-    <!-- Already created nb2ab_sale
     <record id="fiscal_position_tax_template_on2ab_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_ab_en"/>
         <field name="tax_src_id" ref="hst13_sale_en"/>
         <field name="tax_dest_id" ref="gst_sale_en"/>
     </record>
 
-    Already created by nb2bc_sale
     <record id="fiscal_position_tax_template_on2bc_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_bc_en"/>
         <field name="tax_src_id" ref="hst13_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_dest_id" ref="gstpst_bc_sale_en"/>
     </record>
 
-    Already created by nb2mb_sale
     <record id="fiscal_position_tax_template_on2mb_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_mb_en"/>
         <field name="tax_src_id" ref="hst13_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_dest_id" ref="gstpst_mb_sale_en"/>
     </record>
 
-    Already created by nb2ns_sale
+    <record id="fiscal_position_tax_template_on2nb_sale_en" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_nb_en"/>
+        <field name="tax_src_id" ref="hst13_sale_en"/>
+        <field name="tax_dest_id" ref="hst15_sale_en"/>
+    </record>
+
+    <record id="fiscal_position_tax_template_on2nl_sale_en" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fiscal_position_template_nl_en"/>
+        <field name="tax_src_id" ref="hst13_sale_en"/>
+        <field name="tax_dest_id" ref="hst15_sale_en"/>
+    </record>
+
     <record id="fiscal_position_tax_template_on2ns_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_ns_en"/>
         <field name="tax_src_id" ref="hst13_sale_en"/>
         <field name="tax_dest_id" ref="hst15_sale_en"/>
     </record>
 
-    Already created by nb2nt_sale
     <record id="fiscal_position_tax_template_on2nt_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nt_en"/>
         <field name="tax_src_id" ref="hst13_sale_en"/>
         <field name="tax_dest_id" ref="gst_sale_en"/>
     </record>
 
-    Already created nb2nu_sale
     <record id="fiscal_position_tax_template_on2nu_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nu_en"/>
         <field name="tax_src_id" ref="hst13_sale_en"/>
         <field name="tax_dest_id" ref="gst_sale_en"/>
     </record>
 
-    Already created by nb2pe_sale
     <record id="fiscal_position_tax_template_on2pe_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_pe_en"/>
         <field name="tax_src_id" ref="hst13_sale_en"/>
         <field name="tax_dest_id" ref="hst15_sale_en"/>
     </record>
 
-    Already created by nb2qc_sale
     <record id="fiscal_position_tax_template_on2qc_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_qc_en"/>
         <field name="tax_src_id" ref="hst13_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_dest_id" ref="gstqst_sale_en"/>
     </record>
 
-    Already created by nb2sk_sale
     <record id="fiscal_position_tax_template_on2sk_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_sk_en"/>
         <field name="tax_src_id" ref="hst13_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_dest_id" ref="gstpst_sk_sale_en"/>
     </record>
 
-    Already created by nb2yt_sale
     <record id="fiscal_position_tax_template_on2yt_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_yt_en"/>
         <field name="tax_src_id" ref="hst13_sale_en"/>
         <field name="tax_dest_id" ref="gst_sale_en"/>
     </record>
 
-    Already created by nb2intl_sale
     <record id="fiscal_position_tax_template_on2intl_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_intl_en"/>
         <field name="tax_src_id" ref="hst13_sale_en"/>
     </record>
-    -->
 
-    <!-- Purchases --> 
+    <!-- Purchases -->
 
-    <!-- Already created by intl2nb_purc
     <record id="fiscal_position_tax_template_intl2on_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_intl_en"/>
         <field name="tax_src_id" ref="hst13_purc_en"/>
     </record>
-    -->
 
     <!--  Company is in Prince Edward Islands (default is hst15) -->
 
@@ -932,28 +922,28 @@
     <record id="fiscal_position_tax_template_pe2bc_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_bc_en"/>
         <field name="tax_src_id" ref="hst15_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_dest_id" ref="gstpst_bc_sale_en"/>
     </record>
 
     Already created by ns2mb_sale
     <record id="fiscal_position_tax_template_pe2mb_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_mb_en"/>
         <field name="tax_src_id" ref="hst15_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_dest_id" ref="gstpst_mb_sale_en"/>
     </record>
 
     Already created by ns2nb_sale
     <record id="fiscal_position_tax_template_pe2nb_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nb_en"/>
         <field name="tax_src_id" ref="hst15_sale_en"/>
-        <field name="tax_dest_id" ref="hst13_sale_en"/>
+        <field name="tax_dest_id" ref="hst15_sale_en"/>
     </record>
 
     Already created by ns2nl_sale
     <record id="fiscal_position_tax_template_pe2nl_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nl_en"/>
         <field name="tax_src_id" ref="hst15_sale_en"/>
-        <field name="tax_dest_id" ref="hst13_sale_en"/>
+        <field name="tax_dest_id" ref="hst15_sale_en"/>
     </record>
 
     Already created by ns2nt_sale
@@ -981,14 +971,14 @@
     <record id="fiscal_position_tax_template_pe2qc_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_qc_en"/>
         <field name="tax_src_id" ref="hst15_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_dest_id" ref="gstqst_sale_en"/>
     </record>
 
     Already created by ns2sk_sale
     <record id="fiscal_position_tax_template_pe2sk_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_sk_en"/>
         <field name="tax_src_id" ref="hst15_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_dest_id" ref="gstpst_sk_sale_en"/>
     </record>
 
     Already created by ns2yt_sale
@@ -1027,25 +1017,25 @@
     <record id="fiscal_position_tax_template_qc2bc_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_bc_en"/>
         <field name="tax_src_id" ref="gstqst_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_dest_id" ref="gstpst_bc_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_qc2mb_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_mb_en"/>
         <field name="tax_src_id" ref="gstqst_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_dest_id" ref="gstpst_mb_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_qc2nb_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nb_en"/>
         <field name="tax_src_id" ref="gstqst_sale_en"/>
-        <field name="tax_dest_id" ref="hst13_sale_en"/>
+        <field name="tax_dest_id" ref="hst15_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_qc2nl_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nl_en"/>
         <field name="tax_src_id" ref="gstqst_sale_en"/>
-        <field name="tax_dest_id" ref="hst13_sale_en"/>
+        <field name="tax_dest_id" ref="hst15_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_qc2ns_sale_en" model="account.fiscal.position.tax.template">
@@ -1081,7 +1071,7 @@
     <record id="fiscal_position_tax_template_qc2sk_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_sk_en"/>
         <field name="tax_src_id" ref="gstqst_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_dest_id" ref="gstpst_sk_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_qc2yt_sale_en" model="account.fiscal.position.tax.template">
@@ -1106,31 +1096,31 @@
     <record id="fiscal_position_tax_template_bc2qc_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_bc_en"/>
         <field name="tax_src_id" ref="gstqst_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="gstpst_bc_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_mb2qc_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_mb_en"/>
         <field name="tax_src_id" ref="gstqst_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="gstpst_mb_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_nb2qc_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nb_en"/>
         <field name="tax_src_id" ref="gstqst_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="hst15_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_nl2qc_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nl_en"/>
         <field name="tax_src_id" ref="gstqst_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="hst15_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_ns2qc_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_ns_en"/>
         <field name="tax_src_id" ref="gstqst_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="hst15_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_nt2qc_purc_en" model="account.fiscal.position.tax.template">
@@ -1148,19 +1138,19 @@
     <record id="fiscal_position_tax_template_on2qc_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_on_en"/>
         <field name="tax_src_id" ref="gstqst_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="hst13_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_pe2qc_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_pe_en"/>
         <field name="tax_src_id" ref="gstqst_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="hst15_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_sk2qc_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_sk_en"/>
         <field name="tax_src_id" ref="gstqst_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="gstpst_sk_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_yt2qc_purc_en" model="account.fiscal.position.tax.template">
@@ -1187,25 +1177,25 @@
     <record id="fiscal_position_tax_template_sk2bc_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_bc_en"/>
         <field name="tax_src_id" ref="gstpst_sk_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_dest_id" ref="gstpst_bc_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_sk2mb_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_mb_en"/>
         <field name="tax_src_id" ref="gstpst_sk_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_dest_id" ref="gstpst_mb_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_sk2nb_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nb_en"/>
         <field name="tax_src_id" ref="gstpst_sk_sale_en"/>
-        <field name="tax_dest_id" ref="hst13_sale_en"/>
+        <field name="tax_dest_id" ref="hst15_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_sk2nl_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nl_en"/>
         <field name="tax_src_id" ref="gstpst_sk_sale_en"/>
-        <field name="tax_dest_id" ref="hst13_sale_en"/>
+        <field name="tax_dest_id" ref="hst15_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_sk2ns_sale_en" model="account.fiscal.position.tax.template">
@@ -1241,7 +1231,7 @@
     <record id="fiscal_position_tax_template_sk2qc_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_qc_en"/>
         <field name="tax_src_id" ref="gstpst_sk_sale_en"/>
-        <field name="tax_dest_id" ref="gst_sale_en"/>
+        <field name="tax_dest_id" ref="gstqst_sale_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_sk2yt_sale_en" model="account.fiscal.position.tax.template">
@@ -1266,31 +1256,31 @@
     <record id="fiscal_position_tax_template_bc2sk_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_bc_en"/>
         <field name="tax_src_id" ref="gstpst_sk_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="gstpst_bc_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_mb2sk_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_mb_en"/>
         <field name="tax_src_id" ref="gstpst_sk_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="gstpst_mb_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_nb2sk_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nb_en"/>
         <field name="tax_src_id" ref="gstpst_sk_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="hst15_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_nl2sk_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nl_en"/>
         <field name="tax_src_id" ref="gstpst_sk_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="hst15_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_ns2sk_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_ns_en"/>
         <field name="tax_src_id" ref="gstpst_sk_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="hst15_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_nt2sk_purc_en" model="account.fiscal.position.tax.template">
@@ -1308,19 +1298,19 @@
     <record id="fiscal_position_tax_template_on2sk_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_on_en"/>
         <field name="tax_src_id" ref="gstpst_sk_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="hst13_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_pe2sk_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_pe_en"/>
         <field name="tax_src_id" ref="gstpst_sk_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="hst15_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_qc2sk_purc_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_qc_en"/>
         <field name="tax_src_id" ref="gstpst_sk_purc_en"/>
-        <field name="tax_dest_id" ref="gst_purc_en"/>
+        <field name="tax_dest_id" ref="gstqst_purc_en"/>
     </record>
 
     <record id="fiscal_position_tax_template_yt2sk_purc_en" model="account.fiscal.position.tax.template">
@@ -1340,14 +1330,14 @@
     <record id="fiscal_position_tax_template_yt2nb_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nb_en"/>
         <field name="tax_src_id" ref="gst_sale_en"/>
-        <field name="tax_dest_id" ref="hst13_sale_en"/>
+        <field name="tax_dest_id" ref="hst15_sale_en"/>
     </record>
 
     Already created by ab2nl_sale
     <record id="fiscal_position_tax_template_yt2nl_sale_en" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fiscal_position_template_nl_en"/>
         <field name="tax_src_id" ref="gst_sale_en"/>
-        <field name="tax_dest_id" ref="hst13_sale_en"/>
+        <field name="tax_dest_id" ref="hst15_sale_en"/>
     </record>
 
     Already created by ab2ns_sale


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
As the whole localization was not up-to-date anymore, this is an update to properly update taxes and fiscal positions based on official resources and provided data
https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/gst-hst-businesses/charge-collect-which-rate/calculator.html

**Current behavior before PR:**
Missing taxes and wrong fiscal positions as outdated

**Desired behavior after PR is merged:**
Hopefully a better experience out of the box for users of the CA localization

Info: @wt-io-it

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
