### PR TITLE
[IMP] point_of_sale, pos_self_order: remove replaceDataByKey method

### DIFF
--- a/addons/point_of_sale/static/src/app/models/data_service.js
+++ b/addons/point_of_sale/static/src/app/models/data_service.js
@@ -106,7 +106,7 @@ export class PosData extends Reactive {
         };
 
         for (const [model, params] of Object.entries(this.opts.databaseTable)) {
-            const nbrRecords = Object.values(records[model]).length;
+            const nbrRecords = records[model].size;
 
             if (!nbrRecords) {
                 continue;
@@ -231,8 +231,7 @@ export class PosData extends Reactive {
         const { models, records, indexedRecords } = createRelatedModels(
             relations,
             modelClasses,
-            this.opts.databaseIndex,
-            this.opts.databaseTable
+            this.opts
         );
 
         this.records = records;

--- a/addons/point_of_sale/static/src/app/models/data_service_options.js
+++ b/addons/point_of_sale/static/src/app/models/data_service_options.js
@@ -44,7 +44,8 @@ export class DataServiceOptions {
     }
 
     get databaseIndex() {
-        return {
+        const databaseTable = this.databaseTable;
+        const indexes = {
             "pos.order": ["uuid"],
             "pos.order.line": ["uuid"],
             "product.product": ["barcode", "pos_categ_ids", "write_date"],
@@ -54,6 +55,16 @@ export class DataServiceOptions {
             "calendar.event": ["appointment_resource_ids"],
             "res.partner": ["barcode"],
         };
+
+        for (const model in databaseTable) {
+            if (!indexes[model]) {
+                indexes[model] = [databaseTable[model].key];
+            } else if (!indexes[model].includes(databaseTable[model].key)) {
+                indexes[model].push(databaseTable[model].key);
+            }
+        }
+
+        return indexes;
     }
 
     get autoLoadedOrmMethods() {

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -24,6 +24,10 @@ export class PosOrder extends Base {
     setup(vals) {
         super.setup(vals);
 
+        if (!this.session_id && !this.finalized) {
+            this.update({ session_id: this.session.id });
+        }
+
         // Data present in python model
         this.date_order = vals.date_order || getUTCString(luxon.DateTime.now());
         this.to_invoice = vals.to_invoice || false;
@@ -530,7 +534,7 @@ export class PosOrder extends Base {
             this.select_paymentline(undefined);
         }
 
-        line.delete();
+        line.delete({ backend: true });
     }
 
     clean_empty_paymentlines() {

--- a/addons/point_of_sale/static/src/app/models/utils/order_change.js
+++ b/addons/point_of_sale/static/src/app/models/utils/order_change.js
@@ -34,6 +34,7 @@ export const getOrderChanges = (order, skipped = false, orderPreparationCategori
     const changes = {};
     let changesCount = 0;
     let changeAbsCount = 0;
+    let skipCount = 0;
 
     // Compares the orderlines of the order with the last ones sent.
     // When one of them has changed, we add the change.
@@ -69,6 +70,10 @@ export const getOrderChanges = (order, skipped = false, orderPreparationCategori
                     orderline.setHasChange(true);
                 }
             } else {
+                if (quantityDiff) {
+                    skipCount += quantityDiff;
+                }
+
                 orderline.setHasChange(false);
             }
         } else {
@@ -97,6 +102,7 @@ export const getOrderChanges = (order, skipped = false, orderPreparationCategori
     }
 
     return {
+        nbrOfSkipped: skipCount,
         nbrOfChanges: changeAbsCount,
         orderlines: changes,
         count: changesCount,

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -50,6 +50,15 @@ export class PaymentScreen extends Component {
     }
 
     onMounted() {
+        const order = this.pos.get_order();
+
+        for (const payment of order.payment_ids) {
+            const pmid = payment.payment_method_id.id;
+            if (!this.pos.config.payment_method_ids.map((pm) => pm.id).includes(pmid)) {
+                payment.delete({ backend: true });
+            }
+        }
+
         if (this.payment_methods_from_config.length == 1) {
             this.addNewPaymentLine(this.payment_methods_from_config[0]);
         }

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -3,7 +3,7 @@ import { useService } from "@web/core/utils/hooks";
 import { useBarcodeReader } from "@point_of_sale/app/barcode/barcode_reader_hook";
 import { _t } from "@web/core/l10n/translation";
 import { usePos } from "@point_of_sale/app/store/pos_hook";
-import { Component, onMounted, useState, reactive } from "@odoo/owl";
+import { Component, onMounted, useState, reactive, onWillRender } from "@odoo/owl";
 import { CategorySelector } from "@point_of_sale/app/generic_components/category_selector/category_selector";
 import { Input } from "@point_of_sale/app/generic_components/inputs/input/input";
 import {
@@ -62,6 +62,14 @@ export class ProductScreen extends Component {
             // the callbacks in `onMounted` hook.
             this.numberBuffer.reset();
         });
+
+        onWillRender(() => {
+            // If its a shared order it can be paid from another POS
+            if (this.currentOrder.state !== "draft") {
+                this.pos.add_new_order();
+            }
+        });
+
         this.barcodeReader = useService("barcode_reader");
 
         useBarcodeReader({

--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -32,7 +32,7 @@ patch(PosStore.prototype, {
 
         effect(
             batched((orders) => {
-                const order = Object.values(orders).find(
+                const order = Array.from(orders.values()).find(
                     (order) => order.uuid === this.selectedOrderUuid
                 );
 
@@ -528,7 +528,7 @@ patch(PosStore.prototype, {
 
         this.computeDiscountProductIdsForAllRewards({
             model: "product.product",
-            ids: Object.keys(this.data.records["product.product"]),
+            ids: Array.from(this.data.records["product.product"].keys()),
         });
 
         this.models["product.product"].addEventListener(

--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
@@ -100,7 +100,7 @@
                         </div>
                         <div t-else="" t-ref="map" t-att-class="{'floor-kanban d-grid gap-3 p-3': pos.floorPlanStyle == 'kanban'}">
                            <t t-foreach="activeTables.sort((a,b)=>a.id-b.id)" t-as="table" t-key="table.id" >
-                                <t t-set="isOccupied" t-value="table.hasOrder || table.uiState.orderCount > 0"/>
+                                <t t-set="isOccupied" t-value="table.hasOrder"/>
                                 <t t-set="isIntersecting" t-value="state.potentialLink?.child?.id === table.id"/>
                                 <t t-set="isIntersected" t-value="state.potentialLink?.parent?.id === table.id"/>
                                 <div
@@ -141,12 +141,14 @@
                                     >
                                         <div t-esc="table.table_number" class="label fw-bolder fs-4 position-absolute top-50 start-50 translate-middle" />
                                     </div>
+                                    <t t-set="data" t-value="getChangeCount(table)"/>
                                     <div
-                                        t-esc="getOrderCount(table)" t-if="getOrderCount(table)"
+                                        t-if="data.changes > 0 || data.skip > 0 || table.hasOrder"
+                                        t-esc="data.changes > 0 ? data.changes : table.hasOrder ? 1 : data.skip"
                                         t-att-class="{
-                                            'text-bg-danger': table.uiState.changeCount,
-                                            'text-bg-info'  : !table.uiState.changeCount and table.uiState.skipCount,
-                                            'text-bg-dark'  : !table.uiState.changeCount and !table.uiState.skipCount
+                                            'text-bg-danger': data.changes,
+                                            'text-bg-info'  : !data.changes and data.skip,
+                                            'text-bg-dark'  : !data.changes and !data.skip
                                         }"
                                         class="order-count d-flex align-items-center justify-content-center position-absolute top-0 start-100 translate-middle rounded-circle smaller fw-bolder z-2"
                                         t-attf-style="width: 2rem; height: 2rem;"

--- a/addons/pos_restaurant/static/src/app/models/restaurant_table.js
+++ b/addons/pos_restaurant/static/src/app/models/restaurant_table.js
@@ -8,11 +8,8 @@ export class RestaurantTable extends Base {
         super.setup(vals);
 
         this.table_number = vals.table_number || 0;
-
         this.uiState = {
-            orderCount: 0,
-            changeCount: 0,
-            skipCount: 0,
+            initialPosition: {},
         };
     }
     isParent(t) {
@@ -64,6 +61,14 @@ export class RestaurantTable extends Base {
             x: this.getX() + this.width / 2,
             y: this.getY() + this.height / 2,
         };
+    }
+    get orders() {
+        return this.models["pos.order"].filter(
+            (o) =>
+                o.table_id?.id === this.id &&
+                // Include the orders that are in tipping state.
+                (!o.finalized || o.uiState.screen_data?.value?.name === "TipScreen")
+        );
     }
     getOrder() {
         return this.parent_id?.getOrder?.() || this["<-pos.order.table_id"][0];

--- a/addons/pos_restaurant/static/src/overrides/models/pos_order_line.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_order_line.js
@@ -21,6 +21,7 @@ patch(PosOrderline.prototype, {
     },
     toggleSkipChange() {
         if (this.uiState.hasChange || this.skip_change) {
+            this.setDirty();
             this.skip_change = !this.skip_change;
         }
     },

--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -32,7 +32,7 @@ patch(PosStore.prototype, {
             this.showScreen("FloorScreen", { floor: this.selectedTable?.floor || null });
             this.currentFloor = this.config.floor_ids?.length > 0 ? this.config.floor_ids[0] : null;
             // Sync the number of orders on each table with other PoS
-            this.getTableOrderCount();
+            this.bus.subscribe("SYNC_ORDERS", this.ws_syncTableCount.bind(this));
         }
     },
     async onDeleteOrder(order) {
@@ -44,59 +44,17 @@ patch(PosStore.prototype, {
         }
         return super.onDeleteOrder(...arguments);
     },
-    async getTableOrderCount() {
-        const result = await this.data.call(
-            "pos.config",
-            "get_tables_order_count_and_printing_changes",
-            [this.config.id]
-        );
-        this.ws_syncTableCount({ order_count: result, table_ids: [] });
-        this.bus.subscribe("TABLE_ORDER_COUNT", this.ws_syncTableCount.bind(this));
-    },
     // using the same floorplan.
     async ws_syncTableCount(data) {
-        const missingTable = data["order_count"].find(
-            (table) => !(table.id in this.models["restaurant.table"].getAllBy("id"))
-        );
-
-        if (missingTable) {
-            const response = await this.data.searchRead("restaurant.floor", [
-                ["pos_config_ids", "in", this.config.id],
-            ]);
-
-            const table_ids = response.map((floor) => floor.raw.table_ids).flat();
-            await this.data.read("restaurant.table", table_ids);
+        if (data["login_number"] === this.session.login_number) {
+            return;
         }
-        const tableByIds = this.models["restaurant.table"].getAllBy("id");
-        const tables = data["table_ids"].map((id) => this.models["restaurant.table"].get(id));
-        const draftTableOrders = [
-            ...new Set(
-                tables
-                    .map((t) => t["<-pos.order.table_id"])
-                    .flat()
-                    .filter((o) => !o.finalized)
-            ),
-        ];
-        await this.loadServerOrders([
-            "|",
 
-            // draft table orders in the server
-            ["state", "=", "draft"],
-
-            // draft table orders in client but paid in the server
-            "&",
-            ["state", "in", ["paid", "invoiced"]],
-            ["id", "in", draftTableOrders.map((t) => t.id)],
-
-            ["config_id", "in", [...this.config.raw.trusted_config_ids, this.config.id]],
-            ["table_id", "in", data["table_ids"]],
-            ["session_id", "=", odoo.pos_session_id],
-        ]);
-        for (const table of data["order_count"]) {
-            tableByIds[table.id].uiState.changeCount = table.changes;
-            tableByIds[table.id].uiState.orderCount = table.orders;
-            tableByIds[table.id].uiState.skipCount = table.skip_changes;
-        }
+        const orderIds = this.models["pos.order"]
+            .filter((order) => !order.finalized && typeof order.id === "number")
+            .map((o) => o.id);
+        const orderToLoad = new Set([...data["order_ids"], ...orderIds]);
+        await this.data.read("pos.order", [...orderToLoad]);
     },
     get categoryCount() {
         const orderChange = this.getOrderChanges().orderlines;
@@ -274,16 +232,22 @@ patch(PosStore.prototype, {
         this.selectedTable = table;
         try {
             this.loadingOrderState = true;
-            await this.syncAllOrders();
+            const orders = await this.syncAllOrders();
+            const orderUuids = orders.map((order) => order.uuid);
+
+            for (const order of table.orders) {
+                if (
+                    !orderUuids.includes(order.uuid) &&
+                    typeof order.id === "number" &&
+                    order.uiState.screen_data?.value?.name !== "TipScreen"
+                ) {
+                    order.delete();
+                }
+            }
         } finally {
             this.loadingOrderState = false;
 
-            const tableOrders = this.models["pos.order"].filter(
-                (o) =>
-                    o.table_id?.id === table.id &&
-                    // Include the orders that are in tipping state.
-                    (!o.finalized || o.uiState.screen_data?.value?.name === "TipScreen")
-            );
+            const tableOrders = table.orders;
 
             let currentOrder = tableOrders.find((order) =>
                 orderUuid ? order.uuid === orderUuid : !order.finalized

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -76,7 +76,7 @@ export class SelfOrder extends Reactive {
 
         this.onNotified = getOnNotified(this.bus, this.access_token);
         this.onNotified("PRODUCT_CHANGED", (payload) => {
-            this.models.replaceDataByKey("uuid", payload);
+            this.models.loadData(payload);
         });
         if (this.config.self_ordering_mode === "kiosk") {
             this.onNotified("STATUS", ({ status }) => {
@@ -91,7 +91,7 @@ export class SelfOrder extends Reactive {
             });
             this.onNotified("PAYMENT_STATUS", ({ payment_result, data }) => {
                 if (payment_result === "Success") {
-                    this.models.replaceDataByKey("uuid", data);
+                    this.models.loadData(data);
                     const order = this.models["pos.order"].find(
                         (o) => o.access_token === data["pos.order"][0].access_token
                     );
@@ -628,7 +628,7 @@ export class SelfOrder extends Reactive {
                     table_identifier: this.currentOrder?.table_id?.identifier || false,
                 }
             );
-            this.models.replaceDataByKey("uuid", data);
+            this.models.loadData(data);
             for (const order of data["pos.order"]) {
                 this.subscribeToOrderChannel(order);
             }


### PR DESCRIPTION
Before this commit when we would like to replace a local network with the server one, we was using a specific method that was using a specific record key. That was because the local record created in the front end doesn't have any server id. So we was using an UUID.

Now, the classic load data method is able to replace the local record by the server one using the specific local key. So we don't need anymore the replaceDataByKey method.

taskId: 4167707


