### PR TITLE
[FIX] base: fix maldivian rufiyaa currency symbol

### DIFF
--- a/odoo/addons/base/data/res_currency_data.xml
+++ b/odoo/addons/base/data/res_currency_data.xml
@@ -659,7 +659,7 @@
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Rubles</field>
-            <field name="currency_subunit_label">Kopeks</field>            
+            <field name="currency_subunit_label">Kopeks</field>
         </record>
 
         <record id="BZD" model="res.currency">
@@ -1164,7 +1164,7 @@
             <field name="name">MVR</field>
             <field name="iso_numeric">462</field>
             <field name="full_name">Maldivian rufiyaa</field>
-            <field name="symbol">.ރ</field>
+            <field name="symbol">Rf</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="position">before</field>


### PR DESCRIPTION
This commit replaces the old Maldivian rufiyaa symbol (ރ) with Rf because ރ is a RTL symbol which causes a lot of parsing issues when handling it (in PDFs and monetary field among others).

task-4095603
