### PR TITLE
[FIX] hr_holidays: fix accrual yearly cap constraint

### DIFF
--- a/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
@@ -141,7 +141,7 @@ class AccrualPlanLevel(models.Model):
         ('added_value_greater_than_zero', 'CHECK(added_value > 0)', "You must give a rate greater than 0 in accrual plan levels."),
         (
             'valid_yearly_cap_value',
-            'CHECK(cap_accrued_time_yearly IS NULL OR COALESCE(maximum_leave_yearly, 0) > 0)',
+            'CHECK(cap_accrued_time_yearly IS NOT TRUE OR COALESCE(maximum_leave_yearly, 0) > 0)',
             "You cannot have a cap on yearly accrued time without setting a maximum amount."
         ),
     ]

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -1216,6 +1216,12 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'cap_accrued_time_yearly': True,
             'maximum_leave_yearly': 1,
         })
+        accrual_plan.level_ids[0].write({
+            'cap_accrued_time_yearly': False,
+            'maximum_leave_yearly': 0,
+        })
+        self.env.cr.precommit.run()
+        self.env.flush_all()
 
     def test_yearly_cap(self):
         leave_type = self.env['hr.leave.type'].create({


### PR DESCRIPTION
Steps to reproduce the issue:
- go on an accrual plan
- add a yearly cap on any level
- save
- remove the yearly cap
- you get an error

After this commit, the error no longer pops up, as it shouldn't since the yearly cap is not set.