### PR TITLE
[IMP] web: list selection box on mobile

### DIFF
--- a/addons/web/static/src/core/dropdown/dropdown.scss
+++ b/addons/web/static/src/core/dropdown/dropdown.scss
@@ -98,3 +98,12 @@
         }
     }
 }
+
+// Unstyle buttons so they behave like regular dropdown-item
+.o-dropdown-item-unstyled-button {
+    &, .o_web_client.o_touch_device & {
+        button, button:hover, button:disabled {
+            all: unset;
+        }
+    }
+}

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -19,7 +19,7 @@
                     <t t-call="web.embeddedActionsDropdown" />
                 </div>
             </Transition>
-            <div class="o_control_panel_main d-flex flex-wrap flex-lg-nowrap justify-content-between align-items-lg-start gap-1 gap-lg-3 flex-grow-1">
+            <div class="o_control_panel_main d-flex flex-wrap flex-lg-nowrap justify-content-between align-items-lg-start gap-lg-3 flex-grow-1">
                 <div class="o_control_panel_breadcrumbs d-flex align-items-center gap-1 order-0 h-lg-100">
                     <div class="o_control_panel_main_buttons d-flex gap-1 d-empty-none d-print-none" t-ref="mainButtons" t-on-keydown="onMainButtonsKeydown">
                         <div t-if="env.isSmall" class="btn-group o_control_panel_collapsed_create">

--- a/addons/web/static/src/search/search_bar/search_bar.xml
+++ b/addons/web/static/src/search/search_bar/search_bar.xml
@@ -102,7 +102,7 @@
     </t>
 
     <t t-name="web.SearchBar">
-        <div class="o_cp_searchview d-flex input-group" role="search" t-ref="root">
+        <div class="o_cp_searchview d-flex input-group mt-1 mt-md-0" role="search" t-ref="root">
             <div class="o_searchview form-control d-print-contents d-flex align-items-center py-1 border-end-0"
                  role="search" aria-autocomplete="list">
                 <button class="d-print-none btn border-0 p-0"

--- a/addons/web/static/src/views/form/status_bar_buttons/status_bar_buttons.scss
+++ b/addons/web/static/src/views/form/status_bar_buttons/status_bar_buttons.scss
@@ -1,8 +1,0 @@
-// Unstyle buttons so they behave like regular dropdown-item
-.o_statusbar_button_dropdown_item {
-    &, .o_web_client.o_touch_device & {
-        button, button:hover, button:disabled {
-            all: unset;
-        }
-    }
-}

--- a/addons/web/static/src/views/form/status_bar_dropdown_items/status_bar_dropdown_items.xml
+++ b/addons/web/static/src/views/form/status_bar_dropdown_items/status_bar_dropdown_items.xml
@@ -3,7 +3,7 @@
 
     <t t-name="web.StatusBarDropdownItems">
         <t t-foreach="visibleSlotNames" t-as="slot" t-key="slot">
-            <DropdownItem class="'o_statusbar_button_dropdown_item'">
+            <DropdownItem class="'o-dropdown-item-unstyled-button'">
                 <t t-slot="{{ slot }}" />
             </DropdownItem>
         </t>

--- a/addons/web/static/src/views/list/list_cog_menu.js
+++ b/addons/web/static/src/views/list/list_cog_menu.js
@@ -1,0 +1,13 @@
+import { CogMenu } from "../../search/cog_menu/cog_menu";
+
+export class ListCogMenu extends CogMenu {
+    static template = "web.ListCogMenu";
+    static props = {
+        ...CogMenu.props,
+        hasSelectedRecords: { type: Number, optional: true },
+        slots: { type: Object, optional: true },
+    };
+    _registryItems() {
+        return this.props.hasSelectedRecords ? [] : super._registryItems();
+    }
+}

--- a/addons/web/static/src/views/list/list_cog_menu.xml
+++ b/addons/web/static/src/views/list/list_cog_menu.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="web.ListCogMenu" t-inherit="web.CogMenu">
+        <xpath expr="//t[@t-if='state.printItems.length']" position="before">
+            <t t-slot="default"/>
+        </xpath>
+        <xpath expr="//t[@t-if='state.printItems.length']/Dropdown" position="before">
+            <div role="separator" class="dropdown-divider"/>
+        </xpath>
+    </t>
+
+</templates>

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -25,8 +25,9 @@ import { ExportDataDialog } from "@web/views/view_dialogs/export_data_dialog";
 import { ListConfirmationDialog } from "./list_confirmation_dialog";
 import { SearchBar } from "@web/search/search_bar/search_bar";
 import { useSearchBarToggler } from "@web/search/search_bar/search_bar_toggler";
-import { CogMenu } from "@web/search/cog_menu/cog_menu";
 import { session } from "@web/session";
+import { ListCogMenu } from "./list_cog_menu";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 
 import {
     Component,
@@ -49,7 +50,8 @@ export class ListController extends Component {
         ViewButton,
         MultiRecordViewButton,
         SearchBar,
-        CogMenu,
+        CogMenu: ListCogMenu,
+        DropdownItem,
     };
     static props = {
         ...standardViewProps,

--- a/addons/web/static/src/views/list/list_controller.xml
+++ b/addons/web/static/src/views/list/list_controller.xml
@@ -36,31 +36,51 @@
                     <SearchBar t-if="searchBarToggler.state.showSearchBar" autofocus="firstLoad"/>
                 </t>
                 <t t-set-slot="control-panel-navigation-additional">
-                    <t t-component="searchBarToggler.component" t-props="searchBarToggler.props"/>
+                    <t t-if="!hasSelectedRecords" t-component="searchBarToggler.component" t-props="searchBarToggler.props"/>
                 </t>
 
                 <t t-set-slot="control-panel-additional-actions">
-                    <CogMenu t-if="!nbSelected and !model.root.isDomainSelected"/>
+                    <CogMenu t-if="!hasSelectedRecords"/>
+                    <CogMenu t-elif="env.isSmall and props.info.actionMenus" t-props="this.actionMenuProps" hasSelectedRecords="hasSelectedRecords">
+                        <t t-foreach="archInfo.headerButtons" t-as="button" t-key="button.id" t-if="!evalViewModifier(button.invisible)">
+                            <DropdownItem class="'o-dropdown-item-unstyled-button'">
+                                <MultiRecordViewButton
+                                    t-if="button.display !== 'always'"
+                                    list="model.root"
+                                    className="button.className"
+                                    clickParams="button.clickParams"
+                                    defaultRank="'btn-secondary'"
+                                    domain="props.domain"
+                                    icon="button.icon"
+                                    string="button.string"
+                                    title="button.title"
+                                    attrs="button.attrs"
+                                />
+                            </DropdownItem>
+                        </t>
+                    </CogMenu>
                 </t>
                 <t t-set-slot="control-panel-selection-actions">
-                    <div t-if="hasSelectedRecords" class="d-flex gap-1">
+                    <div t-if="hasSelectedRecords" class="o_list_selection_container d-flex gap-1 w-100 w-md-auto">
                         <t t-call="web.ListView.Selection"/>
-                        <t t-foreach="archInfo.headerButtons" t-as="button" t-key="button.id" t-if="!evalViewModifier(button.invisible)">
-                            <MultiRecordViewButton
-                                t-if="button.display !== 'always'"
-                                list="model.root"
-                                className="button.className"
-                                clickParams="button.clickParams"
-                                defaultRank="'btn-secondary'"
-                                domain="props.domain"
-                                icon="button.icon"
-                                string="button.string"
-                                title="button.title"
-                                attrs="button.attrs"
-                            />
-                        </t>
-                        <t t-if="props.info.actionMenus">
-                            <ActionMenus t-props="this.actionMenuProps"/>
+                        <t t-if="!env.isSmall">
+                            <t t-foreach="archInfo.headerButtons" t-as="button" t-key="button.id" t-if="!evalViewModifier(button.invisible)">
+                                <MultiRecordViewButton
+                                    t-if="button.display !== 'always'"
+                                    list="model.root"
+                                    className="button.className"
+                                    clickParams="button.clickParams"
+                                    defaultRank="'btn-secondary'"
+                                    domain="props.domain"
+                                    icon="button.icon"
+                                    string="button.string"
+                                    title="button.title"
+                                    attrs="button.attrs"
+                                />
+                            </t>
+                            <t t-if="props.info.actionMenus">
+                                <ActionMenus t-props="this.actionMenuProps"/>
+                            </t>
                         </t>
                     </div>
                 </t>
@@ -95,24 +115,29 @@
     </t>
 
     <t t-name="web.ListView.Selection">
-        <div class="o_list_selection_box list-group flex-row" role="alert">
-            <span class="list-group-item active d-flex align-items-center pe-0 py-0 rounded-1 lh-1">
+        <div class="o_list_selection_box list-group flex-row w-auto" t-att-class="{'mt-1 gap-1': env.isSmall}" role="alert">
+            <span class="list-group-item active d-flex align-items-center pe-0 py-0 rounded-1 gap-1 flex-grow-1" t-att-class="{'shadow': env.isSmall}">
                 <span t-if="isDomainSelected">All <b t-esc="nbTotal"/> selected</span>
                 <t t-else="">
-                    <b class="me-1" t-esc="nbSelected"/> selected
-                    <a t-if="isPageSelected and (!model.root.isRecordCountTrustable or nbTotal > nbSelected)"
-                        href="#"
-                        class="o_list_select_domain ms-3 btn btn-sm btn-info p-1 me-n2 border-0 fw-normal"
+                    <b t-esc="nbSelected"/> selected
+                    <button t-if="!env.isSmall and isPageSelected and (!model.root.isRecordCountTrustable or nbTotal > nbSelected)"
+                        class="o_list_select_domain btn btn-sm btn-info p-1 ms-2 me-n2 border-0 fw-normal"
                         title="Select all records matching the search"
                         t-on-click="onSelectDomain">
                         <i class="oi oi-fw oi-arrow-right"/>
                         Select all <span t-if="model.root.isRecordCountTrustable" t-esc="nbTotal"/>
-                    </a>
+                    </button>
                 </t>
-                <a href="#" title="Unselect All" class="o_list_unselect_all btn btn-link py-0" t-on-click="onUnselectAll">
+                <button title="Unselect All" class="o_list_unselect_all" t-att-class="env.isSmall ? 'btn btn-primary ms-auto' : 'btn btn-link ms-auto border-0'" t-on-click="onUnselectAll">
                     <i class="oi oi-close"/>
-                </a>
+                </button>
             </span>
+            <button t-if="env.isSmall and !isDomainSelected and isPageSelected and (!model.root.isRecordCountTrustable or nbTotal > nbSelected)"
+                class="o_list_select_domain btn btn-info shadow"
+                title="Select all records matching the search"
+                t-on-click="onSelectDomain">
+                All
+            </button>
         </div>
     </t>
 

--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -580,6 +580,25 @@
     }
 }
 
+@include media-breakpoint-down(md) {
+    .o_web_client:has(.o_list_selection_container) .o_navbar {
+        opacity: 0.15;
+    }
+
+    .o_list_view .o_list_selection_container {
+        position: fixed;
+        top: 0;
+        right: 0;
+        left: 0;
+        justify-content: center;
+        
+        .o_list_selection_box {
+            --#{$variable-prefix}list-group-active-color: #{$white};
+            --#{$variable-prefix}list-group-active-border-color: RGB(var(--primary-rgb));
+            --#{$variable-prefix}list-group-active-bg: RGB(var(--primary-rgb));
+        }
+    }
+}
 .modal-footer .o_list_selection_box {
     margin-bottom: 0rem !important;
 }

--- a/addons/web/static/tests/views/form/form_renderer.test.js
+++ b/addons/web/static/tests/views/form/form_renderer.test.js
@@ -92,7 +92,7 @@ test.tags("mobile")("compile header and buttons on mobile", async () => {
     });
     await contains(`.o_cp_action_menus button:has(.fa-cog)`).click();
     expect(
-        `.o_statusbar_button_dropdown_item button[name=action_button]:contains(ActionButton)`
+        `.o-dropdown-item-unstyled-button button[name=action_button]:contains(ActionButton)`
     ).toHaveCount(1);
 });
 

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -3156,8 +3156,8 @@ test.tags("mobile")(`buttons should be in CogMenu in form view header on mobile`
     });
 
     await contains(`.o_cp_action_menus button:has(.fa-cog)`).click();
-    expect(`.o_statusbar_button_dropdown_item > button`).toHaveAttribute("name", "0");
-    expect(`.o_statusbar_button_dropdown_item > div`).toHaveAttribute("name", "foo");
+    expect(`.o-dropdown-item-unstyled-button > button`).toHaveAttribute("name", "0");
+    expect(`.o-dropdown-item-unstyled-button > div`).toHaveAttribute("name", "foo");
 });
 
 test(`button in form view and long willStart`, async () => {
@@ -3292,11 +3292,11 @@ test.tags("mobile")(`button in form view and long willStart on mobile`, async ()
     expect.verifySteps(["web_read1"]);
 
     await contains(`.o_cp_action_menus button:has(.fa-cog)`).click();
-    await contains(`.o_statusbar_button_dropdown_item button.child_ids`).click();
+    await contains(`.o-dropdown-item-unstyled-button button.child_ids`).click();
     expect.verifySteps(["web_read2", "willUpdateProps"]);
 
     await contains(`.o_cp_action_menus button:has(.fa-cog)`).click();
-    await contains(`.o_statusbar_button_dropdown_item button.child_ids`).click();
+    await contains(`.o-dropdown-item-unstyled-button button.child_ids`).click();
     expect.verifySteps(["web_read3", "willUpdateProps"]);
 });
 
@@ -3430,7 +3430,7 @@ test.tags("mobile")(
         });
 
         await contains(`.o_cp_action_menus button:has(.fa-cog)`).click();
-        await contains(`.o_statusbar_button_dropdown_item button.child_ids`).click();
+        await contains(`.o-dropdown-item-unstyled-button button.child_ids`).click();
         expect.verifySteps(["get_views", "onchange", "web_save", "execute_action", "web_read"]);
     }
 );
@@ -8764,16 +8764,16 @@ test.tags("mobile")(
 
         // click on button, and cancel in confirm dialog
         await contains(`.o_cp_action_menus button:has(.fa-cog)`).click();
-        await contains(`.o_statusbar_button_dropdown_item button`).click();
-        expect(`.o_statusbar_button_dropdown_item button`).not.toBeEnabled();
+        await contains(`.o-dropdown-item-unstyled-button button`).click();
+        expect(`.o-dropdown-item-unstyled-button button`).not.toBeEnabled();
 
         await contains(`.modal-footer button.btn-secondary`).click();
-        expect(`.o_statusbar_button_dropdown_item button`).toBeEnabled();
+        expect(`.o-dropdown-item-unstyled-button button`).toBeEnabled();
 
         expect.verifySteps(["get_views", "onchange"]);
 
         // click on button, and click on ok in confirm dialog
-        await contains(`.o_statusbar_button_dropdown_item button`).click();
+        await contains(`.o-dropdown-item-unstyled-button button`).click();
         expect.verifySteps([]);
         await contains(`.modal-footer button.btn-primary`).click();
         expect.verifySteps(["web_save", "execute_action"]);
@@ -8826,7 +8826,7 @@ test.tags("mobile")(
         `,
         });
         await contains(`.o_cp_action_menus button:has(.fa-cog)`).click();
-        await contains(`.o_statusbar_button_dropdown_item button`).click();
+        await contains(`.o-dropdown-item-unstyled-button button`).click();
         expect(`.modal-title`).toHaveText("Confirm Title");
         expect(`.modal-footer button.btn-primary`).toHaveText("Confirm Label");
         expect.verifySteps(["get_views", "onchange"]);
@@ -8888,7 +8888,7 @@ test.tags("mobile")(`buttons with "confirm" attribute: click twice on "Ok" on mo
     expect.verifySteps(["get_views", "onchange"]);
 
     await contains(`.o_cp_action_menus button:has(.fa-cog)`).click();
-    await contains(`.o_statusbar_button_dropdown_item button`).click();
+    await contains(`.o-dropdown-item-unstyled-button button`).click();
     expect.verifySteps([]);
 
     contains(`.modal-footer button.btn-primary`).click();
@@ -9400,7 +9400,7 @@ test.tags("mobile")(
         `,
         });
         await contains(`.o_cp_action_menus button:has(.fa-cog)`).click();
-        await contains(`.o_statusbar_button_dropdown_item button`).click();
+        await contains(`.o-dropdown-item-unstyled-button button`).click();
         expect.verifySteps(["doActionButton"]);
     }
 );

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -874,7 +874,7 @@ test(`list view: action button in controlPanel with display='always'`, async () 
     await contains(`.o_data_row .o_list_record_selector input[type="checkbox"]`).click();
     expect(
         queryAllTexts(`div.o_control_panel_breadcrumbs button, div.o_control_panel_actions button`)
-    ).toEqual(["New", "display", "default-selection"]);
+    ).toEqual(["New", "display", "" /* unselect all btn */, "default-selection"]);
 
     await contains(`.o_data_row .o_list_record_selector input[type="checkbox"]`).click();
     expect(

--- a/addons/web/static/tests/views/view_dialogs/export_data_dialog.test.js
+++ b/addons/web/static/tests/views/view_dialogs/export_data_dialog.test.js
@@ -3,7 +3,6 @@ import {
     check,
     dblclick,
     pointerDown,
-    pointerUp,
     queryAll,
     queryAllTexts,
     queryFirst,
@@ -32,7 +31,6 @@ const openExportDialog = async () => {
     if (getMockEnv().isSmall) {
         await pointerDown(".o_data_row:nth-child(1)");
         await runAllTimers();
-        await pointerUp(".o_data_row:nth-child(1)");
     } else {
         await contains(".o_list_record_selector input[type='checkbox']").click();
     }

--- a/addons/web/static/tests/views/view_dialogs/select_create_dialog.test.js
+++ b/addons/web/static/tests/views/view_dialogs/select_create_dialog.test.js
@@ -415,7 +415,7 @@ test("SelectCreateDialog calls on_selected with every record matching without se
 
     await contains("thead .o_list_record_selector input").click();
     await contains(".o_list_selection_box").click();
-    await clickModalButton({ text: "Select" });
+    await clickModalButton({ text: "Select", index: 1 });
 });
 
 test("SelectCreateDialog: multiple clicks on record", async () => {

--- a/addons/web/static/tests/webclient/actions/window_action.test.js
+++ b/addons/web/static/tests/webclient/actions/window_action.test.js
@@ -2321,9 +2321,9 @@ test.tags("mobile")("do not restore after action button clicked on mobile", asyn
     await contains("div[name='display_name'] input").edit("Edited value");
     expect(".o_form_button_save").toBeVisible();
     await contains(`.o_cp_action_menus button:has(.fa-cog)`).click();
-    expect(".o_statusbar_button_dropdown_item button[name=do_something]").toBeVisible();
+    expect(".o-dropdown-item-unstyled-button button[name=do_something]").toBeVisible();
 
-    await contains(".o_statusbar_button_dropdown_item button[name=do_something]").click();
+    await contains(".o-dropdown-item-unstyled-button button[name=do_something]").click();
     expect(".o_form_buttons_view .o_form_button_save").not.toBeVisible();
 });
 
@@ -2441,7 +2441,7 @@ test.tags("mobile")("window action in target new fails (onchange) on mobile", as
     await mountWithCleanup(WebClient);
     await getService("action").doAction(2);
     await contains(`.o_cp_action_menus button:has(.fa-cog)`).click();
-    await contains(".o_statusbar_button_dropdown_item button[name='5']").click();
+    await contains(".o-dropdown-item-unstyled-button button[name='5']").click();
     await waitFor(".modal"); // errors are async
     expect(".modal").toHaveCount(1);
     expect(".modal .o_error_dialog").toHaveCount(1);
@@ -2512,7 +2512,7 @@ test.tags("mobile")("Uncaught error in target new is catch only once on mobile",
     await mountWithCleanup(WebClient);
     await getService("action").doAction(2);
     await contains(`.o_cp_action_menus button:has(.fa-cog)`).click();
-    await contains(".o_statusbar_button_dropdown_item button[name='26']").click();
+    await contains(".o-dropdown-item-unstyled-button button[name='26']").click();
     await waitFor(".modal"); // errors are async
     expect(".modal").toHaveCount(1);
     expect(".modal .o_error_dialog").toHaveCount(1);


### PR DESCRIPTION
Ths List view allows to select one or multiple records. While doing so,
an indicator is displayed, showing how much records are selected and
providing actions to perform on them.

On regular computer's screen, the central part of the ControlPanel is
used to display this indicator and its related buttons, hiding the
SearchBar. On smaller screens, all those visual elements take a lot of
space, easily triggering an horizontal scrolling and taking an
additional line in the ControlPanel, which push the records a bit down
on the screen.

This commit reuses the CogMenu paradigm to group all the actions/buttons
in a single element. To avoid the records being pushed down, the
selection indicator is transformed into a floating "Toast" as an overlay
to the Navbar (similar to what was previously done to the Pager).

task-3336242




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
