### PR TITLE
[FIX] l10n_ar: Add available document type 82

### DIFF
--- a/addons/l10n_ar/models/account_journal.py
+++ b/addons/l10n_ar/models/account_journal.py
@@ -87,7 +87,7 @@ class AccountJournal(models.Model):
         receipt_m_code = ['54']
         receipt_codes = ['4', '9', '15']
         expo_codes = ['19', '20', '21']
-        zeta_codes = ['80', '83']
+        zeta_codes = ['80', '82', '83']
         if afip_pos_system == 'II_IM':
             # pre-printed invoice
             return usual_codes + receipt_codes + expo_codes + invoice_m_code + receipt_m_code


### PR DESCRIPTION
Description of the issue/feature this PR addresses: 
It is necessary to be able to select document types TIQUE - FACTURA B in an invoice if the journal of the invoice has "Online Invoice" set on field "AFIP POS System".

Current behavior before PR:
User is not able to select document types TIQUE - FACTURA B in an invoice if the journal of the invoice has "Online Invoice" set on the field "AFIP POS System".

Desired behavior after PR is merged:
User is able to select document types TIQUE - FACTURA B in an invoice if the journal of the invoice has "Online Invoice" set on the field "AFIP POS System".

Task Adhoc side: 42561

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
