### PR TITLE
[IMP] account: recipient bank selection

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -877,9 +877,11 @@ class AccountMove(models.Model):
     @api.depends('bank_partner_id')
     def _compute_partner_bank_id(self):
         for move in self:
+            # This will get the bank account from the partner in an order with the trusted first
             bank_ids = move.bank_partner_id.bank_ids.filtered(
-                lambda bank: not bank.company_id or bank.company_id == move.company_id)
-            move.partner_bank_id = bank_ids[0] if bank_ids else False
+                lambda bank: not bank.company_id or bank.company_id == move.company_id
+            ).sorted(lambda bank: not bank.allow_out_payment)
+            move.partner_bank_id = bank_ids[:1]
 
     @api.depends('partner_id')
     def _compute_invoice_payment_term_id(self):


### PR DESCRIPTION
Partners can have multiple Bank accounts in an active database, some being even added automatically on Bank reconciliation. But usually, only some specific accounts that are used for outgoing payments will be marked as "trusted".

Currently, when you select a Vendor on a draft Vendor Bill, the first account of the partner is taken, whether or not the account is trusted. This Pr will give priority to the accounts that are trusted.

task: 4166740




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
