### PR TITLE
[IMP] point_of_sale: allow opening control when offline

### DIFF
--- a/addons/point_of_sale/static/src/app/store/cash_opening_popup/cash_opening_popup.js
+++ b/addons/point_of_sale/static/src/app/store/cash_opening_popup/cash_opening_popup.js
@@ -33,11 +33,13 @@ export class CashOpeningPopup extends Component {
     }
     confirm() {
         this.pos.session.state = "opened";
-        this.pos.data.call("pos.session", "set_cashbox_pos", [
-            this.pos.session.id,
-            parseFloat(this.state.openingCash),
-            this.state.notes,
-        ]);
+        this.pos.data.call(
+            "pos.session",
+            "set_cashbox_pos",
+            [this.pos.session.id, parseFloat(this.state.openingCash), this.state.notes],
+            {},
+            true
+        );
         this.props.close();
     }
     async openDetailsPopup() {


### PR DESCRIPTION
Before, it was not possible to handle opening control when offline because that request wasn't queued.

Now, we queue the request and we handle it when the connection is back.

taskId: 4161223

