### PR TITLE
[FIX] l10n_ec_website_sale: remove unneeded test inheritance

### DIFF
--- a/addons/l10n_ec_website_sale/tests/test_l10n_ec_website_sale.py
+++ b/addons/l10n_ec_website_sale/tests/test_l10n_ec_website_sale.py
@@ -1,16 +1,21 @@
 from odoo.tests.common import HttpCase, tagged
-from odoo.addons.l10n_ec_edi.tests.common import TestEcEdiCommon
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 
 @tagged('post_install_l10n', 'post_install', '-at_install')
-class TestUi(HttpCase, TestEcEdiCommon):
+class TestUi(HttpCase, AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
     def test_checkout_address_ec(self):
+        self.env.company.country_id = self.env.ref('base.ec').id
         self.env.ref('base.user_admin').write({
             'company_id': self.env.company.id,
             'company_ids': [(4, self.env.company.id)],
         })
-        self.env.company = self.company_data['company']
         self.env['product.product'].create({
             'name': 'Test Product',
             'sale_ok': True,


### PR DESCRIPTION
Issues:
The test I created here had an inheritance which was in enterprise, as pointed by gawa https://github.com/odoo/odoo/pull/168930#issuecomment-2340200503

Solution:
Correct the test to remove the inheritance.

opw-3921156