### PR TITLE
[FIX] html_editor: correct the selection to draw a peer selection

### DIFF
--- a/addons/html_editor/static/src/others/collaboration/collaboration_selection_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_selection_plugin.js
@@ -59,9 +59,18 @@ export class CollaborationSelectionPlugin extends Plugin {
             anchorOffset = 0;
             focusOffset = 0;
         }
-
-        [anchorNode, anchorOffset] = getDeepestPosition(anchorNode, anchorOffset);
-        [focusNode, focusOffset] = getDeepestPosition(focusNode, focusOffset);
+        if (anchorNode.isConnected && focusNode.isConnected) {
+            [anchorNode, anchorOffset] = getDeepestPosition(anchorNode, anchorOffset);
+            [focusNode, focusOffset] = getDeepestPosition(focusNode, focusOffset);
+        } else {
+            // todo: We should not be able to get here, this fixes multiples
+            // issues where we temporarily try to draw a an impossible
+            // selection. We should investigate the root cause of this issue.
+            anchorNode = this.editable.children[0];
+            focusNode = this.editable.children[0];
+            anchorOffset = 0;
+            focusOffset = 0;
+        }
 
         const direction = getCursorDirection(anchorNode, anchorOffset, focusNode, focusOffset);
         const range = new Range();


### PR DESCRIPTION
Prior to this commit, attempting to draw a peer's selection within an element that was not present in the DOM would result in a crash.

Under certain race conditions, it is possible for an element to exist outside of the DOM. To enhance resilience and prevent crashes, this commit adjusts the selection as necessary to ensure it can be drawn correctly.

task-4143889



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
