### PR TITLE
[FIX] mrp: fix the timezone issue for start_date wo test

### DIFF
--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -3893,6 +3893,7 @@ class TestMrpOrder(TestMrpCommon):
         will be set too. As if the finish date is not set the planned workorder will not
         be shown in planning gantt view
         """
+        self.env.company.resource_calendar_id.tz = 'Europe/Brussels'
         mo = self.env['mrp.production'].create({
             'product_id': self.product.id,
             'product_uom_id': self.bom_1.product_uom_id.id,


### PR DESCRIPTION
The issue:
While running the test test_multi_edit_start_date_wo, the calendar is set to the Europe/Brussels timezone. However, when demo data is not present, the calendar defaults to the UTC timezone.

The fix:
Adapt the timezone

back-port of https://github.com/odoo/odoo/pull/177235

runbot-56562