### PR TITLE
[FIX] base: prevent storage of wrong password

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1641,8 +1641,8 @@ class CheckIdentity(models.TransientModel):
             self.create_uid._check_credentials(self.password, {'interactive': True})
         except AccessDenied:
             raise UserError(_("Incorrect Password, try again or click on Forgot Password to reset your password."))
-
-        self.password = False
+        finally:
+            self.password = False
 
         request.session['identity-check-last'] = time.time()
         ctx, model, ids, method = json.loads(self.sudo().request)


### PR DESCRIPTION
Check identity would previously store a wrong password until the next grabage collection. 
This commit fix this behaviour.

