### PR TITLE
[FIX] website_sale: use website for product base_url microdata tags

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -936,7 +936,9 @@
                             <t t-call="website_sale.shop_product_images"/>
                         </div>
                         <div t-attf-class="col-lg-#{image_cols[1]} mt-md-4" id="product_details">
-                            <t t-set="base_url" t-value="product.get_base_url()"/>
+                            <t t-set="base_url" t-value="website.get_base_url()"/>
+                            <!-- TODO: remove next line in master. Stable fix not to break custos. -->
+                            <t t-if="False" t-set="base_url" t-value="product.get_base_url()"/>
                             <h1 itemprop="name" t-field="product.name">Product Name</h1>
                             <span itemprop="url" style="display:none;" t-esc="base_url + product.website_url"/>
                             <span itemprop="image" style="display:none;" t-esc="base_url + website.image_url(product, 'image_1920')" />


### PR DESCRIPTION
Steps to reproduce:
- Create 2 websites and give them a different domain
- Go to any product page (shared between all websites)
- Check the source code with https://validator.schema.org/: the URL and image microdata start with the wrong domain.
=> Case 1: if no company_id was set on the product, the URL returns `web.base.url`.
=> Case 2: if a company_id is set and that company has a website_id set, both websites return the company's website domain.

This commit makes sure to return the current website domain.

opw-4113559