### PR TITLE
[FIX] base: enable duplicating languages.

### DIFF
--- a/odoo/addons/base/models/res_lang.py
+++ b/odoo/addons/base/models/res_lang.py
@@ -332,6 +332,16 @@ class Lang(models.Model):
 
         return formatted
 
+    def copy_data(self, default=None):
+        default = dict(default or {})
+
+        if "name" not in default:
+            default["name"] = _("%s (copy)", self.name)
+        if "code" not in default:
+            default["code"] = _("%s (copy)", self.code)
+        if "url_code" not in default:
+            default["url_code"] = _("%s (copy)", self.url_code)
+        return super().copy_data(default=default)
 
 def split(l, counts):
     """


### PR DESCRIPTION
Duplicating languages wasn't possible because no logic was added to it, so it threw an error whenever trying to duplicate a language. The main reason is that when you try to duplicate a language, the ORM tries to create a new record with the same fields. However, the `name`, `code` , and `url_code` fields should be unique. This commit adds the needed logic to handle duplicating languages by adding a `(copy)` postfix to the fields.

Task-4141689