### PR TITLE
[FIX] base: fix address widgets in RTL reports

### DIFF
--- a/odoo/addons/base/views/ir_qweb_widget_templates.xml
+++ b/odoo/addons/base/views/ir_qweb_widget_templates.xml
@@ -26,7 +26,7 @@
 
             <div t-if="address and 'address' in fields" t-attf-class="d-flex align-items-baseline gap-1">
                 <i t-if="not options.get('no_marker')" class="fa fa-map-marker fa-fw" role="img" aria-label="Address" title="Address"/>
-                <span class="w-100 lh-sm text-truncate" itemprop="streetAddress" t-esc="address"/>
+                <span class="w-100 lh-sm text-truncate d-block" itemprop="streetAddress" t-esc="address"/>
             </div>
             <div t-if="city and 'city' in fields" t-attf-class="d-flex align-items-baseline gap-1">
                 <i t-if="not options.get('no_marker')" class="fa fa-map-marker fa-fw" role="img" aria-label="Address" title="Address"/>


### PR DESCRIPTION
Currently, int RTL reports, the address is not correctly aligned.

### Steps to reproduce
* install `l10n_sa` module
* switch to a Saudi company
* print an invoice

You will see that the address is not correctly aligned.

opw-4156154
opw-4155864

Before:
![before](https://github.com/user-attachments/assets/510bbcf9-dd1d-411f-9fa6-2ae772015795)

After:
![after](https://github.com/user-attachments/assets/d102c63f-5415-42d6-b67b-2c44a705217f)


