### PR TITLE
[FIX] website_sale: prevent error when access alternate products of archived products

### DIFF
--- a/addons/website_sale/models/website_snippet_filter.py
+++ b/addons/website_sale/models/website_snippet_filter.py
@@ -167,7 +167,9 @@ class WebsiteSnippetFilter(models.Model):
         self, website, limit, domain, product_template_id, **kwargs,
     ):
         products = self.env['product.product']
-        current_template = self.env['product.template'].browse(int(product_template_id)).exists()
+        current_template = self.env['product.template'].browse(
+            product_template_id and int(product_template_id)
+        ).exists()
         if current_template:
             sale_orders = self.env['sale.order'].sudo().search([
                 ('website_id', '=', website.id),
@@ -193,7 +195,9 @@ class WebsiteSnippetFilter(models.Model):
 
     def _get_products_accessories(self, website, limit, domain, product_template_id=None, **kwargs):
         products = self.env['product.product']
-        current_template = self.env['product.template'].browse(int(product_template_id)).exists()
+        current_template = self.env['product.template'].browse(
+            product_template_id and int(product_template_id)
+        ).exists()
         if current_template:
             excluded_products = website.sale_get_order().order_line.product_id.ids
             excluded_products.extend(current_template.product_variant_ids.ids)
@@ -213,7 +217,9 @@ class WebsiteSnippetFilter(models.Model):
         self, website, limit, domain, product_template_id=None, **kwargs,
     ):
         products = self.env['product.product']
-        current_template = self.env['product.template'].browse(int(product_template_id)).exists()
+        current_template = self.env['product.template'].browse(
+            product_template_id and int(product_template_id)
+        ).exists()
         if current_template:
             excluded_products = website.sale_get_order().order_line.product_id
             excluded_products |= current_template.product_variant_ids


### PR DESCRIPTION
Currently, an exception was generated when the user added a dynamic filter like 
'Recently Sold Products', 'Accessories for Product', or 'Products Recently Sold With Product'
to the product website view and tried to preview archived products from website.

Steps to produce:
1. Create a product with Alternative Products from the sales tab.
2. Archive this product
3. Click on Go to Website Icon >> error occurs

Error:
`TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'`

This is because we receive 'product_template_id' as None, and when [1] tries to convert it onto Integer,
 it will generate an exception. With the recently merged https://github.com/odoo/odoo/commit/d526b6c70bcf21bf84be83615daefee5ad972d14, added this code but not handled case with product_template_id as None.

This commit will resolve the above issue by setting 'current_template'
as false when `current_template` is None.

[1] - https://github.com/odoo/odoo/blob/2aa4ee0d66af8079694a42b84d341fe118f12c0b/addons/website_sale/models/website_snippet_filter.py#L216


sentry-5704306029





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
