### PR TITLE
[IMP] website: carousel snippets, additional improvements after the redesign

### DIFF
--- a/addons/website/static/src/scss/bootstrap_overridden.scss
+++ b/addons/website/static/src/scss/bootstrap_overridden.scss
@@ -374,3 +374,6 @@ $pagination-padding-x-lg: $pagination-padding-x !default;
 
 $pagination-border-radius-lg: $pagination-border-radius !default;
 $pagination-border-radius-sm: $pagination-border-radius !default;
+
+// Carousel
+$carousel-control-width: 10% !default;

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1004,6 +1004,13 @@ table.table_desc tr td {
             border: $border-width solid $border-color;
             background-size: 50%;
             background-color: $carousel-dark-indicator-active-bg;
+            filter: $carousel-dark-control-icon-filter;
+        }
+
+        &.carousel-dark {
+            .carousel-control-prev-icon, .carousel-control-next-icon {
+                filter: none;
+            }
         }
     }
 

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1020,6 +1020,12 @@ table.table_desc tr td {
         }
     }
 
+    &.s_carousel_arrows_hidden {
+        .carousel-control-prev, .carousel-control-next {
+            display: none;
+        }
+    }
+
     // Content
     .carousel-inner {
         // Create a new stacking context to ensure that elements like indicators

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -795,6 +795,10 @@ table.table_desc tr td {
 // Snippets
 //
 
+// Variables shared between carousel snippets and s_image_gallery
+$-o-carousel-indicators-dots-size: .75rem;
+$-o-carousel-controllers-size: map-get($spacers, 5);
+
 // This style is shared by old versions of carousels
 // 000 for s_carousel & 000 and 001 for s_quotes_carousel
 %old_s_carousel_variants {
@@ -958,26 +962,34 @@ table.table_desc tr td {
 // This style is shared by the new versions of carousels
 // 001 for s_carousel & 002 for s_quotes_carousel
 %s_carousel_variants {
-
-    --o-carousel-indicators-dots-size: .75rem;
-    --o-carousel-controllers-size: #{map-get($spacers, 5)};
-
-    // Controls
+    // Controllers in Mobile
     @include media-breakpoint-down(md) {
         .carousel-control-prev,
         .carousel-control-next {
-            display: none; // remove arrows on mobile
+            top: auto;
+            bottom: map-get($spacers, 3);
+            height: $-o-carousel-controllers-size;
+            width: auto;
+            margin: 0 map-get($spacers, 3);
+        }
+
+        &:not(.s_carousel_arrows_hidden) .carousel-indicators {
+            $-margin-x: map-get($spacers, 3) * 2 + $-o-carousel-controllers-size;
+
+            margin: 0 $-margin-x 1em;
         }
     }
 
-    &.carousel-dark {
-        --o-carousel-indicator-dots-bg-color: #{to-rgb(#fff)};
+    .carousel-control-prev,
+    .carousel-control-next,
+    .carousel-indicators {
+        position: absolute;
     }
 
-    .carousel-control-prev,
-    .carousel-control-next {
-        position: absolute;
-        width: 10%;
+    .carousel-control-prev-icon, .carousel-control-next-icon {
+        width: $-o-carousel-controllers-size;
+        height: $-o-carousel-controllers-size;
+        background-size: 50%;
     }
 
     &.s_carousel_default {
@@ -998,11 +1010,8 @@ table.table_desc tr td {
 
     &.s_carousel_boxed, &.s_carousel_rounded {
         .carousel-control-prev-icon, .carousel-control-next-icon {
-            width: var(--o-carousel-controllers-size);
-            height: var(--o-carousel-controllers-size);
             border-radius: $border-radius;
             border: $border-width solid $border-color;
-            background-size: 50%;
             background-color: $carousel-dark-indicator-active-bg;
             filter: $carousel-dark-control-icon-filter;
         }
@@ -1046,10 +1055,12 @@ table.table_desc tr td {
 
     // Indicators
     .carousel-indicators {
+        align-items: center;
+        height: $-o-carousel-controllers-size;
+
         &.s_carousel_indicators_dots > button {
-            --o-carousel-indicators-spacer: #{$carousel-indicator-spacer * -4};
-            width: var(--o-carousel-indicators-dots-size);
-            height: var(--o-carousel-indicators-dots-size);
+            width: $-o-carousel-indicators-dots-size;
+            height: $-o-carousel-indicators-dots-size;
             border: 0;
             border-radius: $border-radius-pill;
             transform: scale(.5);
@@ -1058,7 +1069,7 @@ table.table_desc tr td {
             // Increases the click area for easier navigation.
             &:before {
                 position: absolute;
-                inset: var(--o-carousel-indicators-spacer);
+                inset: $carousel-indicator-spacer * -4;
                 display: block;
                 content: '';
             }
@@ -1068,8 +1079,7 @@ table.table_desc tr td {
             }
 
             &.active {
-                --o-carousel-indicators-spacer: #{$carousel-indicator-spacer * -1};
-
+                inset: $carousel-indicator-spacer * -1;
                 transform: scale(1);
             }
         }
@@ -1080,12 +1090,19 @@ table.table_desc tr td {
     }
 
     // Style - Indicators outside
-    &.s_carousel_controllers_indicators_outside .carousel-indicators {
-        position: relative;
+    &.s_carousel_controllers_indicators_outside {
+        .carousel-control-prev, .carousel-control-next {
+            margin-bottom: $-o-carousel-controllers-size;
+        }
 
-        button {
-            background-color: currentColor;
-            color: inherit;
+        .carousel-indicators {
+            position: relative;
+            margin-bottom: 0;
+
+            button {
+                background-color: currentColor;
+                color: inherit;
+            }
         }
     }
 }

--- a/addons/website/static/src/snippets/s_image_gallery/000.js
+++ b/addons/website/static/src/snippets/s_image_gallery/000.js
@@ -60,7 +60,10 @@ const GalleryWidget = publicWidget.Widget.extend({
         };
 
         const milliseconds = this.el.dataset.interval || false;
-        this.$modal = $(renderToElement('website.gallery.slideshow.lightbox', {
+        const lightboxTemplate = this.$target[0].dataset.vcss === "002" ?
+            "website.gallery.s_image_gallery_mirror.lightbox" :
+            "website.gallery.slideshow.lightbox";
+        this.$modal = $(renderToElement(lightboxTemplate, {
             images: imageEls,
             index: currentImageIndex,
             dim: dimensions,

--- a/addons/website/static/src/snippets/s_image_gallery/001.xml
+++ b/addons/website/static/src/snippets/s_image_gallery/001.xml
@@ -26,4 +26,18 @@
             </div>
         </div>
     </t>
+
+    <t t-name="website.gallery.s_image_gallery_mirror.lightbox">
+        <div role="dialog" class="modal o_technical_modal fade s_gallery_lightbox p-0" aria-label="Image Gallery Dialog" tabindex="-1">
+            <div class="modal-dialog m-0" role="Picture Gallery"
+                t-attf-style="">
+                <div class="modal-content bg-transparent modal-fullscreen">
+                    <main class="modal-body o_slideshow bg-transparent">
+                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close" style="position: absolute; right: 10px; top: 10px;"></button>
+                        <t t-call="website.s_image_gallery_mirror"/>
+                    </main>
+                </div>
+            </div>
+        </div>
+    </t>
 </templates>

--- a/addons/website/static/src/snippets/s_image_gallery/002.scss
+++ b/addons/website/static/src/snippets/s_image_gallery/002.scss
@@ -333,3 +333,64 @@
         }
     }
 }
+
+.s_gallery_lightbox {
+    .modal-dialog {
+        height: 100%;
+        background-color: rgba(0,0,0,0.7);
+    }
+
+    @include media-breakpoint-up(sm) {
+        .modal-dialog {
+            max-width: 100%;
+            padding: 0;
+        }
+    }
+
+    div.carousel-indicators {
+        display: none;
+    }
+
+    .modal-body.o_slideshow {
+        .carousel-item {
+            > a {
+                display: flex;
+                height: 100%;
+                width: 100%;
+            }
+
+            > a > img,
+            > img {
+                max-height: 100%;
+                max-width: 100%;
+                margin: auto;
+            }
+        }
+
+        .carousel {
+            height: 100%;
+
+            .carousel-inner {
+                height: 100%;
+            }
+
+            .carousel-item.active,
+            .carousel-item-next,
+            .carousel-item-prev,
+            .carousel-control-next,
+            .carousel-control-prev {
+                display: flex;
+                align-items: center;
+                height: 100%;
+            }
+
+            .carousel-control-prev-icon, .carousel-control-next-icon {
+                width: $-o-carousel-controllers-size;
+                height: $-o-carousel-controllers-size;
+                background-size: 50%;
+                background-color: $carousel-dark-indicator-active-bg;
+                border-radius: $btn-border-radius;
+            }
+        }
+    }
+}

--- a/addons/website/static/src/snippets/s_image_gallery/002.scss
+++ b/addons/website/static/src/snippets/s_image_gallery/002.scss
@@ -161,6 +161,13 @@
                 border-radius: $btn-border-radius;
                 border: $border-width solid $border-color;
                 background-color: $carousel-dark-indicator-active-bg;
+                filter: $carousel-dark-control-icon-filter;
+            }
+
+            .carousel-dark {
+                .carousel-control-prev-icon, .carousel-control-next-icon {
+                    filter: none;
+                }
             }
         }
 

--- a/addons/website/static/src/snippets/s_image_gallery/002.scss
+++ b/addons/website/static/src/snippets/s_image_gallery/002.scss
@@ -90,9 +90,6 @@
     }
 
     &.o_slideshow {
-        --o-carousel-indicators-dots-size: .75rem;
-        --o-carousel-controllers-size: #{map-get($spacers, 5)};
-
         .carousel {
             &, .carousel-inner {
                 height: var(--snippet-preview-height, 100%);
@@ -126,6 +123,7 @@
 
         .carousel-indicators {
             align-items: center;
+            min-width: 0;
         }
 
         .carousel-control-prev, .carousel-control-next {
@@ -133,8 +131,8 @@
         }
 
         .carousel-control-prev-icon, .carousel-control-next-icon {
-            width: var(--o-carousel-controllers-size);
-            height: var(--o-carousel-controllers-size);
+            width: $-o-carousel-controllers-size;
+            height: $-o-carousel-controllers-size;
             background-size: 50%;
         }
 
@@ -193,8 +191,8 @@
         // Indicators - Squared Miniatures / Rounded Miniatures
         &.s_image_gallery_indicators_squared, &.s_image_gallery_indicators_rounded {
             .carousel-indicators > button {
-                width: var(--o-carousel-controllers-size);
-                height: var(--o-carousel-controllers-size);
+                width: $-o-carousel-controllers-size;
+                height: $-o-carousel-controllers-size;
                 border: 0;
                 background-size: cover;
                 background-position: center;
@@ -217,10 +215,8 @@
         // Indicators - Dots
         &.s_image_gallery_indicators_dots {
             .carousel-indicators > button {
-                --o-carousel-indicators-spacer: #{$carousel-indicator-spacer * -4};
-
-                width: var(--o-carousel-indicators-dots-size);
-                height: var(--o-carousel-indicators-dots-size);
+                width: $-o-carousel-indicators-dots-size;
+                height: $-o-carousel-indicators-dots-size;
                 border: 0;
                 border-radius: $border-radius-pill;
                 background-image: none !important;
@@ -230,14 +226,13 @@
                 // Increases the click area for easier navigation.
                 &:before {
                     position: absolute;
-                    inset: var(--o-carousel-indicators-spacer);
+                    inset: $carousel-indicator-spacer * -4;
                     display: block;
                     content: '';
                 }
 
                 &.active {
-                    --o-carousel-indicators-spacer: #{$carousel-indicator-spacer * -1};
-
+                    inset: $carousel-indicator-spacer * -1;
                     transform: scale(.8);
                 }
             }
@@ -253,10 +248,10 @@
         &.s_image_gallery_controllers_outside {
 
             .carousel-inner {
-                padding-bottom: calc(var(--o-carousel-controllers-size) + #{map-get($spacers, 2)});
+                padding-bottom: $-o-carousel-controllers-size + map-get($spacers, 2);
             }
             .o_carousel_controllers {
-                height: var(--o-carousel-controllers-size);
+                height: $-o-carousel-controllers-size;
             }
         }
 
@@ -266,13 +261,15 @@
                 justify-content: center;
             }
 
-            .carousel-control-prev, .carousel-control-next {
-                bottom: calc(var(--o-carousel-controllers-size) + #{map-get($spacers, 2)});
+            &:not(.s_image_gallery_indicators_hidden) {
+                .carousel-control-prev, .carousel-control-next {
+                    bottom: $-o-carousel-controllers-size + map-get($spacers, 2);
+                }
             }
 
             .carousel-indicators {
                 bottom: 0;
-                height: var(--o-carousel-controllers-size);
+                height: $-o-carousel-controllers-size;
                 margin-bottom: 0;
             }
         }

--- a/addons/website/views/snippets/s_carousel.xml
+++ b/addons/website/views/snippets/s_carousel.xml
@@ -61,7 +61,7 @@
                 <span class="visually-hidden">Next</span>
             </button>
             <!-- Indicators -->
-            <div class="carousel-indicators">
+            <div class="carousel-indicators o_not_editable">
                 <button type="button" t-attf-data-bs-target="#myCarousel{{uniq}}" data-bs-slide-to="0" class="active"/>
                 <button type="button" t-attf-data-bs-target="#myCarousel{{uniq}}" data-bs-slide-to="1"/>
                 <button type="button" t-attf-data-bs-target="#myCarousel{{uniq}}" data-bs-slide-to="2"/>

--- a/addons/website/views/snippets/s_carousel.xml
+++ b/addons/website/views/snippets/s_carousel.xml
@@ -50,16 +50,16 @@
                         </div>
                     </div>
                 </div>
-                <!-- Controls -->
-                <button class="carousel-control-prev o_not_editable" contenteditable="false" t-attf-data-bs-target="#myCarousel{{uniq}}" data-bs-slide="prev" aria-label="Previous" title="Previous">
-                    <span class="carousel-control-prev-icon" aria-hidden="true"/>
-                    <span class="visually-hidden">Previous</span>
-                </button>
-                <button class="carousel-control-next o_not_editable" contenteditable="false" t-attf-data-bs-target="#myCarousel{{uniq}}" data-bs-slide="next" role="img" aria-label="Next" title="Next">
-                    <span class="carousel-control-next-icon" aria-hidden="true"/>
-                    <span class="visually-hidden">Next</span>
-                </button>
             </div>
+            <!-- Controls -->
+            <button class="carousel-control-prev o_not_editable" contenteditable="false" t-attf-data-bs-target="#myCarousel{{uniq}}" data-bs-slide="prev" aria-label="Previous" title="Previous">
+                <span class="carousel-control-prev-icon" aria-hidden="true"/>
+                <span class="visually-hidden">Previous</span>
+            </button>
+            <button class="carousel-control-next o_not_editable" contenteditable="false" t-attf-data-bs-target="#myCarousel{{uniq}}" data-bs-slide="next" role="img" aria-label="Next" title="Next">
+                <span class="carousel-control-next-icon" aria-hidden="true"/>
+                <span class="visually-hidden">Next</span>
+            </button>
             <!-- Indicators -->
             <div class="carousel-indicators py-3">
                 <button type="button" t-attf-data-bs-target="#myCarousel{{uniq}}" data-bs-slide-to="0" class="active"/>

--- a/addons/website/views/snippets/s_carousel.xml
+++ b/addons/website/views/snippets/s_carousel.xml
@@ -61,7 +61,7 @@
                 <span class="visually-hidden">Next</span>
             </button>
             <!-- Indicators -->
-            <div class="carousel-indicators py-3">
+            <div class="carousel-indicators">
                 <button type="button" t-attf-data-bs-target="#myCarousel{{uniq}}" data-bs-slide-to="0" class="active"/>
                 <button type="button" t-attf-data-bs-target="#myCarousel{{uniq}}" data-bs-slide-to="1"/>
                 <button type="button" t-attf-data-bs-target="#myCarousel{{uniq}}" data-bs-slide-to="2"/>

--- a/addons/website/views/snippets/s_image_gallery.xml
+++ b/addons/website/views/snippets/s_image_gallery.xml
@@ -96,8 +96,8 @@
                 <we-button data-select-class="">Classic</we-button>
                 <we-button data-select-class="s_image_gallery_controllers_indicators_outside">Indicators outside</we-button>
                 <we-button data-select-class="s_image_gallery_controllers_outside">Outside, center</we-button>
-                <we-button data-select-class="s_image_gallery_controllers_outside s_image_gallery_controllers_outside_arrows_left">Outside, at left</we-button>
-                <we-button data-select-class="s_image_gallery_controllers_outside s_image_gallery_controllers_outside_arrows_right">Outside, at right</we-button>
+                <we-button data-select-class="s_image_gallery_controllers_outside s_image_gallery_controllers_outside_arrows_left">Outside, at right</we-button>
+                <we-button data-select-class="s_image_gallery_controllers_outside s_image_gallery_controllers_outside_arrows_right">Outside, at left</we-button>
             </we-select>
             <we-checkbox string="Invert colors" data-dependencies="slideshow_mode_opt" data-apply-to=".carousel" class="o_we_sublevel_1" data-select-class="carousel-dark"/>
             <we-select string="Arrows" data-dependencies="slideshow_mode_opt" class="o_we_sublevel_1">

--- a/addons/website/views/snippets/s_quotes_carousel.xml
+++ b/addons/website/views/snippets/s_quotes_carousel.xml
@@ -75,7 +75,7 @@
                 <span class="visually-hidden">Next</span>
             </button>
             <!-- Indicators -->
-            <div class="carousel-indicators s_carousel_indicators_dots">
+            <div class="carousel-indicators s_carousel_indicators_dots o_not_editable">
                 <button type="button" t-attf-data-bs-target="#myQuoteCarousel{{uniq}}" data-bs-slide-to="0" class="active"/>
                 <button type="button" t-attf-data-bs-target="#myQuoteCarousel{{uniq}}" data-bs-slide-to="1"/>
                 <button type="button" t-attf-data-bs-target="#myQuoteCarousel{{uniq}}" data-bs-slide-to="2"/>

--- a/addons/website/views/snippets/s_quotes_carousel.xml
+++ b/addons/website/views/snippets/s_quotes_carousel.xml
@@ -75,7 +75,7 @@
                 <span class="visually-hidden">Next</span>
             </button>
             <!-- Indicators -->
-            <div class="carousel-indicators s_carousel_indicators_dots py-3">
+            <div class="carousel-indicators s_carousel_indicators_dots">
                 <button type="button" t-attf-data-bs-target="#myQuoteCarousel{{uniq}}" data-bs-slide-to="0" class="active"/>
                 <button type="button" t-attf-data-bs-target="#myQuoteCarousel{{uniq}}" data-bs-slide-to="1"/>
                 <button type="button" t-attf-data-bs-target="#myQuoteCarousel{{uniq}}" data-bs-slide-to="2"/>

--- a/addons/website/views/snippets/s_quotes_carousel.xml
+++ b/addons/website/views/snippets/s_quotes_carousel.xml
@@ -9,66 +9,60 @@
             <div class="carousel-inner">
                 <!-- #01 -->
                 <div class="carousel-item active oe_img_bg o_bg_img_center pt80 pb80" style="background-image: url('/web/image/website.s_quotes_carousel_demo_image_0'); background-position: 50% 50%;" data-name="Slide">
-                    <div class="container">
-                        <blockquote data-name="Blockquote" data-snippet="s_blockquote" class="s_blockquote s_blockquote_with_icon o_cc o_cc1 o_animable position-relative d-flex flex-column gap-4 w-50 mx-auto p-5 fst-normal" data-vcss="001">
-                            <div class="s_blockquote_line_elt position-absolute top-0 start-0 bottom-0 bg-o-color-1"/>
-                            <div class="s_blockquote_wrap_icon position-absolute top-0 start-50 translate-middle w-100">
-                                <i class="s_blockquote_icon fa fa-quote-right d-block mx-auto rounded bg-o-color-1" role="img"/>
+                    <blockquote data-name="Blockquote" data-snippet="s_blockquote" class="s_blockquote s_blockquote_with_icon o_cc o_cc1 o_animable position-relative d-flex flex-column gap-4 w-50 mx-auto p-5 fst-normal" data-vcss="001">
+                        <div class="s_blockquote_line_elt position-absolute top-0 start-0 bottom-0 bg-o-color-1"/>
+                        <div class="s_blockquote_wrap_icon position-absolute top-0 start-50 translate-middle w-100">
+                            <i class="s_blockquote_icon fa fa-quote-right d-block mx-auto rounded bg-o-color-1" role="img"/>
+                        </div>
+                        <p class="s_blockquote_quote my-auto h4-fs" style="text-align:center;">" Write a quote here from one of your customers. Quotes are a great way to build confidence in your products or services. "</p>
+                        <div class="s_blockquote_infos d-flex gap-2 flex-column align-items-center w-100 text-center">
+                            <img src="/web/image/website.s_quotes_carousel_demo_image_3" class="s_blockquote_avatar img rounded-circle" alt=""/>
+                            <div class="s_blockquote_author">
+                                <span class="o_small">
+                                    <strong>Jane DOE</strong><br/>
+                                    <span class="text-muted">CEO of MyCompany</span>
+                                </span>
                             </div>
-                            <p class="s_blockquote_quote my-auto h4-fs" style="text-align:center;">" Write a quote here from one of your customers. Quotes are a great way to build confidence in your products or services. "</p>
-                            <div class="s_blockquote_infos d-flex gap-2 flex-column align-items-center w-100 text-center">
-                                <img src="/web/image/website.s_quotes_carousel_demo_image_3" class="s_blockquote_avatar img rounded-circle" alt=""/>
-                                <div class="s_blockquote_author">
-                                    <span class="o_small">
-                                        <strong>Jane DOE</strong><br/>
-                                        <span class="text-muted">CEO of MyCompany</span>
-                                    </span>
-                                </div>
-                            </div>
-                        </blockquote>
-                    </div>
+                        </div>
+                    </blockquote>
                 </div>
                 <!-- #02 -->
                 <div class="carousel-item oe_img_bg o_bg_img_center pt80 pb80" style="background-image: url('/web/image/website.s_quotes_carousel_demo_image_1'); background-position: 50% 50%;" data-name="Slide">
-                    <div class="container">
-                        <blockquote data-name="Blockquote" data-snippet="s_blockquote" class="s_blockquote s_blockquote_with_icon o_cc o_cc1 o_animable position-relative d-flex flex-column gap-4 w-50 mx-auto p-5 fst-normal" data-vcss="001">
-                            <div class="s_blockquote_line_elt position-absolute top-0 start-0 bottom-0 bg-o-color-1"/>
-                            <div class="s_blockquote_wrap_icon position-absolute top-0 start-50 translate-middle w-100">
-                                <i class="s_blockquote_icon fa fa-quote-right d-block mx-auto rounded bg-o-color-1" role="img"/>
+                    <blockquote data-name="Blockquote" data-snippet="s_blockquote" class="s_blockquote s_blockquote_with_icon o_cc o_cc1 o_animable position-relative d-flex flex-column gap-4 w-50 mx-auto p-5 fst-normal" data-vcss="001">
+                        <div class="s_blockquote_line_elt position-absolute top-0 start-0 bottom-0 bg-o-color-1"/>
+                        <div class="s_blockquote_wrap_icon position-absolute top-0 start-50 translate-middle w-100">
+                            <i class="s_blockquote_icon fa fa-quote-right d-block mx-auto rounded bg-o-color-1" role="img"/>
+                        </div>
+                        <p class="s_blockquote_quote my-auto h4-fs" style="text-align:center;">" Write a quote here from one of your customers. Quotes are a great way to build confidence in your products or services. "</p>
+                        <div class="s_blockquote_infos d-flex gap-2 flex-column align-items-center w-100 text-center">
+                            <img src="/web/image/website.s_quotes_carousel_demo_image_4" class="s_blockquote_avatar img rounded-circle" alt=""/>
+                            <div class="s_blockquote_author">
+                                <span class="o_small">
+                                    <strong>John DOE</strong><br/>
+                                    <span class="text-muted">CCO of MyCompany</span>
+                                </span>
                             </div>
-                            <p class="s_blockquote_quote my-auto h4-fs" style="text-align:center;">" Write a quote here from one of your customers. Quotes are a great way to build confidence in your products or services. "</p>
-                            <div class="s_blockquote_infos d-flex gap-2 flex-column align-items-center w-100 text-center">
-                                <img src="/web/image/website.s_quotes_carousel_demo_image_4" class="s_blockquote_avatar img rounded-circle" alt=""/>
-                                <div class="s_blockquote_author">
-                                    <span class="o_small">
-                                        <strong>John DOE</strong><br/>
-                                        <span class="text-muted">CCO of MyCompany</span>
-                                    </span>
-                                </div>
-                            </div>
-                        </blockquote>
-                    </div>
+                        </div>
+                    </blockquote>
                 </div>
                 <!-- #03 -->
                 <div class="carousel-item oe_img_bg o_bg_img_center pt80 pb80" style="background-image: url('/web/image/website.s_quotes_carousel_demo_image_2'); background-position: 50% 50%;" data-name="Slide">
-                    <div class="container">
-                        <blockquote data-name="Blockquote" data-snippet="s_blockquote" class="s_blockquote s_blockquote_with_icon o_cc o_cc1 o_animable position-relative d-flex flex-column gap-4 w-50 mx-auto p-5 fst-normal" data-vcss="001">
-                            <div class="s_blockquote_line_elt position-absolute top-0 start-0 bottom-0 bg-o-color-1"/>
-                            <div class="s_blockquote_wrap_icon position-absolute top-0 start-50 translate-middle w-100">
-                                <i class="s_blockquote_icon fa fa-quote-right d-block mx-auto rounded bg-o-color-1" role="img"/>
+                    <blockquote data-name="Blockquote" data-snippet="s_blockquote" class="s_blockquote s_blockquote_with_icon o_cc o_cc1 o_animable position-relative d-flex flex-column gap-4 w-50 mx-auto p-5 fst-normal" data-vcss="001">
+                        <div class="s_blockquote_line_elt position-absolute top-0 start-0 bottom-0 bg-o-color-1"/>
+                        <div class="s_blockquote_wrap_icon position-absolute top-0 start-50 translate-middle w-100">
+                            <i class="s_blockquote_icon fa fa-quote-right d-block mx-auto rounded bg-o-color-1" role="img"/>
+                        </div>
+                        <p class="s_blockquote_quote my-auto h4-fs" style="text-align:center;">" Write a quote here from one of your customers. Quotes are a great way to build confidence in your products or services. "</p>
+                        <div class="s_blockquote_infos d-flex gap-2 flex-column align-items-center w-100 text-center">
+                            <img src="/web/image/website.s_quotes_carousel_demo_image_5" class="s_blockquote_avatar img rounded-circle" alt=""/>
+                            <div class="s_blockquote_author">
+                                <span class="o_small">
+                                    <strong>Iris DOE</strong><br/>
+                                    <span class="text-muted">Manager of MyCompany</span>
+                                </span>
                             </div>
-                            <p class="s_blockquote_quote my-auto h4-fs" style="text-align:center;">" Write a quote here from one of your customers. Quotes are a great way to build confidence in your products or services. "</p>
-                            <div class="s_blockquote_infos d-flex gap-2 flex-column align-items-center w-100 text-center">
-                                <img src="/web/image/website.s_quotes_carousel_demo_image_5" class="s_blockquote_avatar img rounded-circle" alt=""/>
-                                <div class="s_blockquote_author">
-                                    <span class="o_small">
-                                        <strong>Iris DOE</strong><br/>
-                                        <span class="text-muted">Manager of MyCompany</span>
-                                    </span>
-                                </div>
-                            </div>
-                        </blockquote>
-                    </div>
+                        </div>
+                    </blockquote>
                 </div>
             </div>
             <!-- Controls -->

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -655,7 +655,6 @@
         <t t-set="with_images" t-value="True"/>
         <t t-set="with_videos" t-value="True"/>
         <t t-set="with_shapes" t-value="True"/>
-        <t t-set="css_compatible" t-value="True"/>
         <t t-set="with_gradients" t-value="True"/>
         <t t-set="with_color_combinations" t-value="True"/>
     </t>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -673,6 +673,7 @@
             <we-button data-select-class="s_carousel_default">Default</we-button>
             <we-button data-select-class="s_carousel_boxed">Boxed</we-button>
             <we-button data-select-class="s_carousel_rounded">Rounded</we-button>
+            <we-button data-select-class="s_carousel_arrows_hidden">Hidden</we-button>
         </we-select>
         <we-select string="Indicators" data-apply-to=".carousel-indicators" class="o_we_sublevel_1">
             <we-button data-select-class="">Bars</we-button>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -700,7 +700,7 @@
     </div>
 
     <div data-js="GalleryElement"
-        data-selector=".s_image_gallery img, .s_carousel .carousel-item">
+        data-selector=".s_image_gallery img, .s_carousel .carousel-item, .s_quotes_carousel .carousel-item">
         <we-row string="Re-order" data-no-preview="true">
             <we-button class="fa fa-fw fa-angle-double-left" title="Move to first" data-position="first"/>
             <we-button class="fa fa-fw fa-angle-left" title="Move to previous" data-position="prev"/>


### PR DESCRIPTION
This PR improves some necessary points after the carousel redesign made in https://github.com/odoo/odoo/pull/172727:

### 1. Adapt background option for carousels
Prior to this PR, there was a bug when the user tried to apply a preset color to a carousel. This was due to a conflict between `with_color_combinations` and `css_compatible` variables. The system tried to add the css variable as a class.
This PR removes this conflict.

### 2. Simplify `s_quotes_carousel` structure
Since the redesign of the `s_quotes_carousel` snippet in 3deb8050831c69ca1e32039622b322ffa38cc497, `container` divs have been added to wrap blockquotes in order to maintain a consistent structure with the `s_carousel` snippet. But as the blockquote block is not editable like a column in the `s_carousel` snippet, these `container` divs are unnecessary and also add unwanted horizontal padding.
This PR simplifies the `s_quotes_carousel` by removing these unnecessary `container` divs.

### 3. Move arrows outside `carousel-inner` in `s_carousel`
This PR moves the arrows outside `.carousel-inner` to maintain consistency with `s_quotes_carousel` and the carousel structure provided by Bootstrap.

### 4. Adapt labels of "Style" option for `s_image_gallery`
Prior to this PR, labels "Outside, at left" and "Outside, at right" were confusing as to what they actually meant. In fact, the user could expect the indicators to be placed outside, on the left, but these elements were then placed on the right or vice versa. 
This PR reverses the two labels to avoid confusion.

### 5. Invert "boxed" and "rounded" colors of carousel arrows
Prior to this PR, the colors of "boxed" and "rounded" arrows were inconsistent with the color of the indicators (eg. black background with white indicators). This also created an issue of readability, depending on the background the arrows or indicators were not really visible.
This PR reverses the colors of the "boxed" and "rounded" arrows to make them more consistent with the indicators.

### 6. Allow to hide carousel arrows
This PR adds the ability for the user to hide the arrows in the carousel snippets.

### 7. Adapt controllers in mobile
Prior to this PR, arrows were always hidden on mobile. If the user hid the indicators, there were no controllers to indicate to the user that he could swap to change slides.
This PR allows the arrows to be displayed on mobile and adapts their position.

### 8. Adapt default arrow size
This PR standardizes the size of arrows between the different designs (default, boxed, rounded) to maintain consistency.

### 9. Review width of default arrows
Prior to this PR, the default arrow width and horizontal padding of carousel slides were different (10% and 15%). This created a gap between the arrows and the slide content, preventing the content from reaching its full width.
This PR adapts the property values of these elements to fit them correctly

### 10. Optimize variables
This PR optimizes the code by using SCSS variables instead of CSS variables.

### 11. Adjust `s_image_gallery` arrow height
Prior to this PR, the height of the arrows wasn't correct when "Style" was set on "Indicators outside" and the indicators were "Hidden".

This PR adapts the height of arrows correctly.

### 12. Allow to reorder slides in `s_quotes_carousel`
This PR allows slides in `s_quotes_carousel` to be reorganized in the same way as in `s_carousel`.

---

task-4167538
Part of task-3619705

---

Requires:
- https://github.com/odoo/design-themes/pull/898


---

1. Adapt background option for carousels

| Before | After |
|--------|--------|
| <img width="1790" alt="Capture d’écran 2024-09-05 à 16 58 20" src="https://github.com/user-attachments/assets/43af1c4c-c51f-459f-8889-83cbd40ea700"> | <img width="1791" alt="Capture d’écran 2024-09-05 à 16 59 04" src="https://github.com/user-attachments/assets/f0cbbadf-5b11-4684-8b1d-4af34d5c8d81"> |

4. Adapt labels of "Style" option for `s_image_gallery`

| Before | After |
|--------|--------|
| <img width="1791" alt="Capture d’écran 2024-09-05 à 17 00 58" src="https://github.com/user-attachments/assets/0ee5578d-8c6c-4304-b4ac-073f4646a054"> | <img width="1792" alt="Capture d’écran 2024-09-05 à 17 01 20" src="https://github.com/user-attachments/assets/19f56e1a-bea9-4c1f-8228-96550762f128"> |

5. Invert "boxed" and "rounded" colors of carousel arrows

| Before | After |
|--------|--------|
| <img width="1501" alt="Capture d’écran 2024-09-05 à 17 03 25" src="https://github.com/user-attachments/assets/f11f59d2-2b79-40e9-980b-986379bcb569"> | <img width="1500" alt="Capture d’écran 2024-09-05 à 17 03 41" src="https://github.com/user-attachments/assets/3d67d8e3-bb1f-4e1d-8e54-70b1117431bc"> |

6. Allow to hide carousel arrows

| Before | After |
|--------|--------|
| <img width="1787" alt="Capture d’écran 2024-09-05 à 17 04 39" src="https://github.com/user-attachments/assets/9651aef5-8fca-406d-af2c-d08d0feb244c"> | <img width="1789" alt="Capture d’écran 2024-09-05 à 17 04 59" src="https://github.com/user-attachments/assets/2bcb9315-05a1-41c0-a604-68649650cf0e"> |

7. Adapt controllers in mobile

| Before | After |
|--------|--------|
| <img width="463" alt="Capture d’écran 2024-09-05 à 17 06 26" src="https://github.com/user-attachments/assets/48624b82-cd1d-4e83-9ffe-a34efbaccdd8"> | <img width="446" alt="Capture d’écran 2024-09-05 à 17 06 57" src="https://github.com/user-attachments/assets/acff51e2-8720-44e8-89d4-2c8eadcd9785"> |

9. Review width of default arrows

| Before | After |
|--------|--------|
| <img width="461" alt="Capture d’écran 2024-09-05 à 17 08 27" src="https://github.com/user-attachments/assets/22dd6432-a024-4636-993a-c1343fb566d1"> | <img width="440" alt="Capture d’écran 2024-09-05 à 17 08 47" src="https://github.com/user-attachments/assets/5bbe556e-d0ca-4eaf-943a-6c68eec7bbd1"> |

11. Ajust `s_image_gallery` arrow height

| Before | After |
|--------|--------|
| <img width="719" alt="Capture d’écran 2024-09-10 à 14 32 35" src="https://github.com/user-attachments/assets/015fe2ec-2b26-4499-87fd-e20a59569995"> | <img width="734" alt="Capture d’écran 2024-09-10 à 14 34 55" src="https://github.com/user-attachments/assets/213292b8-e0a3-4af3-97b4-ebbc5cf436e9"> |

12. Allow to reorder slides in `s_quotes_carousel`

| Before | After |
|--------|--------|
| <img width="290" alt="Capture d’écran 2024-09-05 à 17 16 18" src="https://github.com/user-attachments/assets/5a07c8f6-8cf5-4cc6-813f-721d2a244a01"> | <img width="279" alt="Capture d’écran 2024-09-05 à 17 16 35" src="https://github.com/user-attachments/assets/2fa73bbc-68fe-44dc-be35-4b92b7c11985"> |






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
