### PR TITLE
[IMP] account: Added a view button on each line of the tax group list

### DIFF
--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -234,7 +234,7 @@
             <field name="name">account.tax.group.list</field>
             <field name="model">account.tax.group</field>
             <field name="arch" type="xml">
-                <list string="Account Tax Group" editable="bottom" create="false">
+                <list string="Account Tax Group" editable="bottom" create="false" open_form_view="True">
                     <field name="sequence" widget="handle"/>
                     <field name="name"/>
                     <field name="country_id"/>


### PR DESCRIPTION
When we are in debug mode, we get the view button as optional hide from the account.tax.group list view. It made no sense to keep it that way.
Instead of keeping it like that it has been concluded to keep it visible anytime.

task-4170673

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
