### PR TITLE
[FIX] html_editor: close the toolbar when no node is selected

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -4,6 +4,7 @@ import {
     isMediaElement,
     isProtected,
     isProtecting,
+    isTextNode,
     paragraphRelatedElements,
     previousLeaf,
 } from "@html_editor/utils/dom_info";
@@ -572,6 +573,10 @@ export class SelectionPlugin extends Plugin {
             (nodes) => {
                 const edgeNodes = getUnselectedEdgeNodes(selection);
                 return nodes.filter((node) => !edgeNodes.has(node));
+            },
+            // Filter whitespace
+            (nodes) => {
+                return nodes.filter((node) => !isTextNode(node) || node.textContent !== "\n");
             },
             // Custom modifiers
             ...(this.resources.modifyTraversedNodes || []),

--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -132,7 +132,7 @@ export class ToolbarPlugin extends Plugin {
         const isCollapsed = selectionData.editableSelection.isCollapsed;
 
         if (this.overlay.isOpen) {
-            if (!inEditable || isCollapsed) {
+            if (!inEditable || isCollapsed || !this.shared.getTraversedNodes().length) {
                 const preventClosing = selectionData.documentSelection?.anchorNode?.closest?.(
                     "[data-prevent-closing-overlay]"
                 );


### PR DESCRIPTION
Before this commit, it was possible to have an empty-looking selection that opened the toolbar. For example, when double-clicking at the end of a line.

Solution:
The toolbar is only opened if there is at least 1 traversedNode.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
