### PR TITLE
[FIX] point_of_sale: prevent creation of empty order during syncAllOrders

### DIFF
--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import odoo
+from uuid import uuid4
 
 from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
 from odoo.tests import Form
@@ -477,7 +478,8 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
              {'amount': 10,
               'name': fields.Datetime.now(),
               'payment_method_id': self.main_pos_config.payment_method_ids[0].id}]],
-           'user_id': self.env.uid
+           'user_id': self.env.uid,
+           'uuid': str(uuid4()),
             }
 
         self.env['pos.order'].sync_from_ui([pos_order])

--- a/addons/pos_self_order/tests/test_frontend.py
+++ b/addons/pos_self_order/tests/test_frontend.py
@@ -62,6 +62,7 @@ class TestFrontendMobile(SelfOrderCommonTest):
                         "lines": [],
                         "tracking_number": None,
                         "takeaway": True,
+                        "uuid": str(uuid4()),
                     },
                     "table_identifier": None,
                 }


### PR DESCRIPTION
Since 63a14fd0cad1bcf2eca80e38ca09cd00e9c78008, lines of pos.order are synced
with orm commands, e.g. adding a new line will assign `[0, 0, [line_vals]]` to
the `lines` field when calling `serialize`. Because of this, the heuristics we
introduced in the `sync_from_ui` that compares the order-being-synced to the
existing-order no longer works (and will not work). Keeping the logic will
create empty order during call for `sync_from_ui`. We're now removing the
heuristics, such that when we try to sync an order that already exists, we
ignore it.

Enterprise: https://github.com/odoo/enterprise/pull/69778

