### PR TITLE
[IMP] mail,web: better understand emoji reaction being used

### DIFF
--- a/addons/mail/static/src/core/common/message_reaction_list.scss
+++ b/addons/mail/static/src/core/common/message_reaction_list.scss
@@ -6,10 +6,10 @@
     }
 }
 
-.o-mail-MessageReactionList-preview {
-    font-family: "text-emoji", $font-family-base;
+.o-mail-MessageReactionList-preview:hover {
+    background-color: $o-gray-100 !important;
+}
 
-    &:hover {
-        background-color: $o-gray-100 !important;
-    }
+.o-mail-MessageReactionList-previewText {
+    max-width: 200px;
 }

--- a/addons/mail/static/src/core/common/message_reaction_list.xml
+++ b/addons/mail/static/src/core/common/message_reaction_list.xml
@@ -10,7 +10,7 @@
     </t>
     
     <t t-name="mail.MessageReactionList.button">
-        <button class="position-relative o-mail-MessageReaction btn d-flex p-0 border rounded-2 mb-1 fs-4 px-1 gap-1 align-items-center" t-on-click="() => this.onClickReaction(props.reaction)" t-on-contextmenu="onContextMenu" t-ref="reactionButton" t-att-class="{
+        <button class="position-relative o-mail-MessageReaction btn d-flex p-0 border rounded-2 mb-1 fs-4 px-1 gap-1 align-items-center" t-on-click="() => this.onClickReaction(props.reaction)" t-on-contextmenu="onContextMenu" t-on-mouseenter="loadEmoji" t-ref="reactionButton" t-att-class="{
             'o-selfReacted border-primary text-primary fw-bold': hasSelfReacted(props.reaction),
             'bg-view': !hasSelfReacted(props.reaction),
             'ms-1': env.inChatWindow and env.alignedRight,
@@ -22,9 +22,10 @@
     </t>
     
     <t t-name="mail.MessageReactionList.preview">
-        <div class="o-mail-MessageReactionList-preview px-0 py-1 border cursor-pointer" t-on-click="(ev) => this.props.openReactionMenu(props.reaction)" t-ref="reactionList">
-            <div class="text-truncate mx-2 small">
-                <span t-esc="previewText(props.reaction)"/>
+        <div class="o-mail-MessageReactionList-preview px-0 py-1 border cursor-pointer d-flex" t-on-click="(ev) => this.props.openReactionMenu(props.reaction)" t-ref="reactionList">
+            <div class="d-flex align-items-center mx-2 gap-2">
+                <span class="fs-1" t-esc="props.reaction.content"/>
+                <span class="o-mail-MessageReactionList-previewText small me-1" t-esc="previewText(props.reaction)"/>
             </div>
         </div>
     </t>

--- a/addons/mail/static/src/core/common/message_reaction_menu.js
+++ b/addons/mail/static/src/core/common/message_reaction_menu.js
@@ -1,9 +1,10 @@
-import { loadEmoji } from "@web/core/emoji_picker/emoji_picker";
+import { loadEmoji, loader } from "@web/core/emoji_picker/emoji_picker";
 import { onExternalClick } from "@mail/utils/common/hooks";
 
 import {
     Component,
-    onWillStart,
+    onMounted,
+    onPatched,
     useEffect,
     useExternalListener,
     useRef,
@@ -24,6 +25,7 @@ export class MessageReactionMenu extends Component {
         this.store = useState(useService("mail.store"));
         this.ui = useState(useService("ui"));
         this.state = useState({
+            emojiLoaded: Boolean(loader.loaded),
             reaction: this.props.initialReaction
                 ? this.props.initialReaction
                 : this.props.message.reactions[0],
@@ -43,10 +45,16 @@ export class MessageReactionMenu extends Component {
             },
             () => [this.props.message.reactions.length]
         );
-        onWillStart(async () => {
-            const { emojis } = await loadEmoji();
-            this.emojis = emojis;
+        onMounted(async () => {
+            if (!loader.loaded) {
+                loadEmoji();
+            }
         });
+        if (!loader.loaded) {
+            loader.onEmojiLoaded(() => (this.state.emojiLoaded = true));
+        }
+        onMounted(() => void this.state.emojiLoaded);
+        onPatched(() => void this.state.emojiLoaded);
     }
 
     onKeydown(ev) {
@@ -63,6 +71,6 @@ export class MessageReactionMenu extends Component {
     }
 
     getEmojiShortcode(reaction) {
-        return this.emojis.find((emoji) => emoji.codepoints === reaction.content).shortcodes[0];
+        return loader.loaded?.emojiValueToShortcode?.[reaction.content] ?? "?";
     }
 }

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -663,11 +663,11 @@ test("Reaction summary", async () => {
     await contains(".o-mail-Message", { text: "Hello world" });
     const partnerNames = ["Foo", "Bar", "FooBar", "Bob", "Baz"];
     const expectedSummaries = [
-        "😅 reacted by Foo",
-        "😅 reacted by Foo and Bar",
-        "😅 reacted by Foo, Bar, and FooBar",
-        "😅 reacted by Foo, Bar, FooBar, and 1 other",
-        "😅 reacted by Foo, Bar, FooBar, and 2 others",
+        "😅:sweat_smile: reacted by Foo",
+        "😅:sweat_smile: reacted by Foo and Bar",
+        "😅:sweat_smile: reacted by Foo, Bar, and FooBar",
+        "😅:sweat_smile: reacted by Foo, Bar, FooBar, and 1 other",
+        "😅:sweat_smile: reacted by Foo, Bar, FooBar, and 2 others",
     ];
     for (const [idx, name] of partnerNames.entries()) {
         const partner_id = pyEnv["res.partner"].create({ name });


### PR DESCRIPTION
Before this commit, when hovering on an emoji reaction, the floating text was stating who was reacting with the emoji, but there was not textual representation of the emoji.

Most emojis are relatively easy to understand by their icon, but sometimes a textual representation helps understanding what the emoji means and/or understand the purpose of given reaction as this could be heavily related to the shortcode name.

This commit changes the emoji reaction list preview as follow:

```
Before: "👍 reacted by Mitchell Admin"
After: "👍 :thumbs_up: reacted by Mitchell Admin"
```

The icon is also made bigger, as problems to understand the emoji sometimes come from its small sizing.

Before / After
<img width="230" alt="Screenshot 2024-09-05 at 12 58 39" src="https://github.com/user-attachments/assets/6958f56f-6e3f-4c61-b5c1-8e89366a3a08"> <img width="282" alt="Screenshot 2024-09-05 at 12 58 15" src="https://github.com/user-attachments/assets/6201be33-368d-4d82-a9c2-148d92f11614">
