### PR TITLE
[IMP] sale_pdf_quote_builder: no product documents once order confirmed

### DIFF
--- a/addons/sale_pdf_quote_builder/models/ir_actions_report.py
+++ b/addons/sale_pdf_quote_builder/models/ir_actions_report.py
@@ -23,6 +23,8 @@ class IrActionsReport(models.Model):
         orders = self.env['sale.order'].browse(res_ids)
 
         for order in orders:
+            if order.state == 'sale':
+                continue
             initial_stream = result[order.id]['stream']
             if initial_stream:
                 quotation_documents = order.quotation_document_ids


### PR DESCRIPTION
Before this commit:
The product documents would still be included in the quote PDF even after the order was confirmed, which was unnecessary because those documents were intended to encourage the customer to accept the quotation.

After this commit:
Once the sales order is confirmed, the PDF of the order will not include the quote documents (header/footer or product documents).

task-4107330