### PR TITLE
[FIX] web: configure hidden smart button under more

### DIFF
--- a/addons/web/static/src/views/form/button_box/button_box.js
+++ b/addons/web/static/src/views/form/button_box/button_box.js
@@ -17,21 +17,24 @@ export class ButtonBox extends Component {
     setup() {
         const ui = useService("ui");
         onWillRender(() => {
-            const maxVisibleButtons = [3, 4, 5, 7, 4, 5, 8][ui.size] || 8;
-            const allVisibleButtons = Object.entries(this.props.slots)
-                .filter(([_, slot]) => this.isSlotVisible(slot))
-                .map(([slotName]) => slotName);
-            if (allVisibleButtons.length <= maxVisibleButtons) {
-                this.visibleButtons = allVisibleButtons;
-                this.additionalButtons = [];
-                this.isFull = allVisibleButtons.length === maxVisibleButtons;
-            } else {
-                // -1 for "More" dropdown
-                this.visibleButtons = allVisibleButtons.slice(0, maxVisibleButtons - 1);
-                this.additionalButtons = allVisibleButtons.slice(maxVisibleButtons - 1);
-                this.isFull = true;
-            }
+            this.updateButtonVisibility([3, 4, 5, 7, 4, 5, 8][ui.size] || 8);
         });
+    }
+
+    updateButtonVisibility(maxVisibleButtons) {
+        const allVisibleButtons = Object.entries(this.props.slots)
+            .filter(([_, slot]) => this.isSlotVisible(slot))
+            .map(([slotName]) => slotName);
+        if (allVisibleButtons.length <= maxVisibleButtons) {
+            this.visibleButtons = allVisibleButtons;
+            this.additionalButtons = [];
+            this.isFull = allVisibleButtons.length === maxVisibleButtons;
+        } else {
+            // -1 for "More" dropdown
+            this.visibleButtons = allVisibleButtons.slice(0, maxVisibleButtons - 1);
+            this.additionalButtons = allVisibleButtons.slice(maxVisibleButtons - 1);
+            this.isFull = true;
+        }
     }
 
     isSlotVisible(slot) {


### PR DESCRIPTION
before this commit:
when a user enables the invisible elements and tries to reconfigure the smart buttons which are expanded on clicking 'more' drop-down. It does not work.

after this commit:
clicking on 'more' drop-down and then after selecting drop-down items should be configure.

Enterprise PR:https://github.com/odoo/enterprise/pull/60302

Task-3797105