### PR TITLE
[IMP] web_tour: forbid actions on elements behind a modal

### DIFF
--- a/addons/account/static/src/js/tours/account.js
+++ b/addons/account/static/src/js/tours/account.js
@@ -64,7 +64,12 @@ registry.category("web_tour.tours").add('account_tour', {
         trigger: ".modal-content button.btn-primary",
         content: markup(_t("Once everything is set, you are good to continue. You will be able to edit this later in the <b>Customers</b> menu.")),
         run: "click",
-    }, 
+    },
+    {
+        isActive: ["auto"],
+        content: "Wait for the modal is closed before continuing the tour",
+        trigger: "body:not(:has(.modal:contains(create partner)))",
+    },
     {
         isActive: ["auto"],
         trigger: "[name=move_type] [raw-value=out_invoice]",
@@ -115,13 +120,13 @@ registry.category("web_tour.tours").add('account_tour', {
         run: "click",
     },
     {
-        isActive: ["auto"],
-        trigger: "div.modal-dialog",
-    },
-    {
-        trigger: ".modal button[name=document_layout_save]",
+        trigger: ".modal button[name=document_layout_save]:contains(continue)",
         content: _t("Configure document layout."),
         run: "click",
+    },
+    {
+        isActive: ["auto"],
+        trigger: "body:not(:has(.modal:contains(configure your document layout)))",
     },
     {
         trigger: "div[name=account_missing_email] a",
@@ -158,6 +163,10 @@ registry.category("web_tour.tours").add('account_tour', {
         content: _t("Let's send the invoice."),
         tooltipPosition: "top",
         run: "click",
+    },
+    {
+        isActive: ["auto"],
+        trigger: "body:not(:has(.modal:contains(print & send)))",
     },
     {
         isActive: ["auto"],

--- a/addons/web_tour/static/src/tour_service/tour_helpers.js
+++ b/addons/web_tour/static/src/tour_service/tour_helpers.js
@@ -25,6 +25,7 @@ export class TourHelpers {
     check(selector) {
         const element = this._get_action_element(selector);
         this._ensureEnabled(element, "check");
+        this._ensureElementIsInModal(element, "check");
         hoot.check(element);
     }
 
@@ -45,6 +46,7 @@ export class TourHelpers {
     clear(selector) {
         const element = this._get_action_element(selector);
         this._ensureEnabled(element, "clear");
+        this._ensureElementIsInModal(element, "clear");
         hoot.click(element);
         hoot.clear();
     }
@@ -61,6 +63,7 @@ export class TourHelpers {
     click(selector) {
         const element = this._get_action_element(selector);
         this._ensureEnabled(element, "click");
+        this._ensureElementIsInModal(element, "click");
         hoot.click(element);
     }
 
@@ -76,6 +79,7 @@ export class TourHelpers {
     dblclick(selector) {
         const element = this._get_action_element(selector);
         this._ensureEnabled(element, "dblclick");
+        this._ensureElementIsInModal(element, "dblclick");
         hoot.dblclick(element);
     }
 
@@ -135,6 +139,7 @@ export class TourHelpers {
      */
     edit(text, selector) {
         const element = this._get_action_element(selector);
+        this._ensureElementIsInModal(element, "edit");
         hoot.click(element);
         hoot.edit(text);
     }
@@ -146,6 +151,7 @@ export class TourHelpers {
      */
     editor(text, selector) {
         const element = this._get_action_element(selector);
+        this._ensureElementIsInModal(element, "editor");
         const InEditor = !!element.closest(".odoo-editor-editable");
         if (!InEditor) {
             throw new Error("run 'editor' always on an element in an editor");
@@ -172,6 +178,7 @@ export class TourHelpers {
      */
     fill(value, selector) {
         const element = this._get_action_element(selector);
+        this._ensureElementIsInModal(element, "fill");
         hoot.click(element);
         hoot.fill(value);
     }
@@ -184,6 +191,7 @@ export class TourHelpers {
      */
     hover(selector) {
         const element = this._get_action_element(selector);
+        this._ensureElementIsInModal(element, "hover");
         hoot.hover(element);
     }
 
@@ -195,6 +203,7 @@ export class TourHelpers {
     range(value, selector) {
         const element = this._get_action_element(selector);
         this._ensureEnabled(element, "range");
+        this._ensureElementIsInModal(element, "range");
         hoot.click(element);
         hoot.setInputRange(element, value);
     }
@@ -224,6 +233,7 @@ export class TourHelpers {
     select(value, selector) {
         const element = this._get_action_element(selector);
         this._ensureEnabled(element, "select");
+        this._ensureElementIsInModal(element, "select");
         hoot.click(element);
         hoot.select(value, { target: element });
     }
@@ -239,6 +249,7 @@ export class TourHelpers {
     selectByIndex(index, selector) {
         const element = this._get_action_element(selector);
         this._ensureEnabled(element, "selectByIndex");
+        this._ensureElementIsInModal(element, "selectByIndex");
         hoot.click(element);
         const value = hoot.queryValue(`option:eq(${index})`, { root: element });
         if (value) {
@@ -258,6 +269,7 @@ export class TourHelpers {
     selectByLabel(contains, selector) {
         const element = this._get_action_element(selector);
         this._ensureEnabled(element, "selectByLabel");
+        this._ensureElementIsInModal(element, "selectByLabel");
         hoot.click(element);
         const values = hoot.queryAllValues(`option:contains(${contains})`, { root: element });
         hoot.select(values, { target: element });
@@ -309,14 +321,29 @@ export class TourHelpers {
     }
 
     /**
-     * Return true when element is not disabled
+     * Throw an error when element is disabled
      * @param {Node} element
      */
-    _ensureEnabled(element, action = "do action") {
+    _ensureEnabled(element, action = "an action") {
         if (element.disabled) {
             throw new Error(
-                `Element can't be disabled when you want to ${action} on it.
-Tip: You can add the ":enabled" pseudo selector to your selector to wait for the element is enabled.`
+                `TourHelpers: Element can't be disabled when you want to run **${action}** on it.
+TIP: You can use the pseudo selector **:enabled** to your selector to wait for the element is enabled.`
+            );
+        }
+    }
+
+    /**
+     * Throw an error when element is below a modal or not in backdrop
+     * @param {Node} element
+     */
+    _ensureElementIsInModal(element, action = "an action") {
+        const root = hoot.queryFirst(".modal:not(.o_inactive_modal)");
+        if (root && !root.contains(element)) {
+            throw new Error(
+                `TourHelpers: It is forbidden to run **${action}** on an element that is not in the active modal.
+TIP: When a modal is closed in a tour, create a step that ensure it is really closed, e.g. { trigger: "body:not(:has(.modal:contains(my title)))" }.
+TIP: To only check if an element is in DOM without doing an action on it, create a step without run key.`
             );
         }
     }

--- a/addons/web_tour/static/src/tour_service/tour_step_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_step_automatic.js
@@ -140,7 +140,8 @@ export class TourStepAutomatic extends TourStep {
 
     get describeWhyIFailed() {
         if (!this.triggerFound) {
-            return `The cause is that trigger (${this.trigger}) element cannot be found in DOM. TIP: You can use :not(:visible) to force the search for an invisible element.`;
+            return `The cause is that trigger (${this.trigger}) element cannot be found in DOM. 
+TIP: You can use :not(:visible) to force the search for an invisible element.`;
         } else if (this.isBlocked) {
             return "Element has been found but DOM is blocked by UI.";
         } else if (!this.hasRun) {


### PR DESCRIPTION
In this commit, we add a verification in tour_helpers to prevent actions that are run on an element that is below a modal

task~4163658