### PR TITLE
[FIX] account_edi_ubl_cii: use stream instead of dict in send & print

### DIFF
--- a/addons/account_edi_ubl_cii/wizard/account_move_send.py
+++ b/addons/account_edi_ubl_cii/wizard/account_move_send.py
@@ -198,7 +198,7 @@ class AccountMoveSend(models.TransientModel):
 
         # Read pdf content.
         pdf_values = invoice_data.get('pdf_attachment_values') or invoice_data['proforma_pdf_attachment_values']
-        reader_buffer = io.BytesIO(pdf_values['raw'])
+        reader_buffer = pdf_values['raw']['stream']
         reader = OdooPdfFileReader(reader_buffer, strict=False)
 
         # Post-process.


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/167729, the return value of the rendering method has changed from a binary value to a dictionary. This was not taken into account in the send and print wizard in `account_edi_ubl_cii`.

opw-4140992
opw-4141009
opw-4143248
opw-4144142
opw-4145603
opw-4147219
opw-4148447
opw-4159727
opw-4162854
opw-4162855
opw-4165230