### PR TITLE
[FIX] website: prevent error while searching in website without pages

### DIFF
--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -295,7 +295,7 @@ class Page(models.Model):
         )
         results = most_specific_pages.filtered_domain(domain)  # already sudo
 
-        if with_description and search:
+        if with_description and search and most_specific_pages:
             # Perform search in translations
             # TODO Remove when domains will support xml_translate fields
             query = sql.SQL("""


### PR DESCRIPTION
Currently, an exception was generated when the user deleted all website pages and tried to search for anything on the website.

error: 
```
SyntaxError: syntax error at or near ")"
LINE 7:                 AND "website_page".id IN ()
                                                  ^

  File "odoo/http.py", line 2383, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1913, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1976, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1943, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2100, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 227, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 757, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/website/controllers/main.py", line 606, in hybrid_list
    data = self.autocomplete(search_type=search_type, term=search, order='name asc', limit=500, max_nb_chars=200, options=options)
  File "odoo/http.py", line 757, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/website/controllers/main.py", line 487, in autocomplete
    results_count, search_results, fuzzy_term = request.website._search_with_fuzzy(search_type, term, limit, order, options)
  File "addons/website/models/website.py", line 1711, in _search_with_fuzzy
    count, results = self._search_exact(search_details, fuzzy_term, limit, order)
  File "addons/website/models/website.py", line 1740, in _search_exact
    results, count = model._search_fetch(search_detail, search, limit, order)
  File "addons/website/models/website_page.py", line 259, in _search_fetch
    self.env.cr.execute(SQL(
  File "odoo/sql_db.py", line 347, in execute
    res = self._obj.execute(query, params)
```

This is because the user deleted all pages, and we got an empty list on `most_specific_pages`.

This commit will fix the above issue by preventing the execution of the query when most_specific_pages is empty.

sentry-5449704973

