### PR TITLE
[IMP] web, _*: convert images to webp

### DIFF
--- a/addons/html_editor/static/src/others/x2many_media_viewer.js
+++ b/addons/html_editor/static/src/others/x2many_media_viewer.js
@@ -7,6 +7,10 @@ import { CustomMediaDialog } from "./custom_media_dialog";
 
 export class X2ManyMediaViewer extends X2ManyField {
     static template = "html_editor.X2ManyMediaViewer";
+    static props = {
+        ...X2ManyField.props,
+        convertToWebp: { type: Boolean, optional: true },
+    };
 
     setup() {
         super.setup();
@@ -43,10 +47,10 @@ export class X2ManyMediaViewer extends X2ManyField {
         const attachmentRecords = await this.orm.searchRead(
             "ir.attachment",
             [["id", "in", attachmentIds]],
-            ["id", "datas", "name"],
+            ["id", "datas", "name", "mimetype"],
             {}
         );
-        attachmentRecords.forEach((attachment) => {
+        for (let attachment of attachmentRecords) {
             const imageList = this.props.record.data[this.props.name];
             if (!attachment.datas) {
                 // URL type attachments are mostly demo records which don't have any ir.attachment datas
@@ -55,6 +59,77 @@ export class X2ManyMediaViewer extends X2ManyField {
                     type: "warning",
                 });
             }
+            if (
+                this.props.convertToWebp &&
+                !["image/gif", "image/svg+xml"].includes(attachment.mimetype)
+            ) {
+                // This method is widely adapted from onFileUploaded in ImageField.
+                // Upon change, make sure to verify whether the same change needs
+                // to be applied on both sides.
+                // Generate alternate sizes and format for reports.
+                const image = document.createElement("img");
+                image.src = `data:${attachment.mimetype};base64,${attachment.datas}`;
+                await new Promise((resolve) => image.addEventListener("load", resolve));
+
+                const originalSize = Math.max(image.width, image.height);
+                const smallerSizes = [1024, 512, 256, 128].filter((size) => size < originalSize);
+                let referenceId = undefined;
+
+                for (const size of [originalSize, ...smallerSizes]) {
+                    const ratio = size / originalSize;
+                    const canvas = document.createElement("canvas");
+                    canvas.width = image.width * ratio;
+                    canvas.height = image.height * ratio;
+                    const ctx = canvas.getContext("2d");
+                    ctx.drawImage(
+                        image, 0, 0, image.width, image.height, 0, 0, canvas.width, canvas.height
+                    );
+
+                    // WebP format
+                    const webpData = canvas.toDataURL("image/webp", 0.75).split(",")[1];
+                    const [resizedId] = await this.orm.call("ir.attachment", "create_unique", [
+                        [
+                            {
+                                name: attachment.name.replace(/\.[^/.]+$/, ".webp"),
+                                description:
+                                size === originalSize ? "" : `resize: ${size}`,
+                                datas: webpData,
+                                res_id: referenceId,
+                                res_model: "ir.attachment",
+                                mimetype: "image/webp",
+                            },
+                        ],
+                    ]);
+
+                    referenceId = referenceId || resizedId;
+
+                    // JPEG format for compatibility
+                    const jpegData = canvas.toDataURL("image/jpeg", 0.75).split(",")[1];
+                    await this.orm.call("ir.attachment", "create_unique", [
+                        [
+                            {
+                                name: attachment.name.replace(/\.[^/.]+$/, ".jpg"),
+                                description: `resize: ${size} - format: jpeg`,
+                                datas: jpegData,
+                                res_id: resizedId,
+                                res_model: "ir.attachment",
+                                mimetype: "image/jpeg",
+                            }
+                        ],
+                    ]);
+                }
+                const canvas = document.createElement("canvas");
+                canvas.width = image.width;
+                canvas.height = image.height;
+                const ctx = canvas.getContext("2d");
+                ctx.drawImage(image, 0, 0, image.width, image.height);
+
+                const webpData = canvas.toDataURL("image/webp", 0.75).split(",")[1];
+                attachment.datas = webpData;
+                attachment.mimetype = "image/webp";
+                attachment.name = attachment.name.replace(/\.[^/.]+$/, ".webp");
+            }
+
             imageList.addNewRecord({ position: "bottom" }).then((record) => {
                 const activeFields = imageList.activeFields;
                 const updateData = {};
@@ -66,7 +141,7 @@ export class X2ManyMediaViewer extends X2ManyField {
                 }
                 record.update(updateData);
             });
-        });
+        }
     }
 
     async onAdd({ context, editable } = {}) {
@@ -77,6 +152,19 @@ export class X2ManyMediaViewer extends X2ManyField {
 export const x2ManyMediaViewer = {
     ...x2ManyField,
     component: X2ManyMediaViewer,
+    extractProps: (
+        { attrs, relatedFields, viewMode, views, widget, options, string },
+        dynamicInfo
+    ) => {
+        const x2ManyFieldProps = x2ManyField.extractProps(
+            { attrs, relatedFields, viewMode, views, widget, options, string },
+            dynamicInfo
+        );
+        return {
+            ...x2ManyFieldProps,
+            convertToWebp: options.convert_to_webp,
+        };
+    },
 };
 
 registry.category("fields").add("x2_many_media_viewer", x2ManyMediaViewer);

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -55,7 +55,12 @@
                     </div>
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                     <field name="id" invisible="True"/>
-                    <field name="image_1920" widget="image" class="oe_avatar" options="{'preview_image': 'image_128'}"/>
+                    <field
+                        name="image_1920"
+                        widget="image"
+                        class="oe_avatar"
+                        options="{'convert_to_webp': True, 'preview_image': 'image_128'}"
+                    />
                     <div class="oe_title">
                         <label for="name" string="Product"/>
                         <h1>
@@ -324,7 +329,7 @@
                         <field name="active" invisible="1"/>
                         <field name="id" invisible="1"/>
                         <field name="company_id" invisible="1"/>
-                        <field name="image_1920" widget="image" class="oe_avatar" options="{'preview_image': 'image_128'}"/>
+                        <field name="image_1920" widget="image" class="oe_avatar" options="{'convert_to_webp': True,'preview_image': 'image_128'}"/>
                         <div class="oe_title">
                             <label for="name" string="Product Name"/>
                             <h1><field name="name" readonly="1" placeholder="e.g. Odoo Enterprise Subscription"/></h1>
@@ -518,7 +523,7 @@
             <field name="arch" type="xml">
                 <form>
                     <sheet>
-                        <field name="image_1920" widget="image" class="oe_avatar" nolabel="1" options="{'preview_image': 'image_128'}"/>
+                        <field name="image_1920" widget="image" class="oe_avatar" nolabel="1" options="{'convert_to_webp': True,'preview_image': 'image_128'}"/>
                         <group name="name">
                                 <field name="company_id" invisible="1"/>
                                 <field name="currency_id" invisible="1"/>

--- a/addons/website_sale/views/product_views.xml
+++ b/addons/website_sale/views/product_views.xml
@@ -171,7 +171,17 @@
             </group>
             <xpath expr="//page[@name='sales']/group[@name='sale']" position="inside">
                 <group colspan="2" name="product_template_images" string="eCommerce Media" invisible="not sale_ok">
-                    <field colspan="2" name="product_template_image_ids" class="o_website_sale_image_list" context="{'default_name': name}" mode="kanban" add-label="Add Media" nolabel="1" widget="x2_many_media_viewer"/>
+                    <field
+                        colspan="2"
+                        name="product_template_image_ids"
+                        class="o_website_sale_image_list"
+                        context="{'default_name': name}"
+                        mode="kanban"
+                        add-label="Add Media"
+                        nolabel="1"
+                        widget="x2_many_media_viewer"
+                        options="{'convert_to_webp': True}"
+                    />
                 </group>
             </xpath>
             <xpath expr="//page[@name='sales']//group[@name='description']" position="after">
@@ -228,7 +238,7 @@
             </group>
             <group name="packaging" position="after">
                 <group colspan="2" name="product_variant_images" string="Extra Variant Media">
-                    <field name="product_variant_image_ids" class="o_website_sale_image_list" context="{'default_name': name}" mode="kanban" add-label="Add Media" nolabel="1" widget="x2_many_media_viewer"/>
+                    <field name="product_variant_image_ids" class="o_website_sale_image_list" context="{'default_name': name}" mode="kanban" add-label="Add Media" nolabel="1" widget="x2_many_media_viewer" options="{'convert_to_webp': True}"/>
                 </group>
             </group>
         </field>


### PR DESCRIPTION
_* = html_editor, website_sale, product

Before this commit:
Previously, extra images and the main image for a product uploaded from the product form view in the backend were not converted to `webp`, unlike those uploaded from the frontend using the web editor.

After this commit:
Now, the main product image and the extra images will be converted to `webp` when uploaded from backend.

task-3845144