### PR TITLE
[IMP] base_import: enable drag-and-drop to import record from files

### DIFF
--- a/addons/base_import/static/src/import_action/import_action.js
+++ b/addons/base_import/static/src/import_action/import_action.js
@@ -4,7 +4,7 @@ import { registry } from "@web/core/registry";
 import { useFileUploader } from "@web/core/utils/files";
 import { useService } from "@web/core/utils/hooks";
 import { FileInput } from "@web/core/file_input/file_input";
-import { useDropzone } from "@web/core/dropzone/dropzone_hook";
+import { useImportRecordsDropzone } from "@base_import/import_records_dropzone/import_records_dropzone_hook";
 import { useImportModel } from "../import_model";
 import { ImportDataContent } from "../import_data_content/import_data_content";
 import { ImportDataProgress } from "../import_data_progress/import_data_progress";
@@ -56,38 +56,17 @@ export class ImportAction extends Component {
         });
 
         this.uploadFiles = useFileUploader();
-        useDropzone(useRef("root"), async event => {
-            const { files } = event.dataTransfer;
-            if (files.length === 0) {
-                this.notification.add(_t("Please upload an Excel (.xls or .xlsx) or .csv file to import."), {
-                    type: "danger",
-                });
-            } else if (files.length > 1) {
-                this.notification.add(_t("Please upload a single file."), {
-                    type: "danger",
-                });
-            } else {
-                const file = files[0];
-                const isValidFile = file.name.endsWith(".csv")
-                                 || file.name.endsWith(".xls")
-                                 || file.name.endsWith(".xlsx");
-                if (!isValidFile) {
-                    this.notification.add(_t("Please upload an Excel (.xls or .xlsx) or .csv file to import."), {
-                        type: "danger",
-                    });
-                } else {
-                    await this.uploadFiles(this.uploadFilesRoute, {
-                        csrf_token: odoo.csrf_token,
-                        ufile: [file],
-                        model: this.resModel,
-                        id: this.model.id,
-                    });
-                    this.handleFilesUpload([file]);
-                }
-            }
+        useImportRecordsDropzone(useRef("root"), this.resModel, file => {
+            this.onDropFile(file);
         });
 
-        onWillStart(() => this.model.init());
+        onWillStart(async () => {
+            await this.model.init();
+            const file = this.props.action?.params?.file;
+            if (file) {
+                await this.onDropFile(file);
+            }
+        });
         onMounted(() => this.enter());
     }
 
@@ -165,6 +144,19 @@ export class ImportAction extends Component {
     //--------------------------------------------------------------------------
     // File
     //--------------------------------------------------------------------------
+
+    /**
+     * @param {File} file
+     */
+    async onDropFile(file) {
+        await this.uploadFiles(this.uploadFilesRoute, {
+            csrf_token: odoo.csrf_token,
+            ufile: [file],
+            model: this.resModel,
+            id: this.model.id,
+        });
+        this.handleFilesUpload([file]);
+    }
 
     async handleFilesUpload(files) {
         if (!files || files.length <= 0) {

--- a/addons/base_import/static/src/import_records_dropzone/import_records_dropzone.js
+++ b/addons/base_import/static/src/import_records_dropzone/import_records_dropzone.js
@@ -1,0 +1,16 @@
+import { Component } from "@odoo/owl";
+import { Dropzone } from "@web/core/dropzone/dropzone";
+
+export class ImportRecordsDropzone extends Component {
+    static template = "base_import.ImportRecordsDropzone";
+    static components = { Dropzone };
+    static props = { onDrop: Function, ref: Object, resModel: String };
+
+    /** @returns {Object} */
+    get dropzoneProps() {
+        return {
+            ref: this.props.ref,
+            onDrop: this.props.onDrop,
+        };
+    }
+}

--- a/addons/base_import/static/src/import_records_dropzone/import_records_dropzone.xml
+++ b/addons/base_import/static/src/import_records_dropzone/import_records_dropzone.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="base_import.ImportRecordsDropzone">
+        <Dropzone t-props="dropzoneProps">
+            <h4>Drop a file to import new "<t t-out="props.resModel"/>" <i class="fa fa-download"/></h4>
+        </Dropzone>
+    </t>
+</templates>

--- a/addons/base_import/static/src/import_records_dropzone/import_records_dropzone_hook.js
+++ b/addons/base_import/static/src/import_records_dropzone/import_records_dropzone_hook.js
@@ -1,0 +1,41 @@
+import { _t } from "@web/core/l10n/translation";
+import { ImportRecordsDropzone } from "./import_records_dropzone";
+import { useCustomDropzone } from "@web/core/dropzone/dropzone_hook";
+import { useService } from "@web/core/utils/hooks";
+
+/**
+ * @param {Object} targetRef
+ * @param {string} resModel
+ * @param {function} onDropFile
+ */
+export function useImportRecordsDropzone (targetRef, resModel, onDropFile) {
+    const notification = useService("notification");
+    useCustomDropzone(targetRef, ImportRecordsDropzone, {
+        resModel,
+        /** @param {Event} event */
+        onDrop: async event => {
+            const { files } = event.dataTransfer;
+            if (files.length === 0) {
+                notification.add(_t("Please upload an Excel (.xls or .xlsx) or .csv file to import."), {
+                    type: "danger",
+                });
+            } else if (files.length > 1) {
+                notification.add(_t("Please upload a single file."), {
+                    type: "danger",
+                });
+            } else {
+                const file = files[0];
+                const isValidFile = file.name.endsWith(".csv")
+                                 || file.name.endsWith(".xls")
+                                 || file.name.endsWith(".xlsx");
+                if (!isValidFile) {
+                    notification.add(_t("Please upload an Excel (.xls or .xlsx) or .csv file to import."), {
+                        type: "danger",
+                    });
+                } else {
+                    onDropFile(file);
+                }
+            }
+        }
+    });
+}

--- a/addons/base_import/static/src/views/kanban_renderer.js
+++ b/addons/base_import/static/src/views/kanban_renderer.js
@@ -1,0 +1,21 @@
+import { patch } from "@web/core/utils/patch";
+import { useImportRecordsDropzone } from "@base_import/import_records_dropzone/import_records_dropzone_hook";
+import { useService } from "@web/core/utils/hooks";
+import { KanbanRenderer } from "@web/views/kanban/kanban_renderer";
+
+patch(KanbanRenderer.prototype, {
+    setup() {
+        super.setup(...arguments);
+        if (this.props.archInfo?.canImportRecords) {
+            const actionService = useService("action");
+            const { context, resModel } = this.props.list.model.config;
+            useImportRecordsDropzone(this.rootRef, resModel, async file => {
+                await actionService.doAction({
+                    type: "ir.actions.client",
+                    tag: "import",
+                    params: { model: resModel, context, file },
+                });
+            });
+        }
+    }
+});

--- a/addons/base_import/static/src/views/list_renderer.js
+++ b/addons/base_import/static/src/views/list_renderer.js
@@ -1,0 +1,21 @@
+import { patch } from "@web/core/utils/patch";
+import { useImportRecordsDropzone } from "@base_import/import_records_dropzone/import_records_dropzone_hook";
+import { useService } from "@web/core/utils/hooks";
+import { ListRenderer } from "@web/views/list/list_renderer";
+
+patch(ListRenderer.prototype, {
+    setup() {
+        super.setup(...arguments);
+        if (this.props.archInfo?.canImportRecords) {
+            const actionService = useService("action");
+            const { context, resModel } = this.props.list.model.config;
+            useImportRecordsDropzone(this.rootRef, resModel, async file => {
+                await actionService.doAction({
+                    type: "ir.actions.client",
+                    tag: "import",
+                    params: { model: resModel, context, file },
+                });
+            });
+        }
+    }
+});

--- a/addons/base_import/static/tests/import_action_tests.js
+++ b/addons/base_import/static/tests/import_action_tests.js
@@ -229,7 +229,8 @@ function executeFailingImport(field, isMultiline, field_path = "") {
     };
 }
 
-async function createImportAction(customRouter = {}) {
+/** @param {Object} customRouter */
+function createWebClientWithBaseImportRoutes(customRouter) {
     const router = {
         "/web/dataset/call_kw/partner/get_import_templates": (route, args) => Promise.resolve([]),
         "/web/dataset/call_kw/base_import.import/parse_preview": (route, args) =>
@@ -245,7 +246,7 @@ async function createImportAction(customRouter = {}) {
         router["/web/dataset/call_kw/" + key] = customRouter[key];
     }
 
-    const webClient = await createWebClient({
+    return createWebClient({
         serverData,
         mockRPC: function (route, { args }) {
             if (route in router) {
@@ -253,7 +254,11 @@ async function createImportAction(customRouter = {}) {
             }
         },
     });
+}
 
+/** @param {Object} customRouter */
+async function createImportAction(customRouter = {}) {
+    const webClient = await createWebClientWithBaseImportRoutes(customRouter);
     await doAction(webClient, 1);
 }
 
@@ -578,6 +583,57 @@ QUnit.module("Base Import Tests", (hooks) => {
             ".o_import_action .o_import_data_content",
             "content panel is visible"
         );
+    });
+
+    QUnit.test("Import view: drag-and-drop file support on standard views", async function (assert) {
+        serverData.views = {
+            "partner,false,list": `<list><field name="display_name"/></list>`,
+            "partner,false,kanban": `
+                <kanban>
+                    <templates>
+                        <t t-name="card">
+                            <field name="display_name"/>
+                        </t>
+                    </templates>
+                </kanban>`,
+            "partner,false,search": `<search/>`,
+        };
+
+        registerFakeHTTPService((route, params) => {
+            assert.strictEqual(route, "/base_import/set_file");
+            assert.strictEqual(
+                params.ufile[0].name,
+                "fake_file.csv",
+                "file is correctly uploaded to the server"
+            );
+        });
+
+        const webClient = await createWebClientWithBaseImportRoutes();
+        const file = new File(["fake_file"], "fake_file.csv", {
+            type: "text/plain"
+        });
+
+        const views = [
+            { type: "list", dropzone: ".o_list_renderer" },
+            { type: "kanban", dropzone: ".o_kanban_renderer" },
+        ];
+
+        for (const { type, dropzone } of views) {
+            await doAction(webClient, {
+                res_model: "partner",
+                type: "ir.actions.act_window",
+                views: [[false, type]],
+            }, { stackPosition: "replaceCurrentAction" });
+
+            await dragenterFiles(dropzone, [file]);
+            await dropFiles(".o-Dropzone", [file]);
+            await nextTick();
+            assert.containsOnce(
+                target,
+                ".o_import_action .o_import_data_content",
+                "content panel is visible"
+            );
+        }
     });
 
     QUnit.test("Import view: additional options in debug", async function (assert) {

--- a/addons/web/static/src/core/dropzone/dropzone.js
+++ b/addons/web/static/src/core/dropzone/dropzone.js
@@ -5,6 +5,7 @@ export class Dropzone extends Component {
         extraClass: { type: String, optional: true },
         onDrop: { type: Function, optional: true },
         ref: Object,
+        slots: { type: Object, optional: true }
     };
     static template = "web.Dropzone";
 

--- a/addons/web/static/src/core/dropzone/dropzone.xml
+++ b/addons/web/static/src/core/dropzone/dropzone.xml
@@ -10,7 +10,9 @@
         t-on-drop="props.onDrop"
         t-ref="root"
     >
-        <h4>Drag Files Here <i class="fa fa-download"/></h4>
+        <t t-slot="default">
+            <h4>Drag Files Here <i class="fa fa-download"/></h4>
+        </t>
     </div>
 </t>
 

--- a/addons/web/static/src/core/dropzone/dropzone_hook.js
+++ b/addons/web/static/src/core/dropzone/dropzone_hook.js
@@ -8,6 +8,10 @@ const componentRegistry = registry.category("main_components");
 
 let id = 1;
 export function useDropzone(targetRef, onDrop, extraClass, isDropzoneEnabled = () => true) {
+    useCustomDropzone(targetRef, Dropzone, { extraClass, onDrop }, isDropzoneEnabled);
+}
+
+export function useCustomDropzone(targetRef, dropzoneComponent, dropzoneComponentProps, isDropzoneEnabled = () => true) {
     const dropzoneId = `web.dropzone_${id++}`;
     let dragCount = 0;
     let hasTarget = false;
@@ -28,8 +32,11 @@ export function useDropzone(targetRef, onDrop, extraClass, isDropzoneEnabled = (
         const hasDropzone = componentRegistry.contains(dropzoneId);
         if (shouldDisplayDropzone && !hasDropzone) {
             componentRegistry.add(dropzoneId, {
-                Component: Dropzone,
-                props: { extraClass, onDrop, ref: targetRef },
+                Component: dropzoneComponent,
+                props: {
+                    ref: targetRef,
+                    ...dropzoneComponentProps
+                },
             });
         }
         if (!shouldDisplayDropzone && hasDropzone) {

--- a/addons/web/static/src/views/kanban/kanban_arch_parser.js
+++ b/addons/web/static/src/views/kanban/kanban_arch_parser.js
@@ -13,6 +13,7 @@ export class KanbanArchParser {
         const fields = models[modelName].fields;
         const className = xmlDoc.getAttribute("class") || null;
         const canOpenRecords = exprToBoolean(xmlDoc.getAttribute("can_open"), true);
+        const canImportRecords = exprToBoolean(xmlDoc.getAttribute("import"), true);
         let defaultOrder = stringToOrderBy(xmlDoc.getAttribute("default_order") || null);
         const defaultGroupBy = xmlDoc.getAttribute("default_group_by");
         const limit = xmlDoc.getAttribute("limit");
@@ -141,6 +142,7 @@ export class KanbanArchParser {
         return {
             activeActions,
             canOpenRecords,
+            canImportRecords,
             cardClassName,
             cardColorField: xmlDoc.getAttribute("highlight_color"),
             className,

--- a/addons/web/static/src/views/list/list_arch_parser.js
+++ b/addons/web/static/src/views/list/list_arch_parser.js
@@ -193,6 +193,8 @@ export class ListArchParser {
                     ? exprToBoolean(xmlDoc.getAttribute("open_form_view") || "")
                     : false;
 
+                treeAttr.canImportRecords = exprToBoolean(xmlDoc.getAttribute("import"), true);
+
                 const limitAttr = node.getAttribute("limit");
                 treeAttr.limit = limitAttr && parseInt(limitAttr, 10);
 


### PR DESCRIPTION
When a CSV file is dropped onto a kanban or list view, the system will open the import record view and load the file. If the file is valid, users will be able to map the columns from the CSV to the corresponding model fields and import the records into the database. This new feature simplifies the process of importing records into Odoo, allowing users to import data by simply dragging and dropping a file onto a view.

Note that the dropzone will be disabled if the import feature is explicitly turned off, i.e., when the `import` attribute in the arch view is set to `False`.

task-3956293

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
