### PR TITLE
[IMP] uom: number of labels per unit

### DIFF
--- a/addons/stock/wizard/product_label_layout.py
+++ b/addons/stock/wizard/product_label_layout.py
@@ -37,13 +37,13 @@ class ProductLabelLayout(models.TransientModel):
         elif self.move_quantity == 'move' and self.move_ids.move_line_ids:
             custom_barcodes = defaultdict(list)
             for line in self.move_ids.move_line_ids:
-                if line.product_uom_id.category_id == uom_unit:
+                if line.product_uom_id.allow_label:
                     if (line.lot_id or line.lot_name) and int(line.quantity):
                         custom_barcodes[line.product_id.id].append((line.lot_id.name or line.lot_name, int(line.quantity)))
                         continue
                     quantities[line.product_id.id] += line.quantity
                 else:
-                    quantities[line.product_id.id] = 1
+                    quantities[line.product_id.id] += 1
             # Pass only products with some quantity done to the report
             data['quantity_by_product'] = {p: int(q) for p, q in quantities.items() if q}
             data['custom_barcodes'] = custom_barcodes

--- a/addons/uom/data/uom_data.xml
+++ b/addons/uom/data/uom_data.xml
@@ -26,6 +26,7 @@
     <record id="product_uom_unit" model="uom.uom">
         <field name="category_id" ref="product_uom_categ_unit"/>
         <field name="name">Units</field>
+        <field name="allow_label">True</field>
         <field name="factor" eval="1.0"/>
         <field name="uom_type">reference</field>
     </record>
@@ -33,6 +34,7 @@
     <record id="product_uom_dozen" model="uom.uom">
         <field name="category_id" ref="uom.product_uom_categ_unit"/>
         <field name="name">Dozens</field>
+        <field name="allow_label">True</field>
         <field name="factor_inv" eval="12"/>
         <field name="uom_type">bigger</field>
     </record>

--- a/addons/uom/models/uom_uom.py
+++ b/addons/uom/models/uom_uom.py
@@ -52,6 +52,10 @@ class UoM(models.Model):
             "product_uom_dozen",
         ]
 
+    def _default_allow_label(self):
+        unit_category = self.env.ref('uom.product_uom_categ_unit', raise_if_not_found=False)
+        return unit_category and self._context.get('default_category_id') == unit_category.id
+
     name = fields.Char('Unit of Measure', required=True, translate=True)
     category_id = fields.Many2one(
         'uom.category', 'Category', required=True, ondelete='restrict',
@@ -75,6 +79,7 @@ class UoM(models.Model):
         default='reference', required=True)
     ratio = fields.Float('Combined Ratio', compute='_compute_ratio', inverse='_set_ratio', store=False)
     color = fields.Integer('Color', compute='_compute_color')
+    allow_label = fields.Boolean('Labelable', default=lambda self: self._default_allow_label(), help="Print 1 product label per unit transferred")
 
     _sql_constraints = [
         ('factor_gt_zero', 'CHECK (factor!=0)', 'The conversion ratio for a unit of measure cannot be 0!'),

--- a/addons/uom/views/uom_uom_views.xml
+++ b/addons/uom/views/uom_uom_views.xml
@@ -104,6 +104,7 @@
                                     <field name="factor_inv" column_invisible="True"/>
                                     <field name="ratio" string="Ratio" readonly="uom_type == 'reference'" digits="[42,5]"/>
                                     <field name="active"/>
+                                    <field name="allow_label"/>
                                     <field name="rounding" digits="[42, 5]"/>
                                 </list>
                             </field>


### PR DESCRIPTION
In this commit:
===================
- introduced a new feature that allows users to print 1 product label per unit transferred, regardless of the UoM type. ensures that users can print multiple labels based on the UoM by enabling the labellable and improving the handling of product labeling for different unit types.

task-4150552
