### PR TITLE
[FIX] survey: Fix appraisal feedback deadline

### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -82,6 +82,9 @@ class Survey(http.Controller):
         if (not survey_sudo.page_ids and survey_sudo.questions_layout == 'page_per_section') or not survey_sudo.question_ids:
             return 'survey_void'
 
+        if answer_sudo and answer_sudo.deadline and answer_sudo.deadline < datetime.now():
+            return 'answer_deadline'
+
         if answer_sudo and check_partner:
             if request.env.user._is_public() and answer_sudo.partner_id and not answer_token:
                 # answers from public user should not have any partner_id; this indicates probably a cookie issue
@@ -89,9 +92,6 @@ class Survey(http.Controller):
             if not request.env.user._is_public() and answer_sudo.partner_id != request.env.user.partner_id:
                 # partner mismatch, probably a cookie issue
                 return 'answer_wrong_user'
-
-        if answer_sudo and answer_sudo.deadline and answer_sudo.deadline < datetime.now():
-            return 'answer_deadline'
 
         return True
 


### PR DESCRIPTION
in appraisal, the method `_check_validity` is overriden to make different checks in case of `answer_wrong_user`, to make sure that all the checks are OK before handling `answer_wrong_user` case the deadline check should be done before the user check.

opw-4128638

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
