### PR TITLE
[FIX] point_of_sale: creation of empty draft order

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1043,7 +1043,7 @@ class PosOrder(models.Model):
 
             if existing_draft_order:
                 order_ids.append(self._process_order(order, existing_draft_order))
-            else:
+            elif order.get('lines') or order.get('payment_ids'):
                 existing_orders = self.env['pos.order'].search([('pos_reference', '=', order.get('name', False))])
                 if all(not self._is_the_same_order(order, existing_order) for existing_order in existing_orders):
                     order_ids.append(self._process_order(order, False))

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -396,7 +396,7 @@ export class TicketScreen extends Component {
             return _t("Paid");
         } else {
             const screen = order.get_screen_data();
-            return this._getOrderStates().get(this._getScreenToStatusMap()[screen.name]).text;
+            return this._getOrderStates().get(this._getScreenToStatusMap()[screen.name])?.text;
         }
     }
     /**

--- a/addons/pos_self_order/tests/test_frontend.py
+++ b/addons/pos_self_order/tests/test_frontend.py
@@ -14,6 +14,12 @@ class TestFrontendMobile(SelfOrderCommonTest):
     def test_order_fiscal_position(self):
         """ Orders made in take away should have the alternative fiscal position. """
 
+        product = self.env["product.product"].create(
+            {
+                "name": "Test Product",
+                "lst_price": 30,
+            }
+        )
         tax30 = self.env['account.tax'].create({
             'name': '30%',
             'amount': 30,
@@ -59,7 +65,19 @@ class TestFrontendMobile(SelfOrderCommonTest):
                         "amount_tax": 0,
                         "amount_paid": 0,
                         "amount_return": 0,
-                        "lines": [],
+                        "lines": [
+                            (
+                                0,
+                                0,
+                                {
+                                    "product_id": product.id,
+                                    "qty": 1,
+                                    "price_unit": 30,
+                                    "price_subtotal": 30,
+                                    "price_subtotal_incl": 34.5,
+                                },
+                            ),
+                        ],
                         "tracking_number": None,
                         "takeaway": True,
                     },


### PR DESCRIPTION
Steps:
- Install pos_urban_piper
- Open Point of Sale.
- Configure Food Delivery Connector for one of pos
- Place a test order.
- Edit order and add a new product.
- Accept the order.
- Mark as ready the order.

Issue:
Empty draft order in the backend is created.

Fix:
- Restricting creation of empty order whose orderline is not present.

task-4147488
