### PR TITLE
[FIX] point_of_sale: ensure pending orders sync on load

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -401,6 +401,7 @@ export class PosStore extends Reactive {
 
     async afterProcessServerData() {
         const openOrders = this.data.models["pos.order"].filter((order) => !order.finalized);
+        this.syncAllOrders();
 
         if (!this.config.module_pos_restaurant) {
             this.selectedOrderUuid = openOrders.length

--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -26,10 +26,9 @@ function inverted(fn) {
 
 patch(PosStore.prototype, {
     async setup() {
-        await super.setup(...arguments);
-
         this.couponByLineUuidCache = {};
         this.rewardProductByLineUuidCache = {};
+        await super.setup(...arguments);
 
         effect(
             batched((orders) => {


### PR DESCRIPTION
Before this commit, capturing orders while offline and then refreshing the browser upon returning online would show the WiFi icon in green, and captured orders would appear in the paid orders list. However, these orders were not yet synced with the backend, leading to confusion for the user. Although pending orders would sync after capturing the first order post-refresh, the initial state upon loading the PoS was misleading.

opw-4157460

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
