### PR TITLE
[FIX] mail: notification message in thread are too big

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.Message">
-        <div t-if="message.isNotification" class="o-mail-NotificationMessage text-break mx-auto text-500 px-3 text-center" t-on-click="onClickNotificationMessage"  t-att-class="props.className" t-ref="root">
+        <div t-if="message.isNotification" class="o-mail-NotificationMessage text-break mx-auto text-500 px-3 text-center smaller" t-on-click="onClickNotificationMessage"  t-att-class="props.className" t-ref="root">
             <i t-if="message.notificationIcon" t-attf-class="{{ message.notificationIcon }} me-1"/>
             <span class="o-mail-NotificationMessage-author d-inline" t-if="message.author and !message.body.includes(escape(message.author.name))" t-esc="message.author.name"/> <t t-out="message.body"/>
         </div>


### PR DESCRIPTION
Before this commit, the notification message in a thread such as when pinning a new message or starting a call were too big, which makes them too distracting compared to messages.

This commit makes them smaller.

Before
<img width="512" alt="Screenshot 2024-09-05 at 17 06 17" src="https://github.com/user-attachments/assets/d1fed1e1-6bb8-48a1-a374-4c993b4201a5">
After
<img width="509" alt="Screenshot 2024-09-05 at 17 03 56" src="https://github.com/user-attachments/assets/1093f616-56b5-4499-a51c-649f20e17f71">
