### PR TITLE
[FIX] purchase_requisition: don’t copy product name in alternative PO

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -1282,12 +1282,12 @@ class PurchaseOrderLine(models.Model):
                     False
                 )
                 line.price_unit = float_round(price_unit, precision_digits=max(line.currency_id.decimal_places, self.env['decimal.precision'].precision_get('Product Price')))
-                continue
 
-            price_unit = line.env['account.tax']._fix_tax_included_price_company(seller.price, line.product_id.supplier_taxes_id, line.taxes_id, line.company_id) if seller else 0.0
-            price_unit = seller.currency_id._convert(price_unit, line.currency_id, line.company_id, line.date_order or fields.Date.context_today(line), False)
-            price_unit = float_round(price_unit, precision_digits=max(line.currency_id.decimal_places, self.env['decimal.precision'].precision_get('Product Price')))
-            line.price_unit = seller.product_uom._compute_price(price_unit, line.product_uom)
+            elif seller:
+                price_unit = line.env['account.tax']._fix_tax_included_price_company(seller.price, line.product_id.supplier_taxes_id, line.taxes_id, line.company_id) if seller else 0.0
+                price_unit = seller.currency_id._convert(price_unit, line.currency_id, line.company_id, line.date_order or fields.Date.context_today(line), False)
+                price_unit = float_round(price_unit, precision_digits=max(line.currency_id.decimal_places, self.env['decimal.precision'].precision_get('Product Price')))
+                line.price_unit = seller.product_uom._compute_price(price_unit, line.product_uom)
 
             # record product names to avoid resetting custom descriptions
             default_names = []

--- a/addons/purchase_requisition/tests/test_purchase_requisition.py
+++ b/addons/purchase_requisition/tests/test_purchase_requisition.py
@@ -447,10 +447,12 @@ class TestPurchaseRequisition(TestPurchaseRequisitionCommon):
             'seller_ids': [(0, 0, {
                 'partner_id': vendor_a.id,
                 'price': 5,
+                'product_code': 'code A',
             }), (0, 0, {
                 'partner_id': vendor_b.id,
                 'price': 4,
                 'min_qty': 10,
+                'product_code': 'code B',
             }), (0, 0, {
                 'partner_id': vendor_b.id,
                 'price': 6,
@@ -465,6 +467,7 @@ class TestPurchaseRequisition(TestPurchaseRequisitionCommon):
             line.product_qty = 100
         po_orig = po_form.save()
         self.assertEqual(po_orig.order_line.price_unit, 5)
+        self.assertEqual(po_orig.order_line.name, '[code A] Product')
         # Creates an alternative PO
         action = po_orig.action_create_alternative()
         alt_po_wizard_form = Form(self.env['purchase.requisition.create.alternative'].with_context(**action['context']))
@@ -474,6 +477,7 @@ class TestPurchaseRequisition(TestPurchaseRequisitionCommon):
         alt_po_wizard.action_create_alternative()
         po_alt = po_orig.alternative_po_ids - po_orig
         self.assertEqual(po_alt.order_line.price_unit, 4)
+        self.assertEqual(po_alt.order_line.name, '[code B] Product')
 
     def test_08_purchase_requisition_sequence(self):
         new_company = self.env['res.company'].create({'name': 'Company 2'})

--- a/addons/purchase_requisition/wizard/purchase_requisition_create_alternative.py
+++ b/addons/purchase_requisition/wizard/purchase_requisition_create_alternative.py
@@ -85,6 +85,6 @@ class PurchaseRequisitionCreateAlternative(models.TransientModel):
                 'product_qty': line.product_qty,
                 'product_uom': line.product_uom.id,
                 'display_type': line.display_type,
-                'name': line.name,
+                **({'name': line.name} if line.display_type in ('line_section', 'line_note') else {}),
             }) for line in self.origin_po_id.order_line]
         return vals


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1”:
    - vendors:
        -Azure interior, code: Vendor 1
        - Deco Addict, code: Vendor 2
- Create a purchase order:
    - product P1
    - Vendor: Azure interior

> Description P1 [Vendor 1]

- Create an Alternative PO:
    - Vendor: Deco Addict
    - Copy products: True

Problem:
The description of POL is incorrect: P1 [Vendor 1] instead of P1 [Vendor 2]

opw-4133933	