### PR TITLE
[FIX] stock_picking_batch: fix assign batch responsible from kanban

### DIFF
--- a/addons/stock_picking_batch/views/stock_picking_batch_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_batch_views.xml
@@ -171,6 +171,7 @@
                                 </div>
                                 <div class="oe_kanban_bottom_right">
                                     <field name="scheduled_date" widget="date" readonly="state in ['cancel', 'done']"/>
+                                    <field name="company_id" invisible="1"/>
                                     <field name="user_id" widget="many2one_avatar_user" readonly="state not in ['draft', 'in_progress']"/>
                                 </div>
                             </div>


### PR DESCRIPTION
This commit fixes the error that was triggered when trying to assign a responsible user for a picking batch from the kanban view of batches. The error was thrown because the `user_id` field depends on `company_id` field in its domain, which was not existent in the kanban view.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
