### PR TITLE
[FIX] mail: allow portal users to react to channel messages (16.0)

### DIFF
--- a/addons/mail/controllers/discuss.py
+++ b/addons/mail/controllers/discuss.py
@@ -323,17 +323,14 @@ class DiscussController(http.Controller):
     @http.route('/mail/message/add_reaction', methods=['POST'], type='json', auth='public')
     def mail_message_add_reaction(self, message_id, content):
         guest_sudo = request.env['mail.guest']._get_guest_from_request(request).sudo()
-        message_sudo = guest_sudo.env['mail.message'].browse(int(message_id)).exists()
+        message_sudo = guest_sudo.env["mail.message"]._get_with_access(int(message_id), "create")
         if not message_sudo:
             raise NotFound()
+        message_sudo._message_add_reaction(content=content)
         if request.env.user.sudo()._is_public():
-            if not guest_sudo or not message_sudo.model == 'mail.channel' or message_sudo.res_id not in guest_sudo.channel_ids.ids:
-                raise NotFound()
-            message_sudo._message_add_reaction(content=content)
             guests = [('insert', {'id': guest_sudo.id})]
             partners = []
         else:
-            message_sudo.sudo(False)._message_add_reaction(content=content)
             guests = []
             partners = [('insert', {'id': request.env.user.partner_id.id})]
         reactions = message_sudo.env['mail.message.reaction'].search([('message_id', '=', message_sudo.id), ('content', '=', content)])
@@ -351,17 +348,14 @@ class DiscussController(http.Controller):
     @http.route('/mail/message/remove_reaction', methods=['POST'], type='json', auth='public')
     def mail_message_remove_reaction(self, message_id, content):
         guest_sudo = request.env['mail.guest']._get_guest_from_request(request).sudo()
-        message_sudo = guest_sudo.env['mail.message'].browse(int(message_id)).exists()
+        message_sudo = guest_sudo.env["mail.message"]._get_with_access(int(message_id), "create")
         if not message_sudo:
             raise NotFound()
+        message_sudo._message_remove_reaction(content=content)
         if request.env.user.sudo()._is_public():
-            if not guest_sudo or not message_sudo.model == 'mail.channel' or message_sudo.res_id not in guest_sudo.channel_ids.ids:
-                raise NotFound()
-            message_sudo._message_remove_reaction(content=content)
             guests = [('insert-and-unlink', {'id': guest_sudo.id})]
             partners = []
         else:
-            message_sudo.sudo(False)._message_remove_reaction(content=content)
             guests = []
             partners = [('insert-and-unlink', {'id': request.env.user.partner_id.id})]
         reactions = message_sudo.env['mail.message.reaction'].search([('message_id', '=', message_sudo.id), ('content', '=', content)])

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -418,6 +418,18 @@ class MailThread(models.AbstractModel):
         return _('%s created', doc_name)
 
     @api.model
+    def _filter_accessible_for_message_operation(self, model_name, res_ids, msg_operation):
+        """Among the records defined by the given model name and ids, returns those
+        that can be accessed by the current user for the given message operation."""
+        model_class = self.env[model_name]
+        if not hasattr(model_class, "_get_mail_message_access"):
+            model_class = self.env["mail.thread"]
+        check_operation = model_class._get_mail_message_access(res_ids, msg_operation, model_name)
+        records = self.env[model_name].browse(res_ids)
+        records.check_access_rights(check_operation)
+        return records._filter_access_rules(check_operation)
+
+    @api.model
     def _get_mail_message_access(self, res_ids, operation, model_name=None):
         """ mail.message check permission rules for related document. This method is
             meant to be inherited in order to implement addons-specific behavior.

--- a/addons/mail/tests/__init__.py
+++ b/addons/mail/tests/__init__.py
@@ -12,6 +12,7 @@ from . import test_mail_mail_stable_selection
 from . import test_mail_render
 from . import test_mail_template
 from . import test_mail_tools
+from . import test_message_reaction_controller
 from . import test_res_partner
 from . import test_res_users
 from . import test_res_users_settings

--- a/addons/mail/tests/test_message_reaction_controller.py
+++ b/addons/mail/tests/test_message_reaction_controller.py
@@ -1,0 +1,160 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import json
+
+import odoo
+from odoo.addons.base.tests.common import HttpCaseWithUserDemo
+from odoo.addons.mail.tests.common import MailCommon
+
+
+@odoo.tests.tagged("-at_install", "post_install")
+class TestMessageReactionControllerCommon(HttpCaseWithUserDemo, MailCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._create_portal_user()
+        cls.public_user = cls.env.ref("base.public_user")
+        cls.guest = cls.env["mail.guest"].create({"name": "Guest"})
+        cls.public_w_guest = cls.public_user
+        cls.no_user = cls.env["res.users"]  # same as public user but with no guest
+        last_message = cls.env["mail.message"].search([], order="id desc", limit=1)
+        cls.fake_message = cls.env["mail.message"].browse(last_message.id + 1000000)
+        cls.reaction = "😊"
+
+    def _execute_subtests(self, message, subtests):
+        for user, allowed in subtests:
+            if not user:
+                self.authenticate(None, None)
+            elif user != self.public_w_guest:
+                self.authenticate(user.login, user.login)
+            else:
+                self.authenticate(None, None)
+                self.opener.cookies[self.guest._cookie_name] = (
+                    f"{self.guest.id}{self.guest._cookie_separator}{self.guest.access_token}"
+                )
+            msg = str(message.body) if message != self.fake_message else "fake message"
+            with self.subTest(message=msg, login=user.login):
+                if allowed:
+                    data = self._add_reaction(message, self.reaction)
+                    self.assertNotIn("error", data)
+                    reactions = self._find_reactions(message)
+                    self.assertEqual(len(reactions), 1)
+                    if user == self.public_w_guest:
+                        self.assertEqual(reactions.guest_id, self.guest)
+                    else:
+                        self.assertEqual(reactions.partner_id, user.partner_id)
+                    data = self._remove_reaction(message, self.reaction)
+                    self.assertNotIn("error", data)
+                    self.assertEqual(len(self._find_reactions(message)), 0)
+                else:
+                    data = self._add_reaction(message, self.reaction)
+                    self.assertIn("error", data)
+                    data = self._remove_reaction(message, self.reaction)
+                    self.assertIn("error", data)
+
+    def _add_reaction(self, message, content):
+        res = self.opener.post(
+            url=f"{self.env.user.get_base_url()}/mail/message/add_reaction",
+            json={"params": {"message_id": message.id, "content": content}},
+        )
+        return json.loads(res.content)
+
+    def _remove_reaction(self, message, content):
+        res = self.opener.post(
+            url=f"{self.env.user.get_base_url()}/mail/message/remove_reaction",
+            json={"params": {"message_id": message.id, "content": content}},
+        )
+        return json.loads(res.content)
+
+    def _find_reactions(self, message):
+        return self.env["mail.message.reaction"].search([("message_id", "=", message.id)])
+
+
+@odoo.tests.tagged("-at_install", "post_install")
+class TestMessageReactionController(TestMessageReactionControllerCommon):
+    def test_message_reaction_partner(self):
+        """Test access of message reaction for partner chatter."""
+        message = self.user_demo.partner_id.message_post(body="partner message")
+        self._execute_subtests(
+            message,
+            (
+                (self.no_user, False),
+                (self.public_w_guest, False),
+                (self.user_portal, False),
+                # False because not group_partner_manager
+                (self.user_employee, False),
+                (self.user_demo, True),
+                (self.user_admin, True),
+            ),
+        )
+
+    def test_message_reaction_public_channel(self):
+        """Test access of message reaction for a public channel."""
+        channel = self.env["mail.channel"].create(
+            {"group_public_id": None, "name": "public channel"}
+        )
+        message = channel.message_post(body="public message")
+        self._execute_subtests(
+            message,
+            (
+                (self.no_user, False),
+                (self.public_w_guest, True),
+                (self.user_portal, True),
+                (self.user_employee, True),
+                (self.user_demo, True),
+                (self.user_admin, True),
+            ),
+        )
+
+    def test_message_reaction_channel_as_member(self):
+        """Test access of message reaction for a channel as member."""
+        channel = self.env["mail.channel"].browse(
+            self.env["mail.channel"].create_group(
+                partners_to=(self.user_portal + self.user_employee + self.user_demo).partner_id.ids
+            )["id"]
+        )
+        channel.add_members(guest_ids=self.guest.ids)
+        message = channel.message_post(body="invite message")
+        self._execute_subtests(
+            message,
+            (
+                (self.no_user, False),
+                (self.public_w_guest, True),
+                (self.user_portal, True),
+                (self.user_employee, True),
+                (self.user_demo, True),
+                (self.user_admin, True),
+            ),
+        )
+
+    def test_message_reaction_channel_as_non_member(self):
+        """Test access of message reaction for a channel as non-member."""
+        channel = self.env["mail.channel"].browse(
+            self.env["mail.channel"].create_group(partners_to=[])["id"]
+        )
+        message = channel.message_post(body="private message")
+        self._execute_subtests(
+            message,
+            (
+                (self.no_user, False),
+                (self.public_w_guest, False),
+                (self.user_portal, False),
+                (self.user_employee, False),
+                (self.user_demo, False),
+                (self.user_admin, True),
+            ),
+        )
+
+    def test_message_reaction_fake_message(self):
+        """Test access of message reaction for a non-existing message."""
+        self._execute_subtests(
+            self.fake_message,
+            (
+                (self.no_user, False),
+                (self.public_w_guest, False),
+                (self.user_portal, False),
+                (self.user_employee, False),
+                (self.user_demo, False),
+                (self.user_admin, False),
+            ),
+        )


### PR DESCRIPTION
As admin:

- Create a channel
- Make it public
- Post a message in public channel
- Invite portal user to channel

As portal:

- Join channel
- Try to react to admin message -> crash

task-4165120

17.0: https://github.com/odoo/odoo/pull/179411
master: https://github.com/odoo/odoo/pull/179530

Note: the PR in 17.0 and up is much easier because channels ACL have been fixed, so standard code of message can be used.

But in 16.0, it is necessary to hook into the related-document checking part of message to introduce custom channel behavior (checking members instead of relying on any kind of ACL).