### PR TITLE
[FIX] website_sale: show vat for b2b partner

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1143,6 +1143,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
                         partner_sudo == order_sudo.partner_id
                         and (can_edit_vat or partner_sudo.vat)
                     )  # On the main partner only, if the VAT was set.
+                    or order_sudo.website_id._display_partner_b2b_fields()
                 )
             ),
             'vat_label': _lt("VAT"),


### PR DESCRIPTION
Steps to reproduce:
[l10n_ec]
- put an item on the cart
- create a new adress

Issue:
JS error thrown

Cause:
We don't find the associate field to be set as required https://github.com/odoo/odoo/blob/2361d4606cee0dfea115caf2af8948390a8a71e9/addons/website_sale/static/src/js/address.js#L126-L138

Since we are not editing an existing adress, we are not a sudo_partner and we don't show the vat https://github.com/odoo/odoo/blob/cbe1fbaaa7c82d2c31961d81a223cfa386c89020/addons/website_sale/views/templates.xml#L1988

Therefore the Xpath won't find the vat and we are not setting the necessary fields https://github.com/odoo/odoo/blob/453cfab758505ae15135703fb7be8bdb54981444/addons/l10n_ec_website_sale/views/portal_templates.xml#L27-L33 https://github.com/odoo/odoo/blob/3a73bf6cac9cfed4be7805356378cd064cb8351f/addons/l10n_ec_website_sale/controllers/portal.py#L12-L17

Solution:
We show the vat when a localization should always display b2b fields

opw-4139919