### PR TITLE
[FIX] account,point_of_sale: No more factoring of tax amount in taxes…

### DIFF
--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -99,7 +99,7 @@ export const accountTaxHelpers = {
         }
 
         function add_extra_base(other_tax, sign) {
-            const tax_amount = taxes_data[tax.id].tax_amount_factorized;
+            const tax_amount = taxes_data[tax.id].tax_amount;
             if (!("tax_amount" in taxes_data[other_tax.id])) {
                 taxes_data[other_tax.id].extra_base_for_tax += sign * tax_amount;
             }
@@ -169,7 +169,7 @@ export const accountTaxHelpers = {
         if (tax.amount_type === "percent") {
             const total_percentage =
                 batch.reduce(
-                    (sum, batch_tax) => sum + batch_tax.total_tax_factor * batch_tax.amount,
+                    (sum, batch_tax) => sum + batch_tax.amount,
                     0
                 ) / 100.0;
             const to_price_excluded_factor =
@@ -195,7 +195,7 @@ export const accountTaxHelpers = {
         if (tax.amount_type === "division") {
             const total_percentage =
                 batch.reduce(
-                    (sum, batch_tax) => sum + batch_tax.total_tax_factor * batch_tax.amount,
+                    (sum, batch_tax) => sum + batch_tax.amount,
                     0
                 ) / 100.0;
             const incl_base_multiplicator = total_percentage === 1.0 ? 1.0 : 1 - total_percentage;
@@ -223,10 +223,9 @@ export const accountTaxHelpers = {
 
         function add_tax_amount_to_results(tax, tax_amount) {
             taxes_data[tax.id].tax_amount = tax_amount;
-            taxes_data[tax.id].tax_amount_factorized = tax_amount * tax.total_tax_factor;
             if (rounding_method === "round_per_line") {
-                taxes_data[tax.id].tax_amount_factorized = roundPrecision(
-                    taxes_data[tax.id].tax_amount_factorized,
+                taxes_data[tax.id].tax_amount = roundPrecision(
+                    taxes_data[tax.id].tax_amount,
                     precision_rounding
                 );
             }
@@ -326,7 +325,7 @@ export const accountTaxHelpers = {
             }
 
             const total_tax_amount = taxes_data[tax.id].batch.reduce(
-                (sum, other_tax) => sum + taxes_data[other_tax.id].tax_amount_factorized,
+                (sum, other_tax) => sum + taxes_data[other_tax.id].tax_amount,
                 0
             );
             let base = raw_base + taxes_data[tax.id].extra_base_for_base;
@@ -347,7 +346,7 @@ export const accountTaxHelpers = {
         if (taxes_data_list.length > 0) {
             total_excluded = taxes_data_list[0].base;
             const tax_amount = taxes_data_list.reduce(
-                (sum, tax_data) => sum + tax_data.tax_amount_factorized,
+                (sum, tax_data) => sum + tax_data.tax_amount,
                 0
             );
             total_included = total_excluded + tax_amount;
@@ -362,8 +361,7 @@ export const accountTaxHelpers = {
                 tax: tax_data.tax,
                 group: batching_results.group_per_tax[tax_data.tax.id],
                 batch: batching_results.batch_per_tax[tax_data.tax.id],
-                tax_amount_unfactorized: tax_data.tax_amount,
-                tax_amount: tax_data.tax_amount_factorized,
+                tax_amount: tax_data.tax_amount,
                 base_amount: tax_data.base
             })),
             tax_data_index: taxes_data_list.reduce(function(results, tax_data, i){

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -824,7 +824,6 @@ class TestTaxCommon(AccountTestInvoicingHttpCommon):
             'price_include': tax.price_include,
             'include_base_amount': tax.include_base_amount,
             'is_base_affected': tax.is_base_affected,
-            'total_tax_factor': tax.total_tax_factor,
             'children_tax_ids': [self._jsonify_tax(child) for child in tax.children_tax_ids],
         }
 

--- a/addons/account/tests/test_tax.py
+++ b/addons/account/tests/test_tax.py
@@ -66,20 +66,20 @@ class TestTax(TestTaxCommon):
         tax_price_excluded = self.percent_tax(21.0, **common_values)
         tax_price_included = self.percent_tax(21.0, price_include=True, **common_values)
 
-        for tax in (tax_price_included, tax_price_excluded):
+        for tax, price_unit in ((tax_price_included, 121.0), (tax_price_excluded, 100.0)):
             for sign in (1, -1):
                 with self.subTest(sign=sign, price_include=tax.price_include):
                     self._check_compute_all_results(
                         tax,
                         {
-                            'total_included': sign * 100.0,
+                            'total_included': sign * 121.0,
                             'total_excluded': sign * 100.0,
                             'taxes': (
                                 (sign * 100.0, sign * 21.0),
                                 (sign * 100.0, -sign * 21.0),
                             ),
                         },
-                        sign * 100.0,
+                        sign * price_unit,
                     )
 
     def test_tax_repartition_lines_dispatch_amount_1(self):
@@ -111,7 +111,7 @@ class TestTax(TestTaxCommon):
                 self._check_compute_all_results(
                     tax,
                     {
-                        'total_included': sign * 1.09,
+                        'total_included': sign * 1.03,
                         'total_excluded': sign * 1.0,
                         'taxes': (
                             (sign * 1.0, sign * 0.01),
@@ -154,7 +154,7 @@ class TestTax(TestTaxCommon):
                 self._check_compute_all_results(
                     tax,
                     {
-                        'total_included': sign * 1.0,
+                        'total_included': sign * 1.03,
                         'total_excluded': sign * 1.0,
                         'taxes': (
                             (sign * 1.0, sign * 0.02),
@@ -190,35 +190,4 @@ class TestTax(TestTaxCommon):
         self.assertListEqual(
             [x[0] for x in self.env["account.tax"].name_search("Ten \"tix\"")],
             ten_fixed_tax_tix.ids,
-        )
-
-    def test_repartition_line_in(self):
-        tax = self.env['account.tax'].create({
-            'name': 'tax20',
-            'amount_type': 'percent',
-            'amount': 20,
-            'type_tax_use': 'none',
-            'invoice_repartition_line_ids': [
-                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
-                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0}),
-                Command.create({'repartition_type': 'tax', 'factor_percent': -100.0}),
-            ],
-            'refund_repartition_line_ids': [
-                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
-                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0}),
-                Command.create({'repartition_type': 'tax', 'factor_percent': -100.0}),
-            ],
-        })
-        self.env.company.country_id = self.env.ref('base.in')
-        self._check_compute_all_results(
-            tax,
-            {
-                'total_included': 1000,
-                'total_excluded': 1000,
-                'taxes': (
-                    (1000, 200.0),
-                    (1000, -200.0),
-                ),
-            },
-            1000.0,
         )

--- a/addons/account/tests/test_taxes_computation.py
+++ b/addons/account/tests/test_taxes_computation.py
@@ -1,3 +1,4 @@
+from odoo import Command
 from odoo.addons.account.tests.common import TestTaxCommon
 from odoo.tests import tagged
 
@@ -617,13 +618,6 @@ class TestTaxesComputation(TestTaxCommon):
         tax4 = self.division_tax(9)
         tax5 = self.division_tax(15)
 
-        # Same of tax4/tax5 except the amount is based on 32% of the base amount.
-        tax4_32 = self.division_tax(9)
-        tax5_32 = self.division_tax(15)
-        (tax4_32 + tax5_32).invoice_repartition_line_ids\
-            .filtered(lambda x: x.repartition_type == 'tax')\
-            .factor_percent = 32
-
         self.assert_taxes_computation(
             tax1 + tax2 + tax3 + tax4 + tax5,
             32.33,
@@ -636,22 +630,6 @@ class TestTaxesComputation(TestTaxCommon):
                     (32.33, 0.312019),
                     (32.33, 4.320267),
                     (32.33, 7.200445),
-                ),
-            },
-            rounding_method='round_globally',
-        )
-        self.assert_taxes_computation(
-            tax1 + tax2 + tax3 + tax4_32 + tax5_32,
-            836.7,
-            {
-                'total_included': 1000.0,
-                'total_excluded': 836.7,
-                'taxes_data': (
-                    (836.7, 50.0),
-                    (836.7, 30.0),
-                    (836.7, 6.5),
-                    (836.7, 28.8),
-                    (836.7, 48.0),
                 ),
             },
             rounding_method='round_globally',
@@ -674,22 +652,33 @@ class TestTaxesComputation(TestTaxCommon):
             },
             rounding_method='round_globally',
         )
-        (tax4_32 + tax5_32).price_include = True
+        self._run_js_tests()
+
+    def test_division_taxes_for_l10n_au_differed_gst(self):
+        tax = self.division_tax(
+            amount=100,
+            price_include=True,
+            invoice_repartition_line_ids=[
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': -100.0}),
+            ],
+            refund_repartition_line_ids=[
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': -100.0}),
+            ],
+        )
         self.assert_taxes_computation(
-            tax1 + tax2 + tax3 + tax4_32 + tax5_32,
-            1000.0,
+            tax,
+            100.0,
             {
-                'total_included': 1000.0,
-                'total_excluded': 836.7,
+                'total_included': 100.0,
+                'total_excluded': 0.0,
                 'taxes_data': (
-                    (836.7, 50.0),
-                    (836.7, 30.0),
-                    (836.7, 6.5),
-                    (836.7, 28.8),
-                    (836.7, 48.0),
+                    (0.0, 100.0),
                 ),
             },
-            rounding_method='round_globally',
         )
         self._run_js_tests()
 

--- a/addons/point_of_sale/models/account_tax.py
+++ b/addons/point_of_sale/models/account_tax.py
@@ -58,6 +58,6 @@ class AccountTax(models.Model):
     @api.model
     def _load_pos_data_fields(self, config_id):
         return [
-            'id', 'name', 'price_include', 'include_base_amount', 'is_base_affected', 'total_tax_factor',
+            'id', 'name', 'price_include', 'include_base_amount', 'is_base_affected',
             'amount_type', 'children_tax_ids', 'amount', 'company_id', 'id', 'sequence', 'tax_group_id',
         ]


### PR DESCRIPTION
… computation

Suppose a tax of 21% having +100%, -100% as repartition lines. Before, when applying the tax on 100, the computed amounts was: tax_amount = 100 * 0.21 = 21
tax_amount_factorized = tax_amount * (100 - 100) = 0 So the tax amount for the line was equal to 0.
In fact, that was a bad idea to involve the repartition lines in the taxes computation. With this commit, the repartition lines are strictly about reporting amounts to the tax report but no longer impact the resulting tax amount.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
