### PR TITLE
[FIX] [16.0] account, error when adding a line from a statement by accessing the bank statement

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -176,6 +176,9 @@ class AccountBankStatementLine(models.Model):
         # the user can split on that lines, but their balance should be the same as previous posted line
         # we do the same for the canceled lines, in order to keep using them as anchor points
 
+        for record in self:
+            record.running_balance = 0
+
         self.statement_id.flush_model(['balance_start', 'first_line_index'])
         self.flush_model(['internal_index', 'date', 'journal_id', 'statement_id', 'amount', 'state'])
         record_by_id = {x.id: x for x in self}

--- a/doc/cla/individual/iaranburu.md
+++ b/doc/cla/individual/iaranburu.md
@@ -1,0 +1,11 @@
+Spain, 2024-09-10
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Imanol Aranburu Leunda iaranburu@binovo.es https://github.com/iaranburu


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When adding a line from a statement accessing from the bank statement, an error occurs

Current behavior before PR:

We go to Accounting Dashboard / Bank Statements and choose a statement. In the statement form (account_statement_base.view_bank_statement_form) if we add a line we get an error.
File "/opt/ocb/odoo/fields.py", line 1219, in __get__
raise ValueError(f"Compute method failed to assign {missing_recs}.{self.name}")

Desired behavior after PR is merged:

With the correction we ensure that the "running_balance" field in the "_compute_running_balance" function of the "account.bank.statement.line" model is correctly updated. In this way, the restrictions for compute type fields are not violated.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
