### PR TITLE
[FIX] website: adapt `s_image_gallery` lightbox

### DIFF
--- a/addons/website/static/src/snippets/s_image_gallery/000.js
+++ b/addons/website/static/src/snippets/s_image_gallery/000.js
@@ -60,14 +60,16 @@ const GalleryWidget = publicWidget.Widget.extend({
         };
 
         const milliseconds = this.el.dataset.interval || false;
-        this.$modal = $(renderToElement('website.gallery.slideshow.lightbox', {
+        const lightboxTemplate = this.$target[0].dataset.vcss === '002' ? 'website.gallery.s_image_gallery_mirror.lightbox' : 'website.gallery.slideshow.lightbox';
+        let params = {
             images: imageEls,
             index: currentImageIndex,
             dim: dimensions,
             interval: milliseconds || 0,
             ride: !milliseconds ? "false" : "carousel",
             id: uniqueId("slideshow_"),
-        }));
+        }
+        this.$modal = $(renderToElement(lightboxTemplate, params));
         this.__onModalKeydown = this._onModalKeydown.bind(this);
         this.$modal.on('hidden.bs.modal', function () {
             $(this).hide();

--- a/addons/website/static/src/snippets/s_image_gallery/001.xml
+++ b/addons/website/static/src/snippets/s_image_gallery/001.xml
@@ -26,4 +26,18 @@
             </div>
         </div>
     </t>
+
+    <t t-name="website.gallery.s_image_gallery_mirror.lightbox">
+        <div role="dialog" class="modal o_technical_modal fade s_gallery_lightbox p-0" aria-label="Image Gallery Dialog" tabindex="-1">
+            <div class="modal-dialog m-0" role="Picture Gallery"
+                t-attf-style="">
+                <div class="modal-content bg-transparent modal-fullscreen">
+                    <main class="modal-body o_slideshow bg-transparent">
+                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close" style="position: absolute; right: 10px; top: 10px;"></button>
+                        <t t-call="website.s_image_gallery_mirror"/>
+                    </main>
+                </div>
+            </div>
+        </div>
+    </t>
 </templates>

--- a/addons/website/static/src/snippets/s_image_gallery/002.scss
+++ b/addons/website/static/src/snippets/s_image_gallery/002.scss
@@ -329,3 +329,61 @@
         }
     }
 }
+
+.s_gallery_lightbox {
+    .modal-dialog {
+        height: 100%;
+        background-color: rgba(0,0,0,0.7);
+    }
+    @include media-breakpoint-up(sm) {
+        .modal-dialog {
+            max-width: 100%;
+            padding: 0;
+        }
+    }
+    div.carousel-indicators {
+        display: none;
+    }
+
+    .modal-body.o_slideshow {
+        @extend %image-gallery-slideshow-styles;
+    }
+}
+
+%image-gallery-slideshow-styles {
+    &:not(.s_image_gallery_cover) .carousel-item {
+        > a {
+            display: flex;
+            height: 100%;
+            width: 100%;
+        }
+        > a > img,
+        > img {
+            max-height: 100%;
+            max-width: 100%;
+            margin: auto;
+        }
+    }
+    .carousel {
+        height: 100%;
+
+        .carousel-inner {
+            height: 100%;
+        }
+        .carousel-item.active,
+        .carousel-item-next,
+        .carousel-item-prev,
+        .carousel-control-next,
+        .carousel-control-prev {
+            display: flex;
+            align-items: center;
+            height: 100%;
+        }
+        .carousel-control-next,
+        .carousel-control-prev {
+            .fa, .oi {
+                text-shadow: 0px 0px 3px $gray-800;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Since the redesign of `s_image_gallery` in 9042b1cae7b630b20e0670788b7a4ed9e4c97609, the style of `s_image_wall` lightbox was broken.

This commit adapts this lightbox following the redesign of `s_image_gallery` and reintroduces the missing styles.

task-4176685

| Before | After |
|--------|--------|
| <img width="1775" alt="Capture d’écran 2024-09-10 à 13 47 55" src="https://github.com/user-attachments/assets/72fa6829-def5-4d44-bdec-22bf3683502b"> | <img width="1789" alt="Capture d’écran 2024-09-10 à 13 48 46" src="https://github.com/user-attachments/assets/5305cf51-6123-49ae-9378-a6f9fa0193b6"> |




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
