### PR TITLE
[IMP] hw_drivers: open kiosk via action

### DIFF
--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -344,14 +344,11 @@ class PosConfig(models.Model):
             session.set_opening_control(0, "")
             self._notify('STATUS', {'status': 'open'})
 
-        ctx = dict(self._context, app_id='pos_self_order', footer=False)
-
         return {
-            'res_model': 'pos.config',
-            'type': 'ir.actions.client',
-            'tag': 'install_kiosk_pwa',
+            'type': 'ir.actions.act_url',
+            'name': _('Self Order'),
             'target': 'new',
-            'context': ctx
+            'url': self.get_kiosk_url(),
         }
 
     def get_kiosk_url(self):


### PR DESCRIPTION
When clicking on "Start" on a self order PoS, an action is triggered via websocket to display the self order on 
the IoT Box display.

Enterprise PR: [https://github.com/odoo/enterprise/pull/69771](https://github.com/odoo/enterprise/pull/69771)
Task: 4166305