### PR TITLE
[FIX] html_editor: stageSelection fail with mutation in currentStep

### DIFF
--- a/addons/html_editor/static/src/core/overlay.js
+++ b/addons/html_editor/static/src/core/overlay.js
@@ -18,6 +18,7 @@ export class EditorOverlay extends Component {
         editable: { validate: (el) => el.nodeType === Node.ELEMENT_NODE },
         bus: Object,
         getContainer: Function,
+        history: Object,
     };
 
     setup() {
@@ -86,6 +87,10 @@ export class EditorOverlay extends Component {
         }
         let rect = range.getBoundingClientRect();
         if (rect.x === 0 && rect.width === 0 && rect.height === 0) {
+            // Attention, using disableObserver and enableObserver is always dangerous (when we add or remove nodes)
+            // because if another mutation uses the target that is not observed, that mutation can never be applied
+            // again (when undo/redo and in collaboration).
+            this.props.history.disableObserver();
             const clonedRange = range.cloneRange();
             const shadowCaret = doc.createTextNode("|");
             clonedRange.insertNode(shadowCaret);
@@ -93,6 +98,7 @@ export class EditorOverlay extends Component {
             rect = clonedRange.getBoundingClientRect();
             shadowCaret.remove();
             clonedRange.detach();
+            this.props.history.enableObserver();
         }
         // Html element with a patched getBoundingClientRect method. It
         // represents the range as a (HTMLElement) target for the usePosition

--- a/addons/html_editor/static/src/core/overlay_plugin.js
+++ b/addons/html_editor/static/src/core/overlay_plugin.js
@@ -10,6 +10,7 @@ import { findUpTo } from "@html_editor/utils/dom_traversal";
  */
 export class OverlayPlugin extends Plugin {
     static name = "overlay";
+    static dependencies = ["history"];
     static shared = ["createOverlay"];
 
     handleCommand(command) {
@@ -99,6 +100,10 @@ export class Overlay {
                     initialSelection,
                     bus: this.bus,
                     getContainer: this.getContainer,
+                    history: {
+                        enableObserver: this.plugin.shared.enableObserver,
+                        disableObserver: this.plugin.shared.disableObserver,
+                    },
                 }),
                 {
                     sequence: this.config.sequence || 50,

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -106,6 +106,7 @@ export class LinkPlugin extends Plugin {
     static shared = ["createLink", "insertLink", "getPathAsUrlCommand"];
     /** @type { (p: LinkPlugin) => Record<string, any> } */
     static resources = (p) => ({
+        onBeforeInput: { handler: p.onBeforeInput.bind(p), sequence: 10 },
         toolbarCategory: {
             id: "link",
             sequence: 40,
@@ -165,11 +166,6 @@ export class LinkPlugin extends Plugin {
             if (ev.target.tagName === "A" && ev.target.isContentEditable) {
                 ev.preventDefault();
                 this.toggleLinkTools({ link: ev.target });
-            }
-        });
-        this.addDomListener(this.editable, "keydown", (ev) => {
-            if (ev.key === "Enter" || ev.key === " ") {
-                this.handleAutomaticLinkInsertion();
             }
         });
         // link creation is added to the command service because of a shortcut conflict,
@@ -492,6 +488,15 @@ export class LinkPlugin extends Plugin {
         }
     }
 
+    onBeforeInput(ev) {
+        if (
+            ev.inputType === "insertParagraph" ||
+            ev.inputType === "insertLineBreak" ||
+            (ev.inputType === "insertText" && ev.data === " ")
+        ) {
+            this.handleAutomaticLinkInsertion();
+        }
+    }
     /**
      * Inserts a link in the editor. Called after pressing space or (shif +) enter.
      * Performs a regex check to determine if the url has correct syntax.

--- a/addons/html_editor/static/src/main/table/table_ui_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_ui_plugin.js
@@ -88,11 +88,6 @@ export class TableUIPlugin extends Plugin {
     }
 
     openPicker() {
-        const range = this.document.getSelection().getRangeAt(0);
-        const rect = range.getBoundingClientRect();
-        if (rect.width === 0 && rect.height === 0 && rect.x === 0) {
-            range.startContainer.parentElement.appendChild(this.document.createElement("br"));
-        }
         this.picker.open({
             props: {
                 dispatch: this.dispatch,

--- a/addons/html_editor/static/tests/_helpers/collaboration.js
+++ b/addons/html_editor/static/tests/_helpers/collaboration.js
@@ -102,6 +102,7 @@ export const setupMultiEditor = async (spec) => {
         peerInfo.editor = base.editor;
         if (selection && selection.anchorNode) {
             base.editor.shared.setSelection(selection);
+            base.plugins.get("history").stageSelection();
         } else {
             base.editor.document.getSelection().removeAllRanges();
         }

--- a/addons/html_editor/static/tests/chatgpt.test.js
+++ b/addons/html_editor/static/tests/chatgpt.test.js
@@ -232,7 +232,7 @@ test("insert the response from ChatGPT translate dialog", async () => {
 
     // Expect to undo and redo the inserted text.
     editor.dispatch("HISTORY_UNDO");
-    expect(getContent(el)).toBe(`<p>[]Hello</p>`);
+    expect(getContent(el)).toBe(`<p>[Hello]</p>`);
     editor.dispatch("HISTORY_REDO");
     expect(getContent(el)).toBe(`<p>Bonjour[]</p>`);
 });

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -454,7 +454,7 @@ describe("Link creation", () => {
             expect(cleanLinkArtifacts(getContent(el))).toBe('<p><a href="#">Hello[]</a></p>');
 
             undo(editor);
-            expect(cleanLinkArtifacts(getContent(el))).toBe("<p>[]Hello</p>");
+            expect(cleanLinkArtifacts(getContent(el))).toBe("<p>[Hello]</p>");
         });
         test("extend a link on selection and undo it", async () => {
             const { el, editor } = await setupEditor(
@@ -470,7 +470,7 @@ describe("Link creation", () => {
 
             undo(editor);
             expect(cleanLinkArtifacts(getContent(el))).toBe(
-                `<p><a href="https://www.test.com">Hello[]</a> my friend</p>`
+                `<p>[<a href="https://www.test.com">Hello</a> my friend]</p>`
             );
         });
     });

--- a/addons/html_editor/static/tests/link/transform.test.js
+++ b/addons/html_editor/static/tests/link/transform.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { manuallyDispatchProgrammaticEvent, press } from "@odoo/hoot-dom";
+import { manuallyDispatchProgrammaticEvent } from "@odoo/hoot-dom";
 import { setupEditor, testEditor } from "../_helpers/editor";
 import { getContent, setSelection } from "../_helpers/selection";
 import { insertText, undo } from "../_helpers/user_actions";
@@ -7,7 +7,8 @@ import { cleanLinkArtifacts } from "../_helpers/format";
 
 async function insertSpace(editor) {
     manuallyDispatchProgrammaticEvent(editor.editable, "keydown", { key: " " });
-    manuallyDispatchProgrammaticEvent(editor.editable, "input", {
+    // InputEvent is required to simulate the insert text.
+    manuallyDispatchProgrammaticEvent(editor.editable, "beforeinput", {
         inputType: "insertText",
         data: " ",
     });
@@ -37,6 +38,11 @@ async function insertSpace(editor) {
     setSelection({
         anchorNode: node,
         anchorOffset: offset,
+    });
+
+    manuallyDispatchProgrammaticEvent(editor.editable, "input", {
+        inputType: "insertText",
+        data: " ",
     });
 
     // KeyUpEvent is not required but is triggered like the browser would.
@@ -106,8 +112,10 @@ test("should transform url after enter", async () => {
     await testEditor({
         contentBefore: "<p>a http://test.com b http://test.com[] c http://test.com d</p>",
         stepFunction: async (editor) => {
-            press("enter");
-            editor.dispatch("SPLIT_BLOCK");
+            // Simulate "Enter"
+            manuallyDispatchProgrammaticEvent(editor.editable, "beforeinput", {
+                inputType: "insertParagraph",
+            });
         },
         contentAfter:
             '<p>a http://test.com b <a href="http://test.com">http://test.com</a></p><p>[]&nbsp;c http://test.com d</p>',
@@ -118,8 +126,10 @@ test("should transform url after shift+enter", async () => {
     await testEditor({
         contentBefore: "<p>a http://test.com b http://test.com[] c http://test.com d</p>",
         stepFunction: async (editor) => {
-            press(["shift", "enter"]);
-            editor.dispatch("INSERT_LINEBREAK");
+            // Simulate "Shift + Enter"
+            manuallyDispatchProgrammaticEvent(editor.editable, "beforeinput", {
+                inputType: "insertLineBreak",
+            });
         },
         contentAfter:
             '<p>a http://test.com b <a href="http://test.com">http://test.com</a><br>[]&nbsp;c http://test.com d</p>',


### PR DESCRIPTION
Before this commit, stageSelection could update the currentStep
selection with mutations (‘add’, ‘remove’ and ‘characterData’) in
progress.
We should not have this type of mutations in the currentStep before
staging the selection or the selection could be wrong when reverting
that step in the future.

When staging the selection, we shouldn't have any ‘attributes’
mutations either. Unfortunately, this is too common at the moment, so
we've chosen to ignore them in this commit as they should not generate
bugs.

Before this commit, 3 related bugs have been found:
1) When an overlay was opened
2) When the table picker was opened (a temporary node was added for
   technical reasons).
3) When you press ‘enter’ or ‘ ’, the code call `normalise` without
   `ADD_STEP`. Our solution is to move this code so that it takes
   place at beforeInput and the mutations are added in the ‘enter’
   or ‘ ’ step.