### PR TITLE
[FIX] html_editor: Prevent element duplication during unserialization

### DIFF
--- a/addons/html_editor/static/tests/collaboration.test.js
+++ b/addons/html_editor/static/tests/collaboration.test.js
@@ -752,6 +752,48 @@ describe("post process external steps", () => {
         });
     });
 });
+describe("serialize/unserialize", () => {
+    test("Should add a new node that contain an existing node", async () => {
+        const peerInfos = await setupMultiEditor({
+            peerIds: ["c1", "c2"],
+            contentBefore: "<p>x</p>",
+        });
+        applyConcurrentActions(peerInfos, {
+            c1: (editor) => {
+                const divA = editor.document.createElement("div");
+                divA.textContent = "a";
+                editor.editable.append(divA);
+                const p = editor.editable.querySelector("p");
+                divA.append(p);
+                editor.dispatch("ADD_STEP");
+            },
+        });
+        mergePeersSteps(peerInfos);
+        validateSameHistory(peerInfos);
+        validateContent(peerInfos, "<div>a<p>x</p></div>");
+    });
+    test("Should add a new node that contain another node created in the same mutation stack", async () => {
+        const peerInfos = await setupMultiEditor({
+            peerIds: ["c1", "c2"],
+            contentBefore: "<p>x</p>",
+        });
+        applyConcurrentActions(peerInfos, {
+            c1: (editor) => {
+                const divA = editor.document.createElement("div");
+                divA.textContent = "a";
+                editor.editable.append(divA);
+                const divB = editor.document.createElement("div");
+                divB.textContent = "b";
+                editor.editable.append(divB);
+                divB.append(divA);
+                editor.dispatch("ADD_STEP");
+            },
+        });
+        mergePeersSteps(peerInfos);
+        validateSameHistory(peerInfos);
+        validateContent(peerInfos, "<p>x</p><div>b<div>a</div></div>");
+    });
+});
 
 describe("Collaboration with embedded components", () => {
     test("should send an empty embedded element", async () => {

--- a/addons/html_editor/static/tests/embedded_components.test.js
+++ b/addons/html_editor/static/tests/embedded_components.test.js
@@ -897,7 +897,7 @@ describe("In-editor manipulations", () => {
             }
         );
         const historyPlugin = plugins.get("history");
-        const node = historyPlugin.unserializeNode(historyPlugin.serializeNode(el));
+        const node = historyPlugin._unserializeNode(historyPlugin.serializeNode(el))[0];
         expect(getContent(node, { sortAttrs: true })).toBe(
             `<div><p>a</p></div><div contenteditable="false" data-embedded="counter" data-oe-protected="true"></div>`
         );
@@ -918,7 +918,7 @@ describe("In-editor manipulations", () => {
             { config: getConfig([]) }
         );
         const historyPlugin = plugins.get("history");
-        const node = historyPlugin.unserializeNode(historyPlugin.serializeNode(el));
+        const node = historyPlugin._unserializeNode(historyPlugin.serializeNode(el))[0];
         expect(getContent(node)).toBe(`<div data-embedded="unknown"><p>UNKNOWN</p></div>`);
     });
 });
@@ -1082,7 +1082,7 @@ describe("editable descendants", () => {
             }
         );
         const historyPlugin = plugins.get("history");
-        const node = historyPlugin.unserializeNode(historyPlugin.serializeNode(el));
+        const node = historyPlugin._unserializeNode(historyPlugin.serializeNode(el))[0];
         expect(getContent(node, { sortAttrs: true })).toBe(
             unformat(`
                 <div contenteditable="false" data-embedded="wrapper" data-oe-protected="true">


### PR DESCRIPTION
Prior to this commit, unserializing an element could lead to the duplication of its child elements if they were already present in the DOM. This duplication also resulted in the `nodeToIdMap` and `idToNodeMap` being updated with the new, duplicated elements.

This issue is problematic for several reasons:
1. The documents become inconsistent across different peers.
2. The mapping structures are corrupted, as both the original and duplicated elements would reference the same ID in the `nodeToIdMap`, leading to subtle and hard-to-detect bugs.

For instance, we encountered a situation with the `/table` command that resulted in a `<BR>` tag being duplicated inside a `<P>` tag. This allowed one peer to type before the `<BR>` without the other peer being able to recognize the change, ultimately leading to scenarios where a peer could save a paragraph that was later unintentionally removed.

task-4144164




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
