### PR TITLE
[IMP] mail: prettify message links

### DIFF
--- a/addons/mail/controllers/webclient.py
+++ b/addons/mail/controllers/webclient.py
@@ -64,6 +64,8 @@ class WebclientController(http.Controller):
                 )
             else:
                 store.add(thread, request_list=params["request_list"], as_thread=True)
+        if name == "messages":
+            store.add(request.env["mail.message"].search([("id", "in", params)]))
 
     @classmethod
     def _process_request_for_logged_in_user(self, store: Store, name, params):

--- a/addons/mail/models/mail_link_preview.py
+++ b/addons/mail/models/mail_link_preview.py
@@ -39,7 +39,9 @@ class MailLinkPreview(models.Model):
         if not tools.is_html_empty(message.body):
             urls = OrderedSet(html.fromstring(message.body).xpath("//a[not(@data-oe-model)]/@href"))
             if request_url:
-                ignore_pattern = re.compile(f"{re.escape(request_url)}(odoo|web|chat)(/|$|#|\\?)")
+                ignore_pattern = re.compile(
+                    f"{re.escape(request_url)}(((odoo|web|chat)(/|$|#|\\?))|mail/message/\\d+(/|$|#|\\?))"
+                )
                 urls = list(filter(lambda url: not ignore_pattern.match(url), urls))
         requests_session = requests.Session()
         message_link_previews_ok = self.env["mail.message.link.preview"]

--- a/addons/mail/static/src/core/common/core.dark.scss
+++ b/addons/mail/static/src/core/common/core.dark.scss
@@ -2,7 +2,7 @@
     background-color: mix($o-gray-100, $o-gray-200, 15%);
 }
 
-a.o_mail_redirect, a.o_channel_redirect {
+a.o_mail_redirect, a.o_channel_redirect, a.o_message_redirect {
     @include o-mention-variant(rgba(lighten($o-action, 5%), .075), rgba(lighten($o-action, 10%), .25), lighten($o-action, 10%), rgba(lighten($o-action, 5%), .2), rgba(lighten($o-action, 5%), .3), lighten($o-action, 10%));
 }
 

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -125,7 +125,7 @@ $o-discuss-talkingColor: lighten($success, 10%);
     }
 }
 
-a.o_mail_redirect, a.o_channel_redirect, a.o-discuss-mention {
+a.o_mail_redirect, a.o_channel_redirect, a.o-discuss-mention, a.o_message_redirect {
     border-radius: $btn-border-radius-sm;
     padding: 0rem 0.1875rem;
     border: 1px solid;
@@ -133,7 +133,7 @@ a.o_mail_redirect, a.o_channel_redirect, a.o-discuss-mention {
     display: inline-block;
 }
 
-a.o_mail_redirect, a.o_channel_redirect {
+a.o_mail_redirect, a.o_channel_redirect, a.o_message_redirect {
     @include o-mention-variant(rgba($primary, .15), rgba($primary, .25), darken($primary, 10%), rgba($primary, .2), rgba($primary, .5), darken($primary, 15%));
 }
 

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -34,7 +34,7 @@ import { _t } from "@web/core/l10n/translation";
 import { usePopover } from "@web/core/popover/popover_hook";
 import { useService } from "@web/core/utils/hooks";
 import { createElementWithContent } from "@web/core/utils/html";
-import { url } from "@web/core/utils/urls";
+import { getOrigin, url } from "@web/core/utils/urls";
 import { useMessageActions } from "./message_actions";
 import { cookie } from "@web/core/browser/cookie";
 import { rpc } from "@web/core/network/rpc";
@@ -190,7 +190,9 @@ export class Message extends Component {
         useEffect(
             () => {
                 if (!this.state.isEditing) {
-                    this.prepareMessageBody(this.messageBody.el);
+                    this.prepareMessageBody(this.messageBody.el)?.then(() =>
+                        this.prepareMessageBody(this.messageBody.el, false)
+                    );
                 }
             },
             () => [this.state.isEditing, this.message.body]
@@ -375,19 +377,44 @@ export class Message extends Component {
     }
 
     /** @param {HTMLElement} bodyEl */
-    prepareMessageBody(bodyEl) {
+    prepareMessageBody(bodyEl, fetchIfNotFound = true) {
         if (!bodyEl) {
             return;
         }
-        const linkEls = bodyEl.querySelectorAll(".o_channel_redirect");
+
+        /** @param {HTMLAnchorElement} el */
+        function getMsgLinkOrigin(el) {
+            return `${el.protocol}//${el.host}`;
+        }
+
+        const linkEls = bodyEl.getElementsByTagName("a");
+        const msgIds = [];
         for (const linkEl of linkEls) {
-            const text = linkEl.textContent.substring(1); // remove '#' prefix
-            const icon = linkEl.classList.contains("o_channel_redirect_asThread")
-                ? "fa fa-comments-o"
-                : "fa fa-hashtag";
-            const iconEl = renderToElement("mail.Message.mentionedChannelIcon", { icon });
-            linkEl.replaceChildren(iconEl);
-            linkEl.insertAdjacentText("beforeend", ` ${text}`);
+            if (linkEl.classList.contains("o_channel_redirect")) {
+                const text = linkEl.textContent.substring(1); // remove '#' prefix
+                const icon = linkEl.classList.contains("o_channel_redirect_asThread")
+                    ? "fa fa-comments-o"
+                    : "fa fa-hashtag";
+                const iconEl = renderToElement("mail.Message.mentionedChannelIcon", { icon });
+                linkEl.replaceChildren(iconEl);
+                linkEl.insertAdjacentText("beforeend", ` ${text}`);
+            } else if (getMsgLinkOrigin(linkEl) === getOrigin()) {
+                const match = linkEl.pathname.match(/^\/mail\/message\/(\d+)$/);
+                if (match) {
+                    const msg = this.store["mail.message"].insert(parseInt(match[1]));
+                    if (fetchIfNotFound && !msg.thread?.displayName) {
+                        msgIds.push(msg.id);
+                    }
+                    const threadName = msg.thread?.displayName ?? _t("Unknown");
+                    const msgLink = renderToElement("mail.Message.messageLink", { threadName });
+                    linkEl.replaceChildren(msgLink);
+                    linkEl.classList.add("o_message_redirect");
+                }
+            }
+        }
+        if (msgIds.length) {
+            const messageIds = this.store.fetchParams["messages"] || [];
+            return this.store.fetchStoreData("messages", [...messageIds, ...msgIds]);
         }
     }
 

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -175,3 +175,8 @@
 .o-mail-Message-translated {
     color: $o-enterprise-action-color;
 }
+
+.o-mail-Message-link-arrow {
+    margin-left: 4px;
+    margin-right: 2px;
+}

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -214,4 +214,12 @@
     <i t-att-class="icon"/>
 </t>
 
+<t t-name="mail.Message.messageLink">
+    <span>
+        <t t-out="threadName" />
+        <i class='o-mail-Message-link-arrow fa fa-angle-right' aria-hidden='true'/>
+        <i class='fa fa-comment' aria-hidden='true'/>
+    </span>
+</t>
+
 </templates>

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -85,7 +85,7 @@ export class Store extends BaseStore {
 
     fetchDeferred = new Deferred();
     /** @type {[string | [string, any]]} */
-    fetchParams = [];
+    fetchParams = {};
     fetchReadonly = true;
     fetchSilent = true;
 
@@ -193,7 +193,7 @@ export class Store extends BaseStore {
      * @returns {Deferred}
      */
     async fetchStoreData(name, params, { readonly = true, silent = true } = {}) {
-        this.fetchParams.push(params ? [name, params] : name);
+        this.fetchParams[name] = params;
         this.fetchReadonly = this.fetchReadonly && readonly;
         this.fetchSilent = this.fetchSilent && silent;
         const fetchDeferred = this.fetchDeferred;
@@ -250,7 +250,12 @@ export class Store extends BaseStore {
         const fetchDeferred = this.fetchDeferred;
         rpc(
             this.fetchReadonly ? "/mail/data" : "/mail/action",
-            { fetch_params: this.fetchParams, context: user.context },
+            {
+                fetch_params: Object.entries(this.fetchParams).map((param) =>
+                    param[1] ? param : param[0]
+                ),
+                context: user.context,
+            },
             {
                 silent: this.fetchSilent,
             }
@@ -266,7 +271,7 @@ export class Store extends BaseStore {
 
     resetFetchState() {
         this.fetchDeferred = new Deferred();
-        this.fetchParams = [];
+        this.fetchParams = {};
         this.fetchReadonly = true;
         this.fetchSilent = true;
     }

--- a/addons/mail/static/src/core/web/store_service_patch.js
+++ b/addons/mail/static/src/core/web/store_service_patch.js
@@ -38,14 +38,14 @@ const StorePatch = {
      * Override to initialise using the lazy_session to initialise the webclient part
      */
     _fetchStoreDataDebounced() {
-        if (!this.fetchParams.includes("init_messaging")) {
+        if (!Object.prototype.hasOwnProperty.call(this.fetchParams, "init_messaging")) {
             return super._fetchStoreDataDebounced();
         }
         this.env.services["lazy_session"].getValue("store_data", (storeData) => {
             const result = this.insert(storeData);
             // if the "init_messaging" isn't the only param
-            this.fetchParams = this.fetchParams.filter((param) => param !== "init_messaging");
-            if (this.fetchParams.length > 0) {
+            delete this.fetchParams["init_messaging"];
+            if (Object.keys(this.fetchParams).length > 0) {
                 return super._fetchStoreDataDebounced();
             }
             this.fetchDeferred.resolve(result);

--- a/addons/mail/static/src/core/web_portal/message_patch.js
+++ b/addons/mail/static/src/core/web_portal/message_patch.js
@@ -20,9 +20,10 @@ patch(Message.prototype, {
         if (!bodyEl) {
             return;
         }
-        super.prepareMessageBody(...arguments);
+        const res = super.prepareMessageBody(...arguments);
         Array.from(bodyEl.querySelectorAll(".o-mail-ellipsis")).forEach((el) => el.remove());
         this.insertEllipsisbtn(bodyEl);
+        return res;
     },
 
     /**

--- a/addons/mail/static/src/discuss/core/common/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/common/store_service_patch.js
@@ -45,15 +45,8 @@ const storeServicePatch = {
     },
     /** @param {number} channelId */
     async fetchChannel(channelId) {
-        const channelIds = this.fetchParams.find(
-            (fetchParams) => fetchParams[0] === "discuss.channel"
-        );
-        if (channelIds) {
-            channelIds[1].push(channelId);
-            await this.fetchDeferred;
-        } else {
-            await this.fetchStoreData("discuss.channel", [channelId]);
-        }
+        const channelIds = this.fetchParams["discuss.channel"] || [];
+        await this.fetchStoreData("discuss.channel", [...channelIds, channelId]);
     },
     /**
      * List of known partner ids with a direct chat, ordered

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -1064,6 +1064,9 @@ function _process_request_for_all(store, name, params, context = {}) {
             store.add(channel, makeKwArgs({ delete: true }));
         }
     }
+    if (name === "messages") {
+        store.add(MailMessage.search([["id", "in", params]]));
+    }
 }
 
 function _process_request_for_internal_user(store, name, params) {

--- a/addons/mail/tests/test_link_preview.py
+++ b/addons/mail/tests/test_link_preview.py
@@ -196,6 +196,8 @@ class TestLinkPreview(MailCommon):
                 ("http://www.odoo.com/", "https://www.odoo.com/chat/5/bFtIfYHRco", 1),
                 ("https://clients.odoo.com/", "https://www.odoo.com/odoo/1519/tasks/4102866", 1),
                 ("https://clients.odoo.com/", "https://www.odoo.com/chat/5/bFtIfYHRco", 1),
+                ("https://www.odoo.com/", "https://www.odoo.com/mail/message/111", 0),
+                ("https://www.odoo.com/", "https://www.odoo.com/mail/message/xyz", 1),
             ]
             for request_url, url, counter in urls:
                 with self.subTest(request_url=request_url, url=url, counter=counter):


### PR DESCRIPTION
**PURPOSE:**

Currently, internal links that redirect to messages are displayed as raw URLs,
which makes them hard to read and understand. This PR aims to enhance
the user experience by improving the display of these message links.

**SPECIFICATION:**

Message links should be presented in a more user-friendly format,
displaying the `Thread name > {Comment Icon}`,
similar to how other platforms like Discord handle message links.

**task**-[4095268](https://www.odoo.com/odoo/project/1519/tasks/4095268)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
