### PR TITLE
[IMP] l10n_es: tax updates according to BOE-A-2024-12944

### DIFF
--- a/addons/l10n_es/__init__.py
+++ b/addons/l10n_es/__init__.py
@@ -1,2 +1,1 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.

--- a/addons/l10n_es/__manifest__.py
+++ b/addons/l10n_es/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 # List of contributors:
@@ -13,9 +12,9 @@
 # Roberto Lizana <robertolizana@trey.es>
 
 {
-    "name" : "Spain - Accounting (PGCE 2008)",
-    "version" : "5.2",
-    "author" : "Spanish Localization Team",
+    "name": "Spain - Accounting (PGCE 2008)",
+    "version": "5.3",
+    "author": "Spanish Localization Team",
     'category': 'Accounting/Localizations/Account Charts',
     "description": """
 Spanish charts of accounts (PGCE 2008).
@@ -29,13 +28,15 @@ Spanish charts of accounts (PGCE 2008).
     * Defines tax templates
     * Defines fiscal positions for spanish fiscal legislation
     * Defines tax reports mod 111, 115 and 303
+
+5.3: Update taxes starting Q4 2024 according to BOE-A-2024-12944 (Royal Decree 4/2024) https://www.boe.es/buscar/act.php?id=BOE-A-2024-12944
 """,
-    "depends" : [
+    "depends": [
         "account",
         "base_iban",
         "base_vat",
     ],
-    "data" : [
+    "data": [
         'data/account_chart_template_data.xml',
         'data/account_group.xml',
         'data/account.account.template-common.csv',

--- a/addons/l10n_es/data/account_fiscal_position_template_data.xml
+++ b/addons/l10n_es/data/account_fiscal_position_template_data.xml
@@ -174,6 +174,16 @@
             <field name="tax_src_id" ref="account_tax_template_p_iva0_s_sc"/>
             <field name="tax_dest_id" ref="account_tax_template_p_iva0_isc"/>
         </record>
+        <record id="fptt_extra_2b" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_extra"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva2_bc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva2_ibc"/>
+        </record>
+        <record id="fptt_extra_2s" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_extra"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva2_sc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva2_isc"/>
+        </record>
         <record id="fptt_extra_4b" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fp_extra"/>
             <field name="tax_src_id" ref="account_tax_template_p_iva4_bc"/>
@@ -199,6 +209,16 @@
             <field name="position_id" ref="fp_extra"/>
             <field name="tax_src_id" ref="account_tax_template_p_iva5_sc"/>
             <field name="tax_dest_id" ref="account_tax_template_p_iva5_isc"/>
+        </record>
+        <record id="fptt_extra_7-5b" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_extra"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva7-5_bc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva7-5_ibc"/>
+        </record>
+        <record id="fptt_extra_7-5s" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_extra"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva7-5_sc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva7-5_isc"/>
         </record>
         <record id="fptt_extra_10b" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fp_extra"/>
@@ -244,6 +264,18 @@
             <field name="tax_src_id" ref="account_tax_template_s_iva0s"/>
             <field name="tax_dest_id" ref="account_tax_template_s_iva_e"/>
         </record>
+        <record id="fptt_extra_ventas_2b"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_extra"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva2b"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_iva0_e"/>
+        </record>
+        <record id="fptt_extra_ventas_2s"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_extra"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva2s"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_iva_e"/>
+        </record>
         <record id="fptt_extra_ventas_4b"
             model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fp_extra"/>
@@ -266,6 +298,18 @@
             model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fp_extra"/>
             <field name="tax_src_id" ref="account_tax_template_s_iva5s"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_iva_e"/>
+        </record>
+        <record id="fptt_extra_ventas_7-5b"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_extra"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva7-5b"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_iva0_e"/>
+        </record>
+        <record id="fptt_extra_ventas_7-5s"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_extra"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva7-5s"/>
             <field name="tax_dest_id" ref="account_tax_template_s_iva_e"/>
         </record>
         <record id="fptt_extra_ventas_10b"
@@ -311,6 +355,16 @@
             <field name="tax_src_id" ref="account_tax_template_p_iva0_s_sc"/>
             <field name="tax_dest_id" ref="account_tax_template_p_iva0_ic_sc"/>
         </record>
+        <record id="fptt_intra_2b" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_intra"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva2_bc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva2_ic_bc"/>
+        </record>
+        <record id="fptt_intra_2s" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_intra"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva2_sc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva2_ic_sc"/>
+        </record>
         <record id="fptt_intra_4b" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fp_intra"/>
             <field name="tax_src_id" ref="account_tax_template_p_iva4_bc"/>
@@ -336,6 +390,16 @@
             <field name="position_id" ref="fp_intra"/>
             <field name="tax_src_id" ref="account_tax_template_p_iva5_sc"/>
             <field name="tax_dest_id" ref="account_tax_template_p_iva5_ic_sc"/>
+        </record>
+        <record id="fptt_intra_7-5b" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_intra"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva7-5_bc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva7-5_ic_bc"/>
+        </record>
+        <record id="fptt_intra_7-5s" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_intra"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva7-5_sc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva7-5_ic_sc"/>
         </record>
         <record id="fptt_intra_10b" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fp_intra"/>
@@ -381,6 +445,18 @@
             <field name="tax_src_id" ref="account_tax_template_s_iva0s"/>
             <field name="tax_dest_id" ref="account_tax_template_s_iva0_sp_i"/>
         </record>
+        <record id="fptt_intra_ventas_2b"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_intra"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva2b"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_iva0_ic"/>
+        </record>
+        <record id="fptt_intra_ventas_2s"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_intra"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva2s"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_iva0_sp_i"/>
+        </record>
         <record id="fptt_intra_ventas_4b"
             model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fp_intra"/>
@@ -403,6 +479,18 @@
             model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fp_intra"/>
             <field name="tax_src_id" ref="account_tax_template_s_iva5s"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_iva0_sp_i"/>
+        </record>
+        <record id="fptt_intra_ventas_7-5b"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_intra"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva7-5b"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_iva0_ic"/>
+        </record>
+        <record id="fptt_intra_ventas_7-5s"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_intra"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva7-5s"/>
             <field name="tax_dest_id" ref="account_tax_template_s_iva0_sp_i"/>
         </record>
         <record id="fptt_intra_ventas_10b"
@@ -553,6 +641,28 @@
             <field name="tax_src_id" ref="account_tax_template_s_iva0s"/>
             <field name="tax_dest_id" ref="account_tax_template_s_req0"/>
         </record>
+        <record id="fptt_recargo_2b" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_recargo"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva2b"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_iva2b"/>
+        </record>
+        <record id="fptt_recargo_2b_2"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_recargo"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva2b"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_req026"/>
+        </record>
+        <record id="fptt_recargo_2s" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_recargo"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva2s"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_iva2s"/>
+        </record>
+        <record id="fptt_recargo_2s_2"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_recargo"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva2s"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_req026"/>
+        </record>
         <record id="fptt_recargo_4b" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fp_recargo"/>
             <field name="tax_src_id" ref="account_tax_template_s_iva4b"/>
@@ -596,6 +706,28 @@
             <field name="position_id" ref="fp_recargo"/>
             <field name="tax_src_id" ref="account_tax_template_s_iva5s"/>
             <field name="tax_dest_id" ref="account_tax_template_s_req062"/>
+        </record>
+        <record id="fptt_recargo7-5b" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_recargo"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva7-5b"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_iva7-5b"/>
+        </record>
+        <record id="fptt_recargo_7-5b_2"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_recargo"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva7-5b"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_req1"/>
+        </record>
+        <record id="fptt_recargo_7-5s" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_recargo"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva7-5s"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_iva7-5s"/>
+        </record>
+        <record id="fptt_recargo_7-5s_2"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_recargo"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva7-5s"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_req1"/>
         </record>
         <record id="fptt_recargo_10b" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fp_recargo"/>
@@ -677,6 +809,30 @@
             <field name="tax_src_id" ref="account_tax_template_p_iva0_s_sc"/>
             <field name="tax_dest_id" ref="account_tax_template_p_req0"/>
         </record>
+        <record id="fptt_recargo_buy_2b"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_recargo"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva2_bc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva2_bc"/>
+        </record>
+        <record id="fptt_recargo_buy_2b_2"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_recargo"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva2_bc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_req026"/>
+        </record>
+        <record id="fptt_recargo_buy_2s"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_recargo"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva2_sc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva2_sc"/>
+        </record>
+        <record id="fptt_recargo_buy_2s_2"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_recargo"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva2_sc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_req026"/>
+        </record>
         <record id="fptt_recargo_buy_4b"
             model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fp_recargo"/>
@@ -736,6 +892,30 @@
             <field name="position_id" ref="fp_recargo"/>
             <field name="tax_src_id" ref="account_tax_template_p_iva5_sc"/>
             <field name="tax_dest_id" ref="account_tax_template_p_req062"/>
+        </record>
+        <record id="fptt_recargo_buy_7-5b"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_recargo"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva7-5_bc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva7-5_bc"/>
+        </record>
+        <record id="fptt_recargo_buy_7-5b_2"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_recargo"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva7-5_bc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_req1"/>
+        </record>
+        <record id="fptt_recargo_buy_7-5s"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_recargo"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva7-5_sc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva7-5_sc"/>
+        </record>
+        <record id="fptt_recargo_buy_7-5s_2"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_recargo"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva7-5_sc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_req1"/>
         </record>
         <record id="fptt_recargo_buy_10b"
             model="account.fiscal.position.tax.template">

--- a/addons/l10n_es/data/account_tax_data.xml
+++ b/addons/l10n_es/data/account_tax_data.xml
@@ -275,6 +275,26 @@
         <field name="applicability">taxes</field>
         <field name="country_id" ref="base.es"/>
     </record>
+    <record id="mod_303_165" model="account.account.tag">
+        <field name="name">mod303[165]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_303_167" model="account.account.tag">
+        <field name="name">mod303[167]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_303_168" model="account.account.tag">
+        <field name="name">mod303[168]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
+    <record id="mod_303_170" model="account.account.tag">
+        <field name="name">mod303[170]</field>
+        <field name="applicability">taxes</field>
+        <field name="country_id" ref="base.es"/>
+    </record>
     <record id="mod_303_59" model="account.account.tag">
         <field name="name">mod303[59]</field>
         <field name="applicability">taxes</field>
@@ -1136,7 +1156,109 @@
             }),
         ]"/>
     </record>
+    <record id="account_tax_template_p_iva7-5_ic_bc" model="account.tax.template">
+        <field name="amount" eval="7.5"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount_type">percent</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="name">IVA 7.5% Adquisición Intracomunitario. Bienes corrientes</field>
+        <field name="tax_group_id" ref="tax_group_iva_7-5"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_36'), ref('mod_303_10')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_37')],
+                'account_id': ref('l10n_es.account_common_472'),
+            }),
+
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_es.account_common_477'),
+                'tag_ids': [ref('mod_303_11')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_40'), ref('mod_303_14_purchase')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_41')],
+                'account_id': ref('l10n_es.account_common_472'),
+            }),
+
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_es.account_common_477'),
+                'tag_ids': [ref('mod_303_15')],
+            }),
+        ]"/>
+    </record>
+    <record id="account_tax_template_p_iva7-5_ic_sc" model="account.tax.template">
+        <field name="amount" eval="7.5"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount_type">percent</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="name">IVA 7.5% Adquisición de servicios intracomunitarios</field>
+        <field name="tax_group_id" ref="tax_group_iva_7-5"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_36'), ref('mod_303_10')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_37')],
+                'account_id': ref('l10n_es.account_common_472'),
+            }),
+
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_es.account_common_477'),
+                'tag_ids': [ref('mod_303_11')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_40'), ref('mod_303_14_purchase')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_41')],
+                'account_id': ref('l10n_es.account_common_472'),
+            }),
+
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_es.account_common_477'),
+                'tag_ids': [ref('mod_303_15')],
+            }),
+        ]"/>
+    </record>
     <record id="account_tax_template_p_iva5_ic_bc" model="account.tax.template">
+        <!-- Not used anymore since Q4 2024 -->
+        <field name="active" eval="False"/>
         <field name="amount" eval="5"/>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount_type">percent</field>
@@ -1187,12 +1309,114 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_iva5_ic_sc" model="account.tax.template">
+        <!-- Not used anymore since Q4 2024 -->
+        <field name="active" eval="False"/>
         <field name="amount" eval="5"/>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">IVA 5% Adquisición de servicios intracomunitarios</field>
         <field name="tax_group_id" ref="tax_group_iva_5"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_36'), ref('mod_303_10')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_37')],
+                'account_id': ref('l10n_es.account_common_472'),
+            }),
+
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_es.account_common_477'),
+                'tag_ids': [ref('mod_303_11')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_40'), ref('mod_303_14_purchase')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_41')],
+                'account_id': ref('l10n_es.account_common_472'),
+            }),
+
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_es.account_common_477'),
+                'tag_ids': [ref('mod_303_15')],
+            }),
+        ]"/>
+    </record>
+    <record id="account_tax_template_p_iva2_ic_bc" model="account.tax.template">
+        <field name="amount" eval="2"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount_type">percent</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="name">IVA 2% Adquisición Intracomunitario. Bienes corrientes</field>
+        <field name="tax_group_id" ref="tax_group_iva_2"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_36'), ref('mod_303_10')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_37')],
+                'account_id': ref('l10n_es.account_common_472'),
+            }),
+
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_es.account_common_477'),
+                'tag_ids': [ref('mod_303_11')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_40'), ref('mod_303_14_purchase')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_41')],
+                'account_id': ref('l10n_es.account_common_472'),
+            }),
+
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_es.account_common_477'),
+                'tag_ids': [ref('mod_303_15')],
+            }),
+        ]"/>
+    </record>
+    <record id="account_tax_template_p_iva2_ic_sc" model="account.tax.template">
+        <field name="amount" eval="2"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount_type">percent</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="name">IVA 2% Adquisición de servicios intracomunitarios</field>
+        <field name="tax_group_id" ref="tax_group_iva_2"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
@@ -1656,7 +1880,97 @@
             }),
         ]"/>
     </record>
+    <record id="account_tax_template_p_iva7-5_ibc" model="account.tax.template">
+        <field name="type_tax_use">purchase</field>
+        <field name="name">IVA 7.5% Importaciones bienes corrientes</field>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="7.5"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_iva_7-5"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_32')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_33')],
+                'account_id': ref('l10n_es.account_common_472'),
+            }),
+
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_40')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_41')],
+                'account_id': ref('l10n_es.account_common_472'),
+            }),
+        ]"/>
+    </record>
+    <record id="account_tax_template_p_iva7-5_isc" model="account.tax.template">
+        <field name="type_tax_use">purchase</field>
+        <field name="name">IVA 7.5% Adquisición de servicios extracomunitarios</field>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="7.5"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_iva_7-5"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_12'), ref('mod_303_28')],
+            }),
+
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_es.account_common_477'),
+                'tag_ids': [ref('mod_303_13')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_29')],
+                'account_id': ref('l10n_es.account_common_472'),
+            }),
+
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_14_purchase'), ref('mod_303_40')],
+            }),
+
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_es.account_common_477'),
+                'tag_ids': [ref('mod_303_15')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_41')],
+                'account_id': ref('l10n_es.account_common_472'),
+            }),
+        ]"/>
+    </record>
     <record id="account_tax_template_p_iva5_ibc" model="account.tax.template">
+        <!-- Not used anymore since Q4 2024 -->
+        <field name="active" eval="False"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">IVA 5% Importaciones bienes corrientes</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -1694,12 +2008,102 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_iva5_isc" model="account.tax.template">
+        <!-- Not used anymore since Q4 2024 -->
+        <field name="active" eval="False"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">IVA 5% Adquisición de servicios extracomunitarios</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount" eval="5"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_iva_5"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_12'), ref('mod_303_28')],
+            }),
+
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_es.account_common_477'),
+                'tag_ids': [ref('mod_303_13')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_29')],
+                'account_id': ref('l10n_es.account_common_472'),
+            }),
+
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_14_purchase'), ref('mod_303_40')],
+            }),
+
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_es.account_common_477'),
+                'tag_ids': [ref('mod_303_15')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_41')],
+                'account_id': ref('l10n_es.account_common_472'),
+            }),
+        ]"/>
+    </record>
+    <record id="account_tax_template_p_iva2_ibc" model="account.tax.template">
+        <field name="type_tax_use">purchase</field>
+        <field name="name">IVA 2% Importaciones bienes corrientes</field>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="2"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_iva_2"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_32')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_33')],
+                'account_id': ref('l10n_es.account_common_472'),
+            }),
+
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_40')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_41')],
+                'account_id': ref('l10n_es.account_common_472'),
+            }),
+        ]"/>
+    </record>
+    <record id="account_tax_template_p_iva2_isc" model="account.tax.template">
+        <field name="type_tax_use">purchase</field>
+        <field name="name">IVA 2% Adquisición de servicios extracomunitarios</field>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="2"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_iva_2"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
@@ -1870,6 +2274,74 @@
             }),
         ]"/>
     </record>
+    <record id="account_tax_template_p_iva2_bc" model="account.tax.template">
+        <field name="type_tax_use">purchase</field>
+        <field name="name">2% IVA soportado (bienes corrientes)</field>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="2"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_iva_2"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_28')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_29')],
+                'account_id': ref('l10n_es.account_common_472'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_40')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_41')],
+                'account_id': ref('l10n_es.account_common_472'),
+            }),
+        ]"/>
+    </record>
+    <record id="account_tax_template_p_iva2_sc" model="account.tax.template">
+        <field name="type_tax_use">purchase</field>
+        <field name="name">2% IVA soportado (servicios corrientes)</field>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="2"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_iva_2"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_28')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_29')],
+                'account_id': ref('l10n_es.account_common_472'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_40')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_41')],
+                'account_id': ref('l10n_es.account_common_472'),
+            }),
+        ]"/>
+    </record>
     <record id="account_tax_template_p_iva4_bi" model="account.tax.template">
         <field name="description"/> <!-- for resetting the value on existing DBs -->
         <field name="type_tax_use">purchase</field>
@@ -1947,6 +2419,8 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_iva5_bc" model="account.tax.template">
+        <!-- Not used anymore since Q4 2024 -->
+        <field name="active" eval="False"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">5% IVA soportado (bienes corrientes)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -1981,6 +2455,8 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_iva5_sc" model="account.tax.template">
+        <!-- Not used anymore since Q4 2024 -->
+        <field name="active" eval="False"/>
         <field name="description"/> <!-- for resetting the value on existing DBs -->
         <field name="type_tax_use">purchase</field>
         <field name="name">5% IVA soportado (servicios corrientes)</field>
@@ -1988,6 +2464,74 @@
         <field name="amount" eval="5"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_iva_5"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_28')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_29')],
+                'account_id': ref('l10n_es.account_common_472'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_40')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_41')],
+                'account_id': ref('l10n_es.account_common_472'),
+            }),
+        ]"/>
+    </record>
+    <record id="account_tax_template_p_iva7-5_bc" model="account.tax.template">
+        <field name="type_tax_use">purchase</field>
+        <field name="name">7.5% IVA soportado (bienes corrientes)</field>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="7.5"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_iva_7-5"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_28')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_29')],
+                'account_id': ref('l10n_es.account_common_472'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_40')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_41')],
+                'account_id': ref('l10n_es.account_common_472'),
+            }),
+        ]"/>
+    </record>
+    <record id="account_tax_template_p_iva7-5_sc" model="account.tax.template">
+        <field name="type_tax_use">purchase</field>
+        <field name="name">7.5% IVA soportado (servicios corrientes)</field>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="7.5"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_iva_7-5"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
@@ -2305,6 +2849,44 @@
             }),
         ]"/>
     </record>
+    <record id="account_tax_template_s_req026" model="account.tax.template">
+        <field name="description">0.26% Rec. Eq.</field>
+        <field name="type_tax_use">sale</field>
+        <field name="name">0.26% Recargo Equivalencia Ventas</field>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="0.26"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_recargo_0-26"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_168')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_170')],
+                'account_id': ref('l10n_es.account_common_477'),
+            }),
+
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_25')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_26')],
+                'account_id': ref('l10n_es.account_common_477'),
+            }),
+        ]"/>
+    </record>
     <record id="account_tax_template_s_req05" model="account.tax.template">
         <field name="description">0.50% Rec. Eq.</field>
         <field name="type_tax_use">sale</field>
@@ -2344,6 +2926,8 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_req062" model="account.tax.template">
+        <!-- Not used anymore since Q4 2024 -->
+        <field name="active" eval="False"/>
         <field name="description">0.62% Rec. Eq.</field>
         <field name="type_tax_use">sale</field>
         <field name="name">0.62% Recargo Equivalencia Ventas</field>
@@ -2351,6 +2935,44 @@
         <field name="amount" eval="0.62"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_recargo_0-62"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_16')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_18')],
+                'account_id': ref('l10n_es.account_common_477'),
+            }),
+
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_25')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_26')],
+                'account_id': ref('l10n_es.account_common_477'),
+            }),
+        ]"/>
+    </record>
+    <record id="account_tax_template_s_req1" model="account.tax.template">
+        <field name="description">1% Rec. Eq.</field>
+        <field name="type_tax_use">sale</field>
+        <field name="name">1% Recargo Equivalencia Ventas</field>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="1"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_recargo_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
@@ -2522,7 +3144,41 @@
             }),
         ]"/>
     </record>
+    <record id="account_tax_template_p_iva7-5_nd" model="account.tax.template">
+        <field name="type_tax_use">purchase</field>
+        <field name="name">7.5% IVA Soportado no deducible</field>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="7.5"/>
+        <field name="amount_type">percent</field>
+        <field name="analytic" eval="True"/>
+        <field name="tax_group_id" ref="tax_group_iva_nd"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+            }),
+
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+            }),
+        ]"/>
+    </record>
     <record id="account_tax_template_p_iva5_nd" model="account.tax.template">
+        <!-- Not used anymore since Q4 2024 -->
+        <field name="active" eval="False"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">5% IVA Soportado no deducible</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -2559,6 +3215,38 @@
         <field name="name">4% IVA Soportado no deducible</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount" eval="4"/>
+        <field name="amount_type">percent</field>
+        <field name="analytic" eval="True"/>
+        <field name="tax_group_id" ref="tax_group_iva_nd"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+            }),
+
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+            }),
+        ]"/>
+    </record>
+    <record id="account_tax_template_p_iva2_nd" model="account.tax.template">
+        <field name="type_tax_use">purchase</field>
+        <field name="name">2% IVA Soportado no deducible</field>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="2"/>
         <field name="amount_type">percent</field>
         <field name="analytic" eval="True"/>
         <field name="tax_group_id" ref="tax_group_iva_nd"/>
@@ -2646,6 +3334,74 @@
             }),
         ]"/>
     </record>
+    <record id="account_tax_template_s_iva2s" model="account.tax.template">
+        <field name="type_tax_use">sale</field>
+        <field name="name">IVA 2% (Servicios)</field>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="2"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_iva_2"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_165')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_167')],
+                'account_id': ref('l10n_es.account_common_477'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_14_sale')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_15')],
+                'account_id': ref('l10n_es.account_common_477'),
+            }),
+        ]"/>
+    </record>
+    <record id="account_tax_template_s_iva2b" model="account.tax.template">
+        <field name="type_tax_use">sale</field>
+        <field name="name">IVA 2% (Bienes)</field>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="2"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_iva_2"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_165')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_167')],
+                'account_id': ref('l10n_es.account_common_477'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_14_sale')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_15')],
+                'account_id': ref('l10n_es.account_common_477'),
+            }),
+        ]"/>
+    </record>
     <record id="account_tax_template_s_iva4s" model="account.tax.template">
         <field name="description"/> <!-- for resetting the value on existing DBs -->
         <field name="type_tax_use">sale</field>
@@ -2685,6 +3441,8 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_iva5s" model="account.tax.template">
+        <!-- Not used anymore since Q4 2024 -->
+        <field name="active" eval="False"/>
         <field name="description"/> <!-- for resetting the value on existing DBs -->
         <field name="type_tax_use">sale</field>
         <field name="name">IVA 5% (Servicios)</field>
@@ -2720,12 +3478,82 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_iva5b" model="account.tax.template">
+        <!-- Not used anymore since Q4 2024 -->
+        <field name="active" eval="False"/>
         <field name="type_tax_use">sale</field>
         <field name="name">IVA 5% (Bienes)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount" eval="5"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_iva_5"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_153')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_155')],
+                'account_id': ref('l10n_es.account_common_477'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_14_sale')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_15')],
+                'account_id': ref('l10n_es.account_common_477'),
+            }),
+        ]"/>
+    </record>
+    <record id="account_tax_template_s_iva7-5s" model="account.tax.template">
+        <field name="type_tax_use">sale</field>
+        <field name="name">IVA 7.5% (Servicios)</field>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="7.5"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_iva_7-5"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_153')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_155')],
+                'account_id': ref('l10n_es.account_common_477'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_14_sale')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'tag_ids': [ref('mod_303_15')],
+                'account_id': ref('l10n_es.account_common_477'),
+            }),
+        ]"/>
+    </record>
+    <record id="account_tax_template_s_iva7-5b" model="account.tax.template">
+        <field name="type_tax_use">sale</field>
+        <field name="name">IVA 7.5% (Bienes)</field>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="7.5"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_iva_7-5"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
@@ -3818,6 +4646,43 @@
             }),
         ]"/>
     </record>
+    <record id="account_tax_template_p_req026" model="account.tax.template">
+        <field name="type_tax_use">purchase</field>
+        <field name="name">0.26% Recargo Equivalencia Compras</field>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="0.26"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_recargo_0-26"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_28')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_es.account_common_472'),
+                'tag_ids': [ref('mod_303_29')],
+            }),
+
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_40')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_es.account_common_472'),
+                'tag_ids': [ref('mod_303_41')],
+            }),
+        ]"/>
+    </record>
     <record id="account_tax_template_p_req05" model="account.tax.template">
         <field name="description"/> <!-- for resetting the value on existing DBs -->
         <field name="type_tax_use">purchase</field>
@@ -3857,12 +4722,51 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_req062" model="account.tax.template">
+        <!-- Not used anymore since Q4 2024 -->
+        <field name="active" eval="False"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">0.62% Recargo Equivalencia Compras</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount" eval="0.62"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_recargo_0-62"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_28')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_es.account_common_472'),
+                'tag_ids': [ref('mod_303_29')],
+            }),
+
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+                'tag_ids': [ref('mod_303_40')],
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_es.account_common_472'),
+                'tag_ids': [ref('mod_303_41')],
+            }),
+        ]"/>
+    </record>
+    <record id="account_tax_template_p_req1" model="account.tax.template">
+        <field name="type_tax_use">purchase</field>
+        <field name="name">1% Recargo Equivalencia Compras</field>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="1"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_recargo_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
@@ -5025,7 +5929,7 @@
             }),
         ]"/>
     </record>
-     <record id="account_tax_template_p_irpf19ca" model="account.tax.template">
+    <record id="account_tax_template_p_irpf19ca" model="account.tax.template">
         <field name="description"/> <!-- for resetting the value on existing DBs -->
         <field name="type_tax_use">purchase</field>
         <field name="name">Retenciones IRPF 19% (Compra consejero de persona física)</field>
@@ -5063,7 +5967,7 @@
             }),
         ]"/>
     </record>
-     <record id="account_tax_template_p_irpf19cs" model="account.tax.template">
+    <record id="account_tax_template_p_irpf19cs" model="account.tax.template">
         <field name="description"/> <!-- for resetting the value on existing DBs -->
         <field name="type_tax_use">purchase</field>
         <field name="name">Retenciones IRPF 19% (Compra consejero de sociedad)</field>

--- a/addons/l10n_es/data/account_tax_group_data.xml
+++ b/addons/l10n_es/data/account_tax_group_data.xml
@@ -9,12 +9,20 @@
             <field name="name">Recargo de Equivalencia 0%</field>
             <field name="country_id" ref="base.es"/>
         </record>
+        <record id="tax_group_recargo_0-26" model="account.tax.group">
+            <field name="name">Recargo de Equivalencia 0.26%</field>
+            <field name="country_id" ref="base.es"/>
+        </record>
         <record id="tax_group_recargo_0-5" model="account.tax.group">
             <field name="name">Recargo de Equivalencia 0.5%</field>
             <field name="country_id" ref="base.es"/>
         </record>
         <record id="tax_group_recargo_0-62" model="account.tax.group">
             <field name="name">Recargo de Equivalencia 0.62%</field>
+            <field name="country_id" ref="base.es"/>
+        </record>
+        <record id="tax_group_recargo_1" model="account.tax.group">
+            <field name="name">Recargo de Equivalencia 1%</field>
             <field name="country_id" ref="base.es"/>
         </record>
         <record id="tax_group_retenciones_1" model="account.tax.group">
@@ -27,6 +35,10 @@
         </record>
         <record id="tax_group_retenciones_2" model="account.tax.group">
             <field name="name">Retenciones 2%</field>
+            <field name="country_id" ref="base.es"/>
+        </record>
+        <record id="tax_group_iva_2" model="account.tax.group">
+            <field name="name">IVA 2%</field>
             <field name="country_id" ref="base.es"/>
         </record>
         <record id="tax_group_iva_4" model="account.tax.group">
@@ -43,6 +55,10 @@
         </record>
         <record id="tax_group_retenciones_7" model="account.tax.group">
             <field name="name">Retenciones 7%</field>
+            <field name="country_id" ref="base.es"/>
+        </record>
+        <record id="tax_group_iva_7-5" model="account.tax.group">
+            <field name="name">IVA 7.5%</field>
             <field name="country_id" ref="base.es"/>
         </record>
         <record id="tax_group_retenciones_9" model="account.tax.group">

--- a/addons/l10n_es/migrations/5.3/post-migrate_update_taxes.py
+++ b/addons/l10n_es/migrations/5.3/post-migrate_update_taxes.py
@@ -1,0 +1,28 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import api, SUPERUSER_ID
+from odoo.addons.account.models.chart_template import update_taxes_from_templates
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    for company in env.companies:
+        taxes_to_disable = (
+            f'{company.id}_account_tax_template_p_iva5_ic_bc',
+            f'{company.id}_account_tax_template_p_iva5_ic_sc',
+            f'{company.id}_account_tax_template_p_iva5_ibc',
+            f'{company.id}_account_tax_template_p_iva5_isc',
+            f'{company.id}_account_tax_template_p_iva5_bc',
+            f'{company.id}_account_tax_template_p_iva5_sc',
+            f'{company.id}_account_tax_template_p_iva5_nd',
+            f'{company.id}_account_tax_template_s_iva5s',
+            f'{company.id}_account_tax_template_s_iva5b',
+            f'{company.id}_account_tax_template_s_req062',
+            f'{company.id}_account_tax_template_p_req062',
+        )
+        tax_ids = env['ir.model.data'].search([
+            ('name', 'in', taxes_to_disable),
+            ('model', '=', 'account.tax'),
+        ]).mapped('res_id')
+        env['account.tax'].browse(tax_ids).active = False
+
+    update_taxes_from_templates(cr, 'l10n_es.account_chart_template_common')


### PR DESCRIPTION
[Real Decreto-ley 4/2024] of June 26, 2024 introduces some changes to the tax rates to address the economic and social consequences arising from the conflicts in Ukraine and the Middle East.

The VAT reductions of 5% (pasta and seed oils) and 0% (basic foodstuffs and olive oils) previously introduced will be increased to 7.5% and 2%, respectively, starting on October 1, 2024.

The rates of the equivalence surcharge applicable to these products will increase from 0.6% and 0%, to 1% and 0.26%, respectively.

An upgrade script is provided that automatically disables the deprecated VAT of 5% and Rec. Eq. of 0.62% when upgrading the `l10n_es` module.

[Real Decreto-ley 4/2024]: https://www.boe.es/buscar/act.php?id=BOE-A-2024-12944

[task-4147046](https://www.odoo.com/odoo/all-tasks/4147046)

Related to https://github.com/odoo/enterprise/pull/69736