### PR TITLE
[FIX] core: allow Python identifiers as field names

### DIFF
--- a/odoo/addons/base/tests/test_sql.py
+++ b/odoo/addons/base/tests/test_sql.py
@@ -92,6 +92,10 @@ class TestSQL(BaseCase):
         self.assertEqual(sql.code, '"foo"')
         self.assertEqual(sql.params, [])
 
+        sql = SQL.identifier('année')
+        self.assertEqual(sql.code, '"année"')
+        self.assertEqual(sql.params, [])
+
         sql = SQL.identifier('foo', 'bar')
         self.assertEqual(sql.code, '"foo"."bar"')
         self.assertEqual(sql.params, [])

--- a/odoo/tools/sql.py
+++ b/odoo/tools/sql.py
@@ -147,10 +147,10 @@ class SQL:
     @classmethod
     def identifier(cls, name: str, subname: (str | None) = None) -> SQL:
         """ Return an SQL object that represents an identifier. """
-        assert IDENT_RE.match(name), f"{name!r} invalid for SQL.identifier()"
+        assert name.isidentifier() or IDENT_RE.match(name), f"{name!r} invalid for SQL.identifier()"
         if subname is None:
             return cls(f'"{name}"')
-        assert IDENT_RE.match(subname), f"{subname!r} invalid for SQL.identifier()"
+        assert subname.isidentifier() or IDENT_RE.match(subname), f"{subname!r} invalid for SQL.identifier()"
         return cls(f'"{name}"."{subname}"')
 
 


### PR DESCRIPTION
Before 020ddc3a we allowed any Python identifier as column names. The usual field definition `name = fields.FieldType(...)` restricts  `name` to be a valid Python identifier. Forbidding it in 17.0 causes issues during upgrades.

For example, with the model:
```py
class CustomModel(models.Model):
    _name = 'mymodule.custom.model'
    _description = "custom"

    année = fields.Char()
```

In 17.0 before this patch we get errors like:
```
  File "/home/odoo/src/odoo/17.0/odoo/tools/sql.py", line 150, in identifier
    assert IDENT_RE.match(name), f"{name!r} invalid for SQL.identifier()"
           ^^^^^^^^^^^^^^^^^^^^
AssertionError: 'année' invalid for SQL.identifier()
```





### Possible issue during upgrade from < `17.0` to >= `17.0`:

1. Install fresh db in `16.0`
2. Add custom field `année` to the `res.users` with custom module
3. Go to `Settings --> Manage Users` add the field `année` in the list view
    by installing studio
4. Upgrade to `17.0`

You will get error like this:

```
('base.menu_action_res_users', 64, 'Settings > Users & Companies > Users', 70):
 Traceback (most recent call last):
   File "/tmp/tmpcmtylywh/migrations/base/tests/test_mock_crawl.py", line 256, in crawl_menu
    self.mock_action(action_vals)
   File "/tmp/tmpcmtylywh/migrations/base/tests/test_mock_crawl.py", line 429, in mock_action
    mock_method(model, view, fields_list, domain, group_by)
   File "/tmp/tmpcmtylywh/migrations/base/tests/test_mock_crawl.py", line 557, in mock_view_tree
    self.mock_web_search_read(model, view, [domain], fields_list)
   File "/tmp/tmpcmtylywh/migrations/base/tests/test_mock_crawl.py", line 591, in mock_web_search_read
    data = model.search_read(domain=domain, fields=fields_list, limit=80)
   File "/home/odoo/src/odoo/17.0/odoo/models.py", line 5756, in search_read
    records = self.search_fetch(domain or [], fields, offset=offset, limit=limit, order=order)
   File "/home/odoo/src/odoo/17.0/odoo/models.py", line 1648, in search_fetch
    return self._fetch_query(query, fields_to_fetch)
   File "/home/odoo/src/odoo/17.0/odoo/addons/base/models/res_users.py", line 545, in _fetch_query
    records = super()._fetch_query(query, fields)
   File "/home/odoo/src/odoo/17.0/odoo/models.py", line 3929, in _fetch_query
    sql = self._field_to_sql(self._table, field.name, query)
   File "/home/odoo/src/odoo/17.0/odoo/models.py", line 2863, in _field_to_sql
    return SQL.identifier(alias, fname)
   File "/home/odoo/src/odoo/17.0/odoo/tools/sql.py", line 153, in identifier
    assert IDENT_RE.match(subname), f"{subname!r} invalid for SQL.identifier()"
 AssertionError: 'année' invalid for SQL.identifier()

```


Actually, the issue can occur anywhere that the new `SQL.Identifier()` is used.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
