### PR TITLE
[FIX] profiler: monotonic timer

### DIFF
--- a/odoo/tools/profiler.py
+++ b/odoo/tools/profiler.py
@@ -19,7 +19,7 @@ _logger = logging.getLogger(__name__)
 
 # ensure we have a non patched time for profiling times when using freezegun
 real_datetime_now = datetime.now
-real_time = time.time.__call__
+real_time = time.perf_counter.__call__
 
 def _format_frame(frame):
     code = frame.f_code


### PR DESCRIPTION
The profiler is a case where having a monotonic timer is an absolute requirement.
One way of seeing this is that when using the profiler there is often a `⚠ Profiler freezed` that appears. It could indeed be because the profiler freezed, but it can also be because the time read the second time is earlier than the time read the first time. Since we are only comparing time differences, we don't need the attribute of `time.time` to return a time based on the epoch.

```
In [1]: import time

In [2]: time.get_clock_info('time')
Out[2]:
namespace(implementation='clock_gettime(CLOCK_REALTIME)',
          monotonic=False,
          adjustable=True,
          resolution=1e-09)

In [3]: time.get_clock_info('perf_counter')
Out[3]:
namespace(implementation='clock_gettime(CLOCK_MONOTONIC)',
          monotonic=True,
          adjustable=False,
          resolution=1e-09)
```

