### PR TITLE
[FIX] account: Added out_refund to the margin calculation from the invoice analysis report

### DIFF
--- a/addons/account/report/account_invoice_report.py
+++ b/addons/account/report/account_invoice_report.py
@@ -112,7 +112,8 @@ class AccountInvoiceReport(models.Model):
                    * (NULLIF(COALESCE(uom_line.factor, 1), 0.0) / NULLIF(COALESCE(uom_template.factor, 1), 0.0)),
                    0.0) * currency_table.rate                               AS price_average,
                 CASE
-                    WHEN move.move_type NOT IN ('out_invoice', 'out_receipt') THEN 0.0
+                    WHEN move.move_type NOT IN ('out_invoice', 'out_receipt', 'out_refund') THEN 0.0
+                    WHEN move.move_type = 'out_refund' THEN -line.balance * currency_table.rate + (line.quantity / NULLIF(COALESCE(uom_line.factor, 1) / COALESCE(uom_template.factor, 1), 0.0)) * COALESCE(product_standard_price.value_float, 0.0)
                     ELSE -line.balance * currency_table.rate - (line.quantity / NULLIF(COALESCE(uom_line.factor, 1) / COALESCE(uom_template.factor, 1), 0.0)) * COALESCE(product_standard_price.value_float, 0.0)
                 END
                                                                             AS price_margin,

--- a/addons/account/tests/test_account_invoice_report.py
+++ b/addons/account/tests/test_account_invoice_report.py
@@ -120,7 +120,7 @@ class TestAccountInvoiceReport(AccountTestInvoicingCommon):
             [             6,              6,        1,            0,            -800], # price_unit = 12,   currency.rate = 2.0
             [            20,            -20,       -1,            0,             800], # price_unit = 60,   currency.rate = 3.0
             [            20,            -20,       -1,            0,             800], # price_unit = 60,   currency.rate = 3.0
-            [           600,           -600,       -1,            0,             800], # price_unit = 1200, currency.rate = 2.0
+            [           600,           -600,       -1,          200,             800],  # price_unit = 1200, currency.rate = 2.0
         ])
 
     def test_invoice_report_multicompany_product_cost(self):
@@ -141,5 +141,5 @@ class TestAccountInvoiceReport(AccountTestInvoicingCommon):
             [             6,              6,        1,            0,            -800], # price_unit = 12,   currency.rate = 2.0
             [            20,            -20,       -1,            0,             800], # price_unit = 60,   currency.rate = 3.0
             [            20,            -20,       -1,            0,             800], # price_unit = 60,   currency.rate = 3.0
-            [           600,           -600,       -1,            0,             800], # price_unit = 1200, currency.rate = 2.0
+            [           600,           -600,       -1,          200,             800],  # price_unit = 1200, currency.rate = 2.0
         ])


### PR DESCRIPTION
In a previous commit: https://github.com/odoo/odoo/pull/151805/, the goal was to add margin to the account invoice report.

No negative margins were possible before because it didn't take the customer's credit notes.

This is now fixed with this commit, that aims to add customer's credit note to margin calculations

task-4167630

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
