### PR TITLE
[FIX] base, tools, *: remove deprecated usages of crypt_context.encrypt

### DIFF
--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -38,7 +38,7 @@ class View(models.Model):
         crypt_context = self.env.user._crypt_context()
         for r in self:
             if r.type == 'qweb':
-                r.sudo().visibility_password = r.visibility_password_display and crypt_context.encrypt(r.visibility_password_display) or ''
+                r.sudo().visibility_password = (r.visibility_password_display and crypt_context.hash(r.visibility_password_display)) or ''
                 r.visibility = r.visibility  # double check access
 
     def _compute_first_page_id(self):

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -36,11 +36,6 @@ class CryptContext:
     def __init__(self, *args, **kwargs):
         self.__obj__ = _CryptContext(*args, **kwargs)
 
-    @property
-    def encrypt(self):
-        # deprecated alias
-        return self.hash
-
     def copy(self):
         """
             The copy method must create a new instance of the

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -780,8 +780,7 @@ class configmanager(object):
         return os.path.join(self['data_dir'], 'filestore', dbname)
 
     def set_admin_password(self, new_password):
-        hash_password = crypt_context.hash if hasattr(crypt_context, 'hash') else crypt_context.encrypt
-        self.options['admin_passwd'] = hash_password(new_password)
+        self.options['admin_passwd'] = crypt_context.hash(new_password)
 
     def verify_admin_password(self, password):
         """Verifies the super-admin password, possibly updating the stored hash if needed"""


### PR DESCRIPTION
*: website

`crypt_context.encrypt` is deprecated since passlib 1.7. We don't support passlib 1.6 and lower anymore, so this commit changes all usages of `encrypt` to `hash` and removes the `encrypt` method in the wrapper class.

task-4179594
