### PR TITLE
[IMP] base, account: `refs` for multiple records retrieval

### DIFF
--- a/addons/account/demo/account_demo.py
+++ b/addons/account/demo/account_demo.py
@@ -65,22 +65,22 @@ class AccountChartTemplate(models.AbstractModel):
         }
 
     def _post_load_demo_data(self, company=False):
-        invoices = (
-            self.ref('demo_invoice_1')
-            + self.ref('demo_invoice_2')
-            + self.ref('demo_invoice_3')
-            + self.ref('demo_invoice_followup')
-            + self.ref('demo_invoice_5')
-            + self.ref('demo_invoice_equipment_purchase')
-            + self.ref('demo_move_auto_reconcile_1')
-            + self.ref('demo_move_auto_reconcile_2')
-            + self.ref('demo_move_auto_reconcile_3')
-            + self.ref('demo_move_auto_reconcile_4')
-            + self.ref('demo_move_auto_reconcile_5')
-            + self.ref('demo_move_auto_reconcile_6')
-            + self.ref('demo_move_auto_reconcile_7')
-            + self.ref('demo_move_auto_reconcile_8')
-            + self.ref('demo_move_auto_reconcile_9')
+        invoices = self.ref(
+            'demo_invoice_1',
+            'demo_invoice_2',
+            'demo_invoice_3',
+            'demo_invoice_followup',
+            'demo_invoice_5',
+            'demo_invoice_equipment_purchase',
+            'demo_move_auto_reconcile_1',
+            'demo_move_auto_reconcile_2',
+            'demo_move_auto_reconcile_3',
+            'demo_move_auto_reconcile_4',
+            'demo_move_auto_reconcile_5',
+            'demo_move_auto_reconcile_6',
+            'demo_move_auto_reconcile_7',
+            'demo_move_auto_reconcile_8',
+            'demo_move_auto_reconcile_9',
         )
 
         # the invoice_extract acts like a placeholder for the OCR to be ran and doesn't contain

--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -301,7 +301,7 @@ class ResConfigSettings(models.TransientModel):
             'type': 'ir.actions.act_window',
             'view_mode': 'form',
             'res_model': 'res.company',
-            'view_id': self.env.ref("account.res_company_view_form_terms", False).id,
+            'view_id': self.env.ref("account.res_company_view_form_terms").id,
             'target': 'new',
             'res_id': self.company_id.id,
         }

--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -55,10 +55,7 @@ class TestAccountComposerPerformance(AccountTestInvoicingCommon, MailCommon):
             'country_id': cls.env.ref('base.be').id,
             'email': 'e.e@example.com',
             'groups_id': [
-                (6, 0, [cls.env.ref('base.group_user').id,
-                        cls.env.ref('account.group_account_invoice').id,
-                        cls.env.ref('base.group_partner_manager').id
-                       ])
+                (6, 0, cls.env.ref('base.group_user', 'account.group_account_invoice', 'base.group_partner_manager').ids)
             ],
             'login': 'user_account',
             'name': 'Ernest Employee Account',
@@ -71,10 +68,7 @@ class TestAccountComposerPerformance(AccountTestInvoicingCommon, MailCommon):
             'country_id': cls.env.ref('base.be').id,
             'email': 'e.e.other@example.com',
             'groups_id': [
-                (6, 0, [cls.env.ref('base.group_user').id,
-                        cls.env.ref('account.group_account_invoice').id,
-                        cls.env.ref('base.group_partner_manager').id
-                       ])
+                (6, 0, cls.env.ref('base.group_user', 'account.group_account_invoice', 'base.group_partner_manager').ids)
             ],
             'login': 'user_account_other',
             'name': 'Eglantine Employee AccountOther',

--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -200,7 +200,7 @@ class AccountPayment(models.Model):
         if not check_layout or check_layout == 'disabled':
             msg = _("You have to choose a check layout. For this, go in Invoicing/Accounting Settings, search for 'Checks layout' and set one.")
             raise RedirectWarning(msg, redirect_action.id, _('Go to the configuration panel'))
-        report_action = self.env.ref(check_layout, False)
+        report_action = self.env.ref(check_layout, raise_if_not_found=False)
         if not report_action:
             msg = _("Something went wrong with Check Layout, please select another layout in Invoicing/Accounting Settings and try again.")
             raise RedirectWarning(msg, redirect_action.id, _('Go to the configuration panel'))

--- a/addons/account_fleet/models/fleet_vehicle.py
+++ b/addons/account_fleet/models/fleet_vehicle.py
@@ -33,12 +33,13 @@ class FleetVehicle(models.Model):
     def action_view_bills(self):
         self.ensure_one()
 
-        form_view_ref = self.env.ref('account.view_move_form', False)
-        list_view_ref = self.env.ref('account_fleet.account_move_view_tree', False)
-
+        form_view_ref, tree_view_ref = self.env.ref(
+            'account.view_move_form',
+            'account_fleet.account_move_view_tree'
+        )
         result = self.env['ir.actions.act_window']._for_xml_id('account.action_move_in_invoice_type')
         result.update({
             'domain': [('id', 'in', self.account_move_ids.ids)],
-            'views': [(list_view_ref.id, 'list'), (form_view_ref.id, 'form')],
+            'views': [(tree_view_ref.id, 'list'), (form_view_ref.id, 'form')],
         })
         return result

--- a/addons/auth_oauth/models/res_config_settings.py
+++ b/addons/auth_oauth/models/res_config_settings.py
@@ -18,7 +18,7 @@ class ResConfigSettings(models.TransientModel):
     @api.model
     def get_values(self):
         res = super(ResConfigSettings, self).get_values()
-        google_provider = self.env.ref('auth_oauth.provider_google', False)
+        google_provider = self.env.ref('auth_oauth.provider_google', raise_if_not_found=False)
         if google_provider:
             res.update(
                 auth_oauth_google_enabled=google_provider.enabled,
@@ -28,7 +28,7 @@ class ResConfigSettings(models.TransientModel):
 
     def set_values(self):
         super().set_values()
-        google_provider = self.env.ref('auth_oauth.provider_google', False)
+        google_provider = self.env.ref('auth_oauth.provider_google', raise_if_not_found=False)
         if google_provider:
             google_provider.write({
                 'enabled': self.auth_oauth_google_enabled,

--- a/addons/hr_presence/models/hr_employee.py
+++ b/addons/hr_presence/models/hr_employee.py
@@ -142,7 +142,7 @@ class HrEmployeeBase(models.AbstractModel):
         context = dict(self.env.context)
         context.update(default_res_model='hr.employee', default_res_ids=self.ids, default_composition_mode='mass', default_number_field_name='mobile_phone', default_mass_keep_log=True)
 
-        template = self.env.ref('hr_presence.sms_template_presence', False)
+        template = self.env.ref('hr_presence.sms_template_presence', raise_if_not_found=False)
         if not template:
             context['default_body'] = _("""We hope this message finds you well. It has come to our attention that you are currently not present at work, and there is no record of a time off request from you. If this absence is due to an oversight on our part, we sincerely apologize for any confusion.
 Please take the necessary steps to address this unplanned absence. Should you have any questions or need assistance, do not hesitate to reach out to your manager or the HR department at your earliest convenience.

--- a/addons/hr_skills/controllers/main.py
+++ b/addons/hr_skills/controllers/main.py
@@ -23,7 +23,7 @@ class HrEmployeeCV(Controller):
         resume_type_education = request.env.ref('hr_skills.resume_type_education', raise_if_not_found=False)
         skill_type_language = request.env.ref('hr_skills.hr_skill_type_lang', raise_if_not_found=False)
 
-        report = request.env.ref('hr_skills.action_report_employee_cv', False)
+        report = request.env.ref('hr_skills.action_report_employee_cv', raise_if_not_found=False)
 
         pdf_content, dummy = request.env['ir.actions.report'].sudo()._render_qweb_pdf(
             report, employees.ids, data={

--- a/addons/l10n_ar/demo/account_demo.py
+++ b/addons/l10n_ar/demo/account_demo.py
@@ -10,10 +10,11 @@ class AccountChartTemplate(models.AbstractModel):
     @api.model
     def _get_demo_data(self, company=False):
         demo_data = super()._get_demo_data(company)
-        if company in (
-            self.env.ref('base.company_mono', raise_if_not_found=False),
-            self.env.ref('base.company_exento', raise_if_not_found=False),
-            self.env.ref('base.company_ri', raise_if_not_found=False),
+        if company in self.env.ref(
+            'base.company_mono',
+            'base.company_exento',
+            'base.company_ri',
+            raise_if_not_found=False
         ):
             # Do not load generic demo data on these companies
             return {}
@@ -40,10 +41,11 @@ class AccountChartTemplate(models.AbstractModel):
         return data
 
     def _post_load_demo_data(self, company=False):
-        if company not in (
-            self.env.ref('base.company_mono', raise_if_not_found=False),
-            self.env.ref('base.company_exento', raise_if_not_found=False),
-            self.env.ref('base.company_ri', raise_if_not_found=False),
+        if company not in self.env.ref(
+            'base.company_mono',
+            'base.company_exento',
+            'base.company_ri',
+            raise_if_not_found=False
         ):
             # Do not load generic demo data on these companies
             return super()._post_load_demo_data(company)

--- a/addons/l10n_ec/models/account_move.py
+++ b/addons/l10n_ec/models/account_move.py
@@ -141,7 +141,7 @@ class AccountMove(models.Model):
     def _get_l10n_ec_documents_allowed(self, identification_code):
         documents_allowed = self.env['l10n_latam.document.type']
         for document_ref in _DOCUMENTS_MAPPING.get(identification_code.value, []):
-            document_allowed = self.env.ref('l10n_ec.%s' % document_ref, False)
+            document_allowed = self.env.ref('l10n_ec.%s' % document_ref, raise_if_not_found=False)
             if document_allowed:
                 documents_allowed |= document_allowed
         return documents_allowed

--- a/addons/l10n_ec/models/res_partner.py
+++ b/addons/l10n_ec/models/res_partner.py
@@ -59,40 +59,35 @@ class ResPartner(models.Model):
 
     @api.constrains("vat", "country_id", "l10n_latam_identification_type_id")
     def check_vat(self):
-        it_ruc = self.env.ref("l10n_ec.ec_ruc", False)
-        it_dni = self.env.ref("l10n_ec.ec_dni", False)
+        it_ruc, it_dni = self.env.ref("l10n_ec.ec_ruc", "l10n_ec.ec_dni")
         ecuadorian_partners = self.filtered(
             lambda x: x.country_id == self.env.ref("base.ec")
         )
         for partner in ecuadorian_partners:
             if partner.vat:
-                if partner.l10n_latam_identification_type_id.id in (
-                    it_ruc.id,
-                    it_dni.id,
-                ):
-                    if partner.l10n_latam_identification_type_id.id == it_dni.id and len(partner.vat) != 10:
+                if partner.l10n_latam_identification_type_id in (it_ruc + it_dni):
+                    if partner.l10n_latam_identification_type_id == it_dni and len(partner.vat) != 10:
                         raise ValidationError(_('If your identification type is %s, it must be 10 digits',
                                                 it_dni.display_name))
-                    if partner.l10n_latam_identification_type_id.id == it_ruc.id and len(partner.vat) != 13:
+                    if partner.l10n_latam_identification_type_id == it_ruc and len(partner.vat) != 13:
                         raise ValidationError(_('If your identification type is %s, it must be 13 digits',
                                                 it_ruc.display_name))
         return super(ResPartner, self - ecuadorian_partners).check_vat()
 
     @api.depends("vat", "country_id", "l10n_latam_identification_type_id")
     def _compute_l10n_ec_vat_validation(self):
-        it_ruc = self.env.ref("l10n_ec.ec_ruc", False)
-        it_dni = self.env.ref("l10n_ec.ec_dni", False)
+        it_ruc, it_dni = self.env.ref("l10n_ec.ec_ruc", "l10n_ec.ec_dni")
         ruc = stdnum.util.get_cc_module("ec", "ruc")
         ci = stdnum.util.get_cc_module("ec", "ci")
         for partner in self:
             partner.l10n_ec_vat_validation = False
-            if partner and partner.l10n_latam_identification_type_id in (it_ruc, it_dni) and partner.vat:
+            if partner and partner.l10n_latam_identification_type_id in (it_ruc + it_dni) and partner.vat:
                 final_consumer = verify_final_consumer(partner.vat)
                 if not final_consumer:
-                    if partner.l10n_latam_identification_type_id.id == it_dni.id and not ci.is_valid(partner.vat):
+                    if partner.l10n_latam_identification_type_id == it_dni and not ci.is_valid(partner.vat):
                         partner.l10n_ec_vat_validation = _("The VAT %s seems to be invalid as the tenth digit doesn't comply with the validation algorithm "
                                                            "(could be an old VAT number)", partner.vat)
-                    if partner.l10n_latam_identification_type_id.id == it_ruc.id and not ruc.is_valid(partner.vat):
+                    if partner.l10n_latam_identification_type_id == it_ruc and not ruc.is_valid(partner.vat):
                         partner.l10n_ec_vat_validation = _("The VAT %s seems to be invalid as the tenth digit doesn't comply with the validation algorithm "
                                                            "(SRI has stated that this validation is not required anymore for some VAT numbers)", partner.vat)
 

--- a/addons/l10n_in/demo/account_demo.py
+++ b/addons/l10n_in/demo/account_demo.py
@@ -585,23 +585,23 @@ class AccountChartTemplate(models.AbstractModel):
     def _post_load_demo_data(self, company=False):
         if company.account_fiscal_country_id.code == "IN":
             if company.state_id:
-                invoices = (
-                    self.ref('demo_invoice_b2b_1')
-                    + self.ref('demo_invoice_b2b_2')
-                    + self.ref('demo_invoice_b2cs')
-                    + self.ref('demo_invoice_b2cl')
-                    + self.ref('demo_invoice_exp')
-                    + self.ref('demo_invoice_nill')
-                    + self.ref('demo_invoice_cdnr_1')
-                    + self.ref('demo_invoice_cdnr_2')
-                    + self.ref('demo_invoice_cdnur')
-                    + self.ref('demo_bill_b2b_1')
-                    + self.ref('demo_bill_b2b_2')
-                    + self.ref('demo_bill_b2b_3')
-                    + self.ref('demo_bill_imp')
-                    + self.ref('demo_bill_cdnr_1')
-                    + self.ref('demo_bill_cdnr_2')
-                    + self.ref('demo_invoice_service')
+                invoices = self.ref(
+                    'demo_invoice_b2b_1',
+                    'demo_invoice_b2b_2',
+                    'demo_invoice_b2cs',
+                    'demo_invoice_b2cl',
+                    'demo_invoice_exp',
+                    'demo_invoice_nill',
+                    'demo_invoice_cdnr_1',
+                    'demo_invoice_cdnr_2',
+                    'demo_invoice_cdnur',
+                    'demo_bill_b2b_1',
+                    'demo_bill_b2b_2',
+                    'demo_bill_b2b_3',
+                    'demo_bill_imp',
+                    'demo_bill_cdnr_1',
+                    'demo_bill_cdnr_2',
+                    'demo_invoice_service',
                 )
                 for move in invoices:
                     try:

--- a/addons/l10n_in_edi/models/account_edi_format.py
+++ b/addons/l10n_in_edi/models/account_edi_format.py
@@ -35,19 +35,19 @@ class AccountEdiFormat(models.Model):
         return journal.country_code == 'IN' and journal.type == 'sale'
 
     def _get_l10n_in_gst_tags(self):
-        return (
-           self.env.ref('l10n_in.tax_tag_base_sgst')
-           + self.env.ref('l10n_in.tax_tag_base_cgst')
-           + self.env.ref('l10n_in.tax_tag_base_igst')
-           + self.env.ref('l10n_in.tax_tag_base_cess')
-           + self.env.ref('l10n_in.tax_tag_zero_rated')
+        return self.env['account.chart.template'].ref(
+           'l10n_in.tax_tag_base_sgst',
+           'l10n_in.tax_tag_base_cgst',
+           'l10n_in.tax_tag_base_igst',
+           'l10n_in.tax_tag_base_cess',
+           'l10n_in.tax_tag_zero_rated',
         ).ids
 
     def _get_l10n_in_non_taxable_tags(self):
-        return (
-           self.env.ref("l10n_in.tax_tag_exempt")
-           + self.env.ref("l10n_in.tax_tag_nil_rated")
-           + self.env.ref("l10n_in.tax_tag_non_gst_supplies")
+        return self.env['account.chart.template'].ref(
+           "l10n_in.tax_tag_exempt",
+           "l10n_in.tax_tag_nil_rated",
+           "l10n_in.tax_tag_non_gst_supplies",
         ).ids
 
     def _get_move_applicability(self, move):

--- a/addons/l10n_uy/demo/account_demo.py
+++ b/addons/l10n_uy/demo/account_demo.py
@@ -24,22 +24,22 @@ class AccountChartTemplate(models.AbstractModel):
     def _post_load_demo_data(self, company=False):
         if company.account_fiscal_country_id.code != "UY":
             return super()._post_load_demo_data(company)
-        invoices = (
-            self.ref('demo_invoice_1')
-            + self.ref('demo_invoice_2')
-            + self.ref('demo_invoice_3')
-            + self.ref('demo_invoice_4')
-            + self.ref('demo_invoice_5')
-            + self.ref('demo_invoice_6')
-            + self.ref('demo_invoice_8')
-            + self.ref('demo_invoice_9')
-            + self.ref('demo_sup_invoice_1')
-            + self.ref('demo_sup_invoice_2')
-            + self.ref('demo_sup_invoice_3')
-            + self.ref('demo_sup_invoice_6')
-            + self.ref('demo_sup_invoice_7')
-            + self.ref('demo_sup_invoice_8')
-            + self.ref('demo_sup_invoice_9')
+        invoices = self.ref(
+            'demo_invoice_1',
+            'demo_invoice_2',
+            'demo_invoice_3',
+            'demo_invoice_4',
+            'demo_invoice_5',
+            'demo_invoice_6',
+            'demo_invoice_8',
+            'demo_invoice_9',
+            'demo_sup_invoice_1',
+            'demo_sup_invoice_2',
+            'demo_sup_invoice_3',
+            'demo_sup_invoice_6',
+            'demo_sup_invoice_7',
+            'demo_sup_invoice_8',
+            'demo_sup_invoice_9',
         )
         # the invoice_extract acts like a placeholder for the OCR to be ran and
         # doesn't contain any lines yet
@@ -50,13 +50,13 @@ class AccountChartTemplate(models.AbstractModel):
                 _logger.exception('Error while posting invoices')
 
         # Post the reversal moves
-        invoices_to_revert = (
-            self.ref('demo_refund_invoice_1')
-            + self.ref('demo_refund_invoice_2')
-            + self.ref('demo_refund_invoice_3')
-            + self.ref('demo_refund_invoice_4')
-            + self.ref('demo_sup_refund_invoice_3')
-            + self.ref('demo_sup_refund_invoice_2')
+        invoices_to_revert = self.ref(
+            'demo_refund_invoice_1',
+            'demo_refund_invoice_2',
+            'demo_refund_invoice_3',
+            'demo_refund_invoice_4',
+            'demo_sup_refund_invoice_2',
+            'demo_sup_refund_invoice_3',
         )
         for move in invoices_to_revert:
             try:

--- a/addons/loyalty/models/loyalty_card.py
+++ b/addons/loyalty/models/loyalty_card.py
@@ -92,7 +92,7 @@ class LoyaltyCard(models.Model):
         """
         self.ensure_one()
         default_template = self._get_default_template()
-        compose_form = self.env.ref('mail.email_compose_message_wizard_form', False)
+        compose_form = self.env.ref('mail.email_compose_message_wizard_form', raise_if_not_found=False)
         ctx = dict(
             default_model='loyalty.card',
             default_res_ids=self.ids,

--- a/addons/loyalty/models/product_product.py
+++ b/addons/loyalty/models/product_product.py
@@ -19,11 +19,11 @@ class ProductProduct(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_loyalty_products(self):
-        product_data = [
-            self.env.ref('loyalty.gift_card_product_50', False),
-            self.env.ref('loyalty.ewallet_product_50', False),
-        ]
-        for product in self.filtered(lambda p: p in product_data):
+        for product in self.filtered(lambda p: p in self.env.ref(
+            'loyalty.gift_card_product_50',
+            'loyalty.ewallet_product_50',
+            raise_if_not_found=False
+        )):
             raise UserError(_(
                 "You cannot delete %(name)s as it is used in 'Coupons & Loyalty'."
                 " Please archive it instead.",

--- a/addons/loyalty/models/product_template.py
+++ b/addons/loyalty/models/product_template.py
@@ -9,10 +9,11 @@ class ProductTemplate(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_loyalty_products(self):
-        product_data = [
-            self.env.ref('loyalty.gift_card_product_50', False),
-            self.env.ref('loyalty.ewallet_product_50', False),
-        ]
+        product_data = self.env.ref(
+            'loyalty.gift_card_product_50',
+            'loyalty.ewallet_product_50',
+            raise_if_not_found=False
+        )
         for product in self.filtered(lambda p: p.product_variant_id in product_data):
             raise UserError(_(
                 "You cannot delete %(name)s as it is used in 'Coupons & Loyalty'."

--- a/addons/membership/wizard/membership_invoice.py
+++ b/addons/membership/wizard/membership_invoice.py
@@ -21,9 +21,11 @@ class MembershipInvoice(models.TransientModel):
     def membership_invoice(self):
         invoice_list = self.env['res.partner'].browse(self._context.get('active_ids')).create_membership_invoice(self.product_id, self.member_price)
 
-        search_view_ref = self.env.ref('account.view_account_invoice_filter', False)
-        form_view_ref = self.env.ref('account.view_move_form', False)
-        list_view_ref = self.env.ref('account.view_move_tree', False)
+        search_view_ref, form_view_ref, list_view_ref = self.env.ref(
+            'account.view_account_invoice_filter',
+            'account.view_move_form',
+            'account.view_move_tree',
+        )
 
         return  {
             'domain': [('id', 'in', invoice_list.ids)],

--- a/addons/mrp_account/tests/test_bom_price.py
+++ b/addons/mrp_account/tests/test_bom_price.py
@@ -19,10 +19,8 @@ class TestBomPriceCommon(common.TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        # Required for `product_uom_id ` to be visible in the view
-        cls.env.user.groups_id += cls.env.ref('uom.group_uom')
-        # Required for `product_id ` to be visible in the view
-        cls.env.user.groups_id += cls.env.ref('product.group_product_variant')
+        # Required for `product_uom_id` and `product_id` to be visible in the view
+        cls.env.user.groups_id += cls.env.ref('uom.group_uom', 'product.group_product_variant')
         cls.Product = cls.env['product.product']
         cls.Bom = cls.env['mrp.bom']
 

--- a/addons/payment/wizards/payment_onboarding_wizard.py
+++ b/addons/payment/wizards/payment_onboarding_wizard.py
@@ -138,6 +138,6 @@ class PaymentProviderOnboardingWizard(models.TransientModel):
 
     def _start_stripe_onboarding(self):
         """ Start Stripe Connect onboarding. """
-        menu = self.env.ref('account_payment.payment_provider_menu', False)
+        menu = self.env.ref('account_payment.payment_provider_menu', raise_if_not_found=False)
         menu_id = menu and menu.id  # Only set if `account_payment` is installed.
         return self.env.company._run_payment_onboarding_step(menu_id)

--- a/addons/payment_stripe/models/payment_provider.py
+++ b/addons/payment_stripe/models/payment_provider.py
@@ -156,7 +156,7 @@ class PaymentProvider(models.Model):
             if not menu_id:
                 # Fall back on `account_payment`'s menu if it is installed. If not, the user is
                 # redirected to the provider's form view but without any menu in the breadcrumb.
-                menu = self.env.ref('account_payment.payment_provider_menu', False)
+                menu = self.env.ref('account_payment.payment_provider_menu', raise_if_not_found=False)
                 menu_id = menu and menu.id  # Only set if `account_payment` is installed.
 
             account_link_url = self._stripe_create_account_link(connected_account['id'], menu_id)

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -398,7 +398,7 @@ class PosConfig(models.Model):
 
     def _reset_default_on_vals(self, vals):
         if 'tip_product_id' in vals and not vals['tip_product_id'] and 'iface_tipproduct' in vals and vals['iface_tipproduct']:
-            default_product = self.env.ref('point_of_sale.product_product_tip', False)
+            default_product = self.env.ref('point_of_sale.product_product_tip', raise_if_not_found=False)
             if default_product:
                 vals['tip_product_id'] = default_product.id
             else:

--- a/addons/pos_loyalty/models/loyalty_card.py
+++ b/addons/pos_loyalty/models/loyalty_card.py
@@ -28,7 +28,7 @@ class LoyaltyCard(models.Model):
     def _get_default_template(self):
         self.ensure_one()
         if self.source_pos_order_id:
-            return self.env.ref('pos_loyalty.mail_coupon_template', False)
+            return self.env.ref('pos_loyalty.mail_coupon_template', raise_if_not_found=False)
         return super()._get_default_template()
 
     def _mail_get_partner_fields(self, introspect_fields=False):

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1925,7 +1925,7 @@ class ProjectTask(models.Model):
                 'type': 'ir.actions.act_window',
                 'res_model': 'project.task',
                 'res_id': self.id,
-                'views': [(self.env.ref('project.project_task_convert_to_subtask_view_form', False).id, 'form')],
+                'views': [(self.env.ref('project.project_task_convert_to_subtask_view_form').id, 'form')],
                 'target': 'new',
             }
         return {

--- a/addons/project/tests/test_project_stage_multicompany.py
+++ b/addons/project/tests/test_project_stage_multicompany.py
@@ -17,11 +17,12 @@ class TestProjectStagesMulticompany(TestMultiCompanyProject):
             'company_id': cls.company_a.id,
             'company_ids': [(4, cls.company_a.id), (4, cls.company_b.id)],
             'groups_id':
-                [(6, 0, [
-                    cls.env.ref('base.group_user').id,
-                    cls.env.ref('project.group_project_stages').id,
-                    cls.env.ref('project.group_project_manager').id,
-                ])]
+                [(6, 0, cls.env.ref(
+                    'base.group_user',
+                    'project.group_project_stages',
+                    'project.group_project_manager',
+                    raise_if_not_found=False
+                ).ids)]
         })
         cls.stage_company_a, cls.stage_company_b, cls.stage_company_none = cls.env['project.project.stage'].create([{
             'name': 'Stage Company A',

--- a/addons/project/tests/test_project_stage_multicompany.py
+++ b/addons/project/tests/test_project_stage_multicompany.py
@@ -21,7 +21,6 @@ class TestProjectStagesMulticompany(TestMultiCompanyProject):
                     'base.group_user',
                     'project.group_project_stages',
                     'project.group_project_manager',
-                    raise_if_not_found=False
                 ).ids)]
         })
         cls.stage_company_a, cls.stage_company_b, cls.stage_company_none = cls.env['project.project.stage'].create([{

--- a/addons/project_sms/tests/test_project_sharing.py
+++ b/addons/project_sms/tests/test_project_sharing.py
@@ -75,15 +75,15 @@ class TestPostInstallProjectSharingWithSms(TestProjectSharingWithSms):
 
             The sms template should be sent and the stage should be changed on the task.
         """
-        project_user_group = self.env.ref('project.group_project_user')
-        sale_manager_group = self.env.ref('sales_team.group_sale_manager', False)
+        project_user_group, sale_manager_group = self.env.ref(
+            'project.group_project_user',
+            'sales_team.group_sale_manager',
+            raise_if_not_found=False
+        )
         if not sale_manager_group:
             self.skipTest('`sale_sms` not installed')
         self.user_projectuser.write({
-            'groups_id': [
-                Command.link(project_user_group.id),
-                Command.link(sale_manager_group.id),
-            ]
+            'groups_id': [Command.set((project_user_group + sale_manager_group).ids)]
         })
         self.assertTrue(self.task_cow.with_user(self.user_projectuser).has_access('write'))
         with self.mockSMSGateway():

--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -155,7 +155,7 @@ class AccountMove(models.Model):
         if len(source_orders) > 1:
             result['domain'] = [('id', 'in', source_orders.ids)]
         elif len(source_orders) == 1:
-            result['views'] = [(self.env.ref('purchase.purchase_order_form', False).id, 'form')]
+            result['views'] = [(self.env.ref('purchase.purchase_order_form').id, 'form')]
             result['res_id'] = source_orders.id
         else:
             result = {'type': 'ir.actions.act_window_close'}

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -829,7 +829,7 @@ class PurchaseOrder(models.Model):
         if len(invoices) > 1:
             result['domain'] = [('id', 'in', invoices.ids)]
         elif len(invoices) == 1:
-            res = self.env.ref('account.view_move_form', False)
+            res = self.env.ref('account.view_move_form', raise_if_not_found=False)
             form_view = [(res and res.id or False, 'form')]
             if 'views' in result:
                 result['views'] = form_view + [(state, view) for state, view in result['views'] if view != 'form']

--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -190,7 +190,7 @@ class PurchaseOrder(models.Model):
         if not pickings or len(pickings) > 1:
             result['domain'] = [('id', 'in', pickings.ids)]
         elif len(pickings) == 1:
-            res = self.env.ref('stock.view_picking_form', False)
+            res = self.env.ref('stock.view_picking_form', raise_if_not_found=False)
             form_view = [(res and res.id or False, 'form')]
             result['views'] = form_view + [(state, view) for state, view in result.get('views', []) if view != 'form']
             result['res_id'] = pickings.id

--- a/addons/resource/models/res_users.py
+++ b/addons/resource/models/res_users.py
@@ -18,10 +18,10 @@ class ResUsers(models.Model):
 
         # If the timezone of the admin user gets set on their first login, also update the timezone of the default working calendar
         if (vals.get('tz') and len(self) == 1 and not self.env.user.login_date
-            and self.env.user == self.env.ref('base.user_admin', False) and self == self.env.user):
+            and self.env.user == self.env.ref('base.user_admin', raise_if_not_found=False) and self == self.env.user):
             if self.resource_calendar_id:
                 self.resource_calendar_id.tz = vals['tz']
             else:
-                self.env.ref('resource.resource_calendar_std', False).tz = vals['tz']
+                self.env.ref('resource.resource_calendar_std', raise_if_not_found=False).tz = vals['tz']
 
         return rslt

--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -131,7 +131,7 @@ class AccountMove(models.Model):
         if len(source_orders) > 1:
             result['domain'] = [('id', 'in', source_orders.ids)]
         elif len(source_orders) == 1:
-            result['views'] = [(self.env.ref('sale.view_order_form', False).id, 'form')]
+            result['views'] = [(self.env.ref('sale.view_order_form').id, 'form')]
             result['res_id'] = source_orders.id
         else:
             result = {'type': 'ir.actions.act_window_close'}

--- a/addons/sale_expense/data/sale_expense_data.xml
+++ b/addons/sale_expense/data/sale_expense_data.xml
@@ -3,22 +3,22 @@
     <data noupdate="1">
 
         <function model="product.product" name="write">
-            <value eval="[ref('hr_expense.expense_product_meal', False)]"/>
+            <value eval="[ref('hr_expense.expense_product_meal', raise_if_not_found=False)]"/>
             <value eval="{'expense_policy': 'sales_price'}"/>
         </function>
 
         <function model="product.product" name="write">
-            <value eval="[ref('hr_expense.expense_product_mileage', False)]"/>
+            <value eval="[ref('hr_expense.expense_product_mileage', raise_if_not_found=False)]"/>
             <value eval="{'expense_policy': 'sales_price', 'invoice_policy': 'delivery'}"/>
         </function>
 
         <function model="product.product" name="write">
-            <value eval="[ref('hr_expense.expense_product_travel_accommodation', False)]"/>
+            <value eval="[ref('hr_expense.expense_product_travel_accommodation', raise_if_not_found=False)]"/>
             <value eval="{'expense_policy': 'cost', 'invoice_policy': 'delivery'}"/>
         </function>
 
         <function model="product.product" name="write">
-            <value eval="[ref('hr_expense.expense_product_communication', False)]"/>
+            <value eval="[ref('hr_expense.expense_product_communication', raise_if_not_found=False)]"/>
             <value eval="{'expense_policy': 'cost'}"/>
         </function>
     </data>

--- a/addons/sale_timesheet/models/project_project.py
+++ b/addons/sale_timesheet/models/project_project.py
@@ -17,13 +17,13 @@ class ProjectProject(models.Model):
         """ Pre-fill timesheet product as "Time" data product when creating new project allowing billable tasks by default. """
         result = super().default_get(fields)
         if 'timesheet_product_id' in fields and result.get('allow_billable') and result.get('allow_timesheets') and not result.get('timesheet_product_id'):
-            default_product = self.env.ref('sale_timesheet.time_product', False)
+            default_product = self.env.ref('sale_timesheet.time_product', raise_if_not_found=False)
             if default_product:
                 result['timesheet_product_id'] = default_product.id
         return result
 
     def _default_timesheet_product_id(self):
-        return self.env.ref('sale_timesheet.time_product', False)
+        return self.env.ref('sale_timesheet.time_product', raise_if_not_found=False)
 
     pricing_type = fields.Selection([
         ('task_rate', 'Task rate'),
@@ -134,7 +134,7 @@ class ProjectProject(models.Model):
 
     @api.depends('allow_timesheets', 'allow_billable')
     def _compute_timesheet_product_id(self):
-        default_product = self.env.ref('sale_timesheet.time_product', False)
+        default_product = self.env.ref('sale_timesheet.time_product', raise_if_not_found=False)
         for project in self:
             if not project.allow_timesheets or not project.allow_billable:
                 project.timesheet_product_id = False

--- a/addons/snailmail/models/ir_actions_report.py
+++ b/addons/snailmail/models/ir_actions_report.py
@@ -17,7 +17,7 @@ class IrActionsReport(models.Model):
     def get_paperformat(self):
         # force the right format (euro/A4) when sending letters, only if we are not using the l10n_DE layout
         res = super(IrActionsReport, self).get_paperformat()
-        if self.env.context.get('snailmail_layout') and res != self.env.ref('l10n_de.paperformat_euro_din', False):
+        if self.env.context.get('snailmail_layout') and res != self.env.ref('l10n_de.paperformat_euro_din', raise_if_not_found=False):
             paperformat_id = self.env.ref('base.paperformat_euro')
             return paperformat_id
         else:

--- a/addons/snailmail/models/snailmail_letter.py
+++ b/addons/snailmail/models/snailmail_letter.py
@@ -286,7 +286,7 @@ class SnailmailLetter(models.Model):
                         'error_code': 'ATTACHMENT_ERROR'
                     })
                     continue
-                if letter.company_id.external_report_layout_id == self.env.ref('l10n_de.external_layout_din5008', False):
+                if letter.company_id.external_report_layout_id == self.env.ref('l10n_de.external_layout_din5008', raise_if_not_found=False):
                     document.update({
                         'rightaddress': 0,
                     })

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -514,7 +514,7 @@ class StockQuant(models.Model):
         quants_already_set = self.filtered(lambda quant: quant.inventory_quantity_set)
         if quants_already_set:
             ctx = dict(self.env.context or {}, default_quant_ids=self.ids)
-            view = self.env.ref('stock.inventory_warning_set_view', False)
+            view = self.env.ref('stock.inventory_warning_set_view', raise_if_not_found=False)
             return {
                 'name': _('Quantities Already Set'),
                 'type': 'ir.actions.act_window',
@@ -533,7 +533,7 @@ class StockQuant(models.Model):
     def action_apply_all(self):
         quant_ids = self.env['stock.quant'].search(self.env.context['active_domain']).ids
         ctx = dict(self.env.context or {}, default_quant_ids=quant_ids)
-        view = self.env.ref('stock.stock_inventory_adjustment_name_form_view', False)
+        view = self.env.ref('stock.stock_inventory_adjustment_name_form_view', raise_if_not_found=False)
         return {
             'name': _('Inventory Adjustment Reference / Reason'),
             'type': 'ir.actions.act_window',
@@ -545,7 +545,7 @@ class StockQuant(models.Model):
 
     def action_reset(self):
         ctx = dict(self.env.context or {}, default_quant_ids=self.ids)
-        view = self.env.ref('stock.inventory_warning_reset_view', False)
+        view = self.env.ref('stock.inventory_warning_reset_view', raise_if_not_found=False)
         return {
             'name': _('Quantities To Reset'),
             'type': 'ir.actions.act_window',
@@ -1289,7 +1289,7 @@ class StockQuant(models.Model):
                            _('This analysis gives you an overview of the current stock level of your products.')),
         }
 
-        target_action = self.env.ref('stock.dashboard_open_quants', False)
+        target_action = self.env.ref('stock.dashboard_open_quants', raise_if_not_found=False)
         if target_action:
             action['id'] = target_action.id
 

--- a/addons/stock/tests/test_move_lines.py
+++ b/addons/stock/tests/test_move_lines.py
@@ -13,10 +13,12 @@ class StockMoveLine(TestStockCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.env.user.groups_id += cls.env.ref("stock.group_tracking_owner")
-        cls.env.user.groups_id += cls.env.ref("stock.group_tracking_lot")
-        cls.env.user.groups_id += cls.env.ref("stock.group_production_lot")
-        cls.env.user.groups_id += cls.env.ref('stock.group_stock_multi_locations')
+        cls.env.user.groups_id += cls.env.ref(
+            "stock.group_tracking_owner",
+            "stock.group_tracking_lot",
+            "stock.group_production_lot",
+            "stock.group_stock_multi_locations",
+        )
         cls.product = cls.env['product.product'].create({
             'name': 'Product A',
             'is_storable': True,

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -1516,7 +1516,7 @@ class TestComposerResultsComment(TestMailComposer, CronMixinCase):
         self.assertFalse(message.email_layout_xmlid)
         self.assertEqual(message.message_type, 'comment', 'Mail: default message type with composer is user comment')
         self.assertEqual(message.record_name, self.test_record.name)
-        self.assertEqual(message.subtype_id, self.env.ref('mail.mt_comment', 'Mail: default subtype is comment'))
+        self.assertEqual(message.subtype_id, self.env.ref('mail.mt_comment'), 'Mail: default subtype is comment')
 
         # tweaks
         composer = self.env['mail.compose.message'].with_context(

--- a/addons/test_website/tests/test_views_during_module_operation.py
+++ b/addons/test_website/tests/test_views_during_module_operation.py
@@ -183,7 +183,7 @@ def test_02_copy_ids_views_unlink_on_module_update(env):
 
     # Ensure the theme.ir.ui.view got removed (since there is an IMD but not
     # present in XML files)
-    view = env.ref('theme_default.theme_child_view', False)
+    view = env.ref('theme_default.theme_child_view', raise_if_not_found=False)
     assert not view, "Theme view should have been removed during module update."
     assert not theme_child_view.exists(),\
         "Theme view should have been removed during module update. (2)"
@@ -206,7 +206,7 @@ def test_02_copy_ids_views_unlink_on_module_update(env):
 
     # Ensure the theme.ir.ui.view got removed (since there is an IMD but not
     # present in XML files)
-    view = env.ref('theme_default.theme_child_view', False)
+    view = env.ref('theme_default.theme_child_view', raise_if_not_found=False)
     assert not view, "Theme view should have been removed during module update."
     assert not theme_child_view.exists(),\
         "Theme view should have been removed during module update. (2)"

--- a/addons/web/controllers/utils.py
+++ b/addons/web/controllers/utils.py
@@ -159,7 +159,7 @@ def get_action(env, path_part):
         if someid.isdigit():  # record id
             action = Actions.sudo().browse(int(someid)).exists()
         elif '.' in someid:   # xml id
-            action = env.ref(someid, False)
+            action = env.ref(someid, raise_if_not_found=False)
             if not action or not action._name.startswith('ir.actions'):
                 action = Actions
         else:

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -316,8 +316,8 @@ class Website(Home):
     def sitemap_website_info(env, rule, qs):
         website = env['website'].get_current_website()
         if not (
-            website.viewref('website.website_info', False).active
-            and website.viewref('website.show_website_info', False).active
+            website.viewref('website.website_info', raise_if_not_found=False).active
+            and website.viewref('website.show_website_info', raise_if_not_found=False).active
         ):
             # avoid 404 or blank page in sitemap
             return False
@@ -381,7 +381,7 @@ class Website(Home):
         suggested_controllers = []
         for name, url, mod in current_website.get_suggested_controllers():
             if needle.lower() in name.lower() or needle.lower() in url.lower():
-                module_sudo = mod and request.env.ref('base.module_%s' % mod, False).sudo()
+                module_sudo = mod and request.env.ref('base.module_%s' % mod, raise_if_not_found=False).sudo()
                 icon = mod and '%s' % (module_sudo and module_sudo.icon or mod) or ''
                 suggested_controllers.append({
                     'value': url,
@@ -648,7 +648,7 @@ class Website(Home):
 
         if not template and ext_special_case:
             default_templ = 'website.default_%s' % ext.lstrip('.')
-            if request.env.ref(default_templ, False):
+            if request.env.ref(default_templ, raise_if_not_found=False):
                 template = default_templ
 
         template = template and dict(template=template) or {}

--- a/addons/website/models/website_visitor.py
+++ b/addons/website/models/website_visitor.py
@@ -174,7 +174,7 @@ class WebsiteVisitor(models.Model):
         if not self._check_for_message_composer():
             raise UserError(_("There are no contact and/or no email linked to this visitor."))
         visitor_composer_ctx = self._prepare_message_composer_context()
-        compose_form = self.env.ref('mail.email_compose_message_wizard_form', False)
+        compose_form = self.env.ref('mail.email_compose_message_wizard_form')
         compose_ctx = dict(
             default_composition_mode='comment',
         )

--- a/addons/website/tests/test_qweb.py
+++ b/addons/website/tests/test_qweb.py
@@ -30,7 +30,7 @@ class TestQwebProcessAtt(TransactionCase):
         super(TestQwebProcessAtt, self).setUp()
         self.website = self.env.ref('website.default_website')
         self.env['res.lang']._activate_lang('fr_FR')
-        self.website.language_ids = self.env.ref('base.lang_en') + self.env.ref('base.lang_fr')
+        self.website.language_ids = self.env.ref('base.lang_en', 'base.lang_fr')
         self.website.default_lang_id = self.env.ref('base.lang_en')
         self.website.cdn_activated = True
         self.website.cdn_url = "http://test.cdn"

--- a/addons/website_crm_iap_reveal/tests/test_lead_reveal.py
+++ b/addons/website_crm_iap_reveal/tests/test_lead_reveal.py
@@ -14,8 +14,8 @@ class TestLeadMine(TestCrmCommon, MockIAPReveal):
         super(TestLeadMine, cls).setUpClass()
         cls.registry.enter_test_mode(cls.cr)
 
-        cls.test_industry_tags = cls.env.ref('crm_iap_mine.crm_iap_mine_industry_33') + cls.env.ref('crm_iap_mine.crm_iap_mine_industry_148')
-        cls.test_roles = cls.env.ref('crm_iap_mine.crm_iap_mine_role_11') + cls.env.ref('crm_iap_mine.crm_iap_mine_role_19')
+        cls.test_industry_tags = cls.env.ref('crm_iap_mine.crm_iap_mine_industry_33', 'crm_iap_mine.crm_iap_mine_industry_148')
+        cls.test_roles = cls.env.ref('crm_iap_mine.crm_iap_mine_role_11', 'crm_iap_mine.crm_iap_mine_role_19')
         cls.test_seniority = cls.env.ref('crm_iap_mine.crm_iap_mine_seniority_2')
 
         cls.test_crm_tags = cls.env['crm.tag'].create([

--- a/addons/website_crm_partner_assign/models/crm_lead.py
+++ b/addons/website_crm_partner_assign/models/crm_lead.py
@@ -72,7 +72,7 @@ class CrmLead(models.Model):
             if not partner_id:
                 partner_id = partner_dict.get(lead.id, False)
             if not partner_id:
-                tag_to_add = self.env.ref('website_crm_partner_assign.tag_portal_lead_partner_unavailable', False)
+                tag_to_add = self.env.ref('website_crm_partner_assign.tag_portal_lead_partner_unavailable', raise_if_not_found=False)
                 if tag_to_add:
                     lead.write({'tag_ids': [(4, tag_to_add.id, False)]})
                 continue
@@ -211,7 +211,7 @@ class CrmLead(models.Model):
         }
 
         if spam:
-            tag_spam = self.env.ref('website_crm_partner_assign.tag_portal_lead_is_spam', False)
+            tag_spam = self.env.ref('website_crm_partner_assign.tag_portal_lead_is_spam', raise_if_not_found=False)
             if tag_spam and tag_spam not in self.tag_ids:
                 values['tag_ids'] = [(4, tag_spam.id, False)]
         if partner_ids:
@@ -268,7 +268,7 @@ class CrmLead(models.Model):
             return {
                 'errors': _('All fields are required!')
             }
-        tag_own = self.env.ref('website_crm_partner_assign.tag_portal_lead_own_opp', False)
+        tag_own = self.env.ref('website_crm_partner_assign.tag_portal_lead_own_opp', raise_if_not_found=False)
         values = {
             'contact_name': values['contact_name'],
             'name': values['title'],

--- a/addons/website_crm_partner_assign/wizard/crm_forward_to_partner.py
+++ b/addons/website_crm_partner_assign/wizard/crm_forward_to_partner.py
@@ -34,7 +34,8 @@ class CrmLeadForwardToPartner(models.TransientModel):
         res = super(CrmLeadForwardToPartner, self).default_get(fields)
         active_ids = self.env.context.get('active_ids')
         if 'body' in fields:
-            template = self.env.ref('website_crm_partner_assign.email_template_lead_forward_mail', False)
+            template = self.env.ref('website_crm_partner_assign.email_template_lead_forward_mail',
+                                    raise_if_not_found=False)
             if template:
                 res['body'] = template.body_html
         if active_ids:
@@ -54,7 +55,8 @@ class CrmLeadForwardToPartner(models.TransientModel):
 
     def action_forward(self):
         self.ensure_one()
-        template = self.env.ref('website_crm_partner_assign.email_template_lead_forward_mail', False)
+        template = self.env.ref('website_crm_partner_assign.email_template_lead_forward_mail',
+                                raise_if_not_found=False)
         if not template:
             raise UserError(_('The Forward Email Template is not in the database'))
         portal_group = self.env.ref('base.group_portal')

--- a/addons/website_event_sale/data/event_data.xml
+++ b/addons/website_event_sale/data/event_data.xml
@@ -3,7 +3,7 @@
     <data noupdate="1">
         <!-- Update the event type if exists -->
         <function model="event.type" name="write">
-            <value eval="[ref('event.event_type_data_ticket', False)]"/>
+            <value eval="[ref('event.event_type_data_ticket', raise_if_not_found=False)]"/>
             <value eval="{'name': 'Sell Online', 'website_menu': True}"/>
         </function>
     </data>

--- a/addons/website_event_track/data/event_data.xml
+++ b/addons/website_event_track/data/event_data.xml
@@ -3,7 +3,7 @@
     <data noupdate="1">
         <!-- Update the event type if exists -->
         <function model="event.type" name="write">
-            <value eval="[ref('event.event_type_data_conference', False)]"/>
+            <value eval="[ref('event.event_type_data_conference', raise_if_not_found=False)]"/>
             <value eval="{'website_menu': True, 'website_track': True, 'website_track_proposal': True}"/>
         </function>
     </data>

--- a/addons/website_sale/tests/test_website_sale_pricelist.py
+++ b/addons/website_sale/tests/test_website_sale_pricelist.py
@@ -504,12 +504,10 @@ class TestWebsitePriceListAvailableGeoIP(TestWebsitePriceListAvailable):
         c_EUR = self.env.ref('base.europe')
         c_BENELUX = self.env['res.country.group'].create({
             'name': 'BeNeLux',
-            'country_ids': [(6, 0, (self.env.ref('base.be') + self.env.ref('base.lu') + self.env.ref('base.nl')).ids)]
+            'country_ids': [(6, 0, self.env.ref('base.be', 'base.lu', 'base.nl').ids)]
         })
 
-        self.BE = self.env.ref('base.be')
-        self.US = self.env.ref('base.us')
-        NL = self.env.ref('base.nl')
+        self.BE, self.US, NL = self.env.ref('base.be', 'base.us', 'base.nl')
         c_BE, c_NL = self.env['res.country.group'].create([
             {'name': 'Belgium', 'country_ids': [(6, 0, [self.BE.id])]},
             {'name': 'Netherlands', 'country_ids': [(6, 0, [NL.id])]},

--- a/odoo/addons/base/models/ir_binary.py
+++ b/odoo/addons/base/models/ir_binary.py
@@ -41,7 +41,7 @@ class IrBinary(models.AbstractModel):
         """
         record = None
         if xmlid:
-            record = self.env.ref(xmlid, False)
+            record = self.env.ref(xmlid, raise_if_not_found=False)
         elif res_id is not None and res_model in self.env:
             record = self.env[res_model].browse(res_id).exists()
         if not record:

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -898,7 +898,7 @@ class IrModuleModule(models.Model):
 
             excluded_category_ids = []
             for excluded_xmlid in excluded_xmlids:
-                categ = self.env.ref(excluded_xmlid, False)
+                categ = self.env.ref(excluded_xmlid, raise_if_not_found=False)
                 if not categ:
                     continue
                 excluded_category_ids.append(categ.id)

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -86,7 +86,7 @@ class ResCompany(models.Model):
 
     def init(self):
         for company in self.search([('paperformat_id', '=', False)]):
-            paperformat_euro = self.env.ref('base.paperformat_euro', False)
+            paperformat_euro = self.env.ref('base.paperformat_euro', raise_if_not_found=False)
             if paperformat_euro:
                 company.write({'paperformat_id': paperformat_euro.id})
         sup = super()

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -843,8 +843,8 @@ class ResUsers(models.Model):
 
     @api.ondelete(at_uninstall=True)
     def _unlink_except_master_data(self):
-        portal_user_template = self.env.ref('base.template_portal_user_id', False)
-        default_user_template = self.env.ref('base.default_user', False)
+        portal_user_template = self.env.ref('base.template_portal_user_id', raise_if_not_found=False)
+        default_user_template = self.env.ref('base.default_user', raise_if_not_found=False)
         if SUPERUSER_ID in self.ids:
             raise UserError(_('You can not remove the admin user as it is used internally for resources created by Odoo (updates, module installation, ...)'))
         user_admin = self.env.ref('base.user_admin', raise_if_not_found=False)
@@ -1926,7 +1926,7 @@ class UsersView(models.Model):
         res = super().write(values)
         if 'company_ids' not in values:
             return res
-        group_multi_company = self.env.ref('base.group_multi_company', False)
+        group_multi_company = self.env.ref('base.group_multi_company', raise_if_not_found=False)
         if group_multi_company:
             for user in self:
                 if len(user.company_ids) <= 1 and user.id in group_multi_company.users.ids:
@@ -1941,7 +1941,7 @@ class UsersView(models.Model):
             values = {}
         values = self._remove_reified_groups(values)
         user = super().new(values=values, origin=origin, ref=ref)
-        group_multi_company = self.env.ref('base.group_multi_company', False)
+        group_multi_company = self.env.ref('base.group_multi_company', raise_if_not_found=False)
         if group_multi_company and 'company_ids' in values:
             if len(user.company_ids) <= 1 and user.id in group_multi_company.users.ids:
                 user.update({'groups_id': [Command.unlink(group_multi_company.id)]})

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1966,7 +1966,7 @@ class UsersView(models.Model):
 
         missing_groups = {}
         # We don't want to show warning for "Technical" and "Extra Rights" groups
-        categories_to_ignore = self.env.ref('base.module_category_hidden') + self.env.ref('base.module_category_usability')
+        categories_to_ignore = self.env.ref('base.module_category_hidden', 'base.module_category_usability')
         for group in current_groups:
             # Get the updated group from current groups
             missing_implied_groups = group.implied_ids - user.groups_id


### PR DESCRIPTION
The `ref` method both in Environment and in ChartTemplate can now accept multiple `xml_ids`, reducing the number of queries necessary. The `xml_ids` must all refer to the same model, or `ValueError` is raised.
`raise_if_not_found` argument is made a keyword-only argument so now it's mandatory for the function calls to include the argument name.

Documentation PR: odoo/documentation#10992
Enterprise PR: odoo/enterprise#69800