### PR TITLE
[FIX] website_forum: fix post flag traceback

### DIFF
--- a/addons/website_forum/controllers/website_forum.py
+++ b/addons/website_forum/controllers/website_forum.py
@@ -598,7 +598,7 @@ class WebsiteForum(WebsiteProfile):
             url = f'/forum/{slug(forum)}/closed_posts'
         else:
             url = f'/forum/{slug(forum)}/validation_queue'
-        post._validate()
+        post.validate()
         return request.redirect(url)
 
     @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/refuse', type='http', auth="user", website=True)

--- a/addons/website_forum/models/forum_post.py
+++ b/addons/website_forum/models/forum_post.py
@@ -527,7 +527,7 @@ class Post(models.Model):
         })
         return True
 
-    def _validate(self):
+    def validate(self):
         for post in self:
             if not post.can_moderate:
                 raise AccessError(_('%d karma required to validate a post.', post.forum_id.karma_moderate))

--- a/addons/website_forum/tests/test_forum_karma_access.py
+++ b/addons/website_forum/tests/test_forum_karma_access.py
@@ -349,27 +349,27 @@ class TestForumKarma(TestForumCommon):
 
         # portal user validate a post: not allowed, unsufficient karma
         with self.assertRaises(AccessError):
-            post.with_user(self.user_portal)._validate()
+            post.with_user(self.user_portal).validate()
 
         # portal user validate a pending post
         self.user_portal.karma = KARMA['moderate']
         post.state = 'pending'
         init_karma = post.create_uid.karma
-        post.with_user(self.user_portal)._validate()
+        post.with_user(self.user_portal).validate()
         self.assertEqual(post.state, 'active', 'website_forum: wrong state when validate a post after pending')
         self.assertEqual(post.create_uid.karma, init_karma + KARMA['gen_que_new'], 'website_forum: wrong karma when validate a post after pending')
 
         # portal user validate a flagged post: ok if enough karma
         self.user_portal.karma = KARMA['moderate']
         post.state = 'flagged'
-        post.with_user(self.user_portal)._validate()
+        post.with_user(self.user_portal).validate()
         self.assertEqual(post.state, 'active', 'website_forum: wrong state when validate a post after flagged')
 
         # portal user validate an offensive post: ok if enough karma
         self.user_portal.karma = KARMA['moderate']
         post.state = 'offensive'
         init_karma = post.create_uid.karma
-        post.with_user(self.user_portal)._validate()
+        post.with_user(self.user_portal).validate()
         self.assertEqual(post.state, 'active', 'website_forum: wrong state when validate a post after offensive')
 
     def test_vote(self):


### PR DESCRIPTION
Purpose
=======
Fix the traceback appearing when trying to validate a flagged post.

Specification
=============
In this commit odoo/odoo@876ebbee6b769c18172e6a61bd7248ee4c034ca7 the validate method has been changed to be private as it didn't look like it was called from the JS.
However when validating a flagged post, the name of the orm method to call through JS is actually hidden being the current target data-action. Changing back the '_validate' method to be public so that it can be called from the JS again.

Task-4163955

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
