### PR TITLE
[IMP] website_sale: improve product categories pages

### DIFF
--- a/addons/website_sale/models/product_public_category.py
+++ b/addons/website_sale/models/product_public_category.py
@@ -55,6 +55,13 @@ class ProductPublicCategory(models.Model):
         translate=html_translate,
     )
 
+    website_footer = fields.Html(
+        string="Category Footer",
+        sanitize_attributes=False,
+        sanitize_form=False,
+        translate=html_translate,
+    )
+
     #=== COMPUTE METHODS ===#
 
     def _compute_parents_and_self(self):

--- a/addons/website_sale/views/product_public_category_views.xml
+++ b/addons/website_sale/views/product_public_category_views.xml
@@ -14,6 +14,8 @@
                             <field name="parent_id"/>
                             <field name="website_id" options="{'no_create': True}" groups="website.group_multi_website"/>
                             <field name="sequence" groups="base.group_no_one"/>
+                            <field name="website_description"
+                                   placeholder="Description displayed on the eCommerce categories page."/>
                         </group>
                     </div>
                 </sheet>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -311,7 +311,7 @@
     <!-- /shop product listing -->
     <template id="products" name="Products">
         <t t-call="website.layout">
-            <t t-set="additional_title">Shop</t>
+            <t t-set="additional_title" t-value="category.name"/>
             <t t-set="grid_block_name">Grid</t>
             <t t-set="product_block_name">Product</t>
 
@@ -373,6 +373,25 @@
                             <t t-call="website_sale.products_breadcrumb">
                                 <t t-set="_classes" t-valuef="d-none d-lg-flex w-100 p-0 small"/>
                             </t>
+
+                            <h1 t-if="category">
+                                <t t-esc="category.name"/>
+                            </h1>
+
+                            <t t-if="category">
+                                <t t-set='editor_msg'>
+                                    Drag building blocks here to customize the header for
+                                    "<t t-esc='category.name'/>" category.
+                                </t>
+                                <div class="mb16"
+                                    id="category_header"
+                                    t-att-data-editor-message="editor_msg"
+                                    t-field="category.website_description"/>
+                            </t>
+
+                            <t t-if="opt_wsale_categories_top"
+                               t-call="website_sale.filmstrip_categories"/>
+
                             <div class="products_header btn-toolbar flex-nowrap align-items-center justify-content-between gap-3 mb-3">
                                 <t t-if="is_view_active('website_sale.search')" t-call="website_sale.search">
                                     <t t-set="search" t-value="original_search or search"/>
@@ -410,16 +429,9 @@
                                 </button>
                             </div>
 
-                            <t t-if="opt_wsale_categories_top" t-call="website_sale.filmstrip_categories"/>
-
                             <div t-if="original_search and products" class="alert alert-warning mt8">
                                 No results found for '<span t-esc="original_search"/>'. Showing results for '<span t-esc="search"/>'.
                             </div>
-
-                            <t t-if="category">
-                                <t t-set='editor_msg'>Drag building blocks here to customize the header for "<t t-esc='category.name'/>" category.</t>
-                                <div class="mb16" id="category_header" t-att-data-editor-message="editor_msg" t-field="category.website_description"/>
-                            </t>
 
                             <div t-if="products" class="o_wsale_products_grid_table_wrapper pt-3 pt-lg-0">
                                 <t t-set="grid_md_allow_custom_cols" t-value="hasLeftColumn"/>
@@ -483,6 +495,18 @@
                             <div class="products_pager d-flex justify-content-center pt-5 pb-3">
                                 <t t-call="website.pager"/>
                             </div>
+                            <t t-if="category">
+                                <t t-set='footer_editor_message'>
+                                    Drag building blocks here to customize the footer for
+                                    "<t t-esc='category.name'/>" category.
+                                </t>
+                                <div
+                                    class="mb16"
+                                    id="category_footer"
+                                    t-att-data-editor-message="footer_editor_message"
+                                    t-field="category.website_footer"
+                                />
+                            </t>
                         </div>
                     </div>
 


### PR DESCRIPTION
This update introduces several enhancements to product category pages in the
  eCommerce module:

- Building blocks can now be added directly after the shared website header and to the category-specific footer.
- These blocks are visible only on their respective category pages.
- Ensures that headers and footers are not shared between parent and child categories, maintaining a unique layout per category.

- The page title now changes to match the category name. For example, instead of "Shop | My Website," it will show "Desks | My Website."

- The category name is now shown as an H1 heading on the category page for better visibility.

- A new website description field has been added in the back-end. This allows you to add HTML descriptions for categories, which will be shown on the front end below the category title.

- The category page now includes: Breadcrumb navigation Category title (H1) Description Child categories A search bar and filters for easy navigation

task-3747565