### PR TITLE
[IMP] sale: enable tracking of the "locked" field in the chatter

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -73,7 +73,11 @@ class SaleOrder(models.Model):
         readonly=True, copy=False, index=True,
         tracking=3,
         default='draft')
-    locked = fields.Boolean(default=False, copy=False, help="Locked orders cannot be modified.")
+    locked = fields.Boolean(
+        help="Locked orders cannot be modified.",
+        default=False,
+        copy=False,
+        tracking=True)
     has_archived_products = fields.Boolean(compute="_compute_has_archived_products")
 
     client_order_ref = fields.Char(string="Customer Reference", copy=False)


### PR DESCRIPTION
Before this commit :
The locked field  was not tracked in the chatter.
As a result, changes to this field were not visible in the activity log.

After this commit :
The locked field is now tracked in the chatter.

task-4133451