### PR TITLE
[IMP] sale,website_sale: replace cart recovery into general action

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -989,23 +989,37 @@ class SaleOrder(models.Model):
 
     def action_quotation_send(self):
         """ Opens a wizard to compose an email, with relevant mail template loaded by default """
-        self.ensure_one()
-        self.order_line._validate_analytic_distribution()
+        self.filtered(lambda so: so.state in ('draft', 'sent')).order_line._validate_analytic_distribution()
         lang = self.env.context.get('lang')
-        mail_template = self._find_mail_template()
-        if mail_template and mail_template.lang:
-            lang = mail_template._render_lang(self.ids)[self.id]
+
         ctx = {
             'default_model': 'sale.order',
             'default_res_ids': self.ids,
-            'default_template_id': mail_template.id if mail_template else None,
             'default_composition_mode': 'comment',
-            'mark_so_as_sent': True,
             'default_email_layout_xmlid': 'mail.mail_notification_layout_with_responsible_signature',
             'proforma': self.env.context.get('proforma', False),
-            'force_email': True,
-            'model_description': self.with_context(lang=lang).type_name,
         }
+
+        if len(self) > 1:
+            ctx['default_composition_mode'] = 'mass_mail'
+        else:
+            ctx.update({
+                'force_email': True,
+                'model_description': self.with_context(lang=lang).type_name,
+            })
+            if not self.env.context.get('hide_default_template'):
+                mail_template = self._find_mail_template()
+                if mail_template:
+                    ctx.update({
+                        'default_template_id': mail_template.id,
+                        'mark_so_as_sent': True,
+                    })
+                if mail_template and mail_template.lang:
+                    lang = mail_template._render_lang(self.ids)[self.id]
+            else:
+                for order in self:
+                    order._portal_ensure_token()
+
         action = {
             'type': 'ir.actions.act_window',
             'view_mode': 'form',

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -1100,4 +1100,17 @@
         <field name="state">code</field>
         <field name="code">action = records.action_share()</field>
     </record>
+
+    <record id="model_sale_order_send_mail" model="ir.actions.server">
+        <field name="name">Send an email</field>
+        <field name="model_id" ref="sale.model_sale_order"/>
+        <field name="sequence">1</field>
+        <field name="binding_model_id" ref="sale.model_sale_order"/>
+        <field name="binding_view_types">list,form</field>
+        <field name="state">code</field>
+        <field name="code">
+            if records:
+                action = records.with_context(hide_default_template=True).action_quotation_send()
+        </field>
+    </record>
 </odoo>

--- a/addons/website_sale/static/tests/tours/website_sale_shop_cart_recovery.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_cart_recovery.js
@@ -42,9 +42,19 @@ registry.category("web_tour.tours").add('shop_cart_recovery', {
         run: "click",
     },
     {
-        content: "click Send a Cart Recovery Email",
-        trigger: "span:contains(/^Send a Cart Recovery Email$/)",
+        content: "click Send an Email",
+        trigger: "span:contains(/^Send an email$/)",
         run: "click",
+    },
+    {
+        content: "select template",
+        trigger: ".mail-composer-template-dropdown-btn",
+        run: "click",
+    },
+    {
+        content: 'Select the "Ecommerce: Cart Recovery" template from the list.',
+        trigger: '.mail-composer-template-dropdown.popover .o-dropdown-item:contains("Ecommerce: Cart Recovery")',
+        run: 'click'
     },
     {
         content: "click Send email",

--- a/addons/website_sale/views/sale_order_views.xml
+++ b/addons/website_sale/views/sale_order_views.xml
@@ -134,17 +134,6 @@
     </record>
 
     <!-- Server action to send multiple recovery email-->
-    <record id="ir_actions_server_sale_cart_recovery_email" model="ir.actions.server">
-        <field name="name">Send a Cart Recovery Email</field>
-        <field name="model_id" ref="model_sale_order"/>
-        <field name="state">code</field>
-        <field name="code">
-            if records:
-                action = records.action_recovery_email_send()
-        </field>
-        <field name="binding_model_id" ref="sale.model_sale_order"/>
-        <field name="binding_view_types">list,form</field>
-    </record>
 
     <record id="action_view_unpaid_quotation_tree" model="ir.actions.act_window">
         <field name="name">Unpaid Orders</field>


### PR DESCRIPTION
In this commit, The 'Send Cart Recovery Email' action has been removed and merged into this general email action to simplify things. Now, when you open the email wizard, no template is pre-selected, so user can create custom messages.

task-4102978
