### PR TITLE
[FIX] mrp: prevent error when saving manufacturing order

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -866,8 +866,10 @@ class MrpProduction(models.Model):
                 location_source = self.env['stock.location'].browse(vals.get('location_src_id'))
                 warehouse_id = location_source.warehouse_id.id
             for move_vals in vals[move_str]:
-                command, _id, field_values = move_vals
-                if command == Command.CREATE and not field_values.get('warehouse_id', False):
+                if move_vals[0] != Command.CREATE:
+                    continue
+                _command, _id, field_values = move_vals
+                if not field_values.get('warehouse_id'):
                     field_values['warehouse_id'] = warehouse_id
 
         if vals.get('picking_type_id'):


### PR DESCRIPTION
This error occurs when attempting to save a manufacturing order that is in a confirmed state.

Steps to reproduce:
- Install the ``mrp_workorder_hr_account`` module
- Create a new MO, add a line, and ``Confirm``
- Now remove a line and click on the ``Save`` button

Traceback:
``ValueError: not enough values to unpack (expected 3, got 2)``

The error at [1] occurred because we were not receiving the expected value of ``field_values`` in ``move_vals``. We expected 3 values but only received 2.

[1]- https://github.com/odoo/odoo/blob/c48d62098b2809cd046742435afd4f7ba3a4cbe1/addons/mrp/models/mrp_production.py#L843-L844

sentry-5819387893

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
