### PR TITLE
[FIX] purchase_stock: make use of hook method

### DIFF
--- a/addons/purchase_stock/models/account_invoice.py
+++ b/addons/purchase_stock/models/account_invoice.py
@@ -40,7 +40,7 @@ class AccountMove(models.Model):
             for line in move.invoice_line_ids:
                 # Filter out lines being not eligible for price difference.
                 # Moreover, this function is used for standard cost method only.
-                if not line.product_id.is_storable or line.product_id.valuation != 'real_time' or line.product_id.cost_method != 'standard':
+                if not line._eligible_for_cogs() or line.product_id.cost_method != 'standard':
                     continue
 
                 # Retrieve accounts needed to generate the price difference.


### PR DESCRIPTION
It's better to be consistent. Methods should be used when possible.

The method is defined in `stock_account` module.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr