### PR TITLE
[FIX] web: prevent error on hovering reporting

### DIFF
--- a/addons/web/static/src/libs/bootstrap.js
+++ b/addons/web/static/src/libs/bootstrap.js
@@ -58,7 +58,7 @@ const bootstrapShowFunction = Tooltip.prototype.show;
 Tooltip.prototype.show = function () {
     // Overwrite bootstrap tooltip method to prevent showing 2 tooltip at the
     // same time
-    $(".tooltip").remove();
+    document.querySelectorAll(".tooltip").forEach((el) => el.remove());
     const errorsToIgnore = ["Please use show on visible elements"];
     try {
         return bootstrapShowFunction.call(this);


### PR DESCRIPTION
Steps to reproduce
1. Go to the social feed 
2. Add a stream
3. Hover on the reporting /insight tab 
4. Traceback occurs

Technical Reason:
Removed jQuery, which caused a ReferenceError, replaced jQuery with vanilla JavaScript to resolve the issue and improve performance.

After this commit:
No traceback will occur while hovering.

Task-4166306