### PR TITLE
[FIX] sale: missing view in generic SO action

### DIFF
--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -954,6 +954,20 @@
         </field>
     </record>
 
+    <record id="sale_order_action_view_quotation_tree" model="ir.actions.act_window.view">
+        <field name="sequence" eval="1"/>
+        <field name="view_mode">tree</field>
+        <field name="view_id" ref="sale.view_quotation_tree_with_onboarding"/>
+        <field name="act_window_id" ref="action_quotations_with_onboarding"/>
+    </record>
+
+    <record id="sale_order_action_view_quotation_kanban" model="ir.actions.act_window.view">
+        <field name="sequence" eval="2"/>
+        <field name="view_mode">kanban</field>
+        <field name="view_id" ref="sale.view_quotation_kanban_with_onboarding"/>
+        <field name="act_window_id" ref="action_quotations_with_onboarding"/>
+    </record>
+
     <record id="action_quotations" model="ir.actions.act_window">
         <field name="name">Quotations</field>
         <field name="res_model">sale.order</field>
@@ -977,18 +991,18 @@
         </field>
     </record>
 
-    <record id="sale_order_action_view_quotation_tree" model="ir.actions.act_window.view">
+    <record id="action_quotations_tree" model="ir.actions.act_window.view">
         <field name="sequence" eval="1"/>
         <field name="view_mode">tree</field>
-        <field name="view_id" ref="sale.view_quotation_tree_with_onboarding"/>
-        <field name="act_window_id" ref="action_quotations_with_onboarding"/>
+        <field name="view_id" ref="sale.view_quotation_tree"/>
+        <field name="act_window_id" ref="action_quotations"/>
     </record>
 
-    <record id="sale_order_action_view_quotation_kanban" model="ir.actions.act_window.view">
+    <record id="action_quotations_kanban" model="ir.actions.act_window.view">
         <field name="sequence" eval="2"/>
         <field name="view_mode">kanban</field>
-        <field name="view_id" ref="sale.view_quotation_kanban_with_onboarding"/>
-        <field name="act_window_id" ref="action_quotations_with_onboarding"/>
+        <field name="view_id" ref="sale.view_sale_order_kanban"/>
+        <field name="act_window_id" ref="action_quotations"/>
     </record>
 
     <record id="sale_order_action_view_quotation_form" model="ir.actions.act_window.view">


### PR DESCRIPTION
By mistake, commit f4b617f1ce1e21ea3ff478c3d09681ec6ab01165 updated the existing act_window views of the `action_quotations` instead of creating new ones for the updated `action_quotations_with_onboarding`.

This caused an issue in `sale_crm`, where the 'My quotations' menu uses this specific action, which had no specified tree and kanban view anymore.

This commit resurrects those two act_window view for the action_quotations, but under another xml id (since it breaks to do the opposite in stable).

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
