### PR TITLE
[FIX] payment_xendit: allow paying by card with other providers

### DIFF
--- a/addons/payment_xendit/models/payment_transaction.py
+++ b/addons/payment_xendit/models/payment_transaction.py
@@ -27,7 +27,7 @@ class PaymentTransaction(models.Model):
         :rtype: dict
         """
         res = super()._get_specific_rendering_values(processing_values)
-        if self.provider_code != 'xendit' and self.payment_method_code != 'card':
+        if self.provider_code != 'xendit' or self.payment_method_code != 'card':
             return res
 
         # Initiate the payment and retrieve the invoice data.


### PR DESCRIPTION
Following commit a4afe63a952f0dab3cf2157ee301c4540454b903 it wasn't possible to pay by card with something else than xendit any more.
