### PR TITLE
[FIX] web: search panel filter_domain for localized dates

### DIFF
--- a/addons/web/static/src/legacy/js/control_panel/control_panel_model_extension.js
+++ b/addons/web/static/src/legacy/js/control_panel/control_panel_model_extension.js
@@ -1059,10 +1059,18 @@ odoo.define("web/static/src/js/control_panel/control_panel_model_extension.js", 
             const domains = filterQueryElements.map(({ label, value, operator }) => {
                 let domain;
                 if (filter.filterDomain) {
+                    let self;
+                    // Dates from the search panel can come in a variety of formats, but
+                    // we want the universal formatted value to use it in the domain
+                    if (filter.type === "field" && ["datetime", "date"].includes(filter.fieldType)) {
+                        self = value;
+                    } else {
+                        self = label;
+                    }
                     domain = Domain.prototype.stringToArray(
                         filter.filterDomain,
                         {
-                            self: label,
+                            self: self,
                             raw_value: value,
                         }
                     );

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -1524,7 +1524,15 @@ export class SearchModel extends EventBus {
         const domains = autocompleteValues.map(({ label, value, operator }) => {
             let domain;
             if (field.filterDomain) {
-                domain = new Domain(field.filterDomain).toList({ self: label, raw_value: value });
+                let self;
+                // Dates from the search panel can come in a variety of formats, but
+                // we want the universal formatted value to use it in the domain
+                if (["datetime", "date"].includes(field.fieldType)) {
+                    self = value;
+                } else {
+                    self = label;
+                }
+                domain = new Domain(field.filterDomain).toList({ self: self, raw_value: value });
             } else {
                 domain = [[field.fieldName, operator, value]];
             }


### PR DESCRIPTION
When we define a date field filter_domain for a search view, we'll get an error formatting as the value for the domain is the label one and not the properly formatted for the database search.

For example, with this filter:

```
<field name="date_done" filter_domain="[('date_done', '&gt;=', self)]"/>
```

When we search in a DD/MM/YYYY localization a date like 13/8/2024 we had an error like:

```
psycopg2.errors.DatetimeFieldOverflow: date/time field value out of range: "13/8/2024"
LINE 1: ...ck_picking" WHERE ("stock_picking"."date_done" >= '13/8/2024...
                                                             ^
HINT:  Perhaps you need a different "datestyle" setting.
```

cc @Tecnativa ping @sergio-teruel @pedrobaeza 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
