### PR TITLE
[FIX] project: fix tags search in tasks

### DIFF
--- a/addons/project/models/project_tags.py
+++ b/addons/project/models/project_tags.py
@@ -70,7 +70,7 @@ class ProjectTags(models.Model):
             # optimisation for large projects, we look first for tags present on the last 1000 tasks of said project.
             # when not enough results are found, we complete them with a fallback on a regular search
             tag_sql = SQL("""
-                SELECT DISTINCT project_tasks_tags.id
+                (SELECT DISTINCT project_tasks_tags.id
                 FROM (
                     SELECT rel.project_tags_id AS id
                     FROM project_tags_project_task_rel AS rel
@@ -80,7 +80,7 @@ class ProjectTags(models.Model):
                     ORDER BY task.id DESC
                     LIMIT 1000
                 ) AS project_tasks_tags
-            """, project_id=self.env.context['project_id'])
+            )""", project_id=self.env.context['project_id'])
             tags += self.search_fetch(expression.AND([[('id', 'in', tag_sql)], domain]), ['display_name'], limit=limit)
         if len(tags) < limit:
             tags += self.search_fetch(expression.AND([[('id', 'not in', tags.ids)], domain]), ['display_name'], limit=limit - len(tags))


### PR DESCRIPTION
Versions:
-------------
- master

Steps to Reproduce
--------------
- Install project.
- Create a project and create a task in it.
- Open the task and click on the tags field.

Issue
----------
- We get a traceback error.

Cause
------------
- The SQL query is missing the parentheses that is passed in the domain.

Fix
-----------
- With this fix, we add the parentheses.

Effected commit- https://github.com/odoo/odoo/commit/c2d47b976d1ac0eba6bd16add3d54f84e5e2d3d3

task-4172822