### PR TITLE
[FIX] web_editor: use addClass instead of addStyle

### DIFF
--- a/addons/web_editor/static/src/js/editor/drag_and_drop.js
+++ b/addons/web_editor/static/src/js/editor/drag_and_drop.js
@@ -116,7 +116,7 @@ const dragAndDropHookParams = {
         ctx.current.container = ctx.scrollingElement;
         ctx.current.helperOffset = { x: 0, y: 0 };
     },
-    onDragStart: ({ ctx, addStyle, addCleanup }) => {
+    onDragStart: ({ ctx, addStyle, addCleanup, addClass }) => {
         // Use the helper as the tracking element to properly update scroll values.
         ctx.current.element = ctx.getHelper({ ...ctx.current, ...ctx.pointer });
         ctx.current.helper = ctx.current.element;
@@ -132,7 +132,7 @@ const dragAndDropHookParams = {
         // the cursor.
         const frameElement = ctx.current.helper.ownerDocument.defaultView.frameElement;
         if (frameElement) {
-            addStyle(frameElement, { pointerEvents: "auto" });
+            addClass(frameElement, "pe-auto");
         }
 
         addCleanup(() => ctx.current.helper.remove());


### PR DESCRIPTION
Issue:
======
mass mailing iframe size isn't correct.

Steps to reproduce the issue:
=============================
It doesn't alwyas happen because of race condition, so you may need to
try multiple times.

- Create a new mass mailing
- Add 3 `image-text` snippets
- You can't scroll down in the editable area because the size of the
  iframe is smaller than it's content.

Origin of the issue:
====================
The function that resizes the iframe in mass mailing is defined in [1].

In `onDragStart` in [2] we call `addStyle` on the iframe to make sure it
has `pointerEvents:auto` style.

Now when the drag ends there are 2 events executing in parallel which
are :

- `onPointerUp` in [3]: which will call `dragEnd` which itself will call
  `cleanup` so it will assign the old style attribute to the iframe.

- resizing of the iframe from the `_resizeObserver`

Now if `_resizeMailingEditorIframe` is called first then it will have
the new size and then the cleanup will assign the old style which have
the wrong size which makes the editable smaller than its content and we
can't scroll down the editable.

Solution:
=========
We use `addClass` instead of `addStyle`.

task-4041275

[1]: https://github.com/odoo/odoo/blob/db29299d91111837d02bc62d573afb915fe673dd/addons/mass_mailing/static/src/js/mailing_mailing_view_form_full_width.js#L19
[2]: https://github.com/odoo/odoo/blob/db29299d91111837d02bc62d573afb915fe673dd/addons/web_editor/static/src/js/editor/drag_and_drop.js#L135
[3]: https://github.com/odoo/odoo/blob/db29299d91111837d02bc62d573afb915fe673dd/addons/web/static/src/core/utils/draggable_hook_builder.js#L752