### PR TITLE
[IMP] hr, *: simplify kanban archs

### DIFF
--- a/addons/hr/static/src/scss/hr.scss
+++ b/addons/hr/static/src/scss/hr.scss
@@ -1,4 +1,4 @@
-.o_kanban_dashboard.o_hr_department_kanban .o_kanban_renderer {
+.o_hr_department_kanban .o_kanban_renderer {
     --KanbanRecord-width: 450px;
     --KanbanRecord-width-small: 350px;
 }

--- a/addons/hr/views/hr_department_views.xml
+++ b/addons/hr/views/hr_department_views.xml
@@ -76,18 +76,13 @@
             <field name="name">hr.department.kanban</field>
             <field name="model">hr.department</field>
             <field name="arch" type="xml">
-                <kanban class="o_kanban_dashboard o_hr_department_kanban o_kanban_small_column" can_open="0" sample="1">
-                    <field name="name"/>
-                    <field name="company_id"/>
-                    <field name="manager_id"/>
-                    <field name="color"/>
-                    <field name="total_employee"/>
+                <kanban highlight_color="color" class="o_hr_department_kanban o_kanban_small_column" can_open="0" sample="1">
                     <field name="active"/>
                     <templates>
                         <t t-name="kanban-menu" t-if="!selection_mode">
                             <div class="container">
                                 <div class="row">
-                                    <div class="o_kanban_card_manage_section o_kanban_manage_view col-6 o_kanban_manage_views">
+                                    <div class="col-6">
                                         <h5 role="menuitem" class="o_kanban_card_manage_title">
                                             <span>View</span>
                                         </h5>
@@ -98,7 +93,7 @@
                                             <a name="action_open_view_child_departments" type="object">Child departments</a>
                                         </div>
                                     </div>
-                                    <div class="o_kanban_card_manage_section o_kanban_manage_view col-6 o_kanban_manage_reports">
+                                    <div class="col-6 o_kanban_manage_reports">
                                         <h5 role="menuitem" class="o_kanban_card_manage_title">
                                             <span>Reporting</span>
                                         </h5>
@@ -106,46 +101,34 @@
                                 </div>
                                 <div class="o_kanban_card_manage_settings row" groups="hr.group_hr_user">
                                     <div t-if="widget.editable" role="menuitem" aria-haspopup="true" class="col-6">
-                                        <ul class="oe_kanban_colorpicker" data-field="color" role="menu"/>
+                                        <field name="color" widget="kanban_color_picker"/>
                                     </div>
                                     <div class="col-6">
-                                        <a t-if="widget.editable" role="menuitem" class="dropdown-item" type="edit">Configuration</a>
+                                        <a t-if="widget.editable" role="menuitem" class="dropdown-item" type="open">Configuration</a>
                                         <a t-if="record.active.raw_value" role="menuitem" type="archive" class="dropdown-item">Archive</a>
                                         <a t-if="!record.active.raw_value" role="menuitem" type="unarchive" class="dropdown-item">Unarchive</a>
                                     </div>
                                 </div>
                             </div>
                         </t>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="#{!selection_mode ? kanban_color(record.color.raw_value) : ''}">
-                                <div t-attf-class="o_kanban_card_header oe_kanban_details">
-                                    <div class="o_kanban_card_header_title">
-                                        <div class="o_primary"><a type="edit"><field name="name"/></a></div>
-                                        <div class="text-muted">
-                                            <field name="manager_id" widget="many2one_avatar_employee" options="{'display_avatar_name': True}" readonly="1"/>
-                                        </div>
-                                        <div class="o_secondary" groups="base.group_multi_company">
-                                            <small>
-                                                <i class="fa fa-building-o" role="img" aria-label="Company" title="Company"/> <field name="company_id"/>
-                                            </small>
-                                        </div>
-                                    </div>
+                        <t t-name="kanban-card">
+                            <a type="open"><field name="name" class="fw-bold fs-4 d-bolck ms-2"/></a>
+                            <field name="manager_id" widget="many2one_avatar_employee" options="{'display_avatar_name': True}" readonly="1" class="text-muted ms-2"/>
+                            <div class="small mt-1 ms-2" groups="base.group_multi_company">
+                                <i class="fa fa-building-o" role="img" aria-label="Company" title="Company"/> <field name="company_id"/>
+                            </div>
+                            <div class="row g-0 mt-3 mb-2 ms-2" t-if="!selection_mode">
+                                <div class="col-6">
+                                    <button class="btn btn-primary" name="action_employee_from_department" type="object">
+                                        <field name="total_employee"/> Employees
+                                    </button>
                                 </div>
-                                <div class="container o_kanban_card_content" t-if="!selection_mode">
-                                    <div class="row o_kanban_card_upper_content">
-                                        <div class="col-6 o_kanban_primary_left">
-                                            <button class="btn btn-primary" name="action_employee_from_department" type="object">
-                                                <t t-out="record.total_employee.raw_value"/> Employees
-                                            </button>
-                                        </div>
-                                        <div class="col-6 o_kanban_primary_right">
-                                        </div>
-                                    </div>
-                                    <div class="o_kanban_card_lower_content"
-                                         style="justify-content: end">
-                                        <!-- placeholder for bottom content -->
-                                    </div>
+                                <div name="o_kanban_primary_right" class="col-6">
+                                    <!-- placeholder for xpaths -->
                                 </div>
+                            </div>
+                            <div name="o_kanban_card_lower_content" class="mt-auto" t-if="!selection_mode">
+                                <!-- placeholder for bottom content -->
                             </div>
                         </t>
                     </templates>

--- a/addons/hr_expense/views/hr_department_views.xml
+++ b/addons/hr_expense/views/hr_department_views.xml
@@ -6,17 +6,11 @@
         <field name="inherit_id" ref="hr.hr_department_view_kanban"/>
         <field name="arch" type="xml">
             <data>
-                <xpath expr="//templates" position="before">
-                    <field name="expense_sheets_to_approve_count" groups="hr_expense.group_hr_expense_team_approver"/>
-                </xpath>
-
-                <xpath expr="//div[hasclass('o_kanban_primary_right')]" position="inside">
-                    <div t-if="record.expense_sheets_to_approve_count.raw_value > 0" class="row ml16" groups="hr_expense.group_hr_expense_team_approver">
-                        <div class="col">
-                            <a name="%(action_hr_expense_sheet_department_to_approve)d" type="action">
-                                <t t-out="record.expense_sheets_to_approve_count.raw_value"/> Expense Reports
-                            </a>
-                        </div>
+                <xpath expr="//div[@name='o_kanban_primary_right']" position="inside">
+                    <div t-if="record.expense_sheets_to_approve_count.raw_value > 0" class="row ml32 g-0" groups="hr_expense.group_hr_expense_team_approver">
+                        <a name="%(action_hr_expense_sheet_department_to_approve)d" class="col" type="action">
+                            <field name="expense_sheets_to_approve_count" groups="hr_expense.group_hr_expense_team_approver"/> Expense Reports
+                        </a>
                     </div>
                 </xpath>
 

--- a/addons/hr_holidays/views/hr_views.xml
+++ b/addons/hr_holidays/views/hr_views.xml
@@ -23,44 +23,34 @@
             <data>
                 <xpath expr="//templates" position="before">
                     <t groups="hr_holidays.group_hr_holidays_user">
-                        <field name="leave_to_approve_count"/>
-                        <field name="allocation_to_approve_count"/>
                         <field name="total_employee"/>
                         <field name="absence_of_today"/>
                     </t>
                 </xpath>
 
-                <xpath expr="//div[hasclass('o_kanban_primary_right')]" position="inside">
-                    <t groups="hr_holidays.group_hr_holidays_user">
-                        <div t-if="record.leave_to_approve_count.raw_value > 0" class="row ml16">
-                            <div class="col">
-                                <a name="action_open_leave_department" type="object">
-                                    <field name="leave_to_approve_count"/> Time Off Requests
-                                </a>
-                            </div>
-                        </div>
-                        <div t-if="record.allocation_to_approve_count.raw_value > 0" class="row ml16">
-                            <div class="col">
-                                <a name="action_open_allocation_department" type="object">
-                                    <field name="allocation_to_approve_count"/> Allocation Requests
-                                </a>
-                            </div>
-                        </div>
-                    </t>
+                <xpath expr="//div[@name='o_kanban_primary_right']" position="inside">
+                    <div t-if="record.leave_to_approve_count.raw_value > 0" class="row ml32 g-0" groups="hr_holidays.group_hr_holidays_user">
+                        <a name="action_open_leave_department" class="col" type="object">
+                            <field name="leave_to_approve_count" groups="hr_holidays.group_hr_holidays_user"/> Time Off Requests
+                        </a>
+                    </div>
+                    <div t-if="record.allocation_to_approve_count.raw_value > 0" class="row ml32 g-0" groups="hr_holidays.group_hr_holidays_user">
+                        <a name="action_open_allocation_department" class="col" type="object">
+                            <field name="allocation_to_approve_count" groups="hr_holidays.group_hr_holidays_user"/> Allocation Requests
+                        </a>
+                    </div>
                 </xpath>
 
-                <xpath expr="//div[hasclass('o_kanban_card_lower_content')]" position="inside">
-                    <t groups="hr_holidays.group_hr_holidays_user">
-                        <div class="row o_kanban_primary_bottom bottom_block bg-view"
-                             t-if="record.absence_of_today.raw_value > 0">
-                            <div class="col-3">
-                                <a name="%(hr_employee_action_from_department)d" type="action" title="Absent Employee(s), Whose time off requests are either confirmed or validated on today">Absence</a>
-                            </div>
-                            <div class="col-9">
-                                <field name="absence_of_today" widget="progressbar" options="{'current_value': 'absence_of_today', 'max_value': 'total_employee', 'editable': false}"/>
-                            </div>
+                <xpath expr="//div[@name='o_kanban_card_lower_content']" position="inside">
+                    <div class="row g-0 border-top border-1 mt-2 pt-2 mx-n2 bg-view"
+                            t-if="record.absence_of_today.raw_value > 0" groups="hr_holidays.group_hr_holidays_user">
+                        <div class="col-3 ms-3">
+                            <a name="%(hr_employee_action_from_department)d" type="action" title="Absent Employee(s), Whose time off requests are either confirmed or validated on today">Absence</a>
                         </div>
-                    </t>
+                        <div class="col-7">
+                            <field name="absence_of_today" widget="progressbar" options="{'current_value': 'absence_of_today', 'max_value': 'total_employee', 'editable': false}"/>
+                        </div>
+                    </div>
                 </xpath>
 
                 <xpath expr="//div[hasclass('o_kanban_manage_reports')]" position="inside">

--- a/addons/hr_recruitment/views/hr_department_views.xml
+++ b/addons/hr_recruitment/views/hr_department_views.xml
@@ -6,24 +6,12 @@
         <field name="inherit_id" ref="hr.hr_department_view_kanban"/>
         <field name="arch" type="xml">
             <data>
-                <xpath expr="//templates" position="before">
-                    <t groups="hr_recruitment.group_hr_recruitment_user">
-                        <field name="new_applicant_count"/>
-                        <field name="new_hired_employee"/>
-                        <field name="expected_employee"/>
-                    </t>
-                </xpath>
-
-                <xpath expr="//div[hasclass('o_kanban_primary_right')]" position="inside">
-                    <t groups="hr_recruitment.group_hr_recruitment_user">
-                        <div t-if="record.new_applicant_count.raw_value > 0" class="row ml16">
-                            <div class="col">
-                                <a name="%(hr_applicant_action_from_department)d" type="action">
-                                    <field name="new_applicant_count"/> New Applicants
-                                </a>
-                            </div>
-                        </div>
-                    </t>
+                <xpath expr="//div[@name='o_kanban_primary_right']" position="inside">
+                    <div t-if="record.new_applicant_count.raw_value > 0" class="row g-0 ml32" groups="hr_recruitment.group_hr_recruitment_user">
+                        <a name="%(hr_applicant_action_from_department)d" class="col" type="action">
+                            <field name="new_applicant_count"/> New Applicants
+                        </a>
+                    </div>
                 </xpath>
 
                 <xpath expr="//div[hasclass('o_kanban_manage_reports')]" position="inside">


### PR DESCRIPTION
*hr_expense,hr_holidays,hr_recruitment
In this commit we have simplified the kanban arch for the hr module dashboard. the goal is to simplify them, make them easier to read and use bootstrap utility classnames.

- Previously, we used kanban-box, but now we are using kanban-card instead.
- Deprecated oe_kanban_global_click and oe_kanban_global_click_edit.
- More use of `<field/>` tags
- Removed the oe_kanban_colorpicker class and replaced it with the kanban_color_picker widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- kanban_image from rendering context, is deprecated so we use `<field name="..." widget="image"/>` instead
- kanban_color, kanban_getcolor and kanban_getcolorname are deprecated use new attribute highlight_color="color_field_name" on root node

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
