### PR TITLE
[FIX] web: improve performance when many dropdowns

### DIFF
--- a/addons/web/static/src/core/dropdown/_behaviours/dropdown_nesting.js
+++ b/addons/web/static/src/core/dropdown/_behaviours/dropdown_nesting.js
@@ -18,7 +18,9 @@ class DropdownNestingState {
 
     set isOpen(value) {
         this._isOpen = value;
-        BUS.trigger("state-changed", this);
+        if (this._isOpen) {
+            BUS.trigger("dropdown-opened", this);
+        }
     }
 
     get isOpen() {
@@ -90,7 +92,7 @@ export function useDropdownNesting(state) {
     );
 
     useChildSubEnv({ [DROPDOWN_NESTING]: current });
-    useBus(BUS, "state-changed", ({ detail: other }) => current.handleChange(other));
+    useBus(BUS, "dropdown-opened", ({ detail: other }) => current.handleChange(other));
 
     effect(
         (state) => {


### PR DESCRIPTION
Have 1000 drodowns to setup. Setup one of them will trigger the event
state-changed and the dropdowns already setuped will react to that event.
In the end, DropdownNestingState.handleChange will be called
(999 * 1000) / 2 = 499500
that means quadraticaly with the number of dropdowns.
Here we avoid to trigger that event when setuping a closed dropdown.

This problem was originaly observed in a pivot view with many headers.