### PR TITLE
[REF] pos_restaurant: simplify order transfer

### DIFF
--- a/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.js
+++ b/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.js
@@ -46,9 +46,25 @@ patch(ControlButtons.prototype, {
         });
     },
     clickTransferOrder() {
-        this.pos.orderToTransferUuid = this.pos.get_order().uuid;
+        this.dialog.closeAll();
+        this.pos.isOrderTransferMode = true;
+        const orderUuid = this.pos.get_order().uuid;
         this.pos.get_order().setBooked(true);
         this.pos.showScreen("FloorScreen");
+        document.addEventListener(
+            "click",
+            async (ev) => {
+                this.pos.isOrderTransferMode = false;
+                const tableElement = ev.target.closest(".table");
+                if (!tableElement) {
+                    return;
+                }
+                const table = this.pos.getTableFromElement(tableElement);
+                await this.pos.transferOrder(orderUuid, table);
+                this.pos.setTableFromUi(table);
+            },
+            { once: true }
+        );
     },
     clickTakeAway() {
         const isTakeAway = !this.currentOrder.takeaway;

--- a/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.xml
+++ b/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.xml
@@ -23,7 +23,7 @@
                     t-on-click="() => pos.showScreen('SplitBillScreen')">
                     <i class="fa fa-files-o me-1"/>Split
                 </button>
-                <button class="btn btn-secondary btn-lg py-5" t-on-click="clickTransferOrder">
+                <button class="btn btn-secondary btn-lg py-5" t-on-click.stop="() => this.clickTransferOrder()">
                     <i class="oi oi-arrow-right me-1" />Transfer / Merge
                 </button>
                 <button t-if="!pos.get_order()?.table_id" class="btn btn-secondary btn-lg py-5" t-on-click="() => this.editFloatingOrderName(this.pos.get_order())">

--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
@@ -225,8 +225,7 @@ export class FloorScreen extends Component {
                 }
                 const oToTrans = this.pos.getActiveOrdersOnTable(table)[0];
                 if (oToTrans) {
-                    this.pos.orderToTransferUuid = oToTrans.uuid;
-                    this.pos.transferOrder(this.state.potentialLink.parent);
+                    this.pos.transferOrder(oToTrans.uuid, this.state.potentialLink.parent);
                 }
                 this.pos.data.write("restaurant.table", [table.id], {
                     parent_id: this.state.potentialLink.parent.id,
@@ -261,9 +260,7 @@ export class FloorScreen extends Component {
         );
     }
     getPosTable(el) {
-        return this.pos.models["restaurant.table"].get(
-            [...el.classList].find((c) => c.includes("tableId")).split("-")[1]
-        );
+        return this.pos.getTableFromElement(el);
     }
     useResizeHook() {
         let startX, startY;
@@ -377,7 +374,10 @@ export class FloorScreen extends Component {
             ? -12 + Math.min(table.width / 2, table.height / 2) * 0.2929
             : -12;
     }
-    onClickFloorMap() {
+    onClickFloorMap(ev) {
+        if (ev.target.closest(".table")) {
+            return;
+        }
         for (const tableId of this.state.selectedTableIds) {
             const table = this.pos.models["restaurant.table"].get(tableId);
             this.pos.data.write("restaurant.table", [tableId], {
@@ -609,11 +609,7 @@ export class FloorScreen extends Component {
             this.onClickTable(table.parent_id, ev);
             return;
         }
-        const oToTrans = this.pos.models["pos.order"].getBy("uuid", this.pos.orderToTransferUuid);
-        if (oToTrans) {
-            await this.pos.transferOrder(table);
-            this.pos.showScreen("ProductScreen");
-        } else {
+        if (!this.pos.isOrderTransferMode) {
             await this.pos.setTableFromUi(table);
         }
     }

--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
@@ -105,7 +105,7 @@
                                 <t t-set="isIntersecting" t-value="state.potentialLink?.child?.id === table.id"/>
                                 <t t-set="isIntersected" t-value="state.potentialLink?.parent?.id === table.id"/>
                                 <div
-                                    t-on-click.stop="(ev) => this.onClickTable(table, ev)"
+                                    t-on-click="(ev) => this.onClickTable(table, ev)"
                                     class="table o_draggable d-flex flex-column align-items-center justify-content-between cursor-pointer"
                                     t-att-class="{
                                         'position-relative m-0': isKanban,

--- a/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
@@ -22,15 +22,9 @@ patch(Navbar.prototype, {
         }
         return super.orderCount;
     },
-    getTable() {
-        return this.pos.orderToTransferUuid
-            ? this.pos.models["pos.order"].find((o) => o.uuid == this.pos.orderToTransferUuid)
-                  ?.table_id
-            : this.pos.selectedTable;
-    },
     showTabs() {
         if (this.pos.config.module_pos_restaurant) {
-            return !(this.pos.selectedTable || this.pos.orderToTransferUuid);
+            return !this.pos.selectedTable;
         } else {
             return super.showTabs();
         }
@@ -49,9 +43,6 @@ patch(Navbar.prototype, {
         this.pos.showScreen("ProductScreen");
     },
     async onClickTableTab() {
-        if (this.pos.orderToTransferUuid) {
-            return this.pos.setTableFromUi(this.getTable());
-        }
         await this.pos.syncAllOrders();
         this.dialog.add(TableSelector, {
             title: _t("Table Selector"),
@@ -86,15 +77,7 @@ patch(Navbar.prototype, {
             },
         });
     },
-    getOrderToDisplay() {
-        const currentOrder = this.pos.get_order();
-        const orderToTransfer = this.pos.models["pos.order"].find((order) => {
-            return order.uuid === this.pos.orderToTransferUuid;
-        });
-        return currentOrder || orderToTransfer;
-    },
     onClickPlanButton() {
-        this.pos.orderToTransferUuid = null;
         this.pos.showScreen("FloorScreen", { floor: this.floor });
     },
 });

--- a/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.xml
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.xml
@@ -18,12 +18,12 @@
             <div t-if="pos.config.module_pos_restaurant" class="d-flex flex-shrink-0 gap-1 position-relative">
                <div class="navbar-menu d-flex d-lg-grid gap-1">
                     <t t-set="screen" t-value="pos.mainScreen.component.name" />
-                    <button class="back-button btn btn-lg lh-lg" t-att-class="{'btn-primary': screen === 'FloorScreen' and !pos.orderToTransferUuid}" t-on-click="() => this.onClickPlanButton()">
+                    <button class="back-button btn btn-lg lh-lg" t-att-class="{'btn-primary': screen === 'FloorScreen'}" t-on-click="() => this.onClickPlanButton()">
                         <span t-if="!ui.isSmall">Plan</span>
                         <img t-else="" src="/pos_restaurant/static/img/plan.svg" class="navbar-icon" alt="Floor Plan"/>
                     </button>
-                    <button class="table-free-order-label btn btn-lg lh-lg" t-att-class="{'btn-primary': !['ActionScreen', 'FloorScreen'].includes(screen) or pos.orderToTransferUuid}" t-on-click="() => this.onClickTableTab()">
-                        <span t-if="getOrderToDisplay()" t-esc="getOrderToDisplay().getName().slice(0, 7)"/>
+                    <button class="table-free-order-label btn btn-lg lh-lg" t-att-class="{'btn-primary': !['ActionScreen', 'FloorScreen'].includes(screen)}" t-on-click="() => this.onClickTableTab()">
+                        <span t-if="pos.get_order()" t-esc="pos.get_order().getName().slice(0, 7)"/>
                         <span t-elif="!ui.isSmall">Table</span>
                         <img t-else="" src="/pos_restaurant/static/img/table.svg" class="navbar-icon" alt="Table Selector"/>
                     </button>


### PR DESCRIPTION
    In pos restaurant when doing a transfer we set the order to transfer in
    a key of `pos` and then whenever we have a click handler we have to
    check if there is an order to transfer or not and adapt the code
    accordingly. This is inconvenient and error prone.

    In this commit we adapt the code such that we no longer need to store
    this global state and that the transfering logic is handled in a
    sequential way.

    task: 4167376


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
