### PR TITLE
[FIX] web_editor: fix traceback when user upload having no name

### DIFF
--- a/addons/web_editor/static/src/components/upload_progress_toast/upload_service.js
+++ b/addons/web_editor/static/src/components/upload_progress_toast/upload_service.js
@@ -121,7 +121,7 @@ export const uploadService = {
                             file.progress = 100;
                         });
                         const attachment = await rpc('/web_editor/attachment/add_data', {
-                            'name': file.name,
+                            'name': file.name || '',
                             'data': dataURL.split(',')[1],
                             'res_id': resId,
                             'res_model': resModel,
@@ -147,7 +147,7 @@ export const uploadService = {
                                 ctx.drawImage(image, 0, 0);
                                 const altDataURL = canvas.toDataURL('image/jpeg', 0.75);
                                 await rpc('/web_editor/attachment/add_data', {
-                                    'name': file.name.replace(/\.webp$/, '.jpg'),
+                                    'name': attachment.name.replace(/\.webp$/, '.jpg'),
                                     'data': altDataURL.split(',')[1],
                                     'res_id': attachment.id,
                                     'res_model': 'ir.attachment',


### PR DESCRIPTION
Currently, a traceback may arise when the user uploads a file with no name.

Error:-
```
TypeError: Web_Editor.add_data() missing 1 required positional argument: 'name'
```

When the value of the `name` we get from the RPC call is `undefined`, we get this traceback on the backend.

If there is no `name`, this case is already  handled in the python side https://github.com/odoo/odoo/blob/6838782baf222db4591edce5fe80f5af3a39810c/addons/web_editor/controllers/main.py#L261-L266

So by just giving the fallback value if there is no name, we can resolve this issue.

sentry-5741581459

