### PR TITLE
[FIX] sale_project: add uninstall hook for embedded actions

### DIFF
--- a/addons/sale_project/__init__.py
+++ b/addons/sale_project/__init__.py
@@ -16,3 +16,11 @@ def _set_allow_billable_in_project(env):
     )[0]
     projects += non_billable_projects
     projects.allow_billable = True
+
+
+def uninstall_hook(env):
+    actions = env['ir.embedded.actions'].search([
+        ('parent_res_model', '=', 'project.project'),
+        ('python_method', 'in', ['action_open_project_invoices', 'action_view_sos'])
+    ])
+    actions.domain = [(0, '=', 1)]

--- a/addons/sale_project/__manifest__.py
+++ b/addons/sale_project/__manifest__.py
@@ -40,5 +40,6 @@ This module allows to generate a project/task from sales orders.
         ],
     },
     'post_init_hook': '_set_allow_billable_in_project',
+    'uninstall_hook': 'uninstall_hook',
     'license': 'LGPL-3',
 }


### PR DESCRIPTION
Steps to reproduce:
- Install sale_project
- Uninstall sale
- Open Project and click on any of the projects

Issues:
Traceback is shown, as we are computing a domain using a field which doesn't exist anymore `allow_billable`.
This domain comes from two embedded actions which are in `sale_project`.

https://github.com/odoo/odoo/blob/d9d0b1c66dd608e475bdb7d29c162b6251b0f329/addons/sale_project/views/project_views.xml#L23-L43

To solve the issue, we change the domain to something that it always false in order to deactivate those actions.

opw-4161620