### PR TITLE
[IMP] account: notebook in payment view

### DIFF
--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -329,6 +329,10 @@
                                 </div>
                             </group>
                         </group>
+                        <group>
+                            <!-- To be used in localizations requiring to add a page -->
+                            <notebook name="payment_notebook" colspan="2"/>
+                        </group>
                     </sheet>
                     <div class="o_attachment_preview"/>
                     <div class="oe_chatter">


### PR DESCRIPTION
Adding pages to a notebook is required in
a few l10n, so providing it by default will
help avoid issues when adding pages.
An empty notebook does not show, so it should
be fine to have it there.

Task id # 3639230

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
