### PR TITLE
[FIX] web_editor: fix popup when visibility condition on language

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2755,8 +2755,9 @@ class SnippetsMenu extends Component {
             //     └ descendantInvisibleSnippet
             //          └ descendantOfDescendantInvisibleSnippet
             //               └ etc...
-            const createInvisibleElements = (snippetEls, isDescendant) => {
-                return Promise.all((snippetEls).map(async (snippetEl) => {
+            const createInvisibleElements = async (snippetEls, isDescendant) => {
+                const results = [];
+                for (const snippetEl of snippetEls) {
                     const descendantSnippetEls = descendantPerSnippet.get(snippetEl);
                     // An element is considered as "RootParent" if it has one or
                     // more invisible descendants but is not a descendant.
@@ -2765,8 +2766,9 @@ class SnippetsMenu extends Component {
                     if (descendantSnippetEls) {
                         invisibleElement.children = await createInvisibleElements(descendantSnippetEls, true);
                     }
-                    return invisibleElement;
-                }));
+                    results.push(invisibleElement);
+                }
+                return results;
             };
             this.state.invisibleElements = await createInvisibleElements(rootInvisibleSnippetEls, false, this.state.invisibleElements);
         }, false);


### PR DESCRIPTION
Since [1] and the OWL conversion of the snippet menu, a bug was
introduced.

Steps to reproduce:

- Navigate to Website Settings and install the French (BE) language.
- Set French (BE) as the default language.
- Save the new settings.
- Open the Website Editor.
- Drag and drop a Banner snippet.
- Add conditional visibility to the snippet: Languages -> Visible for ->
  French (BE).
- Save and verify if the conditional visibility is functioning
  correctly.
- Edit the page and add a Popup snippet.
- Save the changes.
- Edit again, and click on the Popup under "Invisible Elements." Result:
  A traceback error occurs.

This commit resolves the issue.

[1]: https://github.com/odoo/odoo/commit/91293fe4a8125f65cd7e5f487aacbc62c35c0f74#diff-52a4f9d2c217548e69e6b7fd097f286f1754a6389734eea254b87255e501cbef

opw-4127338
