### PR TITLE
[FIX] pos_self_order: fix kitchen printing

### DIFF
--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -446,11 +446,11 @@ export class SelfOrder extends Reactive {
 
     _getKioskPrintingCategoriesChanges(categories) {
         return this.currentOrder.lines.filter((orderline) =>
-            categories.some((categId) =>
+            categories.some((category) =>
                 this.models["product.product"]
-                    .get(orderline["product_id"])
+                    .get(orderline.product_id.id)
                     .pos_categ_ids.map((categ) => categ.id)
-                    .includes(categId)
+                    .includes(category.id)
             )
         );
     }
@@ -469,7 +469,7 @@ export class SelfOrder extends Reactive {
                 const printingChanges = {
                     new: orderlines,
                     tracker: this.currentOrder.table_stand_number,
-                    trackingNumber: this.currentOrder.trackingNumber || "unknown number",
+                    trackingNumber: this.currentOrder.tracking_number || "unknown number",
                     name: this.currentOrder.pos_reference || "unknown order",
                     time: {
                         hours,


### PR DESCRIPTION
The kitchen printing was broken due to a couple of bugs that prevented it from checking the product
category correctly, and also using the wrong
variable name for the tracking number. This PR
fixes those issues.

Steps to reproduce:

- Go to the settings of default PoS Kiosk
- Enable Preparation -> Prepartion Printers, and add a new Printer
- Configure either IoT or Epson printer, and add 'Food' product category
- Make sure the new printer is added in the Preparation Printers selection for the Kiosk
- Open the kiosk session and make an order with a food item
- Printer does not print on order confirmation
  - EXPECTED BEHAVIOR: Printer prints order details on confirmation


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
