### PR TITLE
[BUG] one2many widget: Demonstrate ordering not preserved

### DIFF
--- a/addons/account/__manifest__.py
+++ b/addons/account/__manifest__.py
@@ -79,7 +79,8 @@ You could use this simplified accounting in case you work with an (external) acc
         'views/tests_shared_js_python.xml',
         'views/base_document_layout_views.xml',
         'views/account_lock_exception_views.xml',
-        'views/report_templates.xml'
+        'views/report_templates.xml',
+        'wizard/account_one2many_test_wizard_views.xml',
     ],
     'demo': [
         'demo/account_demo.xml',

--- a/addons/account/security/ir.model.access.csv
+++ b/addons/account/security/ir.model.access.csv
@@ -138,3 +138,6 @@ access_account_report_column_ac_user,account.report.column.ac.user,model_account
 
 access_account_report_external_value_readonly,account.report.external.value.readonly,model_account_report_external_value,account.group_account_readonly,1,0,0,0
 access_account_report_external_value_ac_user,account.report.external.value.ac.user,model_account_report_external_value,account.group_account_manager,1,1,1,1
+
+access_account_one2many_test_wizard_manager,account.one2many.test.wizard,model_account_one2many_test_wizard,account.group_account_manager,1,1,1,1
+access_account_one2many_test_wizard_line_manager,account.one2many.test.wizard.line,model_account_one2many_test_wizard_line,account.group_account_manager,1,1,1,1

--- a/addons/account/wizard/__init__.py
+++ b/addons/account/wizard/__init__.py
@@ -12,3 +12,4 @@ from . import base_document_layout
 from . import account_payment_register
 from . import accrued_orders
 from . import base_partner_merge
+from . import account_one2many_test_wizard

--- a/addons/account/wizard/account_one2many_test_wizard.py
+++ b/addons/account/wizard/account_one2many_test_wizard.py
@@ -1,0 +1,58 @@
+from odoo import _, api, fields, models, Command
+from odoo.exceptions import UserError
+
+
+class AccountOne2manyTestWizard(models.TransientModel):
+    _name = 'account.one2many.test.wizard'
+    _description = "Account One2many test wizard"
+
+    account_ids = fields.Many2many('account.account')
+    some_field = fields.Char('Some Field')
+    wizard_line_ids = fields.One2many(
+        comodel_name='account.one2many.test.wizard.line',
+        inverse_name='wizard_id',
+        compute='_compute_wizard_line_ids',
+        store=True,
+        readonly=False,
+    )
+
+    @api.model
+    def default_get(self, fields):
+        res = super().default_get(fields)
+        if not set(fields) & {'account_ids', 'wizard_line_ids'}:
+            return res
+
+        if self.env.context.get('active_model') != 'account.account' or not self.env.context.get('active_ids'):
+            raise UserError(_("This can only be used on accounts."))
+
+        res['account_ids'] = [Command.set(self.env.context.get('active_ids'))]
+        return res
+
+    @api.depends('some_field', 'account_ids')
+    def _compute_wizard_line_ids(self):
+        """ Determine which accounts to merge together. """
+        for wizard in self:
+            wizard_lines_vals_list = [
+                {
+                    'sequence': sequence,
+                    'account_id': account.id,
+                }
+                for sequence, account in enumerate(wizard.account_ids)
+            ]
+
+            wizard.wizard_line_ids = [Command.unlink(wizard_line.id) for wizard_line in wizard.wizard_line_ids] + \
+                                     [Command.create(vals) for vals in wizard_lines_vals_list]
+
+
+class AccountOne2manyTestWizardLine(models.TransientModel):
+    _name = 'account.one2many.test.wizard.line'
+    _description = "Account One2many test wizard line"
+    _order = 'sequence, id'
+
+    wizard_id = fields.Many2one(
+        comodel_name='account.one2many.test.wizard',
+        required=True,
+        ondelete='cascade',
+    )
+    sequence = fields.Integer()
+    account_id = fields.Many2one(comodel_name='account.account')

--- a/addons/account/wizard/account_one2many_test_wizard_views.xml
+++ b/addons/account/wizard/account_one2many_test_wizard_views.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="account_one2many_test_wizard_form" model="ir.ui.view">
+            <field name="name">account.one2many.test.wizard.form</field>
+            <field name="model">account.one2many.test.wizard</field>
+            <field name="arch" type="xml">
+                <form>
+                    <field name="some_field"/>
+                    <label for="wizard_line_ids" string="These are the wizard lines:"/>
+                    <field name="wizard_line_ids" class="d-block">
+                        <tree string="Wizard Lines" editable="bottom" create="0" delete="0">
+                            <field name="sequence"/>
+                            <field name="account_id"/>
+                        </tree>
+                    </field>
+                </form>
+            </field>
+        </record>
+
+        <record id="account_one2many_test_wizard_action" model="ir.actions.act_window">
+            <field name="name">Test One2many widget</field>
+            <field name="res_model">account.one2many.test.wizard</field>
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="account_one2many_test_wizard_form"/>
+            <field name="target">new</field>
+            <field name="groups_id" eval="[(6, 0, [ref('account.group_account_manager')])]"/>
+            <field name="binding_model_id" ref="account.model_account_account"/>
+            <field name="binding_type">action</field>
+            <field name="binding_view_types">list</field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Steps to reproduce:
- Go to Accounting -> Configuration -> Chart of Accounts
- Select all the accounts
- In the action menu, select 'Test One2many widget'
- Use the pager to cycle through the accounts
- Notice how the order of the wizard lines is not respected: the first page shows up in the right order, but the subsequent ones have the ordering of the lines reversed.