### PR TITLE
[FIX] web_editor, website_{forum, profile}: show code in textarea editor

### DIFF
--- a/addons/web_editor/static/src/js/frontend/loader.js
+++ b/addons/web_editor/static/src/js/frontend/loader.js
@@ -71,7 +71,7 @@ exports.loadFromTextarea = async (parent, textarea, options) => {
         $form.find('.note-editable').find('img.o_we_selected_image').removeClass('o_we_selected_image');
         // float-start class messes up the post layout OPW 769721
         $form.find('.note-editable').find('img.float-start').removeClass('float-start');
-        $textarea.html(wysiwyg.getValue());
+        $textarea.val(wysiwyg.getValue());
     });
 
     return wysiwyg;

--- a/addons/website_forum/static/tests/tours/website_forum_question.js
+++ b/addons/website_forum/static/tests/tours/website_forum_question.js
@@ -17,7 +17,7 @@ odoo.define('website_forum.tour_forum_question', function (require) {
         content: "Put your question here.",
         extra_trigger: "#wrap:not(:has(input[name=post_name]:propValue('')))",
         trigger: '.note-editable p',
-        run: 'text First Question',
+        run: 'text First Question <p>code here</p>',
     }, {
         content: "Insert tags related to your question.",
         extra_trigger: '.note-editable:not(:has(br))',
@@ -35,8 +35,23 @@ odoo.define('website_forum.tour_forum_question', function (require) {
         content: "Close modal once modal animation is done.",
         extra_trigger: 'div.modal.modal_shown',
         trigger: ".modal-header button.btn-close",
-    },
-    {
+    }, {
+        content: "Check that the code still exists as it was written.",
+        trigger: 'div[data-oe-field="content"]:contains("First Question <p>code here</p>")',
+    }, {
+        content: "Open dropdown to edit the post",
+        trigger: 'div.dropdown a#dropdownMenuLink',
+    }, {
+        content: "Click on edit",
+        trigger: 'form button:contains("Edit")',
+    }, {
+        content: "Check that the content is the same",
+        trigger: 'div.odoo-editor-editable p:contains("First Question <p>code here</p>")',
+        run: function () {}, //it's a check
+    }, {
+        content: "Save changes",
+        trigger: 'button:contains("Save Changes")',
+    }, {
         trigger: "a:contains(\"Answer\").collapsed",
         content: "Click to answer.",
         position: "bottom",

--- a/addons/website_profile/__manifest__.py
+++ b/addons/website_profile/__manifest__.py
@@ -22,6 +22,9 @@
             'website_profile/static/src/scss/website_profile.scss',
             'website_profile/static/src/js/website_profile.js',
         ],
+        'web.assets_tests': [
+            'website_profile/static/tests/tours/tour_website_profile_description.js',
+        ],
     },
     'license': 'LGPL-3',
 }

--- a/addons/website_profile/models/res_users.py
+++ b/addons/website_profile/models/res_users.py
@@ -64,3 +64,6 @@ class Users(models.Model):
         if token == validation_token and self.karma == 0:
             return self.write({'karma': VALIDATION_KARMA_GAIN})
         return False
+
+    def get_website_description(self):
+        return self.partner_id.website_description

--- a/addons/website_profile/static/src/js/website_profile.js
+++ b/addons/website_profile/static/src/js/website_profile.js
@@ -3,6 +3,7 @@ odoo.define('website_profile.website_profile', function (require) {
 
 var publicWidget = require('web.public.widget');
 var wysiwygLoader = require('web_editor.loader');
+const rpc = require('web.rpc');
 
 publicWidget.registry.websiteProfile = publicWidget.Widget.extend({
     selector: '.o_wprofile_email_validation_container',
@@ -60,12 +61,21 @@ publicWidget.registry.websiteProfileEditor = publicWidget.Widget.extend({
 
         var $textarea = this.$('textarea.o_wysiwyg_loader');
 
+        const resId = parseInt(this.$('input[name=user_id]').val());
+        const recordContent = await rpc.query({
+            model: 'res.users',
+            method: 'get_website_description',
+            args: [[resId]],
+        }) || '';
+
         this._wysiwyg = await wysiwygLoader.loadFromTextarea(this, $textarea[0], {
             recordInfo: {
                 context: this._getContext(),
                 res_model: 'res.users',
-                res_id: parseInt(this.$('input[name=user_id]').val()),
+                res_id: resId,
+
             },
+            value: recordContent,
             resizable: true,
             userGeneratedContent: true,
         });

--- a/addons/website_profile/static/tests/tours/tour_website_profile_description.js
+++ b/addons/website_profile/static/tests/tours/tour_website_profile_description.js
@@ -1,0 +1,28 @@
+odoo.define('website_profile.tour_website_profile_description', function (require) {
+    'use strict';
+
+    var tour = require("web_tour.tour");
+
+    tour.register("website_profile_description", {
+            test: true,
+            url: "/profile/users",
+        }, [{
+            content: "Click on one user profile card",
+            trigger: "div[onclick]",
+        },{
+            content: "Edit profile",
+            trigger: "a:contains('EDIT PROFILE')",
+        }, {
+            content: "Add some content",
+            trigger: ".odoo-editor-editable p",
+            run: "text content <p>code here</p>",
+        }, {
+            content: "Save changes",
+            trigger: "button:contains('Update')",
+        }, {
+            content: "Check the content is saved",
+            trigger:
+                "span[data-oe-field='website_description']:contains('content <p>code here</p>')",
+        }]
+    );
+});

--- a/addons/website_profile/tests/__init__.py
+++ b/addons/website_profile/tests/__init__.py
@@ -1,0 +1,2 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import test_website_profile

--- a/addons/website_profile/tests/test_website_profile.py
+++ b/addons/website_profile/tests/test_website_profile.py
@@ -1,0 +1,10 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo.tests
+from odoo.addons.gamification.tests.common import HttpCaseGamification
+
+
+@odoo.tests.tagged('post_install', '-at_install')
+class TestWebsiteProfile(HttpCaseGamification):
+    def test_save_change_description(self):
+        self.start_tour("/", 'website_profile_description', login="admin")


### PR DESCRIPTION
Issue:
=====
Written html code inside the forum post gets rendered in the readonly
view.

Steps to reproduce the issue:
=============================
- Create a new forum post
- Write `<p>abc</p>`
- Save
- The `p` element disappears (it got rendered, you can check it by
  inspecting the element).

Origin of the issue and solution:
=================================

Let's first name the `p` element added by the editor as `pe` to
differenciate between them.

The issue is divided into 2 subproblems:

- We need to save the correct value: currently if we have written in the
  editor `<p>abc</p>`, it will save the value `<pe><p>abc</p></pe>`
  which means that the two `p` element will be handled the same either
  both will appear as a string in the readonly view or will be rendered
  which is not right. To solve the issue, we need to override the
  `value` of the text area and not the html before the submit. By
  doing this the textarea.value will be equal to
  `<pe>&lt;p&gt;abcdef&lt;/p&gt;</pe>` which is the correct value.

- Now the second problem is when we edit the post , it will render again
  the `p` element that we wrote. The fetched template actually have the
  correct value inside the textarea, but seems like the browser when
  rendering it, it will convert the value to `<pe><p>abd</p></pe>` which
  is not right, and if we use textarea.html it will encode the `<pe>`
  element which is wrong too. To get the original value, we fetch if
  again and use it in the options of the wysiwyg.

  opw-4148163