### PR TITLE
[IMP] mail: adding edited label for messages

### DIFF
--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -157,6 +157,6 @@ class ThreadController(http.Controller):
             raise NotFound()
         body = Markup(body) if body else body  # may contain HTML such as @mentions
         guest.env[message_sudo.model].browse([message_sudo.res_id])._message_update_content(
-            message_sudo, body, attachment_ids=attachment_ids, partner_ids=partner_ids
+            message_sudo, body=body, attachment_ids=attachment_ids, partner_ids=partner_ids
         )
         return Store(message_sudo, for_current_user=True).get_result()

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -22,6 +22,10 @@
     opacity: 75%;
 }
 
+.o-mail-Message-edited {
+    display: none;
+}
+
 .o-mail-Message-seenContainer {
     font-size: 0.65rem;
     right: 2px;
@@ -82,10 +86,6 @@
 
     & > p {
         margin-bottom: 0 !important;
-
-        &:last-of-type:has(~ .o-mail-Message-edited) {
-            display: inline-block;
-        }
     }
 }
 

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -65,7 +65,7 @@
                             <div class="o-mail-Message-content o-min-width-0" t-att-class="{ 'w-100': state.isEditing, 'opacity-50': message.isPending, 'pt-1': message.is_note }">
                                 <div class="o-mail-Message-textContent position-relative d-flex" t-att-class="{ 'w-100': state.isEditing }">
                                     <t t-if="message.message_type === 'notification' and message.body" t-call="mail.Message.bodyAsNotification" name="bodyAsNotification"/>
-                                    <t t-if="message.message_type !== 'notification' and !message.is_transient and (message.hasTextContent or message.subtype_description or state.isEditing)">
+                                    <t t-if="message.message_type !== 'notification' and !message.is_transient and (message.hasTextContent or message.subtype_description or state.isEditing or message.edited)">
                                         <LinkPreviewList t-if="!state.isEditing and message.linkPreviewSquash" linkPreviews="message.linkPreviews" deletable="false"/>
                                         <t t-else="">
                                             <div class="position-relative overflow-x-auto d-inline-block" t-att-class="{ 'w-100': state.isEditing }">
@@ -90,6 +90,7 @@
                                                         <div class="overflow-x-auto" t-if="message.message_type and message.message_type.includes('email')" t-ref="shadowBody"/>
                                                         <t t-elif="state.showTranslation" t-out="message.translationValue"/>
                                                         <t t-elif="message.body" t-out="props.messageSearch?.highlight(message.body) ?? message.body"/>
+                                                        <em t-if="message.edited" class="smaller fw-bold text-500"> (edited)</em>
                                                         <p class="fst-italic text-muted small" t-if="state.showTranslation">
                                                             <t t-if="message.translationSource" t-esc="translatedFromText"/>
                                                         </p>
@@ -97,7 +98,6 @@
                                                             <i class="text-danger fa fa-warning" role="img" aria-label="Translation Failure"/>
                                                             <t t-if="message.translationErrors" t-esc="translationFailureText"/>
                                                         </p>
-                                                        <!-- <small t-if="message.editDate" class="o-mail-Message-edited fst-italic text-muted" t-att-class="{ 'ms-2': !message.isBodyEmpty }" t-att-title="message.editDatetimeHuge">(edited)</small> --> <!-- DISABLED because new messages sent by email are wrongly flagged as (edited) -->
                                                         <t t-if="showSubtypeDescription" t-out="props.messageSearch?.highlight(message.subtype_description) ?? message.subtype_description"/>
                                                     </t>
                                                 </div>

--- a/addons/mail/static/src/core/common/message_in_reply.xml
+++ b/addons/mail/static/src/core/common/message_in_reply.xml
@@ -14,6 +14,7 @@
                         <span class="o-mail-MessageInReply-message ms-1 text-break">
                             <t t-if="!props.message.parentMessage.isBodyEmpty">
                                 <t t-out="props.message.parentMessage.body"/>
+                                <em t-if="props.message.parentMessage.edited" class="smaller fw-bold text-500"> (edited)</em>
                             </t>
                             <t t-elif="props.message.parentMessage.attachment_ids.length > 0">
                                 <span class="me-2 fst-italic">Click to see the attachments</span>

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -85,7 +85,7 @@ test("Edit message (mobile)", async () => {
     await click(".o-mail-Message-moreMenu [title='Edit']");
     await insertText(".o-mail-Message .o-mail-Composer-input", "edited message", { replace: true });
     await click(".o-mail-Message .fa-paper-plane-o");
-    await contains(".o-mail-Message-content", { text: "edited message" });
+    await contains(".o-mail-Message-content", { text: "edited message (edited)" });
 });
 
 test("Editing message keeps the mentioned channels", async () => {
@@ -109,7 +109,7 @@ test("Editing message keeps the mentioned channels", async () => {
     await contains(".o-mail-Message .o-mail-Composer-input", { value: "#other" });
     await insertText(".o-mail-Message .o-mail-Composer-input", "#other bye", { replace: true });
     await click(".o-mail-Message a", { text: "save" });
-    await contains(".o-mail-Message-content", { text: "#other bye" });
+    await contains(".o-mail-Message-content", { text: "#other bye (edited)" });
     await click(".o_channel_redirect", { text: "#other" });
     await contains(".o-mail-Discuss-threadName", { value: "other" });
 });
@@ -130,7 +130,7 @@ test("Can edit message comment in chatter", async () => {
     await click(".o-mail-Message-moreMenu [title='Edit']");
     await insertText(".o-mail-Message .o-mail-Composer-input", "edited message", { replace: true });
     await click(".o-mail-Message a", { text: "save" });
-    await contains(".o-mail-Message-content", { text: "edited message" });
+    await contains(".o-mail-Message-content", { text: "edited message (edited)" });
 });
 
 test("Can edit message comment in chatter (mobile)", async () => {
@@ -151,7 +151,7 @@ test("Can edit message comment in chatter (mobile)", async () => {
     await contains("button", { text: "Discard editing" });
     await insertText(".o-mail-Message .o-mail-Composer-input", "edited message", { replace: true });
     await click("button[aria-label='Save editing']");
-    await contains(".o-mail-Message-content", { text: "edited message" });
+    await contains(".o-mail-Message-content", { text: "edited message (edited)" });
 });
 
 test("Cursor is at end of composer input on edit", async () => {
@@ -301,7 +301,7 @@ test("Edit and click save", async () => {
     await click(".o-mail-Message-moreMenu [title='Edit']");
     await insertText(".o-mail-Message .o-mail-Composer-input", "Goodbye World", { replace: true });
     await click(".o-mail-Message a", { text: "save" });
-    await contains(".o-mail-Message-body", { text: "Goodbye World" });
+    await contains(".o-mail-Message-body", { text: "Goodbye World (edited)" });
 });
 
 test("Do not call server on save if no changes", async () => {
@@ -398,7 +398,7 @@ test("mentions are kept when editing message", async () => {
     });
     await click(".o-mail-Message a", { text: "save" });
     await contains(".o-mail-Message", {
-        text: "Hi @Mitchell Admin",
+        text: "Hi @Mitchell Admin (edited)",
         contains: ["a.o_mail_redirect", { text: "@Mitchell Admin" }],
     });
 });
@@ -434,7 +434,7 @@ test("can add new mentions when editing message", async () => {
     await contains(".o-mail-Composer-input", { value: "Hello @TestPartner " });
     await click(".o-mail-Message a", { text: "save" });
     await contains(".o-mail-Message", {
-        text: "Hello @TestPartner",
+        text: "Hello @TestPartner (edited)",
         contains: ["a.o_mail_redirect", { text: "@TestPartner" }],
     });
 });
@@ -505,7 +505,7 @@ test("Updating the parent message of a reply also updates the visual of the repl
         replace: true,
     });
     triggerHotkey("Enter");
-    await contains(".o-mail-MessageInReply-message", { text: "Goodbye World" });
+    await contains(".o-mail-MessageInReply-message", { text: "Goodbye World (edited)" });
 });
 
 test("Deleting parent message of a reply should adapt reply visual", async () => {
@@ -1577,6 +1577,11 @@ test("message considered empty", async () => {
         },
         {
             body: "<p>   </p>  ",
+            model: "discuss.channel",
+            res_id: channelId,
+        },
+        {
+            body: '<span class="o-mail-Message-edited"></span>',
             model: "discuss.channel",
             res_id: channelId,
         },

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -692,7 +692,11 @@ async function mail_message_update_content(request) {
 
     const { attachment_ids, body, message_id } = await parseRequestParams(request);
     const [message] = MailMessage.browse(message_id);
-    const msg_values = { body };
+    const msg_values = {};
+    if (body !== null) {
+        const edit_label = "<span class='o-mail-Message-edited'/>";
+        msg_values.body = body === "" && attachment_ids.length === 0 ? "" : body + edit_label;
+    }
     if (attachment_ids.length === 0) {
         IrAttachment.unlink(message.attachment_ids);
     } else {


### PR DESCRIPTION
This commit adds a new label for messages that have been edited. The label is displayed in the end of the message.

Related tests have been modified.

Current behavior before PR:
![image](https://github.com/user-attachments/assets/6d3f8df0-5bc0-4d66-8f43-fa5d4826bed9)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
