### PR TITLE
[FIX] point_of_sale: fix variant price added with barcode

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -583,7 +583,7 @@ export class PosStore extends Reactive {
             } else {
                 return;
             }
-        } else if (values.product_id.product_template_variant_value_ids.length > 0) {
+        } else if (values.product_id.product_template_variant_value_ids.length > 0 && configure) {
             // Verify price extra of variant products
             const priceExtra = values.product_id.product_template_variant_value_ids.reduce(
                 (acc, attr) => acc + attr.price_extra,

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -328,3 +328,15 @@ registry.category("web_tour.tours").add("PosCustomerAllFieldsDisplayed", {
             PartnerList.searchCustomerValue("john@doe.com"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("VariantBarcodePrice", {
+    test: true,
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            ProductScreen.scan_barcode("123"),
+            ProductScreen.selectedOrderlineHas("Rock (red)", "1.0", "6.0"),
+            ProductScreen.scan_barcode("456"),
+            ProductScreen.selectedOrderlineHas("Rock (blue)", "1.0", "11.0"),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1475,6 +1475,32 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'CashRoundingPayment', login="accountman")
 
+    def test_variant_price_barcode(self):
+        attribute = self.env['product.attribute'].create({
+            'name': 'color',
+            'display_type': 'color',
+            'create_variant': 'always',
+            'value_ids': [
+                Command.create({'name': 'red', 'default_extra_price': 5}),
+                Command.create({'name': 'blue', 'default_extra_price': 10}),
+            ]
+        })
+        tmpl_id = self.env['product.template'].create({
+            'name': 'Rock',
+            'available_in_pos': True,
+            'taxes_id': False,
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': attribute.id,
+                    'value_ids': [Command.set(attribute.value_ids.ids)],
+                }),
+            ],
+        })
+        tmpl_id.product_variant_ids[0].barcode = "123"
+        tmpl_id.product_variant_ids[1].barcode = "456"
+        self.main_pos_config.open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'VariantBarcodePrice', login="accountman")
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
When you add attributes that always create a variant to a product. The extra price would be applied 2 times when adding it scanning the barcode

Steps to reproduce:
-------------------
* Create a product A with price 10€
* Create an attribute that always create a variant
* Add 2 values one with an extra price of 5€
* Set a barcode for each variant
* Open the PoS
* Scan the barcode of the variant with the extra price
> Observation: The product is added with the wrong price 20€ instead of
10€

Why the fix:
------------
We make sure to not apply the extra price for product that are already fully configured (product that have only always create attribute). Because these products already have the correct price.

opw-4171596
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
