### PR TITLE
[IMP] project: add 'project' breadcrumb in  project sharing

### DIFF
--- a/addons/project/static/src/project_sharing/components/control_panel/project_sharing_control_panel.js
+++ b/addons/project/static/src/project_sharing/components/control_panel/project_sharing_control_panel.js
@@ -1,0 +1,15 @@
+import { ControlPanel } from "@web/search/control_panel/control_panel";
+
+
+export class ProjectSharingControlPanel extends ControlPanel {
+    setup() {
+        super.setup();
+        this.breadcrumbs.unshift({
+            name: 'Project',
+            url: '/my/projects',
+            onSelected: () => {
+                window.top.location.href = '/my/projects';
+            },
+        });
+    }
+}

--- a/addons/project/static/src/project_sharing/views/form/project_sharing_form_view.js
+++ b/addons/project/static/src/project_sharing/views/form/project_sharing_form_view.js
@@ -1,6 +1,8 @@
 import { formView } from '@web/views/form/form_view';
 import { ProjectSharingFormController } from './project_sharing_form_controller';
 import { ProjectSharingFormRenderer } from './project_sharing_form_renderer';
+import { ProjectSharingControlPanel } from '../../components/control_panel/project_sharing_control_panel';
 
 formView.Controller = ProjectSharingFormController;
 formView.Renderer = ProjectSharingFormRenderer;
+formView.ControlPanel = ProjectSharingControlPanel;

--- a/addons/project/static/src/project_sharing/views/kanban/project_sharing_kanban_view.js
+++ b/addons/project/static/src/project_sharing/views/kanban/project_sharing_kanban_view.js
@@ -1,0 +1,5 @@
+import { kanbanView } from '@web/views/kanban/kanban_view';
+
+import { ProjectSharingControlPanel } from '../../components/control_panel/project_sharing_control_panel';
+
+kanbanView.ControlPanel = ProjectSharingControlPanel;

--- a/addons/project/static/src/project_sharing/views/list/list_view.js
+++ b/addons/project/static/src/project_sharing/views/list/list_view.js
@@ -1,5 +1,7 @@
 import { listView } from "@web/views/list/list_view";
 
+import { ProjectSharingControlPanel } from '../../components/control_panel/project_sharing_control_panel';
+
 const props = listView.props;
 listView.props = function (genericProps, view) {
     const result = props(genericProps, view);
@@ -8,3 +10,5 @@ listView.props = function (genericProps, view) {
         allowSelectors: false,
     };
 };
+
+listView.ControlPanel = ProjectSharingControlPanel;

--- a/addons/project/static/tests/tours/project_sharing_tour.js
+++ b/addons/project/static/tests/tours/project_sharing_tour.js
@@ -206,3 +206,23 @@ registry.category("web_tour.tours").add("portal_project_sharing_tour_with_disall
         },
     ],
 });
+
+registry.category("web_tour.tours").add("project_sharing_with_project_breadcrumb", {
+    url: "/my/projects",
+    steps: () => [{
+        trigger: 'table > tbody > tr a:has(span:contains("Project Sharing"))',
+        content: 'Click on the portal project.',
+        run: "click",
+    }, {
+        trigger: ':iframe .o_back_button > a[href="/my/projects"]',
+        run: "click",
+    }, {
+        content: "Check if we have been redirected to my/projects",
+        trigger: "body",
+        run: () => {
+            if (window.location.pathname !== '/my/projects') {
+                console.log("We should be on /my/projects.");
+            }
+        }
+    },
+]});

--- a/addons/project/tests/test_project_sharing_ui.py
+++ b/addons/project/tests/test_project_sharing_ui.py
@@ -110,6 +110,7 @@ class TestProjectSharingUi(HttpCase):
             })],
         })
         self.start_tour("/my/projects", 'portal_project_sharing_tour', login='georges1')
+        self.start_tour("/my/projects", 'project_sharing_with_project_breadcrumb', login="georges1")
 
     def test_03_project_sharing(self):
         self.env['project.share.wizard'].create({


### PR DESCRIPTION
Currently, if the user wants to navigate back to the 'all projects' view from the project sharing view, they have to manually add 'my/projects' to the browser's URL

In this commit, we have added the project to the first position in the breadcrumb. As a result, the project will be added in the breadcrumb, allowing the user to navigate back easily.

task-3368896
