### PR TITLE
[IMP] website: introduce `s_company_team_grid` snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -80,6 +80,7 @@
         'views/snippets/s_company_team_shapes.xml',
         'views/snippets/s_company_team_detail.xml',
         'views/snippets/s_company_team_spotlight.xml',
+        'views/snippets/s_company_team_grid.xml',
         'views/snippets/s_call_to_action.xml',
         'views/snippets/s_references.xml',
         'views/snippets/s_references_social.xml',

--- a/addons/website/views/snippets/s_company_team_grid.xml
+++ b/addons/website/views/snippets/s_company_team_grid.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_company_team_grid" name="Company Team Grid">
+    <section class="s_company_team_grid o_colored_level o_cc o_cc1 pt48 pb48">
+        <div class="container">
+            <div class="row o_grid_mode" data-row-count="25">
+                <div class="o_grid_item g-height-2 g-col-lg-12 col-lg-12" style="grid-area: 1 / 1 / 3 / 13; z-index: 1;">
+                    <h2>Get to know us</h2>
+                </div>
+                <div data-name="Team Member" class="o_grid_item g-col-lg-4 g-height-11 col-lg-4" style="grid-area: 3 / 1 / 14 / 5; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px; z-index: 2;">
+                    <div class="s_card o_card_img_top card o_cc o_cc2" data-vxml="001" data-snippet="s_card" data-name="Card" style="border-width: 0px !important;">
+                        <figure class="o_card_img_wrapper ratio ratio-1x1 mb-0">
+                            <img class="o_card_img card-img-top rounded pb-0" src="/web/image/website.s_company_team_image_1" style="padding: 16px;"/>
+                        </figure>
+                        <div class="card-body">
+                            <h3 class="card-title h5-fs" style="text-align: center;">Tony Fred</h3>
+                            <p class="card-text" style="text-align: center;">Chief Executive Officer</p>
+                        </div>
+                    </div>
+                </div>
+                <div data-name="Team Member" class="o_grid_item g-col-lg-4 g-height-11 col-lg-4" style="grid-area: 4 / 5 / 15 / 9; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px; z-index: 3;">
+                    <div class="s_card o_card_img_top card o_cc o_cc2" data-vxml="001" data-snippet="s_card" data-name="Card" style="border-width: 0px !important;">
+                        <figure class="o_card_img_wrapper ratio ratio-1x1 mb-0">
+                            <img class="o_card_img card-img-top rounded pb-0" src="/web/image/website.s_company_team_image_2" style="padding: 16px;"/>
+                        </figure>
+                        <div class="card-body">
+                            <h3 class="card-title h5-fs" style="text-align: center;">Mich Stark</h3>
+                            <p class="card-text" style="text-align: center;">Chief Technical Manager</p>
+                        </div>
+                    </div>
+                </div>
+                <div data-name="Team Member" class="o_grid_item g-col-lg-4 g-height-11 col-lg-4" style="grid-area: 3 / 9 / 14 / 13; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px; z-index: 4;">
+                    <div class="s_card o_card_img_top card o_cc o_cc2" data-vxml="001" data-snippet="s_card" data-name="card" style="border-width: 0px !important;">
+                        <figure class="o_card_img_wrapper ratio ratio-1x1 mb-0">
+                            <img class="o_card_img card-img-top rounded pb-0" src="/web/image/website.s_company_team_image_3" style="padding: 16px;"/>
+                        </figure>
+                        <div class="card-body">
+                            <h3 class="card-title h5-fs" style="text-align: center;">Aline Turner</h3>
+                            <p class="card-text" style="text-align: center;">Chief Financial Officer</p>
+                        </div>
+                    </div>
+                </div>
+                <div data-name="Team Member" class="o_grid_item g-col-lg-4 g-height-11 col-lg-4" style="grid-area: 14 / 1 / 25 / 5; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px; z-index: 5;">
+                    <div class="s_card o_card_img_top card o_cc o_cc2" data-vxml="001" data-snippet="s_card" data-name="card" style="border-width: 0px !important;">
+                        <figure class="o_card_img_wrapper ratio ratio-1x1 mb-0">
+                            <img class="o_card_img card-img-top rounded pb-0" src="/web/image/website.s_company_team_image_4" style="padding: 16px;"/>
+                        </figure>
+                        <div class="card-body">
+                            <h3 class="card-title h5-fs" style="text-align: center;">Iris Joe</h3>
+                            <p class="card-text" style="text-align: center;">Chief Operational Officer</p>
+                        </div>
+                    </div>
+                </div>
+                <div data-name="Team Member" class="o_grid_item g-col-lg-4 g-height-11 col-lg-4" style="grid-area: 15 / 5 / 26 / 9; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px; z-index: 6;">
+                    <div class="s_card o_card_img_top card o_cc o_cc2" data-vxml="001" data-snippet="s_card" data-name="card" style="border-width: 0px !important;">
+                        <figure class="o_card_img_wrapper ratio ratio-1x1 mb-0">
+                            <img class="o_card_img card-img-top rounded pb-0" src="/web/image/website.s_company_team_image_5" style="padding: 16px;"/>
+                        </figure>
+                        <div class="card-body">
+                            <h3 class="card-title h5-fs" style="text-align: center;">Pete Bluestork</h3>
+                            <p class="card-text" style="text-align: center;">Chief Communication Officer</p>
+                        </div>
+                    </div>
+                </div>
+                <div data-name="Team Member" class="o_grid_item g-col-lg-4 g-height-11 col-lg-4" style="grid-area: 14 / 9 / 25 / 13; --grid-item-padding-y: 16px; --grid-item-padding-x: 16px; z-index: 7;">
+                    <div class="s_card o_card_img_top card o_cc o_cc2" data-vxml="001" data-snippet="s_card" data-name="card" style="border-width: 0px !important;">
+                        <figure class="o_card_img_wrapper ratio ratio-1x1 mb-0">
+                            <img class="o_card_img card-img-top rounded pb-0" src="/web/image/website.s_company_team_image_6" style="padding: 16px;"/>
+                        </figure>
+                        <div class="card-body">
+                            <h3 class="card-title h5-fs" style="text-align: center;">Sophia Langston</h3>
+                            <p class="card-text" style="text-align: center;">Chief Marketing Officer</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -301,6 +301,9 @@
                 <t t-snippet="website.s_company_team_spotlight" string="Team Spotlight" group="people">
                     <keywords>organization, company, people, members, staffs, profiles, bios, roles, personnel, crew, patterned</keywords>
                 </t>
+                <t t-snippet="website.s_company_team_grid" string="Company Team Grid" group="people">
+                    <keywords>organization, structure, people, team, name, role, position, image, portrait, photo, employees, shapes</keywords>
+                </t>
                 <t t-snippet="website.s_references" string="References" group="people">
                     <keywords>customers, clients, sponsors, partners, supporters, case-studies, collaborators, associations, associates, testimonials, endorsements</keywords>
                 </t>
@@ -786,7 +789,7 @@
              which the s_card options should be bound (instead of the s_card).
              Note: defined here to be set above all the other options that might
              need it. -->
-        <t t-set="card_parent_handlers" t-value="'.s_three_columns .row > div, .s_comparisons .row > div, .s_cards_grid .row > div, .s_cards_soft .row > div, .s_product_list .row > div, .s_newsletter_centered .row > div, .s_company_team_spotlight .row > div, .s_comparisons_horizontal .row > div'"/>
+        <t t-set="card_parent_handlers" t-value="'.s_three_columns .row > div, .s_comparisons .row > div, .s_cards_grid .row > div, .s_cards_soft .row > div, .s_product_list .row > div, .s_newsletter_centered .row > div, .s_company_team_spotlight .row > div, .s_comparisons_horizontal .row > div, .s_company_team_grid .row > div'"/>
 
         <!-- Binding the option on the snippet if it is not a s_card with a
              handler parent -->


### PR DESCRIPTION
This commit adds the new `s_company_team_grid` snippet.

task-4150614
Part-of: task-4077427

requires: https://github.com/odoo/design-themes/pull/901

| New snippet: Company Team Grid |
|--------|
| ![image](https://github.com/user-attachments/assets/16cf68b4-e4b0-4c3e-b7f0-ec99d8ef1d86) | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
