### PR TITLE
[PERF] stock: lower limit for report_stock_quantity

### DIFF
--- a/addons/stock/report/report_stock_quantity.py
+++ b/addons/stock/report/report_stock_quantity.py
@@ -144,7 +144,7 @@ FROM (SELECT
         GENERATE_SERIES(
         CASE
             WHEN m.state = 'done' THEN (now() at time zone 'utc')::date - interval '%(report_period)s month'
-            ELSE m.date::date
+            ELSE GREATEST(m.date::date, (now() at time zone 'utc')::date - interval '%(report_period)s month')
         END,
         CASE
             WHEN m.state != 'done' THEN (now() at time zone 'utc')::date + interval '%(report_period)s month'


### PR DESCRIPTION
Currently the `report_stock_quantity` view third `UNION ALL` does a `generate_series` between the moves date and `now()` in case the move is not in done.

This can lead to significant slowdowns when querying the view in case some databases have old moves not in done, cancel, draft. In that case, the report will generate a row for each day between the move.date and `now()`, leading to thousands of rows for 1 stock.move.

To alleviate that, this commit uses the `report_period` as a lower bound. This greatly reduces the number of rows generated by the third `UNION ALL` without losing forecasted accuracy since the moves are not in done.

#### speedup

In a v17 database where `all_sm` returns 600 000 rows, querying the `report_stock_quantity` view goes from 20s -> 7s.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
