### PR TITLE
[FIX] point_of_sale: correct extra price computation for variants

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -439,10 +439,9 @@ export class PosStore extends Reactive {
         return {
             attribute_value_ids: attributeLinesValues.map((values) => values[0].id),
             attribute_custom_values: [],
-            price_extra: attributeLinesValues.reduce(
-                (acc, values) => acc + values[0].price_extra,
-                0
-            ),
+            price_extra: attributeLinesValues
+                .filter((attr) => attr[0].attribute_id.create_variant !== "always")
+                .reduce((acc, values) => acc + values[0].price_extra, 0),
             quantity: 1,
         };
     }
@@ -551,7 +550,9 @@ export class PosStore extends Reactive {
                             if (productFound) {
                                 const attr =
                                     this.data.models["product.template.attribute.value"].get(a);
-                                return attr.is_custom;
+                                return (
+                                    attr.is_custom || attr.attribute_id.create_variant !== "always"
+                                );
                             }
                             return true;
                         })
@@ -573,7 +574,7 @@ export class PosStore extends Reactive {
                             ];
                         }
                     ),
-                    price_extra: productFound ? 0 : values.price_extra + payload.price_extra,
+                    price_extra: values.price_extra + payload.price_extra,
                     qty: payload.qty || values.qty,
                     product_id: productFound || values.product_id,
                 });
@@ -582,10 +583,9 @@ export class PosStore extends Reactive {
             }
         } else if (values.product_id.product_template_variant_value_ids.length > 0) {
             // Verify price extra of variant products
-            const priceExtra = values.product_id.product_template_variant_value_ids.reduce(
-                (acc, attr) => acc + attr.price_extra,
-                0
-            );
+            const priceExtra = values.product_id.product_template_variant_value_ids
+                .filter((attr) => attr.attribute_id.create_variant !== "always")
+                .reduce((acc, attr) => acc + attr.price_extra, 0);
             values.price_extra += priceExtra;
         }
 

--- a/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.js
@@ -137,8 +137,10 @@ export class ProductConfiguratorPopup extends Component {
                 // for custom values, it will never be a multiple attribute
                 attribute_custom_values[valueIds[0]] = custom_value;
             }
-
-            price_extra += extra;
+            const attr = this.pos.data.models["product.template.attribute.value"].get(valueIds[0]);
+            if (attr && attr.attribute_id.create_variant !== "always") {
+                price_extra += extra;
+            }
         });
 
         attribute_value_ids = attribute_value_ids.flat();


### PR DESCRIPTION
Before this commit, when adding a product variant with an attribute that does not trigger variant creation (create_variant !== "always"), the system failed to include the extra price of this attribute if another attribute with variant creation mode was present. Additionally, for variants of an attribute that triggers variant creation and is added by a barcode, the it would computed the extra price twice.

opw-4151754

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
