### PR TITLE
[FIX] l10n_es_edi_{sii|tbai}: use 'IE' Causa for OSS taxes

### DIFF
--- a/addons/l10n_es_edi_tbai/data/template_invoice.xml
+++ b/addons/l10n_es_edi_tbai/data/template_invoice.xml
@@ -184,7 +184,7 @@
             <NoSujeta t-if="desglose.get('NoSujeta')">
                 <t t-set="no_sujeta" t-value="desglose['NoSujeta']"/>
                 <DetalleNoSujeta>
-                    <Causa>RL</Causa>
+                    <Causa t-out="nosujeto_causa"/>
                     <!-- NOTE: Causa should be 
                         'OT' if 'the' ClaveRegimenIvaOpTrascendencia == 10
                         'RL' if 'some' ClaveRegimenIvaOpTrascendencia == 08

--- a/addons/l10n_es_edi_tbai/models/account_edi_format.py
+++ b/addons/l10n_es_edi_tbai/models/account_edi_format.py
@@ -396,6 +396,7 @@ class AccountEdiFormat(models.Model):
 
         if invoice._is_l10n_es_tbai_simplified():
             values['regime_key'].append(52)  # code for simplified invoices
+        values['nosujeto_causa'] = 'IE' if is_oss else 'RL'
 
         return values
 


### PR DESCRIPTION
**Steps to reproduce:**
- Install Invoicing, l10n_eu_oss and l10n_es_edi_tbai
- Switch to a Spanish company (e.g. ES Company)
- Create an invoice for a Portugese customer:
  * Customer: [a Portugese customer]
  * Invoice Lines: [a line with OSS tax "23.0% PT VAT (Goods)"]
- Make sure that "Tax Type (Spain)" of the tax is set to "No Sujeto por reglas de Localization"
- Confirm the invoice
- Process the invoice by E-invoicing service: TicketBAI (ES)
- Check the generated EDI document

**Issue:**
The value of "Causa" in "NoSujeta" section is "RL". It should be "IE" for OSS taxes.

opw-4034659




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
