### PR TITLE
[FIX] pos_self_order: prevent duplicate and irrelevant attribute show

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -40,6 +40,14 @@ export class ProductProduct extends Base {
         return this.attribute_line_ids.map((a) => a.product_template_value_ids).flat().length > 1;
     }
 
+    needToConfigure() {
+        return (
+            this.isConfigurable() &&
+            this.attribute_line_ids.length > 0 &&
+            !this.attribute_line_ids.every((l) => l.attribute_id.create_variant === "always")
+        );
+    }
+
     isCombo() {
         return this.combo_ids.length;
     }

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -186,12 +186,11 @@ export class ProductScreen extends Component {
             return;
         }
 
-        const configure =
-            product.isConfigurable() &&
-            product.attribute_line_ids.length > 0 &&
-            !product.attribute_line_ids.every((l) => l.attribute_id.create_variant === "always");
-
-        await this.pos.addLineToCurrentOrder({ product_id: product }, { code }, configure);
+        await this.pos.addLineToCurrentOrder(
+            { product_id: product },
+            { code },
+            product.needToConfigure()
+        );
         this.numberBuffer.reset();
     }
     async _getPartnerByBarcode(code) {

--- a/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.js
+++ b/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.js
@@ -17,7 +17,7 @@ export class AttributeSelection extends Component {
         for (const attr of this.props.product.attribute_line_ids) {
             this.gridsRef[attr.id] = useRef(`attribute_grid_${attr.id}`);
             this.valuesRef[attr.id] = {};
-            for (const value of attr.attribute_id.template_value_ids) {
+            for (const value of attr.product_template_value_ids) {
                 this.valuesRef[attr.id][value.id] = useRef(`value_${attr.id}_${value.id}`);
             }
         }
@@ -84,8 +84,14 @@ export class AttributeSelection extends Component {
 
     availableAttributeValue(attribute) {
         return this.selfOrder.config.self_ordering_mode === "kiosk"
-            ? attribute.attribute_id.template_value_ids.filter((a) => !a.is_custom)
-            : attribute.attribute_id.template_value_ids;
+            ? attribute.product_template_value_ids.filter((a) => !a.is_custom)
+            : attribute.product_template_value_ids;
+    }
+
+    availableAttributes() {
+        return this.props.product.attribute_line_ids.filter(
+            (a) => a.attribute_id.create_variant !== "always"
+        );
     }
 
     initAttribute() {
@@ -109,10 +115,10 @@ export class AttributeSelection extends Component {
             return false;
         };
 
-        for (const attr of this.props.product.attribute_line_ids) {
+        for (const attr of this.availableAttributes()) {
             this.selectedValues[attr.id] = {};
 
-            for (const value of attr.attribute_id.template_value_ids) {
+            for (const value of attr.product_template_value_ids) {
                 if (attr.attribute_id.display_type === "multi") {
                     this.selectedValues[attr.id][value.id] = initValue(value);
                 } else if (typeof this.selectedValues[attr.id] !== "number") {

--- a/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
+++ b/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
@@ -4,7 +4,7 @@
         <div class="self_order_attribute_selection d-flex flex-column flex-grow-1">
             <div class="attribute-selection-content align-items-center justify-content-start px-3 flex-grow-1">
                 <div class="d-flex flex-column">
-                    <div t-foreach="this.props.product.attribute_line_ids" t-as="attribute" t-key="attribute.id" class="attribute-row">
+                    <div t-foreach="availableAttributes()" t-as="attribute" t-key="attribute.id" class="attribute-row">
                         <h2 t-out="attribute.attribute_id.name"/>
                         <div class="row g-2 g-md-3 g-xl-4 justify-content-between justify-content-md-start mb-5 row-cols-2 row-cols-sm-3 row-cols-md-4 row-cols-xl-5 row-cols-xxl-6"
                             t-ref="attribute_grid_{{attribute.id}}">

--- a/addons/pos_self_order/static/src/app/components/product_card/product_card.js
+++ b/addons/pos_self_order/static/src/app/components/product_card/product_card.js
@@ -94,7 +94,7 @@ export class ProductCard extends Component {
 
         if (product.isCombo()) {
             this.router.navigate("combo_selection", { id: product.id });
-        } else if (product.isConfigurable()) {
+        } else if (product.needToConfigure()) {
             this.router.navigate("product", { id: product.id });
         } else {
             if (!this.selfOrder.ordering) {


### PR DESCRIPTION
Before this commit, adding the same attribute to multiple products caused the attribute values to appear multiple times in the mobile/kiosk. Moreover, attributes with the variant creation mode were incorrectly displayed as configurable options, despite being intended to represent separate products and not to be shown as options for configuration.

opw-4163858

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
