### PR TITLE
[FIX] html_editor: TablePlugin is more extendable

### DIFF
--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -102,10 +102,15 @@ export class TablePlugin extends Plugin {
         }
     }
 
-    insertTable({ rows = 2, cols = 2 } = {}) {
+    createTable({ rows = 2, cols = 2 } = {}) {
         const tdsHtml = new Array(cols).fill("<td><p><br></p></td>").join("");
         const trsHtml = new Array(rows).fill(`<tr>${tdsHtml}</tr>`).join("");
         const tableHtml = `<table class="table table-bordered o_table"><tbody>${trsHtml}</tbody></table>`;
+        return parseHTML(this.document, tableHtml);
+    }
+
+    _insertTable({ rows = 2, cols = 2 } = {}) {
+        const newTable = this.createTable({ rows, cols });
         let sel = this.shared.getEditableSelection();
         if (!sel.isCollapsed) {
             this.dispatch("DELETE_SELECTION", sel);
@@ -123,7 +128,11 @@ export class TablePlugin extends Plugin {
                 { normalize: false }
             );
         }
-        const [table] = this.shared.domInsert(parseHTML(this.document, tableHtml));
+        const [table] = this.shared.domInsert(newTable);
+        return table;
+    }
+    insertTable({ rows = 2, cols = 2 } = {}) {
+        const table = this._insertTable({ rows, cols });
         this.dispatch("ADD_STEP");
         this.shared.setCursorStart(table.querySelector("p"));
     }


### PR DESCRIPTION
Before this commit, the TablePlugin created the table, inserted in the DOM and triggered an history step all in the same method.

This commit, factorizes those three operations to be able to customize from the outside (via inheritance) the look of the table.

task-4166611

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
