### PR TITLE
[FIX] html_editor: prevent arrow keys from skipping icons

### DIFF
--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -65,6 +65,8 @@ export class MediaPlugin extends Plugin {
         normalize_handlers: this.normalizeMedia.bind(this),
 
         unsplittable_node_predicates: isIconElement, // avoid merge
+
+        selectors_for_feff_providers: () => ICON_SELECTOR,
     };
 
     get recordInfo() {

--- a/addons/html_editor/static/src/main/star_plugin.js
+++ b/addons/html_editor/static/src/main/star_plugin.js
@@ -1,8 +1,4 @@
 import { Plugin } from "@html_editor/plugin";
-import {
-    getAdjacentNextSiblings,
-    getAdjacentPreviousSiblings,
-} from "@html_editor/utils/dom_traversal";
 import { parseHTML } from "@html_editor/utils/html";
 import { _t } from "@web/core/l10n/translation";
 
@@ -52,8 +48,10 @@ export class StarPlugin extends Plugin {
             node.parentElement &&
             node.parentElement.className.includes("o_stars")
         ) {
-            const previousStars = getAdjacentPreviousSiblings(node, isStar);
-            const nextStars = getAdjacentNextSiblings(node, isStar);
+            const allStars = Array.from(node.parentElement.childNodes).filter(isStar);
+            const currentStarIndex = allStars.indexOf(node);
+            const previousStars = allStars.slice(0, currentStarIndex);
+            const nextStars = allStars.slice(currentStarIndex + 1);
             if (nextStars.length || previousStars.length) {
                 const shouldToggleOff =
                     node.classList.contains("fa-star") &&

--- a/addons/html_editor/static/tests/_helpers/format.js
+++ b/addons/html_editor/static/tests/_helpers/format.js
@@ -3,8 +3,8 @@
  */
 export function unformat(html) {
     return html
-        .replace(/(^|[^ ])[\s\n]+([^<>]*?)</g, "$1$2<")
-        .replace(/>([^<>]*?)[\s\n]+([^ ]|$)/g, ">$1$2");
+        .replace(/(^|[^ ])[^\S\ufeff]+([^<>]*?)</g, "$1$2<")
+        .replace(/>([^<>]*?)[^\S\ufeff]+([^ ]|$)/g, ">$1$2");
 }
 
 /**

--- a/addons/html_editor/static/tests/data-oe/protected.test.js
+++ b/addons/html_editor/static/tests/data-oe/protected.test.js
@@ -85,11 +85,11 @@ test("should not normalize protected elements children (true)", async () => {
                 `),
         contentAfterEdit: unformat(`
                 <div>
-                    <p><i class="fa" contenteditable="false">\u200B</i></p>
+                    <p>\ufeff<i class="fa" contenteditable="false">\u200B</i>\ufeff</p>
                     <ul><li><p>abc</p><p><br></p></li></ul>
                 </div>
                 <div data-oe-protected="true" contenteditable="false">
-                    <p><i class="fa"></i></p>
+                    <p>\ufeff<i class="fa"></i>\ufeff</p>
                     <ul><li>abc<p><br></p></li></ul>
                 </div>
                 `),
@@ -124,10 +124,10 @@ test("should normalize unprotected elements children (false)", async () => {
                 `),
         contentAfterEdit: unformat(`
                 <div data-oe-protected="true" contenteditable="false">
-                    <p><i class="fa"></i></p>
+                    <p>\ufeff<i class="fa"></i>\ufeff</p>
                     <ul><li>abc<p><br></p></li></ul>
                     <div data-oe-protected="false" contenteditable="true">
-                        <p><i class="fa" contenteditable="false">\u200B</i></p>
+                        <p>\ufeff<i class="fa" contenteditable="false">\u200B</i>\ufeff</p>
                         <ul><li><p>abc</p><p><br></p></li></ul>
                     </div>
                 </div>

--- a/addons/html_editor/static/tests/font_awesome.test.js
+++ b/addons/html_editor/static/tests/font_awesome.test.js
@@ -14,7 +14,8 @@ describe("parse/render", () => {
     test("should parse an old-school fontawesome", async () => {
         await testEditor({
             contentBefore: '<p><i class="fa fa-star"></i></p>',
-            contentBeforeEdit: '<p><i class="fa fa-star" contenteditable="false">\u200b</i></p>',
+            contentBeforeEdit:
+                '<p>\ufeff<i class="fa fa-star" contenteditable="false">\u200b</i>\ufeff</p>',
             contentAfter: '<p><i class="fa fa-star"></i></p>',
         });
     });
@@ -22,7 +23,8 @@ describe("parse/render", () => {
     test("should parse a brand fontawesome", async () => {
         await testEditor({
             contentBefore: '<p><i class="fab fa-opera"></i></p>',
-            contentBeforeEdit: '<p><i class="fab fa-opera" contenteditable="false">\u200b</i></p>',
+            contentBeforeEdit:
+                '<p>\ufeff<i class="fab fa-opera" contenteditable="false">\u200b</i>\ufeff</p>',
             contentAfter: '<p><i class="fab fa-opera"></i></p>',
         });
     });
@@ -31,7 +33,7 @@ describe("parse/render", () => {
         await testEditor({
             contentBefore: '<p><i class="fad fa-bus-alt"></i></p>',
             contentBeforeEdit:
-                '<p><i class="fad fa-bus-alt" contenteditable="false">\u200b</i></p>',
+                '<p>\ufeff<i class="fad fa-bus-alt" contenteditable="false">\u200b</i>\ufeff</p>',
             contentAfter: '<p><i class="fad fa-bus-alt"></i></p>',
         });
     });
@@ -40,7 +42,7 @@ describe("parse/render", () => {
         await testEditor({
             contentBefore: '<p><i class="fab fa-accessible-icon"></i></p>',
             contentBeforeEdit:
-                '<p><i class="fab fa-accessible-icon" contenteditable="false">\u200b</i></p>',
+                '<p>\ufeff<i class="fab fa-accessible-icon" contenteditable="false">\u200b</i>\ufeff</p>',
             contentAfter: '<p><i class="fab fa-accessible-icon"></i></p>',
         });
     });
@@ -49,7 +51,7 @@ describe("parse/render", () => {
         await testEditor({
             contentBefore: '<p><i class="far fa-money-bill-alt"></i></p>',
             contentBeforeEdit:
-                '<p><i class="far fa-money-bill-alt" contenteditable="false">\u200b</i></p>',
+                '<p>\ufeff<i class="far fa-money-bill-alt" contenteditable="false">\u200b</i>\ufeff</p>',
             contentAfter: '<p><i class="far fa-money-bill-alt"></i></p>',
         });
     });
@@ -59,7 +61,7 @@ describe("parse/render", () => {
             // @phoenix content adapted to make it valid html
             contentBefore: '<p><i class="fa fa-pastafarianism"></i></p>',
             contentBeforeEdit:
-                '<p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i></p>',
+                '<p>\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeff</p>',
             contentAfter: '<p><i class="fa fa-pastafarianism"></i></p>',
         });
     });
@@ -68,13 +70,13 @@ describe("parse/render", () => {
         await testEditor({
             contentBefore: '<p><span class="fa fa-pastafarianism"></span></p>',
             contentBeforeEdit:
-                '<p><span class="fa fa-pastafarianism" contenteditable="false">\u200b</span></p>',
+                '<p>\ufeff<span class="fa fa-pastafarianism" contenteditable="false">\u200b</span>\ufeff</p>',
             contentAfter: '<p><span class="fa fa-pastafarianism"></span></p>',
         });
         await testEditor({
             contentBefore: '<p><span class="oi oi-pastafarianism"></span></p>',
             contentBeforeEdit:
-                '<p><span class="oi oi-pastafarianism" contenteditable="false">\u200b</span></p>',
+                '<p>\ufeff<span class="oi oi-pastafarianism" contenteditable="false">\u200b</span>\ufeff</p>',
             contentAfter: '<p><span class="oi oi-pastafarianism"></span></p>',
         });
     });
@@ -84,14 +86,14 @@ describe("parse/render", () => {
             // @phoenix content adapted to make it valid html
             contentBefore: '<p><i class="fa fa-pastafarianism"></i></p>',
             contentBeforeEdit:
-                '<p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i></p>',
+                '<p>\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeff</p>',
             contentAfter: '<p><i class="fa fa-pastafarianism"></i></p>',
         });
         await testEditor({
             // @phoenix content adapted to make it valid html
             contentBefore: '<p><i class="oi oi-pastafarianism"></i></p>',
             contentBeforeEdit:
-                '<p><i class="oi oi-pastafarianism" contenteditable="false">\u200b</i></p>',
+                '<p>\ufeff<i class="oi oi-pastafarianism" contenteditable="false">\u200b</i>\ufeff</p>',
             contentAfter: '<p><i class="oi oi-pastafarianism"></i></p>',
         });
     });
@@ -100,7 +102,7 @@ describe("parse/render", () => {
         await testEditor({
             contentBefore: '<p><i class="red fa bordered fa-pastafarianism big"></i></p>',
             contentBeforeEdit:
-                '<p><i class="red fa bordered fa-pastafarianism big" contenteditable="false">\u200b</i></p>',
+                '<p>\ufeff<i class="red fa bordered fa-pastafarianism big" contenteditable="false">\u200b</i>\ufeff</p>',
             contentAfter: '<p><i class="red fa bordered fa-pastafarianism big"></i></p>',
         });
     });
@@ -109,8 +111,8 @@ describe("parse/render", () => {
         await testEditor({
             contentBefore: `<p><i class="fa
                                 fa-pastafarianism"></i></p>`,
-            contentBeforeEdit: `<p><i class="fa
-                                fa-pastafarianism" contenteditable="false">\u200b</i></p>`,
+            contentBeforeEdit: `<p>\ufeff<i class="fa
+                                fa-pastafarianism" contenteditable="false">\u200b</i>\ufeff</p>`,
             contentAfter: `<p><i class="fa
                                 fa-pastafarianism"></i></p>`,
         });
@@ -120,8 +122,8 @@ describe("parse/render", () => {
         await testEditor({
             contentBefore: `<p><i class="red fa bordered
                                 big fa-pastafarianism scary"></i></p>`,
-            contentBeforeEdit: `<p><i class="red fa bordered
-                                big fa-pastafarianism scary" contenteditable="false">\u200b</i></p>`,
+            contentBeforeEdit: `<p>\ufeff<i class="red fa bordered
+                                big fa-pastafarianism scary" contenteditable="false">\u200b</i>\ufeff</p>`,
             contentAfter: `<p><i class="red fa bordered
                                 big fa-pastafarianism scary"></i></p>`,
         });
@@ -131,7 +133,7 @@ describe("parse/render", () => {
         await testEditor({
             contentBefore: '<p><i class="fa fa-pastafarianism"></i>a[b]c</p>',
             contentBeforeEdit:
-                '<p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>a[b]c</p>',
+                '<p>\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeffa[b]c</p>',
             contentAfter: '<p><i class="fa fa-pastafarianism"></i>a[b]c</p>',
         });
     });
@@ -140,7 +142,7 @@ describe("parse/render", () => {
         await testEditor({
             contentBefore: '<p>a[b]c<i class="fa fa-pastafarianism"></i>def</p>',
             contentBeforeEdit:
-                '<p>a[b]c<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>def</p>',
+                '<p>a[b]c\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeffdef</p>',
             contentAfter: '<p>a[b]c<i class="fa fa-pastafarianism"></i>def</p>',
         });
     });
@@ -149,7 +151,7 @@ describe("parse/render", () => {
         await testEditor({
             contentBefore: '<p>a[b]c<i class="fa fa-pastafarianism"></i></p>',
             contentBeforeEdit:
-                '<p>a[b]c<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i></p>',
+                '<p>a[b]c\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeff</p>',
             contentAfter: '<p>a[b]c<i class="fa fa-pastafarianism"></i></p>',
         });
     });
@@ -241,7 +243,7 @@ describe("deleteForward", () => {
                 await testEditor({
                     contentBefore: '<p>ab[]<i class="fa fa-pastafarianism"></i>cd</p>',
                     contentBeforeEdit:
-                        '<p>ab[]<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>cd</p>',
+                        '<p>ab[]\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeffcd</p>',
                     stepFunction: deleteForward,
                     contentAfter: "<p>ab[]cd</p>",
                 });
@@ -251,10 +253,10 @@ describe("deleteForward", () => {
                 await testEditor({
                     contentBefore: '<p>ab<i class="fa fa-pastafarianism"></i>[]cd</p>',
                     contentBeforeEdit:
-                        '<p>ab<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]cd</p>',
+                        '<p>ab\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeff[]cd</p>',
                     stepFunction: deleteForward,
                     contentAfterEdit:
-                        '<p>ab<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]d</p>',
+                        '<p>ab\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeff[]d</p>',
                     contentAfter: '<p>ab<i class="fa fa-pastafarianism"></i>[]d</p>',
                 });
             });
@@ -263,14 +265,14 @@ describe("deleteForward", () => {
                 await testEditor({
                     contentBefore: '<p>ab[]cde<i class="fa fa-pastafarianism"></i>fghij</p>',
                     contentBeforeEdit:
-                        '<p>ab[]cde<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>fghij</p>',
+                        '<p>ab[]cde\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufefffghij</p>',
                     stepFunction: async (editor) => {
                         deleteForward(editor);
                         deleteForward(editor);
                         deleteForward(editor);
                     },
                     contentAfterEdit:
-                        '<p>ab[]<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>fghij</p>',
+                        '<p>ab[]\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufefffghij</p>',
                     contentAfter: '<p>ab[]<i class="fa fa-pastafarianism"></i>fghij</p>',
                 });
             });
@@ -279,12 +281,12 @@ describe("deleteForward", () => {
                 await testEditor({
                     contentBefore: '<p>ab[] <i class="fa fa-pastafarianism"></i> cd</p>',
                     contentBeforeEdit:
-                        '<p>ab[] <i class="fa fa-pastafarianism" contenteditable="false">\u200b</i> cd</p>',
+                        '<p>ab[] \ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeff cd</p>',
                     stepFunction: async (editor) => {
                         deleteForward(editor);
                     },
                     contentAfterEdit:
-                        '<p>ab[]<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i> cd</p>',
+                        '<p>ab[]\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeff cd</p>',
                     contentAfter: '<p>ab[]<i class="fa fa-pastafarianism"></i> cd</p>',
                 });
             });
@@ -293,13 +295,13 @@ describe("deleteForward", () => {
                 await testEditor({
                     contentBefore: '<p>a[]b <i class="fa fa-pastafarianism"></i> cd</p>',
                     contentBeforeEdit:
-                        '<p>a[]b <i class="fa fa-pastafarianism" contenteditable="false">\u200b</i> cd</p>',
+                        '<p>a[]b \ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeff cd</p>',
                     stepFunction: async (editor) => {
                         deleteForward(editor);
                         deleteForward(editor);
                     },
                     contentAfterEdit:
-                        '<p>a[]<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i> cd</p>',
+                        '<p>a[]\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeff cd</p>',
                     contentAfter: '<p>a[]<i class="fa fa-pastafarianism"></i> cd</p>',
                 });
             });
@@ -309,13 +311,13 @@ describe("deleteForward", () => {
                     contentBefore:
                         '<p><span class="a">ab[]c </span><i class="fa fa-star"></i> def</p>',
                     contentBeforeEdit:
-                        '<p><span class="a">ab[]c </span><i class="fa fa-star" contenteditable="false">\u200b</i> def</p>',
+                        '<p><span class="a">ab[]c </span>\ufeff<i class="fa fa-star" contenteditable="false">\u200b</i>\ufeff def</p>',
                     stepFunction: async (editor) => {
                         deleteForward(editor);
                         deleteForward(editor);
                     },
                     contentAfterEdit:
-                        '<p><span class="a">ab[]</span><i class="fa fa-star" contenteditable="false">\u200b</i> def</p>',
+                        '<p><span class="a">ab[]</span>\ufeff<i class="fa fa-star" contenteditable="false">\u200b</i>\ufeff def</p>',
                     contentAfter:
                         '<p><span class="a">ab[]</span><i class="fa fa-star"></i> def</p>',
                 });
@@ -350,14 +352,14 @@ describe("deleteBackward", () => {
                 await testEditor({
                     contentBefore: '<p>ab<i class="fa fa-pastafarianism"></i>[]cd</p>',
                     contentBeforeEdit:
-                        '<p>ab<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]cd</p>',
+                        '<p>ab\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeff[]cd</p>',
                     stepFunction: deleteBackward,
                     contentAfter: "<p>ab[]cd</p>",
                 });
                 await testEditor({
                     contentBefore: '<p>ab<i class="oi oi-pastafarianism"></i>[]cd</p>',
                     contentBeforeEdit:
-                        '<p>ab<i class="oi oi-pastafarianism" contenteditable="false">\u200b</i>[]cd</p>',
+                        '<p>ab\ufeff<i class="oi oi-pastafarianism" contenteditable="false">\u200b</i>\ufeff[]cd</p>',
                     stepFunction: deleteBackward,
                     contentAfter: "<p>ab[]cd</p>",
                 });
@@ -368,7 +370,7 @@ describe("deleteBackward", () => {
                     contentBefore:
                         '<p>ab<i class="fa fa-pastafarianism"></i><span class="a">[]cd</span></p>',
                     contentBeforeEdit:
-                        '<p>ab<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i><span class="a">[]cd</span></p>',
+                        '<p>ab\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeff<span class="a">[]cd</span></p>',
                     stepFunction: deleteBackward,
                     contentAfter: '<p>ab[]<span class="a">cd</span></p>',
                 });
@@ -379,10 +381,10 @@ describe("deleteBackward", () => {
                     contentBefore:
                         '<p>ab<i class="fa fa-pastafarianism"></i><span class="a">c[]d</span></p>',
                     contentBeforeEdit:
-                        '<p>ab<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i><span class="a">c[]d</span></p>',
+                        '<p>ab\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeff<span class="a">c[]d</span></p>',
                     stepFunction: deleteBackward,
                     contentAfterEdit:
-                        '<p>ab<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i><span class="a">[]d</span></p>',
+                        '<p>ab\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeff<span class="a">[]d</span></p>',
                     contentAfter:
                         '<p>ab<i class="fa fa-pastafarianism"></i><span class="a">[]d</span></p>',
                 });
@@ -392,10 +394,10 @@ describe("deleteBackward", () => {
                 await testEditor({
                     contentBefore: '<p>ab[]<i class="fa fa-pastafarianism"></i>cd</p>',
                     contentBeforeEdit:
-                        '<p>ab[]<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>cd</p>',
+                        '<p>ab[]\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeffcd</p>',
                     stepFunction: deleteBackward,
                     contentAfterEdit:
-                        '<p>a[]<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>cd</p>',
+                        '<p>a[]\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeffcd</p>',
                     contentAfter: '<p>a[]<i class="fa fa-pastafarianism"></i>cd</p>',
                 });
             });
@@ -404,14 +406,14 @@ describe("deleteBackward", () => {
                 await testEditor({
                     contentBefore: '<p>abcde<i class="fa fa-pastafarianism"></i>fgh[]ij</p>',
                     contentBeforeEdit:
-                        '<p>abcde<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>fgh[]ij</p>',
+                        '<p>abcde\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufefffgh[]ij</p>',
                     stepFunction: async (editor) => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
                     contentAfterEdit:
-                        '<p>abcde<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]ij</p>',
+                        '<p>abcde\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeff[]ij</p>',
                     contentAfter: '<p>abcde<i class="fa fa-pastafarianism"></i>[]ij</p>',
                 });
             });
@@ -420,14 +422,14 @@ describe("deleteBackward", () => {
                 await testEditor({
                     contentBefore: '<p>abcde <i class="fa fa-pastafarianism"></i> fg[]hij</p>',
                     contentBeforeEdit:
-                        '<p>abcde <i class="fa fa-pastafarianism" contenteditable="false">\u200b</i> fg[]hij</p>',
+                        '<p>abcde \ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeff fg[]hij</p>',
                     stepFunction: async (editor) => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
                     contentAfterEdit:
-                        '<p>abcde <i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]hij</p>',
+                        '<p>abcde \ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeff[]hij</p>',
                     contentAfter: '<p>abcde <i class="fa fa-pastafarianism"></i>[]hij</p>',
                 });
             });
@@ -461,7 +463,7 @@ describe("FontAwesome insertion", () => {
             contentBefore: "<p>[]abc</p>",
             stepFunction: insertFontAwesome("fa fa-star"),
             contentAfterEdit:
-                '<p><i class="fa fa-star" contenteditable="false">\u200b</i>[]abc</p>',
+                '<p>\ufeff<i class="fa fa-star" contenteditable="false">\u200b</i>[]\ufeffabc</p>',
             contentAfter: '<p><i class="fa fa-star"></i>[]abc</p>',
         });
     });
@@ -471,7 +473,7 @@ describe("FontAwesome insertion", () => {
             contentBefore: "<p>ab[]cd</p>",
             stepFunction: insertFontAwesome("fa fa-star"),
             contentAfterEdit:
-                '<p>ab<i class="fa fa-star" contenteditable="false">\u200b</i>[]cd</p>',
+                '<p>ab\ufeff<i class="fa fa-star" contenteditable="false">\u200b</i>[]\ufeffcd</p>',
             contentAfter: '<p>ab<i class="fa fa-star"></i>[]cd</p>',
         });
     });
@@ -481,7 +483,7 @@ describe("FontAwesome insertion", () => {
             contentBefore: "<p>abc[]</p>",
             stepFunction: insertFontAwesome("fa fa-star"),
             contentAfterEdit:
-                '<p>abc<i class="fa fa-star" contenteditable="false">\u200b</i>[]</p>',
+                '<p>abc\ufeff<i class="fa fa-star" contenteditable="false">\u200b</i>[]\ufeff</p>',
             contentAfter: '<p>abc<i class="fa fa-star"></i>[]</p>',
         });
     });
@@ -491,7 +493,7 @@ describe("FontAwesome insertion", () => {
             contentBefore: '<p>ab<i class="fa fa-pastafarianism"></i>c[]d</p>',
             stepFunction: insertFontAwesome("fa fa-star"),
             contentAfterEdit:
-                '<p>ab<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>c<i class="fa fa-star" contenteditable="false">\u200b</i>[]d</p>',
+                '<p>ab\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeffc\ufeff<i class="fa fa-star" contenteditable="false">\u200b</i>[]\ufeffd</p>',
             contentAfter:
                 '<p>ab<i class="fa fa-pastafarianism"></i>c<i class="fa fa-star"></i>[]d</p>',
         });
@@ -501,10 +503,10 @@ describe("FontAwesome insertion", () => {
         await testEditor({
             contentBefore: '<p>ab[]<i class="fa fa-pastafarianism"></i>cd</p>',
             contentBeforeEdit:
-                '<p>ab[]<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>cd</p>',
+                '<p>ab[]\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeffcd</p>',
             stepFunction: insertFontAwesome("fa fa-star"),
             contentAfterEdit:
-                '<p>ab<i class="fa fa-star" contenteditable="false">\u200b</i>[]<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>cd</p>',
+                '<p>ab\ufeff<i class="fa fa-star" contenteditable="false">\u200b</i>[]\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeffcd</p>',
             contentAfter:
                 '<p>ab<i class="fa fa-star"></i>[]<i class="fa fa-pastafarianism"></i>cd</p>',
         });
@@ -525,7 +527,7 @@ describe("FontAwesome insertion", () => {
                 execCommand(editor, "insertFontAwesome", { faClass: "fa fa-glass" });
             },
             contentAfterEdit:
-                '<p><i class="fa fa-star" contenteditable="false">\u200b</i><i class="fa fa-glass" contenteditable="false">\u200b</i>[]</p>',
+                '<p>\ufeff<i class="fa fa-star" contenteditable="false">\u200b</i>\ufeff<i class="fa fa-glass" contenteditable="false">\u200b</i>[]\ufeff</p>',
             contentAfter: '<p><i class="fa fa-star"></i><i class="fa fa-glass"></i>[]</p>',
         });
     });
@@ -536,12 +538,12 @@ describe("Text insertion", () => {
         await testEditor({
             contentBefore: '<p>ab[]<i class="fa fa-pastafarianism"></i>cd</p>',
             contentBeforeEdit:
-                '<p>ab[]<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>cd</p>',
+                '<p>ab[]\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeffcd</p>',
             stepFunction: async (editor) => {
                 await insertText(editor, "s");
             },
             contentAfterEdit:
-                '<p>abs[]<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>cd</p>',
+                '<p>abs[]\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeffcd</p>',
             contentAfter: '<p>abs[]<i class="fa fa-pastafarianism"></i>cd</p>',
         });
     });
@@ -550,12 +552,12 @@ describe("Text insertion", () => {
         await testEditor({
             contentBefore: '<p>ab<i class="fa fa-pastafarianism"></i>[]cd</p>',
             contentBeforeEdit:
-                '<p>ab<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]cd</p>',
+                '<p>ab\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeff[]cd</p>',
             stepFunction: async (editor) => {
                 await insertText(editor, "s");
             },
             contentAfterEdit:
-                '<p>ab<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>s[]cd</p>',
+                '<p>ab\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeffs[]cd</p>',
             contentAfter: '<p>ab<i class="fa fa-pastafarianism"></i>s[]cd</p>',
         });
     });
@@ -572,11 +574,11 @@ describe("Text insertion", () => {
     test("undo shouldn't remove changes applied by the editor setup", async () => {
         const { el, editor } = await setupEditor(`<p><i class="fa fa-pastafarianism"></i></p>`);
         expect(getContent(el)).toBe(
-            `<p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i></p>`
+            `<p>\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeff</p>`
         );
         undo(editor);
         expect(getContent(el)).toBe(
-            `<p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i></p>`
+            `<p>\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeff</p>`
         );
     });
 });

--- a/addons/html_editor/static/tests/icon.test.js
+++ b/addons/html_editor/static/tests/icon.test.js
@@ -2,29 +2,89 @@ import { expect, test } from "@odoo/hoot";
 import { click, waitFor } from "@odoo/hoot-dom";
 import { setupEditor } from "./_helpers/editor";
 import { animationFrame } from "@odoo/hoot-mock";
-import { setContent } from "./_helpers/selection";
+import { getContent, setContent, setSelection } from "./_helpers/selection";
 import { undo } from "./_helpers/user_actions";
 
 test("icon toolbar is displayed", async () => {
-    await setupEditor(`<p><span class="fa fa-glass">[]</span></p>`);
+    const { el } = await setupEditor(`<p><span class="fa fa-glass"></span></p>`);
+    expect(getContent(el)).toBe(
+        `<p>\ufeff<span class="fa fa-glass" contenteditable="false">\u200b</span>\ufeff</p>`
+    );
+    // Selection normalization include U+FEFF, moving the cursor outside the
+    // icon and triggering the normal toolbar. To prevent this, we exclude
+    // U+FEFF from selection.
+    setSelection({
+        anchorNode: el.firstChild,
+        anchorOffset: 1,
+        focusNode: el.firstChild,
+        focusOffset: 2,
+    });
+    expect(getContent(el)).toBe(
+        `<p>\ufeff[<span class="fa fa-glass" contenteditable="false">\u200b</span>]\ufeff</p>`
+    );
     await waitFor(".o-we-toolbar");
     expect(".btn-group[name='icon_size']").toHaveCount(1);
 });
 
 test("icon toolbar is displayed (2)", async () => {
-    await setupEditor(`<p>abc<span class="fa fa-glass">[]</span>def</p>`);
+    const { el } = await setupEditor(`<p>abc<span class="fa fa-glass"></span>def</p>`);
+    expect(getContent(el)).toBe(
+        `<p>abc\ufeff<span class="fa fa-glass" contenteditable="false">\u200b</span>\ufeffdef</p>`
+    );
+    // Selection normalization include U+FEFF, moving the cursor outside the
+    // icon and triggering the normal toolbar. To prevent this, we exclude
+    // U+FEFF from selection.
+    setSelection({
+        anchorNode: el.firstChild,
+        anchorOffset: 2,
+        focusNode: el.firstChild,
+        focusOffset: 3,
+    });
+    expect(getContent(el)).toBe(
+        `<p>abc\ufeff[<span class="fa fa-glass" contenteditable="false">\u200b</span>]\ufeffdef</p>`
+    );
     await waitFor(".o-we-toolbar");
     expect(".btn-group[name='icon_size']").toHaveCount(1);
 });
 
 test("icon toolbar is displayed (3)", async () => {
-    await setupEditor(`<p>abc[<span class="fa fa-glass"></span>]def</p>`);
+    const { el } = await setupEditor(`<p>abc<span class="fa fa-glass"></span>def</p>`);
+    expect(getContent(el)).toBe(
+        `<p>abc\ufeff<span class="fa fa-glass" contenteditable="false">\u200b</span>\ufeffdef</p>`
+    );
+    // Selection normalization include U+FEFF, moving the cursor outside the
+    // icon and triggering the normal toolbar. To prevent this, we exclude
+    // U+FEFF from selection.
+    setSelection({
+        anchorNode: el.firstChild,
+        anchorOffset: 2,
+        focusNode: el.firstChild,
+        focusOffset: 3,
+    });
+    expect(getContent(el)).toBe(
+        `<p>abc\ufeff[<span class="fa fa-glass" contenteditable="false">\u200b</span>]\ufeffdef</p>`
+    );
     await waitFor(".o-we-toolbar");
     expect(".btn-group[name='icon_size']").toHaveCount(1);
 });
 
 test("icon toolbar is not displayed on rating stars", async () => {
-    const { el } = await setupEditor(`<p>[<span class="fa fa-glass"></span>]</p>`);
+    const { el } = await setupEditor(`<p><span class="fa fa-glass"></span></p>`);
+    expect(getContent(el)).toBe(
+        `<p>\ufeff<span class="fa fa-glass" contenteditable="false">\u200b</span>\ufeff</p>`
+    );
+    // Selection normalization include U+FEFF, moving the cursor outside the
+    // icon and triggering the normal toolbar. To prevent this, we exclude
+    // U+FEFF from selection.
+    setSelection({
+        anchorNode: el.firstChild,
+        anchorOffset: 1,
+        focusNode: el.firstChild,
+        focusOffset: 2,
+    });
+    expect(getContent(el)).toBe(
+        `<p>\ufeff[<span class="fa fa-glass" contenteditable="false">\u200b</span>]\ufeff</p>`
+    );
     await waitFor(".o-we-toolbar");
     expect(".btn-group[name='icon_size']").toHaveCount(1);
     setContent(
@@ -48,7 +108,22 @@ test("toolbar should not be namespaced for icon (2)", async () => {
 });
 
 test("Can resize an icon", async () => {
-    await setupEditor(`<p><span class="fa fa-glass">[]</span></p>`);
+    const { el } = await setupEditor(`<p><span class="fa fa-glass"></span></p>`);
+    expect(getContent(el)).toBe(
+        `<p>\ufeff<span class="fa fa-glass" contenteditable="false">\u200b</span>\ufeff</p>`
+    );
+    // Selection normalization include U+FEFF, moving the cursor outside the
+    // icon and triggering the normal toolbar. To prevent this, we exclude
+    // U+FEFF from selection.
+    setSelection({
+        anchorNode: el.firstChild,
+        anchorOffset: 1,
+        focusNode: el.firstChild,
+        focusOffset: 2,
+    });
+    expect(getContent(el)).toBe(
+        `<p>\ufeff[<span class="fa fa-glass" contenteditable="false">\u200b</span>]\ufeff</p>`
+    );
     await waitFor(".o-we-toolbar");
     expect("span.fa-glass").toHaveCount(1);
     await click("button[name='icon_size_2']");
@@ -67,7 +142,22 @@ test("Can resize an icon", async () => {
 });
 
 test("Can spin an icon", async () => {
-    await setupEditor(`<p><span class="fa fa-glass">[]</span></p>`);
+    const { el } = await setupEditor(`<p><span class="fa fa-glass"></span></p>`);
+    expect(getContent(el)).toBe(
+        `<p>\ufeff<span class="fa fa-glass" contenteditable="false">\u200b</span>\ufeff</p>`
+    );
+    // Selection normalization include U+FEFF, moving the cursor outside the
+    // icon and triggering the normal toolbar. To prevent this, we exclude
+    // U+FEFF from selection.
+    setSelection({
+        anchorNode: el.firstChild,
+        anchorOffset: 1,
+        focusNode: el.firstChild,
+        focusOffset: 2,
+    });
+    expect(getContent(el)).toBe(
+        `<p>\ufeff[<span class="fa fa-glass" contenteditable="false">\u200b</span>]\ufeff</p>`
+    );
     await waitFor(".o-we-toolbar");
     expect("span.fa-glass").toHaveCount(1);
     await click("button[name='icon_spin']");
@@ -89,7 +179,22 @@ test("Can set icon color", async () => {
 });
 
 test("Can undo to 1x size after applying 2x size", async () => {
-    const { editor } = await setupEditor(`<p><span class="fa fa-glass">[]</span></p>`);
+    const { el, editor } = await setupEditor(`<p><span class="fa fa-glass"></span></p>`);
+    expect(getContent(el)).toBe(
+        `<p>\ufeff<span class="fa fa-glass" contenteditable="false">\u200b</span>\ufeff</p>`
+    );
+    // Selection normalization include U+FEFF, moving the cursor outside the
+    // icon and triggering the normal toolbar. To prevent this, we exclude
+    // U+FEFF from selection.
+    setSelection({
+        anchorNode: el.firstChild,
+        anchorOffset: 1,
+        focusNode: el.firstChild,
+        focusOffset: 2,
+    });
+    expect(getContent(el)).toBe(
+        `<p>\ufeff[<span class="fa fa-glass" contenteditable="false">\u200b</span>]\ufeff</p>`
+    );
     await waitFor(".o-we-toolbar");
     expect("span.fa-glass").toHaveCount(1);
     await click("button[name='icon_size_2']");

--- a/addons/html_editor/static/tests/insert/html.test.js
+++ b/addons/html_editor/static/tests/insert/html.test.js
@@ -24,7 +24,7 @@ describe("collapsed selection", () => {
                 editor.shared.history.addStep();
             },
             contentAfterEdit:
-                '<p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]</p>',
+                '<p>\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeff[]</p>',
             contentAfter: '<p><i class="fa fa-pastafarianism"></i>[]</p>',
         });
     });
@@ -40,7 +40,7 @@ describe("collapsed selection", () => {
                 editor.shared.history.addStep();
             },
             contentAfterEdit:
-                '<p><br></p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]',
+                '<p><br></p>\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeff[]',
             contentAfter: '<p><br></p><i class="fa fa-pastafarianism"></i>[]',
             config: { allowInlineAtRoot: true },
         });
@@ -56,7 +56,7 @@ describe("collapsed selection", () => {
                 editor.shared.history.addStep();
             },
             contentAfterEdit:
-                '<p>a<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]b</p>',
+                '<p>a\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeff[]b</p>',
             contentAfter: '<p>a<i class="fa fa-pastafarianism"></i>[]b</p>',
         });
     });
@@ -71,7 +71,7 @@ describe("collapsed selection", () => {
                 editor.shared.history.addStep();
             },
             contentAfterEdit:
-                '<p>a<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]b</p>',
+                '<p>a\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeff[]b</p>',
             contentAfter: '<p>a<i class="fa fa-pastafarianism"></i>[]b</p>',
         });
     });
@@ -361,7 +361,7 @@ describe("not collapsed selection", () => {
                 );
             },
             contentAfterEdit:
-                '<p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]</p>',
+                '<p>\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeff[]</p>',
             contentAfter: '<p><i class="fa fa-pastafarianism"></i>[]</p>',
         });
     });
@@ -376,7 +376,7 @@ describe("not collapsed selection", () => {
                 editor.shared.history.addStep();
             },
             contentAfterEdit:
-                '<p>a<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]c</p>',
+                '<p>a\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeff[]c</p>',
             contentAfter: '<p>a<i class="fa fa-pastafarianism"></i>[]c</p>',
         });
     });

--- a/addons/html_editor/static/tests/keyboard/arrow.test.js
+++ b/addons/html_editor/static/tests/keyboard/arrow.test.js
@@ -354,22 +354,75 @@ describe("Around links", () => {
 });
 
 describe("Around icons", () => {
-    test("should move past the icon (ArrowRight)", async () => {
+    test("should correctly move cursor over icons (ArrowRight)", async () => {
         await testEditor({
             contentBefore: `<p>abc[]<span class="fa fa-music"></span>def</p>`,
-            contentBeforeEdit: `<p>abc[]<span class="fa fa-music" contenteditable="false">\u200b</span>def</p>`,
+            contentBeforeEdit: `<p>abc[]\ufeff<span class="fa fa-music" contenteditable="false">\u200b</span>\ufeffdef</p>`,
             stepFunction: keyPress("ArrowRight"),
-            contentAfterEdit: `<p>abc<span class="fa fa-music" contenteditable="false">\u200b</span>[]def</p>`,
+            contentAfterEdit: `<p>abc\ufeff<span class="fa fa-music" contenteditable="false">\u200b</span>[]\ufeffdef</p>`,
             contentAfter: `<p>abc<span class="fa fa-music"></span>[]def</p>`,
         });
+        await testEditor({
+            contentBefore: `<p><span class="fa fa-music"></span>[]<span class="fa fa-music"></span></p><p><br></p>`,
+            contentBeforeEdit: `<p>\ufeff<span class="fa fa-music" contenteditable="false">\u200b</span>\ufeff[]<span class="fa fa-music" contenteditable="false">\u200b</span>\ufeff</p><p><br></p>`,
+            stepFunction: keyPress("ArrowRight"),
+            contentAfterEdit: `<p>\ufeff<span class="fa fa-music" contenteditable="false">\u200b</span>\ufeff<span class="fa fa-music" contenteditable="false">\u200b</span>[]\ufeff</p><p><br></p>`,
+            contentAfter: `<p><span class="fa fa-music"></span><span class="fa fa-music"></span>[]</p><p><br></p>`,
+        });
+        await testEditor({
+            contentBefore: `<p><span class="fa fa-music"></span>[]<br><span class="fa fa-music"></span></p><p><br></p>`,
+            contentBeforeEdit: `<p>\ufeff<span class="fa fa-music" contenteditable="false">\u200b</span>\ufeff[]<br>\ufeff<span class="fa fa-music" contenteditable="false">\u200b</span>\ufeff</p><p><br></p>`,
+            stepFunction: keyPress("ArrowRight"),
+            contentAfterEdit: `<p>\ufeff<span class="fa fa-music" contenteditable="false">\u200b</span>\ufeff<br>\ufeff[]<span class="fa fa-music" contenteditable="false">\u200b</span>\ufeff</p><p><br></p>`,
+            contentAfter: `<p><span class="fa fa-music"></span><br>[]<span class="fa fa-music"></span></p><p><br></p>`,
+        });
     });
-    test("should move past the icon (ArrowLeft)", async () => {
+    test("should correctly move cursor over icons (ArrowLeft)", async () => {
         await testEditor({
             contentBefore: `<p>abc<span class="fa fa-music"></span>[]def</p>`,
-            contentBeforeEdit: `<p>abc<span class="fa fa-music" contenteditable="false">\u200b</span>[]def</p>`,
+            contentBeforeEdit: `<p>abc\ufeff<span class="fa fa-music" contenteditable="false">\u200b</span>\ufeff[]def</p>`,
             stepFunction: keyPress("ArrowLeft"),
-            contentAfterEdit: `<p>abc[]<span class="fa fa-music" contenteditable="false">\u200b</span>def</p>`,
+            contentAfterEdit: `<p>abc\ufeff[]<span class="fa fa-music" contenteditable="false">\u200b</span>\ufeffdef</p>`,
             contentAfter: `<p>abc[]<span class="fa fa-music"></span>def</p>`,
+        });
+        await testEditor({
+            contentBefore: `<p><span class="fa fa-music"></span><br><span class="fa fa-music"></span>[]</p>`,
+            contentBeforeEdit: `<p>\ufeff<span class="fa fa-music" contenteditable="false">\u200b</span>\ufeff<br>\ufeff<span class="fa fa-music" contenteditable="false">\u200b</span>\ufeff[]</p>`,
+            stepFunction: keyPress("ArrowLeft"),
+            contentAfterEdit: `<p>\ufeff<span class="fa fa-music" contenteditable="false">\u200b</span>\ufeff<br>\ufeff[]<span class="fa fa-music" contenteditable="false">\u200b</span>\ufeff</p>`,
+            contentAfter: `<p><span class="fa fa-music"></span><br>[]<span class="fa fa-music"></span></p>`,
+        });
+    });
+    test("should correctly move cursor over icons (ArrowUp)", async () => {
+        await testEditor({
+            contentBefore: `<p><br></p><p><span class="fa fa-music"></span></p><p>[]<br></p>`,
+            contentBeforeEdit: `<p><br></p><p>\ufeff<span class="fa fa-music" contenteditable="false">\u200b</span>\ufeff</p><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`,
+            stepFunction: keyPress("ArrowUp"),
+            contentAfterEdit: `<p><br></p><p>[]\ufeff<span class="fa fa-music" contenteditable="false">\u200b</span>\ufeff</p><p><br></p>`,
+            contentAfter: `<p><br></p><p>[]<span class="fa fa-music"></span></p><p><br></p>`,
+        });
+        await testEditor({
+            contentBefore: `<p><br></p><p><span class="fa fa-music"></span><br>[]<span class="fa fa-music"></span></p>`,
+            contentBeforeEdit: `<p><br></p><p>\ufeff<span class="fa fa-music" contenteditable="false">\u200b</span>\ufeff<br>\ufeff[]<span class="fa fa-music" contenteditable="false">\u200b</span>\ufeff</p>`,
+            stepFunction: keyPress("ArrowDown"),
+            contentAfterEdit: `<p><br></p><p>\ufeff<span class="fa fa-music" contenteditable="false">\u200b</span>\ufeff<br>\ufeff<span class="fa fa-music" contenteditable="false">\u200b</span>\ufeff[]</p>`,
+            contentAfter: `<p><br></p><p><span class="fa fa-music"></span><br><span class="fa fa-music"></span>[]</p>`,
+        });
+    });
+    test("should correctly move cursor over icons (ArrowDown)", async () => {
+        await testEditor({
+            contentBefore: `<p>[]<br></p><p><span class="fa fa-music"></span></p><p><br></p>`,
+            contentBeforeEdit: `<p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p><p>\ufeff<span class="fa fa-music" contenteditable="false">\u200b</span>\ufeff</p><p><br></p>`,
+            stepFunction: keyPress("ArrowDown"),
+            contentAfterEdit: `<p><br></p><p>[]\ufeff<span class="fa fa-music" contenteditable="false">\u200b</span>\ufeff</p><p><br></p>`,
+            contentAfter: `<p><br></p><p>[]<span class="fa fa-music"></span></p><p><br></p>`,
+        });
+        await testEditor({
+            contentBefore: `<p>[]<span class="fa fa-music"></span><br><span class="fa fa-music"></span></p><p><br></p>`,
+            contentBeforeEdit: `<p>\ufeff[]<span class="fa fa-music" contenteditable="false">\u200b</span>\ufeff<br>\ufeff<span class="fa fa-music" contenteditable="false">\u200b</span>\ufeff</p><p><br></p>`,
+            stepFunction: keyPress("ArrowDown"),
+            contentAfterEdit: `<p>\ufeff<span class="fa fa-music" contenteditable="false">\u200b</span>\ufeff<br>[]\ufeff<span class="fa fa-music" contenteditable="false">\u200b</span>\ufeff</p><p><br></p>`,
+            contentAfter: `<p><span class="fa fa-music"></span><br>[]<span class="fa fa-music"></span></p><p><br></p>`,
         });
     });
 });

--- a/addons/html_editor/static/tests/link/isolated.test.js
+++ b/addons/html_editor/static/tests/link/isolated.test.js
@@ -295,7 +295,7 @@ test("should not zwnbsp-pad link with block fontawesome", async () => {
         contentBefore:
             '<p>a<a href="#/">[]<i style="display: flex;" class="fa fa-star"></i></a>b</p>',
         contentBeforeEdit:
-            '<p>a<a href="#/">[]<i style="display: flex;" class="fa fa-star" contenteditable="false">\u200b</i></a>b</p>',
+            '<p>a<a href="#/">\ufeff[]<i style="display: flex;" class="fa fa-star" contenteditable="false">\u200b</i>\ufeff</a>b</p>',
     });
 });
 

--- a/addons/html_editor/static/tests/rating_star.test.js
+++ b/addons/html_editor/static/tests/rating_star.test.js
@@ -17,7 +17,7 @@ test("add 3 star elements", async () => {
 
     await press("Enter");
     expect(getContent(el)).toBe(
-        `<p>\u200B<span contenteditable="false" class="o_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i></span>\u200B[]</p>`
+        `<p>\u200B<span contenteditable="false" class="o_stars">\ufeff<i class="fa fa-star-o" contenteditable="false">\u200B</i>\ufeff<i class="fa fa-star-o" contenteditable="false">\u200B</i>\ufeff<i class="fa fa-star-o" contenteditable="false">\u200B</i>\ufeff</span>\u200B[]</p>`
     );
 });
 
@@ -29,7 +29,7 @@ test("add 5 star elements", async () => {
 
     await press("Enter");
     expect(getContent(el)).toBe(
-        `<p>\u200B<span contenteditable="false" class="o_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i></span>\u200B[]</p>`
+        `<p>\u200B<span contenteditable="false" class="o_stars">\ufeff<i class="fa fa-star-o" contenteditable="false">\u200B</i>\ufeff<i class="fa fa-star-o" contenteditable="false">\u200B</i>\ufeff<i class="fa fa-star-o" contenteditable="false">\u200B</i>\ufeff<i class="fa fa-star-o" contenteditable="false">\u200B</i>\ufeff<i class="fa fa-star-o" contenteditable="false">\u200B</i>\ufeff</span>\u200B[]</p>`
     );
 });
 
@@ -41,19 +41,19 @@ test("select star rating", async () => {
     await click("i.fa-star-o:first");
     await animationFrame();
     expect(getContent(el)).toBe(
-        `<p>\u200B<span contenteditable="false" class="o_stars"><i class="fa fa-star" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i></span>\u200B[]</p>`
+        `<p>\u200B<span contenteditable="false" class="o_stars">\ufeff<i class="fa fa-star" contenteditable="false">\u200B</i>\ufeff<i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i>\ufeff<i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i>\ufeff</span>\u200B[]</p>`
     );
 
     await click("i.fa-star-o:last");
     await animationFrame();
     expect(getContent(el)).toBe(
-        `<p>\u200B<span contenteditable="false" class="o_stars"><i class="fa fa-star" contenteditable="false">\u200B</i><i class="o_stars fa fa-star" contenteditable="false">\u200B</i><i class="o_stars fa fa-star" contenteditable="false">\u200B</i></span>\u200B[]</p>`
+        `<p>\u200B<span contenteditable="false" class="o_stars">\ufeff<i class="fa fa-star" contenteditable="false">\u200B</i>\ufeff<i class="o_stars fa fa-star" contenteditable="false">\u200B</i>\ufeff<i class="o_stars fa fa-star" contenteditable="false">\u200B</i>\ufeff</span>\u200B[]</p>`
     );
 
     await click("i.fa-star:last");
     await animationFrame();
     expect(getContent(el)).toBe(
-        `<p>\u200B<span contenteditable="false" class="o_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i></span>\u200B[]</p>`
+        `<p>\u200B<span contenteditable="false" class="o_stars">\ufeff<i class="fa fa-star-o" contenteditable="false">\u200B</i>\ufeff<i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i>\ufeff<i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i>\ufeff</span>\u200B[]</p>`
     );
 });
 


### PR DESCRIPTION
### Steps to reproduce:

ISSUE 1:

- Insert multiple icons (e.g., /image, icon) into a paragraph.
- Place the cursor before the first icon.
- Press the right arrow key, and notice that the selection jumps to the second paragraph, skipping over the icons.

ISSUE 2:

- Create three paragraphs.
- Insert icons into the second paragraph.
- Place the cursor in the first or third paragraph and press the up/down arrow key it skips the second paragraph.
- Set up following HTML:
```html
<p><br></p>
<p><br><span class="fa fa-glass"></span>[]</p>
```
- Press arrow up key.
- Cursor will move to the first paragraph.

### Description of the issue/feature this PR addresses:

- Pressing arrow key (left or right) caused the cursor to consecutively skip over all icons until a text node was reached.
- Pressing up/down arrow keys would skip sibling block containing only icons.
- Pressing the up/down arrow keys would skip over icons in the same block if the cursor is on a `<br>`.

### Desired behavior after PR is merged:

- Add extra `\uFEFF` before and after icons to prevent them from being skipped.

task-3045033