### PR TITLE
[FIX] hr_attendance: correct "0" key behaviour in kiosk PIN

### DIFF
--- a/addons/hr_attendance/static/src/components/pin_code/pin_code.js
+++ b/addons/hr_attendance/static/src/components/pin_code/pin_code.js
@@ -35,7 +35,7 @@ export class KioskPinCode extends Component {
             ev.preventDefault();
             ev.stopPropagation();
 
-            if (allowedKeys[key]) {
+            if (allowedKeys[key] !== null) {
                 await this.onClickPadButton(allowedKeys[key]);
             }
             else {


### PR DESCRIPTION
Change
-----
Take into account the case where the key is 0, which is falsy. Currently 0 acts the same as backspace.

Steps
-----
1. Enable PIN identification in Attendances settings.
2. Attendances > Kiosk mode > Identify manually.

opw-4155987