### PR TITLE
[FIX] account{_audit_trail,_lock}: uninstall hook useful error message

### DIFF
--- a/addons/account_audit_trail/__init__.py
+++ b/addons/account_audit_trail/__init__.py
@@ -7,4 +7,4 @@ from odoo.exceptions import UserError
 
 def uninstall_hook(env):
     if not env.ref('base.module_base').demo:
-        raise UserError("This module cannot be uninstalled.")
+        raise UserError('The module "Account Audit Trail" (account_audit_trail) cannot be uninstalled.')

--- a/addons/account_lock/__init__.py
+++ b/addons/account_lock/__init__.py
@@ -6,4 +6,4 @@ from odoo.exceptions import UserError
 
 def uninstall_hook(env):
     if not env.ref('base.module_base').demo:
-        raise UserError("This module cannot be uninstalled.")
+        raise UserError('The module "Irreversible Lock Date" (account_lock) cannot be uninstalled.')


### PR DESCRIPTION
The modules `account_audit_trail` and `account_lock` cannot be
uninstalled since [1].

The issue is that the error message displayed to the end user is not
specific enough and causes confusion when people are not directly
uninstalling the module, but rather another module that happen to
trigger the uninstallation of `account_audit_trail` or `account_lock`
(`account` for example).

After this commit the human readable and technical name of the module
are displayed in the error message which should allow the end user to
either have a better understanding of why the operation is impossible or
should not be performed, or at the very least will help them go check
the description of the right modules to get further information.

[1] https://github.com/odoo/odoo/pull/171244

opw-4172056
