### PR TITLE
[FIX] website: hide mega menu link if its content is not visible

### DIFF
--- a/addons/website/static/src/js/content/inject_dom.js
+++ b/addons/website/static/src/js/content/inject_dom.js
@@ -3,6 +3,10 @@
 import { cookie as cookieManager } from "@web/core/browser/cookie";
 import { session } from "@web/session";
 
+function getClosestLiEls(selector) {
+    return Array.from(document.querySelectorAll(selector), (el) => el.closest("li"));
+}
+
 /**
  * Unhide elements that are hidden by default and that should be visible
  * according to the snippet visibility option.
@@ -14,7 +18,24 @@ export function unhideConditionalElements() {
     styleEl.id = "conditional_visibility";
     document.head.appendChild(styleEl);
     const conditionalEls = document.querySelectorAll('[data-visibility="conditional"]');
+
+    const desktopMegaMenuLiEls = getClosestLiEls(
+        "header#top nav:not(.o_header_mobile) .o_mega_menu_toggle"
+    );
+    const mobileMegaMenuLiEls = getClosestLiEls(
+        "header#top nav.o_header_mobile .o_mega_menu_toggle"
+    );
     for (const conditionalEl of conditionalEls) {
+        // For mega menu block, add conditional visibility to the navbar link
+        if (conditionalEl.parentElement.classList.contains("o_mega_menu")) {
+            const desktopMegaMenuLiEl = conditionalEl.closest("li");
+            const index = desktopMegaMenuLiEls.indexOf(desktopMegaMenuLiEl);
+            const mobileMegaMenuLiEl = mobileMegaMenuLiEls[index];
+
+            const visibilityId = conditionalEl.dataset.visibilityId;
+            desktopMegaMenuLiEl.dataset.visibilityId = visibilityId;
+            mobileMegaMenuLiEl.dataset.visibilityId = visibilityId;
+        }
         const selectors = conditionalEl.dataset.visibilitySelectors;
         styleEl.sheet.insertRule(`${selectors} { display: none !important; }`);
     }
@@ -53,4 +74,29 @@ document.addEventListener('DOMContentLoaded', () => {
     htmlEl.dataset.logged = !session.is_website_user;
 
     unhideConditionalElements();
+
+    document
+        .querySelectorAll(".o_mega_menu > section.o_snippet_desktop_invisible")
+        .forEach((el) => el.closest("li").classList.add("hidden_mega_menu_li"));
+
+    const mobileInvisibleMegaMenuLiEls = getClosestLiEls(
+        ".o_mega_menu > section.o_snippet_mobile_invisible"
+    );
+    if (!mobileInvisibleMegaMenuLiEls.length) {
+        return;
+    }
+
+    // Since Mega Menus are located in the desktop header at first, we need
+    // to get the indices of the mega menu elements to hide the correct one
+    // in mobile
+    const desktopMegaMenuLiEls = getClosestLiEls(
+        "header#top nav:not(.o_header_mobile) .o_mega_menu_toggle"
+    );
+    const mobileMegaMenuLiEls = getClosestLiEls(
+        "header#top nav.o_header_mobile .o_mega_menu_toggle"
+    );
+    for (const mobileInvisibleMegaMenuLiEl of mobileInvisibleMegaMenuLiEls) {
+        const index = desktopMegaMenuLiEls.indexOf(mobileInvisibleMegaMenuLiEl);
+        mobileMegaMenuLiEls[index].classList.add("hidden_mega_menu_li");
+    }
 });

--- a/addons/website/static/src/scss/website.edit_mode.scss
+++ b/addons/website/static/src/scss/website.edit_mode.scss
@@ -331,3 +331,10 @@ body.editor_enable {
         color: white !important;
     }
 }
+
+// mega_menu nav
+body.editor_enable {
+    .hidden_mega_menu_li {
+        display: block !important;
+    }
+}

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1509,6 +1509,10 @@ header {
             display: none;
         }
     }
+
+    .hidden_mega_menu_li {
+        display: none;
+    }
 }
 
 @if o-website-value('header-template') == 'sidebar' {

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -762,3 +762,6 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_header_color_and_undo_redo_issue(self):
         self.start_tour("/", "undo_redo_header_oriented_issue", login="admin")
+
+    def test_website_edit_megamenu_visibility(self):
+        self.start_tour("/", 'edit_megamenu_visibility', login='admin')


### PR DESCRIPTION
Before this commit, when setting the mega menu content visibility, the
navbar link would still appear even if the user does not have access
to the mega menu content.

This commit hides the navbar link for the mega menu in the mobile and
desktop view when the user does not have access to the mega menu
content, in order to prevent unnecessary elements in the navbar.

Steps to reproduce the bug:
- Add a mega menu element in the navbar
- Open the mega menu
- Set the mega menu content visibility to conditional (logged in)
- Open the website while logged out
(The mega menu link is here but the content is not displayed. However,
the dropdown is still opened but it is empty.)

task-3992066