### PR TITLE
[FIX] website: traceback on page template dialog when leaving too fast

### DIFF
--- a/addons/website/static/src/components/dialog/add_page_dialog.js
+++ b/addons/website/static/src/components/dialog/add_page_dialog.js
@@ -212,7 +212,7 @@ export class AddPageTemplatePreview extends Component {
                 imgEl.setAttribute("loading", "lazy");
             }
             // Wait for fonts.
-            await iframeEl.contentDocument.fonts.ready;
+            await iframeEl.contentDocument?.fonts.ready;
             holderEl.classList.remove("o_loading");
             const adjustHeight = () => {
                 if (!this.previewRef.el) {

--- a/addons/website/static/tests/tours/create_new_page.js
+++ b/addons/website/static/tests/tours/create_new_page.js
@@ -1,0 +1,46 @@
+import { clickOnSave, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
+
+registerWebsitePreviewTour(
+    "website_create_new_page",
+    {
+        test: true,
+        url: "/",
+    },
+    () => [
+        {
+            content: "Open create content menu",
+            trigger: ".o_new_content_container a",
+            run: "click",
+        },
+        {
+            content: "Create a new page",
+            trigger: 'a[title="New Page"]',
+            run: "click",
+        },
+        {
+            content: "Use blank template",
+            trigger: ".o_page_template button",
+            run: "click",
+        },
+        {
+            content: "Name page",
+            trigger: ".modal-body input",
+            run: "edit New Page",
+        },
+        {
+            content: "Don't add to menu",
+            trigger: ".modal-body .o_switch",
+            run: "click",
+        },
+        {
+            content: "Click on Create button",
+            trigger: ".modal-footer .btn-primary",
+            run: "click",
+        },
+        {
+            content: "Wait for editor to open",
+            trigger: ".o_website_navbar_hide",
+        },
+        ...clickOnSave(),
+    ],
+);

--- a/addons/website/tests/__init__.py
+++ b/addons/website/tests/__init__.py
@@ -5,6 +5,7 @@ from . import test_attachment
 from . import test_auth_signup_uninvited
 from . import test_base_url
 from . import test_client_action
+from . import test_create_new_page
 from . import test_configurator
 from . import test_controllers
 from . import test_converter

--- a/addons/website/tests/test_create_new_page.py
+++ b/addons/website/tests/test_create_new_page.py
@@ -1,0 +1,10 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import HttpCase, tagged
+
+
+@tagged('-at_install', 'post_install')
+class TestCreateNewPage(HttpCase):
+
+    def test_create_new_page(self):
+        self.start_tour('/', 'website_create_new_page', login='admin')


### PR DESCRIPTION
Steps to reproduce:
- Go to the website editor
- Click on the New button (top right)
- Click on Page
- Navigate to another page before the template previews have finished loading

Old behavior: tracebacks appear
New behavior: no traceback

It is bad UI (and a bad look) to show an error for a split second before the page is unloaded. Furthermore, it fails the CI.

This commit handles the case where the preview's iframe was unloaded by simply not waiting for the now-non-existant fonts to load.

task-4179590
