### PR TITLE
[FIX] crm, purchase, sale: avoid access error computing order/lead count

### DIFF
--- a/addons/crm/models/res_partner.py
+++ b/addons/crm/models/res_partner.py
@@ -1,9 +1,7 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models
 from odoo.osv import expression
-
 
 
 class Partner(models.Model):
@@ -36,6 +34,10 @@ class Partner(models.Model):
         return rec
 
     def _compute_opportunity_count(self):
+        self.opportunity_count = 0
+        if not self.env.user._has_group('sales_team.group_sale_salesman'):
+            return
+
         # retrieve all children partners and prefetch 'parent_id' on them
         all_partners = self.with_context(active_test=False).search_fetch(
             [('id', 'child_of', self.ids)], ['parent_id'],
@@ -47,7 +49,6 @@ class Partner(models.Model):
         )
         self_ids = set(self._ids)
 
-        self.opportunity_count = 0
         for partner, count in opportunity_data:
             while partner:
                 if partner.id in self_ids:

--- a/addons/purchase/models/res_partner.py
+++ b/addons/purchase/models/res_partner.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models
@@ -10,6 +9,10 @@ class res_partner(models.Model):
     _inherit = 'res.partner'
 
     def _compute_purchase_order_count(self):
+        self.purchase_order_count = 0
+        if not self.env.user._has_group('purchase.group_purchase_user'):
+            return
+
         # retrieve all children partners and prefetch 'parent_id' on them
         all_partners = self.with_context(active_test=False).search_fetch(
             [('id', 'child_of', self.ids)],
@@ -21,7 +24,6 @@ class res_partner(models.Model):
         )
         self_ids = set(self._ids)
 
-        self.purchase_order_count = 0
         for partner, count in purchase_order_groups:
             while partner:
                 if partner.id in self_ids:

--- a/addons/purchase/views/res_partner_views.xml
+++ b/addons/purchase/views/res_partner_views.xml
@@ -52,7 +52,12 @@
             <field name="inherit_id" ref="base.res_partner_kanban_view"/>
             <field name="arch" type="xml">
                 <xpath expr="//footer/div" position="inside">
-                    <a t-if="record.purchase_order_count.value>0" type="action" name="%(purchase.act_res_partner_2_purchase_order)d" class="btn btn-sm btn-link smaller" role="button">
+                    <a t-if="record.purchase_order_count?.value"
+                        class="btn btn-sm btn-link smaller"
+                        groups="purchase.group_purchase_user"
+                        name="%(purchase.act_res_partner_2_purchase_order)d"
+                        role="button"
+                        type="action">
                         <i class="fa fa-credit-card me-1" aria-label="Purchases" role="img" title="Purchases"/>
                         <field name="purchase_order_count"/>
                     </a>

--- a/addons/sale/models/res_partner.py
+++ b/addons/sale/models/res_partner.py
@@ -1,9 +1,9 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models
 from odoo.addons.base.models.res_partner import WARNING_MESSAGE, WARNING_HELP
 from odoo.osv import expression
+
 
 class ResPartner(models.Model):
     _inherit = 'res.partner'
@@ -18,6 +18,10 @@ class ResPartner(models.Model):
         return []
 
     def _compute_sale_order_count(self):
+        self.sale_order_count = 0
+        if not self.env.user._has_group('sales_team.group_sale_salesman'):
+            return
+
         # retrieve all children partners and prefetch 'parent_id' on them
         all_partners = self.with_context(active_test=False).search_fetch(
             [('id', 'child_of', self.ids)],
@@ -29,7 +33,6 @@ class ResPartner(models.Model):
         )
         self_ids = set(self._ids)
 
-        self.sale_order_count = 0
         for partner, count in sale_order_groups:
             while partner:
                 if partner.id in self_ids:

--- a/addons/sale/views/res_partner_views.xml
+++ b/addons/sale/views/res_partner_views.xml
@@ -23,7 +23,12 @@
         <field name="priority" eval="20"/>
         <field name="arch" type="xml">
             <xpath expr="//footer/div" position="inside">
-                <a t-if="record.sale_order_count.value>0" type="object" name="action_view_sale_order" class="btn btn-sm btn-link smaller" role="button">
+                <a t-if="record.sale_order_count?.value"
+                    class="btn btn-sm btn-link smaller"
+                    groups="sales_team.group_sale_salesman"
+                    name="action_view_sale_order"
+                    role="button"
+                    type="object">
                     <i class="fa fa-usd me-1" role="img" aria-label="Sale orders" title="Sales orders"/>
                     <field name="sale_order_count"/>
                 </a>

--- a/addons/website_crm_partner_assign/models/res_partner.py
+++ b/addons/website_crm_partner_assign/models/res_partner.py
@@ -59,6 +59,9 @@ class ResPartner(models.Model):
 
     def _compute_opportunity_count(self):
         super()._compute_opportunity_count()
+        if not self.env.user._has_group('sales_team.group_sale_salesman'):
+            return
+
         opportunity_data = self.env['crm.lead'].with_context(active_test=False)._read_group(
             [('partner_assigned_id', 'in', self.ids)],
             ['partner_assigned_id'], ['__count']


### PR DESCRIPTION
Versions
--------
- saas-17.4+

Steps
-----
1. Have Sales and/or Purchase installed;
2. log in as a user with restricted access rights;
3. open Contacts app.

Issue
-----
Access error.

Cause
-----
Commit 855560e simplified `res_partner` kanban views. In doing so, it removed the `groups` attribute from a couple of buttons. As a consequence, trying to access the `res_partner` kanban view will try to display computed fields the user may not have access to.

Solution
--------
Re-add the `groups` attributes to buttons for `sale_order_count` and `purchase_order_count`.

opw-4145862