### PR TITLE
[IMP] html_editor: keep styles on enter

### DIFF
--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -1,7 +1,7 @@
 import { Plugin } from "../plugin";
 import { closestBlock, isBlock } from "../utils/blocks";
 import { hasAnyNodesColor } from "@html_editor/utils/color";
-import { cleanTextNode, splitTextNode, unwrapContents } from "../utils/dom";
+import { cleanTextNode, splitTextNode, unwrapContents, fillEmpty } from "../utils/dom";
 import {
     areSimilarElements,
     isContentEditable,
@@ -398,7 +398,20 @@ export class FormatPlugin extends Plugin {
 
     cleanForSave({ root, preserveSelection = false } = {}) {
         for (const element of root.querySelectorAll("[data-oe-zws-empty-inline]")) {
+            let currentElement = element.parentElement;
             this.cleanElement(element, { preserveSelection });
+            while (
+                currentElement &&
+                !isBlock(currentElement) &&
+                !currentElement.childNodes.length
+            ) {
+                const parentElement = currentElement.parentElement;
+                currentElement.remove();
+                currentElement = parentElement;
+            }
+            if (currentElement && isBlock(currentElement)) {
+                fillEmpty(currentElement);
+            }
         }
         this.mergeAdjacentInlines(root, { preserveSelection });
     }

--- a/addons/html_editor/static/src/core/split_plugin.js
+++ b/addons/html_editor/static/src/core/split_plugin.js
@@ -80,7 +80,7 @@ export class SplitPlugin extends Plugin {
     // --------------------------------------------------------------------------
     splitBlock() {
         this.dispatchTo("before_split_block_handlers");
-        let selection = this.dependencies.selection.getEditableSelection();
+        let selection = this.dependencies.selection.getSelectionData().deepEditableSelection;
         if (!selection.isCollapsed) {
             // @todo @phoenix collapseIfZWS is not tested
             // this.shared.collapseIfZWS();

--- a/addons/html_editor/static/src/core/split_plugin.js
+++ b/addons/html_editor/static/src/core/split_plugin.js
@@ -139,20 +139,23 @@ export class SplitPlugin extends Plugin {
             blockToSplit.parentElement
         );
         restore();
-        const removeEmptyAndFill = (node) => {
+        const fillEmptyElement = (node) => {
             if (isProtecting(node) || isProtected(node)) {
                 // TODO ABD: add test
                 return;
-            } else if (!isBlock(node) && !isVisible(node)) {
+            } else if (node.nodeType === Node.TEXT_NODE && !isVisible(node)) {
                 const parent = node.parentElement;
                 node.remove();
-                removeEmptyAndFill(parent);
-            } else {
+                fillEmptyElement(parent);
+            } else if (node.nodeType === Node.ELEMENT_NODE) {
+                if (node.hasAttribute("data-oe-zws-empty-inline")) {
+                    delete node.dataset.oeZwsEmptyInline;
+                }
                 fillEmpty(node);
             }
         };
-        removeEmptyAndFill(lastLeaf(beforeElement));
-        removeEmptyAndFill(firstLeaf(afterElement));
+        fillEmptyElement(lastLeaf(beforeElement));
+        fillEmptyElement(firstLeaf(afterElement));
 
         this.dependencies.selection.setCursorStart(afterElement);
 

--- a/addons/html_editor/static/src/main/feff_plugin.js
+++ b/addons/html_editor/static/src/main/feff_plugin.js
@@ -3,7 +3,7 @@ import { cleanTextNode } from "@html_editor/utils/dom";
 import { isTextNode, isZwnbsp } from "@html_editor/utils/dom_info";
 import { prepareUpdate } from "@html_editor/utils/dom_state";
 import { descendants, selectElements } from "@html_editor/utils/dom_traversal";
-import { leftPos } from "@html_editor/utils/position";
+import { leftPos, rightPos } from "@html_editor/utils/position";
 import { callbacksForCursorUpdate } from "@html_editor/utils/selection";
 
 /** @typedef {import("../core/selection_plugin").Cursors} Cursors */
@@ -60,7 +60,7 @@ export class FeffPlugin extends Plugin {
         for (const node of descendants(root).filter((n) => hasFeff(n) && !exclude(n))) {
             // Remove all FEFF within a `prepareUpdate` to make sure to make <br>
             // nodes visible if needed.
-            const restoreSpaces = prepareUpdate(...leftPos(node));
+            const restoreSpaces = prepareUpdate(...leftPos(node), ...rightPos(node));
             cleanTextNode(node, "\ufeff", cursors);
             restoreSpaces();
         }
@@ -117,7 +117,11 @@ export class FeffPlugin extends Plugin {
         // returning a list of them.
         const customFeffNodes = this.getResource("feff_providers").flatMap((p) => p(root, cursors));
         const feffNodesToKeep = new Set([...feffNodesBasedOnSelectors, ...customFeffNodes]);
-        this.removeFeffs(root, cursors, { exclude: (node) => feffNodesToKeep.has(node) });
+        this.removeFeffs(root, cursors, {
+            exclude: (node) =>
+                feffNodesToKeep.has(node) ||
+                this.getResource("legit_feff_predicates").some((predicate) => predicate(node)),
+        });
         cursors.restore();
     }
 

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -60,6 +60,9 @@ function isSelectionHasLink(selection) {
  */
 function isPositionAtEdgeofLink(link, offset) {
     const childNodes = [...link.childNodes];
+    if (!childNodes.length) {
+        return "end";
+    }
     let firstVisibleIndex = childNodes.findIndex(isVisible);
     firstVisibleIndex = firstVisibleIndex === -1 ? 0 : firstVisibleIndex;
     if (offset <= firstVisibleIndex) {

--- a/addons/html_editor/static/tests/color.test.js
+++ b/addons/html_editor/static/tests/color.test.js
@@ -63,7 +63,7 @@ test("should apply a color on empty selection", async () => {
             '<p>[<font data-oe-zws-empty-inline="" style="color: rgb(255, 0, 0);">\u200B</font></p>' +
             '<p><font data-oe-zws-empty-inline="" style="color: rgb(255, 0, 0);">\u200B</font></p>' +
             '<p>]<font data-oe-zws-empty-inline="" style="color: rgb(255, 0, 0);">\u200B</font></p>',
-        contentAfter: "<p>[</p><p></p><p>]</p>",
+        contentAfter: "<p>[<br></p><p><br></p><p>]<br></p>",
     });
 });
 
@@ -75,7 +75,7 @@ test("should apply a background color on empty selection", async () => {
             '<p>[<font data-oe-zws-empty-inline="" style="background-color: rgb(255, 0, 0);">\u200B</font></p>' +
             '<p><font data-oe-zws-empty-inline="" style="background-color: rgb(255, 0, 0);">\u200B</font></p>' +
             '<p>]<font data-oe-zws-empty-inline="" style="background-color: rgb(255, 0, 0);">\u200B</font></p>',
-        contentAfter: "<p>[</p><p></p><p>]</p>",
+        contentAfter: "<p>[<br></p><p><br></p><p>]<br></p>",
     });
 });
 

--- a/addons/html_editor/static/tests/format/underline.test.js
+++ b/addons/html_editor/static/tests/format/underline.test.js
@@ -295,7 +295,7 @@ describe("with italic", () => {
             contentBefore: `<p>ab${u(em(`cd`))}${em(`[]\u200b`)}${u(em(`ef`))}</p>`,
             stepFunction: underline,
             contentAfterEdit: `<p>ab${u(em(`cd`))}${em(u(`[]\u200b`, "last"))}${u(em(`ef`))}</p>`,
-            contentAfter: `<p>ab${u(em(`cd`))}${em(`[]`)}${u(em(`ef`))}</p>`,
+            contentAfter: `<p>ab${u(em(`cd[]ef`))}</p>`,
         });
     });
 

--- a/addons/html_editor/static/tests/insert/line_break.test.js
+++ b/addons/html_editor/static/tests/insert/line_break.test.js
@@ -190,6 +190,7 @@ describe("Selection collapsed", () => {
             await testEditor({
                 contentBefore: "<p><b>abc[]</b> def</p>",
                 stepFunction: insertLineBreak,
+                contentAfterEdit: "<p><b>abc<br>[]\ufeff</b> def</p>",
                 // The space is converted to a non-breaking space so
                 // it is visible (because it's after a <br>).
                 // Visually, the caret does show _after_ the line
@@ -210,8 +211,7 @@ describe("Selection collapsed", () => {
             await testEditor({
                 contentBefore: "<p>[]<b>abc</b></p>",
                 stepFunction: insertLineBreak,
-                // JW cAfter: '<p><b><br>[]abc</b></p>',
-                contentAfter: "<p><br><b>[]abc</b></p>",
+                contentAfter: "<p><b><br>[]abc</b></p>",
             });
             await testEditor({
                 // That selection is equivalent to []<b>
@@ -249,14 +249,22 @@ describe("Selection collapsed", () => {
             });
         });
 
+        test("should insert \uFEFF at the end of format node", async () => {
+            await testEditor({
+                contentBefore: "<p><b>abc[]</b><br><br></p>",
+                stepFunction: insertLineBreak,
+                contentAfterEdit: `<p><b>abc<br>[]\uFEFF</b><br><br></p>`,
+                contentAfter: "<p><b>abc<br>[]</b><br><br></p>",
+            });
+        });
+
         test("should insert a line break (2 <br>) at the end of a format node", async () => {
             await testEditor({
                 contentBefore: "<p><b>abc</b>[]</p>",
                 stepFunction: insertLineBreak,
                 // The second <br> is needed to make the first
                 // one visible.
-                // JW cAfter: '<p><b>abc<br>[]<br></b></p>',
-                contentAfter: "<p><b>abc</b><br>[]<br></p>",
+                contentAfter: "<p><b>abc<br>[]<br></b></p>",
             });
             await testEditor({
                 // That selection is equivalent to </b>[]

--- a/addons/html_editor/static/tests/insert/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/insert/paragraph_break.test.js
@@ -361,12 +361,14 @@ describe("Selection collapsed", () => {
             await testEditor({
                 contentBefore: "<p><b>abc</b>[]def</p>",
                 stepFunction: splitBlock,
+                contentAfterEdit: "<p><b>abc</b></p><p>[]def</p>",
                 contentAfter: "<p><b>abc</b></p><p>[]def</p>",
             });
             await testEditor({
                 // That selection is equivalent to </b>[]
                 contentBefore: "<p><b>abc[]</b>def</p>",
                 stepFunction: splitBlock,
+                contentAfterEdit: `<p><b>abc</b></p><p><b data-oe-zws-empty-inline="">[]\u200b</b>def</p>`,
                 contentAfter: "<p><b>abc</b></p><p>[]def</p>",
             });
             await testEditor({
@@ -374,6 +376,7 @@ describe("Selection collapsed", () => {
                 stepFunction: splitBlock,
                 // The space is converted to a non-breaking
                 // space so it is visible.
+                contentAfterEdit: `<p><b>abc</b></p><p><b data-oe-zws-empty-inline="">[]\u200b</b>&nbsp;def</p>`,
                 contentAfter: "<p><b>abc</b></p><p>[]&nbsp;def</p>",
             });
             await testEditor({
@@ -382,6 +385,7 @@ describe("Selection collapsed", () => {
                 // The space is converted to a non-breaking
                 // space so it is visible (because it's before a
                 // <br>).
+                contentAfterEdit: `<p><b>abc&nbsp;</b></p><p><b data-oe-zws-empty-inline="">[]\u200b</b>def</p>`,
                 contentAfter: "<p><b>abc&nbsp;</b></p><p>[]def</p>",
             });
         });
@@ -390,17 +394,20 @@ describe("Selection collapsed", () => {
             await testEditor({
                 contentBefore: "<p>[]<b>abc</b></p>",
                 stepFunction: splitBlock,
+                contentAfterEdit: "<p><br></p><p><b>[]abc</b></p>",
                 contentAfter: "<p><br></p><p><b>[]abc</b></p>",
             });
             await testEditor({
                 // That selection is equivalent to []<b>
                 contentBefore: "<p><b>[]abc</b></p>",
                 stepFunction: splitBlock,
+                contentAfterEdit: `<p><b data-oe-zws-empty-inline="">\u200b</b><br></p><p><b>[]abc</b></p>`,
                 contentAfter: "<p><br></p><p><b>[]abc</b></p>",
             });
             await testEditor({
                 contentBefore: "<p><b>[] abc</b></p>",
                 stepFunction: splitBlock,
+                contentAfterEdit: `<p><b data-oe-zws-empty-inline="">\u200b</b><br></p><p><b>[] abc</b></p>`,
                 // The space should have been parsed away.
                 // JW cAfter: '<p><br></p><p><b>[]abc</b></p>',
                 contentAfter: "<p><br></p><p><b>[] abc</b></p>",
@@ -433,18 +440,21 @@ describe("Selection collapsed", () => {
             await testEditor({
                 contentBefore: "<p><b>abc</b>[]</p>",
                 stepFunction: splitBlock,
+                contentAfterEdit: `<p><b>abc</b></p><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`,
                 contentAfter: "<p><b>abc</b></p><p>[]<br></p>",
             });
             await testEditor({
                 // That selection is equivalent to </b>[]
                 contentBefore: "<p><b>abc[]</b></p>",
                 stepFunction: splitBlock,
+                contentAfterEdit: `<p><b>abc</b></p><p><b data-oe-zws-empty-inline="">[]\u200b</b><br></p>`,
                 contentAfter: "<p><b>abc</b></p><p>[]<br></p>",
             });
             await testEditor({
                 contentBefore: "<p><b>abc[] </b></p>",
                 stepFunction: splitBlock,
                 // The space should have been parsed away.
+                contentAfterEdit: `<p><b>abc</b></p><p><b data-oe-zws-empty-inline="">[]\u200b</b><br></p>`,
                 contentAfter: "<p><b>abc</b></p><p>[]<br></p>",
             });
         });
@@ -546,7 +556,7 @@ describe("Selection collapsed", () => {
                 contentBefore: '<p><span class="a">ab</span></p><p><span class="b">[]cd</span></p>',
                 stepFunction: splitBlock,
                 contentAfter:
-                    '<p><span class="a">ab</span></p><p><br></p><p><span class="b">[]cd</span></p>',
+                    '<p><span class="a">ab</span></p><p><span class="b">\u200b</span><br></p><p><span class="b">[]cd</span></p>',
             });
         });
 
@@ -582,6 +592,9 @@ describe("Selection collapsed", () => {
                 contentBefore:
                     '<h1><font style="color: red;" data-oe-zws-empty-inline="">[]\u200B</font><br></h1>',
                 stepFunction: splitBlock,
+                contentAfterEdit:
+                    '<h1><font style="color: red;" data-oe-zws-empty-inline="">\u200b</font><br></h1>' +
+                    '<p><font style="color: red;" data-oe-zws-empty-inline="">[]\u200b</font><br></p>',
                 contentAfter: "<h1><br></h1><p>[]<br></p>",
             });
         });
@@ -590,6 +603,7 @@ describe("Selection collapsed", () => {
             await testEditor({
                 contentBefore: `<h1 style="color: red">ab[]</h1>`,
                 stepFunction: splitBlock,
+                contentAfterEdit: `<h1 style="color: red">ab</h1><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`,
                 contentAfter: `<h1 style="color: red">ab</h1><p>[]<br></p>`,
             });
         });
@@ -598,6 +612,28 @@ describe("Selection collapsed", () => {
                 contentBefore: `<h1 dir="rtl">ab[]</h1>`,
                 stepFunction: splitBlock,
                 contentAfter: `<h1 dir="rtl">ab</h1><p dir="rtl">[]<br></p>`,
+            });
+        });
+    });
+    describe("Styles", () => {
+        test("should split a paragraph at the end of style node", async () => {
+            await testEditor({
+                contentBefore: '<p><font style="color: red;">abc[]</font></p>',
+                stepFunction: splitBlock,
+                contentAfterEdit: `<p><font style="color: red;">abc</font></p><p><font style="color: red;" data-oe-zws-empty-inline="">[]\u200b</font><br></p>`,
+                contentAfter: `<p><font style="color: red;">abc</font></p><p>[]<br></p>`,
+            });
+            await testEditor({
+                contentBefore: '<p><font style="background-color: red;">abc[]</font></p>',
+                stepFunction: splitBlock,
+                contentAfterEdit: `<p><font style="background-color: red;">abc</font></p><p><font style="background-color: red;" data-oe-zws-empty-inline="">[]\u200b</font><br></p>`,
+                contentAfter: `<p><font style="background-color: red;">abc</font></p><p>[]<br></p>`,
+            });
+            await testEditor({
+                contentBefore: '<p><span style="font-size: 36px;">abc[]</span></p>',
+                stepFunction: splitBlock,
+                contentAfterEdit: `<p><span style="font-size: 36px;">abc</span></p><p><span style="font-size: 36px;" data-oe-zws-empty-inline="">[]\u200b</span><br></p>`,
+                contentAfter: `<p><span style="font-size: 36px;">abc</span></p><p>[]<br></p>`,
             });
         });
     });

--- a/addons/html_editor/static/tests/insert/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/insert/paragraph_break.test.js
@@ -394,11 +394,10 @@ describe("Selection collapsed", () => {
             await testEditor({
                 contentBefore: "<p>[]<b>abc</b></p>",
                 stepFunction: splitBlock,
-                contentAfterEdit: "<p><br></p><p><b>[]abc</b></p>",
+                contentAfterEdit: `<p><b data-oe-zws-empty-inline="">\u200b</b><br></p><p><b>[]abc</b></p>`,
                 contentAfter: "<p><br></p><p><b>[]abc</b></p>",
             });
             await testEditor({
-                // That selection is equivalent to []<b>
                 contentBefore: "<p><b>[]abc</b></p>",
                 stepFunction: splitBlock,
                 contentAfterEdit: `<p><b data-oe-zws-empty-inline="">\u200b</b><br></p><p><b>[]abc</b></p>`,
@@ -440,7 +439,7 @@ describe("Selection collapsed", () => {
             await testEditor({
                 contentBefore: "<p><b>abc</b>[]</p>",
                 stepFunction: splitBlock,
-                contentAfterEdit: `<p><b>abc</b></p><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`,
+                contentAfterEdit: `<p><b>abc</b></p><p><b data-oe-zws-empty-inline="">[]\u200b</b><br></p>`,
                 contentAfter: "<p><b>abc</b></p><p>[]<br></p>",
             });
             await testEditor({

--- a/addons/html_editor/static/tests/list/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/list/paragraph_break.test.js
@@ -233,7 +233,7 @@ describe("Selection collapsed", () => {
                                 <li class="oe-nested">
                                     <ul>
                                         <li><font style="color: red;">cd</font></li>
-                                        <li>b</li>
+                                        <li><font style="color: red;">b</font></li>
                                         <li>[]<br></li>
                                     </ul>
                                 </li>
@@ -628,7 +628,7 @@ describe("Selection collapsed", () => {
                                 <li class="oe-nested">
                                     <ul class="o_checklist">
                                         <li><font style="color: red;">cd</font></li>
-                                        <li>0</li>
+                                        <li><font style="color: red;">0</font></li>
                                         <li>[]<br></li>
                                     </ul>
                                 </li>
@@ -721,7 +721,7 @@ describe("Selection collapsed", () => {
                                 <li class="oe-nested">
                                     <ul class="o_checklist">
                                         <li class="o_checked"><font style="color: red;">cd</font></li>
-                                        <li>0</li>
+                                        <li><font style="color: red;">0</font></li>
                                         <li>[]<br></li>
                                     </ul>
                                 </li>


### PR DESCRIPTION
Current behavior before PR:

- When pressing Enter, the styles applied to the text were not carried over to the
newly created line.

- When a nested inline element was removed during the editor's cleaning process,
its parent inline element (if also empty) was not removed. This caused the that
inline element to become inaccessible.

- When pressing `shift+enter` within an inline element with a subsequent sibling
`<br>`, a new line break `<br>` is inserted within the inline element. However, the
cursor appears outside the inline element.

Desired behavior after PR is merged:

- Now, when Enter is pressed, if styles are applied to the text, those styles will
be carried over to the newly created line.

- Now, during the editor cleaning process, if an empty inline element is removed,
all of its empty ancestor inline elements are also removed.

- Now, when pressing `shift+enter` inside the inline element with a next sibling
`<br>`, a new line break `<br>` is inserted inside the inline element. Additionally,
a feff character is inserted after the `<br>` tag to ensure that the cursor
remains inside the inline element.

task-2822187