### PR TITLE
[IMP] account: allow defaults based on journal

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -170,6 +170,7 @@ class AccountMove(models.Model):
         string='Journal',
         compute='_compute_journal_id', inverse='_inverse_journal_id', store=True, readonly=False, precompute=True,
         required=True,
+        change_default=True,
         check_company=True,
         domain="[('id', 'in', suitable_journal_ids)]",
     )


### PR DESCRIPTION
It could be useful to be able to have default values based on the journal.

For instance, in India, some use cases could make use of this for the cash rounding: it is the norm to use different journals based on if it is Export, Retail Sales, Wholesale Sales, B2B, B2C, etc. And the rounding to be used can be different depending on which of those it is.

As this is not a common case, we opted to not add a new field on the journal; but use `ir.default` instead, which can also be used for other potential similar use cases.

Related to
task-3614520
odoo/odoo#144117
