### PR TITLE
[IMP] payment: remove o_kanban_dashboard class

### DIFF
--- a/addons/payment/views/payment_provider_views.xml
+++ b/addons/payment/views/payment_provider_views.xml
@@ -136,7 +136,7 @@
         <field name="name">payment.provider.kanban</field>
         <field name="model">payment.provider</field>
         <field name="arch" type="xml">
-            <kanban create="false" quick_create="false" class="o_kanban_dashboard">
+            <kanban create="false" quick_create="false">
                 <field name="is_published"/>
                 <field name="module_id"/>
                 <field name="module_state"/>


### PR DESCRIPTION
With the simplification of the new Kanban architecture, the `o_kanban_dashboard` class is no longer needed and can be removed.

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr