### PR TITLE
[FIX] website,website_sale: fix price display issue on autocomplete

### DIFF
--- a/addons/website/static/src/snippets/s_searchbar/000.xml
+++ b/addons/website/static/src/snippets/s_searchbar/000.xml
@@ -16,7 +16,7 @@
     </t>
     <a t-foreach="results" t-as="result" t-key="result_index"
         t-att-href="result['website_url']" class="dropdown-item p-2 text-wrap">
-        <div class="d-flex align-items-center o_search_result_item">
+        <div class="d-flex align-items-center flex-wrap o_search_result_item">
             <t t-if="widget.displayImage">
                 <img t-if="result['image_url']" t-att-src="result['image_url']" class="flex-shrink-0 o_image_64_contain"/>
                 <i t-else="" t-attf-class="o_image_64_contain text-center pt16 fa #{result['_fa']}" style="font-size: 34px;"/>
@@ -30,7 +30,7 @@
                 <button t-if="extra_link" class="extra_link btn btn-link btn-sm" t-att-data-target="result['extra_link_url']" t-out="extra_link"/>
                 <t t-if="extra_link_html" t-out="extra_link_html"/>
             </div>
-            <div t-if="parts['detail'] and widget.displayDetail" class="flex-shrink-0">
+            <div t-if="parts['detail'] and widget.displayDetail" class="flex-shrink-0 ms-auto">
                 <t t-if="result['detail_strike']">
                     <span class="text-danger text-nowrap" style="text-decoration: line-through;">
                         <t t-out="result['detail_strike']"/>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2688,7 +2688,7 @@
             <t t-else="">Categories:</t>
         </button>
         <t t-foreach="categories" t-as="category">
-            <button class="btn btn-link btn-sm p-0" t-out="category.name"
+            <button class="btn btn-link btn-sm p-0 text-wrap" t-out="category.name"
                 t-attf-onclick="location.href='/shop/category/#{slug(category)}';return false;"/>
         </t>
     </template>


### PR DESCRIPTION
Steps to reproduce the issue:

- Change the header menu layout to "Sales 2."
- Increase the font size of the header (e.g., set it to 20).
- In the backend, add a long product category (e.g., "very long category's name") to a product like "Customizable Table".

Issue: When searching for the product in the search bar, the price is not displayed in full. However, after deleting the product category, the price is shown correctly, even with the large font size.

This commit resolves the issue by adjusting the layout to ensure the price is fully visible, regardless of the font size or category length.

opw-4077768
