### PR TITLE
[FIX] im_livechat: res.users create right with erp_manager


### DIFF
--- a/addons/im_livechat/models/res_users.py
+++ b/addons/im_livechat/models/res_users.py
@@ -29,9 +29,8 @@ class Users(models.Model):
 
     def _inverse_livechat_username(self):
         for user in self:
-            if not user.res_users_settings_id:
-                self.env['res.users.settings']._find_or_create_for_user(user)
-            user.res_users_settings_id.livechat_username = user.livechat_username
+            settings = self.env['res.users.settings']._find_or_create_for_user(user)
+            settings.livechat_username = user.livechat_username
 
     @api.depends('res_users_settings_id.livechat_lang_ids')
     def _compute_livechat_lang_ids(self):
@@ -40,9 +39,8 @@ class Users(models.Model):
 
     def _inverse_livechat_lang_ids(self):
         for user in self:
-            if not user.res_users_settings_id:
-                self.env['res.users.settings']._find_or_create_for_user(user)
-            user.res_users_settings_id.livechat_lang_ids = user.livechat_lang_ids
+            settings = self.env['res.users.settings']._find_or_create_for_user(user)
+            settings.livechat_lang_ids = user.livechat_lang_ids
 
     def _compute_has_access_livechat(self):
         for user in self:

--- a/addons/im_livechat/tests/__init__.py
+++ b/addons/im_livechat/tests/__init__.py
@@ -13,4 +13,5 @@ from . import test_im_livechat_support_page
 from . import test_js
 from . import test_message
 from . import test_upload_attachment
+from . import test_res_users
 from . import test_session_history

--- a/addons/im_livechat/tests/test_res_users.py
+++ b/addons/im_livechat/tests/test_res_users.py
@@ -1,0 +1,20 @@
+from odoo.tests import new_test_user
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestLiveChatResUsers(TransactionCase):
+
+    def test_livechat_create_res_users(self):
+        access_user = new_test_user(
+            self.env,
+            login="admin_access",
+            name="admin_access",
+            groups="base.group_erp_manager,base.group_partner_manager",
+        )
+        access_user.with_user(access_user.id).create({
+            "login": "test_can_be_created",
+            "name": "test_can_be_created",
+            "livechat_username": False,
+            "livechat_lang_ids": [],
+        })


### PR DESCRIPTION

Scenario:

- install im_livechat
- create a new user with a user that has base.group_erp_manager
  (Administration > Access Rights)

=> Access Error because user doesn't have write access to
   res.users.settings record.

Why:

res.users.settings model requires base.group_system to be able to write
on records of other users, but the res.users method _inverse_livechat_username
and _inverse_livechat_lang_ids are writing on it with current users.

Fix:

Use the return value of `res.users.settings()._find_or_create_for_user` for
writing since they are returned in superuser mode.

opw-4157859
