### PR TITLE
[FIX] sale_purchase_stock: Link between SO and PO in mtso

### DIFF
--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -265,6 +265,8 @@ class StockLot(models.Model):
 class ProcurementGroup(models.Model):
     _inherit = 'procurement.group'
 
+    purchase_order_id = fields.One2many('purchase.order', 'group_id', string='Purchases')
+
     @api.model
     def run(self, procurements, raise_user_error=True):
         wh_by_comp = dict()

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -109,6 +109,7 @@ class StockRule(models.Model):
                     # We use SUPERUSER_ID since we don't want the current user to be follower of the PO.
                     # Indeed, the current user may be a user without access to Purchase, or even be a portal user.
                     po = self.env['purchase.order'].with_company(company_id).with_user(SUPERUSER_ID).create(vals)
+                    po._post_run_buy(positive_values)
             else:
                 # If a purchase order is found, adapt its `origin` field.
                 if po.origin:
@@ -280,7 +281,6 @@ class StockRule(models.Model):
         partner = values['supplier'].partner_id
 
         fpos = self.env['account.fiscal.position'].with_company(company_id)._get_fiscal_position(partner)
-
         gpo = self.group_propagation_option
         group = (gpo == 'fixed' and self.group_id.id) or \
                 (gpo == 'propagate' and values.get('group_id') and values['group_id'].id) or False

--- a/addons/sale_purchase_stock/models/sale_order.py
+++ b/addons/sale_purchase_stock/models/sale_order.py
@@ -9,7 +9,9 @@ class SaleOrder(models.Model):
 
     @api.depends('procurement_group_id.stock_move_ids.created_purchase_line_ids.order_id', 'procurement_group_id.stock_move_ids.move_orig_ids.purchase_line_id.order_id')
     def _compute_purchase_order_count(self):
-        super(SaleOrder, self)._compute_purchase_order_count()
+        super()._compute_purchase_order_count()
 
     def _get_purchase_orders(self):
-        return super(SaleOrder, self)._get_purchase_orders() | self.procurement_group_id.stock_move_ids.created_purchase_line_ids.order_id | self.procurement_group_id.stock_move_ids.move_orig_ids.purchase_line_id.order_id
+        po_linked_moves = self.procurement_group_id.stock_move_ids.created_purchase_line_ids.order_id | self.procurement_group_id.stock_move_ids.move_orig_ids.purchase_line_id.order_id
+        po_proc_group = self.procurement_group_id.purchase_order_id
+        return super()._get_purchase_orders() | po_linked_moves | po_proc_group


### PR DESCRIPTION
Make to order else make to stock, now only generate make to stock moves but they can trigger procurements. However it means they are not link together anymore. However the link between SO and PO use the links between the move (same for mrp). In order to do it for mtso we just copy the `sale.order` and `purchase.order` reference between the `procurement.group´

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
