### PR TITLE
[IMP] spreadsheet_dashboard: store main model on dashboards

### DIFF
--- a/addons/spreadsheet_dashboard/models/spreadsheet_dashboard.py
+++ b/addons/spreadsheet_dashboard/models/spreadsheet_dashboard.py
@@ -15,7 +15,7 @@ class SpreadsheetDashboard(models.Model):
     is_published = fields.Boolean(default=True)
     company_id = fields.Many2one('res.company')
     group_ids = fields.Many2many('res.groups', default=lambda self: self.env.ref('base.group_user'))
-
+    main_data_model_ids = fields.Many2many('ir.model')
 
     def get_readonly_dashboard(self):
         self.ensure_one()


### PR DESCRIPTION
Currently, users with an fresh empty database will only see empty dashboard skeletons. They will go through a list of sheets without any data and probably miss the potential of this reporting tool.

For a proper onboarding experience, they should be greeted with sample data to give a better idea of the dashboard look and use.

Technically, we will define if a dashboard requires the sample data by querying if the most important models of the dashboard have any records.

A first step towards this goal is to add the field where we will store this information.

task-3947773

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
