### PR TITLE
[FIX] hr_timesheet: update timesheet timer to single line format

### DIFF
--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -293,7 +293,7 @@
                                 <span t-att-title="record.employee_id.value">
                                     <field name="employee_id" widget="image" options="{'preview_image': 'avatar_128'}" class="o_image_40_cover me-2 float-start"/>
                                 </span>
-                                <div class="d-flex flex-column text-truncate lh-sm col-10">
+                                <div class="d-flex flex-column text-truncate lh-sm col-9">
                                     <span class="text-truncate" t-att-title="record.project_id.value"><field name="project_id" class="p-0 fw-bold fs-5"/></span>
                                     <span class="text-truncate" t-att-title="record.task_id.value"><field name="task_id" class="fst-italic"/></span>
                                     <span class="text-truncate" t-att-title="record.name.value"><field name="name"/></span>


### PR DESCRIPTION
Modified the timesheet timer display to use a single line format for consistency. 
This change ensures that the timer is now presented in a more streamlined manner.

task-4146841