### PR TITLE
[FIX] mrp: not test mo with phatom bom

### DIFF
--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -3987,6 +3987,7 @@ class TestMrpOrder(TestMrpCommon):
         Checks that the expected durations of workorders are updated depending on the produced quantity.
         """
         bom = self.bom_2
+        bom.type = 'normal'
         bom.operation_ids.time_mode = 'manual'
         bom.operation_ids.time_cycle_manual = 60.0
         product = bom.product_id


### PR DESCRIPTION
### Issue:

The test `test_duration_expected_when_done` is currently testing a flow that can not be made that is an MO using a kit bom.

followup of commit 9431c7a
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
