### PR TITLE
[IMP] *: Allow three way fiscal positions

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1324,7 +1324,7 @@ class AccountMove(models.Model):
     def _compute_tax_country_id(self):
         foreign_vat_records = self.filtered(lambda r: r.fiscal_position_id.foreign_vat)
         for fiscal_position_id, record_group in groupby(foreign_vat_records, key=lambda r: r.fiscal_position_id):
-            self.env['account.move'].concat(*record_group).tax_country_id = fiscal_position_id.country_id
+            self.env['account.move'].concat(*record_group).tax_country_id = fiscal_position_id._get_fiscal_country()
         for company_id, record_group in groupby((self-foreign_vat_records), key=lambda r: r.company_id):
             self.env['account.move'].concat(*record_group).tax_country_id = company_id.account_fiscal_country_id
 
@@ -1818,8 +1818,8 @@ class AccountMove(models.Model):
         for record in self:
             amls = record.line_ids
             impacted_countries = amls.tax_ids.country_id | amls.tax_line_id.country_id
-            if impacted_countries and impacted_countries != record.tax_country_id:
-                if record.fiscal_position_id and impacted_countries != record.fiscal_position_id.country_id:
+            if impacted_countries and impacted_countries not in [record.tax_country_id, record.fiscal_position_id.country_id]:
+                if record.fiscal_position_id and impacted_countries != record.fiscal_position_id.country_id and impacted_countries != record.fiscal_position_id._get_fiscal_country():
                     raise ValidationError(_("This entry contains taxes that are not compatible with your fiscal position. Check the country set in fiscal position and in your tax configuration."))
                 raise ValidationError(_("This entry contains one or more taxes that are incompatible with your fiscal country. Check company fiscal country in the settings and tax country in taxes configuration."))
 

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -238,7 +238,7 @@ class ResCompany(models.Model):
     def _compute_account_enabled_tax_country_ids(self):
         for record in self:
             foreign_vat_fpos = self.env['account.fiscal.position'].search([('company_id', '=', record.id), ('foreign_vat', '!=', False)])
-            record.account_enabled_tax_country_ids = foreign_vat_fpos.country_id + record.account_fiscal_country_id
+            record.account_enabled_tax_country_ids = foreign_vat_fpos._get_fiscal_country() + record.account_fiscal_country_id
 
     @api.depends('account_onboarding_create_invoice_state_flag')
     def _compute_account_onboarding_create_invoice_state(self):

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -266,6 +266,9 @@ class AccountFiscalPosition(models.Model):
         self.ensure_one()
         self.env['account.tax.template']._try_instantiating_foreign_taxes(self.country_id, self.company_id)
 
+    def _get_fiscal_country(self):
+        return self.country_id
+
 
 class AccountFiscalPositionTax(models.Model):
     _name = 'account.fiscal.position.tax'

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -57,9 +57,9 @@
                                 options="{'no_open': True, 'no_create': True}"/>
                             <field name="state_ids" widget="many2many_tags" domain="[('country_id', '=', country_id)]"
                                 attrs="{'invisible': ['|', '|', '&amp;', ('auto_apply', '!=', True), ('foreign_vat', '=', False), ('country_id', '=', False), ('states_count', '=', 0)]}"/>
-                            <label for="zip_from" string="Zip Range"
+                            <label for="zip_from" string="Zip Range" name="zip_range_label"
                                 attrs="{'invisible': ['|', ('auto_apply', '!=', True), ('country_id', '=', False)]}"/>
-                            <div attrs="{'invisible': ['|', ('auto_apply', '!=', True), ('country_id', '=', False)]}">
+                            <div attrs="{'invisible': ['|', ('auto_apply', '!=', True), ('country_id', '=', False)]}" name="zip_range_div">
                                 <span> From </span>
                                 <field name="zip_from" class="oe_inline"/>
                                 <div class="oe_edit_only"/>

--- a/addons/account_three_way_fiscal_pos/__init__.py
+++ b/addons/account_three_way_fiscal_pos/__init__.py
@@ -1,0 +1,11 @@
+from . import models
+
+from odoo import api, SUPERUSER_ID
+
+
+def _post_init_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    all_fp = env["account.fiscal.position"].search([])
+    for fp in all_fp:
+        if not fp.fiscal_country_id:
+            fp.write({"fiscal_country_id": fp.country_id})

--- a/addons/account_three_way_fiscal_pos/__manifest__.py
+++ b/addons/account_three_way_fiscal_pos/__manifest__.py
@@ -1,0 +1,22 @@
+{
+    'name': 'Three countries fiscal positions',
+    'version': '1.1',
+    'category': 'Accounting/Accounting',
+    'depends': ['base', 'account', 'base_vat'],
+    'description': """
+Module to allow the creation of fiscal positions between three countries.
+Company country, Fiscal country and Delivery country.
+===============================================
+
+This module allows specific cases to be handled with a single fiscal position.
+Said cases are the ones in which the company country is different than the one
+the goods are expedited from which means that the VAT number and the tax used
+for the mapping should not be the taxes of the company country.
+    """,
+    'data': [
+        'views/partner_view.xml',
+    ],
+    'installable': True,
+    'post_init_hook': '_post_init_hook',
+    'license': 'LGPL-3',
+}

--- a/addons/account_three_way_fiscal_pos/models/__init__.py
+++ b/addons/account_three_way_fiscal_pos/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_fiscal_position

--- a/addons/account_three_way_fiscal_pos/models/account_fiscal_position.py
+++ b/addons/account_three_way_fiscal_pos/models/account_fiscal_position.py
@@ -1,0 +1,105 @@
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
+
+
+class AccountFiscalPosition(models.Model):
+    _inherit = 'account.fiscal.position'
+
+    fiscal_country_id = fields.Many2one('res.country', string='Fiscal Country',
+        help="Country from which's taxes are available for the fiscal position mapping.")
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            vals = self.adjust_vals_fiscal_country_id(vals)
+            vals = self.adjust_vals_country_id(vals)
+            zip_from = vals.get('zip_from')
+            zip_to = vals.get('zip_to')
+            if zip_from and zip_to:
+                vals['zip_from'], vals['zip_to'] = self._convert_zip_values(zip_from, zip_to)
+        return super().create(vals_list)
+
+    def write(self, vals):
+        vals = self.adjust_vals_fiscal_country_id(vals)
+        vals = self.adjust_vals_country_id(vals)
+        zip_from = vals.get('zip_from')
+        zip_to = vals.get('zip_to')
+        if zip_from or zip_to:
+            for rec in self:
+                vals['zip_from'], vals['zip_to'] = self._convert_zip_values(zip_from or rec.zip_from, zip_to or rec.zip_to)
+        return super().write(vals)
+
+    def adjust_vals_fiscal_country_id(self, vals):
+        foreign_vat = vals.get('foreign_vat')
+        country_id = self.country_id or vals.get('country_id')
+        if not (self.fiscal_country_id or vals.get("fiscal_country_id")):
+            if country_id:
+                vals['fiscal_country_id'] = country_id
+            elif foreign_vat:
+                vals['fiscal_country_id'] = self.env['res.country'].search([("code", "=", foreign_vat[:2].upper())], limit=1) or False
+        return vals
+
+    def adjust_vals_country_id(self, vals):
+        fiscal_country_id = self.fiscal_country_id or vals.get('fiscal_country_id')
+        country_id = self.country_id or vals.get('country_id')
+        if not country_id and fiscal_country_id:
+            vals['country_id'] = fiscal_country_id
+        return vals
+
+    @api.depends('foreign_vat', 'country_id')
+    def _compute_foreign_vat_header_mode(self):
+        for record in self:
+            if not record.foreign_vat or not record.country_id:
+                record.foreign_vat_header_mode = None
+                continue
+
+            if self.env['account.tax'].search([('country_id', '=', record.country_id.id)], limit=1) and self.env['account.tax'].search([('country_id', '=', record.fiscal_country_id.id)], limit=1):
+                record.foreign_vat_header_mode = None
+            elif self.env['account.tax.template'].search([('chart_template_id.country_id', '=', record.country_id.id)], limit=1) or self.env['account.tax.template'].search([('chart_template_id.country_id', '=', record.fiscal_country_id.id)], limit=1):
+                record.foreign_vat_header_mode = 'templates_found'
+            else:
+                record.foreign_vat_header_mode = 'no_template'
+
+    @api.constrains('fiscal_country_id', 'country_id', 'country_group_id', 'state_ids', 'foreign_vat')
+    def _validate_foreign_vat_country(self):
+        for record in self:
+            if record.foreign_vat:
+                if record.fiscal_country_id == record.company_id.account_fiscal_country_id:
+                    if record.foreign_vat == record.company_id.vat:
+                        raise ValidationError(_("You cannot create a fiscal position within your fiscal country with the same VAT number as the main one set on your company."))
+
+                    if not record.state_ids:
+                        if record.company_id.account_fiscal_country_id.state_ids:
+                            raise ValidationError(_("You cannot create a fiscal position with a foreign VAT within your fiscal country without assigning it a state."))
+                        else:
+                            raise ValidationError(_("You cannot create a fiscal position with a foreign VAT within your fiscal country."))
+                if record.country_group_id and record.country_id:
+                    if record.country_id not in record.country_group_id.country_ids:
+                        raise ValidationError(_("You cannot create a fiscal position with a country outside of the selected country group."))
+                similar_fpos_domain = [
+                    ('foreign_vat', '!=', False),
+                    ('company_id', '=', record.company_id.id),
+                    ('id', '!=', record.id),
+                ]
+                if record.country_group_id:
+                    foreign_vat_country = self.country_group_id.country_ids.filtered(lambda c: c.code == record.foreign_vat[:2].upper())
+                    if not foreign_vat_country:
+                        raise ValidationError(_("The country code of the foreign VAT number does not match any country in the group."))
+                    similar_fpos_domain += [('country_group_id', '=', record.country_group_id.id), ('fiscal_country_id', '=', foreign_vat_country.id)]
+                elif record.country_id:
+                    similar_fpos_domain += [('country_id', '=', record.country_id.id), ('country_group_id', '=', False), ('fiscal_country_id', '=', record.fiscal_country_id.id)]
+
+                if record.state_ids:
+                    similar_fpos_domain.append(('state_ids', 'in', record.state_ids.ids))
+                else:
+                    similar_fpos_domain.append(('state_ids', '=', False))
+                similar_fpos_count = self.env['account.fiscal.position'].search_count(similar_fpos_domain)
+                if similar_fpos_count:
+                    raise ValidationError(_("A fiscal position with a foreign VAT already exists in this region."))
+
+    def action_create_foreign_taxes(self):
+        super().action_create_foreign_taxes()
+        self.env['account.tax.template']._try_instantiating_foreign_taxes(self.fiscal_country_id, self.company_id)
+
+    def _get_fiscal_country(self):
+        return self.fiscal_country_id

--- a/addons/account_three_way_fiscal_pos/views/partner_view.xml
+++ b/addons/account_three_way_fiscal_pos/views/partner_view.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_account_position_form" model="ir.ui.view">
+        <field name="name">account.fiscal.position.form</field>
+        <field name="model">account.fiscal.position</field>
+        <field name="inherit_id" ref="account.view_account_position_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='country_group_id']" position="replace"/>
+            <xpath expr="//field[@name='country_id']" position="replace"/>
+            <xpath expr="//field[@name='state_ids']" position="replace"/>
+            <xpath expr="//label[@name='zip_range_label']" position="replace"/>
+            <xpath expr="//div[@name='zip_range_div']" position="replace"/>
+
+            <xpath expr="//field[@name='foreign_vat']" position="after">
+                <field name="fiscal_country_id" string="Fiscal Country" attrs="{'required': [('foreign_vat', '=', True)]}"/>
+                <field name="country_group_id" string="Delivery Country Group" attrs="{'invisible': [('auto_apply', '=', False)], 'required': [('foreign_vat', '=', True), ('fiscal_country_id', '=', False)]}" options="{'no_open': True, 'no_create': True}"/>
+                <field name="country_id" string="Delivery Country" attrs="{'invisible': [('auto_apply', '=', False)]}" options="{'no_open': True, 'no_create': True}"/>
+                <field name="state_ids" widget="many2many_tags" domain="[('country_id', '=', country_id)]"
+                    attrs="{'invisible': ['|', '|', '|', '&amp;', ('auto_apply', '!=', True), ('foreign_vat', '=', False), ('fiscal_country_id', '=', False), ('country_id', '=', False), ('states_count', '=', 0)]}"/>
+                <label for="zip_from" string="Zip Range" name="zip_range_label"
+                    attrs="{'invisible': ['|', ('auto_apply', '=', False), ('fiscal_country_id', '=', False)]}"/>
+                <div attrs="{'invisible': ['|', ('auto_apply', '=', False), ('fiscal_country_id', '=', False)]}" name="zip_range_div">
+                    <span> From </span>
+                    <field name="zip_from" class="oe_inline"/>
+                    <div class="oe_edit_only"/>
+                    <span> To </span>
+                    <field name="zip_to" class="oe_inline"/>
+                </div>
+            </xpath>
+
+            <xpath expr="//field[@name='tax_src_id']" position="attributes">
+                <attribute name="domain">[
+                    ('type_tax_use', '!=', 'none'),
+                    '|', ('country_id', '=', parent.company_country_id), ('country_id', '=', parent.fiscal_country_id),
+                    '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)
+                    ]
+                </attribute>
+            </xpath>
+
+            <xpath expr="//field[@name='tax_dest_id']" position="attributes">
+                <attribute name="domain">[
+                    ('type_tax_use', '!=', 'none'),
+                    '|', ('country_id', '=', parent.country_id if parent.foreign_vat else parent.company_country_id),
+                         ('country_id', '=', parent.fiscal_country_id),
+                    '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)
+                    ]
+                </attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
*: account, fiscal_position_three_way, base_vat

---

Description of the issue this commit addresses:

Some companies export goods from warehouses outside of their fiscal country. It is currently not possible to use the "Detect Automatically" feature of the fiscal positions for them as the country they need to set to get the right tax mapping is not the country that needs to be detected for the auto apply.

---

Desired behavior after this commit is merged:

This commit allows users upon the installation of the new module to split the country of the tax mapping and the country of the auto apply. They are named "Fiscal Country" and "Delivery Country" and it grants companies the ability to have a working flow without starting from scratch if they need such a behavior.

---

Enterprise PR: https://github.com/odoo/enterprise/pull/69428
task-4066525

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
