### PR TITLE
Overlays vs scroll container

### DIFF
--- a/addons/html_editor/static/src/main/table/table_ui_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_ui_plugin.js
@@ -55,19 +55,28 @@ export class TableUIPlugin extends Plugin {
         /** @type {import("@html_editor/core/overlay_plugin").Overlay} */
         this.colMenu = this.shared.createOverlay(TableMenu, {
             position: "top-fit",
+            onPositioned: (el, solution) => {
+                // Only accept top position as solution.
+                if (solution.direction !== "top") {
+                    el.style.display = "none"; // avoid glitch
+                    this.colMenu.close();
+                }
+            },
         });
         /** @type {import("@html_editor/core/overlay_plugin").Overlay} */
         this.rowMenu = this.shared.createOverlay(TableMenu, {
             position: "left-fit",
         });
         this.addDomListener(this.document, "pointermove", this.onMouseMove);
-        this.addDomListener(this.document, "click", () => {
+        const closeMenus = () => {
             if (this.isMenuOpened) {
                 this.isMenuOpened = false;
                 this.colMenu.close();
                 this.rowMenu.close();
             }
-        });
+        };
+        this.addDomListener(this.document, "click", closeMenus);
+        this.addDomListener(this.document, "scroll", closeMenus, true);
     }
 
     handleCommand(command) {

--- a/addons/html_editor/static/tests/overlay.test.js
+++ b/addons/html_editor/static/tests/overlay.test.js
@@ -1,0 +1,157 @@
+import { expect, test } from "@odoo/hoot";
+import { setSelection } from "./_helpers/selection";
+import { click, hover, queryAll, queryOne, waitFor, waitForNone } from "@odoo/hoot-dom";
+import { defineModels, fields, models, mountView } from "@web/../tests/web_test_helpers";
+import { animationFrame } from "@odoo/hoot-mock";
+import { unformat } from "./_helpers/format";
+
+class Test extends models.Model {
+    name = fields.Char();
+    txt = fields.Html();
+    _records = [
+        { id: 1, name: "Test", txt: "<p>text</p>".repeat(50) },
+        {
+            id: 2,
+            name: "Test",
+            txt: unformat(`
+                <table><tbody>
+                    <tr>
+                        <td><p>cell 0</p></td>
+                        <td><p>cell 1</p></td>
+                    </tr>
+                </tbody></table>
+                ${"<p>text</p>".repeat(50)}`),
+        },
+    ];
+}
+
+defineModels([Test]);
+
+test.tags("desktop")("Toolbar should not overflow scroll container", async () => {
+    const top = (elementOrRange) => elementOrRange.getBoundingClientRect().top;
+    const bottom = (elementOrRange) => elementOrRange.getBoundingClientRect().bottom;
+
+    await mountView({
+        type: "form",
+        resId: 1,
+        resModel: "test",
+        arch: `
+            <form>
+                <field name="name"/>
+                <field name="txt" widget="html"/>
+            </form>`,
+    });
+
+    const scrollableElement = queryOne(".o_content");
+    const editable = queryOne(".odoo-editor-editable");
+
+    // Select a paragraph in the middle of the text
+    const fifthParagraph = editable.children[5];
+    setSelection({
+        anchorNode: fifthParagraph,
+        anchorOffset: 0,
+        focusNode: fifthParagraph,
+        focusOffset: 1,
+    });
+    const range = document.getSelection().getRangeAt(0);
+
+    const toolbar = await waitFor(".o-we-toolbar");
+
+    // Toolbar should be above the selection
+    expect(bottom(toolbar)).toBeLessThan(top(range));
+
+    // Scroll down to bring the toolbar close to the top
+    let scrollStep = top(toolbar) - top(scrollableElement);
+    scrollableElement.scrollTop += scrollStep;
+    await animationFrame();
+
+    // Toolbar should be below the selection
+    expect(top(toolbar)).toBeGreaterThan(bottom(range));
+
+    // Toolbar should not overflow the scroll container
+    expect(top(toolbar)).toBeGreaterThan(top(scrollableElement));
+
+    // Scroll down to make the toolbar overflow the scroll container
+    scrollStep = top(toolbar) - top(scrollableElement);
+    scrollableElement.scrollTop += scrollStep;
+    await animationFrame();
+
+    // Toolbar should be invisible
+    expect(toolbar).not.toBeVisible();
+
+    // Scroll up to make the toolbar visible again
+    scrollableElement.scrollTop -= scrollStep;
+    await animationFrame();
+
+    expect(toolbar).toBeVisible();
+});
+
+test.tags("desktop")(
+    "Table column control should always be displayed on top of the table",
+    async () => {
+        const top = (el) => el.getBoundingClientRect().top;
+        const bottom = (el) => el.getBoundingClientRect().bottom;
+
+        await mountView({
+            type: "form",
+            resId: 2,
+            resModel: "test",
+            arch: `
+            <form>
+                <field name="name"/>
+                <field name="txt" widget="html"/>
+            </form>`,
+        });
+
+        const scrollableElement = queryOne(".o_content");
+        const table = queryOne(".odoo-editor-editable table");
+        hover(".odoo-editor-editable td");
+        const columnControl = await waitFor(".o-we-table-menu[data-type='column']");
+
+        // Table column control displayed on hover should be above the table
+        expect(bottom(columnControl)).toBeLessThan(top(table));
+
+        // Scroll down so that the table is close to the top
+        const distanceToTop = top(table) - top(scrollableElement);
+        scrollableElement.scrollTop += distanceToTop;
+        await animationFrame();
+
+        hover(".odoo-editor-editable td");
+        await animationFrame();
+
+        // Table control should not be displayed (it should not overflow the scroll
+        // container, nor be placed below the first row).
+        expect(queryAll(".o-we-table-menu[data-type='column']")).toHaveCount(0);
+    }
+);
+
+test.tags("desktop")("Table menu should close on scroll", async () => {
+    await mountView({
+        type: "form",
+        resId: 2,
+        resModel: "test",
+        arch: `
+            <form>
+                <field name="name"/>
+                <field name="txt" widget="html"/>
+            </form>`,
+    });
+
+    const scrollableElement = queryOne(".o_content");
+
+    hover(".odoo-editor-editable td");
+    const columnControl = await waitFor(".o-we-table-menu[data-type='column']");
+    click(columnControl);
+    await animationFrame();
+
+    // Column menu should be displayed.
+    expect(".o-dropdown--menu").toBeVisible();
+
+    // Scroll down
+    scrollableElement.scrollTop += 10;
+    await waitForNone(".o-dropdown--menu");
+
+    // Column menu should not be visible.
+    expect(".o-dropdown--menu").not.toBeVisible();
+});
+

--- a/addons/html_editor/static/tests/table/ui.test.js
+++ b/addons/html_editor/static/tests/table/ui.test.js
@@ -150,6 +150,7 @@ test("should not display the resizeCursor if the table element isContentEditable
 
 test("list of table commands in first column", async () => {
     const { el } = await setupEditor(`
+        <p><br></p>
         <table>
             <tbody>
             <tr><td class="a">1[]</td><td class="b">2</td><td class="c">3</td></tr>


### PR DESCRIPTION
**[FIX] html_editor: overlay overflowing scroll container**
Before:
![Peek 2024-09-06 15-37](https://github.com/user-attachments/assets/4bd0dd41-2383-4ad3-bb66-80045ad0d38f)
After:
![Peek 2024-09-06 15-41](https://github.com/user-attachments/assets/4815e59d-24ea-4f93-93dc-2b5cbd7b1e3a)


**[FIX] html_editor: keep toolbar stable while extending selection**
Before:
![Peek 2024-09-06 15-38](https://github.com/user-attachments/assets/ce330750-850f-4f1c-8c52-185b8b7c8f28)
After:
![Peek 2024-09-06 15-41a](https://github.com/user-attachments/assets/0d04e0f5-4f91-4e94-acdd-d5ed59a9b86a)
