### PR TITLE
[IMP] {google,microsoft}_calendar: make integrations autoinstallable

### DIFF
--- a/addons/google_calendar/__manifest__.py
+++ b/addons/google_calendar/__manifest__.py
@@ -15,6 +15,7 @@
         'views/google_calendar_views.xml',
         ],
     'installable': True,
+    'auto_install': True,
     'assets': {
         'web.assets_backend': [
             'google_calendar/static/src/scss/google_calendar.scss',

--- a/addons/microsoft_calendar/__manifest__.py
+++ b/addons/microsoft_calendar/__manifest__.py
@@ -15,6 +15,7 @@
         'views/microsoft_calendar_views.xml',
         ],
     'installable': True,
+    'auto_install': True,
     'post_init_hook': 'init_initiating_microsoft_uuid',
     'assets': {
         'web.assets_backend': [


### PR DESCRIPTION
This PR makes the Google and Microsoft Calendar integration modules autoinstallable, simplifying the synchronization process, making it more accessible, user-friendly and also encouraging greater adoption among users.

task-4173896