### PR TITLE
[FIX] pos*: improve handling of split orders in kitchen display

### DIFF
--- a/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
+++ b/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
@@ -54,6 +54,19 @@ export class SplitBillScreen extends Component {
     async preSplitOrder(originalOrder, newOrder) {}
     async postSplitOrder(originalOrder, newOrder) {}
 
+    // Calculates the sent quantities for both orders and adjusts for last_order_preparation_change.
+    _getSentQty(ogLine, newLine, orderedQty) {
+        const unorderedQty = ogLine.qty - orderedQty;
+
+        const delta = newLine.qty - unorderedQty;
+        const newQty = delta > 0 ? delta : 0;
+
+        return {
+            [ogLine.preparationKey]: orderedQty - newQty,
+            [newLine.preparationKey]: newQty,
+        };
+    }
+
     async createSplittedOrder() {
         const curOrderUuid = this.currentOrder.uuid;
         const originalOrder = this.pos.models["pos.order"].find((o) => o.uuid === curOrderUuid);
@@ -66,21 +79,27 @@ export class SplitBillScreen extends Component {
         }`;
         newOrder.uiState.splittedOrderUuid = curOrderUuid;
         await this.preSplitOrder(originalOrder, newOrder);
+
+        let sentQty = {};
         // Create lines for the new order
         const lineToDel = [];
         for (const line of originalOrder.lines) {
             if (this.qtyTracker[line.uuid]) {
-                this.pos.models["pos.order.line"].create(
+                const data = line.serialize();
+                delete data.uuid;
+                const newLine = this.pos.models["pos.order.line"].create(
                     {
-                        ...line.serialize(),
+                        ...data,
                         qty: this.qtyTracker[line.uuid],
                         order_id: newOrder.id,
-                        skip_change: true,
                     },
                     false,
                     true
                 );
 
+                const orderedQty =
+                    originalOrder.last_order_preparation_change[line.preparationKey]?.quantity || 0;
+                sentQty = { ...sentQty, ...this._getSentQty(line, newLine, orderedQty) };
                 if (line.get_quantity() === this.qtyTracker[line.uuid]) {
                     lineToDel.push(line);
                 } else {
@@ -93,16 +112,16 @@ export class SplitBillScreen extends Component {
             line.delete();
         }
 
-        // for the kitchen printer we assume that everything
-        // has already been sent to the kitchen before splitting
-        // the bill. So we save all changes both for the old
-        // order and for the new one. This is not entirely correct
-        // but avoids flooding the kitchen with unnecessary orders.
-        // Not sure what to do in this case.
-        if (this.pos.orderPreparationCategories.size) {
-            originalOrder.updateLastOrderChange();
-            newOrder.updateLastOrderChange();
-        }
+        Object.keys(originalOrder.last_order_preparation_change).forEach((linePreparationKey) => {
+            originalOrder.last_order_preparation_change[linePreparationKey]["quantity"] =
+                sentQty[linePreparationKey];
+        });
+        newOrder.updateLastOrderChange();
+        Object.keys(newOrder.last_order_preparation_change).forEach((linePreparationKey) => {
+            newOrder.last_order_preparation_change[linePreparationKey]["quantity"] =
+                sentQty[linePreparationKey];
+        });
+        this.pos.addPendingOrder([originalOrder.id, newOrder.id]);
 
         originalOrder.customer_count -= 1;
         await this.postSplitOrder(originalOrder, newOrder);

--- a/addons/pos_restaurant/static/tests/tours/split_bill_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/split_bill_screen_tour.js
@@ -112,6 +112,11 @@ registry.category("web_tour.tours").add("SplitBillScreenTour3", {
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickValidate(),
+            {
+                ...Dialog.confirm(),
+                content:
+                    "acknowledge printing error ( because we don't have printer in the test. )",
+            },
             ReceiptScreen.clickContinueOrder(),
 
             // Check if there is still water in the order
@@ -121,6 +126,11 @@ registry.category("web_tour.tours").add("SplitBillScreenTour3", {
             PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickValidate(),
             // Check if there is no more order to continue
+            {
+                ...Dialog.confirm(),
+                content:
+                    "acknowledge printing error ( because we don't have printer in the test. )",
+            },
             ReceiptScreen.clickNextOrder(),
         ].flat(),
 });
@@ -169,6 +179,11 @@ registry.category("web_tour.tours").add("SplitBillScreenTour4PosCombo", {
             ProductScreen.clickPayButton(),
             ...PaymentScreen.clickPaymentMethod("Bank"),
             ...PaymentScreen.clickValidate(),
+            {
+                ...Dialog.confirm(),
+                content:
+                    "acknowledge printing error ( because we don't have printer in the test. )",
+            },
             ...ReceiptScreen.clickContinueOrder(),
 
             // Check if there is still water in the order


### PR DESCRIPTION
pos*: pos_restaurant, pos_preparation_display

Before this commit:
==============
- Splitting an order caused the loss of ordered and unordered quantity
  information for the order lines.

After this commit:
==============
- Ordered and unordered quantity information is preserved for all order lines.
- Preparation display quantities remain unaffected.

Task - 4114041

