### PR TITLE
[FIX] web: action service: prevent infinite reloading on error

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -869,6 +869,10 @@ export function makeActionManager(env, router = _router) {
                     // This occurs when clicking on a breadcrumbs.
                     return restore(controllerStack[index - 1].jsId);
                 }
+                if (index === 0) {
+                    // No previous controller to restore, so do nothing but display the error
+                    return;
+                }
                 const lastController = controllerStack.at(-1);
                 if (lastController) {
                     if (lastController.jsId !== controller.jsId) {


### PR DESCRIPTION
Go to a kanban view (directly from a menu, s.t. it's the first item in the breadcrumb), open a record. Simulate a global network error (connection loss, server down, outdated session...). For instance, remove the session_id cookie. Click on the breadcrumb to go back to kanban.

Before this commit, this caused an infinite loop of reloading the kanban and the form views. When the first rpc error occurs, we land into the onError handler in the action service. We detect that we are trying to restore a controller from the stack, which crashes. At that point, we would like to restore the controller which appears before the faulty one in the stack. In our case, there's no such controller (we are the first one). So we reach the other part of the error handling, which concerns controllers that are not yet in the stack. For that case, we try to restore the last controller of the stack (the form view). This one fails as well, so we land again in the onError handler, for a controller that is already in the stack, but not the first one this time. So we try to restore the one before it (the kanban), which fails, and so on.

The issue has been introduced in [1], where we simply forgot to handle the case where the faulty controller is the first one of the stack, and that's exactly what we do in this commit. In that case, there's nothing to do but display the error (there's no controller to restore).

[1] ad35b3069e2efc69b97a283476da4154d49dda8b

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
