### PR TITLE
[FIX] point_of_sale: ensure main product appears in search with variant

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -328,14 +328,24 @@ export class ProductScreen extends Component {
         const exactMatches = products.filter((product) => product.exactMatch(searchWord));
 
         if (exactMatches.length > 0 && searchWord.length > 2) {
-            return exactMatches;
+            return this.addMainProductsToDisplay(exactMatches);
         }
 
         const fuzzyMatches = fuzzyLookup(unaccent(searchWord, false), products, (product) =>
             unaccent(product.searchString, false)
         );
 
-        return Array.from(new Set([...exactMatches, ...fuzzyMatches]));
+        return this.addMainProductsToDisplay([...exactMatches, ...fuzzyMatches]);
+    }
+
+    addMainProductsToDisplay(products) {
+        const uniqueProducts = new Set(products);
+        for (const product of products) {
+            if (product.id in this.pos.mainProductVariant) {
+                uniqueProducts.add(this.pos.mainProductVariant[product.id]);
+            }
+        }
+        return Array.from(uniqueProducts);
     }
 
     getProductsByCategory(category) {

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -118,6 +118,7 @@ export class PosStore extends Reactive {
         this.selectedPartner = null;
         this.selectedCategory = null;
         this.searchProductWord = "";
+        this.mainProductVariant = {};
         this.ready = new Promise((resolve) => {
             this.markReady = resolve;
         });
@@ -232,6 +233,7 @@ export class PosStore extends Reactive {
 
             for (let i = 0; i < nbrProduct - 1; i++) {
                 products[i].available_in_pos = false;
+                this.mainProductVariant[products[i].id] = products[nbrProduct - 1];
             }
         }
     }


### PR DESCRIPTION
Before this commit, searching for a product with attributes that create variants in the PoS interface did not display the main product. This occurred because it was designed to hide variants and show a single product representing all variants, requiring the user to select options in a popup. However, this approach prevented the main product from appearing in search results when attempting to find one of its variants.

This commit fixes the issue by adjusting the search functionality to ensure that the main product is displayed in the search results, even when searching for its variants, improving the user's ability to locate and select products with variants in the PoS interface.

opw-4149878

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
