### PR TITLE
[IMP] account: credit note for early payment discounts

### DIFF
--- a/addons/account/models/account_payment_term.py
+++ b/addons/account/models/account_payment_term.py
@@ -44,6 +44,7 @@ class AccountPaymentTerm(models.Model):
         ('mixed', 'Always (upon invoice)'),
     ], string='Cash Discount Tax Reduction', readonly=False, store=True, compute='_compute_discount_computation')
     early_discount = fields.Boolean(string='Early Discount')
+    early_pay_credit_note = fields.Boolean(string='Create Credit Note', help="Create Credit Note of early payment discount")
 
     @api.depends('company_id')
     @api.depends_context('allowed_company_ids')

--- a/addons/account/views/account_payment_term_views.xml
+++ b/addons/account/views/account_payment_term_views.xml
@@ -59,6 +59,11 @@
                                         <field name="early_pay_discount_computation" class="w-auto"/>
                                     </span>
                                 </div>
+                                <div invisible="not early_discount">
+                                    <span> Create credit note:
+                                        <field name="early_pay_credit_note" class="ms-1"/>
+                                    </span>
+                                </div>
                             </div>
                         </group>
                         <group>

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -1004,6 +1004,7 @@ class AccountPaymentRegister(models.TransientModel):
                 early_payment_values = self.env['account.move']._get_invoice_counterpart_amls_for_early_payment_discount(epd_aml_values_list, open_balance)
                 for aml_values_list in early_payment_values.values():
                     payment_vals['write_off_line_vals'] += aml_values_list
+                self.env['account.move']._create_credit_note_for_early_payment_discount(epd_aml_values_list, open_balance, self.group_payment)
 
             elif not self.currency_id.is_zero(self.payment_difference):
 
@@ -1086,6 +1087,7 @@ class AccountPaymentRegister(models.TransientModel):
                 ._get_invoice_counterpart_amls_for_early_payment_discount(epd_aml_values_list, open_balance)
             for aml_values_list in early_payment_values.values():
                 payment_vals['write_off_line_vals'] += aml_values_list
+            self.env['account.move']._create_credit_note_for_early_payment_discount(epd_aml_values_list, open_balance, self.group_payment)
 
         return payment_vals
 


### PR DESCRIPTION
This PR introduces an option in payment terms to determine whether a credit note should be generated for early payment discounts. If enabled, when an early payment discount is applied to an invoice, a credit note for the discounted amount will be automatically created upon payment.

**task**-4028948