### PR TITLE
[FIX] point_of_sale: fix missing iot build dependancy and rights

### DIFF
--- a/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init_posbox_image.sh
+++ b/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init_posbox_image.sh
@@ -83,6 +83,10 @@ pip() {
 source ~/.bashrc
 source /home/pi/.bashrc
 
+# copy the odoo.conf file to the overwrite directory
+mv -v "/home/pi/odoo/addons/point_of_sale/tools/posbox/configuration/odoo.conf" "/home/pi/"
+chown pi:pi "/home/pi/odoo.conf"
+
 apt-get update
 
 # At the first start it is necessary to configure a password
@@ -106,6 +110,7 @@ PKGS_TO_INSTALL="
     kpartx \
     libcups2-dev \
     libpq-dev \
+    libffi-dev \
     lightdm \
     localepurge \
     nginx-full \

--- a/addons/point_of_sale/tools/posbox/posbox_create_image.sh
+++ b/addons/point_of_sale/tools/posbox/posbox_create_image.sh
@@ -166,10 +166,6 @@ find "${MOUNT_POINT}"/ -type f -name "*.iotpatch"|while read iotpatch; do
     done
 done
 
-# copy the odoo.conf file to the overwrite directory
-mv -v "${MOUNT_POINT}/home/pi/odoo/addons/point_of_sale/tools/posbox/configuration/odoo.conf" "${MOUNT_POINT}/home/pi/"
-chown pi:pi "${MOUNT_POINT}/home/pi/odoo.conf"
-
 # cleanup
 umount -fv "${MOUNT_POINT}"/boot/
 umount -lv "${MOUNT_POINT}"/


### PR DESCRIPTION
IoT Box image build was failing due to missing `libffi-dev` pkg. In addition to that, the previously moved `odoo.conf` was inaccessible due to incorrect access rights. This commit fixes these two problems.