### PR TITLE
[FIX] web: x2many list: can sort on char with falsy values

### DIFF
--- a/addons/web/static/src/legacy/js/views/basic/basic_model.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_model.js
@@ -5193,10 +5193,14 @@ var BasicModel = AbstractModel.extend({
                 var orderData1 = data1[order.name];
                 var orderData2 = data2[order.name];
 
+                var type = list.fields[order.name].type;
                 // If the field is a relation, sort on the display_name of those records
-                if (list.fields[order.name].type === 'many2one') {
+                if (type === 'many2one') {
                     orderData1 = orderData1 ? self.localData[orderData1].data.display_name : "";
                     orderData2 = orderData2 ? self.localData[orderData2].data.display_name : "";
+                } else if (type === 'char' || type === 'text') {
+                    orderData1 = orderData1 || "";
+                    orderData2 = orderData2 || "";
                 }
                 if (orderData1 < orderData2) {
                     return order.asc ? -1 : 1;

--- a/addons/web/static/tests/legacy/fields/relational_fields/field_one2many_tests.js
+++ b/addons/web/static/tests/legacy/fields/relational_fields/field_one2many_tests.js
@@ -2143,6 +2143,40 @@ QUnit.module('fields', {}, function () {
             form.destroy();
         });
 
+        QUnit.test('sorting one2many char field with falsy values', async function (assert) {
+            assert.expect(3);
+
+            this.data.partner.fields.foo.sortable = true;
+            this.data.partner.records.push({ id: 23, foo: "abc" });
+            this.data.partner.records.push({ id: 24, foo: false });
+            this.data.partner.records.push({ id: 25, foo: "def" });
+            this.data.partner.records[0].p = [23, 24, 25];
+
+            var form = await createView({
+                View: FormView,
+                model: 'partner',
+                data: this.data,
+                arch: `
+                    <form>
+                        <field name="p">
+                            <tree>
+                                <field name="foo"/>
+                            </tree>
+                        </field>
+                    </form>`,
+                res_id: 1,
+                debug: 1,
+            });
+
+            assert.deepEqual([...form.el.querySelectorAll(".o_list_char")].map((el) => el.innerText), ["abc", "", "def"]);
+            await testUtils.dom.click(form.$('table thead th:contains(Foo)'));
+            assert.deepEqual([...form.el.querySelectorAll(".o_list_char")].map((el) => el.innerText), ["", "abc", "def"]);
+            await testUtils.dom.click(form.$('table thead th:contains(Foo)'));
+            assert.deepEqual([...form.el.querySelectorAll(".o_list_char")].map((el) => el.innerText), ["def", "abc", ""]);
+
+            form.destroy();
+        });
+
         QUnit.test('one2many list field edition', async function (assert) {
             assert.expect(6);
 


### PR DESCRIPTION
Have an x2many list with a char field and some records having `false` as value for that field. Before this commit, sorting on that field didn't work as expected, because we tried to compare strings with false, which is always false:
```
	"a" < false === false < "a" === false
```

This commit fixes the issue by fallbacking on the empty string before comparing the values.

opw~3979153

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
