### PR TITLE
[FIX] {test_}base_automation: copy with actions

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -442,6 +442,14 @@ class BaseAutomation(models.Model):
         self._update_registry()
         return res
 
+    def copy(self, default=None):
+        """Copy the actions of the automation while
+        copying the automation itself."""
+        actions = self.action_server_ids.copy_multi()
+        record_copy = super().copy(default)
+        record_copy.action_server_ids = actions
+        return record_copy
+
     def action_rotate_webhook_uuid(self):
         for automation in self:
             automation.webhook_uuid = str(uuid4())

--- a/addons/test_base_automation/tests/test_flow.py
+++ b/addons/test_base_automation/tests/test_flow.py
@@ -909,6 +909,23 @@ if env.context.get('old_values', None):  # on write
         record_count = self.env[model.model].search_count([('user_id', '=', 'Test _rec_name Automation')])
         self.assertEqual(record_count, 1, "Only one record should have been created")
 
+    def test_140_copy_should_copy_actions(self):
+        """ Copying an automation should copy its actions. """
+        automation = create_automation(
+            self,
+            model_id=self.lead_model.id,
+            trigger='on_change',
+            _actions={'state': 'code', 'code': "record.write({'name': record.name + '!'})"},
+        )
+        action_ids = automation.action_server_ids
+
+        copy_automation = automation.copy()
+        copy_action_ids = copy_automation.action_server_ids
+        # Same number of actions but id should be different
+        self.assertEqual(len(action_ids), 1)
+        self.assertEqual(len(copy_action_ids), len(action_ids))
+        self.assertNotEqual(copy_action_ids, action_ids)
+
 
 @common.tagged('post_install', '-at_install')
 class TestCompute(common.TransactionCase):


### PR DESCRIPTION
Before this commit, copying an automation rule did not copy its actions. After, it will.

Task: 4055597