### PR TITLE
[IMP] maintenance: simplify kanban archs

### DIFF
--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -791,20 +791,12 @@
         <field name="name">maintenance.team.kanban</field>
         <field name="model">maintenance.team</field>
         <field name="arch" type="xml">
-            <kanban class="o_kanban_dashboard o_maintenance_team_kanban" create="0" can_open="0">
-                <field name="name"/>
-                <field name="color"/>
-                <field name="todo_request_ids"/>
-                <field name="todo_request_count"/>
-                <field name="todo_request_count_date"/>
-                <field name="todo_request_count_high_priority"/>
-                <field name="todo_request_count_block"/>
-                <field name="todo_request_count_unscheduled"/>
+            <kanban highlight_color="color" class="o_maintenance_team_kanban" create="0" can_open="0">
                 <templates>
                     <t t-name="kanban-menu">
                         <div class="container">
                             <div class="row">
-                                <div class="col-6 o_kanban_card_manage_section o_kanban_manage_view">
+                                <div class="col-6">
                                     <h5 role="menuitem" class="o_kanban_card_manage_title">
                                         <span>Requests</span>
                                     </h5>
@@ -829,7 +821,7 @@
                                         </a>
                                     </div>
                                 </div>
-                                <div class="col-6 o_kanban_card_manage_section o_kanban_manage_new">
+                                <div class="col-6">
                                     <h5 role="menuitem" class="o_kanban_card_manage_title">
                                         <span>Reporting</span>
                                     </h5>
@@ -842,58 +834,41 @@
                             </div>
                             <div t-if="widget.editable" class="o_kanban_card_manage_settings row">
                                 <div class="col-8" role="menuitem" aria-haspopup="true">
-                                    <ul role="menu" class="oe_kanban_colorpicker" data-field="color"/>
+                                    <field name="color" widget="kanban_color_picker"/>
                                 </div>
                                 <div role="menuitem" class="col-4">
-                                    <a type="edit" class="dropdown-item">Configuration</a>
+                                    <a type="open" class="dropdown-item">Configuration</a>
                                 </div>
                             </div>
                         </div>
                     </t>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="#{!selection_mode ? kanban_color(record.color.raw_value) : ''}">
-                            <div t-attf-class="o_kanban_card_header">
-                                <div class="o_kanban_card_header_title">
-                                    <div class="o_primary">
-                                        <a name="%(hr_equipment_todo_request_action_from_dashboard)d" type="action">
-                                            <field name="name"/>
-                                        </a></div>
-                                </div>
+                    <t t-name="kanban-card">
+                        <a name="%(hr_equipment_todo_request_action_from_dashboard)d" type="action">
+                            <field name="name" class="fw-bold fs-4 ms-2"/>
+                        </a>
+                        <div class="row g-0 mt-3 ms-2 pb-4">
+                            <div class="col-6">
+                                <button class="btn btn-primary" name="%(hr_equipment_todo_request_action_from_dashboard)d" type="action" context="{'search_default_todo': 1}">
+                                    <field name="todo_request_count"/> To Do
+                                </button>
                             </div>
-                            <div class="container o_kanban_card_content">
-                                <div class="row">
-                                    <div class="col-6 o_kanban_primary_left">
-                                        <button class="btn btn-primary" name="%(hr_equipment_todo_request_action_from_dashboard)d" type="action" context="{'search_default_todo': 1}">
-                                            <t t-esc="record.todo_request_count.value"/> To Do
-                                        </button>
-                                    </div>
-                                    <div class="col-6 o_kanban_primary_right">
-                                        <div t-if="record.todo_request_count_date.raw_value > 0">
-                                            <a name="%(hr_equipment_request_action_cal)d" type="action" context="{'search_default_todo': 1, 'search_default_maintenance_team_id': id}">
-                                                <t t-esc="record.todo_request_count_date.value"/>
-                                                Scheduled
-                                            </a>
-                                        </div>
-                                        <div t-if="record.todo_request_count_high_priority.raw_value > 0">
-                                            <a name="%(hr_equipment_todo_request_action_from_dashboard)d" type="action" context="{'search_default_high_priority': 1}">
-                                                <t t-esc="record.todo_request_count_high_priority.value"/>
-                                                Top Priorities
-                                            </a>
-                                        </div>
-                                        <div t-if="record.todo_request_count_block.raw_value > 0">
-                                            <a name="%(hr_equipment_todo_request_action_from_dashboard)d" type="action" context="{'search_default_kanban_state_block': 1}">
-                                                <t t-esc="record.todo_request_count_block.value"/>
-                                                Blocked
-                                            </a>
-                                        </div>
-                                        <div t-if="record.todo_request_count_unscheduled.raw_value > 0">
-                                            <a name="%(hr_equipment_todo_request_action_from_dashboard)d" type="action" context="{'search_default_todo': 1, 'search_default_unscheduled': 1}">
-                                                <t t-esc="record.todo_request_count_unscheduled.value"/>
-                                                Unscheduled
-                                            </a>
-                                        </div>
-                                    </div>
-                                </div>
+                            <div class="col-6">
+                                <a t-if="record.todo_request_count_date.raw_value > 0" name="%(hr_equipment_request_action_cal)d" type="action" context="{'search_default_todo': 1, 'search_default_maintenance_team_id': id}" class="d-block">
+                                    <field name="todo_request_count_date"/>
+                                    Scheduled
+                                </a>
+                                <a t-if="record.todo_request_count_high_priority.raw_value > 0" name="%(hr_equipment_todo_request_action_from_dashboard)d" type="action" context="{'search_default_high_priority': 1}" class="d-block">
+                                    <field name="todo_request_count_high_priority"/>
+                                    Top Priorities
+                                </a>
+                                <a t-if="record.todo_request_count_block.raw_value > 0" name="%(hr_equipment_todo_request_action_from_dashboard)d" type="action" context="{'search_default_kanban_state_block': 1}" class="d-block">
+                                    <field name="todo_request_count_block"/>
+                                    Blocked
+                                </a>
+                                <a t-if="record.todo_request_count_unscheduled.raw_value > 0" name="%(hr_equipment_todo_request_action_from_dashboard)d" type="action" context="{'search_default_todo': 1, 'search_default_unscheduled': 1}" class="d-block">
+                                    <field name="todo_request_count_unscheduled"/>
+                                    Unscheduled
+                                </a>
                             </div>
                         </div>
                     </t>


### PR DESCRIPTION
In this commit we have simplified the kanban arch for the maintenance module dashboard. the goal is to simplify them, make them easier to read and use bootstrap utility classnames.

- Previously, we used kanban-box, but now we are using kanban-card instead.
- Deprecated oe_kanban_global_click and oe_kanban_global_click_edit.
- More use of <field/> tags
- Removed the oe_kanban_colorpicker class and replaced it with the kanban_color_picker widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- kanban_image from rendering context, is deprecated so we use <field name="..." widget="image"/> instead
- kanban_color, kanban_getcolor and kanban_getcolorname are deprecated use new attribute highlight_color="color_field_name" on root node

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
