### PR TITLE
[FIX] {sale_purchase_,}stock: decrease the SOL qty for MTO product

### DIFF
--- a/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
+++ b/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests.common import TransactionCase, Form
+from odoo import Command
 
 
 class TestSalePurchaseStockFlow(TransactionCase):
@@ -83,3 +84,63 @@ class TestSalePurchaseStockFlow(TransactionCase):
 
         sm.move_line_ids.qty_done = 10
         self.assertEqual(so.order_line.qty_delivered, 10)
+
+    def test_decreasing_sol_qty_for_mto_product(self):
+        """
+        We have two MTO + Buy route products: product1 and product2.
+        product1 has enough units on hand for the sale order but product2 does not.
+        If we lower the SOL quantity for product2 it should merge the negative move and not create a return order.
+        """
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        product1, product2 = self.env['product.product'].create([
+            {
+                'name': 'product1',
+                'uom_id': self.env.ref('uom.product_uom_unit').id,
+                'type': 'product',
+                'route_ids': [(6, 0, (self.mto_route + self.buy_route).ids)]
+            },
+            {
+                'name': 'product2',
+                'uom_id': self.env.ref('uom.product_uom_unit').id,
+                'type': 'product',
+                'route_ids': [(6, 0, (self.mto_route + self.buy_route).ids)]
+            }
+        ])
+        self.env['stock.quant']._update_available_quantity(product1, warehouse.lot_stock_id, 10)
+        products_vendor = self.env['res.partner'].create([
+            {'name': 'product vendor'},
+        ])
+        self.env['product.supplierinfo'].create([
+            {
+                'product_id': product1.id,
+                'partner_id': products_vendor.id,
+                'price': 5,
+            },
+            {
+                'product_id': product2.id,
+                'partner_id': products_vendor.id,
+                'price': 5,
+            }
+        ])
+
+        so = self.env['sale.order'].create({
+            'partner_id': self.env['res.partner'].create({'name': 'Test Partner'}).id,
+            'warehouse_id': warehouse.id,
+            'order_line': [
+                Command.create({
+                    'name': product1.name,
+                    'product_id': product1.id,
+                    'product_uom_qty': 1,
+                }),
+                Command.create({
+                    'name': product2.name,
+                    'product_id': product2.id,
+                    'product_uom_qty': 3,
+                })
+            ]
+        })
+
+        so.action_confirm()
+        so.order_line[1].product_uom_qty = 1
+        self.assertEqual(so.picking_ids.move_ids[1].product_uom_qty, 1)
+        self.assertEqual(so.delivery_count, 1)

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -255,7 +255,12 @@ class StockRule(models.Model):
                 if float_compare(qty_needed, 0, precision_rounding=procurement.product_id.uom_id.rounding) <= 0:
                     procure_method = 'make_to_order'
                     for move in procurement.values.get('group_id', self.env['procurement.group']).stock_move_ids:
-                        if move.rule_id == rule and float_compare(move.product_uom_qty, 0, precision_rounding=move.product_uom.rounding) > 0:
+                        is_sale_line_or_product_match = move.sale_line_id.id == procurement.values['sale_line_id'] if procurement.values.get('sale_line_id') else move.product_id == procurement.product_id
+                        if (
+                            move.rule_id == rule
+                            and float_compare(move.product_uom_qty, 0, precision_rounding=move.product_uom.rounding) > 0
+                            and is_sale_line_or_product_match
+                        ):
                             procure_method = move.procure_method
                             break
                     forecasted_qties_by_loc[rule.location_src_id][procurement.product_id.id] -= qty_needed


### PR DESCRIPTION
Problem: If there are multiple products with the MTO and Buy routes on a sale order, but the first one has enough quantity on hand for the sale order. This sets the procure_method on the associated stock move to “make_to_stock”. However, the procure_method for the second product’s stock move is set to “make_to_order”. When lowering the sale order line quantity for the second product, the negative move’s procure_method gets set to “make_to_stock” from the first product’s positive stock move. Since the procure_methods do not match, a return picking is created, instead of merging the negative move with its positive counterpart.

Purpose: To filter out the stock moves not for the procurement’s product in order for the negative move to follow the same behavior as the initial positive move.

Steps to Reproduce on Runbot:

1. In settings enable “Multi-Step Routes”
2. In Routes, unarchive the “Replenish on Order (MTO)” route
3. Create a storable product A, with the MTO and Buy routes enabled
4. Add a vendor under the Purchase tab on product A
5. Set the On Hand quantity to 10 units for product A
6. Create a storable product B, with the MTO and Buy routes enabled
7. Add a vendor under the Purchase tab on product B
8. Create and confirm a Sales Order for 1 unit of product A and 3 units of product B
9. Lower the quantity on the sale order line for product B to 1 unit
10. Observe a return picking gets created

opw-4138774

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
