### PR TITLE
[FIX] account: skip readonly check on bank statement write

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -431,7 +431,7 @@ class AccountBankStatementLine(models.Model):
     def write(self, vals):
         # OVERRIDE
 
-        res = super().write(vals)
+        res = super(AccountBankStatementLine, self.with_context(skip_readonly_check=True)).write(vals)
         self._synchronize_to_moves(set(vals.keys()))
         return res
 


### PR DESCRIPTION
This commit adds a context to skip the readonly check on bank statement line, because it is required for user to be able to modify a posted move's date in the bank transaction list view.

Background:

From 17.3+, a check was added on `account.move` write function where if the move field to write has an `readonly` attribute and the move is on "posted" state, it will reject the write with an UserError.

This was done so that when 2 or more user are editing the same invoice, if one user posted the invoice, the other can no longer change fields that are supposed to be unchangable.

There are however, multiple places in the code where it is required to modify this "unchangable" field. The correct functional flow would be to reset move to draft, change the field, and re-post the move. It is however too resource heavy for something to be done behind the scene.

Because of that, a context "skip_readonly_check" is added to bypass this check.

[Mentioned commit](https://github.com/odoo/odoo/commit/b5d94f5563641adfd93bf431c139bc2b78d67beb) and [PR](https://github.com/odoo/odoo/pull/160096)

task-id: 4149628