### PR TITLE
[FIX] website: Fix form snippet field options and styling loss on undo

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -1547,7 +1547,6 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
         const previousType = previousInputEl.type;
         [...this.$target[0].childNodes].forEach(node => node.remove());
         [...fieldEl.childNodes].forEach(node => this.$target[0].appendChild(node));
-        [...fieldEl.attributes].forEach(el => this.$target[0].removeAttribute(el.nodeName));
         [...fieldEl.attributes].forEach(el => this.$target[0].setAttribute(el.nodeName, el.nodeValue));
         if (hasConditionalVisibility) {
             this.$target[0].classList.add('s_website_form_field_hidden_if', 'd-none');


### PR DESCRIPTION
In a form snippet, enabling the "Description" option for a field and then undoing this action caused the field to lose its styling and available customization options.

Steps to reproduce:
- Enter Edit mode.
- Add a Form snippet.
- Select any field (e.g., "Your Name").
- Enable the "Description" option from the customization panel.
- Undo the action (Ctrl+Z).

This results in the field losing its padding and the "Description" and other options being removed.

Cause:
A redundant line of code was adding an extra step in the mutation history. When undoing, this extra step caused the removal of essential classes from the field, leading to the loss of styling and options.

Fix:
Removed the redundant line to ensure undoing the action correctly restores the previous state without affecting the field’s styling or customization options.

task-4013551