### PR TITLE
[REV] website_sale: undo remove util function

### DIFF
--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -26,6 +26,17 @@ function assertCssVariable(variableName, variableValue, trigger = 'iframe body')
         },
     };
 }
+function assertPathName(pathName, trigger) {
+    return {
+        content: `Check if we have been redirected to ${pathName}`,
+        trigger: trigger,
+        run: () => {
+            if (!window.location.pathname.startsWith(pathName)) {
+                console.error(`We should be on ${pathName}.`);
+            }
+        }
+    };
+}
 
 function changeBackground(snippet, position = "bottom") {
     return {
@@ -407,23 +418,24 @@ function selectElementInWeSelectWidget(
             run: `text ${elementName}`,
         });
     }
+    steps.push(clickOnElement(`${elementName} in the ${widgetName} widget`,
+        `we-select[data-name=${widgetName}] we-button:contains(${elementName})`));
     steps.push({
-        content: `Clicking on the ${elementName} in the ${widgetName} widget`,
-        trigger: `${we_select} we-button:contains("${elementName}")`,
-        run: "click",
-    });
-    steps.push({
-        content:
-            "Check we-select is set and wait a delay before continue the tour",
-        trigger: `${we_select}:contains(${elementName})`,
+        content: "Check we-select is set",
+        trigger: `we-select[data-name=${widgetName}]:contains(${elementName})`,
         async run() {
-            // fix underterministic error.
-            // When we-select is used twice a row too fast, the second we-select may not open.
-            // The first toggle is open, we click on it and almost at the same time, we click on the second one.
-            // There may be confusion with the active class.
-            // Add a delay before continue the tour solves this problem.
+            // TODO: remove this delay when macro.js has been fixed.
+            // This additionnal line fix an underterministic error.
+            // When we-select is used twice a row too fast,
+            // the second we-select may not open.
+            // The first toggle is open, we click on it and almost
+            // at the same time, we click on the second one.
+            // The problem comes from macro.js which does not give
+            // the DOM time to be stable before looking for the trigger.
+            // We add a delay to let the mutations take place and
+            // therefore wait for the DOM to stabilize.
             await new Promise((resolve) => setTimeout(resolve, 300));
-        },
+        }
     });
     return steps;
 }
@@ -456,6 +468,7 @@ function switchWebsite(websiteId, websiteName) {
 return {
     addMedia,
     assertCssVariable,
+    assertPathName,
     changeBackground,
     changeBackgroundColor,
     changeColumnSize,

--- a/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
@@ -75,15 +75,8 @@ wTourUtils.registerWebsitePreviewTour('add_to_cart_snippet_tour', {
             trigger: "div:contains(Choose a delivery method)",
             run: () => null,
         },
-        {
-            content: `Check if we have been redirected to /shop/payment`,
-            trigger: `button[name=o_payment_submit_button]`,
-            run: () => {
-                if (!window.location.pathname.startsWith("/shop/payment")) {
-                    console.error(`We should be on /shop/payment.`);
-                }
-            },
-        },
+        wTourUtils.assertPathName('/shop/payment', 'button[name=o_payment_submit_button]'),
+
         wsTourUtils.goToCart({quantity: 4, backend: false}),
         wsTourUtils.assertCartContains({productName: 'Acoustic Bloc Screens'}),
         wsTourUtils.assertCartContains({productName: 'Conference Chair (Steel)'}),


### PR DESCRIPTION
In this commit, we revert fd1d3f30521495acd6e1f73c1143c15116a1218e in which we removed a utility.
We take advantage of this commit to remove unnecessary steps, use camelcase instead of snakecase and to improve comments.