### PR TITLE
[FIX] website: fix double escaping in meta default_title

### DIFF
--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -495,8 +495,8 @@ class WithContext(HttpCase):
         # -------------------------------------------
         r = self.url_open(home_url)
         self.assertEqual(r.status_code, 200)
-        self.assertNotIn(b'<title> My Portal', r.content)
-        self.assertIn(b'<title> Contact Us', r.content)
+        self.assertNotIn(b'<title>My Portal', r.content)
+        self.assertIn(b'<title>Contact Us', r.content)
         self.assertURLEqual(r.url, contactus_url_full)
         self.assertEqual(r.history[0].status_code, 303)
         # Now with /contactus which is a public content
@@ -509,8 +509,8 @@ class WithContext(HttpCase):
         })
         r = self.url_open(home_url)
         self.assertEqual(r.status_code, 200)
-        self.assertNotIn(b'<title> My Portal', r.content)
-        self.assertIn(b'<title> Login', r.content)
+        self.assertNotIn(b'<title>My Portal', r.content)
+        self.assertIn(b'<title>Login', r.content)
         self.assertIn('/web/login?redirect', r.url)
         self.assertEqual(r.history[0].status_code, 303)
 

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -103,7 +103,7 @@
             <t t-if="not additional_title and main_object and 'name' in main_object">
                 <t t-set="additional_title" t-value="main_object.name"/>
             </t>
-            <t t-set="default_title" t-translation="off"> <t t-if="additional_title"><t t-out="additional_title"/> | </t><t t-out="(website or res_company).name"/> </t>
+            <t t-set="default_title" t-translation="off" t-value="(additional_title + ' | ' if additional_title else '') + (website or res_company).name"/>
             <t t-set="seo_object" t-value="seo_object or main_object"/>
             <t t-if="seo_object and 'website_meta_title' in seo_object and seo_object.website_meta_title">
                 <t t-set="title" t-value="seo_object.website_meta_title"/>


### PR DESCRIPTION
Since [1] the meta tag 'default_title' was double-escaped due to improper handling of dynamic content within the template, leading to HTML entities being escaping twice. For example, `&#34;` was incorrectly transformed into `&amp34;`

Steps to reproduce:

- Open a product and modify its name by adding a special character, such as a single quote.
- Open the "Optimize SEO" dialog.

Issue: The default title displays `&#39;` instead of the single quote.

This commit resolves this issue and at the same time gets rid of the
trailing spaces.

[1] https://github.com/odoo/odoo/commit/7c54acaebe38e47cad25d8a1bbdb430e5bad265d

task-3974334
