### PR TITLE
[FIX] survey: hide test warning banner on survey results

### DIFF
--- a/addons/survey/views/survey_templates_management.xml
+++ b/addons/survey/views/survey_templates_management.xml
@@ -97,7 +97,7 @@
 
     <template id="survey_button_form_view" name="Survey: back to form view">
         <div groups="survey.group_survey_user" t-ignore="true" class="alert alert-info p-2 border-0 rounded-0 d-print-none css_editable_mode_hidden mb-0 text-center">
-            <a t-attf-href="/web#view_type=form&amp;model=survey.survey&amp;id=#{survey.id}&amp;action=survey.action_survey_form"><span>This is a Test Survey Entry. </span><i class="oi oi-fw oi-arrow-right"/>Edit Survey</a>
+            <a t-attf-href="/web#view_type=form&amp;model=survey.survey&amp;id=#{survey.id}&amp;action=survey.action_survey_form"><span t-if="answer and answer.test_entry">This is a Test Survey Entry. </span><i class="oi oi-fw oi-arrow-right"/>Edit Survey</a>
         </div>
         <div groups="survey.group_survey_user" t-if="survey.scoring_type != 'no_scoring' and survey.scoring_max_obtainable &lt;= 0"
             t-ignore="true" class="alert alert-warning p-2 border-0 rounded-0 d-print-none css_editable_mode_hidden mb-0 text-center">


### PR DESCRIPTION
Steps to reproduce:
- Survey > New > Tick 'Survey'
- Create a question
- Test > Complete the survey
- Edit survey > See results

The banner displays 'This is a test survey entry', despite no longer being in the test. The condition to display this text was removed in c983f8a5343ac623ebc9d6dbddc506db4079ee5e but it is still relevant here.

opw-4160109

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
