### PR TITLE
[FIX] web: Fixed config layout wizard glitch

### DIFF
--- a/addons/web/models/base_document_layout.py
+++ b/addons/web/models/base_document_layout.py
@@ -120,14 +120,6 @@ class BaseDocumentLayout(models.TransientModel):
     @api.depends('report_layout_id', 'logo', 'font', 'primary_color', 'secondary_color', 'report_header', 'report_footer', 'layout_background', 'layout_background_image', 'company_details')
     def _compute_preview(self):
         """ compute a qweb based preview to display on the wizard """
-
-        # This condition below makes sure that preview is computed only if the document layout is still under creation.
-        # If the document layout is finished (i.e., edit wizard is closed), the preview should not be recomputed.
-        # This solves the issue of the preview glitching at the wizard closing.
-        if self.env['base.document.layout'].browse(self.id):
-            self.preview = False
-            return
-
         styles = self._get_asset_style()
 
         for wizard in self:

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -85,12 +85,31 @@
                     .container {
                         font-size: larger;
                     }
+
+                    .loading-spinner {
+                        position: absolute;
+                        top: 50%;
+                        left: 50%;
+                        transform: translate(-50%, -50%);
+                        border-top: 8px solid #e3e3e3;
+                        border-radius: 50%;
+                        width: 60px;
+                        height: 60px;
+                        animation: spin 1s linear infinite;
+                    }
+            
+                    @keyframes spin {
+                        0% { transform: rotate(0deg); }
+                        100% { transform: rotate(360deg); }
+                    }
                 </style>
             </head>
             <body t-att-class="'container' if not full_width else 'container-fluid'" style="overflow:hidden" t-att-dir="env['res.lang']._get_data(code=lang or env.user.lang).direction or 'ltr'">
-                <div id="wrapwrap">
+                <!-- display a spinner instead of the iframe content until the stylesheet is loaded -->
+                <div id="wrapwrap" class="d-block" style="display:none;">
                         <t t-out="0"/>
                 </div>
+                <div class="loading-spinner d-none"/>
             </body>
         </html>
     </template>


### PR DESCRIPTION
- Wizard location
settings app >> companies >> Configure document layout

- Original problem
The PDF layout wizard would show the PDF preview unstyled for a couple of seconds.
This would happen at the wizard opening and at closing (if the user changes the logo).

- Initial fix attempt
For the original problem, there was a workaround introduced in this PR: https://github.com/odoo/odoo/pull/160958
The workaround would simply make the layout preview disappear once it has a record in the DB (at closing time after changing the logo).
It's obvious that the workaround was fragile, and it also had a consequent problem. Therefore, it was reverted in this commit.

- Consequent problem
The aforementioned workaround (initial fix) caused the following problem: https://www.odoo.com/odoo/project/133/tasks/4137809
In summary, the problem was that the layout preview wouldn't show after attempting to add a translation to some of the previewed fields.

- Root cause
The root cause of the original problem was that the stylesheet takes longer to load than the rest of iframe, causing it to show unstyled (glitchy).

- Solution inroduced in this commit
This commit makes use of the fact that bootstrap classes are only loaded in the layout iframe through the delayed stylesheet.
It makes the preview content invisible by default and only visible through the d-block class.
This way the content will remain hidden until the stylesheet loads, preventing it from showing unstyled.
Also, a loading-spinner would show in the absence of the preview, and it would disappear through the d-none class.

task-4164703


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
