### PR TITLE
[FIX] website_payment: skip donation test when demo data is unavailable

### DIFF
--- a/addons/website_payment/tests/test_snippets.py
+++ b/addons/website_payment/tests/test_snippets.py
@@ -1,9 +1,15 @@
 import odoo
 import odoo.tests
+import logging
+
+_logger = logging.getLogger(__name__)
 
 
 @odoo.tests.common.tagged('post_install', '-at_install')
 class TestSnippets(odoo.tests.HttpCase):
 
     def test_01_donation(self):
+        if not odoo.tests.loaded_demo_data(self.env):
+            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
+            return
         self.start_tour("/?enable_editor=1", "donation_snippet_edition", login='admin')


### PR DESCRIPTION
The donation test relies on a complete payment flow using demo data. 
To avoid failures in environments without demo data, the test is now 
skipped when demo data is not loaded. This adjustment ensures accurate 
test results and prevents unnecessary failures in such environments.

**During FW to 16:**
Add check to be sure that payment_demo is available
```python
payment_demo = self.env['ir.module.module']._get('payment_demo')
if payment_demo.state != 'installed':
    self.skipTest("payment_demo module is not installed")
```

runbot-76571