### PR TITLE
[FIX] website_blog: resolve scroll to content traceback on blog page

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -5927,10 +5927,8 @@ registry.SnippetMove = SnippetOptionWidget.extend(ColumnLayoutMixin, {
             const hidden = elTop < 0 || bottomHidden;
             if (hidden) {
                 scrollTo(this.$target[0], {
-                    extraOffset: 50,
-                    forcedOffset: bottomHidden ? heightDiff - 50 : undefined,
-                    easing: 'linear',
-                    duration: 500,
+                    offset: 50,
+                    behavior: "smooth",
                 });
             }
         }

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -8858,45 +8858,6 @@ registry.BackgroundPosition = SnippetOptionWidget.extend({
         this.$target.css('background-size', widgetValue !== 'repeat-pattern' ? '' : '100px');
     },
     /**
-     * Saves current background position and enables overlay.
-     *
-     * @see this.selectClass for params
-     */
-    backgroundPositionOverlay: async function (previewMode, widgetValue, params) {
-        // Updates the internal image
-        await new Promise(resolve => {
-            this.img = document.createElement('img');
-            this.img.addEventListener('load', () => resolve());
-            this.img.src = getBgImageURL(this.$target[0]);
-        });
-
-        const position = this.$target.css('background-position').split(' ').map(v => parseInt(v));
-        const delta = this._getBackgroundDelta();
-        // originalPosition kept in % for when movement in one direction doesn't make sense
-        this.originalPosition = {
-            left: position[0],
-            top: position[1],
-        };
-        // Convert % values to pixels for current position because mouse movement is in pixels
-        this.currentPosition = {
-            left: position[0] / 100 * delta.x || 0,
-            top: position[1] / 100 * delta.y || 0,
-        };
-        // Make sure the element is in a visible area.
-        const rect = this.$target[0].getBoundingClientRect();
-        const viewportTop = $(window).scrollTop();
-        const viewportBottom = viewportTop + $(window).height();
-        const visibleHeight = rect.top < viewportTop
-            ? Math.max(0, Math.min(viewportBottom, rect.bottom) - viewportTop) // Starts above
-            : rect.top < viewportBottom
-                ? Math.min(viewportBottom, rect.bottom) - rect.top // Starts inside
-                : 0; // Starts after
-        if (visibleHeight < 200) {
-            await scrollTo(this.$target[0], { behavior: "smooth", offset: 50 });
-        }
-        this._toggleBgOverlay(true);
-    },
-    /**
      * @override
      */
     selectStyle: function (previewMode, widgetValue, params) {

--- a/addons/website_blog/static/src/js/website_blog.js
+++ b/addons/website_blog/static/src/js/website_blog.js
@@ -47,7 +47,7 @@ publicWidget.registry.websiteBlog = publicWidget.Widget.extend({
         // Use setTimeout() to calculate the 'offset()'' only after that size classes
         // have been applyed and that $el has been resized.
         setTimeout(() => {
-            this._forumScrollAction(ev.currentTarget, 300, function () {
+            this._forumScrollAction(ev.currentTarget, function () {
                 window.location.href = nexInfo.url;
             });
         });
@@ -61,7 +61,7 @@ publicWidget.registry.websiteBlog = publicWidget.Widget.extend({
         ev.stopImmediatePropagation();
         const currentTargetEl = document.querySelector(ev.currentTarget.hash);
 
-        this._forumScrollAction(currentTargetEl, 500, function () {
+        this._forumScrollAction(currentTargetEl, function () {
             window.location.hash = 'blog_content';
         });
     },
@@ -95,7 +95,6 @@ publicWidget.registry.websiteBlog = publicWidget.Widget.extend({
     /**
      * @private
      * @param {HTMLElement} el - the element we are scrolling to
-     * @param {Integer} duration - scroll animation duration
      * @param {Function} callback - to be executed after the scroll is performed
      */
     _forumScrollAction: function (el, callback) {


### PR DESCRIPTION
Resolve a traceback caused by the removal of the duration parameter during the refactoring of legacy code in dom.js. While, calling function are passing duration as params which remove in this PR.

Similarly, extract all the unused code from scrollTo functionality.

task-4095403