### PR TITLE
[IMP] web: avoid debugger break, when using "stop on exception" option

### DIFF
--- a/addons/web/static/src/core/pwa/pwa_service.js
+++ b/addons/web/static/src/core/pwa/pwa_service.js
@@ -53,13 +53,8 @@ const pwaService = {
         });
 
         function _getInstallationState(scope = state.startUrl) {
-            let value;
-            try {
-                value = JSON.parse(browser.localStorage.getItem("pwa.installationState"))[scope];
-            } catch {
-                value = "";
-            }
-            return value;
+            const installationState = browser.localStorage.getItem("pwa.installationState");
+            return installationState ? JSON.parse(installationState)[scope] : "";
         }
 
         function _setInstallationState(value) {


### PR DESCRIPTION
Small code refactor to avoid debugger break when we debug with chrome when "stop on exception" is enabled.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
