### PR TITLE
[FIX] base: invalidate updated fields

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -4214,6 +4214,7 @@ class _RelationalMulti(_Relational):
                         line = browse(command[1])
                         if validate:
                             line.update(command[2])
+                            line.invalidate_recordset([fname for fname in command[2]])
                         else:
                             line._update_cache(command[2], validate=False)
                         ids.add(line.id)


### PR DESCRIPTION
**Current behavior:**
Having a user action that triggers an onchange for some record
as well as a m2o field of that record, it is possible to have
compute methods triggered with bad cache values. This causes
those computed values to be incorrect until a save occurs.

**Expected behavior:**
Correct values in cache.

**Steps to reproduce:**
*E.g., install sale_mangement, enable product packagings*
1. Create a product with 2 packagings (e.g., 2x qty and 4x qty)

2. On a sale order, add a line for 8 units of the product

3. Change the packaging to 4x, then 2x without saving in between
     or after

4. See that the price is 2x what it should be

**Cause of the issue:**
The first onchange for the `sale.order.line` is done with the
newly selected `packaging_id` value. Then, the order's onchange
is performed, wherein the order line is fetched. The newest
(currently selected) value for the packaging should be available
by:
https://github.com/odoo/odoo/blob/21033abc8499ac846e567d981b30b39fe92c87ff/addons/web/models/models.py#L1031-L1034
However the update is performed on a new record, while the cache
still has the version of the order line with the true, currently
stored value for `packagin_id`. So when
`sale.order.line::_compute_product_uom_qty()` is triggered, it
is using the "old" value in the computation.

**Fix:**
Invalidate the fields in cache that have been updated in a `new`
record.

opw-4081405