### PR TITLE
[IMP] hr: make the unarchive wizard work with multiple employees

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -548,6 +548,11 @@ class HrEmployee(models.Model):
     def _get_user_m2o_to_empty_on_archived_employees(self):
         return []
 
+    def _get_departure_date(self):
+        # for overloads
+        self.ensure_one()
+        return self.departure_date
+
     def action_unarchive(self):
         res = super().action_unarchive()
         self.write({

--- a/addons/hr/static/src/views/archive_employee_hook.js
+++ b/addons/hr/static/src/views/archive_employee_hook.js
@@ -5,7 +5,7 @@ import { useComponent } from "@odoo/owl";
 export function useArchiveEmployee() {
     const component = useComponent();
     const action = useService("action");
-    return (id) => {
+    return (ids) => {
         action.doAction(
             {
                 type: "ir.actions.act_window",
@@ -15,7 +15,7 @@ export function useArchiveEmployee() {
                 view_mode: "form",
                 target: "new",
                 context: {
-                    active_id: id,
+                    active_ids: ids,
                     employee_termination: true,
                 },
             },

--- a/addons/hr/static/src/views/form_view.js
+++ b/addons/hr/static/src/views/form_view.js
@@ -13,7 +13,7 @@ export class EmployeeFormController extends FormController {
 
     getStaticActionMenuItems() {
         const menuItems = super.getStaticActionMenuItems();
-        menuItems.archive.callback = this.archiveEmployee.bind(this, this.model.root.resId);
+        menuItems.archive.callback = this.archiveEmployee.bind(this, [this.model.root.resId]);
         return menuItems;
     }
 }

--- a/addons/hr/static/src/views/list_view.js
+++ b/addons/hr/static/src/views/list_view.js
@@ -15,10 +15,10 @@ export class EmployeeListController extends ListController {
         const menuItems = super.getStaticActionMenuItems();
         const selectedRecords = this.model.root.selection;
 
-        // Only override the Archive action when only 1 record is selected.
-        if (selectedRecords.length === 1 && selectedRecords[0].data.active) {
-            menuItems.archive.callback = this.archiveEmployee.bind(this, selectedRecords[0].resId);
-        }
+        menuItems.archive.callback = this.archiveEmployee.bind(
+            this,
+            selectedRecords.map(({resId}) => resId),
+        )
         return menuItems;
     }
 }

--- a/addons/hr/wizard/hr_departure_wizard.py
+++ b/addons/hr/wizard/hr_departure_wizard.py
@@ -7,27 +7,31 @@ from odoo import fields, models
 class HrDepartureWizard(models.TransientModel):
     _description = 'Departure Wizard'
 
-    def _get_employee_departure_date(self):
-        return self.env['hr.employee'].browse(self.env.context['active_id']).departure_date
-
     def _get_default_departure_date(self):
-        departure_date = False
-        if self.env.context.get('active_id'):
-            departure_date = self._get_employee_departure_date()
+        if len(active_ids := self.env.context.get('active_ids', [])) == 1:
+            employee = self.env['hr.employee'].browse(active_ids[0])
+            departure_date = employee._get_departure_date()
+        else:
+            departure_date = False
+
         return departure_date or fields.Date.today()
 
     departure_reason_id = fields.Many2one("hr.departure.reason", default=lambda self: self.env['hr.departure.reason'].search([], limit=1), required=True)
     departure_description = fields.Html(string="Additional Information")
     departure_date = fields.Date(string="Departure Date", required=True, default=_get_default_departure_date)
-    employee_id = fields.Many2one(
-        'hr.employee', string='Employee', required=True,
-        default=lambda self: self.env.context.get('active_id', None),
+    employee_ids = fields.Many2many(
+        'hr.employee', string='Employees', required=True,
+        default=lambda self: self.env.context.get('active_ids', []),
+        context={'active_test': False},
+        domain=[('active', '=', True)],
     )
 
     def action_register_departure(self):
-        employee = self.employee_id
-        if self.env.context.get('employee_termination', False) and employee.active:
-            employee.with_context(no_wizard=True).action_archive()
-        employee.departure_reason_id = self.departure_reason_id
-        employee.departure_description = self.departure_description
-        employee.departure_date = self.departure_date
+        for employee in self.employee_ids.filtered(lambda emp: emp.active):
+            if self.env.context.get('employee_termination', False):
+                employee.with_context(no_wizard=True).action_archive()
+        self.employee_ids.write({
+            'departure_reason_id': self.departure_reason_id,
+            'departure_description': self.departure_description,
+            'departure_date': self.departure_date,
+        })

--- a/addons/hr/wizard/hr_departure_wizard_views.xml
+++ b/addons/hr/wizard/hr_departure_wizard_views.xml
@@ -7,9 +7,9 @@
             <field name="arch" type="xml">
                 <form>
                     <sheet>
-                        <h1><field name="employee_id" readonly="1" options="{'no_open': True}"/></h1>
                         <group>
                             <group id="info">
+                                <field name="employee_ids" widget="many2many_tags"/>
                                 <field name="departure_reason_id" options="{'no_edit': True, 'no_create': True, 'no_open': True}"/>
                                 <field name="departure_date"/>
                             </group>

--- a/addons/hr_contract/models/hr_employee.py
+++ b/addons/hr_contract/models/hr_employee.py
@@ -53,6 +53,17 @@ class HrEmployee(models.Model):
             if not employee.legal_name:
                 employee.legal_name = employee.name
 
+    def _get_departure_date(self):
+        # Primarily used in the archive wizard
+        # to pick a good default for the departure date
+        self.ensure_one()
+        if self.contract_id.state == "open":
+            return False
+        expired_contract = self.env['hr.contract'].search([('employee_id', '=', self.id), ('state', '=', 'close')], limit=1, order='date_end desc')
+        if expired_contract:
+            return expired_contract.date_end
+        return super()._get_departure_date()
+
     def _get_first_contracts(self):
         self.ensure_one()
         contracts = self.sudo().contract_ids.filtered(lambda c: c.state != 'cancel')

--- a/addons/hr_contract/wizard/hr_departure_wizard.py
+++ b/addons/hr_contract/wizard/hr_departure_wizard.py
@@ -8,29 +8,24 @@ from odoo.exceptions import UserError
 class HrDepartureWizard(models.TransientModel):
     _inherit = ['hr.departure.wizard']
 
-    def _get_employee_departure_date(self):
-        employee = self.env['hr.employee'].browse(self.env.context['active_id'])
-        if employee.contract_id.state == "open":
-            return False
-        expired_contract = self.env['hr.contract'].search([('employee_id', '=', employee.id), ('state', '=', 'close')], limit=1, order='date_end desc')
-        if expired_contract:
-            return expired_contract.date_end
-        return super()._get_employee_departure_date()
-
     set_date_end = fields.Boolean(string="Set Contract End Date", default=lambda self: self.env.user.has_group('hr_contract.group_hr_contract_manager'),
         help="Set the end date on the current contract.")
 
     def action_register_departure(self):
         """If set_date_end is checked, set the departure date as the end date to current running contract,
         and cancel all draft contracts"""
-        current_contract = self.sudo().employee_id.contract_id
-        if current_contract and current_contract.date_start > self.departure_date:
+        active_contracts = self.employee_ids.contract_id
+
+        if any(c.date_start > self.departure_date for c in active_contracts):
             raise UserError(_("Departure date can't be earlier than the start date of current contract."))
 
-        super(HrDepartureWizard, self).action_register_departure()
+        super().action_register_departure()
+
         if self.set_date_end:
-            self.sudo().employee_id.contract_ids.filtered(lambda c: c.state == 'draft').write({'state': 'cancel'})
-            if current_contract and current_contract.state in ['open', 'draft']:
-                self.sudo().employee_id.contract_id.write({'date_end': self.departure_date})
-            if current_contract.state == 'open':
-                current_contract.state = 'close'
+            # Write date and update state of current contracts
+            current_contracts = active_contracts.filtered(lambda c: c.state in ['open', 'draft'])
+            current_contracts.write({'date_end': self.departure_date})
+            current_contracts.filtered(lambda c: c.state == 'open').write({'state': 'close'})
+
+            # Cancel draft contracts
+            self.employee_ids.contract_ids.filtered(lambda c: c.state == 'draft').write({'state': 'cancel'})

--- a/addons/hr_fleet/wizard/hr_departure_wizard.py
+++ b/addons/hr_fleet/wizard/hr_departure_wizard.py
@@ -12,16 +12,19 @@ class HrDepartureWizard(models.TransientModel):
     def action_register_departure(self):
         super(HrDepartureWizard, self).action_register_departure()
         if self.release_campany_car:
-            self._free_campany_car()
+            self._free_company_car()
 
-    def _free_campany_car(self):
+    def _free_company_car(self):
         """Find all fleet.vehichle.assignation.log records that link to the employee, if there is no 
         end date or end date > departure date, update the date. Also check fleet.vehicle to see if 
-        there is any record with its dirver_id to be the employee, set them to False."""
-        drivers = self.employee_id.user_id.partner_id | self.employee_id.sudo().work_contact_id
-        assignations = self.env['fleet.vehicle.assignation.log'].search([('driver_id', 'in', drivers.ids)])
-        for assignation in assignations:
-            if self.departure_date and (not assignation.date_end or assignation.date_end > self.departure_date):
-                assignation.write({'date_end': self.departure_date})
+        there is any record with its driver_id to be the employee, set them to False."""
+        drivers = self.employee_ids.user_id.partner_id | self.employee_ids.sudo().work_contact_id
+        assignations = self.env['fleet.vehicle.assignation.log'].search([
+            ('driver_id', 'in', drivers.ids),
+            '|',
+                ('date_end', '=', False),
+                ('date_end', '>', self.departure_date),
+        ])
+        assignations.write({'date_end': self.departure_date})
         cars = self.env['fleet.vehicle'].search([('driver_id', 'in', drivers.ids)])
         cars.write({'driver_id': False, 'driver_employee_id': False})

--- a/addons/hr_holidays/tests/test_hr_departure_wizard.py
+++ b/addons/hr_holidays/tests/test_hr_departure_wizard.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from datetime import date, timedelta
 
+from odoo import Command
 from odoo.addons.hr_holidays.tests.common import TestHrHolidaysCommon
 
 
@@ -16,7 +17,7 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
         cls.departure_wizard = cls.env['hr.departure.wizard'].create({
             'departure_reason_id': departure_reason.id,
             'departure_date': cls.departure_date,
-            'employee_id': cls.employee.id,
+            'employee_ids': [Command.link(cls.employee.id)],
         })
         cls.leave_type = cls.env['hr.leave.type'].create({
             'name': 'Paid Time Off',

--- a/addons/hr_holidays/wizard/hr_departure_wizard.py
+++ b/addons/hr_holidays/wizard/hr_departure_wizard.py
@@ -11,9 +11,10 @@ class HrDepartureWizard(models.TransientModel):
     def action_register_departure(self):
         super(HrDepartureWizard, self).action_register_departure()
         employee_leaves = self.env['hr.leave'].search([
-            ('employee_id', '=', self.employee_id.id),
+            ('employee_id', 'in', self.employee_ids.ids),
             ('date_to', '>', self.departure_date),
         ])
+
         if employee_leaves:
             leaves_with_departure = employee_leaves.filtered(
                 lambda leave: leave.date_from.date() <= self.departure_date)
@@ -42,7 +43,7 @@ class HrDepartureWizard(models.TransientModel):
             leaves_to_delete.with_context(leave_skip_state_check=True).unlink()
 
         employee_allocations = self.env['hr.leave.allocation'].search([
-            ('employee_id', '=', self.employee_id.id),
+            ('employee_id', 'in', self.employee_ids.ids),
             '|',
                 ('date_to', '=', False),
                 ('date_to', '>', self.departure_date),

--- a/addons/hr_maintenance/wizard/hr_departure_wizard.py
+++ b/addons/hr_maintenance/wizard/hr_departure_wizard.py
@@ -11,4 +11,4 @@ class HrDepartureWizard(models.TransientModel):
     def action_register_departure(self):
         super().action_register_departure()
         if self.unassign_equipment:
-            self.employee_id.update({'equipment_ids': [Command.unlink(equipment.id) for equipment in self.employee_id.equipment_ids]})
+            self.employee_ids.write({'equipment_ids': [Command.clear()]})


### PR DESCRIPTION
Before
* From the employee list view: 
  * if we select 1 employee => *actions* > *archive*: a wizard opens 
  * but if multiple employees were selected -> we go through the default unrachive

After
---
The wizard's `employee_id` field is replaced by a m2m to support multiple employees.
We go through the wizard when archiving multiple employees, applying the same data from the wizard (eg Departure Reason...) to all affected employees.

task-3987430
