### PR TITLE
[FIX] account_edi_ubl_cii: enable factur-x for custom PDF reports

### DIFF
--- a/addons/account_edi_ubl_cii/models/ir_actions_report.py
+++ b/addons/account_edi_ubl_cii/models/ir_actions_report.py
@@ -14,6 +14,13 @@ import io
 class IrActionsReport(models.Model):
     _inherit = 'ir.actions.report'
 
+    def _is_invoice_report(self, report_ref):
+        # EXTENDS account
+        # allows to add factur-x.xml to custom PDF templates (comma separated list of template names)
+        custom_templates = self.env['ir.config_parameter'].sudo().get_param('account.custom_templates_facturx_list', '')
+        custom_templates = [report.strip() for report in custom_templates.split(',')]
+        return super()._is_invoice_report(report_ref) or self._get_report(report_ref).report_name in custom_templates
+
     def _add_pdf_into_invoice_xml(self, invoice, stream_data):
         format_codes = ['ubl_bis3', 'ubl_de', 'nlcius_1', 'efff_1']
         edi_attachments = invoice.edi_document_ids.filtered(lambda d: d.edi_format_id.code in format_codes).sudo().attachment_id


### PR DESCRIPTION
It is currently not possible to embed the factur-x.xml in custom pdf templates, although it is supported in 17.4.

In this commit, we add the possibility to to do so, by adding a system parameter "account.custom_templates_facturx_list" that contains a list of the custom report names (field `report_name` on `ir.actions.report`) for which we want to embed a factur-x.xml.

opw-4160945