### PR TITLE
[FIX] point_of_sale: correctly print long name on kitchen printer

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.scss
+++ b/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.scss
@@ -13,6 +13,8 @@
     display: -webkit-box;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;
+    text-overflow: ellipsis;
+    overflow: hidden;
 
     &.no-image {
         -webkit-line-clamp: 7;


### PR DESCRIPTION
When printing order changes that contains a product with a really long name, the product name would overlap on the kitchen receipt.

Steps to reproduce:
-------------------
* Modify the name of a product so that it is really long
* Setup a kitchen printer on a PoS restaurant
* Add some product on an order and send the order in preparation
> Observation: The kitchen receipt has overlapping lines

Why the fix:
------------
We make sure to hide the overflowing text so that it is not overlapping on other lines.

opw-4136775
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
