### PR TITLE
[FIX] web_tour: error with alt_trigger

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_compilers.js
+++ b/addons/web_tour/static/src/tour_service/tour_compilers.js
@@ -526,8 +526,10 @@ export function compileStepManual(stepIndex, step, options) {
 
                     if (subAction.altAnchor) {
                         let altAnchorEl = hoot.queryAll(subAction.altAnchor).at(0);
-                        altAnchorEl = getAnchorEl(altAnchorEl, subAction.event);
-                        consumeEvents.push(...getConsumeEventType(altAnchorEl, subAction.event));
+                        if (altAnchorEl && canContinue(altAnchorEl, step)) {
+                            altAnchorEl = getAnchorEl(altAnchorEl, subAction.event);
+                            consumeEvents.push(...getConsumeEventType(altAnchorEl, subAction.event));
+                        }
                     }
 
                     const updatePointer = () => {


### PR DESCRIPTION
Steps to reproduce:
- use alt_trigger with an element that appears only on hover.
- tour blocked and console error appears.

Source:
- altAnchorEl is undefined and trying to access properties from it.

task-4141027