### PR TITLE
[IMP] mail: make emoji reaction slightly bigger

### DIFF
--- a/addons/mail/static/src/core/common/message_reaction_list.scss
+++ b/addons/mail/static/src/core/common/message_reaction_list.scss
@@ -1,5 +1,7 @@
-.o-mail-MessageReaction:not(.o-selfReacted) {
-    &:hover {
+.o-mail-MessageReaction {
+    line-height: 1.25;
+    
+    &:not(.o-selfReacted):hover {
         --border-color: #{$primary};
     }
 }

--- a/addons/mail/static/src/core/common/message_reaction_list.xml
+++ b/addons/mail/static/src/core/common/message_reaction_list.xml
@@ -10,14 +10,14 @@
     </t>
     
     <t t-name="mail.MessageReactionList.button">
-        <button class="position-relative o-mail-MessageReaction btn d-flex p-0 border rounded-2 mb-1" t-on-click="() => this.onClickReaction(props.reaction)" t-on-contextmenu="onContextMenu" t-ref="reactionButton" t-att-class="{
-            'o-selfReacted border-primary text-primary fw-bolder': hasSelfReacted(props.reaction),
+        <button class="position-relative o-mail-MessageReaction btn d-flex p-0 border rounded-2 mb-1 fs-4 px-1 gap-1 align-items-center" t-on-click="() => this.onClickReaction(props.reaction)" t-on-contextmenu="onContextMenu" t-ref="reactionButton" t-att-class="{
+            'o-selfReacted border-primary text-primary fw-bold': hasSelfReacted(props.reaction),
             'bg-view': !hasSelfReacted(props.reaction),
             'ms-1': env.inChatWindow and env.alignedRight,
             'me-1': !(env.inChatWindow and env.alignedRight),
         }">
-            <span class="mx-1" t-esc="props.reaction.content" />
-            <span class="mx-1" t-esc="props.reaction.count" />
+            <span t-esc="props.reaction.content"/>
+            <span class="small" t-esc="props.reaction.count"/>
         </button>
     </t>
     

--- a/addons/mail/static/src/core/common/message_reactions.scss
+++ b/addons/mail/static/src/core/common/message_reactions.scss
@@ -3,5 +3,6 @@
 }
 
 .o-mail-MessageReaction.o-selfReacted {
+    --border-opacity: 0.75;
     background: mix($o-brand-primary, $o-view-background-color, 10%);
 }

--- a/addons/mail/static/src/core/common/message_reactions.xml
+++ b/addons/mail/static/src/core/common/message_reactions.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
 <t t-name="mail.MessageReactions">
-    <div class="o-mail-MessageReactions position-relative d-flex flex-wrap"
+    <div class="o-mail-MessageReactions position-relative d-flex flex-wrap mt-n1"
         t-att-class="{
             'flex-row-reverse me-3': env.inChatWindow and env.alignedRight,
             'ms-3': !(env.inChatWindow and env.alignedRight) and (props.message.is_discussion),
             'o-emojiPickerOpen': emojiPicker.isOpen,
-        }"
-        t-attf-class="{{ props.message.is_discussion ? 'mt-n1' : 'mt-1' }}">
+        }">
         <t t-foreach="props.message.reactions" t-as="reaction" t-key="reaction.content">
             <MessageReactionList message="this.props.message" openReactionMenu="this.props.openReactionMenu" reaction="reaction"/>
         </t>


### PR DESCRIPTION
Before this commit, message reactions were a bit hard to read. This comes from emoji being quite small.

The container of a single message reaction is good, but the emoji and text are too small. There's padding around that can be removed, so that emoji and counter can be bigger for a similarly sized container.

This commit fixes the issue by making emoji and counter bigger, while keeping a roughly similarly sized container.

Before / After
<img width="250" alt="Screenshot 2024-09-05 at 18 44 30" src="https://github.com/user-attachments/assets/1d1f5e41-4042-4121-b86d-30dc60ddd379"> <img width="244" alt="Screenshot 2024-09-05 at 18 40 12" src="https://github.com/user-attachments/assets/e8575dc5-e1f4-4b40-bd6f-39bc75c70ff0">

