### PR TITLE
[FIX] project_hr_expense: fixed action of expense

### DIFF
--- a/addons/project_hr_expense/models/project.py
+++ b/addons/project_hr_expense/models/project.py
@@ -97,10 +97,10 @@ class Project(models.Model):
         }
         if can_see_expense:
             args = [section_id, [('id', 'in', expense_data['ids'])]]
-            if expense_data['ids']:
-                args.append(expense_data['ids'])
+            if len(expense_data['ids']) == 1:
+                args.append(expense_data['ids'][0])
             action = {'name': 'action_profitability_items', 'type': 'object', 'args': json.dumps(args)}
-            expense_profitability_items['action'] = action
+            expense_profitability_items['costs']['action'] = action
         return expense_profitability_items
 
     def _get_profitability_aal_domain(self):


### PR DESCRIPTION
Steps to reproduce:

- On a fresh DB install only project_hr_expense(Uninstall project_sale_expense).
- Create a expense on a project.
- Go to Project Updates/ Dashboard - i.e., project right side panel

Issue:

- You can see that there is no action click on Expense while there should be.

Reason:

- Incorrect configuration of attaching ids into the action causing this.

Solution:

- Fixed the incorrect in which action is being generated.

Technical:
 - The issue only occurs when the project_hr_expense module is installed.   If the project_sale_expense module is installed, 
    the issue does not reproduce because the expense action is handled properly.

task-4175573
