### PR TITLE
[IMP] mrp: add graph to workcenter overview for barline

### DIFF
--- a/addons/mrp/static/src/scss/mrp_workorder_kanban.scss
+++ b/addons/mrp/static/src/scss/mrp_workorder_kanban.scss
@@ -20,4 +20,17 @@
 }
 .o_workcenter_kanban {
     --KanbanRecord-width: 400px;
+    .o_kanban_renderer {
+        --KanbanRecord-width: 480px;
+
+        @include media-only(screen) {
+            --KanbanGroup-width: 480px;
+        }
+        @include media-only(print) {
+            --KanbanGroup-width: 400px;
+        }
+    }
+    .o_dashboard_graph {
+            margin: 0px -8px;
+    }
 }

--- a/addons/mrp/static/src/workcenter_dashboard_graph/workcenter_dashboard_graph_field.js
+++ b/addons/mrp/static/src/workcenter_dashboard_graph/workcenter_dashboard_graph_field.js
@@ -1,0 +1,122 @@
+import { _t } from "@web/core/l10n/translation";
+import { cookie } from "@web/core/browser/cookie";
+import { getColor, hexToRGBA, darkenColor } from "@web/core/colors/colors";
+import { registry } from "@web/core/registry";
+import { JournalDashboardGraphField } from "@web/views/fields/journal_dashboard_graph/journal_dashboard_graph_field";
+
+export class WorkcenterDashboardGraphField extends JournalDashboardGraphField{
+    getBarChartConfig() {
+        const labels = this.data[0].labels;
+        const color19 = getColor(1, cookie.get("color_scheme"), "odoo");
+        const color13 = getColor(2, cookie.get("color_scheme"), "odoo");
+        const color10 = getColor(3, cookie.get("color_scheme"), "odoo");
+        const loadBarColor = this.data[0].is_sample_data ? hexToRGBA(color19, 0.1) : color19;
+        const excessBarColor = this.data[0].is_sample_data ? hexToRGBA(color13, 0.1) : color13;
+        const maxLoadLineColor = this.data[0].is_sample_data ? hexToRGBA(color10, 0.1) : hexToRGBA(color10, 0.5);
+        return {
+            type: 'scatter',
+            data: {
+                datasets: [
+                    {
+                        type: 'line',
+                        borderColor: maxLoadLineColor,
+                        // normally the line stops in the middle of the first and last columns, which is ugly
+                        // to make it go through all the graph, the single point has been configured as a line
+                        // in the middle of the graph and extended. The real line is not shown.
+                        data: [,,this.data[0].values[1]],
+                        showLine: false,
+                        pointStyle: 'line',
+                        pointRadius: 500,
+                        pointBorderWidth: 2,
+                        // this is so that hovering on the 'line' does not change its appearance
+                        pointHoverRadius: 500,
+                        pointHoverBorderWidth: 2,
+                    },
+                    {
+                        type: 'bar',
+                        backgroundColor: loadBarColor,
+                        data: this.data[0].values[0],
+                        label: "Total Load",
+                        borderWidth: 0,
+                        stack: 'mainStack',
+                        hoverBackgroundColor: function(ctx, options) {
+                            return (ctx.parsed._stacks.y[2] !== 0) ? excessBarColor :  darkenColor(loadBarColor, 0.1);
+                        },
+                    },
+                    {
+                        type: 'bar',
+                        backgroundColor: excessBarColor,
+                        data: this.data[0].values[2],
+                        label: "Excess Load",
+                        borderWidth: 0,
+                        stack: 'mainStack',
+                    }
+                ],
+                labels,
+            },
+            options: {
+                layout: {
+                    autoPadding: false,
+                },
+                interaction: {
+                    includeInvisible: true,
+                    axis: 'x',
+                },
+                plugins: {
+                    legend: { display: false },
+                    tooltip: {
+                        enabled: !this.data[0].is_sample_data,
+                        intersect: true,
+                        mode: 'nearest',
+                        position: 'nearest',
+                        caretSize: 0,
+                        filter: function(ctx) {
+                            if (ctx.dataset.type !== 'line') {
+                                return ctx;
+                            }
+                        },
+                        callbacks: {
+                            label: function(ctx) {
+                                if (ctx.datasetIndex === 1) {
+                                    const totalLoadValue = Object.values(ctx.parsed._stacks.y._visualValues).reduce((accu, curr) => {return accu + curr}, 0);
+                                    return _t(ctx.dataset.label + ": " + totalLoadValue + " hours");
+                                }
+                                return _t(ctx.dataset.label + ": " + ctx.parsed.y + " hours");
+                            },
+                            title: function(ctx) {
+                                return "";
+                            },
+                        },
+                    },
+                },
+                scales: {
+                    y: {
+                        display: false,
+                        suggestedMax: this.data[0].values[1] * 1.5,
+                        stacked: true,
+                    },
+                    x: {
+                        type: 'category',
+                        grid: {
+                            display: false,
+                        },
+                        border: {
+                            display: false,
+                        },
+                    },
+                },
+                maintainAspectRatio: false,
+            },
+        };
+    }
+}
+
+export const workcenterDashboardGraphField = {
+    component: WorkcenterDashboardGraphField,
+    supportedTypes: ["text"],
+    extractProps: ({ attrs }) => ({
+        graphType: attrs.graph_type,
+    }),
+};
+
+registry.category("fields").add("workcenter_dashboard_graph", workcenterDashboardGraphField);

--- a/addons/mrp/tests/__init__.py
+++ b/addons/mrp/tests/__init__.py
@@ -18,3 +18,4 @@ from . import test_smp
 from . import test_performance
 from . import test_consume_component
 from . import test_manual_consumption
+from . import test_workcenter

--- a/addons/mrp/tests/test_workcenter.py
+++ b/addons/mrp/tests/test_workcenter.py
@@ -1,0 +1,56 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from datetime import timedelta, datetime
+from freezegun import freeze_time
+
+from . import common
+from odoo import Command
+from odoo.tests import Form, tagged
+
+
+@tagged('-at_install', 'post_install')
+class TestWorkcenterOverview(common.TestMrpCommon):
+
+    @freeze_time('2020-03-13')  # Friday
+    def test_workcenter_graph_data(self):
+        fake_bom = self.env['mrp.bom'].create({
+            'product_id': self.product_2.id,
+            'product_tmpl_id': self.product_2.product_tmpl_id.id,
+            'product_uom_id': self.uom_unit.id,
+            'product_qty': 1.0,
+            'consumption': 'flexible',
+            'operation_ids': [
+                Command.create({
+                    'name': 'Make it look you are working',
+                    'workcenter_id': self.workcenter_2.id,
+                    'time_cycle_manual': 60, 'sequence': 1})
+            ],
+            'type': 'normal',
+        })
+
+        lang = self.env['res.lang']._lang_get(self.env.user.lang)
+        lang.week_start = '3'   # Wednesday
+        week_range, date_start, date_stop = self.workcenter_2._get_week_range_and_first_last_days()
+        self.assertEqual(next(iter(week_range)), date_start)
+        self.assertEqual(date_stop.strftime('%Y-%m-%d'), '2020-04-07')
+        self.assertEqual(list(week_range.items())[2][1], '18 - 24 Mar')
+
+        mo_form = Form(self.env['mrp.production'])
+        mo_form.product_id = self.product_2
+        mo_form.bom_id = fake_bom
+        mo_form.product_qty = 20
+        mo_form.save().action_confirm()
+
+        mo_form_2 = Form(self.env['mrp.production'])
+        mo_form_2.product_id = self.product_2
+        mo_form_2.bom_id = fake_bom
+        mo_form_2.product_qty = 60
+        mo_form_2.date_start = datetime.today() + timedelta(weeks=1)
+        mo_form_2.save().action_confirm()
+
+        wc_load_data = self.workcenter_2._get_workcenter_load_per_week(week_range, date_start, date_stop)
+        self.assertListEqual(list(wc_load_data[self.workcenter_2].values()), [20.0, 60.0])
+        self.assertListEqual(list(wc_load_data[self.workcenter_2].keys()), [datetime(2020, 3, 11), datetime(2020, 3, 18)])
+        load_graph_data = self.workcenter_2._prepare_graph_data(wc_load_data, week_range)
+        self.assertEqual(load_graph_data[self.workcenter_2.id][0]['is_sample_data'], False)
+        self.assertListEqual(load_graph_data[self.workcenter_2.id][0]['labels'], list(week_range.values()))
+        self.assertListEqual(load_graph_data[self.workcenter_2.id][0]['values'], [[0, 20.0, 40.0, 0, 0], 40.0, [0, 0, 20.0, 0, 0]])

--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -141,7 +141,7 @@
             <field name="name">mrp.workcenter.kanban</field>
             <field name="model">mrp.workcenter</field>
             <field name="arch" type="xml">
-                <kanban highlight_color="color" class="o_workcenter_kanban" create="0" can_open="0" sample="1">
+                <kanban highlight_color="color" class="o_workcenter_kanban" create="0" can_open="0" sample="0">
                     <field name="workorder_count"/>
                     <field name="working_state"/>
                     <field name="oee_target"/>
@@ -186,7 +186,23 @@
                             </div>
                         </t>
                         <t t-name="kanban-card">
-                            <field name="name" class="fw-bold fs-4 ms-2"/>
+                            <div class="ms-1">
+                                <div style="display: inline-block" name="wc_stages">
+                                    <a name="%(act_mrp_block_workcenter)d" type="action" class="o_status float-end"
+                                        title="No workorder currently in progress. Click to mark work center as blocked."
+                                        aria-label="No workorder currently in progress. Click to mark work center as blocked."
+                                        invisible="working_state in ('blocked', 'done')"/>
+                                    <a name="unblock" type="object" class=" o_status o_status_red float-end"
+                                        title="Workcenter blocked, click to unblock."
+                                        aria-label="Workcenter blocked, click to unblock."
+                                        invisible="working_state in ('normal', 'done')"/>
+                                    <a name="%(act_mrp_block_workcenter)d" type="action" class="o_status o_status_green float-end"
+                                        title="Work orders in progress. Click to block work center."
+                                        aria-label="Work orders in progress. Click to block work center."
+                                        invisible="working_state in ('normal', 'blocked')"/>
+                                </div>
+                                <field name="name" class="fw-bold fs-4 ms-2"/>
+                            </div>
                             <div class="row mt-3 pb-3">
                                 <div class="col-6">
                                     <div class="btn-group p-1" name="o_wo">
@@ -229,19 +245,8 @@
                                     </div>
                                 </div>
                             </div>
-                            <div class="ms-auto" name="wc_stages">
-                                <a name="%(act_mrp_block_workcenter)d" type="action" class="o_status float-end"
-                                    title="No workorder currently in progress. Click to mark work center as blocked."
-                                    aria-label="No workorder currently in progress. Click to mark work center as blocked."
-                                    invisible="working_state in ('blocked', 'done')"/>
-                                <a name="unblock" type="object" class=" o_status o_status_red float-end"
-                                    title="Workcenter blocked, click to unblock."
-                                    aria-label="Workcenter blocked, click to unblock."
-                                    invisible="working_state in ('normal', 'done')"/>
-                                <a name="%(act_mrp_block_workcenter)d" type="action" class="o_status o_status_green float-end"
-                                    title="Work orders in progress. Click to block work center."
-                                    aria-label="Work orders in progress. Click to block work center."
-                                    invisible="working_state in ('normal', 'blocked')"/>
+                            <div class="row">
+                                <field name="kanban_dashboard_graph" graph_type="bar" widget="workcenter_dashboard_graph"/>
                             </div>
                         </t>
                     </templates>


### PR DESCRIPTION
This PR adds a graph to the workcenter overview. This graph shows bars and a line:
- the bars show the workorder load from last week to 3 weeks in the future, they change color when going over the line
- the line shows the maximum work load per workcenter
- the tooltips show the load per bar, the excess load or the limit load of the line
- all workcenters have the graph show the line at the same height, even with different load limits

alternative to https://github.com/odoo/odoo/pull/178596
task 4081617

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
