### PR TITLE
[FIX] stock: consider multi-steps in forecast availability

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2250,8 +2250,7 @@ Please change the quantity done or the rounding precision of your unit of measur
         :return: a defaultdict of outgoing moves from warehouse for product_id in self, values are tuple (sum_qty_expected, max_date_expected)
         :rtype: defaultdict
         """
-        wh_location_query = self.env['stock.location']._search([('id', 'child_of', location_id.id if location_id else warehouse.view_location_id.id)])
-
+        wh_location_query = self.env['stock.location']._search([('id', 'child_of', warehouse.view_location_id.id)])
         forecast_lines = self.env['stock.forecasted_product_product']._get_report_lines(False, self.product_id.ids, wh_location_query, location_id or warehouse.lot_stock_id, read=False)
         result = defaultdict(lambda: (0.0, False))
         for line in forecast_lines:


### PR DESCRIPTION
### Steps to reproduce:

- Enable multi-step routes in the settings
- Inventory > Configuration > Warehouse Management > Warehouses
- Change your warehouse to manufacturing in 3 steps
- Create a storable product COMP with 10 units in stock
- Create a manufacturing order for a product Final product using COMP as components

#### > The forcast of the components indicates that they are not available

### Cause of the issue:

The location query of the `_get_forecast_availability_outgoing` was recently changed to:
https://github.com/odoo/odoo/blob/49061347c181b1a451435bc363bb9508db8b6fab/addons/stock/models/stock_move.py#L2253 This change was made for optimisation purposes because the forecast lines now take care of the precise locations here: https://github.com/odoo/odoo/blob/49061347c181b1a451435bc363bb9508db8b6fab/addons/stock/models/stock_move.py#L2255 However, this optimisation is not correct as the forecast the result of this query is used in order to determine if a move is incoming or outgoing here:
https://github.com/odoo/odoo/blob/49061347c181b1a451435bc363bb9508db8b6fab/addons/stock/report/stock_forecasted.py#L31-L44 and these domains only makes sense if the `wh_location_ids` are indeed all the locations of the warehouse and not these that are children of the "pre-prod" location.

opw-3979953
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
