### PR TITLE
[FIX] web: datetime field: correctly handle showTime option

### DIFF
--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -1,18 +1,12 @@
 import { Component, onWillRender, useState } from "@odoo/owl";
 import { useDateTimePicker } from "@web/core/datetime/datetime_hook";
-import {
-    areDatesEqual,
-    deserializeDate,
-    deserializeDateTime,
-    formatDate,
-    formatDateTime,
-    today,
-} from "@web/core/l10n/dates";
+import { areDatesEqual, deserializeDate, deserializeDateTime, today } from "@web/core/l10n/dates";
 import { evaluateBooleanExpr } from "@web/core/py_js/py";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { ensureArray } from "@web/core/utils/arrays";
 import { exprToBoolean } from "@web/core/utils/strings";
+import { formatDate, formatDateTime } from "../formatters";
 import { standardFieldProps } from "../standard_field_props";
 
 /**

--- a/addons/web/static/tests/views/fields/daterange_field.test.js
+++ b/addons/web/static/tests/views/fields/daterange_field.test.js
@@ -1066,3 +1066,24 @@ test("update the selected input date after removing the existing date", async ()
 
     expect("input[data-field=date]").toHaveValue("02/12/2017");
 });
+
+test("daterange field in kanban with show_time option", async () => {
+    mockTimeZone(+2);
+    Partner._records[0].datetime_end = "2017-03-13 00:00:00";
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="kanban-card">
+                        <field name="datetime" widget="daterange" options="{'show_time': false, 'end_date_field': 'datetime_end'}"/>
+                    </t>
+                </templates>
+            </kanban>`,
+        resId: 1,
+    });
+
+    expect(queryAllTexts(".o_field_daterange span")).toEqual(["02/08/2017", "03/13/2017"]);
+});

--- a/addons/web/static/tests/views/fields/datetime_field.test.js
+++ b/addons/web/static/tests/views/fields/datetime_field.test.js
@@ -547,6 +547,26 @@ test("edit a datetime field in form view with show_seconds option", async () => 
     });
 });
 
+test("datetime field (with widget) in kanban with show_time option", async () => {
+    mockTimeZone(+2);
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="kanban-card">
+                        <field name="datetime" widget="datetime" options="{'show_time': false}"/>
+                    </t>
+                </templates>
+            </kanban>`,
+        resId: 1,
+    });
+
+    expect(".o_kanban_record:first").toHaveText("02/08/2017");
+});
+
 test("datetime field in list with show_time option", async () => {
     mockTimeZone(+2);
     onRpc("has_group", () => true);


### PR DESCRIPTION
Before this commit, the datetime field used the formatDatetime function from /core/l10n/dates instead of the field formatter. The latter is the one implementing the showTime option which basically redirects to formatDate when set to false. As a consequence, the time was displayed in kanban views for fields with widget="datetime" or widget="daterange", even if the option was set to false. This issue has been introduced by [1].

[1] odoo/odoo#177747

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
