### PR TITLE
[FIX] web_editor: fix colorpicker UI update 

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
@@ -472,7 +472,10 @@ export class ColorPalette extends Component {
             eventCallback(colorInfo);
         }
         this._buildCustomColors();
-        this.state.customSelectedColor = colorInfo.color;
+        this.state.customSelectedColor = isCSSColor(colorInfo.color)
+            ? colorInfo.color
+            : weUtils.getCSSVariableValue(colorInfo.color, this.style);
+
         const customGradient = weUtils.isColorGradient(colorInfo.color) ? colorInfo.color : false;
         if (this.pickers['custom_gradient']) {
             this._selectGradient(customGradient);


### PR DESCRIPTION
Before this commit, the colorpicker UI would not update when switching
to some colors (grayscale, transparent grayscale, theme colors). It
would therefore be difficult to make small changes to those colors.

This commit make the colorpicker update correctly.

Step to reproduce the bug (example with grayscale colors):
- Add a snippet
- Change the background color to a custom color
(the colorpicker interface was updated to match the color)
- Change the background color to a grayscale color
(the colorpicker interface was not updated to match the color)

task-3806989