### PR TITLE
[FIX] pos_restaurant: orders list not updated when refunding

### DIFF
--- a/addons/pos_restaurant/static/src/overrides/components/receipt_screen/receipt_screen.js
+++ b/addons/pos_restaurant/static/src/overrides/components/receipt_screen/receipt_screen.js
@@ -9,7 +9,7 @@ patch(ReceiptScreen.prototype, {
         onWillUnmount(() => {
             // When leaving the receipt screen to the floor screen the order is paid and can be removed
             if (this.pos.mainScreen.component === FloorScreen && this.currentOrder.finalized) {
-                this.pos.removeOrder(this.currentOrder);
+                this.pos.removeOrder(this.currentOrder, false);
             }
         });
     },


### PR DESCRIPTION
Steps:
- Open restaurant and delete to existing draft orders.
- Open table 1.
- Add order items and pay the order until "New Order" button. Clicking New Order will change the screen to Floor Screen.
- Open table 1 again.
- In Actions button, select Refund.
- The order you just paid will be in the list.
- Refund the order.
- Repeat steps 2 to 7. The new order is not there.

Issue:
Order list is not updated when refunding the order.

Cause:
When we navigate from the receipt screen to the floor screen, the onWillUnmount method will be called to remove the order from the local database and server. So, when we navigate to the order list then new orders will not be there as they are removed.

FIX:
Pass false argument to "removeFromServer" in the removeOrder function, so it will not delete the order from the server. So, the order list will be updated

task-4155780

