### PR TITLE
[FIX] project_purchase: treat refund as negative cost in profitability

### DIFF
--- a/addons/project_purchase/models/project_project.py
+++ b/addons/project_purchase/models/project_project.py
@@ -133,7 +133,7 @@ class Project(models.Model):
                         percentage for ids, percentage in line.analytic_distribution.items()
                         if str(self.analytic_account_id.id) in ids.split(',')
                     ) / 100.
-                    cost = price_subtotal * analytic_contribution
+                    cost = price_subtotal * analytic_contribution * (-1 if line.is_refund else 1)
                     if line.parent_state == 'posted':
                         amount_invoiced -= cost
                     else:


### PR DESCRIPTION
Versions
--------
- saas-17.2+

Steps
-----
1. Enable analytic accounting;
2. create a project with a new analytic account;
3. create a purchase order with a line linked to the analytic account;
4. confirm order;
5. create bill, add bill date, confirm bill;
6. click the "Credit Note" button;
7. confirm the credit note to reverse the bill;
8. go to project profitability panel.

Issue
-----
Instead of reversing the project's costs, the credit note doubled them.

Cause
-----
Commit 9c14dfdf2302 changed the retrieval of profitability costs from purchase orders to vendor bills. In doing so, it assumed each move line's listed amount to be a cost.

Solution
--------
If the line has `is_refund` set, multiply the cost by -1.

opw-4100220