### PR TITLE
[FIX] sale_timesheet: create partners for employees created in demo data

### DIFF
--- a/addons/sale_timesheet/data/sale_service_demo.xml
+++ b/addons/sale_timesheet/data/sale_service_demo.xml
@@ -20,6 +20,12 @@
             <field name="contract_type_id" ref="hr.contract_type_permanent"/>
         </record>
 
+        <record id="work_contact_jjo" model="res.partner">
+            <field name="name">Jessica Johnson</field>
+            <field name="email">jessica.johnson45@example.com</field>
+            <field name="image_1920" type="base64" file="sale_timesheet/static/img/employee_jjo-image.jpg"/>
+        </record>
+
         <record id="employee_jjo" model="hr.employee">
             <field name="name">Jessica Johnson</field>
             <field name="parent_id" ref="hr.employee_al"/>
@@ -28,9 +34,15 @@
             <field name="category_ids" eval="[(6, 0, [ref('hr.employee_category_4')])]"/>
             <field name="work_location_id" ref="hr.work_location_1"/>
             <field name="work_phone">(535)-495-4164</field>
-            <field name="work_contact_id" ref="hr.work_contact_al"/>
+            <field name="work_contact_id" ref="sale_timesheet.work_contact_jjo"/>
             <field name="image_1920" type="base64" file="sale_timesheet/static/img/employee_jjo-image.jpg"/>
             <field name="create_date">2020-02-02 00:00:00</field>
+        </record>
+
+        <record id="work_contact_awa" model="res.partner">
+            <field name="name">Amy Watson</field>
+            <field name="email">amy.watson21@example.com</field>
+            <field name="image_1920" type="base64" file="sale_timesheet/static/img/employee_awa-image.jpg"/>
         </record>
 
         <record id="employee_awa" model="hr.employee">
@@ -41,9 +53,15 @@
             <field name="category_ids" eval="[(6, 0, [ref('hr.employee_category_4')])]"/>
             <field name="work_location_id" ref="hr.work_location_1"/>
             <field name="work_phone">(535)-495-4222</field>
-            <field name="work_contact_id" ref="hr.work_contact_mit"/>
+            <field name="work_contact_id" ref="sale_timesheet.work_contact_awa"/>
             <field name="image_1920" type="base64" file="sale_timesheet/static/img/employee_awa-image.jpg"/>
             <field name="create_date">2020-01-01 00:00:00</field>
+        </record>
+
+        <record id="work_contact_jsm" model="res.partner">
+            <field name="name">Justin Smith</field>
+            <field name="email">justin.smith57@example.com</field>
+            <field name="image_1920" type="base64" file="sale_timesheet/static/img/employee_jsm-image.jpg"/>
         </record>
 
         <record id="employee_jsm" model="hr.employee">
@@ -54,7 +72,7 @@
             <field name="category_ids" eval="[(6, 0, [ref('hr.employee_category_4')])]"/>
             <field name="work_location_id" ref="hr.work_location_1"/>
             <field name="work_phone">(535)-495-4444</field>
-            <field name="work_contact_id" ref="hr.work_contact_niv"/>
+            <field name="work_contact_id" ref="sale_timesheet.work_contact_jsm"/>
             <field name="image_1920" type="base64" file="sale_timesheet/static/img/employee_jsm-image.jpg"/>
             <field name="create_date">2020-02-02 00:00:00</field>
         </record>


### PR DESCRIPTION
The employees created in the demo data (see https://github.com/odoo/odoo/pull/108795) of sale_timesheet were linked to the wrong partners, we then create new partners dedicated to those new employees.

version-17.2
task-3874828

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
