### PR TITLE
[FIX] pos_restaurant: no sync when switch table

### DIFF
--- a/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
@@ -181,6 +181,7 @@ patch(Navbar.prototype, {
         }
         this.pos.selectedTable = null;
         this.pos.searchProductWord = "";
+        await this.pos.syncAllOrders();
         if (table) {
             await this.pos.setTableFromUi(table);
         } else {


### PR DESCRIPTION
Before this commit, when switching from an order to another through the table switcher, the order was not synced with the server and all the changes were forgotten.

task-id: 4169490

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
