### PR TITLE
[FIX] base: prevent traceback when editing the view

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -418,11 +418,12 @@ actual arch.
                     err.context = e.context
                     raise err.with_traceback(e.__traceback__) from None
                 else:
+                    ctx = e.__context__ or e
                     err = ValidationError(_(
-                        "Error while validating view (%(view)s):\n\n%(error)s", view=self.key or self.id, error=tools.ustr(e.__context__),
+                        "Error while validating view (%(view)s):\n\n%(error)s", view=self.key or self.id, error=tools.ustr(ctx),
                     ))
                     err.context = {'name': 'invalid view'}
-                    raise err.with_traceback(e.__context__.__traceback__) from None
+                    raise err.with_traceback(ctx.__traceback__) from None
 
         return True
 


### PR DESCRIPTION
When the user edits the view and adds context with invalid syntax,
a traceback will appear.

Steps to reproduce the error:
- Go to Settings > Technical > Views > Open any view
- Add context = "[]" or context = "{a}" like this in the view
- Save

Traceback:
```
ValueError: Non-dict expression
  File "odoo/addons/base/models/ir_ui_view.py", line 377, in _check_xml
    view._validate_view(combined_arch, view.model)
  File "odoo/addons/base/models/ir_ui_view.py", line 1464, in _validate_view
    self._validate_attributes(node, name_manager, node_info)
  File "odoo/addons/base/models/ir_ui_view.py", line 1789, in _validate_attributes
    for key, val_ast in get_dict_asts(expr).items():
  File "odoo/tools/view_validation.py", line 264, in get_dict_asts
    raise ValueError("Non-dict expression")
AttributeError: 'NoneType' object has no attribute '__traceback__'
  File "odoo/http.py", line 2383, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1913, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1976, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1943, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2187, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 227, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 757, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "home/odoo/src/enterprise/saas-17.4/web_studio/controllers/main.py", line 699, in edit_view
    self._set_studio_view(view, new_arch)
  File "home/odoo/src/enterprise/saas-17.4/web_studio/controllers/main.py", line 459, in _set_studio_view
    studio_view.arch_db = arch
  File "odoo/fields.py", line 1378, in __set__
    records.write({self.name: write_value})
  File "home/odoo/src/enterprise/saas-17.4/web_studio/models/studio_mixin.py", line 33, in write
    res = super(StudioMixin, self).write(vals)
  File "odoo/addons/base/models/ir_ui_view.py", line 531, in write
    res = super(View, self).write(self._compute_defaults(vals))
  File "odoo/models.py", line 4582, in write
    real_recs._validate_fields(vals, inverse_fields)
  File "odoo/models.py", line 1513, in _validate_fields
    check(self)
  File "odoo/addons/base/models/ir_ui_view.py", line 416, in _check_xml
    raise err.with_traceback(e.__context__.__traceback__) from None
```

https://github.com/odoo/odoo/blob/a32f78f93e0afaf997d90237795ca648661a88b0/odoo/addons/base/models/ir_ui_view.py#L416
Here, ```e.__context__``` is None because ```get_dict_asts``` raises the exception,
which clears exception context and prevents exception chaining.
so ```e.__context__``` remains unset.
So, it will lead to the above traceback.

sentry-4736234976

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
