### PR TITLE
[FIX] html_editor: retry refresh selection when it fails to show avatar

### DIFF
--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -187,6 +187,7 @@ export class DeletePlugin extends Plugin {
             this.includeEndOrStartBlock,
         ]);
         range = this.deleteRange(range);
+        this.document.getSelection()?.removeAllRanges();
         this.setCursorFromRange(range, { collapseToEnd: true });
     }
 

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -439,7 +439,7 @@ export class SelectionPlugin extends Plugin {
         const selection = this.document.getSelection();
         const documentSelectionIsInEditable = selection && this.isSelectionInEditable(selection);
         if (selection) {
-            if (documentSelectionIsInEditable) {
+            if (documentSelectionIsInEditable || selection.anchorNode === null) {
                 if (
                     selection.anchorNode !== anchorNode ||
                     selection.focusNode !== focusNode ||
@@ -500,6 +500,7 @@ export class SelectionPlugin extends Plugin {
      * @returns {Cursors}
      */
     preserveSelection() {
+        const hadSelection = this.document.getSelection().anchorNode !== null;
         const selectionData = this.getSelectionData();
         const selection = selectionData.editableSelection;
         const anchor = { node: selection.anchorNode, offset: selection.anchorOffset };
@@ -507,6 +508,9 @@ export class SelectionPlugin extends Plugin {
 
         return {
             restore: () => {
+                if (!hadSelection) {
+                    return;
+                }
                 this.setSelection(
                     {
                         anchorNode: anchor.node,

--- a/addons/html_editor/static/src/others/collaboration/collaboration_selection_avatar_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_selection_avatar_plugin.js
@@ -19,7 +19,7 @@ import { user } from "@web/core/user";
 export const AVATAR_SIZE = 25;
 
 export class CollaborationSelectionAvatarPlugin extends Plugin {
-    static id = "collaboration_selection_avatar";
+    static id = "collaborationSelectionAvatar";
     static dependencies = ["history", "position", "localOverlay", "collaborationOdoo"];
     resources = {
         /** Handlers */
@@ -76,7 +76,7 @@ export class CollaborationSelectionAvatarPlugin extends Plugin {
         const { avatarUrl, peerName = _t("Anonymous") } = peerMetadata;
         const anchorNode = this.dependencies.history.getNodeById(selection.anchorNodeId);
         const focusNode = this.dependencies.history.getNodeById(selection.focusNodeId);
-        if (!anchorNode || !focusNode) {
+        if (!anchorNode || !focusNode || !anchorNode.isConnected || !focusNode.isConnected) {
             return;
         }
         const anchorBlock = closestBlock(anchorNode);

--- a/addons/html_editor/static/tests/odoo_collaboration.test.js
+++ b/addons/html_editor/static/tests/odoo_collaboration.test.js
@@ -1152,3 +1152,32 @@ describe("History steps Ids", () => {
         editor.destroy();
     });
 });
+
+describe("Selection", () => {
+    test("Selection should be updated for peer after delete backward", async () => {
+        const pool = await createPeers(["p1", "p2"]);
+        // editor content : <p>a</p>
+        const peers = pool.peers;
+        await peers.p1.focus(); // <p>a[]</p>
+        await peers.p2.focus();
+        await peers.p1.openDataChannel(peers.p2);
+        await animationFrame();
+        await new Promise((resolve) => setTimeout(resolve));
+        expect(
+            peers.p2.plugins.collaborationSelectionAvatar.selectionInfos.get("p1").selection
+                .anchorOffset
+        ).toBe(1);
+        expect(
+            peers.p2.plugins.collaborationSelection.selectionInfos.get("p1").selection.anchorOffset
+        ).toBe(1);
+        peers.p1.plugins.delete.delete("backward", "character");
+        advanceTime(100);
+        expect(
+            peers.p2.plugins.collaborationSelectionAvatar.selectionInfos.get("p1").selection
+                .anchorOffset
+        ).toBe(0);
+        expect(
+            peers.p2.plugins.collaborationSelection.selectionInfos.get("p1").selection.anchorOffset
+        ).toBe(0);
+    });
+});


### PR DESCRIPTION
Issue:
======
Collaborator avator disappears after delete

Steps to reproduce the issue:
=============================
- Open to do with 2 browsers
- Write 2 lines
- Put the selection of one in first line
- Put the selection of the other in the second line
- Select all the second line and delete
- The avatar of the collaborator you delete with will disappear from the
  others view.

Origin of the issue:
====================
`selectionchange` on document isn't triggered because :
- The delete doesn't trigger it by default from the browser.
- In `setSelection` in `selection_plugin` we only trigger the
  `selectionchange`  by the line of `setBaseAndExtent` which is not
  triggered when the line is empty because the document selection is the
  `p` element and the given selection from the parameters is also the
  `p` element. In the other case where there is some text left, the
  document have the text node as anchor node while the given params have
  the p element so we change the selection and we trigger
  `selectionchange`.

We need `selectionchange` to be triggered because it calls
`onSelectionChange`  which we use to notify the peers that our selection
is changed and dispath the `oe_history_set_selection` command.

So after this flow, the peer selection isn't changed and the avatar
disappears because `oe_history_step` will call `onExternalHistorySteps`
and then will call `refreshSelection` in the avatar plugin which will
update the position and image of the collaborator. Since the text
element is deleted and we don't have a new selection, `drawPeerAvatar`
will find the node by its id but it's not connected to the dom so it
will exit in the `anchorBlock` if condition.

Solution:
=========
We remove ranges and then we put selection again to force trigger the
selectionchange.

task-4166179w