### PR TITLE
[FIX] l10n_id_efaktur: fix traceback when Download e-Faktur

### DIFF
--- a/addons/l10n_id_efaktur/models/account_move.py
+++ b/addons/l10n_id_efaktur/models/account_move.py
@@ -136,7 +136,7 @@ class AccountMove(models.Model):
                 raise ValidationError(_('Could not download E-faktur in draft state'))
 
             if not record.l10n_id_tax_number:
-                if not self.l10n_id_need_kode_transaksi:
+                if not record.l10n_id_need_kode_transaksi:
                     raise ValidationError(_('E-faktur is not available for invoices without any taxes.'))
                 raise ValidationError(_('Connect %(move_number)s with E-faktur to download this report', move_number=record.name))
 


### PR DESCRIPTION
Currently, a traceback is occurring when the user tries to download multiple e-Faktur at a time.

To reproduce this issue:
1) Install `l10n_id_efaktur`
2) Select multiple customer invoices from an accounting 
3) Try to `Download e-Faktur` from actions

Error:- 
```
ValueError: Expected singleton: account.move(65, 57,)
```

This is because when the user selects multiple invoices, the `self` contains multiple recordsets.
Which leads to a traceback when `l10n_id_need_kode_transaksi` is accessing from self.

https://github.com/odoo/odoo/blob/4f044aade6e2a461c854899a8854474e3b22b6d5/addons/l10n_id_efaktur/models/account_move.py#L134-L139

Already a loop is there in that method, so by just changing self with record we can resolve this issue.

sentry-5809438159

