### PR TITLE
[FIX] web_editor: translate paragraph links as a whole.

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
@@ -700,6 +700,16 @@ export function getOrCreateLink({ containerNode, startNode } = {}) {
         }
     } else if (!link && isContained) {
         link = document.createElement('a');
+        // We force links added in paragraphs to be translated "as a whole".
+        // This should allow them to be considered part of the whole text content
+        // and not as separate terms, and will prevent breaking the translation
+        // of a text when only a part of it is transformed into a link.
+        const commonAncestor = range.commonAncestorContainer;
+        const commonAncestorEl = commonAncestor.nodeType !== Node.ELEMENT_NODE ?
+            commonAncestor.parentElement : commonAncestor;
+        if (commonAncestorEl.closest("p")) {
+            link.className = "o_translate_inline";
+        }
         if (range.collapsed) {
             range.insertNode(link);
             needLabel = true;

--- a/addons/web_editor/static/tests/link_tests.js
+++ b/addons/web_editor/static/tests/link_tests.js
@@ -93,7 +93,7 @@ QUnit.module(
             await nextTick();
             assert.strictEqual(
                 editable.innerHTML,
-                `<p>\ufeff<a href="#" target="_blank" class="o_link_in_selection">\ufeff#\ufeff</a>\ufeff<br></p>`
+                `<p>\ufeff<a class="o_translate_inline o_link_in_selection" href="#" target="_blank">\ufeff#\ufeff</a>\ufeff<br></p>`
             );
         });
 
@@ -112,7 +112,7 @@ QUnit.module(
             await nextTick();
             assert.strictEqual(
                 editable.innerHTML,
-                `<p>\ufeff<a href="#" target="_blank" class="o_link_in_selection">\ufeff#\ufeff</a>\ufeff<br></p>`
+                `<p>\ufeff<a class="o_translate_inline o_link_in_selection" href="#" target="_blank">\ufeff#\ufeff</a>\ufeff<br></p>`
             );
         });
 
@@ -135,7 +135,7 @@ QUnit.module(
                 await nextTick();
                 assert.strictEqual(
                     editable.innerHTML,
-                    `<p>H\ufeff<a href="#" target="_blank" class="o_link_in_selection">\ufeffel\ufeff</a>\ufefflo</p>`
+                    `<p>H\ufeff<a class="o_translate_inline o_link_in_selection" href="#" target="_blank">\ufeffel\ufeff</a>\ufefflo</p>`
                 );
             }
         );
@@ -187,7 +187,7 @@ QUnit.module(
             await nextTick();
             assert.strictEqual(
                 editable.innerHTML,
-                `<p>\ufeff<a href="#" target="_blank" class="o_link_in_selection">\ufeffHello\ufeff</a>\ufeff</p>`
+                `<p>\ufeff<a class="o_translate_inline o_link_in_selection" href="#" target="_blank">\ufeffHello\ufeff</a>\ufeff</p>`
             );
         });
 
@@ -207,7 +207,7 @@ QUnit.module(
             await nextTick();
             assert.strictEqual(
                 editable.innerHTML,
-                `<p>H\ufeff<a href="#" target="_blank" class="o_link_in_selection">\ufeffel\ufeff</a>\ufefflo</p>`
+                `<p>H\ufeff<a class="o_translate_inline o_link_in_selection" href="#" target="_blank">\ufeffel\ufeff</a>\ufefflo</p>`
             );
         });
 
@@ -229,7 +229,7 @@ QUnit.module(
             await nextTick();
             assert.strictEqual(
                 editable.innerHTML,
-                `<p>\ufeff<a href="#" target="_blank" class="o_link_in_selection">\ufeff#\ufeff</a>\ufeff<br></p>`
+                `<p>\ufeff<a class="o_translate_inline o_link_in_selection" href="#" target="_blank">\ufeff#\ufeff</a>\ufeff<br></p>`
             );
         });
 
@@ -258,7 +258,7 @@ QUnit.module(
             await nextTick();
             assert.strictEqual(
                 editable.innerHTML,
-                `<p>a \ufeff<a href="#" target="_blank" class="o_link_in_selection">\ufefflink\ufeff</a>\ufeff&nbsp;&nbsp;b</p>`
+                `<p>a \ufeff<a class="o_translate_inline o_link_in_selection" href="#" target="_blank">\ufefflink\ufeff</a>\ufeff&nbsp;&nbsp;b</p>`
             );
         });
 
@@ -284,7 +284,7 @@ QUnit.module(
                 editor.clean();
                 assert.strictEqual(
                     editable.innerHTML,
-                    `<p>a<a href="#" target="_blank">#D</a>b</p>`
+                    `<p>a<a class="o_translate_inline" href="#" target="_blank">#D</a>b</p>`
                 );
             }
         );
@@ -313,7 +313,7 @@ QUnit.module(
                 editor.clean();
                 assert.strictEqual(
                     editable.innerHTML,
-                    `<p>a<a href="#" target="_blank">#ED</a>b</p>`
+                    `<p>a<a class="o_translate_inline" href="#" target="_blank">#ED</a>b</p>`
                 );
             }
         );
@@ -343,7 +343,7 @@ QUnit.module(
                 editor.clean();
                 assert.strictEqual(
                     editable.innerHTML,
-                    `<p>ab<a href="#" target="_blank">linkE</a></p><p><br></p>`
+                    `<p>ab<a class="o_translate_inline" href="#" target="_blank">linkE</a></p><p><br></p>`
                 );
             }
         );
@@ -375,7 +375,7 @@ QUnit.module(
                 editor.clean();
                 assert.strictEqual(
                     editable.innerHTML,
-                    `<p>a<a href="#" target="_blank">linkE</a></p><p>Db</p>`
+                    `<p>a<a class="o_translate_inline" href="#" target="_blank">linkE</a></p><p>Db</p>`
                 );
             }
         );
@@ -406,7 +406,7 @@ QUnit.module(
                 editor.clean();
                 assert.strictEqual(
                     editable.innerHTML,
-                    `<p>a<a href="#" target="_blank">linkE</a><br>b</p>`
+                    `<p>a<a class="o_translate_inline" href="#" target="_blank">linkE</a><br>b</p>`
                 );
             }
         );
@@ -438,7 +438,7 @@ QUnit.module(
                 editor.clean();
                 assert.strictEqual(
                     editable.innerHTML,
-                    `<p>a<a href="#" target="_blank">linkE</a><br>Db</p>`
+                    `<p>a<a class="o_translate_inline" href="#" target="_blank">linkE</a><br>Db</p>`
                 );
             }
         );


### PR DESCRIPTION
[FIX] web_editor: translate paragraph links as a whole.

Steps to reproduce:

1. Enable a second language in the website (e.g., French).

2. Add a "Text" block (in edit mode) > Save the page.

3. Translate a text paragraph to french > Save.

4. In edit mode again, add a link to a word in the paragraph > Save.

5. The translation in French is lost, and sometimes the whole French
   translation is used for the text before or after the link.

This is actually a limitation in the translation implementation. If we
initially have `text_1_en text_2_en text_3_en` translated to French this
way:

terms en_US: `["text_1_en text_2_en text_3_en"]`
terms fr_BE: `["text_1_fr text_2_fr text_3_fr"]`

After adding a link: `text_1_en<a...>text_2_en</a>text_3_en`, and since
the links are not translated as a whole, we should get:

terms en_US: `["text_1_en", "text_2_en", "text_3_en"]`
terms fr_BE: `["text_1_fr text_2_fr text_3_fr"]`

Which means the current translation will be lost, and the result will
depend on the outcome of `get_close_matches()`. Which explains why when
the link is added to the first words of the paragraph, the system still
maps the rest of the paragraph to its "full old translation".

The goal of this commit is to make this behavior less aggressive by
forcing the links added in paragraphs [1] to be translated as a whole.
This way, the `get_close_matches()` will map the new content with a link
to its old translation (without a link), and then, the user can set the
link in the "the most meaningful part of the translation" in the
translate mode.

[1]: We should use the "translate as a whole" feature carefully with
links, since there are already some situations where it's causing
issues (see the fix in [2]). So we only force them inside paragraphs.

[2]: https://github.com/odoo/odoo/commit/9bd60ca93510e410a0136b8b433f596330900593

opw-3984439