### PR TITLE
[IMP] website: introduce `s_cards_soft` snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -58,6 +58,7 @@
         'views/snippets/s_alert.xml',
         'views/snippets/s_motto.xml',
         'views/snippets/s_card.xml',
+        'views/snippets/s_cards_soft.xml',
         'views/snippets/s_share.xml',
         'views/snippets/s_social_media.xml',
         'views/snippets/s_rating.xml',

--- a/addons/website/views/snippets/s_cards_soft.xml
+++ b/addons/website/views/snippets/s_cards_soft.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_cards_soft" name="Cards Soft">
+    <section class="s_cards_soft o_cc o_cc1 pt48 pb32">
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-12">
+                    <h2 style="text-align: center;">Your Journey Begins Here</h2>
+                    <p class="lead" style="text-align: center;">We make every moment count with solutions designed just for you.</p>
+                </div>
+                <div data-name="Card" class="col-lg-4 pt16 pb16">
+                    <div class="s_card card o_cc o_cc2" data-vxml="001" data-snippet="s_card" data-name="Card" style="border-width: 0px !important;">
+                        <div class="card-body">
+                            <h5 class="card-title">Innovative Ideas</h5>
+                            <p class="card-text">Our creativity is at the forefront of everything we do, delivering innovative solutions that make your project stand out while maintaining a balance between originality and functionality.</p>
+                            <img class="img img-fluid rounded" src="/web/image/website.s_three_columns_default_image_1" alt=""/>
+                        </div>
+                    </div>
+                </div>
+                <div data-name="Card" class="col-lg-4 pt16 pb16">
+                    <div class="s_card card o_cc o_cc2" data-vxml="001" data-snippet="s_card" data-name="Card" style="border-width: 0px !important;">
+                        <div class="card-body">
+                            <h5 class="card-title">Comprehensive Support</h5>
+                            <p class="card-text">From the initial stages to completion, we offer support every step of the way, ensuring you feel confident in your choices and that your project is a success.</p>
+                            <img class="img img-fluid rounded" src="/web/image/website.s_three_columns_default_image_2" alt=""/>
+                        </div>
+                    </div>
+                </div>
+                <div data-name="Card" class="col-lg-4 pt16 pb16">
+                    <div class="s_card card o_cc o_cc2" data-vxml="001" data-snippet="s_card" data-name="Card" style="border-width: 0px !important;">
+                        <div class="card-body">
+                            <h5 class="card-title">Timeless Quality</h5>
+                            <p class="card-text">Our services are built to last, ensuring that every solution we provide is of the highest quality, bringing lasting value to your investment and ultimate customer satisfaction.</p>
+                            <img class="img img-fluid rounded" src="/web/image/website.s_three_columns_default_image_3" alt=""/>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -101,6 +101,9 @@
                 <t t-snippet="website.s_key_images" string="Key Images" group="columns">
                     <keywords>columns, gallery, pictures, photos, media, text, content, album, showcase, visuals, portfolio, arrangement, collection, visual-grid, split, alignment, added value</keywords>
                 </t>
+                <t t-snippet="website.s_cards_soft" string="Cards Soft" group="columns">
+                    <keywords>description, containers, layouts, structures, multi-columns, modules, boxes, content, picture, photo, illustration, media, visual, article, story, combination, showcase, announcement, reveal</keywords>
+                </t>
 
                 <!-- Content group -->
                 <t t-snippet="website.s_text_image" string="Text - Image" group="content">
@@ -606,7 +609,7 @@
              which the s_card options should be bound (instead of the s_card).
              Note: defined here to be set above all the other options that might
              need it. -->
-        <t t-set="card_parent_handlers" t-value="'.s_three_columns .row > div, .s_comparisons .row > div'"/>
+        <t t-set="card_parent_handlers" t-value="'.s_three_columns .row > div, .s_comparisons .row > div, .s_cards_soft .row > div'"/>
 
         <!-- Binding the option on the snippet if it is not a s_card with a
              handler parent -->


### PR DESCRIPTION
This commit adds the new `s_cards_soft` snippet.

task-4104941
Part-of: task-4077427

| New snippet: Cards Soft |
|--------|
| ![image](https://github.com/user-attachments/assets/a5b0c0c6-cadc-4bca-9227-e8584b9353d6) | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
