### PR TITLE
[FIX] sale_stock: update DO demand from partially delivered SO

### DIFF
--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -287,7 +287,7 @@ class SaleOrderLine(models.Model):
 
         for move in moves:
             if (strict and move.location_dest_id.usage == "customer") or \
-               (not strict and move.rule_id.id in triggering_rule_ids and move.location_final_id.usage == "customer"):
+               (not strict and move.rule_id.id in triggering_rule_ids and (move.location_final_id or move.location_dest_id).usage == "customer"):
                 if not move.origin_returned_move_id or (move.origin_returned_move_id and move.to_refund):
                     outgoing_moves |= move
             elif move.location_id.usage == "customer" and move.to_refund:

--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -2034,3 +2034,49 @@ class TestSaleStock(TestSaleStockCommon, ValuationReconciliationTestCommon):
         ship02.move_ids.write({'quantity': 7, 'picked': True})
         ship02.button_validate()
         self.assertEqual(so.delivery_status, 'full')
+
+    def test_double_return_on_so(self):
+        """
+        Check that the return of a return of a delivery linked to an SO
+        is seen as an outgoing move for the related procurements.
+        """
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [
+                Command.create({
+                    'name': 'sol_p1',
+                    'product_id': self.env['product.product'].create({'name': 'p1'}).id,
+                    'product_uom_qty': 5,
+                    'product_uom': self.env.ref('uom.product_uom_unit').id,
+                }),
+            ],
+        })
+        so.action_confirm()
+        delivery = so.picking_ids
+        delivery.button_validate()
+        self.assertEqual(so.order_line.qty_delivered, 5.0)
+        # create and validate a return
+        return_form = Form(self.env['stock.return.picking']
+            .with_context(active_id=delivery.id,
+            active_model='stock.picking'))
+        return_wiz = return_form.save()
+        res = return_wiz.create_returns()
+        do_return = self.env['stock.picking'].browse(res['res_id'])
+        do_return.button_validate()
+        self.assertEqual(so.order_line.qty_delivered, 0.0)
+        # create and validate the return of the return
+        return_form = Form(self.env['stock.return.picking']
+            .with_context(active_id=do_return.id,
+            active_model='stock.picking'))
+        return_wiz = return_form.save()
+        res = return_wiz.create_returns()
+        do_return_return = self.env['stock.picking'].browse(res['res_id'])
+        do_return_return.button_validate()
+        self.assertEqual(so.order_line.qty_delivered, 5.0)
+        with Form(so) as so_form:
+            with so_form.order_line.edit(0) as line_form:
+                line_form.product_uom_qty = 8.0
+        delivery_2 = so.picking_ids - delivery - do_return - do_return_return
+        self.assertTrue(delivery_2)
+        self.assertEqual(delivery_2.move_ids.product_uom_qty, 3.0)
+        self.assertEqual(so.order_line.qty_delivered, 5.0)


### PR DESCRIPTION
### Steps to reproduce:

- Create and confirm an SO for 5 units of a consumable product.
- Validate the associated delivery.
- Return and validate the return.
- Return and validate the return of the return.
- Change the demand of the SO from 5 to 8 units.

#### > A delivery order for 8 units is created instead of 3.

### Cause of the issue:

Changing the demand on the SO will trigger the ` _action_launch_stock_rule` to determine which procurement to trigger in order to fulfill the delivery. During this call the qty to deliver will be computed by comparing the quantity handled by incoming and outgoing moves  linked to the sol. However, the return of the return of an outgoing move will not be flagged as an outgoing move since it does not have a `location_final_id` since it was created as a return: https://github.com/odoo/odoo/blob/4a050ec0efb929f7605856f490025f7921d39672/addons/sale_stock/models/sale_order_line.py#L266-L267 https://github.com/odoo/odoo/blob/4a050ec0efb929f7605856f490025f7921d39672/addons/sale_stock/models/sale_order_line.py#L288-L292

opw-4105394
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
