### PR TITLE
[IMP] account_edi_ubl_cii: Import Postal Address of partner from XML

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -363,7 +363,7 @@ class AccountEdiCommon(models.AbstractModel):
 
         return attachments
 
-    def _import_partner(self, company_id, name, phone, email, vat, country_code=False, peppol_eas=False, peppol_endpoint=False):
+    def _import_partner(self, company_id, name, phone, email, vat, peppol_eas=False, peppol_endpoint=False, postal_address={}):
         """ Retrieve the partner, if no matching partner is found, create it (only if he has a vat and a name) """
         logs = []
         if peppol_eas and peppol_endpoint:
@@ -373,17 +373,30 @@ class AccountEdiCommon(models.AbstractModel):
         partner = self.env['res.partner'] \
             .with_company(company_id) \
             ._retrieve_partner(name=name, phone=phone, email=email, vat=vat, domain=domain)
+        country_code = postal_address.get('country_code')
+        country = self.env['res.country'].search([('code', '=', country_code.upper())]) if country_code else self.env['res.country']
+        state_code = postal_address.get('state_code')
+        state = self.env['res.country.state'].search(
+            [('country_id', '=', country.id), ('code', '=', state_code)],
+            limit=1,
+        ) if state_code and country else self.env['res.country.state']
         if not partner and name and vat:
             partner_vals = {'name': name, 'email': email, 'phone': phone}
             if peppol_eas and peppol_endpoint:
                 partner_vals.update({'peppol_eas': peppol_eas, 'peppol_endpoint': peppol_endpoint})
-            country = self.env.ref(f'base.{country_code.lower()}', raise_if_not_found=False) if country_code else False
-            if country:
-                partner_vals['country_id'] = country.id
             partner = self.env['res.partner'].create(partner_vals)
             if vat and self.env['res.partner']._run_vat_test(vat, country, partner.is_company):
                 partner.vat = vat
             logs.append(_("Could not retrieve a partner corresponding to '%s'. A new partner was created.", name))
+        if not partner.country_id and not partner.street and not partner.street2 and not partner.city and not partner.zip and not partner.state_id:
+            partner.write({
+                'country_id': country.id,
+                'street': postal_address.get('street'),
+                'street2': postal_address.get('additional_street'),
+                'city': postal_address.get('city'),
+                'zip': postal_address.get('zip'),
+                'state_id': state.id,
+            })
         return partner, logs
 
     def _import_partner_bank(self, invoice, bank_details):

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
@@ -251,7 +251,16 @@ class AccountEdiXmlCii(models.AbstractModel):
             'name': self._find_value(f".//ram:{role}/ram:Name", tree),
             'phone': self._find_value(f".//ram:{role}/ram:DefinedTradeContact/ram:TelephoneUniversalCommunication/ram:CompleteNumber", tree),
             'email': self._find_value(f".//ram:{role}//ram:URIID[@schemeID='SMTP']", tree),
+            'postal_address': self._get_postal_address(tree, role),
+        }
+
+    def _get_postal_address(self, tree, role):
+        return {
             'country_code': self._find_value(f'.//ram:{role}/ram:PostalTradeAddress//ram:CountryID', tree),
+            'street': self._find_value(f'.//ram:{role}/ram:PostalTradeAddress//ram:LineOne', tree),
+            'additional_street': self._find_value(f'.//ram:{role}/ram:PostalTradeAddress//ram:LineTwo', tree),
+            'city': self._find_value(f'.//ram:{role}/ram:PostalTradeAddress//ram:CityName', tree),
+            'zip': self._find_value(f'.//ram:{role}/ram:PostalTradeAddress//ram:PostcodeCode', tree),
         }
 
     def _import_fill_invoice(self, invoice, tree, qty_factor):

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -643,7 +643,17 @@ class AccountEdiXmlUbl_20(models.AbstractModel):
             'email': self._find_value(f'.//cac:{role}Party/cac:Party//cbc:ElectronicMail', tree),
             'name': self._find_value(f'.//cac:{role}Party/cac:Party//cbc:Name', tree) or
                     self._find_value(f'.//cac:{role}Party/cac:Party//cbc:RegistrationName', tree),
+            'postal_address': self._get_postal_address(tree, role),
+        }
+
+    def _get_postal_address(self, tree, role):
+        return {
             'country_code': self._find_value(f'.//cac:{role}Party/cac:Party//cac:Country//cbc:IdentificationCode', tree),
+            'street': self._find_value(f'.//cac:{role}Party/cac:Party/cac:PostalAddress/cbc:StreetName', tree),
+            'additional_street': self._find_value(f'.//cac:{role}Party/cac:Party/cac:PostalAddress/cbc:AdditionalStreetName', tree),
+            'city': self._find_value(f'.//cac:{role}Party/cac:Party/cac:PostalAddress/cbc:CityName', tree),
+            'zip': self._find_value(f'.//cac:{role}Party/cac:Party/cac:PostalAddress/cbc:PostalZone', tree),
+            'state_code': self._find_value(f'.//cac:{role}Party/cac:Party/cac:PostalAddress/cbc:CountrySubentityCode', tree),
         }
 
     def _import_fill_invoice(self, invoice, tree, qty_factor):

--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -215,3 +215,28 @@ class TestAccountEdiUblCii(AccountTestInvoicingCommon):
         # The partner should be retrieved based on the peppol fields
         imported_invoice = self.import_attachment(xml_attachment, self.company_data["default_journal_sale"])
         self.assertEqual(imported_invoice.partner_id, partner)
+
+    def test_import_partner_postal_address(self):
+        " Test importing postal address when creating new partner from UBL xml."
+        file_path = "bis3_bill_example.xml"
+        file_path = f"{self.test_module}/tests/test_files/{file_path}"
+        with file_open(file_path, 'rb') as file:
+            xml_attachment = self.env['ir.attachment'].create({
+                'mimetype': 'application/xml',
+                'name': 'test_invoice.xml',
+                'raw': file.read(),
+            })
+
+        partner_vals = {
+            'name': "ALD Automotive LU",
+            'email': "adl@test.com",
+            'vat': "LU12977109",
+        }
+        # assert there is no matching partner
+        partner_match = self.env['res.partner']._retrieve_partner(**partner_vals)
+        self.assertFalse(partner_match)
+
+        bill = self.import_attachment(xml_attachment)
+
+        self.assertRecordValues(bill.partner_id, [partner_vals])
+        self.assertEqual(bill.partner_id.contact_address_complete, "270 rte d'Arlon, 8010 Strassen, Luxembourg")


### PR DESCRIPTION
Previously, partner addresses were not imported from the e-invoice XML. This commit ensures that the partner's address is populated if missing.

task-4142055

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
