### PR TITLE
[FIX] web_editor: deleteforward before contenteditable

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/deleteForward.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/deleteForward.js
@@ -163,7 +163,18 @@ HTMLElement.prototype.oDeleteForward = function (offset) {
         return;
     }
 
-    const nextSibling = this.nextSibling;
+    let nextSibling = this.nextSibling;
+    while (nextSibling && isWhitespace(nextSibling)) {
+        const index = childNodeIndex(nextSibling);
+        const left = getState(nextSibling, index, DIRECTIONS.LEFT).cType;
+        const right = getState(nextSibling, index, DIRECTIONS.RIGHT).cType;
+        if (left === CTYPES.BLOCK_OUTSIDE && right === CTYPES.BLOCK_OUTSIDE) {
+            // If the next sibling is a whitespace, remove it.
+            nextSibling.remove();
+            nextSibling = this.nextSibling;
+        }
+    }
+
     if (
         (
             offset === this.childNodes.length ||

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
@@ -490,6 +490,15 @@ X[]
                         contentAfter: `<p>[]&nbsp;def</p>`,
                     });
                 });
+                it('should remove the contentEditable false element', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: `<p>test[]</p>\n<div contentEditable="false"><p>abc</p></div><p>abc</p>`,
+                        stepFunction: async editor => {
+                            await deleteForward(editor);
+                        },
+                        contentAfter: `<p>test[]</p><p>abc</p>`,
+                    });
+                });
             });
             describe('white spaces', () => {
                 describe('no intefering spaces', () => {


### PR DESCRIPTION
**Current behavior before PR:**

When an elements next sibling is a whitespace node, followed by a `contentEditable=false` element, performing the deleteforward action did not remove the `contentEditable=false` element.

**Desired behavior after PR is merged:**

When an elements next sibling is a whitespace node, followed by a `contentEditable=false` element, performing the deleteforward action will now remove both the whitespace and the entire `contentEditable=false` element.

task:4058770
