### PR TITLE
[IMP] account: payment term view

### DIFF
--- a/addons/account/static/src/scss/account_payment_term.scss
+++ b/addons/account/static/src/scss/account_payment_term.scss
@@ -17,6 +17,10 @@
     .note_editable {
         margin-right: 2px;
     }
+
+    p {
+        margin-bottom: 0;
+    }
 }
 
 .o_example_date {

--- a/addons/account/views/account_payment_term_views.xml
+++ b/addons/account/views/account_payment_term_views.xml
@@ -75,7 +75,10 @@
                                 </field>
                             </group>
                             <group string="Preview">
-                                <field name="currency_id" invisible="1"/>
+                                <div colspan="2">
+                                    <field name="display_on_invoice" nolabel="1"/>
+                                    <label for="display_on_invoice"/>
+                                </div>
                                 <div class="d-flex gap-2" colspan="2" col="4">
                                     Example:
                                     <field name="example_amount" class="oe_inline"/>
@@ -83,15 +86,11 @@
                                     <field name="example_date" class="fw-bold border-bottom o_example_date"/>
                                 </div>
                                 <div colspan="2" class="py-1 bg-secondary">
-                                    <field name="note" placeholder="e.g. Payment terms: 30 days after invoice date" class="border-bottom o_example_note"/>
+                                    <field name="note" placeholder="Description on invoice (e.g. Payment terms: 30 days after invoice date)" class="border-bottom o_example_note"/>
                                     <field name="example_preview_discount" class="ps-2"
                                            invisible="not early_discount or not display_on_invoice"/>
                                     <field name="example_preview" class="ps-2"
                                            invisible="not display_on_invoice"/>
-                                </div>
-                                <div colspan="2">
-                                    <field name="display_on_invoice" nolabel="1"/>
-                                    <label for="display_on_invoice"/>
                                 </div>
                             </group>
                         </group>


### PR DESCRIPTION
Before this commit users didn't get that they can edit the payment terms description on invoice. This will change the placeholder, move the field display on invoice and decrease the size below the text because the balise p add a margin.

task: 4167165




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
