### PR TITLE
[FIX] portal: remove tabindex on skip to content link

### DIFF
--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -6,7 +6,7 @@
             <attribute name="t-attf-class" add="#{'o_portal' if is_portal else ''}" separator=" "/>
         </xpath>
         <xpath expr="//div[@id='wrapwrap']/header" position="before">
-            <a class="o_skip_to_content btn btn-primary rounded-0 visually-hidden-focusable position-absolute start-0" href="#wrap" tabindex="2" groups="!base.group_user">Skip to Content</a>
+            <a class="o_skip_to_content btn btn-primary rounded-0 visually-hidden-focusable position-absolute start-0" href="#wrap" groups="!base.group_user">Skip to Content</a>
         </xpath>
         <xpath expr="//div[@id='wrapwrap']/header/img" position="replace">
             <t t-cache="res_company">


### PR DESCRIPTION
Commit [17e55872] added a "Skip to content" link for general accessibility concerns on the website (namely: make it possible to skip the menu links for people who browse the page with tab and for people who use assistive tools - which is a level A requirement, see [WCAG documentation]).
However, the `tabindex` on it is not needed as the link is added at the top of the DOM, and is therefore the first focused element by default. It can also conflict with other focusable elements on the page if different tabindex are set on those.

[17e55872]: https://github.com/odoo/odoo/commit/17e5587275f6b8ece9004993a7642394dfcdfef6
[WCAG documentation]: https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks.html

task-4176181