### PR TITLE
[FIX] base: deletion of duplicate device session

### DIFF
--- a/odoo/addons/base/models/res_device.py
+++ b/odoo/addons/base/models/res_device.py
@@ -123,7 +123,8 @@ class ResDeviceLog(models.Model):
                     AND log1.platform = log2.platform
                     AND log1.browser = log2.browser
                     AND log1.ip_address = log2.ip_address
-                    AND log1.last_activity < log2.last_activity
+                    AND log1.last_activity <= log2.last_activity
+                    AND log1.id != log2.id
             )
         """)
         _logger.info("GC device logs delete %d entries", self.env.cr.rowcount)


### PR DESCRIPTION
[FIX] base: deletion of duplicate device session

Steps:
- Have 2 devices log with the same last_activity, platform, browser, ip, session, user
- Try to change the language of the user

Actual result:
- Missing record The record does not exist or has been deleted.
(Record: res.device(X,), user: Y)

Expected result:
- No error, SQL view have distinct setup

See:
https://github.com/odoo/odoo/pull/162168
https://github.com/odoo/odoo/pull/177233

opw-4148761

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
