### PR TITLE
[PERF] website: avoid extraneous query for first visitor

### DIFF
--- a/addons/website/models/res_users.py
+++ b/addons/website/models/res_users.py
@@ -89,10 +89,9 @@ class ResUsers(models.Model):
                 # visitor records to it.
                 if visitor_pre_authenticate_sudo != visitor_current_user_sudo:
                     visitor_pre_authenticate_sudo._merge_visitor(visitor_current_user_sudo)
-                visitor_current_user_sudo._update_visitor_last_visit()
+                    visitor_current_user_sudo._update_visitor_last_visit()
             else:
                 visitor_pre_authenticate_sudo.access_token = user_partner.id
-                visitor_pre_authenticate_sudo._update_visitor_last_visit()
         return auth_info
 
     @api.constrains('groups_id')


### PR DESCRIPTION
This PR eliminates the redundant query for first-time visitors by ensuring that last_connection_datetime is already set during the visitor record creation. As a result, calling _update_visitor_last_visit immediately after creation is no longer necessary.

task-2761273