### PR TITLE
[FIX] web: Recompute is_favorite properly when using boolean_favorite widget

### DIFF
--- a/addons/web/static/src/views/fields/boolean_favorite/boolean_favorite_field.js
+++ b/addons/web/static/src/views/fields/boolean_favorite/boolean_favorite_field.js
@@ -21,6 +21,7 @@ export class BooleanFavoriteField extends Component {
     async update() {
         const changes = { [this.props.name]: !this.props.record.data[this.props.name] };
         await this.props.record.update(changes, { save: this.props.autosave });
+        await this.props.record.update(changes, { save: false });
     }
 }
 


### PR DESCRIPTION
The issue:
When setting an automation rule to trigger 'On Save' onto a model with the boolean_favorite widget (i.e. project), the display will not update the icon properly when attempting to toggle it. This is due to base_automation populating the old_values which will attempt to read is_favorite, triggering a recomputation before favorite_user_ids is updated.

The Fix:
Retrigger the update without saving. This will force is_favorite to recompute again with the updated favorite_user_ids value and the display will stay consistent with the status of the widget.

OPW: 4106799

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
