### PR TITLE
[FIX] base: prevent wkhtmltopdf from generating device logs

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -567,7 +567,8 @@ class IrActionsReport(models.Model):
         try:
             wkhtmltopdf = [_get_wkhtmltopdf_bin()] + command_args + files_command_args + paths + [pdf_report_path]
             process = subprocess.Popen(wkhtmltopdf, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            out, err = process.communicate()
+            with request.session.no_trace():
+                _, err = process.communicate()
             err = ustr(err)
 
             if process.returncode not in [0, 1]:

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1158,6 +1158,16 @@ class Session(collections.abc.MutableMapping):
         self.is_dirty = True
         return new_trace
 
+    @contextlib.contextmanager
+    def no_trace(self):
+        # The session will no longer trigger the generation of device logs.
+        # Must be effective on other transactions (not yet started).
+        self['_trace_disable'] = True
+        root.session_store.save(self)
+        yield
+        self.pop('_trace_disable', None)
+        root.session_store.save(self)
+
 
 # =========================================================
 # GeoIP


### PR DESCRIPTION
During pdf generation, `wkhtmltopdf` creates device logs via a request whose user agent is:
`Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/534.34 (KHTML, like Gecko) wkhtmltopdf Safari/534.34`.
The result is that a `Linux - Safari` device log is created.

This must be prevented (using the `_disable_trace` server-side mechanism of the session object).