### PR TITLE
[IMP] account, stock_landed_costs, web:  Invoice line display

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~17.4+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-12 07:44+0000\n"
-"PO-Revision-Date: 2024-09-12 07:44+0000\n"
+"POT-Creation-Date: 2024-09-17 13:58+0000\n"
+"PO-Revision-Date: 2024-09-17 13:58+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -2394,6 +2394,7 @@ msgid ""
 msgstr ""
 
 #. module: account
+#: model_terms:ir.ui.view,arch_db:account.view_move_form
 #: model_terms:ir.ui.view,arch_db:account.view_move_line_form
 msgid "Analytic"
 msgstr ""

--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
@@ -223,6 +223,7 @@ export class ProductLabelSectionAndNoteField extends Many2OneField {
 
 export const productLabelSectionAndNoteField = {
     ...many2OneField,
+    listViewWidth: [240, 400],
     component: ProductLabelSectionAndNoteField,
 };
 registry

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1075,6 +1075,7 @@
                                                domain="[('deprecated', '=', False), ('account_type', 'not in', ('asset_receivable', 'liability_payable', 'off_balance')), ('company_id', 'parent_of', parent.company_id)]"
                                                required="display_type not in ('line_note', 'line_section')"/>
                                         <field name="analytic_distribution" widget="analytic_distribution"
+                                               string="Analytic"
                                                groups="analytic.group_analytic_accounting"
                                                optional="show"
                                                options="{'product_field': 'product_id', 'account_field': 'account_id', 'amount_field': 'price_subtotal'}"

--- a/addons/stock_landed_costs/views/account_move_views.xml
+++ b/addons/stock_landed_costs/views/account_move_views.xml
@@ -22,9 +22,9 @@
                 </t>
             </field>
 
-            <xpath expr="//field[@name='invoice_line_ids']/tree/field[@name='name']" position="after">
+            <xpath expr="//field[@name='invoice_line_ids']/tree/field[@name='quantity']" position="before">
                 <field name="product_type" column_invisible="True" groups="stock.group_stock_manager"/>
-                <field name="is_landed_costs_line" string="Landed Costs" column_invisible="parent.move_type != 'in_invoice'" readonly="product_type != 'service'" optional="show" groups="stock.group_stock_manager"/>
+                <field name="is_landed_costs_line" string="Landed Costs" column_invisible="parent.move_type != 'in_invoice'" readonly="product_type != 'service'" optional="hide" groups="stock.group_stock_manager"/>
             </xpath>
 
             <xpath expr="//field[@name='line_ids']/tree/field[@name='name']" position="after">

--- a/addons/web/static/src/views/fields/field.js
+++ b/addons/web/static/src/views/fields/field.js
@@ -67,7 +67,7 @@ fieldRegistry.addValidation({
     },
     useSubView: { type: Boolean, optional: true },
     label: { type: [String, { value: false }], optional: true },
-    listViewWidth: { type: [Number, [Number, Number], Function], optional: true },
+    listViewWidth: { type: [Number, { type: Array, element: Number, validate: (array) => array.length === 2 }, Function], optional: true },
 });
 
 class DefaultField extends Component {


### PR DESCRIPTION
This commit will do multiple things:
- Put a min-width and max width on the product label selected widget
- Change the label of analytic distribution
- Move landed costs before quantity and put it in optional hide
- Fix the accepted props type of listViewWidth to accept list of two elements

task: 4170328




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
