### PR TITLE
[FIX] analytic: give access to analytic account to child company

### DIFF
--- a/addons/analytic/models/analytic_account.py
+++ b/addons/analytic/models/analytic_account.py
@@ -14,6 +14,7 @@ class AccountAnalyticAccount(models.Model):
     _description = 'Analytic Account'
     _order = 'plan_id, name asc'
     _check_company_auto = True
+    _check_company_domain = models.check_company_domain_parent_of
     _rec_names_search = ['name', 'code']
 
     name = fields.Char(

--- a/addons/analytic/models/analytic_distribution_model.py
+++ b/addons/analytic/models/analytic_distribution_model.py
@@ -16,6 +16,8 @@ class AccountAnalyticDistributionModel(models.Model):
     _description = 'Analytic Distribution Model'
     _rec_name = 'create_date'
     _order = 'id desc'
+    _check_company_auto = True
+    _check_company_domain = models.check_company_domain_parent_of
 
     partner_id = fields.Many2one(
         'res.partner',

--- a/addons/analytic/models/analytic_plan.py
+++ b/addons/analytic/models/analytic_plan.py
@@ -284,6 +284,8 @@ class AccountAnalyticPlan(models.Model):
 class AccountAnalyticApplicability(models.Model):
     _name = 'account.analytic.applicability'
     _description = "Analytic Plan's Applicabilities"
+    _check_company_auto = True
+    _check_company_domain = models.check_company_domain_parent_of
 
     analytic_plan_id = fields.Many2one('account.analytic.plan')
     business_domain = fields.Selection(

--- a/addons/analytic/security/analytic_security.xml
+++ b/addons/analytic/security/analytic_security.xml
@@ -6,7 +6,7 @@
         <field name="name">Analytic multi company rule</field>
         <field name="model_id" ref="model_account_analytic_account"/>
         <field eval="True" name="global"/>
-        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
+        <field name="domain_force">['|',('company_id','=',False),('company_id', 'parent_of', company_ids)]</field>
     </record>
 
     <record id="analytic_line_comp_rule" model="ir.rule">
@@ -20,14 +20,14 @@
         <field name="name">Analytic applicability multi company rule</field>
         <field name="model_id" ref="model_account_analytic_applicability"/>
         <field eval="True" name="global"/>
-        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
+        <field name="domain_force">['|',('company_id','=',False),('company_id', 'parent_of', company_ids)]</field>
     </record>
 
     <record id="analytic_distribution_model_comp_rule" model="ir.rule">
         <field name="name">Analytic distribution model multi company rule</field>
         <field name="model_id" ref="model_account_analytic_distribution_model"/>
         <field eval="True" name="global"/>
-        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
+        <field name="domain_force">['|',('company_id','=',False),('company_id', 'parent_of', company_ids)]</field>
     </record>
 </data>
 <data noupdate="0">

--- a/addons/analytic/tests/test_analytic_account.py
+++ b/addons/analytic/tests/test_analytic_account.py
@@ -32,10 +32,11 @@ class TestAnalyticAccount(TransactionCase):
         cls.company_data = cls.env['res.company'].create({
             'name': 'company_data',
         })
-        cls.env.user.company_ids |= cls.company_data
+        cls.company_b_branch = cls.env['res.company'].create({'name': "B Branch", 'parent_id': cls.company_data.id})
+        cls.env.user.company_ids |= cls.company_data + cls.company_b_branch
 
         user.write({
-            'company_ids': [(6, 0, cls.company_data.ids)],
+            'company_ids': [(6, 0, [cls.company_data.id, cls.company_b_branch.id])],
             'company_id': cls.company_data.id,
         })
         cls.analytic_plan_offset = len(cls.env['account.analytic.plan'].get_relevant_plans())
@@ -211,3 +212,15 @@ class TestAnalyticAccount(TransactionCase):
             with self.subTest(plan=plan.name, expected_count=expected_value):
                 with Form(plan) as plan_form:
                     self.assertEqual(plan_form.record.all_account_count, expected_value)
+
+    def test_analytic_account_branches(self):
+        """
+        Test that an analytic account defined in a parent company is accessible in its branches (children)
+        """
+        self.analytic_account_1.company_id = self.company_data
+        self.env['account.analytic.line'].create({
+            'name': 'company specific account',
+            'account_id': self.analytic_account_1.id,
+            'amount': 100,
+            'company_id': self.company_b_branch.id,
+        })


### PR DESCRIPTION
Steps to reproduce:
- Have two Companies A and B
- Create an Analytic Account (AA) for Company A
- In B (A multiselected), create an invoice: company=Company B Set the AA analytic Distribution
- Unselect company A and try to enter the invoice

Issue:
Access error

Solution:
After discussion with PO tsb, children companies need to have access to analytic account (and analytic related stuff) from parent

opw-3764627