### PR TITLE
[FIX] point_of_sale: payment method lines content alignment issue fixed

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.xml
@@ -20,8 +20,10 @@
                                     <i class="oi oi-close text-danger" />
                                 </button>
                             </t>
-                            <t t-else="">
-                                <div class="mx-2 px-4"/>
+                           <t t-elif="line.payment_status and ['waitingCard', 'waitingCapture'].includes(line.payment_status)">
+                                <div class="mx-2 px-3">
+                                    <i class="fa fa-circle-o-notch fa-spin" role="img" />
+                                </div>
                             </t>
                         </div>
                         <t t-if="line and line.payment_status">
@@ -111,9 +113,6 @@
                                     aria-label="Delete" title="Delete">
                                     <i class="oi oi-close text-danger" />
                                 </div>
-                            </t>
-                            <t t-else="">
-                                <div class="mx-2 px-4"/>
                             </t>
                         </div>
                     </t>

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.xml
@@ -7,7 +7,7 @@
                     <t t-if="line.isSelected()">
                         <div t-attf-class="paymentline selected d-flex align-items-center {{ this.ui.isSmall ? 'bg-100' : 'bg-200'}} border rounded-3"
                             t-att-class="selectedLineClass(line)">
-                            <div class="payment-infos d-flex align-items-center justify-content-between flex-grow-1 px-3 py-3 py-lg-4 text-truncate cursor-pointer" t-on-click="() => this.selectLine(line)">
+                            <div class="payment-infos d-flex align-items-center justify-content-between flex-grow-1 px-3 py-3 text-truncate cursor-pointer fs-2" t-on-click="() => this.selectLine(line)">
                                  <span class="payment-name"><t t-esc="line.payment_method_id.name"/></span>
                                  <div class="payment-amount px-3">
                                     <t t-esc="env.utils.formatCurrency(line.get_amount())" />
@@ -19,6 +19,9 @@
                                     aria-label="Delete" title="Delete">
                                     <i class="oi oi-close text-danger" />
                                 </button>
+                            </t>
+                            <t t-else="">
+                                <div class="mx-2 px-4"/>
                             </t>
                         </div>
                         <t t-if="line and line.payment_status">
@@ -96,7 +99,7 @@
                     <t t-else="">
                         <div class="paymentline d-flex align-items-center bg-view border rounded-3"
                             t-att-class="unselectedLineClass(line)">
-                             <div class="payment-infos d-flex align-items-center justify-content-between flex-grow-1 px-3 py-3 py-lg-4 text-truncate cursor-pointer" t-on-click="() => this.selectLine(line)">
+                             <div class="payment-infos d-flex align-items-center justify-content-between flex-grow-1 px-3 py-3 text-truncate cursor-pointer fs-2" t-on-click="() => this.selectLine(line)">
                                  <t t-esc="line.payment_method_id.name" />
                                  <div class="payment-amount px-3">
                                     <t t-esc="env.utils.formatCurrency(line.get_amount())" />
@@ -108,6 +111,9 @@
                                     aria-label="Delete" title="Delete">
                                     <i class="oi oi-close text-danger" />
                                 </div>
+                            </t>
+                            <t t-else="">
+                                <div class="mx-2 px-4"/>
                             </t>
                         </div>
                     </t>

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_status/payment_status.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_status/payment_status.xml
@@ -6,16 +6,16 @@
     Please select a payment method 
         </div>
         <section t-else="" t-attf-class="paymentlines-container p-3 rounded-3 border {{ props.order.get_due() > 0 ? 'bg-danger-subtle border-danger text-danger' : 'bg-success-subtle border-success text-success'}}">
-            <div class="payment-status-container d-flex flex-column-reverse flex-lg-row justify-content-between fs-2">
+            <div class="payment-status-container d-flex flex-column-reverse flex-lg-row justify-content-between fs-2 pe-4 me-2">
                 <div t-if="this.props.order.get_due() gte 0 and props.order.get_change() === 0" class="payment-status-remaining d-flex justify-content-between flex-grow-1">
                     <span class="label pe-2">Remaining</span>
-                    <span class="amount align-self-end" t-att-class="{ 'highlight text-danger fw-bolder': props.order.get_due() > 0 }">
+                    <span class="amount align-self-end pe-5" t-att-class="{ 'highlight text-danger fw-bolder': props.order.get_due() > 0 }">
                         <t t-esc="remainingText" />
                     </span>
                 </div>
                 <div t-else="" class="payment-status-change d-flex justify-content-between flex-grow-1">
                     <span class="label pe-2">Change</span>
-                    <span class="amount" t-att-class="{ 'highlight text-success fw-bolder': props.order.get_change() > 0 }">
+                    <span class="amount align-self-end pe-5" t-att-class="{ 'highlight text-success fw-bolder': props.order.get_change() > 0 }">
                         <t t-esc="changeText" />
                     </span>
                 </div>


### PR DESCRIPTION
Before this commit:
===================
In the payment screen, payment line content is not consistent with the first payment line like font and size were different and the amounts were not aligned -
![image](https://github.com/user-attachments/assets/c35c0321-a583-49b0-8f32-1619730392c6)


After this commit:
===================
Now, payment line content is consistent with the first payment line, font, and size are the same and the amounts are aligned -
![image](https://github.com/user-attachments/assets/fb668f47-2a56-4cfe-9635-42af5a6ede03)


Task - 4160554
