### PR TITLE
[FIX] base: add unique id shared between device logs

### DIFF
--- a/odoo/addons/base/models/res_device.py
+++ b/odoo/addons/base/models/res_device.py
@@ -153,7 +153,30 @@ class ResDevice(models.Model):
 
     @api.model
     def _select(self):
-        return "SELECT DISTINCT ON (D.user_id, D.session_identifier, D.platform, D.browser) D.*"
+        return """
+            SELECT DISTINCT ON (D.user_id, D.session_identifier, D.platform, D.browser)
+            abs(hashtext(
+                D.session_identifier || '_' ||
+                COALESCE(D.platform, 'unknown') || '_' ||
+                COALESCE(D.browser, 'unknown')
+            )) AS id,
+            D.session_identifier AS session_identifier,
+            D.platform AS platform,
+            D.browser AS browser,
+            D.ip_address AS ip_address,
+            D.country AS country,
+            D.city AS city,
+            D.device_type AS device_type,
+            D.user_id AS user_id,
+            D.first_activity AS first_activity,
+            D.last_activity AS last_activity,
+            D.revoked AS revoked,
+
+            D.create_date AS create_date,
+            D.create_uid AS create_uid,
+            D.write_date AS write_date,
+            D.write_uid AS write_uid
+        """
 
     @api.model
     def _from(self):


### PR DESCRIPTION
Issue:
------
The `res.device` view is a view that deduplicates records from the `res.device.log` model. Records from `res.device.log` are added over time (and removed with garbage collector).

The ids of `res.device` records are the ids of the corresponding `res.device.log` records.

For a given device (session identifier, platform, browser), when we deduplicate, we find a `res.device.log` record with id `X`.
If other operations are performed which update the logs, we will obtain a new result for deduplication and therefore find a `res.device.log` record with id `Y` .

If we want to access the information for the device whose id is the same as the associated log (`X`), if the information is not cached, we will re-run the view query (no-materialized). In the resulting table, we won't find the `X` id and this will trigger the error: `"Record does not exist or has been deleted."`.

Solution:
---------
The `res.device` records must have a unique id that can be shared between logs from the same device (over several transactions).
So that in the example, the device has an id which is equal to the result of a deterministic function whose logs X and Y find the same result (and can therefore access the information).