### PR TITLE
[IMP] http: allow deactivating generation of res.device.log per session

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1134,6 +1134,16 @@ class Session(collections.abc.MutableMapping):
         """
             :return: dict if a device log has to be inserted, ``None`` otherwise
         """
+        if self._trace_disable:
+            # To avoid generating useless logs, e.g. for automated technical sessions,
+            # a session can be flagged with `_trace_disable`. This should never be done
+            # without a proper assessment of the consequences for auditability.
+            # Non-admin users have no direct or indirect way to set this flag, so it can't
+            # be abused by unprivileged users. Such sessions will of course still be
+            # subject to all other auditing mechanisms (server logs, web proxy logs,
+            # metadata tracking on modified records, etc.)
+            return
+
         user_agent = request.httprequest.user_agent
         platform = user_agent.platform
         browser = user_agent.browser


### PR DESCRIPTION
In some situations it is useful to avoid generating useless device logs, e.g. for automated technical sessions, platform-generated request, etc.

This commit introduces support for a `_trace_disable` session flag to do so. This should never be done without a proper assessment of the consequences for auditability, as seen from the user's point of view.

Note that non-admin users have no direct or indirect way to set this flag, so it shouldn't be an extra security risk. Privileged users would have different technical ways to set it, but they could just as easily delete the generated logs or modify them.

Also noteworthy: such sessions will of course still be subject to all other auditing mechanisms (server logs, web proxy logs, metadata tracking on modified records, etc.)
