### PR TITLE
[FIX] website_forum: fix flagged post validation

### DIFF
--- a/addons/website_forum/views/forum_forum_templates_post.xml
+++ b/addons/website_forum/views/forum_forum_templates_post.xml
@@ -212,7 +212,7 @@
                 <h5 >You have a pending post</h5>
                 <span>Please wait for a moderator to validate your previous post to be allowed to reply to questions.</span>
             </div>
-            <div t-attf-class="alert alert-danger #{'d-none ' if question.state != 'flagged' else ''}text-center" >
+            <div t-attf-class="alert alert-danger o_wforum_flag_alert #{'d-none ' if question.state != 'flagged' else ''}text-center" >
                 <h5>This question has been flagged</h5>
                 <span t-if="question.can_moderate">As a moderator, you can either validate or reject this answer.</span>
                 <t t-call="website_forum.link_button">


### PR DESCRIPTION
Purpose
=======
Fix the validation button of a flagged post that wasn't doing anything when clicking on it.

Specification
=============
Adding a missing css class named 'o_wforum_flag_alert' that was forgotten during the front-end redesign odoo/odoo@21531bd9b9ac24bec57665432d9c18c807c31b44.
The alert banner is now correctly hidden at validation.

Task-4163955

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
