### PR TITLE
[IMP] mail: add muted icon in sidebar and cleanup

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
@@ -41,7 +41,7 @@ export class DiscussSidebarChannel extends Component {
             "o-active": this.thread.eq(this.store.discuss.thread),
             "o-unread":
                 this.thread.selfMember?.message_unread_counter > 0 && !this.thread.isMuted,
-            "opacity-50": this.thread.mute_until_dt,
+            "opacity-50": this.thread.isMuted,
             "position-relative justify-content-center mx-2 o-compact":
                 this.store.discuss.isSidebarCompact,
             "mx-2": !this.store.discuss.isSidebarCompact,

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -53,7 +53,7 @@
         <div class="o-mail-DiscussSidebarCategory d-flex align-items-center" t-att-class="{ 'm-2 position-relative': store.discuss.isSidebarCompact, 'my-1': !store.discuss.isSidebarCompact }" t-attf-class="#{category.extraClass}" name="header" t-ref="root">
             <button class="o-mail-DiscussSidebarCategory-toggler btn btn-link text-reset flex-grow-1 d-flex p-0 text-start opacity-100-hover opacity-75" t-att-class="{ 'mx-1 align-items-baseline': !store.discuss.isSidebarCompact, 'align-items-center justify-content-center border-0 o-compact': store.discuss.isSidebarCompact }" t-on-click="() => this.toggle()" name="toggler">
                 <t t-if="store.discuss.isSidebarCompact">
-                    <i t-if="store.discuss.isSidebarCompact" class="start-0 position-absolute" t-att-class="{
+                    <i class="start-0 position-absolute" t-att-class="{
                         'oi oi-chevron-down': category.open,
                         'oi oi-chevron-right opacity-50': !category.open,
                     }"/>
@@ -114,22 +114,23 @@
                     <ThreadIcon t-if="thread.channel_type?.includes('chat') or (thread.channel_type === 'channel' and !thread.authorizedGroupFullName)" thread="thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute bottom-0 end-0 p-1 me-n1 mb-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
                     <CountryFlag t-if="thread.anonymous_country" country="thread.anonymous_country" class="'position-absolute o-mail-DiscussSidebarChannel-country border'"/>
                 </div>
-                <span t-if="!store.discuss.isSidebarCompact" class="mx-2 text-truncate" t-att-class="thread.selfMember?.message_unread_counter > 0 and !thread.mute_until_dt ? 'o-item-unread fw-bolder' : 'text-muted'">
+                <span t-if="!store.discuss.isSidebarCompact" class="mx-2 text-truncate" t-att-class="thread.selfMember?.message_unread_counter > 0 and !thread.isMuted ? 'o-item-unread fw-bolder' : 'text-muted'">
                     <t t-esc="thread.displayName"/>
                 </span>
             </button>
-            <div t-if="!store.discuss.isSidebarCompact" class="flex-grow-1"/>
-            <t t-if="!store.discuss.isSidebarCompact" t-call="mail.DiscussSidebarChannel.commands"/>
             <t t-if="!store.discuss.isSidebarCompact">
-                <t t-foreach="indicators" t-as="indicator" t-key="indicator_index" t-component="indicator" t-props="{ thread }"/>
+              <div class="flex-grow-1"/>
+              <t t-call="mail.DiscussSidebarChannel.commands"/>
+              <t t-foreach="indicators" t-as="indicator" t-key="indicator_index" t-component="indicator" t-props="{ thread }"/>
+              <i t-if="thread.isMuted" class="fa fa-fw fa-bell-slash me-3"/>
             </t>
             <t t-else="">
                 <div t-if="indicators.length" class="position-absolute rounded-circle p-0 smaller o-mail-DiscussSidebarChannel-indicatorCompact lh-1 bg-inherit" name="indicator-compact">
                     <t t-component="indicators[0]" t-props="{ thread }"/>
                 </div>
             </t>
-            <span t-if="thread.selfMember?.message_unread_counter > 0 and !thread.mute_until_dt and thread.importantCounter === 0" class="o-mail-DiscussSidebarChannel-unreadIndicator position-absolute" name="unread-indicator" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }" title="Thread has unread messages"><i class="fa fa-circle smaller"/></span>
-            <span t-if="thread.importantCounter > 0" t-attf-class="o-mail-DiscussSidebar-badge badge rounded-pill o-discuss-badge fw-bold {{thread.mute_until_dt ? 'o-muted' : ''}}" t-att-class="{ 'ms-1 me-2': !store.discuss.isSidebarCompact, 'position-absolute top-0 o-compact': store.discuss.isSidebarCompact }" t-esc="thread.importantCounter"/>
+            <span t-if="thread.selfMember?.message_unread_counter > 0 and !thread.isMuted and thread.importantCounter === 0" class="o-mail-DiscussSidebarChannel-unreadIndicator position-absolute" name="unread-indicator" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }" title="Thread has unread messages"><i class="fa fa-circle smaller"/></span>
+            <span t-if="thread.importantCounter > 0" t-attf-class="o-mail-DiscussSidebar-badge badge rounded-pill o-discuss-badge fw-bold {{thread.isMuted ? 'o-muted' : ''}}" t-att-class="{ 'ms-1 me-2': !store.discuss.isSidebarCompact, 'position-absolute top-0 o-compact': store.discuss.isSidebarCompact }" t-esc="thread.importantCounter"/>
         </div>
     </t>
 


### PR DESCRIPTION
This PR:

* Add the channel muted bell icon in the sidebar
* Cleanup some useless `t-if="store.discuss.isSidebarCompact"`
* Replace some `mute_until_dt` with the new getter `thread.isMuted`
