### PR TITLE
[REF] mail,*: remove the dependency for createFile(...)

### DIFF
--- a/addons/im_livechat/static/tests/embed/chat_window.test.js
+++ b/addons/im_livechat/static/tests/embed/chat_window.test.js
@@ -10,7 +10,6 @@ import {
     assertSteps,
     click,
     contains,
-    createFile,
     inputFiles,
     insertText,
     onRpcBefore,
@@ -61,11 +60,7 @@ test("internal users can upload file to temporary thread", async () => {
     await start({ authenticateAs: partnerUser });
     await mountWithCleanup(LivechatButton);
     await click(".o-livechat-LivechatButton");
-    const file = await createFile({
-        content: "hello, world",
-        contentType: "text/plain",
-        name: "text.txt",
-    });
+    const file = new File(["hello, world"], "text.txt", { type: "text/plain" });
     await contains(".o-mail-Composer");
     await contains("button[title='Attach files']");
     await inputFiles(".o-mail-Composer-coreMain .o_input_file", [file]);

--- a/addons/mail/static/tests/activity/activity.test.js
+++ b/addons/mail/static/tests/activity/activity.test.js
@@ -4,7 +4,6 @@ import {
     assertSteps,
     click,
     contains,
-    createFile,
     defineMailModels,
     inputFiles,
     openFormView,
@@ -63,13 +62,8 @@ test("activity can upload a document", async () => {
             </form>`,
     });
     await contains(".o-mail-Activity .btn", { text: "Upload Document" });
-    await inputFiles(".o-mail-Activity .o_input_file", [
-        await createFile({
-            content: "hello, world",
-            contentType: "text/plain",
-            name: "text.txt",
-        }),
-    ]);
+    const file = new File(["hello, world"], "text.txt", { type: "text/plain" });
+    await inputFiles(".o-mail-Activity .o_input_file", [file]);
     await contains(".o-mail-Activity .btn", { count: 0, text: "Upload Document" });
     await contains("button[aria-label='Attach files']", { text: "1" });
 });

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -3,7 +3,6 @@ import {
     assertSteps,
     click,
     contains,
-    createFile,
     defineMailModels,
     focus,
     hover,
@@ -710,6 +709,16 @@ test("chat window should remain folded when new message is received", async () =
 test("chat window: composer state conservation on toggle discuss", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({});
+    const textFile1 = new File(
+        ["hello, world"],
+        "text state conversation on toggle home menu.txt",
+        { type: "text/plain" }
+    );
+    const textFile2 = new File(
+        ["hello, xdu is da best man"],
+        "text2 state conversation on toggle home menu.txt",
+        { type: "text/plain" }
+    );
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem");
@@ -719,18 +728,7 @@ test("chat window: composer state conservation on toggle discuss", async () => {
         count: 0,
     });
     // Set attachments of the composer
-    await inputFiles(".o-mail-Composer-coreMain .o_input_file", [
-        await createFile({
-            name: "text state conservation on toggle home menu.txt",
-            content: "hello, world",
-            contentType: "text/plain",
-        }),
-        await createFile({
-            name: "text2 state conservation on toggle home menu.txt",
-            content: "hello, xdu is da best man",
-            contentType: "text/plain",
-        }),
-    ]);
+    await inputFiles(".o-mail-Composer-coreMain .o_input_file", [textFile1, textFile2]);
     await contains(".o-mail-AttachmentCard .fa-check", { count: 2 });
     await openDiscuss();
     await contains(".o-mail-ChatWindow", { count: 0 });

--- a/addons/mail/static/tests/chatter/web/chatter.test.js
+++ b/addons/mail/static/tests/chatter/web/chatter.test.js
@@ -3,7 +3,6 @@ import {
     assertSteps,
     click,
     contains,
-    createFile,
     defineMailModels,
     dragenterFiles,
     dropFiles,
@@ -195,32 +194,18 @@ test("Composer type is kept when switching from aside to bottom", async () => {
 test("chatter: drop attachments", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({});
+    const text = new File(["hello, world"], "text.txt", { type: "text/plain" });
+    const text2 = new File(["hello, worldub"], "text2.txt", { type: "text/plain" });
+    const text3 = new File(["hello, world"], "text3.txt", { type: "text/plain" });
     await start();
     await openFormView("res.partner", partnerId);
-    const files = [
-        await createFile({
-            content: "hello, world",
-            contentType: "text/plain",
-            name: "text.txt",
-        }),
-        await createFile({
-            content: "hello, worlduh",
-            contentType: "text/plain",
-            name: "text2.txt",
-        }),
-    ];
+    const files = [text, text2];
     await dragenterFiles(".o-mail-Chatter", files);
     await contains(".o-mail-Dropzone");
     await contains(".o-mail-AttachmentCard", { count: 0 });
     await dropFiles(".o-mail-Dropzone", files);
     await contains(".o-mail-AttachmentCard", { count: 2 });
-    const extraFiles = [
-        await createFile({
-            content: "hello, world",
-            contentType: "text/plain",
-            name: "text3.txt",
-        }),
-    ];
+    const extraFiles = [text3];
     await dragenterFiles(".o-mail-Chatter", extraFiles);
     await dropFiles(".o-mail-Dropzone", extraFiles);
     await contains(".o-mail-AttachmentCard", { count: 3 });
@@ -230,6 +215,7 @@ test("chatter: drop attachment should refresh thread data with hasParentReloadOn
     patchUiSize({ size: SIZES.XXL });
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({});
+    const textPdf = new File([new Uint8Array(1)], "text.pdf", { type: "application/pdf" });
 
     await start();
     await openFormView("res.partner", partnerId, {
@@ -242,14 +228,8 @@ test("chatter: drop attachment should refresh thread data with hasParentReloadOn
                 <chatter reload_on_post="True" reload_on_attachment="True"/>
             </form>`,
     });
-    const files = [
-        await createFile({
-            contentType: "application/pdf",
-            name: "text.pdf",
-        }),
-    ];
-    await dragenterFiles(".o-mail-Chatter", files);
-    await dropFiles(".o-mail-Dropzone", files);
+    await dragenterFiles(".o-mail-Chatter", [textPdf]);
+    await dropFiles(".o-mail-Dropzone", [textPdf]);
     await contains(".o-mail-Attachment iframe", { count: 1 });
 });
 
@@ -633,6 +613,7 @@ test("schedule activities on draft record should prompt with scheduling an activ
 });
 
 test("upload attachment on draft record", async () => {
+    const text = new File(["hello, world"], "text.text", { type: "text/plain" });
     await start();
     await openFormView("res.partner", undefined, {
         arch: `
@@ -645,15 +626,8 @@ test("upload attachment on draft record", async () => {
     });
     await contains("button[aria-label='Attach files']");
     await contains("button[aria-label='Attach files']", { count: 0, text: "1" });
-    const files = [
-        await createFile({
-            content: "hello, world",
-            contentType: "text/plain",
-            name: "text.txt",
-        }),
-    ];
-    await dragenterFiles(".o-mail-Chatter", files);
-    await dropFiles(".o-mail-Dropzone", files);
+    await dragenterFiles(".o-mail-Chatter", [text]);
+    await dropFiles(".o-mail-Dropzone", [text]);
     await contains("button[aria-label='Attach files']", { text: "1" });
 });
 

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -2,7 +2,6 @@ import {
     SIZES,
     click,
     contains,
-    createFile,
     defineMailModels,
     dragenterFiles,
     dropFiles,
@@ -562,36 +561,22 @@ test("Select composer suggestion via Enter does not send the message", async () 
 test("composer: drop attachments", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    const text = new File(["hello, world"], "text.txt", { type: "text/plain" });
+    const text2 = new File(["hello, worlduh"], "text2.txt", { type: "text/plain" });
+    const text3 = new File(["hello, world"], "text3.txt", { type: "text/plain" });
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Composer-input");
     await contains(".o-mail-Dropzone", { count: 0 });
     await contains(".o-mail-AttachmentCard", { count: 0 });
-    const files = [
-        await createFile({
-            content: "hello, world",
-            contentType: "text/plain",
-            name: "text.txt",
-        }),
-        await createFile({
-            content: "hello, worlduh",
-            contentType: "text/plain",
-            name: "text2.txt",
-        }),
-    ];
+    const files = [text, text2];
     await dragenterFiles(".o-mail-Composer-input", files);
     await contains(".o-mail-Dropzone");
     await contains(".o-mail-AttachmentCard", { count: 0 });
     await dropFiles(".o-mail-Dropzone", files);
     await contains(".o-mail-Dropzone", { count: 0 });
     await contains(".o-mail-AttachmentCard", { count: 2 });
-    const extraFiles = [
-        await createFile({
-            content: "hello, world",
-            contentType: "text/plain",
-            name: "text3.txt",
-        }),
-    ];
+    const extraFiles = [text3];
     await dragenterFiles(".o-mail-Composer-input", extraFiles);
     await dropFiles(".o-mail-Dropzone", extraFiles);
     await contains(".o-mail-AttachmentCard", { count: 3 });
@@ -600,15 +585,10 @@ test("composer: drop attachments", async () => {
 test("composer: add an attachment", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    const text = new File(["hello, world"], "text.txt", { type: "text/plain" });
     await start();
     await openDiscuss(channelId);
-    await inputFiles(".o-mail-Composer-coreMain .o_input_file", [
-        await createFile({
-            content: "hello, world",
-            contentType: "text/plain",
-            name: "text.txt",
-        }),
-    ]);
+    await inputFiles(".o-mail-Composer-coreMain .o_input_file", [text]);
     await contains(".o-mail-AttachmentCard .fa-check");
     await contains(".o-mail-Composer-footer .o-mail-AttachmentList");
     await contains(".o-mail-Composer-footer .o-mail-AttachmentList .o-mail-AttachmentCard");
@@ -617,6 +597,7 @@ test("composer: add an attachment", async () => {
 test("composer: add an attachment in reply to message in history", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    const text = new File(["hello, world"], "text.txt", { type: "text/plain" });
     const messageId = pyEnv["mail.message"].create({
         body: "not empty",
         model: "discuss.channel",
@@ -631,13 +612,7 @@ test("composer: add an attachment in reply to message in history", async () => {
     await start();
     await openDiscuss("mail.box_history");
     await click("[title='Reply']");
-    await inputFiles(".o-mail-Composer-coreMain .o_input_file", [
-        await createFile({
-            content: "hello, world",
-            contentType: "text/plain",
-            name: "text.txt",
-        }),
-    ]);
+    await inputFiles(".o-mail-Composer-coreMain .o_input_file", [text]);
     await contains(".o-mail-AttachmentCard .fa-check");
     await contains(".o-mail-Composer-footer .o-mail-AttachmentList");
     await contains(".o-mail-Composer-footer .o-mail-AttachmentList .o-mail-AttachmentCard");
@@ -647,16 +622,11 @@ test("composer: send button is disabled if attachment upload is not finished", a
     const pyEnv = await startServer();
     const attachmentUploadedDef = new Deferred();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    const text = new File(["hello, world"], "text.txt", { type: "text/plain" });
     onRpcBefore("/mail/attachment/upload", async () => await attachmentUploadedDef);
     await start();
     await openDiscuss(channelId);
-    await inputFiles(".o-mail-Composer-coreMain .o_input_file", [
-        await createFile({
-            content: "hello, world",
-            contentType: "text/plain",
-            name: "text.txt",
-        }),
-    ]);
+    await inputFiles(".o-mail-Composer-coreMain .o_input_file", [text]);
     await contains(".o-mail-AttachmentCard.o-isUploading");
     await contains(".o-mail-Composer-send:disabled");
     // simulates attachment finishes uploading
@@ -669,15 +639,10 @@ test("composer: send button is disabled if attachment upload is not finished", a
 test("remove an attachment from composer does not need any confirmation", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    const text = new File(["hello, world"], "text.txt", { type: "text/plain" });
     await start();
     await openDiscuss(channelId);
-    await inputFiles(".o-mail-Composer-coreMain .o_input_file", [
-        await createFile({
-            content: "hello, world",
-            contentType: "text/plain",
-            name: "text.txt",
-        }),
-    ]);
+    await inputFiles(".o-mail-Composer-coreMain .o_input_file", [text]);
     await contains(".o-mail-AttachmentCard .fa-check");
     await contains(".o-mail-Composer-footer .o-mail-AttachmentList");
     await contains(".o-mail-AttachmentList .o-mail-AttachmentCard");
@@ -688,18 +653,12 @@ test("remove an attachment from composer does not need any confirmation", async 
 test("composer: paste attachments", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "test" });
+    const text = new File(["hello, world"], "text.txt", { type: "text/plain" });
     await start();
     await openDiscuss(channelId);
-    const files = [
-        await createFile({
-            content: "hello, world",
-            contentType: "text/plain",
-            name: "text.txt",
-        }),
-    ];
     await contains(".o-mail-Composer-input");
     await contains(".o-mail-AttachmentList .o-mail-AttachmentCard", { count: 0 });
-    await pasteFiles(".o-mail-Composer-input", files);
+    await pasteFiles(".o-mail-Composer-input", [text]);
     await contains(".o-mail-AttachmentList .o-mail-AttachmentCard");
 });
 
@@ -724,16 +683,11 @@ test("Replying on a channel should focus composer initially [REQUIRE FOCUS]", as
 test("remove an uploading attachment", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "test" });
+    const text = new File(["hello, world"], "text.txt", { type: "text/plain" });
     onRpc("/mail/attachment/upload", () => new Deferred()); // simulates uploading indefinitely
     await start();
     await openDiscuss(channelId);
-    await inputFiles(".o-mail-Composer-coreMain .o_input_file", [
-        await createFile({
-            content: "hello, world",
-            contentType: "text/plain",
-            name: "text.txt",
-        }),
-    ]);
+    await inputFiles(".o-mail-Composer-coreMain .o_input_file", [text]);
     await contains(".o-mail-AttachmentCard.o-isUploading");
     await click(".o-mail-AttachmentCard-unlink");
     await contains(".o-mail-Composer .o-mail-AttachmentCard", { count: 0 });
@@ -784,21 +738,12 @@ test("Show 'No recipient found.' with 0 followers.", async () => {
 test("Uploading multiple files in the composer create multiple temporary attachments", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "test" });
+    const text1 = new File(["hello, world"], "text1.txt", { type: "text/plain" });
+    const text2 = new File(["hello, world"], "text2.txt", { type: "text/plain" });
     onRpc("/mail/attachment/upload", () => new Deferred());
     await start();
     await openDiscuss(channelId);
-    await inputFiles(".o-mail-Composer-coreMain .o_input_file", [
-        await createFile({
-            name: "text1.txt",
-            content: "hello, world",
-            contentType: "text/plain",
-        }),
-        await createFile({
-            name: "text2.txt",
-            content: "hello, world",
-            contentType: "text/plain",
-        }),
-    ]);
+    await inputFiles(".o-mail-Composer-coreMain .o_input_file", [text1, text2]);
     await contains(".o-mail-AttachmentCard", { text: "text1.txt" });
     await contains(".o-mail-AttachmentCard", { text: "text2.txt" });
     await contains(".o-mail-AttachmentCard-aside div[title='Uploading']", { count: 2 });
@@ -812,21 +757,12 @@ test("[technical] does not crash when an attachment is removed before its upload
     // Promise to block attachment uploading
     const uploadDef = new Deferred();
     const channelId = pyEnv["discuss.channel"].create({ name: "test" });
+    const text1 = new File(["hello, world"], "text1.txt", { type: "text/plain" });
+    const text2 = new File(["hello, world"], "text2.txt", { type: "text/plain" });
     onRpcBefore("/mail/attachment/upload", async () => await uploadDef);
     await start();
     await openDiscuss(channelId);
-    await inputFiles(".o-mail-Composer-coreMain .o_input_file", [
-        await createFile({
-            name: "text1.txt",
-            content: "hello, world",
-            contentType: "text/plain",
-        }),
-        await createFile({
-            name: "text2.txt",
-            content: "hello, world",
-            contentType: "text/plain",
-        }),
-    ]);
+    await inputFiles(".o-mail-Composer-coreMain .o_input_file", [text1, text2]);
     await contains(".o-mail-AttachmentCard.o-isUploading", { text: "text1.txt" });
     await click(".o-mail-AttachmentCard-unlink", {
         parent: [".o-mail-AttachmentCard.o-isUploading", { text: "text2.txt" }],

--- a/addons/mail/static/tests/discuss/voice_message/voice_message.test.js
+++ b/addons/mail/static/tests/discuss/voice_message/voice_message.test.js
@@ -1,7 +1,6 @@
 import {
     click,
     contains,
-    createFile,
     defineMailModels,
     mockGetMedia,
     openDiscuss,
@@ -122,12 +121,7 @@ function patchAudio() {
 }
 
 test("make voice message in chat", async () => {
-    const file = await createFile({
-        content: Array(500).map(() => new Int8Array()), // some non-empty content
-        contentType: "audio/mp3",
-        name: "test.mp3",
-        size: 25_000,
-    });
+    const file = new File([new Uint8Array(25000)], "test.mp3", { type: "audio/mp3" });
     const voicePlayerDrawing = new Deferred();
     patchWithCleanup(VoiceRecorder.prototype, {
         _encode() {},

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -5,7 +5,6 @@ import {
     assertSteps,
     click,
     contains,
-    createFile,
     defineMailModels,
     editInput,
     insertText,
@@ -1594,11 +1593,7 @@ test("warning on send with shortcut when attempting to post message with still-u
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Composer input[type=file]");
-    const file = await createFile({
-        content: "hello, world",
-        contentType: "text/plain",
-        name: "text.txt",
-    });
+    const file = new File(["hello, world"], "text.txt", { type: "text/plain" });
     await insertText(".o-mail-Composer-input", "Dummy Message");
     await editInput(document.body, ".o-mail-Composer input[type=file]", [file]);
     await contains(".o-mail-AttachmentCard");
@@ -1730,11 +1725,7 @@ test("composer state: attachments save and restore", async () => {
         ".o-mail-Composer:has(textarea[placeholder='Message #General…']) input[type=file]"
     );
     // Add attachment in a message for #general
-    const file = await createFile({
-        content: "hello, world",
-        contentType: "text/plain",
-        name: "text.txt",
-    });
+    const file = new File(["hello, world"], "text.txt", { type: "text/plain" });
     await editInput(
         document.body,
         ".o-mail-Composer:has(textarea[placeholder='Message #General…']) input[type=file]",
@@ -1744,23 +1735,11 @@ test("composer state: attachments save and restore", async () => {
     // Switch to #special
     await click("button", { text: "Special" });
     // Attach files in a message for #special
-    const files = await Promise.all([
-        createFile({
-            content: "hello2, world",
-            contentType: "text/plain",
-            name: "text2.txt",
-        }),
-        createFile({
-            content: "hello3, world",
-            contentType: "text/plain",
-            name: "text3.txt",
-        }),
-        createFile({
-            content: "hello4, world",
-            contentType: "text/plain",
-            name: "text4.txt",
-        }),
-    ]);
+    const files = [
+        new File(["hello2, world"], "text2.txt", { type: "text/plain" }),
+        new File(["hello3, world"], "text3.txt", { type: "text/plain" }),
+        new File(["hello4, world"], "text4.txt", { type: "text/plain" }),
+    ];
     await contains(
         ".o-mail-Composer:has(textarea[placeholder='Message #Special…']) input[type=file]"
     );

--- a/addons/mail/static/tests/mail_test_helpers_contains.js
+++ b/addons/mail/static/tests/mail_test_helpers_contains.js
@@ -285,39 +285,6 @@ export async function editInput(el, selector, value) {
 }
 
 /**
- * Create a file object, which can be used for drag-and-drop.
- *
- * @param {Object} data
- * @param {string} data.name
- * @param {string} data.content
- * @param {string} data.contentType
- * @returns {Promise<Object>} resolved with file created
- */
-export function createFile(data) {
-    // Note: this is only supported by Chrome, and does not work in Incognito mode
-    return new Promise(function (resolve, reject) {
-        const requestFileSystem = window.requestFileSystem || window.webkitRequestFileSystem;
-        if (!requestFileSystem) {
-            throw new Error("FileSystem API is not supported");
-        }
-        requestFileSystem(window.TEMPORARY, 1024 * 1024, function (fileSystem) {
-            fileSystem.root.getFile(data.name, { create: true }, function (fileEntry) {
-                fileEntry.createWriter(function (fileWriter) {
-                    fileWriter.onwriteend = function (e) {
-                        fileSystem.root.getFile(data.name, {}, function (fileEntry) {
-                            fileEntry.file(function (file) {
-                                resolve(file);
-                            });
-                        });
-                    };
-                    fileWriter.write(new Blob([data.content], { type: data.contentType }));
-                });
-            });
-        });
-    });
-}
-
-/**
  * Create a fake object 'dataTransfer', linked to some files,
  * which is passed to drag and drop events.
  *

--- a/addons/mail/static/tests/thread/file_upload.test.js
+++ b/addons/mail/static/tests/thread/file_upload.test.js
@@ -1,7 +1,6 @@
 import {
     click,
     contains,
-    createFile,
     defineMailModels,
     inputFiles,
     openDiscuss,
@@ -20,6 +19,8 @@ test("no conflicts between file uploads", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({});
     const channelId = pyEnv["discuss.channel"].create({});
+    const text = new File(["hello, world"], "text1.txt", { type: "text/plain" });
+    const text2 = new File(["hello, world"], "text2.txt", { type: "text/plain" });
     pyEnv["mail.message"].create({
         body: "not empty",
         model: "discuss.channel",
@@ -29,23 +30,11 @@ test("no conflicts between file uploads", async () => {
     // Uploading file in the first thread: res.partner chatter.
     await openFormView("res.partner", partnerId);
     await click("button", { text: "Send message" });
-    await inputFiles(".o-mail-Chatter .o-mail-Composer input[type=file]", [
-        await createFile({
-            name: "text1.txt",
-            content: "hello, world",
-            contentType: "text/plain",
-        }),
-    ]);
+    await inputFiles(".o-mail-Chatter .o-mail-Composer input[type=file]", [text]);
     // Uploading file in the second thread: discuss.channel in chatWindow.
     await click("i[aria-label='Messages']");
     await click(".o-mail-NotificationItem");
-    await inputFiles(".o-mail-ChatWindow .o-mail-Composer input[type=file]", [
-        await createFile({
-            name: "text2.txt",
-            content: "hello, world",
-            contentType: "text/plain",
-        }),
-    ]);
+    await inputFiles(".o-mail-ChatWindow .o-mail-Composer input[type=file]", [text2]);
     await contains(".o-mail-Chatter .o-mail-AttachmentCard");
     await contains(".o-mail-ChatWindow .o-mail-AttachmentCard");
 });
@@ -53,15 +42,10 @@ test("no conflicts between file uploads", async () => {
 test("Attachment shows spinner during upload", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "channel_1" });
+    const text2 = new File(["hello, world"], "text2.txt", { type: "text/plain" });
     onRpc("/mail/attachment/upload", () => new Deferred()); // never fulfill the attachment upload promise.
     await start();
     await openDiscuss(channelId);
-    await inputFiles(".o-mail-Composer input[type=file]", [
-        await createFile({
-            name: "text2.txt",
-            content: "hello, world",
-            contentType: "text/plain",
-        }),
-    ]);
+    await inputFiles(".o-mail-Composer input[type=file]", [text2]);
     await contains(".o-mail-AttachmentCard .fa-spinner");
 });

--- a/addons/mail/static/tests/thread/thread.test.js
+++ b/addons/mail/static/tests/thread/thread.test.js
@@ -3,7 +3,6 @@ import {
     assertSteps,
     click,
     contains,
-    createFile,
     defineMailModels,
     dragenterFiles,
     focus,
@@ -36,16 +35,10 @@ test("dragover files on thread with composer", async () => {
         group_public_id: false,
         name: "General",
     });
+    const text3 = new File(["hello, world"], "text3.txt", { type: "text/plain" });
     await start();
     await openDiscuss(channelId);
-    const files = [
-        await createFile({
-            content: "hello, world",
-            contentType: "text/plain",
-            name: "text3.txt",
-        }),
-    ];
-    await dragenterFiles(".o-mail-Thread", files);
+    await dragenterFiles(".o-mail-Thread", [text3]);
     await contains(".o-mail-Dropzone");
 });
 

--- a/addons/mail/static/tests/tours/discuss_channel_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_public_tour.js
@@ -1,5 +1,5 @@
 import { registry } from "@web/core/registry";
-import { click, contains, createFile, inputFiles } from "@web/../tests/utils";
+import { click, contains, inputFiles } from "@web/../tests/utils";
 
 registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
     test: true,
@@ -42,13 +42,8 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
             content: "Add a text file in composer",
             trigger: ".o-mail-Composer button[aria-label='Attach files']",
             async run() {
-                await inputFiles(".o-mail-Composer-coreMain .o_input_file", [
-                    await createFile({
-                        content: "hello, world",
-                        contentType: "text/plain",
-                        name: "text.txt",
-                    }),
-                ]);
+                const text = new File(["hello, world"], "text.txt", { type: "text/plain" });
+                await inputFiles(".o-mail-Composer-coreMain .o_input_file", [text]);
             },
         },
         {
@@ -158,12 +153,9 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
             content: "Add one more file in composer",
             trigger: ".o-mail-Message .o-mail-Composer button[aria-label='Attach files']",
             async run() {
-                inputFiles(".o-mail-Message .o-mail-Composer-coreMain .o_input_file", [
-                    await createFile({
-                        content: "hello 2",
-                        contentType: "text/plain",
-                        name: "extra.txt",
-                    }),
+                const extratxt = new File(["hello 2"], "extra.txt", { type: "text/plain" });
+                await inputFiles(".o-mail-Message .o-mail-Composer-coreMain .o_input_file", [
+                    extratxt,
                 ]);
             },
         },

--- a/addons/mail/static/tests/tours/mail_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_composer_test_tour.js
@@ -1,5 +1,5 @@
 import { registry } from "@web/core/registry";
-import { contains, createFile, inputFiles } from "@web/../tests/utils";
+import { contains, inputFiles } from "@web/../tests/utils";
 
 /**
  * This tour depends on data created by python test in charge of launching it.
@@ -36,13 +36,8 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
             content: "Add one file in composer",
             trigger: ".o-mail-Composer button[aria-label='Attach files']",
             async run() {
-                await inputFiles(".o-mail-Composer-coreMain .o_input_file", [
-                    await createFile({
-                        content: "hello, world",
-                        contentType: "text/plain",
-                        name: "text.txt",
-                    }),
-                ]);
+                const text = new File(["hello, world"], "text.txt", { type: "text/plain" });
+                await inputFiles(".o-mail-Composer-coreMain .o_input_file", [text]);
             },
         },
         {

--- a/addons/mrp/static/tests/mrp_document_kanban.test.js
+++ b/addons/mrp/static/tests/mrp_document_kanban.test.js
@@ -9,7 +9,7 @@ import {
     startServer,
     step,
 } from "@mail/../tests/mail_test_helpers";
-import { createFile, inputFiles } from "@web/../tests/utils";
+import { inputFiles } from "@web/../tests/utils";
 import { defineMrpModels } from "@mrp/../tests/mrp_test_helpers";
 import { getService, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { fileUploadService } from "@web/core/file_upload/file_upload_service";
@@ -51,6 +51,9 @@ test("mrp: upload multiple files", async () => {
         mimetype: "image/png",
         name: "test.png",
     });
+    const text1 = new File(["hello, world"], "text1.txt", { type: "text/plain" });
+    const text2 = new File(["hello, world"], "text2.txt", { type: "text/plain" });
+    const text3 = new File(["hello, world"], "text3.txt", { type: "text/plain" });
     pyEnv["product.document"].create([
         { name: "test1", ir_attachment_id: irAttachment, mimetype: "image/png" },
         { name: "test2" },
@@ -62,26 +65,9 @@ test("mrp: upload multiple files", async () => {
     await openView({ res_model: "product.document", views: [[false, "kanban"]] });
 
     getService("file_upload").bus.addEventListener("FILE_UPLOAD_ADDED", () => step("xhrSend"));
-    await inputFiles(".o_control_panel_main_buttons .o_input_file", [
-        await createFile({
-            name: "text1.txt",
-            content: "hello, world",
-            contentType: "text/plain",
-        }),
-    ]);
+    await inputFiles(".o_control_panel_main_buttons .o_input_file", [text1]);
     assertSteps(["xhrSend"]);
-    await inputFiles(".o_control_panel_main_buttons .o_input_file", [
-        await createFile({
-            name: "text2.txt",
-            content: "hello, world",
-            contentType: "text/plain",
-        }),
-        await createFile({
-            name: "text3.txt",
-            content: "hello, world",
-            contentType: "text/plain",
-        }),
-    ]);
+    await inputFiles(".o_control_panel_main_buttons .o_input_file", [text2, text3]);
     assertSteps(["xhrSend"]);
 });
 
@@ -132,6 +118,7 @@ test("mrp: upload progress bars", async () => {
         mimetype: "image/png",
         name: "test.png",
     });
+    const text1 = new File(["hello, world"], "text1.txt", { type: "text/plain" });
     pyEnv["product.document"].create([
         { name: "test1", ir_attachment_id: irAttachment, mimetype: "image/png" },
         { name: "test2" },
@@ -151,13 +138,7 @@ test("mrp: upload progress bars", async () => {
         },
     });
 
-    await inputFiles(".o_control_panel_main_buttons .o_input_file", [
-        await createFile({
-            name: "text1.txt",
-            content: "hello, world",
-            contentType: "text/plain",
-        }),
-    ]);
+    await inputFiles(".o_control_panel_main_buttons .o_input_file", [text1]);
 
     const progressEvent = new Event("progress", { bubbles: true });
     progressEvent.loaded = 250000000;

--- a/addons/web/static/tests/legacy/utils.js
+++ b/addons/web/static/tests/legacy/utils.js
@@ -10,39 +10,6 @@ import {
 } from "@web/../tests/helpers/utils";
 
 /**
- * Create a file object, which can be used for drag-and-drop.
- *
- * @param {Object} data
- * @param {string} data.name
- * @param {string} data.content
- * @param {string} data.contentType
- * @returns {Promise<Object>} resolved with file created
- */
-export function createFile(data) {
-    // Note: this is only supported by Chrome, and does not work in Incognito mode
-    return new Promise(function (resolve, reject) {
-        var requestFileSystem = window.requestFileSystem || window.webkitRequestFileSystem;
-        if (!requestFileSystem) {
-            throw new Error("FileSystem API is not supported");
-        }
-        requestFileSystem(window.TEMPORARY, 1024 * 1024, function (fileSystem) {
-            fileSystem.root.getFile(data.name, { create: true }, function (fileEntry) {
-                fileEntry.createWriter(function (fileWriter) {
-                    fileWriter.onwriteend = function (e) {
-                        fileSystem.root.getFile(data.name, {}, function (fileEntry) {
-                            fileEntry.file(function (file) {
-                                resolve(file);
-                            });
-                        });
-                    };
-                    fileWriter.write(new Blob([data.content], { type: data.contentType }));
-                });
-            });
-        });
-    });
-}
-
-/**
  * Create a fake object 'dataTransfer', linked to some files,
  * which is passed to drag and drop events.
  *


### PR DESCRIPTION
*im_livechat, mrp, web

Purpose of this commit:
`createFile` used the File System API to create test files in the browser's
temporary file system. However, since not all browsers support this API,
it has been replaced with the new File(...) constructor, which is supported
 by all browsers. This change makes the tests more compatible across
different browsers.

enterprise: https://github.com/odoo/enterprise/pull/69702
task-4161755