### PR TITLE
[FIX] pos_restaurant: load floor plan for bar scenario

### DIFF
--- a/addons/pos_restaurant/data/scenarios/restaurant_floor.xml
+++ b/addons/pos_restaurant/data/scenarios/restaurant_floor.xml
@@ -1,17 +1,10 @@
 <odoo>
     <data noupdate="1">
 
-        <function model="restaurant.floor" name="unlink">
-            <value model="restaurant.floor" eval="obj().search([
-                    ('pos_config_ids', 'in', ref('pos_config_main_restaurant')),
-                ]).id"/>
-        </function>
-
         <!-- Floors: Main Floor -->
         <record id="floor_main" model="restaurant.floor">
             <field name="name">Main Floor</field>
             <field name="background_color">rgb(255,255,255,0.75)</field>
-            <field name="pos_config_ids" eval="[(6, 0, [ref('pos_restaurant.pos_config_main_restaurant')])]" />
             <field name="floor_background_image" type="base64" file="pos_restaurant/static/img/floor_main.jpeg" />
             <field name="floor_prefix">1</field>
         </record>
@@ -165,7 +158,6 @@
         <record id="floor_patio" model="restaurant.floor">
             <field name="name">Patio</field>
             <field name="background_color">rgb(130, 233, 171)</field>
-            <field name="pos_config_ids" eval="[(6, 0, [ref('pos_restaurant.pos_config_main_restaurant')])]" />
             <field name="floor_prefix">2</field>
         </record>
 

--- a/addons/pos_restaurant/models/pos_config.py
+++ b/addons/pos_restaurant/models/pos_config.py
@@ -85,6 +85,14 @@ class PosConfig(models.Model):
             'record': config,
             'noupdate': True,
         }])
+        if not self.env.ref('pos_restaurant.floor_main', raise_if_not_found=False):
+            convert.convert_file(self._env_with_clean_context(), 'pos_restaurant', 'data/scenarios/restaurant_floor.xml', idref=None, mode='init', noupdate=True)
+        config_floors = [(5, 0)]
+        if (floor_main := self.env.ref('pos_restaurant.floor_main', raise_if_not_found=False)):
+            config_floors += [(4, floor_main.id)]
+        if (floor_patio := self.env.ref('pos_restaurant.floor_patio', raise_if_not_found=False)):
+            config_floors += [(4, floor_patio.id)]
+        config.update({'floor_ids': config_floors})
         if with_demo_data:
             config._load_bar_demo_data()
         return {'config_id': config.id}
@@ -127,8 +135,14 @@ class PosConfig(models.Model):
             'record': config,
             'noupdate': True,
         }])
-        if not self.env.ref('pos_restaurant.floor_main', raise_if_not_found=False) and self.env.ref('pos_restaurant.pos_config_main_restaurant', raise_if_not_found=False):
+        if not self.env.ref('pos_restaurant.floor_main', raise_if_not_found=False):
             convert.convert_file(self._env_with_clean_context(), 'pos_restaurant', 'data/scenarios/restaurant_floor.xml', idref=None, mode='init', noupdate=True)
+        config_floors = [(5, 0)]
+        if (floor_main := self.env.ref('pos_restaurant.floor_main', raise_if_not_found=False)):
+            config_floors += [(4, floor_main.id)]
+        if (floor_patio := self.env.ref('pos_restaurant.floor_patio', raise_if_not_found=False)):
+            config_floors += [(4, floor_patio.id)]
+        config.update({'floor_ids': config_floors})
         if with_demo_data:
             config._load_restaurant_demo_data()
             if self.env.company.id == self.env.ref('base.main_company').id:


### PR DESCRIPTION
Before this commit, the floor plan and the tables were only loaded if the restaurant scenario was selected. Since this plan is also useful in the bar scenario, this commit loads it in both scenarios.

Task-4155648
