### PR TITLE
[IMP] sale_project: upgrade dashboard flow code wise

### DIFF
--- a/addons/project/static/src/components/project_right_side_panel/components/project_profitability.js
+++ b/addons/project/static/src/components/project_right_side_panel/components/project_profitability.js
@@ -3,6 +3,7 @@
 import { Component } from "@odoo/owl";
 
 export class ProjectProfitability extends Component {
+
     static props = {
         data: Object,
         labels: Object,

--- a/addons/sale_project/static/src/components/project_right_side_panel/components/project_profitability.js
+++ b/addons/sale_project/static/src/components/project_right_side_panel/components/project_profitability.js
@@ -1,73 +1,16 @@
 import { patch } from "@web/core/utils/patch";
-import { useService } from "@web/core/utils/hooks";
 import { ProjectProfitability } from "@project/components/project_right_side_panel/components/project_profitability";
-import { formatFloat, formatFloatTime } from "@web/views/fields/formatters";
-
-patch(ProjectProfitability.prototype, {
-    setup() {
-        super.setup();
-        this.orm = useService("orm");
-        this.actionService = useService("action");
-    },
-
-    toggleSaleItems(section) {
-        section.isFolded = !section.isFolded;
-    },
-
-    _getOrmValue(offset, section) {
-        return {
-            function: "get_sale_items_data",
-            args: [this.props.projectId, offset, 5, true, section.id],
-        };
-    },
-
-    async onLoadMoreClick(section) {
-        const offset = section.sale_items.length;
-        const orm_value = this._getOrmValue(offset, section);
-        const newItems = await this.orm.call(
-            "project.project",
-            orm_value.function,
-            orm_value.args,
-            {
-                context: this.props.context,
-            }
-        );
-        if (newItems.length < 5) {
-            section.displayLoadMore = false;
-        }
-        section.sale_items = [...section.sale_items, ...newItems];
-    },
-
-    formatValue(value, unit) {
-        return unit === "Hours" ? formatFloatTime(value) : formatFloat(value);
-    },
-
-    //---------------------------------------------------------------------
-    // Handlers
-    //---------------------------------------------------------------------
-
-    /**
-     * @private
-     * @param {Object} params
-     */
-    async onSaleItemActionClick(params) {
-        if (params.resId && params.type !== "object") {
-            const action = await this.actionService.loadAction(params.name, this.props.context);
-            this.actionService.doAction({
-                ...action,
-                res_id: params.resId,
-                views: [[false, "form"]],
-            });
-        } else {
-            this.props.onProjectActionClick(params);
-        }
-    },
-});
+import { ProjectProfitabilitySection } from "@sale_project/components/project_right_side_panel/components/project_profitability_section";
 
 patch(ProjectProfitability, {
     props: {
         ...ProjectProfitability.props,
         projectId: Number,
         context: Object,
+    },
+
+    components: {
+        ...ProjectProfitability.components,
+        ProjectProfitabilitySection,
     },
 });

--- a/addons/sale_project/static/src/components/project_right_side_panel/components/project_profitability.xml
+++ b/addons/sale_project/static/src/components/project_right_side_panel/components/project_profitability.xml
@@ -2,54 +2,16 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="sale_project.ProjectProfitability" t-inherit="project.ProjectProfitability" t-inherit-mode="extension">
-        <xpath expr="//a[hasclass('revenue_section')]" position="before">
-            <t t-if="revenue.isFolded">
-                <button class="btn o_group_caret fa fa-fw fa-caret-right me-1" t-on-click="() => this.toggleSaleItems(revenue)"/>
-            </t>
-            <t t-if="!revenue.isFolded and revenue.isFolded !== undefined">
-                <button name="displaySaleItems" class="btn o_group_caret fa fa-fw fa-caret-down me-1" t-on-click="() => this.toggleSaleItems(revenue)"/>
-            </t>
-        </xpath>
-        <xpath expr="//tr[hasclass('revenue_section')]" position="after">
-            <t t-if="!revenue.isFolded and revenue.isFolded !== undefined">
-                <tr>
-                    <td colspan="4" class="p-0 m-0">
-                        <table class="table table-sm table-striped table-hover mb-0">
-                            <thead>
-                                <tr class="bg-light">
-                                    <th style="padding-left:30px">Sales Order Items</th>
-                                    <th class="text-end">Sold</th>
-                                    <th class="text-end">Delivered</th>
-                                    <th class="text-end">Invoiced</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr class="bg-light" t-foreach="revenue.sale_items" t-as="sale_item" t-key="sale_item.id">
-                                    <t t-set="uom_name" t-value="sale_item.product_uom and sale_item.product_uom[1]"/>
-                                    <td style="padding-left: 30px">
-                                        <a t-if="sale_item.action" href="#" t-on-click="() => this.onSaleItemActionClick(sale_item.action)">
-                                            <t t-esc="sale_item.name"/>
-                                        </a>
-                                        <t t-else="" t-esc="sale_item.name"/>
-                                    </td>
-                                    <td class="text-end align-middle"><t t-esc="formatValue(sale_item.product_uom_qty, uom_name)"/> <t t-esc="uom_name"/></td>
-                                    <td class="text-end align-middle"><t t-esc="formatValue(sale_item.qty_delivered, uom_name)"/> <t t-esc="uom_name"/></td>
-                                    <td class="text-end align-middle"><t t-esc="formatValue(sale_item.qty_invoiced, uom_name)"/> <t t-esc="uom_name"/></td>
-                                </tr>
-                            </tbody>
-                            <tfoot>
-                                <tr class="border-0 bg-light" t-if="revenue.displayLoadMore">
-                                    <td class="text-center" colspan="4">
-                                        <a class="cursor-pointer btn-link w-100" t-on-click="() => this.onLoadMoreClick(revenue)">
-                                            Load more
-                                        </a>
-                                    </td>
-                                </tr>
-                            </tfoot>
-                        </table>
-                    </td>
-                </tr>
-            </t>
+       <xpath expr="//tr[hasclass('revenue_section')]" position="replace">
+            <ProjectProfitabilitySection
+                revenue="revenue"
+                labels="props.labels"
+                formatMonetary="props.formatMonetary.bind(this)"
+                onProjectActionClick="props.onProjectActionClick.bind(this)"
+                onClick="(params) => this.props.onProjectActionClick(params)"
+                projectId="this.props.projectId"
+                context="this.props.context"
+            />
         </xpath>
     </t>
 </templates>

--- a/addons/sale_project/static/src/components/project_right_side_panel/components/project_profitability_section.js
+++ b/addons/sale_project/static/src/components/project_right_side_panel/components/project_profitability_section.js
@@ -1,0 +1,81 @@
+import { useService } from "@web/core/utils/hooks";
+import { Component, useState } from "@odoo/owl";
+import { formatFloat, formatFloatTime } from "@web/views/fields/formatters";
+
+export class ProjectProfitabilitySection extends Component {
+
+    static props = {
+        revenue: Object,
+        labels: Object,
+        formatMonetary: Function,
+        onProjectActionClick: Function,
+        onClick: Function,
+        projectId: Number,
+        context: Object,
+    };
+    static template = "sale_project.ProjectProfitabilitySection";
+
+
+    setup() {
+        this.orm = useService("orm");
+        this.actionService = useService("action");
+        this.state = useState({
+            isFolded: true,
+            displayLoadMore: null,
+        });
+        this.sale_items = [];
+    }
+
+    get revenue() {
+        return this.props.revenue;
+    }
+
+    async toggleSaleItems() {
+        if (this.state.displayLoadMore === null) {
+            // first time the section is unfold, load the 5 first items.
+            await this.onLoadMoreClick()
+        }
+        // the state change is done at the end to ensure the loaded data are present when the component is rendered
+        this.state.isFolded = !this.state.isFolded;
+    }
+
+    formatValue(value, unit) {
+        return unit === "Hours" ? formatFloatTime(value) : formatFloat(value);
+    }
+
+    _getOrmValue(offset, section_id) {
+        return {
+            function: "get_sale_items_data",
+            args: [this.props.projectId, offset, 5, true, section_id],
+        };
+    }
+
+    async onLoadMoreClick() {
+        const offset = this.sale_items.length;
+        const orm_value = this._getOrmValue(offset, this.props.revenue.id);
+        const newItems = await this.orm.call(
+            "project.project",
+            orm_value.function,
+            orm_value.args,
+            {
+                context: this.props.context,
+            }
+        );
+        this.sale_items = [...this.sale_items, ...newItems.sol_items];
+        this.state.displayLoadMore = newItems.displayLoadMore;
+        this.render();
+    }
+
+    async onSaleItemActionClick(params) {
+        if (params.resId && params.type !== "object") {
+            const action = await this.actionService.loadAction(params.name, this.props.context);
+            this.actionService.doAction({
+                ...action,
+                res_id: params.resId,
+                views: [[false, "form"]],
+            });
+        } else {
+            this.props.onProjectActionClick(params);
+        }
+    }
+}

--- a/addons/sale_project/static/src/components/project_right_side_panel/components/project_profitability_section.xml
+++ b/addons/sale_project/static/src/components/project_right_side_panel/components/project_profitability_section.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="sale_project.ProjectProfitabilitySection">
+        <tr>
+            <t t-set="revenue_label" t-value="props.labels[revenue.id] or revenue.id"/>
+            <td class="align-middle">
+                <t t-if="this.props.revenue.isSectionFoldable">
+                    <button t-attf-class="btn o_group_caret fa fa-fw me-1 #{state.isFolded ? 'fa-caret-right' : 'fa-caret-down'}" t-on-click="() => this.toggleSaleItems()"/>
+                </t>
+                <a class="revenue_section" t-if="revenue.action" href="#"
+                    t-on-click="() => this.props.onClick(revenue.action)"
+                >
+                    <t t-esc="revenue_label"/>
+                </a>
+                <t t-esc="revenue_label" t-else=""/>
+            </td>
+            <td t-attf-class="text-end align-middle {{ revenue.invoiced + revenue.to_invoice === 0 ? 'text-500' : ''}}"><t t-esc="props.formatMonetary(revenue.invoiced + revenue.to_invoice)"/></td>
+            <td t-attf-class="text-end align-middle {{ revenue.to_invoice === 0 ? 'text-500' : ''}}"><t t-esc="props.formatMonetary(revenue.to_invoice)"/></td>
+            <td t-attf-class="text-end align-middle {{ revenue.invoiced === 0 ? 'text-500' : ''}}"><t t-esc="props.formatMonetary(revenue.invoiced)"/></td>
+        </tr>
+        <t t-if="!state.isFolded and this.props.revenue.isSectionFoldable">
+            <tr>
+                <td colspan="4" class="p-0 m-0">
+                    <table class="table table-sm table-striped table-hover mb-0">
+                        <thead>
+                            <tr class="bg-light">
+                                <th style="padding-left:30px">Sales Order Items</th>
+                                <th class="text-end">Sold</th>
+                                <th class="text-end">Delivered</th>
+                                <th class="text-end">Invoiced</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr class="bg-light" t-foreach="sale_items" t-as="sale_item" t-key="sale_item.id">
+                                <t t-set="uom_name" t-value="sale_item.product_uom and sale_item.product_uom[1]"/>
+                                <td style="padding-left: 30px">
+                                    <a t-if="sale_item.action" href="#" t-on-click="() => this.onSaleItemActionClick(sale_item.action)">
+                                        <t t-esc="sale_item.name"/>
+                                    </a>
+                                    <t t-else="" t-esc="sale_item.name"/>
+                                </td>
+                                <td class="text-end align-middle"><t t-esc="formatValue(sale_item.product_uom_qty, uom_name)"/> <t t-esc="uom_name"/></td>
+                                <td class="text-end align-middle"><t t-esc="formatValue(sale_item.qty_delivered, uom_name)"/> <t t-esc="uom_name"/></td>
+                                <td class="text-end align-middle"><t t-esc="formatValue(sale_item.qty_invoiced, uom_name)"/> <t t-esc="uom_name"/></td>
+                            </tr>
+                        </tbody>
+                        <tfoot>
+                            <tr class="border-0 bg-light" t-if="state.displayLoadMore">
+                                <td class="text-center" colspan="4">
+                                    <a class="cursor-pointer btn-link w-100" t-on-click="() => this.onLoadMoreClick(revenue)">
+                                        Load more
+                                    </a>
+                                </td>
+                            </tr>
+                        </tfoot>
+                    </table>
+                </td>
+            </tr>
+        </t>
+    </t>
+</templates>

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -192,18 +192,19 @@ class TestSaleProject(HttpCase, TestSaleProjectCommon):
         self.assertEqual(self.project_global._get_sale_orders(), sale_order | sale_order_2)
 
         sale_order_lines = sale_order.order_line + sale_line_1_order_2  # exclude the Section and Note Sales Order Items
-        sale_items_data = self.project_global.get_sale_items_data(limit=5, with_action=False)
+        sale_items_data = self.project_global.get_sale_items_data(limit=5, with_action=False, section_id='billable_fixed')
+
         expected_sale_line_dict = {
             sol_read['id']: sol_read
-            for sol_read in sale_order_lines._read_format(['name', 'product_uom_qty', 'qty_delivered', 'qty_invoiced', 'product_uom', 'product_id'])
+            for sol_read in sale_order_lines._read_format(
+                ['name', 'product_uom_qty', 'qty_delivered', 'qty_invoiced', 'product_uom', 'product_id'])
         }
         actual_sol_ids = []
-        for section in sale_items_data:
-            for line in sale_items_data[section]['data']:
-                sol_id = line['id']
-                actual_sol_ids.append(sol_id)
-                self.assertIn(sol_id, expected_sale_line_dict)
-                self.assertDictEqual(line, expected_sale_line_dict[sol_id])
+        for line in sale_items_data['sol_items']:
+            sol_id = line['id']
+            actual_sol_ids.append(sol_id)
+            self.assertIn(sol_id, expected_sale_line_dict)
+            self.assertDictEqual(line, expected_sale_line_dict[sol_id])
         self.assertNotIn(section_sale_line_order_2.id, actual_sol_ids, 'The section Sales Order Item should not be takken into account in the Sales section of project.')
         self.assertNotIn(note_sale_line_order_2.id, actual_sol_ids, 'The note Sales Order Item should not be takken into account in the Sales section of project.')
 

--- a/addons/sale_project/tests/test_sale_project_dashboard.py
+++ b/addons/sale_project/tests/test_sale_project_dashboard.py
@@ -64,41 +64,8 @@ class TestDashboardProject(TestProjectDashboardCommon):
     Since the data is different for the same input when the timesheet module is installed, those tests have to be run at_install
     """
 
-    def test_get_sale_item_data_limit_and_load_more(self):
-        """This test ensures that when more than 5 sols are present, only 5 are computed on the first call.
-        It also ensures that the call from the 'load more' button is correctly computed"""
-
-        sols = self.dashboardSaleOrderLine.create([{
-            'product_id': self.dashboard_product_delivery_service.id,
-            'product_uom_qty': i,
-        } for i in range(1, 8)])
-        sale_item_data = self.dashboard_project.get_sale_items_data(limit=5)
-        expected_dict = {
-            'materials': {'data': [], 'displayLoadMore': False},
-            'service_revenues': {
-                'data':
-                    [
-                        {'id': sols[0].id, 'name': '[SERV-ORDERED2] Service Delivery', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.dashboard_product_delivery_service.id, '[SERV-ORDERED2] Service Delivery')},
-                        {'id': sols[1].id, 'name': '[SERV-ORDERED2] Service Delivery', 'product_uom_qty': 2.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.dashboard_product_delivery_service.id, '[SERV-ORDERED2] Service Delivery')},
-                        {'id': sols[2].id, 'name': '[SERV-ORDERED2] Service Delivery', 'product_uom_qty': 3.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.dashboard_product_delivery_service.id, '[SERV-ORDERED2] Service Delivery')},
-                        {'id': sols[3].id, 'name': '[SERV-ORDERED2] Service Delivery', 'product_uom_qty': 4.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.dashboard_product_delivery_service.id, '[SERV-ORDERED2] Service Delivery')},
-                        {'id': sols[4].id, 'name': '[SERV-ORDERED2] Service Delivery', 'product_uom_qty': 5.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.dashboard_product_delivery_service.id, '[SERV-ORDERED2] Service Delivery')},
-                    ],
-                'displayLoadMore': True,
-            },
-        }
-        self.assertEqual(sale_item_data, expected_dict)
-        # add a new call with the 'section_id' to ensure that the 2 extra sol are fetched correctly.
-        sale_item_data = self.dashboard_project.get_sale_items_data(offset=5, limit=5, section_id='service_revenues')
-        expected_list = [
-            {'id': sols[5].id, 'name': '[SERV-ORDERED2] Service Delivery', 'product_uom_qty': 6.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.dashboard_product_delivery_service.id, '[SERV-ORDERED2] Service Delivery')},
-            {'id': sols[6].id, 'name': '[SERV-ORDERED2] Service Delivery', 'product_uom_qty': 7.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.dashboard_product_delivery_service.id, '[SERV-ORDERED2] Service Delivery')},
-        ]
-        self.assertEqual(sale_item_data, expected_list)
-
     def test_get_sale_item_data_various_sols(self):
         """This test ensures that the sols are computed and put into the correct profitability sections"""
-        self.dashboard_project.allow_billable = True
         sol_service_1, sol_service_2, sol_service_3, sol_service_4 = self.dashboardSaleOrderLine.create([{
                 'product_id': self.product_milestone.id,
                 'product_uom_qty': 1,
@@ -112,22 +79,13 @@ class TestDashboardProject(TestProjectDashboardCommon):
                 'product_id': self.dashboard_product_delivery_service.id,
                 'product_uom_qty': 1,
         }])
-        expected_dict = {
-            'materials': {
-                'data': [
-                    {'id': sol_service_3.id, 'name': 'Material', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (1, 'Units'), 'product_id': (self.material_product.id, 'Material')}
-                ],
-                'displayLoadMore': False,
-            },
-            'service_revenues': {
-                'data': [
-                     {'id': sol_service_1.id, 'name': '[SERV-ORDERED2] Service Milestone', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.product_milestone.id, '[SERV-ORDERED2] Service Milestone')},
-                     {'id': sol_service_2.id, 'name': '[SERV-ORDERED2] Product prepaid', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.product_prepaid.id, '[SERV-ORDERED2] Product prepaid')},
-                     {'id': sol_service_4.id, 'name': '[SERV-ORDERED2] Service Delivery', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.dashboard_product_delivery_service.id, '[SERV-ORDERED2] Service Delivery')},
-                ],
-                'displayLoadMore': False,
-            },
-        }
-
-        sale_item_data = self.dashboard_project.get_sale_items_data(limit=5)
-        self.assertEqual(sale_item_data, expected_dict)
+        expected_dict = [{'id': sol_service_3.id, 'name': 'Material', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (1, 'Units'), 'product_id': (self.material_product.id, 'Material')}]
+        sale_item_data = self.dashboard_project.get_sale_items_data(limit=5, with_action=False, section_id='materials')
+        self.assertEqual(sale_item_data['sol_items'], expected_dict)
+        expected_dict = [
+             {'id': sol_service_1.id, 'name': '[SERV-ORDERED2] Service Milestone', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.product_milestone.id, '[SERV-ORDERED2] Service Milestone')},
+             {'id': sol_service_2.id, 'name': '[SERV-ORDERED2] Product prepaid', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.product_prepaid.id, '[SERV-ORDERED2] Product prepaid')},
+             {'id': sol_service_4.id, 'name': '[SERV-ORDERED2] Service Delivery', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.dashboard_product_delivery_service.id, '[SERV-ORDERED2] Service Delivery')},
+        ]
+        sale_item_data = self.dashboard_project.get_sale_items_data(limit=5, with_action=False, section_id='service_revenues')
+        self.assertEqual(sale_item_data['sol_items'], expected_dict)

--- a/addons/sale_timesheet/models/project_project.py
+++ b/addons/sale_timesheet/models/project_project.py
@@ -287,6 +287,15 @@ class ProjectProject(models.Model):
             'account_id': self.account_id.id,
         }
 
+    def _get_foldable_section(self):
+        foldable_section = super()._get_foldable_section()
+        return foldable_section + [
+            'billable_fixed',
+            'billable_milestones',
+            'billable_time',
+            'billable_manual',
+        ]
+
     def _get_sale_order_items_query(self, domain_per_model=None):
         if domain_per_model is None:
             domain_per_model = {'project.task': [('allow_billable', '=', True)]}
@@ -331,15 +340,6 @@ class ProjectProject(models.Model):
             employee_mapping_sql,
         ]))
         return query
-
-    def _get_items_id_per_section_id(self):
-        return {
-            'materials': {'data': [], 'displayLoadMore': False},
-            'billable_fixed': {'data': [], 'displayLoadMore': False},
-            'billable_milestones': {'data': [], 'displayLoadMore': False},
-            'billable_time': {'data': [], 'displayLoadMore': False},
-            'billable_manual': {'data': [], 'displayLoadMore': False},
-        }
 
     def _get_domain_from_section_id(self, section_id):
         section_domains = {

--- a/addons/sale_timesheet/tests/test_sale_timesheet_dashboard.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet_dashboard.py
@@ -44,38 +44,28 @@ class TestSaleTimesheetDashboard(Common):
             'product_id': self.dashboard_product_delivery_service.id,
             'product_uom_qty': 1,
         }])
-        expected_dict = {
-            'materials': {
-                'data': [
-                    {'id': sol_service_3.id, 'name': 'Material', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (1, 'Units'), 'product_id': (self.material_product.id, 'Material')},
-                ],
-                'displayLoadMore': False,
-            },
-            'billable_fixed': {
-                'data': [
-                    {'id': sol_service_2.id, 'name': '[SERV-ORDERED2] Product prepaid', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.product_prepaid.id, '[SERV-ORDERED2] Product prepaid')},
-                ],
-                'displayLoadMore': False,
-            },
-            'billable_milestones': {
-                'data': [
-                    {'id': sol_service_1.id, 'name': '[SERV-ORDERED2] Service Milestone', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.product_milestone.id, '[SERV-ORDERED2] Service Milestone')},
-                ],
-                'displayLoadMore': False,
-            },
-            'billable_time': {
-                'data': [
-                    {'id': sol_service_4.id, 'name': '[SERV-DELI1] Service delivered', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.dashboard_product_delivery_timesheet.id, '[SERV-DELI1] Service delivered')},
-                ],
-                'displayLoadMore': False,
-            },
-            'billable_manual': {
-                'data': [
-                    {'id': sol_service_5.id, 'name': '[SERV-ORDERED2] Service Delivery', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.dashboard_product_delivery_service.id, '[SERV-ORDERED2] Service Delivery')},
-                ],
-                'displayLoadMore': False,
-            },
-        }
-        sale_item_data = self.dashboard_project.get_sale_items_data(with_action=False, limit=5)
-
-        self.assertEqual(sale_item_data, expected_dict)
+        sale_item_data = self.dashboard_project.get_sale_items_data(with_action=False, limit=5, section_id='materials')
+        self.assertEqual(
+            sale_item_data['sol_items'],
+            [{'id': sol_service_3.id, 'name': 'Material', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (1, 'Units'), 'product_id': (self.material_product.id, 'Material')}]
+        )
+        sale_item_data = self.dashboard_project.get_sale_items_data(with_action=False, limit=5, section_id='billable_fixed')
+        self.assertEqual(
+            sale_item_data['sol_items'],
+            [{'id': sol_service_2.id, 'name': '[SERV-ORDERED2] Product prepaid', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.product_prepaid.id, '[SERV-ORDERED2] Product prepaid')}]
+        )
+        sale_item_data = self.dashboard_project.get_sale_items_data(with_action=False, limit=5, section_id='billable_milestones')
+        self.assertEqual(
+            sale_item_data['sol_items'],
+            [{'id': sol_service_1.id, 'name': '[SERV-ORDERED2] Service Milestone', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.product_milestone.id, '[SERV-ORDERED2] Service Milestone')}]
+        )
+        sale_item_data = self.dashboard_project.get_sale_items_data(with_action=False, limit=5, section_id='billable_time')
+        self.assertEqual(
+            sale_item_data['sol_items'],
+            [{'id': sol_service_4.id, 'name': '[SERV-DELI1] Service delivered', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.dashboard_product_delivery_timesheet.id, '[SERV-DELI1] Service delivered')}]
+        )
+        sale_item_data = self.dashboard_project.get_sale_items_data(with_action=False, limit=5, section_id='billable_manual')
+        self.assertEqual(
+            sale_item_data['sol_items'],
+            [{'id': sol_service_5.id, 'name': '[SERV-ORDERED2] Service Delivery', 'product_uom_qty': 1.0, 'qty_delivered': 0.0, 'qty_invoiced': 0.0, 'product_uom': (4, 'Hours'), 'product_id': (self.dashboard_product_delivery_service.id, '[SERV-ORDERED2] Service Delivery')}]
+        )


### PR DESCRIPTION
This commit's purpose is to change the way the dashboard handles the sale items. Instead of loading them when the dashboard page is loaded for the first time, data are fetched when the user unfold the section. This avoids needless data fetch on the first load.

task - 4150611
affected version : master