### PR TITLE
[FIX] mail: save edited message on the first click

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -97,6 +97,7 @@ export class Composer extends Component {
             { composer: this.props.composer }
         );
         this.ui = useState(useService("ui"));
+        this.CANCEL_OR_SAVE_EDIT_TEXT = this.getCancelOrSaveEditText();
         this.mainActionsRef = useRef("main-actions");
         this.ref = useRef("textarea");
         this.fakeTextarea = useRef("fakeTextarea");
@@ -221,7 +222,7 @@ export class Composer extends Component {
         }
     }
 
-    get CANCEL_OR_SAVE_EDIT_TEXT() {
+    getCancelOrSaveEditText() {
         if (this.ui.isSmall) {
             return markup(
                 sprintf(


### PR DESCRIPTION
Problem:
Elements inside `CANCEL_OR_SAVE_EDIT_TEXT` are created twice, which interferes with event handling. To fix this, the element is now created in the setup method.

Steps to reproduce:

- Open the chatter.
- Log a note.
- Edit the note.
- Now, if you click Save or Cancel, both actions will only work on the second click.

opw-4119283


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
