### PR TITLE
[IMP] mail: add link preview settings

### DIFF
--- a/addons/mail/controllers/link_preview.py
+++ b/addons/mail/controllers/link_preview.py
@@ -31,3 +31,15 @@ class LinkPreviewController(http.Controller):
         if not link_preview_sudo.message_id.is_current_user_or_guest_author and not guest.env.user._is_admin():
             return
         link_preview_sudo._hide_and_notify()
+
+    @http.route("/mail/settings/link_preview_html", methods=["POST"], type="json", auth="user")
+    def setting_link_preview_html(self, link_preview_html: bool):
+        record = request.env['res.users.settings']._find_or_create_for_user(request.env.user)
+        record.link_preview_html = link_preview_html
+        record._bus_send("res.users.settings", {"link_preview_html": link_preview_html})
+
+    @http.route("/mail/settings/link_preview_image", methods=["POST"], type="json", auth="user")
+    def setting_link_preview_image(self, link_preview_image: bool):
+        record = request.env['res.users.settings']._find_or_create_for_user(request.env.user)
+        record.link_preview_image = link_preview_image
+        record._bus_send("res.users.settings", {"link_preview_image": link_preview_image})

--- a/addons/mail/data/ir_actions_client.xml
+++ b/addons/mail/data/ir_actions_client.xml
@@ -7,6 +7,12 @@
             <field name="target">new</field>
             <field name="context">{"dialog_size": "medium", "footer": false}</field>
         </record>
+        <record id="mail.link_preview_settings_action" model="ir.actions.client">
+            <field name="name">Link Preview Settings</field>
+            <field name="tag">mail.link_preview_settings_action</field>
+            <field name="target">new</field>
+            <field name="context">{"dialog_size": "medium", "footer": false}</field>
+        </record>
         <record id="mail.discuss_call_settings_action" model="ir.actions.client">
             <field name="name">Voice &amp; Video Settings</field>
             <field name="tag">mail.discuss_call_settings_action</field>

--- a/addons/mail/models/res_users_settings.py
+++ b/addons/mail/models/res_users_settings.py
@@ -22,6 +22,8 @@ class ResUsersSettings(models.Model):
         help="This setting will only be applied to channels. Mentions only if not specified.",
     )
     mute_until_dt = fields.Datetime(string="Mute notifications until", index=True, help="If set, the user will not receive notifications from all the channels until this date.")
+    link_preview_image = fields.Boolean(string="Generate link preview for link to an image", default=True)
+    link_preview_html = fields.Boolean(string="Generate link preview for non-image links", default=False)
 
     @api.model
     def _cleanup_expired_mutes(self):

--- a/addons/mail/static/src/core/common/link_preview_list.js
+++ b/addons/mail/static/src/core/common/link_preview_list.js
@@ -1,6 +1,7 @@
 import { LinkPreview } from "@mail/core/common/link_preview";
 
-import { Component } from "@odoo/owl";
+import { Component, useState } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
 
 /**
  * @typedef {Object} Props
@@ -15,4 +16,21 @@ export class LinkPreviewList extends Component {
         deletable: false,
     };
     static components = { LinkPreview };
+
+    setup() {
+        super.setup();
+        this.store = useState(useService("mail.store"));
+    }
+
+    get linkPreviewList() {
+        return this.props.linkPreviews.filter((linkPreview) => {
+            if (linkPreview.isImage && this.store.settings.link_preview_image) {
+                return true;
+            }
+            if (!linkPreview.isImage && this.store.settings.link_preview_html) {
+                return true;
+            }
+            return false;
+        });
+    }
 }

--- a/addons/mail/static/src/core/common/link_preview_list.xml
+++ b/addons/mail/static/src/core/common/link_preview_list.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.LinkPreviewList">
-        <div class="o-mail-LinkPreviewList d-flex flex-column mt-2" t-att-class="{ 'me-2 pe-4': env.inChatWindow and !env.alignedRight, 'ms-2 ps-4': env.inChatWindow and env.alignedRight }">
+        <div t-if="this.store.hasLinkPreviewFeature and linkPreviewList.length" class="o-mail-LinkPreviewList d-flex flex-column mt-2" t-att-class="{ 'me-2 pe-4': env.inChatWindow and !env.alignedRight, 'ms-2 ps-4': env.inChatWindow and env.alignedRight }">
             <div class="d-flex flex-grow-1 flex-wrap">
-                <t t-foreach="props.linkPreviews" t-as="linkPreview" t-key="linkPreview.id">
+                <t t-foreach="linkPreviewList" t-as="linkPreview" t-key="linkPreview.id">
                    <LinkPreview linkPreview="linkPreview" deletable="props.deletable"/>
                 </t>
             </div>

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -119,7 +119,7 @@
                                     unlinkAttachment.bind="onClickAttachmentUnlink"
                                     imagesHeight="message.attachment_ids.length === 1 ? 300 : 75"
                                     messageSearch="props.messageSearch"/>
-                                <LinkPreviewList t-if="message.linkPreviews.length > 0 and store.hasLinkPreviewFeature and !message.linkPreviewSquash" linkPreviews="message.linkPreviews" deletable="props.message.editable"/>
+                                <LinkPreviewList t-if="!message.linkPreviewSquash" linkPreviews="message.linkPreviews" deletable="props.message.editable"/>
                             </div>
                             <t t-if="!message.is_note and !message.isPending and (!message.hasTextContent or env.inChatWindow)" t-call="mail.Message.actions"/>
                         </div>

--- a/addons/mail/static/src/core/common/settings_model.js
+++ b/addons/mail/static/src/core/common/settings_model.js
@@ -32,6 +32,9 @@ export class Settings extends Record {
     });
     mute_until_dt = Record.attr(false, { type: "datetime" });
 
+    link_preview_html = false;
+    link_preview_image = true;
+
     // Voice settings
     // DeviceId of the audio input selected by the user
     audioInputDeviceId = "";
@@ -148,6 +151,14 @@ export class Settings extends Record {
             minutes,
             channel_id: thread?.id,
         });
+    }
+
+    async setLinkPreviewHtml(link_preview_html) {
+        return rpc("/mail/settings/link_preview_html", { link_preview_html });
+    }
+
+    async setLinkPreviewImage(link_preview_image) {
+        return rpc("/mail/settings/link_preview_image", { link_preview_image });
     }
 
     /**

--- a/addons/mail/static/src/discuss/core/common/link_preview_settings.js
+++ b/addons/mail/static/src/discuss/core/common/link_preview_settings.js
@@ -1,0 +1,39 @@
+import { Component, useState, xml } from "@odoo/owl";
+import { ActionPanel } from "@mail/discuss/core/common/action_panel";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { useService } from "@web/core/utils/hooks";
+import { registry } from "@web/core/registry";
+
+export class LinkPreviewSettings extends Component {
+    static components = { ActionPanel, Dropdown, DropdownItem };
+    static props = ["hasSizeConstraints?", "close?", "className?"];
+    static template = "mail.linkPreviewSettings";
+
+    setup() {
+        this.store = useState(useService("mail.store"));
+        this.dialog = useService("dialog");
+    }
+
+    onChangeLinkPreviewHtml(ev) {
+        this.store.settings.setLinkPreviewHtml(!this.store.settings.link_preview_html);
+    }
+
+    onChangeLinkPreviewImage(ev) {
+        this.store.settings.setLinkPreviewImage(!this.store.settings.link_preview_image);
+    }
+}
+
+export class LinkPreviewSettingsClientAction extends Component {
+    static components = { LinkPreviewSettings };
+    static props = ["*"];
+    static template = xml`
+        <div class="o-mail-LinkPreviewSettingsClientAction mx-3 my-2">
+            <LinkPreviewSettings/>
+        </div>
+    `;
+}
+
+registry
+    .category("actions")
+    .add("mail.link_preview_settings_action", LinkPreviewSettingsClientAction);

--- a/addons/mail/static/src/discuss/core/common/link_preview_settings.xml
+++ b/addons/mail/static/src/discuss/core/common/link_preview_settings.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="mail.linkPreviewSettings">
+        <div class="o-discuss-linkPreviewSettings">
+            <div class="d-flex flex-column my-1">
+                <label class="cursor-pointer d-flex align-items-center">
+                    <h5>Link preview html</h5>
+                    <div class="flex-grow-1"/>
+                    <div class="form-check form-switch">
+                        <input class="form-check-input" type="checkbox" role="switch" t-att-checked="store.settings.link_preview_html" t-on-change="onChangeLinkPreviewHtml"/>
+                    </div>
+                </label>
+                <label class="cursor-pointer d-flex align-items-center">
+                    <h5>Link preview image</h5>
+                    <div class="flex-grow-1"/>
+                    <div class="form-check form-switch">
+                        <input class="form-check-input" type="checkbox" role="switch" t-att-checked="store.settings.link_preview_image" t-on-change="onChangeLinkPreviewImage"/>
+                    </div>
+                </label>
+            </div>
+        </div>
+    </t>
+
+</templates>

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -409,6 +409,28 @@ async function discuss_settings_mute(request) {
     return "dummy";
 }
 
+registerRoute("/mail/settings/link_preview_html", mail_settings_link_preview_html);
+/** @type {RouteCallback} */
+async function mail_settings_link_preview_html(request) {
+    /** @type {import("mock_models").ResUsersSettings} */
+    const ResUsersSettings = this.env["res.users.settings"];
+
+    const { link_preview_html } = await parseRequestParams(request);
+    const settings = ResUsersSettings._find_or_create_for_user(this.env.user.id);
+    ResUsersSettings.set_res_users_settings(settings.id, { link_preview_html });
+}
+
+registerRoute("/mail/settings/link_preview_image", mail_settings_link_preview_image);
+/** @type {RouteCallback} */
+async function mail_settings_link_preview_image(request) {
+    /** @type {import("mock_models").ResUsersSettings} */
+    const ResUsersSettings = this.env["res.users.settings"];
+
+    const { link_preview_image } = await parseRequestParams(request);
+    const settings = ResUsersSettings._find_or_create_for_user(this.env.user.id);
+    ResUsersSettings.set_res_users_settings(settings.id, { link_preview_image });
+}
+
 registerRoute("/discuss/channel/notify_typing", discuss_channel_notify_typing);
 /** @type {RouteCallback} */
 async function discuss_channel_notify_typing(request) {

--- a/addons/mail/static/tests/mock_server/mock_models/res_users_settings.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_users_settings.js
@@ -21,6 +21,9 @@ export class ResUsersSettings extends models.ServerModel {
     is_discuss_sidebar_category_channel_open = fields.Generic({ default: true });
     is_discuss_sidebar_category_chat_open = fields.Generic({ default: true });
 
+    link_preview_image = fields.Boolean({ default: true });
+    link_preview_html = fields.Boolean({ default: false });
+
     /** @param {number|number[]} userIdOrIds */
     _find_or_create_for_user(userIdOrIds) {
         const [userId] = ensureArray(userIdOrIds);

--- a/addons/mail/views/mail_menus.xml
+++ b/addons/mail/views/mail_menus.xml
@@ -19,6 +19,12 @@
         action="mail.discuss_notification_settings_action"
         sequence="1"
     />
+    <menuitem name="Link Preview"
+        id="mail.menu_link_preview_settings"
+        parent="mail.menu_configuration"
+        action="mail.link_preview_settings_action"
+        sequence="3"
+    />
     <menuitem
         id="mail.menu_call_settings"
         name="Voice &amp; Video"

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -403,6 +403,8 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                     "id": self.env["res.users.settings"]._find_or_create_for_user(self.users[0]).id,
                     "is_discuss_sidebar_category_channel_open": True,
                     "is_discuss_sidebar_category_chat_open": True,
+                    "link_preview_html": False,
+                    "link_preview_image": True,
                     "livechat_lang_ids": [],
                     "livechat_username": False,
                     "push_to_talk_key": False,


### PR DESCRIPTION
This PR introduces 2 new user settings that control what kind of link preview
are shown by default:

* link preview images are enabled by default
* link preview html (card) are disabled by default
