### PR TITLE
[FIX] account: display payment reference field in customer invoice

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -965,7 +965,7 @@
                                        invisible="move_type in ('out_invoice', 'out_refund', 'out_receipt') and not quick_edit_mode and not (state == 'posted' and date != invoice_date)"
                                        readonly="state != 'draft'"/>
                                 <field name="payment_reference"
-                                       invisible="move_type not in ('in_invoice', 'in_refund', 'out_receipt', 'in_receipt')"
+                                       invisible="move_type not in ('out_invoice', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')"
                                        readonly="inalterable_hash != False"
                                        placeholder="Use Bill Reference"/>
                                 <field name="partner_bank_id"


### PR DESCRIPTION
In version 17.4, the payment reference field is invisible for customer invoices. This fix ensures that it is visible for customer invoices.

OPW-4156009

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
