### PR TITLE
[FIX] pos_restaurant: multi session table synchronisation

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -945,7 +945,7 @@ export class PosStore extends Reactive {
         return true;
     }
 
-    getSyncAllOrdersContext(orders) {
+    getSyncAllOrdersContext(orders, options = {}) {
         return {
             config_id: this.config.id,
         };
@@ -960,7 +960,7 @@ export class PosStore extends Reactive {
             const orders = [...orderToCreate, ...orderToUpdate, ...paidOrdersNotSent];
 
             this.preSyncAllOrders(orders);
-            const context = this.getSyncAllOrdersContext(orders);
+            const context = this.getSyncAllOrdersContext(orders, options);
 
             // Allow us to force the sync of the orders In the case of
             // pos_restaurant is usefull to get unsynced orders
@@ -1330,11 +1330,12 @@ export class PosStore extends Reactive {
     async sendOrderInPreparationUpdateLastChange(o, cancelled = false) {
         const uuid = o.uuid;
         this.addPendingOrder([o.id]);
-        await this.syncAllOrders();
+        await this.syncAllOrders({ cancel_table_notification: true });
 
         const order = this.models["pos.order"].find((order) => order.uuid === uuid);
         await this.sendOrderInPreparation(order, cancelled);
         order.updateLastOrderChange();
+        await this.syncAllOrders();
     }
     closeScreen() {
         this.addOrderIfEmpty();

--- a/addons/pos_restaurant/models/pos_order.py
+++ b/addons/pos_restaurant/models/pos_order.py
@@ -41,7 +41,8 @@ class PosOrder(models.Model):
 
     def _process_saved_order(self, draft):
         order_id = super()._process_saved_order(draft)
-        self.send_table_count_notification(self.table_id)
+        if not self.env.context.get('cancel_table_notification'):
+            self.send_table_count_notification(self.table_id)
         return order_id
 
     def send_table_count_notification(self, table_ids):
@@ -51,6 +52,11 @@ class PosOrder(models.Model):
             if config.current_session_id:
                 a_config = config
                 order_count = config.get_tables_order_count_and_printing_changes()
-                messages.append(('TABLE_ORDER_COUNT', order_count))
+                messages.append(
+                    (
+                        "TABLE_ORDER_COUNT",
+                        {"order_count": order_count, "table_ids": table_ids.ids},
+                    )
+                )
         if messages:
             a_config._notify(*messages, private=False)

--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -43,12 +43,12 @@ patch(PosStore.prototype, {
             "get_tables_order_count_and_printing_changes",
             [this.config.id]
         );
-        this.ws_syncTableCount(result);
+        this.ws_syncTableCount({ order_count: result, table_ids: [] });
         this.bus.subscribe("TABLE_ORDER_COUNT", this.ws_syncTableCount.bind(this));
     },
     // using the same floorplan.
     async ws_syncTableCount(data) {
-        const missingTable = data.find(
+        const missingTable = data["order_count"].find(
             (table) => !(table.id in this.models["restaurant.table"].getAllBy("id"))
         );
 
@@ -60,9 +60,32 @@ patch(PosStore.prototype, {
             const table_ids = response.map((floor) => floor.raw.table_ids).flat();
             await this.data.read("restaurant.table", table_ids);
         }
-
         const tableByIds = this.models["restaurant.table"].getAllBy("id");
-        for (const table of data) {
+        const tables = data["table_ids"].map((id) => this.models["restaurant.table"].get(id));
+        const draftTableOrders = [
+            ...new Set(
+                tables
+                    .map((t) => t["<-pos.order.table_id"])
+                    .flat()
+                    .filter((o) => !o.finalized)
+            ),
+        ];
+        await this.loadServerOrders([
+            "|",
+
+            // draft table orders in the server
+            ["state", "=", "draft"],
+
+            // draft table orders in client but paid in the server
+            "&",
+            ["state", "in", ["paid", "invoiced"]],
+            ["id", "in", draftTableOrders.map((t) => t.id)],
+
+            ["config_id", "in", [...this.config.raw.trusted_config_ids, this.config.id]],
+            ["table_id", "in", data["table_ids"]],
+            ["session_id", "=", odoo.pos_session_id],
+        ]);
+        for (const table of data["order_count"]) {
             tableByIds[table.id].uiState.changeCount = table.changes;
             tableByIds[table.id].uiState.orderCount = table.orders;
             tableByIds[table.id].uiState.skipCount = table.skip_changes;
@@ -203,8 +226,9 @@ patch(PosStore.prototype, {
         this.addPendingOrder([order.id]);
         return order;
     },
-    getSyncAllOrdersContext(orders) {
+    getSyncAllOrdersContext(orders, options = {}) {
         const context = super.getSyncAllOrdersContext(...arguments);
+        context["cancel_table_notification"] = options["cancel_table_notification"] || false;
         if (this.config.module_pos_restaurant && this.selectedTable) {
             context["table_ids"] = [this.selectedTable.id];
             context["force"] = true;


### PR DESCRIPTION
when opening the same PoS session on different browser. If you create an order on browser A but pay it on browser B, the order would remain on browser A.

Steps to reproduce:
-------------------
* Install pos_restaurant module
* Open the same PoS session on 2 browser A & B
* Create an order on browser A but don't pay for it, and go back to floor screen
* On browser B pay for the order
> Observation: The order is still visible on browser A

Why the fix:
------------
We now make sure to synchronize all the orders when we receive a
notification from the server. This way we are sure to always have the
most up to date versions of the orders.

Note:
------------
It was also required to modify the
`sendOrderInPreparationUpdateLastChange` function. Because when sending
the order the first time to the server it was sent without any
preparationChange, and it would be retrieved by all the pos and appear
as not sent in preparation. So we had to make sure this first synch
would not notify anyone. We also needed to add a new synchronisation
after sending the preparationChanges to notify all the session with the
correct order content.

opw-4126174
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
