### PR TITLE
[FIX] l10n_ar_website_sale: fix traceback when edit information on portal

### DIFF
--- a/addons/l10n_ar_website_sale/__manifest__.py
+++ b/addons/l10n_ar_website_sale/__manifest__.py
@@ -17,6 +17,11 @@
     'demo': [
         'demo/website_demo.xml',
     ],
+    'assets': {
+        'web.assets_tests': [
+            'l10n_ar_website_sale/static/tests/tours/**/*',
+        ],
+    },
     'installable': True,
     'auto_install': True,
     'license': 'LGPL-3',

--- a/addons/l10n_ar_website_sale/static/tests/tours/portal_edit_information_tour.js
+++ b/addons/l10n_ar_website_sale/static/tests/tours/portal_edit_information_tour.js
@@ -1,0 +1,22 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add('portal_edit_information', {
+    test: true,
+    url: '/my',
+    steps: () => [
+        {
+            content: "Check Edit Information button available",
+            trigger: 'a[href*="/my/account"]:contains("Edit Information"):first',
+            run: "click",
+        },
+        {
+            content: "Submit the form",
+            trigger: 'button[type=submit]',
+            run: "click",
+        },
+        {
+            content: "Check that we are back on the portal",
+            trigger: 'a[href*="/my/account"]:contains("Edit Information"):first',
+        }
+    ]
+});

--- a/addons/l10n_ar_website_sale/tests/__init__.py
+++ b/addons/l10n_ar_website_sale/tests/__init__.py
@@ -1,4 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from . import controllers
-from . import models
-from . import tests
+
+from . import test_tours

--- a/addons/l10n_ar_website_sale/tests/test_tours.py
+++ b/addons/l10n_ar_website_sale/tests/test_tours.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.base.tests.common import HttpCaseWithUserPortal
+from odoo.tests import tagged
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestPortalEditInformation(HttpCaseWithUserPortal):
+
+    def test_portal_edit_information(self):
+        self.env.user.company_id.country_id = self.env.ref('base.ar')
+        self.start_tour("/", 'portal_edit_information', login="portal")

--- a/addons/l10n_br_website_sale/views/portal.xml
+++ b/addons/l10n_br_website_sale/views/portal.xml
@@ -12,15 +12,15 @@
                         <select name="l10n_latam_identification_type_id" t-attf-class="form-select #{error.get('l10n_latam_identification_type_id') and 'is-invalid' or ''}">
                             <option value="">Identification Type...</option>
                             <t t-foreach="identification_types or []" t-as="id_type">
-                                <option t-att-value="id_type.id" t-att-selected="id_type.id == partner.l10n_latam_identification_type_id.id">
+                                <option t-att-value="id_type.id" t-att-selected="id_type.id == partner_sudo.l10n_latam_identification_type_id.id">
                                     <t t-esc="id_type.name"/>
                                 </option>
                             </t>
                         </select>
                     </t>
                     <t t-else="">
-                        <p class="form-control" t-esc="partner.l10n_latam_identification_type_id.name" readonly="1" title="Changing Identification type is not allowed once document(s) have been issued for your account. Please contact us directly for this operation."/>
-                        <input name="l10n_latam_identification_type_id" class="form-control" t-att-value="partner.l10n_latam_identification_type_id.id" type='hidden'/>
+                        <p class="form-control" t-esc="partner_sudo.l10n_latam_identification_type_id.name" readonly="1" title="Changing Identification type is not allowed once document(s) have been issued for your account. Please contact us directly for this operation."/>
+                        <input name="l10n_latam_identification_type_id" class="form-control" t-att-value="partner_sudo.l10n_latam_identification_type_id.id" type='hidden'/>
                     </t>
                 </div>
             </t>

--- a/addons/l10n_ec_website_sale/views/portal_templates.xml
+++ b/addons/l10n_ec_website_sale/views/portal_templates.xml
@@ -6,19 +6,19 @@
         <!-- show identification type -->
         <div t-attf-class="mb-3 #{error.get('l10n_latam_identification_type_id') and 'o_has_error' or ''} col-xl-6">
             <label class="col-form-label" for="l10n_latam_identification_type_id">Identification Type</label>
-            <t t-if="partner.can_edit_vat()">
+            <t t-if="partner_sudo.can_edit_vat()">
                 <select name="l10n_latam_identification_type_id" t-attf-class="form-select #{error.get('l10n_latam_identification_type_id') and 'is-invalid' or ''}">
                     <option value="">Identification Type...</option>
                     <t t-foreach="identification_types or []" t-as="id_type">
-                        <option t-att-value="id_type.id" t-att-selected="id_type.id == int(identification) if identification else id_type.id == partner.l10n_latam_identification_type_id.id">
+                        <option t-att-value="id_type.id" t-att-selected="id_type.id == int(identification) if identification else id_type.id == partner_sudo.l10n_latam_identification_type_id.id">
                             <t t-esc="id_type.name"/>
                         </option>
                     </t>
                 </select>
             </t>
             <t t-else="">
-                <p class="form-control" t-esc="partner.l10n_latam_identification_type_id.name" readonly="1" title="Changing Identification type is not allowed once document(s) have been issued for your account. Please contact us directly for this operation."/>
-                <input name="l10n_latam_identification_type_id" class="form-control" t-att-value="partner.l10n_latam_identification_type_id.id" type='hidden'/>
+                <p class="form-control" t-esc="partner_sudo.l10n_latam_identification_type_id.name" readonly="1" title="Changing Identification type is not allowed once document(s) have been issued for your account. Please contact us directly for this operation."/>
+                <input name="l10n_latam_identification_type_id" class="form-control" t-att-value="partner_sudo.l10n_latam_identification_type_id.id" type='hidden'/>
             </t>
         </div>
 

--- a/addons/l10n_pe_pos/views/templates.xml
+++ b/addons/l10n_pe_pos/views/templates.xml
@@ -39,8 +39,8 @@
         <!-- Show PE fields preview info, and show warning is a required field need to be completed -->
         <xpath expr="//t[@id='partner_vat']" position="before">
             <t t-if="pos_order.company_id.country_code == 'PE'">
-                <t t-if="partner.l10n_latam_identification_type_id">
-                    <t t-out="partner.l10n_latam_identification_type_id.name" /> -
+                <t t-if="partner_sudo.l10n_latam_identification_type_id">
+                    <t t-out="partner_sudo.l10n_latam_identification_type_id.name" /> -
                 </t>
                 <t t-else="">
                     <span class="text-danger">* Please configure your Identification Type</span><br />

--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -220,7 +220,7 @@ class PosController(PortalAccount):
                 form_values['partner_address'] = partner._display_address()
 
         return request.render("point_of_sale.ticket_validation_screen", {
-            'partner': partner,
+            'partner_sudo': partner,
             'address_url': f'/my/account?redirect=/pos/ticket/validate?access_token={access_token}',
             'user_is_connected': user_is_connected,
             'format_amount': format_amount,

--- a/addons/point_of_sale/views/pos_ticket_view.xml
+++ b/addons/point_of_sale/views/pos_ticket_view.xml
@@ -54,12 +54,12 @@
                             <t t-else="">
                                 <div class="row">
                                     <div class="col-12">
-                                        <t t-out="partner.name"/>
-                                        <t t-if="partner.company_name">
-                                            , <t t-out="partner.company_name"/>
+                                        <t t-out="partner_sudo.name"/>
+                                        <t t-if="partner_sudo.company_name">
+                                            , <t t-out="partner_sudo.company_name"/>
                                         </t><br />
-                                        <t id="partner_vat" t-if="partner.vat">
-                                            <t t-out="partner.vat" /><br />
+                                        <t id="partner_vat" t-if="partner_sudo.vat">
+                                            <t t-out="partner_sudo.vat" /><br />
                                         </t>
                                         <t t-out="partner_address"/> <a role="button" t-att-href="address_url" class="btn btn-sm btn-link"><i class="fa fa-pencil"/> Edit</a>
                                     </div>

--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -216,7 +216,7 @@ class CustomerPortal(Controller):
         states = request.env['res.country.state'].sudo().search([])
 
         values.update({
-            'partner': partner,
+            'partner_sudo': partner,
             'countries': countries,
             'states': states,
             'has_check_vat': hasattr(request.env['res.partner'], 'check_vat'),

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -455,11 +455,11 @@
         </div>
         <div t-attf-class="mb-3 #{error.get('name') and 'o_has_error' or ''} col-xl-6">
             <label class="col-form-label" for="name">Name</label>
-            <input type="text" name="name" t-attf-class="form-control #{error.get('name') and 'is-invalid' or ''}" t-att-value="name or partner.name" />
+            <input type="text" name="name" t-attf-class="form-control #{error.get('name') and 'is-invalid' or ''}" t-att-value="name or partner_sudo.name" />
         </div>
         <div t-attf-class="mb-3 #{error.get('email') and 'o_has_error' or ''} col-xl-6">
             <label class="col-form-label" for="email">Email</label>
-            <input type="email" name="email" t-attf-class="form-control #{error.get('email') and 'is-invalid' or ''}" t-att-value="email or partner.email" />
+            <input type="email" name="email" t-attf-class="form-control #{error.get('email') and 'is-invalid' or ''}" t-att-value="email or partner_sudo.email" />
         </div>
 
         <div class="clearfix" />
@@ -468,7 +468,7 @@
             <!-- The <input> use "disabled" attribute to avoid sending an unauthorized value on form submit.
                  The user might not have rights to change company_name but should still be able to see it.
             -->
-            <input type="text" name="company_name" t-attf-class="form-control #{error.get('company_name') and 'is-invalid' or ''}" t-att-value="company_name or partner.commercial_company_name" t-att-disabled="None if partner_can_edit_vat else '1'" />
+            <input type="text" name="company_name" t-attf-class="form-control #{error.get('company_name') and 'is-invalid' or ''}" t-att-value="company_name or partner_sudo.commercial_company_name" t-att-disabled="None if partner_can_edit_vat else '1'" />
             <small t-if="not partner_can_edit_vat" class="form-text text-muted d-block d-xl-none">
                 Changing company name is not allowed once document(s) have been issued for your account. Please contact us directly for this operation.
             </small>
@@ -478,33 +478,33 @@
             <!-- The <input> use "disabled" attribute to avoid sending an unauthorized value on form submit.
                  The user might not have rights to change company_name but should still be able to see it.
             -->
-            <input type="text" name="vat" t-attf-class="form-control #{error.get('vat') and 'is-invalid' or ''}" t-att-value="vat or partner.vat" t-att-disabled="None if partner_can_edit_vat else '1'" />
+            <input type="text" name="vat" t-attf-class="form-control #{error.get('vat') and 'is-invalid' or ''}" t-att-value="vat or partner_sudo.vat" t-att-disabled="None if partner_can_edit_vat else '1'" />
             <small t-if="not partner_can_edit_vat" class="form-text text-muted d-block d-xl-none">Changing VAT number is not allowed once document(s) have been issued for your account. Please contact us directly for this operation.</small>
         </div>
         <div t-attf-class="mb-3 #{error.get('phone') and 'o_has_error' or ''} col-xl-6">
             <label class="col-form-label" for="phone">Phone</label>
-            <input type="tel" name="phone" t-attf-class="form-control #{error.get('phone') and 'is-invalid' or ''}" t-att-value="phone or partner.phone" />
+            <input type="tel" name="phone" t-attf-class="form-control #{error.get('phone') and 'is-invalid' or ''}" t-att-value="phone or partner_sudo.phone" />
         </div>
 
         <div class="clearfix" />
         <div t-attf-class="mb-3 #{error.get('street') and 'o_has_error' or ''} col-xl-6">
             <label class="col-form-label" for="street">Street</label>
-            <input type="text" name="street" t-attf-class="form-control #{error.get('street') and 'is-invalid' or ''}" t-att-value="street or partner.street"/>
+            <input type="text" name="street" t-attf-class="form-control #{error.get('street') and 'is-invalid' or ''}" t-att-value="street or partner_sudo.street"/>
         </div>
         <div t-attf-class="mb-3 #{error.get('city') and 'o_has_error' or ''} col-xl-6">
             <label class="col-form-label" for="city">City</label>
-            <input type="text" name="city" t-attf-class="form-control #{error.get('city') and 'is-invalid' or ''}" t-att-value="city or partner.city" />
+            <input type="text" name="city" t-attf-class="form-control #{error.get('city') and 'is-invalid' or ''}" t-att-value="city or partner_sudo.city" />
         </div>
         <div t-attf-class="mb-3 #{error.get('street2') and 'o_has_error' or ''} col-xl-6">
             <label class="col-form-label" for="street2">Street 2</label>
-            <input type="text" name="street2" t-attf-class="form-control #{error.get('street2') and 'is-invalid' or ''}" t-att-value="street2 or partner.street2"/>
+            <input type="text" name="street2" t-attf-class="form-control #{error.get('street2') and 'is-invalid' or ''}" t-att-value="street2 or partner_sudo.street2"/>
         </div>
         <div t-attf-class="mb-3 #{error.get('state_id') and 'o_has_error' or ''} col-xl-6">
             <label class="col-form-label label-optional" for="state_id">State / Province</label>
             <select name="state_id" t-attf-class="form-select #{error.get('state_id') and 'is-invalid' or ''}">
                 <option value="">select...</option>
                 <t t-foreach="states or []" t-as="state">
-                    <option t-att-value="state.id" class="d-none" t-att-data-country_id="state.country_id.id" t-att-selected="state.id == int(state_id) if state_id else state.id == partner.state_id.id">
+                    <option t-att-value="state.id" class="d-none" t-att-data-country_id="state.country_id.id" t-att-selected="state.id == int(state_id) if state_id else state.id == partner_sudo.state_id.id">
                         <t t-esc="state.name" />
                     </option>
                 </t>
@@ -512,14 +512,14 @@
         </div>
         <div t-attf-class="mb-3 #{error.get('zip') and 'o_has_error' or ''} col-xl-6">
             <label class="col-form-label label-optional" for="zipcode">Zip / Postal Code</label>
-            <input type="text" name="zipcode" t-attf-class="form-control #{error.get('zip') and 'is-invalid' or ''}" t-att-value="zipcode or partner.zip" />
+            <input type="text" name="zipcode" t-attf-class="form-control #{error.get('zip') and 'is-invalid' or ''}" t-att-value="zipcode or partner_sudo.zip" />
         </div>
         <div t-attf-class="mb-3 #{error.get('country_id') and 'o_has_error' or ''} col-xl-6">
             <label class="col-form-label" for="country_id">Country</label>
             <select name="country_id" t-attf-class="form-select #{error.get('country_id') and 'is-invalid' or ''}" t-att-disabled="None if partner_can_edit_vat else '1'">
                 <option value="">Country...</option>
                 <t t-foreach="countries or []" t-as="country">
-                    <option t-att-value="country.id" t-att-selected="country.id == int(country_id) if country_id else country.id == partner.country_id.id">
+                    <option t-att-value="country.id" t-att-selected="country.id == int(country_id) if country_id else country.id == partner_sudo.country_id.id">
                         <t t-esc="country.name" />
                     </option>
                 </t>


### PR DESCRIPTION
Version:
-----------
- saas-17.4

Steps to reproduce:
---------------------------
- Install module l10n_ar_website_sale
- go to portal
- click on edit information

Issue:
--------
- it is giving traceback when clicking on edit information

Cause:
----------
- value of 'partner_sudo' is not available when calling 'partner_info' template from 'portal_my_details_fields' template

Solution:
------------
- change partner to partner_sudo while calling 'portal_my_details_fields'
  template to ensure consistency in value of partner in 'partner_info' template.

task-4169074
