### PR TITLE
[FIX] point_of_sale: broken links in web dialogs

### DIFF
--- a/addons/point_of_sale/static/src/overrides/action_service.js
+++ b/addons/point_of_sale/static/src/overrides/action_service.js
@@ -1,0 +1,23 @@
+import { patch } from "@web/core/utils/patch";
+import { actionService } from "@web/webclient/actions/action_service";
+
+patch(actionService, {
+    start(env) {
+        // The action service wants to open the majority of links in the main container, not in new dialog.
+        // The problem is that in pos we don't have the main container, so the links are simply not opened.
+        // This is a workaround to always open links in new dialogs.
+        const superReturn = super.start(env);
+        return {
+            ...superReturn,
+            doAction: async (actionRequest, options = {}) => {
+                if (
+                    document.body.classList.contains("modal-open") &&
+                    typeof actionRequest === "object"
+                ) {
+                    actionRequest.target = "new";
+                }
+                return superReturn.doAction(actionRequest, options);
+            },
+        };
+    },
+});


### PR DESCRIPTION
The action service wants to open the majority of links in the main container, not in new dialog.
The problem is that in pos we don't have the main container, so the links are simply not opened.
This is a workaround to always open links in new dialogs.

Example:
Click on the `session` link in the `pos.order` form view and observe the fact that the dialog simply closes.
![image](https://github.com/user-attachments/assets/886cac49-c941-48bb-9499-f36e2043cd6d)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
