### PR TITLE
[FIX] website: fix warning for unused t-key in list_hybrid template

### DIFF
--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2679,7 +2679,7 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
                     </div>
                 </t>
                 <div t-if="results" class="table-responsive">
-                    <t t-call="website.one_hybrid" t-foreach="results" t-as="result" t-key="result_index"/>
+                    <t t-call="website.one_hybrid" t-foreach="results" t-as="result"/>
                 </div>
                 <div t-if="pager" class="o_portal_pager d-flex justify-content-center">
                     <t t-call="website.pager"/>


### PR DESCRIPTION
This commit fixes a warning raised each time a user runs a search on a website where the results are listed using the list_hybrid template from website/views/website_templates.xml.

As the warning points out, the t-key directive is unused.

**Warning prior to this fix:**

Unknown directives or unused attributes: ["t-key"] in website.list_hybrid

**Expected behaviour after this fix:**

No more warning and no functionality is lost.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
