### PR TITLE
[IMP] website: introduce `s_company_team_card` snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -81,6 +81,7 @@
         'views/snippets/s_company_team_detail.xml',
         'views/snippets/s_company_team_spotlight.xml',
         'views/snippets/s_company_team_grid.xml',
+        'views/snippets/s_company_team_card.xml',
         'views/snippets/s_call_to_action.xml',
         'views/snippets/s_references.xml',
         'views/snippets/s_references_social.xml',

--- a/addons/website/views/snippets/s_company_team_card.xml
+++ b/addons/website/views/snippets/s_company_team_card.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_company_team_card" name="Card Team">
+    <section class="s_company_team_card o_colored_level o_cc o_cc5 pt48 pb48">
+        <div class="container">
+            <h2 style="text-align: center;">Our Team</h2>
+            <div class="row">
+                <div data-name="Team Member" class="col-6 col-lg-3">
+                    <div class="s_card o_card_img_top card o_cc o_cc3" data-name="Card" data-snippet="s_card" data-vxml="001" style="border-width: 0px !important;">
+                        <figure class="o_card_img_wrapper ratio ratio-1x1 mb-0">
+                            <img class="o_card_img card-img-top rounded-circle" src="/web/image/website.s_company_team_image_1" style="padding: 24px;"/>
+                        </figure>
+                        <div class="card-body">
+                            <h3 class="card-title h5-fs" style="text-align: center;">Tony Fred</h3>
+                            <p class="card-text" style="text-align: center;">Chief Executive Officer <br/><br/></p>
+                        </div>
+                    </div>
+                </div>
+                <div data-name="Team Member" class="col-6 col-lg-3">
+                    <div class="s_card o_card_img_top card o_cc o_cc3" data-name="Card" data-snippet="s_card" data-vxml="001" style="border-width: 0px !important;">
+                        <figure class="o_card_img_wrapper ratio ratio-1x1 mb-0">
+                            <img class="o_card_img card-img-top rounded-circle" src="/web/image/website.s_company_team_image_2" style="padding: 24px;"/>
+                        </figure>
+                        <div class="card-body">
+                            <h3 class="card-title h5-fs" style="text-align: center;">Iris Joe</h3>
+                            <p class="card-text" style="text-align: center;">Chief Financial Manager <br/><br/></p>
+                        </div>
+                    </div>
+                </div>
+                <div data-name="Team Member" class="col-6 col-lg-3">
+                    <div class="s_card o_card_img_top card o_cc o_cc3" data-name="Card" data-snippet="s_card" data-vxml="001" style="border-width: 0px !important;">
+                        <figure class="o_card_img_wrapper ratio ratio-1x1 mb-0">
+                            <img class="o_card_img card-img-top rounded-circle" src="/web/image/website.s_company_team_image_3" style="padding: 24px;"/>
+                        </figure>
+                        <div class="card-body">
+                            <h3 class="card-title h5-fs" style="text-align: center;">Mich Stark</h3>
+                            <p class="card-text" style="text-align: center;">Chief Operational Officer <br/><br/></p>
+                        </div>
+                    </div>
+                </div>
+                <div data-name="Team Member" class="col-6 col-lg-3">
+                    <div class="s_card o_card_img_top card o_cc o_cc3" data-name="Card" data-snippet="s_card" data-vxml="001" style="border-width: 0px !important;">
+                        <figure class="o_card_img_wrapper ratio ratio-1x1 mb-0">
+                            <img class="o_card_img card-img-top rounded-circle" src="/web/image/website.s_company_team_image_4" style="padding: 24px;"/>
+                        </figure>
+                        <div class="card-body">
+                            <h3 class="card-title h5-fs" style="text-align: center;">Aline Turner</h3>
+                            <p class="card-text" style="text-align: center;">Chief Technical Officer <br/><br/></p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -307,6 +307,9 @@
                 <t t-snippet="website.s_company_team_grid" string="Company Team Grid" group="people">
                     <keywords>organization, structure, people, team, name, role, position, image, portrait, photo, employees, shapes</keywords>
                 </t>
+                <t t-snippet="website.s_company_team_card" string="Card Team" group="people">
+                    <keywords>organization, structure, people, team, name, role, position, image, portrait, photo, employees, shapes</keywords>
+                </t>
                 <t t-snippet="website.s_references" string="References" group="people">
                     <keywords>customers, clients, sponsors, partners, supporters, case-studies, collaborators, associations, associates, testimonials, endorsements</keywords>
                 </t>
@@ -792,7 +795,7 @@
              which the s_card options should be bound (instead of the s_card).
              Note: defined here to be set above all the other options that might
              need it. -->
-        <t t-set="card_parent_handlers" t-value="'.s_three_columns .row > div, .s_comparisons .row > div, .s_cards_grid .row > div, .s_cards_soft .row > div, .s_product_list .row > div, .s_newsletter_centered .row > div, .s_company_team_spotlight .row > div, .s_comparisons_horizontal .row > div, .s_company_team_grid .row > div'"/>
+        <t t-set="card_parent_handlers" t-value="'.s_three_columns .row > div, .s_comparisons .row > div, .s_cards_grid .row > div, .s_cards_soft .row > div, .s_product_list .row > div, .s_newsletter_centered .row > div, .s_company_team_spotlight .row > div, .s_comparisons_horizontal .row > div, .s_company_team_grid .row > div, .s_company_team_card .row > div'"/>
 
         <!-- Binding the option on the snippet if it is not a s_card with a
              handler parent -->


### PR DESCRIPTION
This commit adds the new `s_company_team_card` snippet.

task-4149441
Part-of: task-4077427

requires: https://github.com/odoo/design-themes/pull/902

| New snippet: Company Team Card |
|--------|
| ![image](https://github.com/user-attachments/assets/64e2346d-d80c-44ca-a70e-9f68472d30ed) | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
