### PR TITLE
[FIX] stock: no copy on creation date

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -310,7 +310,7 @@ class Picking(models.Model):
         help="Is late or will be late depending on the deadline and scheduled date")
     date = fields.Datetime(
         'Creation Date',
-        default=fields.Datetime.now, tracking=True,
+        default=fields.Datetime.now, tracking=True, copy=False,
         states={'done': [('readonly', True)], 'cancel': [('readonly', True)]},
         help="Creation Date, usually the time of the order")
     date_done = fields.Datetime('Date of Transfer', copy=False, readonly=True, help="Date at which the transfer has been processed or cancelled.")


### PR DESCRIPTION
* PROPBLEM: When duplicating a picking, the creation date is not updated to latest date (fields.datetime.now) instead it was taken from the copy value. This will be a problem if user try to search for it, they do not know 'creation_date' actually is because it is not present on picking view
* SOLUTION: this commit add copy=False to update 'creation_date' when duplicating picking

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
