### PR TITLE
[FIX] pos_restaurant: avoid test execution triplicate

### DIFF
--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -9,7 +9,7 @@ from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 
 
 @odoo.tests.tagged('post_install', '-at_install')
-class TestFrontend(AccountTestInvoicingCommon, HttpCaseWithUserDemo):
+class TestFrontendCommon(AccountTestInvoicingCommon, HttpCaseWithUserDemo):
 
     @classmethod
     def setUpClass(cls, chart_template_ref=None):
@@ -250,6 +250,9 @@ class TestFrontend(AccountTestInvoicingCommon, HttpCaseWithUserDemo):
             ],
         })
         cls.pos_admin.partner_id.email = 'pos_admin@test.com'
+
+
+class TestFrontend(TestFrontendCommon):
 
     def test_01_pos_restaurant(self):
 


### PR DESCRIPTION
Currently since TestFrontend has test methods and is imported/inherited, the same test is executed three times.

Fixing it by extracting setup to an utility class




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
