### PR TITLE
[FIX] web: fix double unhandledrejection in make*Handler

### DIFF
--- a/addons/web/static/src/legacy/js/core/minimal_dom.js
+++ b/addons/web/static/src/legacy/js/core/minimal_dom.js
@@ -53,7 +53,7 @@ export function makeAsyncHandler(fct, preventDefault, stopPropagation) {
 
         _lock();
         const result = fct.apply(this, arguments);
-        Promise.resolve(result).finally(_unlock);
+        Promise.resolve(result).then(_unlock, _unlock);
         return result;
     };
 }
@@ -104,7 +104,7 @@ export function makeButtonHandler(fct) {
             .then(function () {
                 buttonEl.classList.remove('pe-none');
                 const restore = addButtonLoadingEffect(buttonEl);
-                return Promise.resolve(result).finally(restore);
+                return Promise.resolve(result).then(restore, restore);
             });
 
         return result;


### PR DESCRIPTION
In makeAsyncHandler and makeButtonHandler have been modified in commit fcb16a3b1bd373726ffb54f0fbe41fb6d1784769 to remove guardedCatch.

However, in both cases, if result is rejected, Promise.resolve(result) will (quite unexpectedly because of the name of the method) be rejected too. Calling finally on this promise will indeed call the callback, but it will still let the exception bubble up, eventually resulting in a second unhandledrejection for the same original exception.

With this commit, we instead call then(callback, callback) on that Promise, so that the rejection is caught and callback is indeed called in both cases.

To reproduce this issue in saas-17.4, raise a UserError in the route /website_sale/should_show_product_configurator and add a Drawer to your cart: the exception message is displayed twice.
This reproduction doesn't work in 17.0 because the promise is a dialog.opened() that crashes and never resolves, masking the issue (but there is a hint of this, because the loading effect is also never removed from the button (meaning that the callback of makeButtonHandler is never called). Many thanks to MCM to help me understand what was happening here.