### PR TITLE
[FIX] crm: group-restrict opportunity_count field in res_partner view

### DIFF
--- a/addons/crm/views/res_partner_views.xml
+++ b/addons/crm/views/res_partner_views.xml
@@ -9,7 +9,12 @@
             <field name="priority" eval="10"/>
             <field name="arch" type="xml">
                 <xpath expr="//footer/div" position="inside">
-                    <a t-if="record.opportunity_count.value>0" type="object" name="action_view_opportunity" class="btn btn-sm btn-link smaller" role="button">
+                    <a t-if="record.opportunity_count.value > 0"
+                        class="btn btn-sm btn-link smaller"
+                        groups="sales_team.group_sale_salesman"
+                        name="action_view_opportunity"
+                        role="button"
+                        type="object">
                         <i class="fa fa-star me-1" aria-label="Opportunities" role="img" title="Opportunities"/>
                         <field name="opportunity_count"/>
                     </a>


### PR DESCRIPTION
Versions
--------
- saas-17.4+

Steps
-----
1. Have Sales & CRM installed;
2. log in as a user with no access to Sales;
3. open Contacts app.

Issue
-----
Access Error

Cause
-----
Commit 855560ed2e21 simplified `res_partner` kanban views. In doing so, it removed the `groups` attribute from the `opportunity_count` button. As a consequence, trying to access the `res_partner` kanban view will always try to compute the `opportunity_count` field, regardless of the user's access rights.

Solution
--------
Re-add the `groups` attribute to restrict the button to `sales_team.group_sale_salesman` users.

opw-4145862