### PR TITLE
[FIX] pos_loyalty: fix traceback on search more in partner screen

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/components/partner_list_screen/partner_list_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/partner_list_screen/partner_list_screen.js
@@ -12,7 +12,7 @@ patch(PartnerList.prototype, {
 
     async searchPartner() {
         const res = await super.searchPartner();
-        const coupons = this.pos.fetchCoupons([
+        const coupons = await this.pos.fetchCoupons([
             ["partner_id", "in", res.map((partner) => partner.id)],
         ]);
         this.pos.computePartnerCouponIds(coupons);


### PR DESCRIPTION
Before this commit:
---------
- A traceback occurs when we click on the 'Search More' button in partner screen.

After this commit:
---------
- Traceback fixed on the search more button.

task - 4179346



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
