### PR TITLE
[FIX] account: preserve Label for Payment Term Journal Items

### DIFF
--- a/addons/l10n_in_pos/models/account_move.py
+++ b/addons/l10n_in_pos/models/account_move.py
@@ -1,16 +1,14 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo import api, fields, models
+from odoo import api, models
 
 
 class AccountMove(models.Model):
     _inherit = 'account.move'
 
-    l10n_in_pos_session_ids = fields.One2many("pos.session", "move_id", "POS Sessions")
-
-    @api.depends('l10n_in_pos_session_ids')
+    @api.depends('pos_session_ids')
     def _compute_l10n_in_state_id(self):
         res = super()._compute_l10n_in_state_id()
-        to_compute = self.filtered(lambda m: m.country_code == 'IN' and not m.l10n_in_state_id and m.journal_id.type == 'general' and m.l10n_in_pos_session_ids)
+        to_compute = self.filtered(lambda m: m.country_code == 'IN' and not m.l10n_in_state_id and m.journal_id.type == 'general' and m.pos_session_ids)
         for move in to_compute:
             move.l10n_in_state_id = move.company_id.state_id
         return res

--- a/addons/point_of_sale/models/account_move.py
+++ b/addons/point_of_sale/models/account_move.py
@@ -12,6 +12,7 @@ class AccountMove(models.Model):
     pos_refunded_invoice_ids = fields.Many2many('account.move', 'refunded_invoices', 'refund_account_move', 'original_account_move')
     reversed_pos_order_id = fields.Many2one('pos.order', string="Reversed POS Order",
         help="The pos order that was reverted after closing the session to create an invoice for it.")
+    pos_session_ids = fields.One2many("pos.session", "move_id", "POS Sessions")
 
     def _stock_account_get_last_step_stock_moves(self):
         stock_moves = super(AccountMove, self)._stock_account_get_last_step_stock_moves()
@@ -67,6 +68,7 @@ class AccountMove(models.Model):
             if move.move_type == 'entry' and move.reversed_pos_order_id:
                 move.amount_total_signed = move.amount_total_signed * -1
 
+
 class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'
 
@@ -79,3 +81,7 @@ class AccountMoveLine(models.Model):
         if sudo_order:
             price_unit = sudo_order._get_pos_anglo_saxon_price_unit(self.product_id, self.move_id.partner_id.id, self.quantity)
         return price_unit
+
+    def _compute_name(self):
+        amls = self.filtered(lambda l: not l.move_id.pos_session_ids)
+        super(AccountMoveLine, amls)._compute_name()


### PR DESCRIPTION
Before this PR:
- When creating journal items of the type "payment term" from the backend, the label for these records would be set at creation. Subsequently, the label for payment term lines within a journal entry could be altered unexpectedly.

After this PR:
- For journal items of the type "payment term" that already have a label, the label will remain unchanged, ensuring consistency and preventing unintended modifications.

Related: https://github.com/odoo/enterprise/pull/69496
