### PR TITLE
[FIX] base: report rendered twice

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4993,9 +4993,10 @@ class AccountMove(models.Model):
         if self.invoice_pdf_report_id:
             attachments = self.env['account.move.send']._get_invoice_extra_attachments(self)
         else:
-            content, _ = self.env['ir.actions.report']._pre_render_qweb_pdf('account.account_invoices', self.ids, data={'proforma': True})
+            content, report_type = self.env['ir.actions.report']._pre_render_qweb_pdf('account.account_invoices', self.ids, data={'proforma': True})
+            content_by_id = self.env['ir.actions.report']._get_splitted_report('account.account_invoices', content, report_type)
             attachments = self.env['ir.attachment'].new({
-                'raw': content[self.id],
+                'raw': content_by_id[self.id],
                 'name': self._get_invoice_proforma_pdf_report_filename(),
                 'mimetype': 'application/pdf',
                 'res_model': self._name,

--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -414,12 +414,13 @@ class AccountMoveSend(models.TransientModel):
             ids = [inv.id for inv in group_invoices_data]
 
             pdf_report = self.env['ir.actions.report'].browse(pdf_report_id)
-            content, _report_type = self.env['ir.actions.report'].with_company(company_id)._pre_render_qweb_pdf(pdf_report.report_name, res_ids=ids)
+            content, report_type = self.env['ir.actions.report'].with_company(company_id)._pre_render_qweb_pdf(pdf_report.report_name, res_ids=ids)
+            content_by_id = self.env['ir.actions.report']._get_splitted_report(pdf_report.report_name, content, report_type)
 
             for invoice, invoice_data in group_invoices_data.items():
                 invoice_data['pdf_attachment_values'] = {
                     'name': invoice._get_invoice_report_filename(),
-                    'raw': content[invoice.id],
+                    'raw': content_by_id[invoice.id],
                     'mimetype': 'application/pdf',
                     'res_model': invoice._name,
                     'res_id': invoice.id,
@@ -433,10 +434,11 @@ class AccountMoveSend(models.TransientModel):
         :param invoice_data:    The collected data for the invoice so far.
         """
         pdf_report = self.env['ir.actions.report'].browse(invoice_data['pdf_report_id'])
-        content, _report_format = self.env['ir.actions.report'].with_company(invoice.company_id)._pre_render_qweb_pdf(pdf_report.report_name, invoice.ids, data={'proforma': True})
+        content, report_type = self.env['ir.actions.report'].with_company(invoice.company_id)._pre_render_qweb_pdf(pdf_report.report_name, invoice.ids, data={'proforma': True})
+        content_by_id = self.env['ir.actions.report']._get_splitted_report(pdf_report.report_name, content, report_type)
 
         invoice_data['proforma_pdf_attachment_values'] = {
-            'raw': content[invoice.id],
+            'raw': content_by_id[invoice.id],
             'name': invoice._get_invoice_proforma_pdf_report_filename(),
             'mimetype': 'application/pdf',
             'res_model': invoice._name,

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -981,7 +981,6 @@ class IrActionsReport(models.Model):
         if report_type != 'pdf':
             return collected_streams, report_type
 
-        collected_streams = self._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
         has_duplicated_ids = res_ids and len(res_ids) != len(set(res_ids))
 
         # access the report details with sudo() but keep evaluation context as current user


### PR DESCRIPTION
Since changes made in https://github.com/odoo/odoo/pull/167729, collected streams is returned by '_pre_render_qweb_pdf', so we don't need anymore to call '_render_qweb_pdf_prepare_streams' as it is already called in '_pre_render_qweb_pdf'.

By removing the second call, we inporve the speed to generate a report by 2.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
