### PR TITLE
[FIX] mail: allow portal users to react to channel messages (master)

### DIFF
--- a/addons/im_livechat/controllers/cors/message_reaction.py
+++ b/addons/im_livechat/controllers/cors/message_reaction.py
@@ -7,6 +7,6 @@ from odoo.addons.im_livechat.tools.misc import force_guest_env
 
 class LivechatMessageReactionController(MessageReactionController):
     @route("/im_livechat/cors/message/reaction", methods=["POST"], type="json", auth="public", cors="*")
-    def livechat_message_reaction(self, guest_token, message_id, content, action):
+    def livechat_message_reaction(self, guest_token, message_id, content, action, **kwargs):
         force_guest_env(guest_token)
-        return self.mail_message_reaction(message_id, content, action)
+        return self.mail_message_reaction(message_id, content, action, **kwargs)

--- a/addons/mail/controllers/message_reaction.py
+++ b/addons/mail/controllers/message_reaction.py
@@ -12,8 +12,8 @@ class MessageReactionController(http.Controller):
     @http.route("/mail/message/reaction", methods=["POST"], type="json", auth="public")
     @add_guest_to_context
     def mail_message_reaction(self, message_id, content, action):
-        message = request.env["mail.message"].browse(int(message_id)).exists()
-        if not message._validate_access_for_current_persona("write"):
+        message = request.env["mail.message"]._get_with_access(int(message_id), "create")
+        if not message:
             raise NotFound()
         partner, guest = request.env["res.partner"]._get_current_persona()
         if not partner and not guest:

--- a/addons/mail/controllers/message_reaction.py
+++ b/addons/mail/controllers/message_reaction.py
@@ -11,14 +11,17 @@ from odoo.addons.mail.tools.discuss import Store
 class MessageReactionController(http.Controller):
     @http.route("/mail/message/reaction", methods=["POST"], type="json", auth="public")
     @add_guest_to_context
-    def mail_message_reaction(self, message_id, content, action):
-        message = request.env["mail.message"]._get_with_access(int(message_id), "create")
+    def mail_message_reaction(self, message_id, content, action, **kwargs):
+        message = request.env["mail.message"]._get_with_access(int(message_id), "create", **kwargs)
         if not message:
             raise NotFound()
-        partner, guest = request.env["res.partner"]._get_current_persona()
+        partner, guest = self._get_reaction_author(message, **kwargs)
         if not partner and not guest:
             raise NotFound()
         store = Store()
         # sudo: mail.message - access mail.message.reaction through an accessible message is allowed
         message.sudo()._message_reaction(content, action, partner, guest, store)
         return store.get_result()
+
+    def _get_reaction_author(self, message, **kwargs):
+        return request.env["res.partner"]._get_current_persona()

--- a/addons/mail/models/discuss/mail_message.py
+++ b/addons/mail/models/discuss/mail_message.py
@@ -7,16 +7,6 @@ from odoo.addons.mail.tools.discuss import Store
 class MailMessage(models.Model):
     _inherit = "mail.message"
 
-    def _validate_access_for_current_persona(self, operation):
-        if not self:
-            return False
-        self.ensure_one()
-        if self.env.user._is_public():
-            guest = self.env["mail.guest"]._get_guest_from_context()
-            # sudo: mail.guest - current guest can read channels they are member of
-            return guest and self.model == "discuss.channel" and self.res_id in guest.sudo().channel_ids.ids
-        return super()._validate_access_for_current_persona(operation)
-
     def _extras_to_store(self, store: Store, format_reply):
         super()._extras_to_store(store, format_reply=format_reply)
         if format_reply:

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -598,7 +598,7 @@ class Message(models.Model):
         )
 
     @api.model
-    def _get_with_access(self, message_id, operation):
+    def _get_with_access(self, message_id, operation, **kwargs):
         """Return the message with the given id if it exists and if the current
         user can access it for the given operation."""
         message = self.browse(message_id).exists()
@@ -614,6 +614,10 @@ class Message(models.Model):
             message.sudo(False).check_access_rule(operation)
             return message
         except AccessError:
+            if message.model and message.res_id:
+                mode = self.env[message.model]._get_mail_message_access([message.res_id], operation)
+                if self.env[message.model]._get_thread_with_access(message.res_id, mode, **kwargs):
+                    return message
             return self.env["mail.message"]
 
     @api.model_create_multi

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4635,8 +4635,8 @@ class MailThread(models.AbstractModel):
     def _get_thread_with_access(self, thread_id, mode="read", **kwargs):
         try:
             thread = self.with_context(active_test=False).search([("id", "=", thread_id)])
-            thread.check_access_rights(mode)
-            thread.check_access_rule(mode)
+            thread.sudo(False).check_access_rights(mode)
+            thread.sudo(False).check_access_rule(mode)
             return thread.with_context(active_test=True)
         except AccessError:
             return self.browse()

--- a/addons/mail/tests/__init__.py
+++ b/addons/mail/tests/__init__.py
@@ -10,6 +10,7 @@ from . import test_mail_message_translate
 from . import test_mail_render
 from . import test_mail_template
 from . import test_mail_tools
+from . import test_message_reaction_controller
 from . import test_res_company
 from . import test_res_partner
 from . import test_res_users

--- a/addons/mail/tests/test_message_reaction_controller.py
+++ b/addons/mail/tests/test_message_reaction_controller.py
@@ -1,0 +1,158 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo
+from odoo.tests import JsonRpcException
+from odoo.addons.base.tests.common import HttpCaseWithUserDemo
+from odoo.addons.mail.tests.common import MailCommon
+
+
+@odoo.tests.tagged("-at_install", "post_install")
+class TestMessageReactionControllerCommon(HttpCaseWithUserDemo, MailCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._create_portal_user()
+        cls.public_user = cls.env.ref("base.public_user")
+        cls.guest = cls.env["mail.guest"].create({"name": "Guest"})
+        cls.public_w_guest = cls.public_user
+        cls.no_user = cls.env["res.users"]  # same as public user but with no guest
+        last_message = cls.env["mail.message"].search([], order="id desc", limit=1)
+        cls.fake_message = cls.env["mail.message"].browse(last_message.id + 1000000)
+        cls.reaction = "😊"
+
+    def _execute_subtests(self, message, subtests):
+        for user, allowed, *args in subtests:
+            route_kw = args[0] if args else {}
+            kwargs = args[1] if len(args) > 1 else {}
+            if not user:
+                self.authenticate(None, None)
+            elif user != self.public_w_guest:
+                self.authenticate(user.login, user.login)
+            else:
+                self.authenticate(None, None)
+                self.opener.cookies[self.guest._cookie_name] = (
+                    f"{self.guest.id}{self.guest._cookie_separator}{self.guest.access_token}"
+                )
+            msg = str(message.body) if message != self.fake_message else "fake message"
+            with self.subTest(message=msg, login=user.login, route_kw=route_kw):
+                if allowed:
+                    self._add_reaction(message, self.reaction, route_kw)
+                    reactions = self._find_reactions(message)
+                    self.assertEqual(len(reactions), 1)
+                    expected_partner = kwargs.get("partner")
+                    if user == self.public_w_guest and not expected_partner:
+                        self.assertEqual(reactions.guest_id, self.guest)
+                    else:
+                        self.assertEqual(reactions.partner_id, expected_partner or user.partner_id)
+                    self._remove_reaction(message, self.reaction, route_kw)
+                    self.assertEqual(len(self._find_reactions(message)), 0)
+                else:
+                    with self.assertRaises(JsonRpcException, msg="werkzeug.exceptions.NotFound"):
+                        self._add_reaction(message, self.reaction, route_kw)
+                    with self.assertRaises(JsonRpcException, msg="werkzeug.exceptions.NotFound"):
+                        self._remove_reaction(message, self.reaction, route_kw)
+
+    def _add_reaction(self, message, content, route_kw):
+        self.make_jsonrpc_request(
+            route=f"{self.env.user.get_base_url()}/mail/message/reaction",
+            params={"action": "add", "content": content, "message_id": message.id, **route_kw},
+        )
+
+    def _remove_reaction(self, message, content, route_kw):
+        self.make_jsonrpc_request(
+            route=f"{self.env.user.get_base_url()}/mail/message/reaction",
+            params={"action": "remove", "content": content, "message_id": message.id, **route_kw},
+        )
+
+    def _find_reactions(self, message):
+        return self.env["mail.message.reaction"].search([("message_id", "=", message.id)])
+
+
+@odoo.tests.tagged("-at_install", "post_install")
+class TestMessageReactionController(TestMessageReactionControllerCommon):
+    def test_message_reaction_partner(self):
+        """Test access of message reaction for partner chatter."""
+        message = self.user_demo.partner_id.message_post(body="partner message")
+        self._execute_subtests(
+            message,
+            (
+                (self.no_user, False),
+                (self.public_w_guest, False),
+                (self.user_portal, False),
+                # False because not group_partner_manager
+                (self.user_employee, False),
+                (self.user_demo, True),
+                (self.user_admin, True),
+            ),
+        )
+
+    def test_message_reaction_public_channel(self):
+        """Test access of message reaction for a public channel."""
+        channel = self.env["discuss.channel"].create(
+            {"group_public_id": None, "name": "public channel"}
+        )
+        message = channel.message_post(body="public message")
+        self._execute_subtests(
+            message,
+            (
+                (self.no_user, False),
+                (self.public_w_guest, True),
+                (self.user_portal, True),
+                (self.user_employee, True),
+                (self.user_demo, True),
+                (self.user_admin, True),
+            ),
+        )
+
+    def test_message_reaction_channel_as_member(self):
+        """Test access of message reaction for a channel as member."""
+        channel = self.env["discuss.channel"].browse(
+            self.env["discuss.channel"].create_group(
+                partners_to=(self.user_portal + self.user_employee + self.user_demo).partner_id.ids
+            )["id"]
+        )
+        channel.add_members(guest_ids=self.guest.ids)
+        message = channel.message_post(body="invite message")
+        self._execute_subtests(
+            message,
+            (
+                (self.no_user, False),
+                (self.public_w_guest, True),
+                (self.user_portal, True),
+                (self.user_employee, True),
+                (self.user_demo, True),
+                (self.user_admin, True),
+            ),
+        )
+
+    def test_message_reaction_channel_as_non_member(self):
+        """Test access of message reaction for a channel as non-member."""
+        channel = self.env["discuss.channel"].browse(
+            self.env["discuss.channel"].create_group(partners_to=[])["id"]
+        )
+        message = channel.message_post(body="private message")
+        self._execute_subtests(
+            message,
+            (
+                (self.no_user, False),
+                (self.public_w_guest, False),
+                (self.user_portal, False),
+                (self.user_employee, False),
+                (self.user_demo, False),
+                (self.user_admin, True),
+            ),
+        )
+
+    def test_message_reaction_fake_message(self):
+        """Test access of message reaction for a non-existing message."""
+        self._execute_subtests(
+            self.fake_message,
+            (
+                (self.no_user, False),
+                (self.public_w_guest, False),
+                (self.user_portal, False),
+                (self.user_employee, False),
+                (self.user_demo, False),
+                (self.user_admin, False),
+            ),
+        )

--- a/addons/portal/controllers/__init__.py
+++ b/addons/portal/controllers/__init__.py
@@ -3,4 +3,5 @@
 from . import web
 from . import portal
 from . import mail
+from . import message_reaction
 from . import thread

--- a/addons/portal/controllers/message_reaction.py
+++ b/addons/portal/controllers/message_reaction.py
@@ -1,0 +1,17 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.http import request
+from odoo.addons.mail.controllers.message_reaction import MessageReactionController
+from odoo.addons.portal.utils import get_portal_partner
+
+
+class PortalMessageReactionController(MessageReactionController):
+    def _get_reaction_author(self, message, **kwargs):
+        partner, guest = super()._get_reaction_author(message, **kwargs)
+        if not partner and message.model and message.res_id:
+            thread = request.env[message.model].browse(message.res_id)
+            if partner := get_portal_partner(
+                thread, kwargs.get("hash"), kwargs.get("pid"), kwargs.get("token")
+            ):
+                guest = request.env["mail.guest"]
+        return partner, guest

--- a/addons/portal/utils.py
+++ b/addons/portal/utils.py
@@ -15,3 +15,12 @@ def validate_thread_with_hash_pid(thread, _hash, pid):
 
 def validate_thread_with_token(thread, token):
     return token and consteq(token, thread[thread._mail_post_token_field])
+
+
+def get_portal_partner(thread, _hash, pid, token):
+    if validate_thread_with_hash_pid(thread, _hash, pid):
+        return thread.env["res.partner"].sudo().browse(int(pid))
+    if validate_thread_with_token(thread, token):
+        if partner := thread._mail_get_partners()[thread.id][:1]:
+            return partner
+    return thread.env["res.partner"]

--- a/addons/test_mail_full/tests/__init__.py
+++ b/addons/test_mail_full/tests/__init__.py
@@ -1,10 +1,10 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_odoobot
 from . import test_mail_performance
 from . import test_mail_thread_internals
 from . import test_mass_mailing
+from . import test_message_reaction_controller_portal
 from . import test_portal
 from . import test_rating
 from . import test_res_users

--- a/addons/test_mail_full/tests/test_message_reaction_controller_portal.py
+++ b/addons/test_mail_full/tests/test_message_reaction_controller_portal.py
@@ -1,0 +1,108 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo
+from odoo.addons.mail.tests.test_message_reaction_controller import (
+    TestMessageReactionControllerCommon,
+)
+
+
+@odoo.tests.tagged("-at_install", "post_install")
+class TestPortalMessageReactionController(TestMessageReactionControllerCommon):
+    def test_message_reaction_portal_no_partner(self):
+        """Test access of message reaction for portal without partner."""
+        record = self.env["mail.test.portal.no.partner"].create({"name": "Test"})
+        message = record.message_post(body="portal no partner")
+        token = record._portal_ensure_token()
+        sign_partner = self.env["res.partner"].create({"name": "Sign Partner"})
+        _hash = record._sign_token(sign_partner.id)
+        token_param = {"token": token}
+        incorrect_token_param = {"token": "incorrect token"}
+        hash_pid_param = {"hash": _hash, "pid": sign_partner.id}
+        incorrect_hash_pid_param = {"hash": "incorrect hash", "pid": sign_partner.id}
+        self._execute_subtests(
+            message,
+            (
+                (self.no_user, False),
+                (self.no_user, False, incorrect_token_param),
+                (self.no_user, False, incorrect_hash_pid_param),
+                # False because no portal partner, no guest
+                (self.no_user, False, token_param),
+                (self.no_user, True, hash_pid_param, {"partner": sign_partner}),
+                (self.public_w_guest, False),
+                (self.public_w_guest, False, incorrect_token_param),
+                (self.public_w_guest, False, incorrect_hash_pid_param),
+                (self.public_w_guest, True, token_param),
+                (self.public_w_guest, True, hash_pid_param, {"partner": sign_partner}),
+                (self.user_portal, False),
+                (self.user_portal, False, incorrect_token_param),
+                (self.user_portal, False, incorrect_hash_pid_param),
+                (self.user_portal, True, token_param),
+                (self.user_portal, True, hash_pid_param),
+                (self.user_employee, True),
+                (self.user_employee, True, incorrect_token_param),
+                (self.user_employee, True, incorrect_hash_pid_param),
+                (self.user_employee, True, token_param),
+                (self.user_employee, True, hash_pid_param),
+                (self.user_demo, True),
+                (self.user_demo, True, incorrect_token_param),
+                (self.user_demo, True, incorrect_hash_pid_param),
+                (self.user_demo, True, token_param),
+                (self.user_demo, True, hash_pid_param),
+                (self.user_admin, True),
+                (self.user_admin, True, incorrect_token_param),
+                (self.user_admin, True, incorrect_hash_pid_param),
+                (self.user_admin, True, token_param),
+                (self.user_admin, True, hash_pid_param),
+            ),
+        )
+
+    def test_message_reaction_portal_assigned_partner(self):
+        """Test access of message reaction for portal with partner."""
+        rec_partner = self.env["res.partner"].create({"name": "Record Partner"})
+        record = self.env["mail.test.portal"].create({"name": "Test", "partner_id": rec_partner.id})
+        message = record.message_post(body="portal with partner")
+        token = record._portal_ensure_token()
+        sign_partner = self.env["res.partner"].create({"name": "Sign Partner"})
+        _hash = record._sign_token(sign_partner.id)
+        token_param = {"token": token}
+        incorrect_token_param = {"token": "incorrect token"}
+        hash_pid_param = {"hash": _hash, "pid": sign_partner.id}
+        incorrect_hash_pid_param = {"hash": "incorrect hash", "pid": sign_partner.id}
+        self._execute_subtests(
+            message,
+            (
+                (self.no_user, False),
+                (self.no_user, False, incorrect_token_param),
+                (self.no_user, False, incorrect_hash_pid_param),
+                (self.no_user, True, token_param, {"partner": rec_partner}),
+                (self.no_user, True, hash_pid_param, {"partner": sign_partner}),
+                # sign has priority over token when both are provided
+                (self.no_user, True, token_param | hash_pid_param, {"partner": sign_partner}),
+                (self.public_w_guest, False),
+                (self.public_w_guest, False, incorrect_token_param),
+                (self.public_w_guest, False, incorrect_hash_pid_param),
+                (self.public_w_guest, True, token_param, {"partner": rec_partner}),
+                (self.public_w_guest, True, hash_pid_param, {"partner": sign_partner}),
+                (self.public_w_guest, True, token_param | hash_pid_param, {"partner": sign_partner}),
+                (self.user_portal, False),
+                (self.user_portal, False, incorrect_token_param),
+                (self.user_portal, False, incorrect_hash_pid_param),
+                (self.user_portal, True, token_param),
+                (self.user_portal, True, hash_pid_param),
+                (self.user_employee, True),
+                (self.user_employee, True, incorrect_token_param),
+                (self.user_employee, True, incorrect_hash_pid_param),
+                (self.user_employee, True, token_param),
+                (self.user_employee, True, hash_pid_param),
+                (self.user_demo, True),
+                (self.user_demo, True, incorrect_token_param),
+                (self.user_demo, True, incorrect_hash_pid_param),
+                (self.user_demo, True, token_param),
+                (self.user_demo, True, hash_pid_param),
+                (self.user_admin, True),
+                (self.user_admin, True, incorrect_token_param),
+                (self.user_admin, True, incorrect_hash_pid_param),
+                (self.user_admin, True, token_param),
+                (self.user_admin, True, hash_pid_param),
+            ),
+        )


### PR DESCRIPTION
#### 1st commit

As admin:

- Create a channel
- Make it public
- Post a message in public channel
- Invite portal user to channel

As portal:

- Join channel
- Try to react to admin message -> crash

task-4165120

16.0: https://github.com/odoo/odoo/pull/179198
17.0: https://github.com/odoo/odoo/pull/179411

#### 2nd commit

This allows public and portal user to access message features with
access token or hash and pid.

In this commit, the focus is on the reaction feature.

Part of task-2828744