### PR TITLE
[FIX] {mass_mailing_}event: stop notifying draft registrations

### DIFF
--- a/addons/event/models/event_mail.py
+++ b/addons/event/models/event_mail.py
@@ -190,11 +190,10 @@ class EventMailScheduler(models.Model):
                     continue
                 # do not send emails if the mailing was scheduled before the event but the event is over
                 if scheduler.scheduled_date <= now and (scheduler.interval_type != 'before_event' or scheduler.event_id.date_end > now):
-                    scheduler.event_id.mail_attendees(scheduler.template_ref.id)
-                    # Mail is sent to all attendees (unconfirmed as well), so count all attendees
+                    scheduler.event_id.mail_attendees(scheduler.template_ref.id, filter_func=lambda reg: reg.state not in ('cancel', 'draft'))
                     scheduler.update({
                         'mail_done': True,
-                        'mail_count_done': len(scheduler.event_id.registration_ids.filtered(lambda r: r.state != 'cancel'))
+                        'mail_count_done': scheduler.event_id.seats_taken,
                     })
         return True
 

--- a/addons/event/tests/test_event_mail_schedule.py
+++ b/addons/event/tests/test_event_mail_schedule.py
@@ -138,25 +138,39 @@ class TestMailSchedule(EventCase, MockEmail, CronMixinCase):
                 'name': 'Reg2',
                 'email': 'reg2@example.com',
             })
+            reg3_draft = self.env['event.registration'].with_user(self.user_eventuser).create({
+                'event_id': test_event.id,
+                'name': 'Reg3',
+                'email': 'reg3_draft@example.com',
+            })
+            reg4_cancel = self.env['event.registration'].with_user(self.user_eventuser).create({
+                'event_id': test_event.id,
+                'name': 'Reg4',
+                'email': 'reg4_cancel@example.com',
+            })
+
+        reg3_draft.action_set_draft()
+        reg4_cancel.action_cancel()
+        registrations = reg1 + reg2 + reg3_draft + reg4_cancel
 
         # REGISTRATIONS / PRE SCHEDULERS
         # --------------------------------------------------
 
         # check registration state
-        self.assertTrue(all(reg.state == 'open' for reg in reg1 + reg2), 'Registrations: should be auto-confirmed')
-        self.assertTrue(all(reg.create_date == now for reg in reg1 + reg2), 'Registrations: should have open date set to confirm date')
+        self.assertListEqual(registrations.mapped('state'), ['open', 'open', 'draft', 'cancel'], 'Registrations: should be auto-confirmed')
+        self.assertListEqual(registrations.mapped('create_date'), [now] * 4, 'Registrations: should have open date set to confirm date')
 
         # verify that subscription scheduler was auto-executed after each registration
-        self.assertEqual(len(after_sub_scheduler.mail_registration_ids), 2, 'event: should have 2 scheduled communication (1 / registration)')
+        self.assertEqual(len(after_sub_scheduler.mail_registration_ids), 4, 'event: should have 4 scheduled communication (1 / registration)')
         for mail_registration in after_sub_scheduler.mail_registration_ids:
             self.assertEqual(mail_registration.scheduled_date, now.replace(microsecond=0))
             self.assertTrue(mail_registration.mail_sent, 'event: registration mail should be sent at registration creation')
         self.assertTrue(after_sub_scheduler.mail_done, 'event: all subscription mails should have been sent')
         self.assertEqual(after_sub_scheduler.mail_state, 'running')
-        self.assertEqual(after_sub_scheduler.mail_count_done, 2)
+        self.assertEqual(after_sub_scheduler.mail_count_done, 4)
 
         # check emails effectively sent
-        self.assertEqual(len(self._new_mails), 2, 'event: should have 2 scheduled emails (1 / registration)')
+        self.assertEqual(len(self._new_mails), 4, 'event: should have 4 scheduled emails (1 / registration)')
         self.assertMailMailWEmails(
             [formataddr((reg1.name, reg1.email)), formataddr((reg2.name, reg2.email))],
             'outgoing',
@@ -167,7 +181,7 @@ class TestMailSchedule(EventCase, MockEmail, CronMixinCase):
             })
 
         # same for second scheduler: scheduled but not sent
-        self.assertEqual(len(after_sub_scheduler_2.mail_registration_ids), 2, 'event: should have 2 scheduled communication (1 / registration)')
+        self.assertEqual(len(after_sub_scheduler_2.mail_registration_ids), 4, 'event: should have 4 scheduled communication (1 / registration)')
         for mail_registration in after_sub_scheduler_2.mail_registration_ids:
             self.assertEqual(mail_registration.scheduled_date, now.replace(microsecond=0) + relativedelta(hours=1))
             self.assertFalse(mail_registration.mail_sent, 'event: registration mail should be scheduled, not sent')
@@ -188,14 +202,14 @@ class TestMailSchedule(EventCase, MockEmail, CronMixinCase):
             after_sub_scheduler_2.execute()
 
         # verify that subscription scheduler was auto-executed after each registration
-        self.assertEqual(len(after_sub_scheduler_2.mail_registration_ids), 2, 'event: should have 2 scheduled communication (1 / registration)')
-        self.assertTrue(all(mail_reg.mail_sent for mail_reg in after_sub_scheduler_2.mail_registration_ids))
+        self.assertEqual(len(after_sub_scheduler_2.mail_registration_ids), 4, 'event: should have 4 scheduled communication (1 / open registration)')
+        self.assertListEqual(after_sub_scheduler_2.mail_registration_ids.mapped('mail_sent'), [True, True, False, False])
         self.assertTrue(after_sub_scheduler_2.mail_done, 'event: all subscription mails should have been sent')
         self.assertEqual(after_sub_scheduler_2.mail_state, 'running')
         self.assertEqual(after_sub_scheduler_2.mail_count_done, 2)
 
         # check emails effectively sent
-        self.assertEqual(len(self._new_mails), 2, 'event: should have 2 scheduled emails (1 / registration)')
+        self.assertEqual(len(self._new_mails), 2, 'event: should have 2 scheduled emails (1 / open registration)')
         self.assertMailMailWEmails(
             [formataddr((reg1.name, reg1.email)), formataddr((reg2.name, reg2.email))],
             'outgoing',
@@ -268,14 +282,14 @@ class TestMailSchedule(EventCase, MockEmail, CronMixinCase):
             reg3.action_confirm()
 
         # verify that subscription scheduler was auto-executed after new registration confirmed
-        self.assertEqual(len(after_sub_scheduler.mail_registration_ids), 3, 'event: should have 3 scheduled communication (1 / registration)')
+        self.assertEqual(len(after_sub_scheduler.mail_registration_ids), 5, 'event: should have 5 scheduled communication (1 / registration)')
         new_mail_reg = after_sub_scheduler.mail_registration_ids.filtered(lambda mail_reg: mail_reg.registration_id == reg3)
         self.assertEqual(new_mail_reg.scheduled_date, now_start.replace(microsecond=0))
         self.assertTrue(new_mail_reg.mail_sent, 'event: registration mail should be sent at registration creation')
         self.assertTrue(after_sub_scheduler.mail_done, 'event: all subscription mails should have been sent')
-        self.assertEqual(after_sub_scheduler.mail_count_done, 3)
+        self.assertEqual(after_sub_scheduler.mail_count_done, 5)
         # verify that subscription scheduler was auto-executed after new registration confirmed
-        self.assertEqual(len(after_sub_scheduler_2.mail_registration_ids), 3, 'event: should have 3 scheduled communication (1 / registration)')
+        self.assertEqual(len(after_sub_scheduler_2.mail_registration_ids), 5, 'event: should have 5 scheduled communication (1 / registration)')
         new_mail_reg = after_sub_scheduler_2.mail_registration_ids.filtered(lambda mail_reg: mail_reg.registration_id == reg3)
         self.assertEqual(new_mail_reg.scheduled_date, now_start.replace(microsecond=0) + relativedelta(hours=1))
         self.assertTrue(new_mail_reg.mail_sent, 'event: registration mail should be sent at registration creation')

--- a/addons/event_sms/models/event_mail.py
+++ b/addons/event_sms/models/event_mail.py
@@ -52,13 +52,15 @@ class EventMailScheduler(models.Model):
                     continue
                 # Do not send SMS if the communication was scheduled before the event but the event is over
                 if scheduler.scheduled_date <= now and (scheduler.interval_type != 'before_event' or scheduler.event_id.date_end > now):
-                    scheduler.event_id.registration_ids.filtered(lambda registration: registration.state != 'cancel')._message_sms_schedule_mass(
+                    scheduler.event_id.registration_ids.filtered(
+                        lambda registration: registration.state not in ('cancel', 'draft')
+                    )._message_sms_schedule_mass(
                         template=scheduler.template_ref,
                         mass_keep_log=True
                     )
                     scheduler.update({
                         'mail_done': True,
-                        'mail_count_done': len(scheduler.event_id.registration_ids.filtered(lambda r: r.state != 'cancel'))
+                        'mail_count_done': scheduler.event_id.seats_taken,
                     })
 
         return super(EventMailScheduler, self).execute()

--- a/addons/mass_mailing_event/models/event_event.py
+++ b/addons/mass_mailing_event/models/event_event.py
@@ -16,7 +16,7 @@ class Event(models.Model):
             'target': 'current',
             'context': {
                 'default_mailing_model_id': self.env.ref('event.model_event_registration').id,
-                'default_mailing_domain': repr([('event_id', 'in', self.ids), ('state', '!=', 'cancel')])
+                'default_mailing_domain': repr([('event_id', 'in', self.ids), ('state', 'not in', ['cancel', 'draft'])])
             },
         }
 

--- a/addons/mass_mailing_event/models/event_registration.py
+++ b/addons/mass_mailing_event/models/event_registration.py
@@ -9,4 +9,4 @@ class EventRegistration(models.Model):
     _mailing_enabled = True
 
     def _mailing_get_default_domain(self, mailing):
-        return [('state', '!=', 'cancel')]
+        return [('state', 'not in', ['cancel', 'draft'])]


### PR DESCRIPTION
Draft registrations should not receive any periodic email until they confirm they will be attending.

This avoids awkward situations where the reminder contains a ticket but their ticket isn't validated yet.

reverts part of [1] where we adjusted the sent count to match drafts

[1] https://github.com/odoo/odoo/commit/78aea4c0d6d0d60cb355851b28b246be48875e76

task-4104891
