### PR TITLE
[IMP] l10n_cl: Show client's commercial partner in invoice report

### DIFF
--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -86,7 +86,7 @@
                 <br/>
 
                 <strong>Customer:</strong>
-                <span t-field="o.partner_id.name"/>
+                <span t-out="o.partner_id.commercial_partner_id.name or o.partner_id.name"/>
                 <br/>
 
                 <t t-if="o.partner_id.vat and o.partner_id.l10n_latam_identification_type_id">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

## Current behavior before PR:
For legal reasons, the name that should appear in the invoice report is the contact's parent (aka, their employer company). Currently, the child contact appears. 
![image](https://github.com/euvm-odoo/odoo/assets/141070241/508ed141-bedd-40c2-a65d-76337b678f4d)


Desired behavior after PR is merged:
The parent contact should appear if it exists
![image](https://github.com/euvm-odoo/odoo/assets/141070241/6d5f4447-3d0c-4a07-9656-25d2208a08f8)


TaskL: https://www.odoo.com/odoo/project/49/tasks/4048759?cids=17

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
