### PR TITLE
[IMP] website: introduce `s_company_team_spotlight` snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -77,6 +77,7 @@
         'views/snippets/s_company_team_basic.xml',
         'views/snippets/s_company_team_shapes.xml',
         'views/snippets/s_company_team_detail.xml',
+        'views/snippets/s_company_team_spotlight.xml',
         'views/snippets/s_call_to_action.xml',
         'views/snippets/s_references.xml',
         'views/snippets/s_references_social.xml',

--- a/addons/website/views/snippets/s_company_team_spotlight.xml
+++ b/addons/website/views/snippets/s_company_team_spotlight.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_company_team_spotlight" name="Team Spotlight">
+    <section class="s_company_team_spotlight o_colored_level o_cc o_cc1 pt48 pb48">
+        <div class="container">
+            <div class="row s_nb_column_fixed">
+                <div class="col-lg-12 pb24">
+                    <h2 style="text-align: center;">Team spotlight</h2>
+                </div>
+                <div data-name="Team Member" class="col-6 col-lg-3">
+                    <div class="s_card o_card_img_top card o_cc o_cc1" data-vxml="001" data-snippet="s_card" data-name="Card">
+                        <figure class="o_card_img_wrapper ratio ratio-1x1 mb-0">
+                            <img class="o_card_img card-img-top" src="/web/image/website.s_company_team_image_1"/>
+                        </figure>
+                        <div class="card-body">
+                            <h5 class="card-title">Tony Fred</h5>
+                            <p class="card-text">Chief Executive Officer</p>
+                        </div>
+                    </div>
+                </div>
+                <div data-name="Team Member" class="col-6 col-lg-3">
+                    <div class="s_card o_card_img_top card o_cc o_cc1" data-vxml="001" data-snippet="s_card" data-name="Card">
+                        <figure class="o_card_img_wrapper ratio ratio-1x1 mb-0">
+                            <img class="o_card_img card-img-top" src="/web/image/website.s_company_team_image_2"/>
+                        </figure>
+                        <div class="card-body">
+                            <h5 class="card-title">Mich Stark</h5>
+                            <p class="card-text">Chief Technical Manager</p>
+                        </div>
+                    </div>
+                </div>
+                <div data-name="Team Member" class="col-6 col-lg-3">
+                    <div class="s_card o_card_img_top card o_cc o_cc1" data-vxml="001" data-snippet="s_card" data-name="Card">
+                        <figure class="o_card_img_wrapper ratio ratio-1x1 mb-0">
+                            <img class="o_card_img card-img-top" src="/web/image/website.s_company_team_image_3"/>
+                        </figure>
+                        <div class="card-body">
+                            <h5 class="card-title">Aline Turner</h5>
+                            <p class="card-text">Chief Financial Officer</p>
+                        </div>
+                    </div>
+                </div>
+                <div data-name="Team Member" class="col-6 col-lg-3">
+                    <div class="s_card o_card_img_top card o_cc o_cc1" data-vxml="001" data-snippet="s_card" data-name="Card">
+                        <figure class="o_card_img_wrapper ratio ratio-1x1 mb-0">
+                            <img class="o_card_img card-img-top" src="/web/image/website.s_company_team_image_4"/>
+                        </figure>
+                        <div class="card-body">
+                            <h5 class="card-title">Iris Joe</h5>
+                            <p class="card-text">Chief Operational Officer</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -295,6 +295,9 @@
                 <t t-snippet="website.s_company_team_detail" string="Team Detail" group="people">
                     <keywords>organization, company, people, members, staffs, profiles, bios, roles, personnel, crew, patterned, trendy, social</keywords>
                 </t>
+                <t t-snippet="website.s_company_team_spotlight" string="Team Spotlight" group="people">
+                    <keywords>organization, company, people, members, staffs, profiles, bios, roles, personnel, crew, patterned</keywords>
+                </t>
                 <t t-snippet="website.s_references" string="References" group="people">
                     <keywords>customers, clients, sponsors, partners, supporters, case-studies, collaborators, associations, associates, testimonials, endorsements</keywords>
                 </t>
@@ -751,7 +754,7 @@
              which the s_card options should be bound (instead of the s_card).
              Note: defined here to be set above all the other options that might
              need it. -->
-        <t t-set="card_parent_handlers" t-value="'.s_three_columns .row > div, .s_comparisons .row > div, .s_cards_grid .row > div, .s_cards_soft .row > div, .s_product_list .row > div, .s_newsletter_centered .row > div'"/>
+        <t t-set="card_parent_handlers" t-value="'.s_three_columns .row > div, .s_comparisons .row > div, .s_cards_grid .row > div, .s_cards_soft .row > div, .s_product_list .row > div, .s_newsletter_centered .row > div, .s_company_team_spotlight .row > div'"/>
 
         <!-- Binding the option on the snippet if it is not a s_card with a
              handler parent -->


### PR DESCRIPTION
This commit adds the new `s_company_team_spotlight` snippet.

task-4147920
Part-of: task-4077427

requires: https://github.com/odoo/design-themes/pull/903

| New snippet: Company Team Spotlight |
|--------|
| ![image](https://github.com/user-attachments/assets/2a604d75-4741-4dc2-9374-38f2f3712745) | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
