### PR TITLE
[FIX] mrp: separate integrated workorder list view from original

### DIFF
--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -81,8 +81,8 @@
                 <field name="name" string="Operation" readonly="state in ['cancel', 'done']"/>
                 <field name="workcenter_id" readonly="state in ['cancel', 'done', 'progress']"/>
                 <field name="product_id" optional="show"/>
-                <field name="qty_remaining" optional="show" string="Remaining Quantity " column_invisible="parent.state == 'done'"/>
-                <field name="qty_produced" optional="show" string="Produced Quantity" column_invisible="parent.state != 'done'"/>
+                <field name="qty_remaining" optional="show" string="Quantity Remaining"/>
+                <field name="qty_produced" optional="hide" string="Quantity Produced"/>
                 <field name="finished_lot_id" optional="hide" string="Lot/Serial"/>
                 <field name="date_start" optional="hide" readonly="state in ['progress', 'done', 'cancel']"/>
                 <field name="date_finished" optional="hide" readonly="state in ['progress', 'done', 'cancel']"/>


### PR DESCRIPTION
### Steps to reporduce:

- Go to Manufacturing > Operations > Work Orders

#### > Traceback

### Cause of the issue:

Since commit 6334294 there is an column_invisible attribure relying on `parent.state` in the `mrp_production_workorder_tree_editable_view`: https://github.com/odoo/odoo/blob/688ea6ba1433169523bdab928cf6c1950b71b514/addons/mrp/views/mrp_workorder_views.xml#L84-L85 However, since parent is not defined in the tree view of mrp.workorder's when these are not integrated in the mrp.production form view, this generate a traceback.

### Note:

In 16.0 this expression is understood as being falsy if parent is not defined which is the expected behavior and does not lead to a traceback.

opw-3873108
opw-4010550
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
