### PR TITLE
[IMP] web: allow always close column's quick create

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_renderer.xml
+++ b/addons/web/static/src/views/kanban/kanban_renderer.xml
@@ -87,7 +87,7 @@
                 <t t-if="canCreateGroup()">
                     <KanbanColumnQuickCreate
                         folded="state.columnQuickCreateIsFolded"
-                        onFoldChange="folded => state.columnQuickCreateIsFolded = props.list.groups.length > 0 and folded"
+                        onFoldChange="folded => state.columnQuickCreateIsFolded = folded"
                         onValidate="props.list.createGroup.bind(props.list)"
                         exampleData="exampleData"
                         groupByField="props.list.groupByField"

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -5957,7 +5957,7 @@ test("quick create column should be opened if there is no column", async () => {
     });
 });
 
-test("quick create column should not be closed on window click if there is no column", async () => {
+test("quick create column should close on window click if there is no column", async () => {
     await mountView({
         type: "kanban",
         resModel: "partner",
@@ -5980,8 +5980,8 @@ test("quick create column should not be closed on window click if there is no co
     });
     // click outside should not discard quick create column
     await contains(".o_kanban_example_background_container").click();
-    expect(".o_column_quick_create input").toHaveCount(1, {
-        message: "the quick create should still be opened",
+    expect(".o_column_quick_create input").toHaveCount(0, {
+        message: "the quick create should be closed",
     });
 });
 


### PR DESCRIPTION
Before this commit to close a column's quick create in a kanban the user
could click outside the quick create, or push the ESC key. This will
work only if it already exists a group in the kanban.

This commit allows you to close a column's quick create in Kanban
without any conditions.

task-id-4060130
