### PR TITLE
[IMP] base: add a mechanism to block the generation of device logs

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -516,10 +516,13 @@ class IrActionsReport(models.Model):
         temporary_files = []
 
         # Passing the cookie to wkhtmltopdf in order to resolve internal links.
-        if request and request.db:
+        if request and request.db and request.session.sid:
             base_url = self._get_report_url()
             domain = urlparse(base_url).hostname
-            cookie = f'session_id={request.session.sid}; HttpOnly; domain={domain}; path=/;'
+            sid = request.session.sid
+            token = self.env['res.device.log']._generate_no_trace_token(sid)
+            cookie = f'session_id={sid}; HttpOnly; domain={domain}; path=/;\n'
+            cookie += f'no_trace={token}; HttpOnly; domain={domain}; path=/;'
             cookie_jar_file_fd, cookie_jar_file_path = tempfile.mkstemp(suffix='.txt', prefix='report.cookie_jar.tmp.')
             temporary_files.append(cookie_jar_file_path)
             with closing(os.fdopen(cookie_jar_file_fd, 'wb')) as cookie_jar_file:

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1811,14 +1811,14 @@ class HttpCase(TransactionCase):
             message,
         )
 
-    def url_open(self, url, data=None, files=None, timeout=12, headers=None, allow_redirects=True, head=False):
+    def url_open(self, url, data=None, files=None, timeout=12, headers=None, allow_redirects=True, head=False, cookies=None):
         if url.startswith('/'):
             url = self.base_url() + url
         if head:
-            return self.opener.head(url, data=data, files=files, timeout=timeout, headers=headers, allow_redirects=False)
+            return self.opener.head(url, data=data, files=files, timeout=timeout, headers=headers, allow_redirects=False, cookies=cookies)
         if data or files:
-            return self.opener.post(url, data=data, files=files, timeout=timeout, headers=headers, allow_redirects=allow_redirects)
-        return self.opener.get(url, timeout=timeout, headers=headers, allow_redirects=allow_redirects)
+            return self.opener.post(url, data=data, files=files, timeout=timeout, headers=headers, allow_redirects=allow_redirects, cookies=cookies)
+        return self.opener.get(url, timeout=timeout, headers=headers, allow_redirects=allow_redirects, cookies=cookies)
 
     def _wait_remaining_requests(self, timeout=10):
 


### PR DESCRIPTION
In certain scenarios, we don't want to create logs. For example, the activity of the support staff or the generation of a pdf with wkhtmltopdf will create device logs which are not necessary and which can be annoying for users.

To deactivate the generation of device logs for a given session (and for a limited time), the `res.device.log` model offers the option of generating a token which must be placed in the cookies (with the name `no_trace`).
Using this cookie with another session does not work.

Requests generated directly by the platform could use this mechanism and the support staff would have a way of generating this token in order to use it.