### PR TITLE
[PERF] point_of_sale: loading only necessary attribute values

### DIFF
--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -277,6 +277,11 @@ class ProductTemplateAttributeLine(models.Model):
     def _load_pos_data_fields(self, config_id):
         return ['display_name', 'attribute_id', 'product_template_value_ids']
 
+    @api.model
+    def _load_pos_data_domain(self, data):
+        loaded_product_tmpl_ids = list({p['product_tmpl_id'] for p in data['product.product']['data']})
+        return [('product_tmpl_id', 'in', loaded_product_tmpl_ids)]
+
 
 class ProductTemplateAttributeValue(models.Model):
     _name = 'product.template.attribute.value'
@@ -284,7 +289,12 @@ class ProductTemplateAttributeValue(models.Model):
 
     @api.model
     def _load_pos_data_domain(self, data):
-        return AND([[('ptav_active', '=', True)], [('attribute_id', 'in', [attr['id'] for attr in data['product.attribute']['data']])]])
+        loaded_product_tmpl_ids = list({p['product_tmpl_id'] for p in data['product.product']['data']})
+        return AND([
+            [('ptav_active', '=', True)],
+            [('attribute_id', 'in', [attr['id'] for attr in data['product.attribute']['data']])],
+            [('product_tmpl_id', 'in', loaded_product_tmpl_ids)]
+        ])
 
     @api.model
     def _load_pos_data_fields(self, config_id):


### PR DESCRIPTION
Before this commit, all attribute values were loaded into the POS, regardless of necessity. This commit optimizes performance by ensuring only the required attribute values are loaded, reducing unnecessary data processing and memory usage.

opw-4169060

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
