### PR TITLE
[FIX] mail: reload_on_attachment should not close attachment box

### DIFF
--- a/addons/mail/static/src/core/web/chatter.js
+++ b/addons/mail/static/src/core/web/chatter.js
@@ -194,7 +194,8 @@ export class Chatter extends Component {
                 } else {
                     this.state.showAttachmentLoading = false;
                     this.state.isAttachmentBoxOpened =
-                        this.props.isAttachmentBoxVisibleInitially && this.attachments.length > 0;
+                        this.state.isAttachmentBoxOpened ||
+                        (this.props.isAttachmentBoxVisibleInitially && this.attachments.length > 0);
                 }
                 return () => browser.clearTimeout(this.loadingAttachmentTimeout);
             },

--- a/addons/test_mail/static/tests/chatter_tests.js
+++ b/addons/test_mail/static/tests/chatter_tests.js
@@ -2,9 +2,10 @@
 
 import { startServer } from "@bus/../tests/helpers/mock_python_environment";
 
+import { patchUiSize, SIZES } from "@mail/../tests/helpers/patch_ui_size";
 import { start } from "@mail/../tests/helpers/test_utils";
 
-import { contains } from "@web/../tests/utils";
+import { click, contains, createFile, inputFiles, insertText } from "@web/../tests/utils";
 
 QUnit.module("chatter");
 
@@ -98,3 +99,55 @@ QUnit.test("Send message button activation (access rights dependent)", async fun
     await assertSendButton(true, "Draft record", "mail.test.multi.company");
     await assertSendButton(true, "Draft record", "mail.test.multi.company.read");
 });
+
+QUnit.test(
+    "opened attachment box should remain open after adding a new attachment",
+    async (assert) => {
+        const pyEnv = await startServer();
+        const recordId = pyEnv["mail.test.simple.main.attachment"].create({});
+        const attachmentId = pyEnv["ir.attachment"].create({
+            mimetype: "image/jpeg",
+            res_id: recordId,
+            res_model: "mail.test.simple.main.attachment",
+        });
+        pyEnv["mail.message"].create({
+            attachment_ids: [attachmentId],
+            model: "mail.test.simple.main.attachment",
+            res_id: recordId,
+        });
+        const views = {
+            "mail.test.simple.main.attachment,false,form": `
+            <form string="Test document">
+                <sheet>
+                    <field name="name"/>
+                </sheet>
+                <div class="o_attachment_preview"/>
+                <div class="oe_chatter">
+                    <field name="message_ids"  options="{'post_refresh': 'always'}"/>
+                </div>
+            </form>`,
+        };
+        patchUiSize({ size: SIZES.XXL });
+        const { openFormView } = await start({
+            async mockRPC(route, args) {
+                if (String(route).includes("/mail/thread/data")) {
+                    await new Promise((resolve) => setTimeout(resolve, 1)); // need extra time for useEffect
+                }
+            },
+            serverData: { views },
+        });
+        await openFormView("mail.test.simple.main.attachment", recordId);
+        await contains(".o_attachment_preview");
+        await click("button", { text: "Send message" });
+        await inputFiles(".o-mail-Composer-coreMain .o_input_file", [
+            await createFile({ name: "testing.jpeg", contentType: "image/jpeg" }),
+        ]);
+        await click(".o-mail-Composer-send:enabled");
+        await click(".o-mail-Chatter-attachFiles");
+        await contains(".o-mail-AttachmentBox");
+        await click("button", { text: "Send message" });
+        await insertText(".o-mail-Composer-input", "test");
+        await click(".o-mail-Composer-send:enabled");
+        await contains(".o-mail-AttachmentBox .o-mail-AttachmentImage", { count: 2 });
+    }
+);

--- a/addons/test_mail/static/tests/helpers/model_definitions_setup.js
+++ b/addons/test_mail/static/tests/helpers/model_definitions_setup.js
@@ -8,4 +8,5 @@ addModelNamesToFetch([
     "mail.test.multi.company",
     "mail.test.multi.company.read",
     "mail.test.properties",
+    "mail.test.simple.main.attachment",
 ]);


### PR DESCRIPTION
**Current behavior before PR:**

prior to this PR after posting an attachment, if the attachment box was opened it closes after the reload.


**Desired behavior after PR is merged:**

this PR addresses this issue by updating the behavior to ensure that the attachment box remains open even after the reload.

task-4161477

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
