### PR TITLE
[17.0][FIX] sale_project: avoid error column reference "id" is ambiguous

### DIFF
--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -366,7 +366,7 @@ class Project(models.Model):
             ])
         project_query = self.env['project.project']._where_calc(project_domain)
         self._apply_ir_rules(project_query, 'read')
-        project_sql = project_query.select('id', 'sale_line_id')
+        project_sql = project_query.select(f'{self._table}.id ', f'{self._table}.sale_line_id')
 
         Task = self.env['project.task']
         task_domain = [('project_id', 'in', self.ids), ('sale_line_id', '!=', False)]


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
I can't reproduce the error in Runbot, but the error is real.
Try opening the project settings.
![image](https://github.com/user-attachments/assets/8a36063b-a60e-44ca-b0a8-2d2131b6b193)

![image](https://github.com/user-attachments/assets/13b6362e-8619-4eb1-9174-543831cba61a)

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
