### PR TITLE
[FIX] l10n_fi: default tax didn't change after 17.0

### DIFF
--- a/addons/l10n_fi/models/template_fi.py
+++ b/addons/l10n_fi/models/template_fi.py
@@ -29,7 +29,7 @@ class AccountChartTemplate(models.AbstractModel):
                 'expense_currency_exchange_account_id': 'account_4380',
                 'account_journal_early_pay_discount_loss_account_id': 'account_4230',
                 'account_journal_early_pay_discount_gain_account_id': 'account_3500',
-                'account_sale_tax_id': 'tax_dom_sales_goods_24',
-                'account_purchase_tax_id': 'tax_dom_purchase_goods_24',
+                'account_sale_tax_id': 'tax_dom_sales_goods_25_5',
+                'account_purchase_tax_id': 'tax_dom_purchase_goods_25_5',
             },
         }


### PR DESCRIPTION
Description of the issue this commit addresses:

With the change of the taxes in Finland, the default tax was modified but the way it is decided isn't the same as from 17.0. Because of that, in 17.0 and later versions, the default tax remained 24.0%.

---

Desired behavior after this commit is merged:

The default tax in the company template is 25.5%

---

no-task

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
