### PR TITLE
[FIX] web_editor: Fix error Invalid ids list while insert signature

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -2453,7 +2453,7 @@ export class Wysiwyg extends Component {
                 fontawesome: 'fa-pencil-square-o',
                 isDisabled: () => !this.odooEditor.isSelectionInBlockRoot(),
                 callback: async () => {
-                    const uid = Array.isArray(session.user_id) ? session.user_id[0] : session.user_id;
+                    const uid = (Array.isArray(session.user_id) ? session.user_id[0] : session.user_id)  | session.uid;
                     const [user] = await this.orm.read(
                         'res.users',
                         [uid],


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:
In the chatter if you try to insert signature with: /Signature , an error appear if auth_totp is not installed:

>  Error: Invalid ids list: 
>     Error: Invalid ids list: 
>         at validatePrimitiveList (https://www.stesi.consulting/web/assets/debug/web.assets_web_dark.js:28515:15) (/web/static/src/core/orm_service.js:73)
>         at ORM.read (https://www.stesi.consulting/web/assets/debug/web.assets_web_dark.js:28596:9) (/web/static/src/core/orm_service.js:154)
>         at ORM.read (https://www.stesi.consulting/web/assets/debug/web.assets_web_dark.js:39288:41) (/web/static/src/core/utils/hooks.js:101)
>         at Object.callback (https://www.stesi.consulting/web/assets/debug/web_editor.backend_assets_wysiwyg.js:25785:51) (/web_editor/static/src/js/wysiwyg/wysiwyg.js:2463)
>         at Powerbox._pickCommand (https://www.stesi.consulting/web/assets/debug/web_editor.backend_assets_wysiwyg.js:14811:27) (/web_editor/static/src/js/editor/odoo-editor/src/powerbox/Powerbox.js:232)  

### Current behavior before PR:
The error above appears because the web_editor get the session_user_id from session_info that is set by auth_totp or in a frontend session. 
Using uid it works on both 

### Desired behavior after PR is merged:
No error should appear



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
