### PR TITLE
[IMP] base, *: simplify kanban archs

### DIFF
--- a/addons/account/views/account_payment_method.xml
+++ b/addons/account/views/account_payment_method.xml
@@ -17,10 +17,8 @@
         <field name="model">account.payment.method.line</field>
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile">
-                <t t-name="kanban-box">
-                    <div t-attf-class="oe_kanban_card">
-                        <field name="display_name"/>
-                    </div>
+                <t t-name="kanban-card">
+                    <field name="display_name"/>
                 </t>
             </kanban>
         </field>

--- a/addons/marketing_card/static/src/scss/card_campaign.scss
+++ b/addons/marketing_card/static/src/scss/card_campaign.scss
@@ -1,5 +1,5 @@
 .o_kanban_view .o_marketing_card_campaign_kanban {
-    .oe_kanban_action_a:hover > .badge {
+    a:hover > .badge {
         background-color: $o-brand-primary;
         color: white;
     }

--- a/addons/marketing_card/views/card_campaign_views.xml
+++ b/addons/marketing_card/views/card_campaign_views.xml
@@ -155,37 +155,26 @@
         <field name="arch" type="xml">
             <kanban sample="1">
                 <templates>
-                    <t t-name='kanban-box'>
-                        <div class='oe_kanban_content oe_kanban_global_click o_marketing_card_campaign_kanban'>
-                            <div class="oe_kanban_details">
-                                <div class="o_kanban_record_top">
-                                    <strong class="o_kanban_record_title">
-                                        <field name="name"/>
-                                    </strong>
-                                </div>
-
-                                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
-                                <div class="o_kanban_record_bottom">
-                                    <div class="oe_kanban_bottom_left">
-                                        <a data-type="object" data-name="action_view_cards_shared" href="#" class="oe_kanban_action oe_kanban_action_a me-1">
-                                             <span class="badge rounded-pill">
-                                                 <i class="fa fa-fw fa-share" aria-label="Shares" role="img" title="Shares"/>
-                                                 <field name="card_share_count"/>
-                                             </span>
-                                         </a>
-                                         <a data-type="object" data-name="action_view_cards_clicked" href="#" class="oe_kanban_action oe_kanban_action_a me-1">
-                                            <span class="badge rounded-pill">
-                                                <i class="fa fa-fw fa-mouse-pointer" aria-label="Clicks" role="img" title="Clicks"/>
-                                                <field name="target_url_click_count"/>
-                                            </span>
-                                        </a>
-                                    </div>
-                                    <div class="oe_kanban_bottom_right">
-                                        <field name="user_id" widget="many2one_avatar_user"/>
-                                    </div>
-                                </div>
+                    <t t-name="kanban-card" class="o_marketing_card_campaign_kanban">
+                        <field name="name" class="fw-bolder fs-5"/>
+                        <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" class="mt-2"/>
+                        <footer class="fs-6 pt-0">
+                            <div>
+                                <a data-type="object" data-name="action_view_cards_shared" href="#" class="me-1">
+                                    <span class="badge rounded-pill">
+                                        <i class="fa fa-fw fa-share" aria-label="Shares" role="img" title="Shares"/>
+                                        <field name="card_share_count"/>
+                                    </span>
+                                </a>
+                                <a data-type="object" data-name="action_view_cards_clicked" href="#" class="me-1">
+                                    <span class="badge rounded-pill">
+                                        <i class="fa fa-fw fa-mouse-pointer" aria-label="Clicks" role="img" title="Clicks"/>
+                                        <field name="target_url_click_count"/>
+                                    </span>
+                                </a>
                             </div>
-                        </div>
+                            <field name="user_id" class="ms-auto" widget="many2one_avatar_user"/>
+                        </footer>
                     </t>
                 </templates>
             </kanban>

--- a/addons/sale_pdf_quote_builder/views/quotation_document_views.xml
+++ b/addons/sale_pdf_quote_builder/views/quotation_document_views.xml
@@ -81,46 +81,22 @@
                             class="dropdown-item"
                         >Download</a>
                     </t>
-                    <t t-name="kanban-box">
-                        <div class="oe_kanban_global_area o_kanban_attachment">
-                            <div class="ribbon ribbon-top-right" invisible="active">
-                                <span class="text-bg-danger">Archived</span>
+                    <t t-name="kanban-card" class="o_kanban_attachment flex-row">
+                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
+                        <aside>
+                            <div class="o_image ms-3" t-att-data-mimetype="record.mimetype.value"/>
+                        </aside>
+                        <main class="ms-2">
+                            <field name="name" class="fw-bolder text-truncate"/>
+                            <div class="d-flex mt-2">
+                                <span>Document type:</span>
+                                <field name="document_type" class="ms-2" widget="selection"/>
                             </div>
-                            <div class="o_kanban_image">
-                                <div class="o_kanban_image_wrapper o_kanban_previewer">
-                                    <div
-                                        class="o_image o_image_thumbnail"
-                                        t-att-data-mimetype="record.mimetype.value"
-                                    />
-                                </div>
+                            <div t-if="!!record.quotation_template_ids.raw_value.length" class="mt-2">
+                                <span class="pe-2">Templates:</span>
+                                <field name="quotation_template_ids" class="d-inline-block" widget="many2many_tags"/>
                             </div>
-                            <div class="o_kanban_details h-100">
-                                <div class="o_kanban_details_wrapper h-100 justify-content-between">
-                                    <div class="o_kanban_record_title">
-                                        <field name="name" class="o_text_overflow"/>
-                                    </div>
-                                    <div class="o_kanban_record_bottom flex-column" name="bottom">
-                                        <div class="mt-2">
-                                            <span class="pe-2">Document type:</span>
-                                            <field
-                                                name="document_type" widget="selection"
-                                            />
-                                        </div>
-                                        <div
-                                            t-if="!!record.quotation_template_ids.raw_value.length"
-                                            class="mt-2"
-                                        >
-                                            <span class="pe-2">Templates:</span>
-                                            <field
-                                                name="quotation_template_ids"
-                                                class="d-inline-block"
-                                                widget="many2many_tags"
-                                            />
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        </main>
                     </t>
                 </templates>
             </kanban>

--- a/odoo/addons/base/views/res_device_views.xml
+++ b/odoo/addons/base/views/res_device_views.xml
@@ -48,43 +48,30 @@
             <field name="arch" type="xml">
                 <kanban create="false" default_order="is_current desc, last_activity desc">
                     <field name="id"/>
-                    <field name="display_name" string="Name"/>
                     <field name="device_type"/>
-                    <field name="country"/>
-                    <field name="city"/>
                     <field name="last_activity"/>
                     <field name="is_current"/>
                     <templates>
-                        <t t-name="kanban-box">
-                            <div class="oe_kanban_card oe_kanban_global_click">
-                                <div class="o_kanban_card_content d-flex">
-                                    <div>
-                                        <t t-if="record.device_type.raw_value === 'computer'">
-                                            <span class="fa fa-laptop fs-1" title="Computer" role="img" aria-label="Computer"/>
-                                        </t>
-                                        <t t-else="">
-                                            <span class="fa fa-mobile fs-1" title="Mobile" role="img" aria-label="Mobile"/>
-                                        </t>
-                                    </div>
-                                    <div class="oe_kanban_details d-flex flex-column ms-3">
-                                        <div class="d-flex align-items-center">
-                                            <strong class="o_kanban_title">
-                                                <field name="display_name" string="Name"/>
-                                            </strong>
-                                            <t t-if="record.is_current.raw_value">
-                                                <span class="ms-2 text-success o_status o_status_green"></span>
-                                            </t>
-                                        </div>
-                                        <field name="ip_address"/>
-                                        <field name="country"/>
-                                        <field name="city"/>
-                                        <t t-out="luxon.DateTime.fromISO(record.last_activity.raw_value).toRelative()"/>
-                                    </div>
-                                    <div class="o_kanban_button">
-                                        <button name="revoke" type="object" string="Revoke" class="btn btn-secondary"/>
-                                    </div>
+                        <t t-name="kanban-card" class="flex-row">
+                            <t t-if="record.device_type.raw_value === 'computer'">
+                                <span class="fa fa-laptop fs-1" title="Computer" role="img" aria-label="Computer"/>
+                            </t>
+                            <t t-else="">
+                                <span class="fa fa-mobile fs-1" title="Mobile" role="img" aria-label="Mobile"/>
+                            </t>
+                            <div class="d-flex flex-column ms-3">
+                                <div class="d-flex align-items-center">
+                                    <field name="display_name" string="Name" class="fw-bolder"/>
+                                    <t t-if="record.is_current.raw_value">
+                                        <span class="ms-2 text-success o_status o_status_green"></span>
+                                    </t>
                                 </div>
+                                <field name="ip_address"/>
+                                <field name="country"/>
+                                <field name="city"/>
+                                <t t-out="luxon.DateTime.fromISO(record.last_activity.raw_value).toRelative()"/>
                             </div>
+                            <button name="revoke" type="object" string="Revoke" class="btn btn-secondary ms-auto mt-auto"/>
                         </t>
                     </templates>
                 </kanban>
@@ -95,7 +82,7 @@
             <field name="name">User Devices</field>
             <field name="res_model">res.device</field>
             <field name="path">user-device</field>
-            <field name="view_id" ref="res_device_view_tree"/>
+            <field name="view_mode">list,kanban,form</field>
         </record>
         <menuitem action="action_user_device" id="menu_action_user_device" parent="base.menu_security" sequence="10"/>
 


### PR DESCRIPTION
* = [account, marketing_card, sale_pdf_quote_builder]

In this commit we have simplified the kanban arch for the base, account, marketing_card and sale_pdf_quote_builder modules. The goal is to simplify them, make them easier to read, and use bootstrap utility classnames.

- Previously, we used `kanban-box`, but now we are using `kanban-card` instead.
- Deprecated `oe_kanban_global_click` and `oe_kanban_global_click_edit`.
- More use of `<field/>` tags
- Removed the `oe_kanban_colorpicker` class and replaced it with the `kanban_color_picker` widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- `kanban_image` from rendering context, is deprecated so we use `<field name=... widget=image/>` instead

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
