### PR TITLE
[FIX] base: prevent indeterministic device ids

### DIFF
--- a/odoo/addons/base/models/res_device.py
+++ b/odoo/addons/base/models/res_device.py
@@ -165,7 +165,10 @@ class ResDevice(models.Model):
 
     @api.model
     def _order_by(self):
-        return "ORDER BY D.user_id, D.session_identifier, D.platform, D.browser, D.last_activity DESC"
+        return """
+            ORDER BY D.user_id, D.session_identifier, D.platform, D.browser,
+            D.last_activity DESC, D.id DESC
+        """
 
     @property
     def _query(self):


### PR DESCRIPTION
Issue:
------
Within the same transaction, the ids of the `res.device` model (non-materialised view) may not be consistent. This inconsistency triggers the error:
```
Record does not exist or has been deleted.
```

This behaviour can occur during an onchange on the `res.user` model, for example. We will determine the ids of the `device_ids` linked to the user with the following query (A):
```
SELECT id, user_id FROM res_device WHERE user_id=<user_id> ORDER BY id
```
We will obtain the ids of the devices linked to the user. However, for a given device, it is possible to perform a fetch to retrieve the field values. A query (B) of the following form is used:
```
SELECT <field_to_fetch> FROM res_device WHERE id=<id>
```
Unfortunately, it can happen that the id is no longer present in the `res_device` table. If we look at the query plans (in the appendices), postgresql takes the decision to remove the `user_id` from the `DISTINCT ON` clause when it is used in a `WHERE` clause (which influences the internal logic of Postgresql).

In practice, we sometimes get different results because of the sorting, which can be indeterministic depending on (d.session_identifier, d.platform, d.browser, d.last_activity DESC). In fact, there is a scenario (multiple workers) in which a device will create two logs with the same `last_activity`.

Solution:
---------
Add the `id` to the `ORDER BY` to obtain a deterministic sort.

Appendices:
-----------
Query A:
```
explain select id, user_id from res_device where user_id=2;
                                        QUERY PLAN
-------------------------------------------------------------------------------------------
 Subquery Scan on res_device  (cost=39.39..42.13 rows=125 width=8)
   ->  Unique  (cost=39.39..40.88 rows=125 width=233)
         ->  Sort  (cost=39.39..39.76 rows=149 width=233)
               Sort Key: d.session_identifier, d.platform, d.browser, d.last_activity DESC
               ->  Seq Scan on res_device_log d  (cost=0.00..34.01 rows=149 width=233)
                     Filter: ((NOT revoked) AND (user_id = 2))
```

Query B:
```
explain select id, user_id from res_device;
                                              QUERY PLAN
------------------------------------------------------------------------------------------------------
 Subquery Scan on res_device  (cost=39.29..42.52 rows=128 width=8)
   ->  Unique  (cost=39.29..41.24 rows=128 width=233)
         ->  Sort  (cost=39.29..39.68 rows=156 width=233)
               Sort Key: d.user_id, d.session_identifier, d.platform, d.browser, d.last_activity DESC
               ->  Seq Scan on res_device_log d  (cost=0.00..33.61 rows=156 width=233)
                     Filter: (NOT revoked)
```