### PR TITLE
[IMP] web: convert /web to a user route

### DIFF
--- a/addons/web/controllers/home.py
+++ b/addons/web/controllers/home.py
@@ -46,17 +46,11 @@ class Home(http.Controller):
         return False
 
     # ideally, this route should be `auth="user"` but that don't work in non-monodb mode.
-    @http.route(['/web', '/odoo', '/odoo/<path:subpath>', '/scoped_app/<path:subpath>'], type='http', auth="none", readonly=_web_client_readonly)
+    @http.route(['/web', '/odoo', '/odoo/<path:subpath>', '/scoped_app/<path:subpath>'], type='http', auth="user", readonly=_web_client_readonly)
     def web_client(self, s_action=None, **kw):
 
         # Ensure we have both a database and a user
         ensure_db()
-        if not request.session.uid:
-            return request.redirect_query('/web/login', query={'redirect': request.httprequest.full_path}, code=303)
-        if kw.get('redirect'):
-            return request.redirect(kw.get('redirect'), 303)
-        if not security.check_session(request.session, request.env, request):
-            raise http.SessionExpiredException("Session expired")
         if not is_user_internal(request.session.uid):
             return request.redirect('/web/login_successful', 303)
 

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -2392,10 +2392,8 @@ class Application:
                 # Logs the error here so the traceback starts with ``__call__``.
                 if hasattr(exc, 'loglevel'):
                     _logger.log(exc.loglevel, exc, exc_info=getattr(exc, 'exc_info', None))
-                elif isinstance(exc, HTTPException):
+                elif isinstance(exc, (HTTPException, SessionExpiredException)):
                     pass
-                elif isinstance(exc, SessionExpiredException):
-                    _logger.info(exc)
                 elif isinstance(exc, (UserError, AccessError)):
                     _logger.warning(exc)
                 else:


### PR DESCRIPTION
The code removed in this controller is basically
what does the `auth='user'`:
- it redirects to login page when not logged in
- it handles the redirection automatically
- it checks the validity of the session

The change in `http.__call__` regarding the `_logger.info` of `SessionExpiredException` is because
of a very small change of behavior during the test `test_session10_explicit_session`, where, in addition to the warning logger "called ignoring args", a second logger was in the capture:
`odoo.http: Session expired`

This is because for the case `if request.session.uid` in the `web_client` controller, before it was redirecting to the login page without raising the SessionExpired Exception,
while the `auth="user" raises first the `SessionExpiredException` which then leads to the redirect to the `/web/login` page.

The decision is taken to simply not log in such a case, because the log produced was simply, e.g.:
`2024-01-01 08:00:01,000 26 INFO 67784250-master-all odoo.http: Session expired` which doesn't hold any pertinent information: We do not know which session is expired, for who, for what reason. Just that "a" session expired.
