### PR TITLE
[MERGE][IMP] web_hierarchy: improve hierarchy view

### DIFF
--- a/addons/hr/models/hr_employee_base.py
+++ b/addons/hr/models/hr_employee_base.py
@@ -159,7 +159,7 @@ class HrEmployeeBase(models.AbstractModel):
         working_now_list = employee_to_check_working._get_employee_working_now()
         for employee in self:
             state = 'out_of_working_hour'
-            if employee.company_id.hr_presence_control_login:
+            if employee.company_id.sudo().hr_presence_control_login:
                 if 'online' in str(employee.user_id.im_status):
                     state = 'present'
                 elif 'offline' in str(employee.user_id.im_status) and employee.id in working_now_list:

--- a/addons/hr/models/hr_employee_base.py
+++ b/addons/hr/models/hr_employee_base.py
@@ -272,6 +272,11 @@ class HrEmployeeBase(models.AbstractModel):
             employee.is_flexible = employee.is_fully_flexible or employee.resource_calendar_id.flexible_hours
 
     @api.model
+    def search_panel_select_range(self, field_name, **kwargs):
+        # make sure all the companies/departments accessible by the current user are visible in the search panel since the user can see employees in other companies.
+        return super(HrEmployeeBase, self.with_context(allowed_company_ids=self.env.user._get_company_ids())).search_panel_select_range(field_name, **kwargs)
+
+    @api.model
     def _get_employee_working_now(self):
         working_now = []
         # We loop over all the employee tz and the resource calendar_id to detect working hours in batch.

--- a/addons/hr/security/hr_security.xml
+++ b/addons/hr/security/hr_security.xml
@@ -25,32 +25,10 @@
         <field name="groups_id" eval="[(4,ref('group_hr_manager'))]"/>
     </record>
 
-    <record id="hr_employee_comp_rule" model="ir.rule">
-        <field name="name">Employee multi company rule</field>
-        <field name="model_id" ref="model_hr_employee"/>
-        <field name="domain_force">['|', '|', '|',
-            ('company_id', 'in', company_ids + [False]),
-            ('parent_id.user_id', '=', user.id),
-            ('id', '=', user.employee_id.parent_id.id),
-            ('user_id', '=', user.id)
-        ]</field>
-    </record>
-
     <record id="hr_dept_comp_rule" model="ir.rule">
         <field name="name">Department multi company rule</field>
         <field name="model_id" ref="model_hr_department"/>
         <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
-    </record>
-
-    <record id="hr_employee_public_comp_rule" model="ir.rule">
-        <field name="name">Employee multi company rule</field>
-        <field name="model_id" ref="model_hr_employee_public"/>
-        <field name="domain_force">['|', '|', '|',
-            ('company_id', 'in', company_ids + [False]),
-            ('parent_id.user_id', '=', user.id),
-            ('id', '=', user.employee_id.parent_id.id),
-            ('user_id', '=', user.id)
-        ]</field>
     </record>
 
     <record id="hr_job_comp_rule" model="ir.rule">

--- a/addons/hr/tests/test_multi_company.py
+++ b/addons/hr/tests/test_multi_company.py
@@ -1,12 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.hr.tests.common import TestHrCommon
-from odoo.addons.base.models.ir_qweb import QWebException
-
-from odoo.addons.mail.tests.common import mail_new_test_user
-
-from odoo.exceptions import AccessError
 
 
 class TestMultiCompanyReport(TestHrCommon):
@@ -36,64 +30,3 @@ class TestMultiCompanyReport(TestHrCommon):
         )._render_qweb_pdf('hr.hr_employee_print_badge', res_ids=self.employees.ids)
         self.assertIn(b'Bidule', content)
         self.assertIn(b'Machin', content)
-
-    def test_single_company_report(self):
-        with self.assertRaises(QWebException):  # CacheMiss followed by AccessError
-            self.env['ir.actions.report'].with_user(self.res_users_hr_officer).with_company(
-                self.company_1
-            )._render_qweb_pdf('hr.hr_employee_print_badge', res_ids=self.employees.ids)
-
-
-class TestMultiCompany(TestHrCommon):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-
-        cls.company_a = cls.env['res.company'].create({'name': 'Company A'})
-        cls.company_b = cls.env['res.company'].create({'name': 'Company B'})
-
-        cls.user_a = mail_new_test_user(cls.env, login='user_a', company_id=cls.company_a.id, company_ids=(cls.company_a | cls.company_b).ids)
-        cls.user_b = mail_new_test_user(cls.env, login='user_b', company_id=cls.company_b.id)
-
-        cls.employee_a = cls.env['hr.employee'].create({
-            'name': 'Employee A',
-            'company_id': cls.company_a.id,
-            'user_id': cls.user_a.id,
-        })
-
-        cls.employee_other_a = cls.env['hr.employee'].create({
-            'name': 'Employee Other A',
-            'company_id': cls.company_a.id,
-        })
-
-        cls.employee_b = cls.env['hr.employee'].create({
-            'name': 'Employee B',
-            'company_id': cls.company_b.id,
-            'user_id': cls.user_b.id,
-            'parent_id': cls.employee_a.id,
-        })
-
-        cls.employee_other_b = cls.env['hr.employee'].create({
-            'name': 'Employee Other B',
-            'company_id': cls.company_b.id,
-        })
-
-        cls.env.flush_all()
-        cls.env.invalidate_all()
-
-    def test_read_manager_employee(self):
-        # UserB should be able to read its manager's record - without being connected
-        # on company A
-        self.employee_a.with_user(self.user_b).with_company(self.company_b).name
-
-        self.employee_b.with_user(self.user_a).with_company(self.company_a).name
-
-        # UserB should not be able to read other employees in that company
-        with self.assertRaises(AccessError):
-            self.employee_other_a.with_user(self.user_b).with_company(self.company_b).name
-
-    def test_read_no_manager_company(self):
-        self.employee_b.parent_id = False
-
-        with self.assertRaises(AccessError):
-            self.employee_a.with_user(self.user_b).name

--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -8,7 +8,7 @@
             <field name="arch" type="xml">
                 <search string="Employees">
                     <field name="name" string="Employees" filter_domain="['|',('work_email','ilike',self),('name','ilike',self)]"/>
-                    <searchpanel>
+                    <searchpanel view_types="kanban,list,graph,pivot,hierarchy">
                         <field name="company_id" groups="base.group_multi_company" icon="fa-building" enable_counters="1"/>
                         <field name="department_id" icon="fa-users" enable_counters="1"/>
                     </searchpanel>

--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -167,7 +167,7 @@
         <record id="hr_employee_public_action" model="ir.actions.act_window">
             <field name="name">Employees</field>
             <field name="res_model">hr.employee.public</field>
-            <field name="domain">[('company_id', 'in', allowed_company_ids)]</field>
+            <field name="domain">[]</field>
             <field name="context">{'chat_icon': True}</field>
             <field name="view_id" eval="False"/>
             <field name="search_view_id" ref="hr_employee_public_view_search"/>

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -9,7 +9,7 @@
                 <search string="Employees">
                     <field name="name" string="Employee" filter_domain="['|', ('work_email', 'ilike', self), ('name', 'ilike', self)]"/>
                     <field name="department_id"/>
-                    <searchpanel>
+                    <searchpanel view_types="kanban,list,graph,pivot,hierarchy">
                         <field name="company_id" groups="base.group_multi_company" icon="fa-building" enable_counters="1"/>
                         <field name="department_id" icon="fa-users" enable_counters="1"/>
                     </searchpanel>

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -388,7 +388,7 @@
             <field name="name">Employees</field>
             <field name="path">employees</field>
             <field name="res_model">hr.employee</field>
-            <field name="domain">[('company_id', 'in', allowed_company_ids)]</field>
+            <field name="domain">[]</field>
             <field name="context">{'chat_icon': True}</field>
             <field name="view_id" eval="False"/>
             <field name="search_view_id" ref="view_employee_filter"/>

--- a/addons/hr_org_chart/tests/test_employee.py
+++ b/addons/hr_org_chart/tests/test_employee.py
@@ -1,9 +1,9 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests import tagged
 
 from odoo.addons.hr.tests.common import TestHrCommon
+
 
 @tagged('-at_install', 'post_install')
 class TestEmployee(TestHrCommon):
@@ -57,53 +57,59 @@ class TestEmployee(TestHrCommon):
     def test_hierarchy_read(self):
         HrEmployee = self.env['hr.employee']
         employees = self.employee_georges + self.employee_paul + self.employee_pierre
-        result = HrEmployee.hierarchy_read([('id', 'in', employees.ids)], ['id'], 'parent_id')
+        specification = {'id': {}}
+
+        def get_expected_dict(employee):
+            return {
+                'id': employee.id,
+                'parent_id':
+                    employee.parent_id.id
+                    and {'id': employee.parent_id.id, 'display_name': employee.parent_id.display_name},
+            }
+
+        result = HrEmployee.hierarchy_read([('id', 'in', employees.ids)], specification, 'parent_id')
         for emp in employees:
-            self.assertIn({'id': emp.id, 'parent_id': False}, result)
+            self.assertIn(get_expected_dict(emp), result)
 
         self.employee_georges.parent_id = self.employee_paul
         self.employee_pierre.parent_id = self.employee_paul
-        result = HrEmployee.hierarchy_read([('id', 'in', employees.ids)], ['id'], 'parent_id')
+        result = HrEmployee.hierarchy_read([('id', 'in', employees.ids)], specification, 'parent_id')
         self.assertEqual(len(result), 3)
         for emp in employees:
-            emp_dict = {'id': emp.id, 'parent_id': emp.parent_id.id and (emp.parent_id.id, emp.parent_id.display_name)}
+            emp_dict = get_expected_dict(emp)
             if not emp.parent_id:
                 emp_dict['__child_ids__'] = [self.employee_georges.id, self.employee_pierre.id]
             self.assertIn(emp_dict, result)
 
         employee_count = HrEmployee.search_count([('id', 'not in', employees.ids), ('parent_id', '=', False)])
-        result = HrEmployee.hierarchy_read([('parent_id', '=', False)], ['id'], 'parent_id')
+        result = HrEmployee.hierarchy_read([('parent_id', '=', False)], specification, 'parent_id')
         self.assertEqual(len(result), 1 + employee_count)
         for employee_dict in result:
             self.assertFalse(employee_dict['parent_id'], "Each employee in the result should not have any parent set.")
-        self.assertIn({'id': self.employee_paul.id, 'parent_id': False, '__child_ids__': [self.employee_georges.id, self.employee_pierre.id]}, result)
+        expected_emp_dict = get_expected_dict(self.employee_paul)
+        self.assertIn(
+            {**expected_emp_dict, '__child_ids__': [self.employee_georges.id, self.employee_pierre.id]},
+            result
+        )
 
-        result = HrEmployee.hierarchy_read([('id', '=', self.employee_paul.id)], ['id'], 'parent_id')
+        result = HrEmployee.hierarchy_read([('id', '=', self.employee_paul.id)], specification, 'parent_id')
+        self.assertEqual(len(result), 3)
+
+        for emp in employees:
+            self.assertIn(get_expected_dict(emp), result)
+
+        result = HrEmployee.hierarchy_read([('id', '=', self.employee_georges.id)], specification, 'parent_id')
         self.assertEqual(len(result), 3)
         for emp in employees:
-            emp_dict = {'id': emp.id, 'parent_id': emp.parent_id.id and (emp.parent_id.id, emp.parent_id.display_name)}
-            self.assertIn(emp_dict, result)
-
-        result = HrEmployee.hierarchy_read([('id', '=', self.employee_georges.id)], ['id'], 'parent_id')
-        self.assertEqual(len(result), 3)
-        for emp in employees:
-            emp_dict = {'id': emp.id, 'parent_id': emp.parent_id.id and (emp.parent_id.id, emp.parent_id.display_name)}
-            self.assertIn(emp_dict, result)
+            self.assertIn(get_expected_dict(emp), result)
 
         self.employee_pierre.parent_id = self.employee_georges
-        result = HrEmployee.hierarchy_read([('id', '=', self.employee_georges.id)], ['id'], 'parent_id')
+        result = HrEmployee.hierarchy_read([('id', '=', self.employee_georges.id)], specification, 'parent_id')
         self.assertEqual(len(result), 3)
         for emp in employees:
-            emp_dict = {'id': emp.id, 'parent_id': emp.parent_id.id and (emp.parent_id.id, emp.parent_id.display_name)}
-            self.assertIn(emp_dict, result)
+            self.assertIn(get_expected_dict(emp), result)
 
-        result = HrEmployee.hierarchy_read([('id', '=', self.employee_pierre.id)], ['id'], 'parent_id')
+        result = HrEmployee.hierarchy_read([('id', '=', self.employee_pierre.id)], specification, 'parent_id')
         self.assertEqual(len(result), 2)
-        self.assertIn(
-            {'id': self.employee_pierre.id, 'parent_id': (self.employee_georges.id, self.employee_georges.name)},
-            result
-        )
-        self.assertIn(
-            {'id': self.employee_georges.id, 'parent_id': (self.employee_paul.id, self.employee_paul.name)},
-            result
-        )
+        self.assertIn(get_expected_dict(self.employee_pierre), result)
+        self.assertIn(get_expected_dict(self.employee_georges), result)

--- a/addons/web_hierarchy/static/src/hierarchy_card.xml
+++ b/addons/web_hierarchy/static/src/hierarchy_card.xml
@@ -2,7 +2,7 @@
 <templates>
 
     <t t-name="web_hierarchy.HierarchyCard">
-        <div class="o_hierarchy_node_container mb-4 d-flex flex-column" t-att-class="classNames" t-att-data-node-id="props.node.id">
+        <div class="o_hierarchy_node_container d-flex flex-column" t-att-class="classNames" t-att-data-node-id="props.node.id">
             <div class="o_hierarchy_node_button_container w-100 d-flex justify-content-end">
                 <button t-if="props.node.parentResId !== false and !props.node.parentNode"
                         name="hierarchy_search_parent_node"

--- a/addons/web_hierarchy/static/src/hierarchy_card.xml
+++ b/addons/web_hierarchy/static/src/hierarchy_card.xml
@@ -4,7 +4,7 @@
     <t t-name="web_hierarchy.HierarchyCard">
         <div class="o_hierarchy_node_container d-flex flex-column" t-att-class="classNames" t-att-data-node-id="props.node.id">
             <div class="o_hierarchy_node_button_container w-100 d-flex justify-content-end">
-                <button t-if="props.node.parentResId !== false and !props.node.parentNode"
+                <button t-if="props.node.canShowParentNode"
                         name="hierarchy_search_parent_node"
                         class="btn p-0"
                         t-on-click.synthetic="onClickArrowUp"

--- a/addons/web_hierarchy/static/src/hierarchy_controller.js
+++ b/addons/web_hierarchy/static/src/hierarchy_controller.js
@@ -5,6 +5,7 @@ import { Component, useRef } from "@odoo/owl";
 import { useBus } from "@web/core/utils/hooks";
 import { useModel } from "@web/model/model";
 import { addFieldDependencies, extractFieldsFromArchInfo } from "@web/model/relational_model/utils";
+import { useSetupAction } from "@web/search/action_hook";
 import { CogMenu } from "@web/search/cog_menu/cog_menu";
 import { Layout } from "@web/search/layout";
 import { SearchBar } from "@web/search/search_bar/search_bar";
@@ -36,7 +37,9 @@ export class HierarchyController extends Component {
             additionalFields.push({ name: childFieldName });
         }
         addFieldDependencies(activeFields, fields, additionalFields);
+        const modelConfig = this.props.state?.modelState?.config || {};
         this.model = useModel(this.props.Model, {
+            config: modelConfig,
             resModel: this.props.resModel,
             activeFields,
             defaultOrderBy: this.props.archInfo.defaultOrder,
@@ -55,6 +58,14 @@ export class HierarchyController extends Component {
             beforeExecuteAction: this.beforeExecuteActionButton.bind(this),
             afterExecuteAction: this.afterExecuteActionButton.bind(this),
             reload: this.model.reload.bind(this.model),
+        });
+        useSetupAction({
+            rootRef: this.rootRef,
+            getLocalState: () => {
+                return {
+                    modelState: this.model.exportState(),
+                };
+            },
         });
         this.searchBarToggler = useSearchBarToggler();
     }

--- a/addons/web_hierarchy/static/src/hierarchy_controller.js
+++ b/addons/web_hierarchy/static/src/hierarchy_controller.js
@@ -31,7 +31,11 @@ export class HierarchyController extends Component {
         this.rootRef = useRef("root");
         const { parentFieldName, childFieldName } = this.props.archInfo;
         const { activeFields, fields } = extractFieldsFromArchInfo(this.props.archInfo, this.props.fields);
-        addFieldDependencies(activeFields, fields, [{ name: parentFieldName }]);
+        const additionalFields = [{ name: parentFieldName }];
+        if (childFieldName) {
+            additionalFields.push({ name: childFieldName });
+        }
+        addFieldDependencies(activeFields, fields, additionalFields);
         this.model = useModel(this.props.Model, {
             resModel: this.props.resModel,
             activeFields,

--- a/addons/web_hierarchy/static/src/hierarchy_model.js
+++ b/addons/web_hierarchy/static/src/hierarchy_model.js
@@ -603,7 +603,7 @@ export class HierarchyModel extends Model {
         const data = await this.keepLast.add(this._loadData({ ...config, resIds }));
         this.root = this._createRoot(config, data);
         this.config = config;
-        this.notify();
+        this.notify({ scrollTarget: "none" });
     }
 
     /**
@@ -785,6 +785,12 @@ export class HierarchyModel extends Model {
     isSearchDefaultOrEmpty() {
         if (!this.env.searchModel) {
             return true;
+        }
+        if (this.env.searchModel.display?.searchPanel) {
+            const searchPanelDomain = this.env.searchModel._getSearchPanelDomain();
+            if (searchPanelDomain.toList(this.env.searchModel.context).length) {
+                return false;
+            }
         }
         const isDisabledOptionalSearchMenuType = (type) => {
             return (

--- a/addons/web_hierarchy/static/src/hierarchy_model.js
+++ b/addons/web_hierarchy/static/src/hierarchy_model.js
@@ -667,7 +667,7 @@ export class HierarchyModel extends Model {
             );
             parentNode.createChildNodes();
             node.setParentNode(parentNode);
-            this.notify();
+            this.notify({ scrollTarget: "up" });
         }
     }
 

--- a/addons/web_hierarchy/static/src/hierarchy_model.js
+++ b/addons/web_hierarchy/static/src/hierarchy_model.js
@@ -964,6 +964,9 @@ export class HierarchyModel extends Model {
                 (childResId) => !excludeResIds.includes(childResId)
             );
         }
+        if (!childrenResIds.length) {
+            return [];
+        }
         const { records } = await this.orm.webSearchRead(
             this.resModel,
             [["id", "in", childrenResIds]],

--- a/addons/web_hierarchy/static/src/hierarchy_model.js
+++ b/addons/web_hierarchy/static/src/hierarchy_model.js
@@ -139,6 +139,7 @@ export class HierarchyNode {
     get canShowParentNode() {
         return (
             Boolean(this.parentResId) &&
+            this.parentResId !== this.resId &&
             !this.parentNode &&
             this.tree.forest.resIds.filter((resId) => resId === this.resId).length === 1
         );
@@ -689,7 +690,10 @@ export class HierarchyModel extends Model {
                 if (existingChildResIds.length) {
                     // special case with result found with the search view
                     for (const tree of this.root.trees) {
-                        if (existingChildResIds.includes(tree.root.resId)) {
+                        if (
+                            existingChildResIds.includes(tree.root.resId) &&
+                            tree.root.id !== node.id
+                        ) {
                             nodesToUpdate.push(tree.root);
                         }
                     }

--- a/addons/web_hierarchy/static/src/hierarchy_model.js
+++ b/addons/web_hierarchy/static/src/hierarchy_model.js
@@ -325,8 +325,6 @@ export class HierarchyNode {
      * @param {HierarchyNode} node parent node to set
      */
     setParentNode(node) {
-        this.parentNode = node;
-        node.addChildNode(this);
         const tree = node.tree;
         if (tree.root === this) {
             tree.root = node;
@@ -334,6 +332,8 @@ export class HierarchyNode {
             this.tree.removeRoot();
             this.setTree(node.tree);
         }
+        this.parentNode = node;
+        node.addChildNode(this);
     }
 
     setTree(tree) {

--- a/addons/web_hierarchy/static/src/hierarchy_renderer.js
+++ b/addons/web_hierarchy/static/src/hierarchy_renderer.js
@@ -97,11 +97,11 @@ export class HierarchyRenderer extends Component {
     }
 
     get rows() {
-        const rootNodes = this.props.model.root.rootNodes.filter((n) => !n.hidden);
+        const rootNodes = this.props.model.root.rootNodes;
         const rows = [{ nodes: rootNodes }];
         const processNode = (node) => {
-            if (!node.isLeaf) {
-                const subNodes = node.nodes.filter((n) => !n.hidden);
+            const subNodes = node.nodes;
+            if (subNodes.length) {
                 rows.push({ parentNode: node, nodes: subNodes });
                 for (const subNode of subNodes) {
                     processNode(subNode);
@@ -109,7 +109,7 @@ export class HierarchyRenderer extends Component {
             }
         };
 
-        for (const node of this.props.model.root.rootNodes) {
+        for (const node of rootNodes) {
             processNode(node);
         }
 

--- a/addons/web_hierarchy/static/src/hierarchy_renderer.js
+++ b/addons/web_hierarchy/static/src/hierarchy_renderer.js
@@ -70,17 +70,21 @@ export class HierarchyRenderer extends Component {
     }
 
     onPatched() {
-        if (this.scrollTarget === "none") {
-            return;
+        let row;
+        switch (this.scrollTarget) {
+            case "none":
+                return;
+            case "bottom":
+                row = this.rendererRef.el.querySelector(":scope .o_hierarchy_row:last-child");
+                break;
+            case "up":
+                row = this.rendererRef.el.querySelector(":scope .o_hierarchy_row:first-child");
+                break;
+            default:
+                row = this.rendererRef.el
+                    .querySelector(`:scope .o_hierarchy_node[data-node-id="${this.scrollTarget}"]`)
+                    ?.closest(".o_hierarchy_row");
         }
-        const row =
-            this.scrollTarget === "bottom"
-                ? this.rendererRef.el.querySelector(":scope .o_hierarchy_row:last-child")
-                : this.rendererRef.el
-                      .querySelector(
-                          `:scope .o_hierarchy_node[data-node-id="${this.scrollTarget}"]`
-                      )
-                      ?.closest(".o_hierarchy_row");
         this.scrollTarget = "none";
         if (!row) {
             return;

--- a/addons/web_hierarchy/static/src/hierarchy_renderer.scss
+++ b/addons/web_hierarchy/static/src/hierarchy_renderer.scss
@@ -18,8 +18,6 @@ $o-chart-line-color: #ababb1;
 
         .o_hierarchy_separator {
             position: relative;
-            margin-top: 10px;
-            margin-bottom: 10px;
             width: 100%;
 
             .o_hierarchy_line_left {

--- a/addons/web_hierarchy/static/src/hierarchy_renderer.xml
+++ b/addons/web_hierarchy/static/src/hierarchy_renderer.xml
@@ -3,7 +3,7 @@
 
     <t t-name="web_hierarchy.HierarchyRenderer">
         <div class="o_hierarchy_renderer w-100 d-flex justify-content-center" t-ref="renderer">
-            <div class="o_hierarchy_container d-flex flex-column w-100 w-lg-75 h-100 pt-5 px-2">
+            <div class="o_hierarchy_container d-flex flex-column w-100 w-lg-75 h-100 p-2">
                 <t t-foreach="rows" t-as="row" t-key="row_index">
                     <t t-set="previousRow" t-value="!row_first ? rows[row_index - 1] : null"/>
                     <t t-if="!row_first">
@@ -12,12 +12,12 @@
                         >
                             <span t-esc="row.parentNode.data.display_name || row.parentNode.data.name" />
                         </div>
-                        <div class="o_hierarchy_separator d-flex pb-4">
+                        <div class="o_hierarchy_separator d-flex">
                             <div class="o_hierarchy_line_part o_hierarchy_line_left"></div>
                             <div class="o_hierarchy_line_part o_hierarchy_line_right"></div>
                         </div>
                     </t>
-                    <div class="o_hierarchy_row row justify-content-center flex-wrap row-cols-2 row-cols-lg-5 g-2 g-lg-3 pt-3"
+                    <div class="o_hierarchy_row row justify-content-center flex-wrap row-cols-2 row-cols-lg-5 g-2 g-lg-3"
                         t-att-class="{ 'pb-4': row_last }" t-att-data-parent-node-id="row.parentNode?.id"
                         t-att-data-row-id="row_index"
                     >

--- a/addons/web_hierarchy/static/tests/hierarchy_view.test.js
+++ b/addons/web_hierarchy/static/tests/hierarchy_view.test.js
@@ -1520,4 +1520,6 @@ test("Avoid fetching subnodes if those subnodes are already in the view", async 
         "Georges\nAlbert",
         "Josephine\nAlbert",
     ]);
+    // The button to show the subnodes should be displayed for Georges and Josephine
+    expect(".o_hierarchy_node_button.btn-primary").toHaveCount(2);
 });

--- a/addons/web_hierarchy/static/tests/hierarchy_view.test.js
+++ b/addons/web_hierarchy/static/tests/hierarchy_view.test.js
@@ -1427,3 +1427,54 @@ test("Keep the same hierarchy state when we go back to the view with the breadcr
         "Louis\nJosephine",
     ]);
 });
+
+test("Keep the state of the branch when we open another branch in the same level", async () => {
+    Employee._records.push(
+        { id: 5, name: "Jean", parent_id: 2, child_ids: [6] },
+        { id: 6, name: "Claude", parent_id: 5, child_ids: [] }
+    );
+    // check we keep in cache the previous branch to avoid fetching again the same data
+    await mountView({
+        resModel: "hr.employee",
+        type: "hierarchy",
+    });
+    expect(".o_hierarchy_view").toHaveCount(1);
+    expect(".o_hierarchy_row").toHaveCount(2);
+    expect(queryAllTexts(".o_hierarchy_node_content")).toEqual([
+        "Albert",
+        "Georges\nAlbert",
+        "Josephine\nAlbert",
+    ]);
+    await contains(".o_hierarchy_node_button.btn-primary:eq(0)").click();
+    expect(queryAllTexts(".o_hierarchy_node_content")).toEqual([
+        "Albert",
+        "Georges\nAlbert",
+        "Josephine\nAlbert",
+        "Jean\nGeorges",
+    ]);
+    await contains(".o_hierarchy_node_button.btn-primary:eq(1)").click();
+    expect(queryAllTexts(".o_hierarchy_node_content")).toEqual([
+        "Albert",
+        "Georges\nAlbert",
+        "Josephine\nAlbert",
+        "Jean\nGeorges",
+        "Claude\nJean",
+    ]);
+    expect(".o_hierarchy_node_button.btn-primary").toHaveCount(1);
+    await contains(".o_hierarchy_node_button.btn-primary").click();
+    expect(queryAllTexts(".o_hierarchy_node_content")).toEqual([
+        "Albert",
+        "Georges\nAlbert",
+        "Josephine\nAlbert",
+        "Louis\nJosephine",
+    ]);
+    expect(".o_hierarchy_node_button.btn-primary").toHaveCount(1);
+    await contains(".o_hierarchy_node_button.btn-primary").click();
+    expect(queryAllTexts(".o_hierarchy_node_content")).toEqual([
+        "Albert",
+        "Georges\nAlbert",
+        "Josephine\nAlbert",
+        "Jean\nGeorges",
+        "Claude\nJean",
+    ]);
+});

--- a/addons/web_hierarchy/static/tests/hierarchy_view.test.js
+++ b/addons/web_hierarchy/static/tests/hierarchy_view.test.js
@@ -120,7 +120,7 @@ test("load hierarchy view", async () => {
 });
 
 test("display child nodes", async () => {
-    onRpc("search_read", () => {
+    onRpc("web_search_read", () => {
         expect.step("get child data");
     });
     onRpc("read_group", () => {
@@ -164,7 +164,7 @@ test("display child nodes", async () => {
 });
 
 test("display child nodes with child_field set on the view", async () => {
-    onRpc("search_read", () => {
+    onRpc("web_search_read", () => {
         expect.step("get child data with descendants");
     });
     await mountView({


### PR DESCRIPTION
## Purpose

The goal of this task is 
- to follow the convention implemented in the other views when we fetch the data by giving a specification of fields instead of a list of fields.
- improve the UI to reduce the space around the different hierarchy levels to be able to see at least 3 levels of hierarchy if possible.
- restore the state of the hierarchy when the user goes to the form view and go back to the hierarchy view. Without that, the user had to refetched the subordinates to be able to see the hierarchy view he left when he clicked to a card to go to the form view of the record contained in the card clicked.
- keep in cache the nodes fetched when the user navigates in the hierarchy because if the user does not drag and drop a node, we can assume the hierarchy does not change. 
- makes sure the search panel is managed in the hierarchy view.
- allow to the internal user to see all employees in all companies.
- improve the UI and the performance of the hierarchy view (by avoiding to do useless npc call for instance)
- (Employee app only) display the search panel in all views of employee except the activity view.
- (Employee app only) display all companies accessible by the current user in the search panel.

### Implementation details

The different commits apply the following changes:

- update the hierarchy model to use the web_read,
  web_search_read methods as the other views, by doing that we can easily
  fetch the fields needed for the relational fields thanks to the fields
  specification given in parameter. It also updates the hierarchy_read to
  give fields specification instead of a list of fields to be consistent
  with the other methods to load data in views.
- reduce the padding and the margin to be sure to be able to
  see 3 levels of hierarchy on a big screen.
- store in the localState the records fetched in the
  localState to be able to get the same view as he left when he goes to
  the form view.
- keep the state of a branch when the user goes
  to another branch to avoid forcing him to fetch again the records since
  we can assume the records don't force frequently. However, if the user
  would like to reload a branch, he can click on the button to collapse
  the sub nodes and click to the button to show the same sub nodes. By
  doing that, the sub nodes will be fetched instead of toggle hidden
  property of descendant nodes.
- allow to display the search panel in all views of employees 
  (`hr.employee`,     `hr.employee.public` models) except of the activity 
  since it is not really needed in that view.
- makes sure the search panel is taken into account to make
  sure the hierarchy_read rpc is not called twice for nothing.
- make sure to scroll up when fetching manager (if needed).
- remove the multi company rule defined in `hr.employee` and `hr.employee.public` to 
  allow the user to see the employees in any companies.
- avoid doing an rpc in hierarchy view to fetch subordinates when the domain is falsy.
- display all companies available by the current user in the search panel of employee
  app (`hr.employee` and `hr.employee.public` models) are
  the ones accessible by the current user even if he does not select them
  since he can now see all employees in all companies thanks to the multi
  company rule removed for `hr.employee` and `hr.employee.public` models.

task-4149953