### PR TITLE
[FIX] account(_tax_python): round base before calculating tax

### DIFF
--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -367,9 +367,14 @@ export const accountTaxHelpers = {
         } else if (!precision_rounding) {
             precision_rounding = 0.01;
         }
+        let raw_price = price_unit * quantity
+        if (precision_rounding) {
+            raw_price = roundPrecision(raw_price, precision_rounding);
+        }
         return {
             product: product_values,
             price_unit: price_unit,
+            raw_price: raw_price,
             quantity: quantity,
             rounding_method: rounding_method,
             precision_rounding: precision_rounding,
@@ -390,9 +395,7 @@ export const accountTaxHelpers = {
             return evaluation_context.quantity * evaluation_context.quantity_multiplicator;
         }
 
-        let raw_base =
-            evaluation_context.quantity * evaluation_context.price_unit +
-            evaluation_context.extra_base;
+        let raw_base = evaluation_context.raw_price + evaluation_context.extra_base;
         if (
             "incl_base_multiplicator" in evaluation_context &&
             ((price_include && !special_mode) || special_mode === "total_included")
@@ -415,9 +418,7 @@ export const accountTaxHelpers = {
         const amount_type = tax_data.amount_type;
         const total_tax_amount = evaluation_context.total_tax_amount;
         const special_mode = evaluation_context.special_mode;
-        const raw_base =
-            evaluation_context.quantity * evaluation_context.price_unit +
-            evaluation_context.extra_base;
+        const raw_base = evaluation_context.raw_price + evaluation_context.extra_base;
 
         if (price_include) {
             const base = special_mode === "total_excluded" ? raw_base : raw_base - total_tax_amount;
@@ -525,8 +526,7 @@ export const accountTaxHelpers = {
             }
             total_included = total_excluded + tax_amount;
         } else {
-            total_excluded = total_included =
-                evaluation_context.quantity * evaluation_context.price_unit;
+            total_excluded = total_included = evaluation_context.raw_price;
             if (rounding_method === "round_per_line") {
                 total_excluded = total_included = roundPrecision(total_excluded, prec_rounding);
             }

--- a/addons/account/tests/test_invoice_tax_totals.py
+++ b/addons/account/tests/test_invoice_tax_totals.py
@@ -868,6 +868,25 @@ class TestTaxTotals(AccountTestInvoicingCommon):
             'subtotals_order': ["Untaxed Amount"],
         })
 
+    def test_round_globally_taxes_base(self):
+        self.env.company.tax_calculation_rounding_method = 'round_globally'
+        tax = self.env['account.tax'].create({
+            'name': '21%',
+            'amount_type': 'percent',
+            'amount': 21.0
+        })
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_line_ids': [Command.create({
+                'price_unit': 5.75,
+                'discount': 18.0,
+                'quantity': 5,
+                'tax_ids': [tax.id],
+            }) for i in range(6)]
+        })
+        self.assertEqual(invoice.currency_id.compare_amounts(invoice.amount_tax, 29.71), 0)
+
     def test_cash_rounding_amount_total_rounded(self):
         tax_15 = self.env['account.tax'].create({
             'name': "tax_15",

--- a/addons/account_tax_python/models/account_tax.py
+++ b/addons/account_tax_python/models/account_tax.py
@@ -66,7 +66,7 @@ class AccountTaxPython(models.Model):
         amount_type = tax_data['amount_type']
         if amount_type == 'code':
             tax = self.browse(tax_data['id'])
-            raw_base = (evaluation_context['quantity'] * evaluation_context['price_unit']) + evaluation_context['extra_base']
+            raw_base = evaluation_context['raw_price'] + evaluation_context['extra_base']
             local_dict = {**evaluation_context, 'base_amount': raw_base}
             json.dumps(local_dict) # Ensure it contains only json serializable data (security).
             try:


### PR DESCRIPTION
### Steps to reproduce the issue:

1. Make sure the Rounding Method is set to "Round Globally"
2. Have a Tax of 21%
3. Create a Product with sale price 5.75 and set the Sale Tax
4. Create an Invoice and add 6 lines with the Product
5. For each line, set the quantity to 5 and add an 18% discount
6. The Tax Amount is of 29.70 when the Total Tax Excluded is of 141.48 (141.48 * 21% ~= 29.71)

### Explanation:

Since 17.2, the base amount of a tax is not rounded before the calculation of the tax amount, this creates an issue where the base amount and `amount_untaxed` are different when `tax_calculation_rounding_method` is set to 'round_globally'. (e.g.: 141.45 vs 141.48)

### Fix reasoning:

`raw_price` is rounded out if `precision_rounding` is specified to avoid rounding to unit, it will replace all occurences of `price_unit * quantity` in the tax calculation.

opw-4136024