### PR TITLE
[IMP] account: Removed unused mark_as_reconciled function

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -522,10 +522,6 @@ class ResPartner(models.Model):
                 """, (partner.id,))
             partner.has_unreconciled_entries = self.env.cr.rowcount == 1
 
-    def mark_as_reconciled(self):
-        self.env['account.partial.reconcile'].check_access_rights('write')
-        return self.sudo().write({'last_time_entries_checked': time.strftime(DEFAULT_SERVER_DATETIME_FORMAT)})
-
     def _get_company_currency(self):
         for partner in self:
             if partner.company_id:


### PR DESCRIPTION
The function mark_as_reconciled of res.partner was not used in the code, so it could be removed.

task-4085127



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
