### PR TITLE
[FIX] web: x2many: correct pager when receiving many commands 0

### DIFF
--- a/addons/web/static/src/model/relational_model/static_list.js
+++ b/addons/web/static/src/model/relational_model/static_list.js
@@ -507,7 +507,6 @@ export class StaticList extends DataPoint {
         // For performance reasons, we accumulate removed ids (commands DELETE and UNLINK), and at
         // the end, we filter once this.records and this._currentIds to remove them.
         const removedIds = {};
-
         const recordsToLoad = [];
         for (const command of commands) {
             switch (command[0]) {
@@ -516,7 +515,11 @@ export class StaticList extends DataPoint {
                     const record = this._createRecordDatapoint(command[2], { virtualId });
                     this.records.push(record);
                     addOwnCommand([CREATE, virtualId]);
-                    this._currentIds.splice(this.offset + this.limit, 0, virtualId);
+                    const index = this.offset + this.limit + this._tmpIncreaseLimit;
+                    this._currentIds.splice(index, 0, virtualId);
+                    this._tmpIncreaseLimit = Math.max(this.records.length - this.limit, 0);
+                    const nextLimit = this.limit + this._tmpIncreaseLimit;
+                    this.model._updateConfig(this.config, { limit: nextLimit }, { reload: false });
                     this.count++;
                     break;
                 }

--- a/addons/web/static/tests/views/fields/many2one_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2one_field_tests.js
@@ -2243,16 +2243,13 @@ QUnit.module("Fields", (hooks) => {
                 "first record",
                 "should show display_name of trululu of 1st record"
             );
-
-            await click(target, "button.o_pager_next");
-
             assert.strictEqual(
-                target.querySelectorAll("td.o_data_cell")[0].textContent,
+                target.querySelectorAll("td.o_data_cell")[2].textContent,
                 "record2",
                 "should show display_name of 2nd record"
             );
             assert.strictEqual(
-                target.querySelectorAll("td.o_data_cell")[1].textContent,
+                target.querySelectorAll("td.o_data_cell")[3].textContent,
                 "second record",
                 "should show display_name of trululu of 2nd record"
             );

--- a/addons/web/static/tests/views/fields/one2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/one2many_field_tests.js
@@ -13847,6 +13847,44 @@ QUnit.module("Fields", (hooks) => {
         assert.containsNone(target, ".o_x2m_control_panel .o_pager");
     });
 
+    QUnit.test("new record, receive more create commands than limit", async function (assert) {
+        serverData.models.partner.fields.sequence = { type: "integer" };
+        serverData.models.partner.onchanges = {
+            p: function (obj) {
+                obj.p = [
+                    [0, 0, { sequence: 1, display_name: "Record 1" }],
+                    [0, 0, { sequence: 2, display_name: "Record 2" }],
+                    [0, 0, { sequence: 3, display_name: "Record 3" }],
+                    [0, 0, { sequence: 4, display_name: "Record 4" }],
+                ];
+            },
+        };
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <group>
+                        <field name="p">
+                            <tree limit="2">
+                                <field name="sequence"/>
+                                <field name="display_name"/>
+                            </tree>
+                        </field>
+                    </group>
+                </form>`,
+        });
+
+        assert.deepEqual(getNodesTextContent(target.querySelectorAll(".o_data_cell.o_list_char")), [
+            "Record 1",
+            "Record 2",
+            "Record 3",
+            "Record 4",
+        ]);
+        assert.containsNone(target, ".o_x2m_control_panel .o_pager");
+    });
+
     QUnit.test("active actions are passed to o2m field", async (assert) => {
         serverData.models.partner.records[0].turtles = [1, 2, 3];
 


### PR DESCRIPTION
Have a form view with an x2many field displayed as a list or kanban. Create a new record, and have an onchange/default value for that x2many that returns more commands 0 (create) than the limit. Before this commit, all records where displayed on the first page (as expected when new records are created in an x2many) but the pager was displayed. Then, if you went to the second page, you would see records in the reverse order.

This commit fixes the order issue by inserting records in the correct order when processing commands. But in the meantime, it also fixes the fact that a pager was displayed.

Issue reported on discord (more details here [1])

[1] odoo/odoo#179650

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
