### PR TITLE
[FIX] base_import: avoid import of defusedxml

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -56,6 +56,7 @@ except ImportError:
     odf_ods_reader = None
 
 try:
+    os.environ['OPENPYXL_DEFUSEDXML'] = 'False'
     from openpyxl import load_workbook
 except ImportError:
     load_workbook = None


### PR DESCRIPTION
import defusedxml.ElementTree clashes with the xml lib, so we want to avoid it when importing openpyxl

```
def stuff():
    import xml.etree.ElementTree as ET
    import _elementtree
    test = ET.Element("test")
    print(test.find("ns:boom"))
    
stuff() #succeed
import defusedxml.ElementTree
stuff() #fails
```

It depends on the version of the packages (openpyxl==3.0.3 and defusedxml==0.6.0). Odoo 15.0, which should support running on ubuntu 20.04 uses those version when using the debian version.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
