### PR TITLE
[FIX] sale: fix traceback while downloading the planning report

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1180,7 +1180,7 @@ class SaleOrderLine(models.Model):
 
     def _get_partner_display(self):
         self.ensure_one()
-        commercial_partner = self.order_partner_id.commercial_partner_id
+        commercial_partner = self.sudo().order_partner_id.commercial_partner_id
         return f'({commercial_partner.ref or commercial_partner.name})'
 
     def _additional_name_per_id(self):


### PR DESCRIPTION
- 17.0

### Steps to reproduce:
- Install sale_planning app.
- Create a sale order with the planning product (e.g. Developer (Plan services)) and confirm it.
- Create planning for that sale order and set resource (e.g. Marc demo) to it.
- Click 'Publish & Send' button.
- Set 'User: Own Documents Only' rights for the sales and 'User' or 'none' for the planning for Marc demo.
- Login from that user and open the planning app.
- Open assigned planning form view.
- Print planning.

### Issue:
- Traceback occurs of access right.

### Cause:
- While downloading the report, it goes to access the "display_name" field of sale order line that is computed in the _compute_display_name, but the user does not have access to "sale.order.line".

### Solution:
- Give access to the record by using sudo().

task-3978552


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
