### PR TITLE
[FIX] html_editor: test inde 'can replace an image'

### DIFF
--- a/addons/html_editor/static/tests/media.test.js
+++ b/addons/html_editor/static/tests/media.test.js
@@ -1,6 +1,6 @@
 import { expect, test } from "@odoo/hoot";
 import { click, press, waitFor } from "@odoo/hoot-dom";
-import { animationFrame } from "@odoo/hoot-mock";
+import { animationFrame, tick } from "@odoo/hoot-mock";
 import { setupEditor } from "./_helpers/editor";
 import { makeMockEnv, onRpc } from "@web/../tests/web_test_helpers";
 import { getContent } from "./_helpers/selection";
@@ -23,6 +23,7 @@ test("Can replace an image", async () => {
     await setupEditor(`<p> <img class="img-fluid" src="/web/static/img/logo.png"> </p>`, { env });
     expect("img[src='/web/static/img/logo.png']").toHaveCount(1);
     click("img");
+    await tick(); // selectionchange
     await waitFor(".o-we-toolbar");
     expect("button[name='replace_image']").toHaveCount(1);
     click("button[name='replace_image']");


### PR DESCRIPTION
In this commit, we're trying to prevent the indeterministic fail of the ‘can replace an image’ test. This test fails 1 time by month. We think we need to wait for a tick to ensure that the selectionchange event occurs before the waitFor.

Runbot: https://runbot.odoo.com/runbot/build/67699956

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
