### PR TITLE
[FIX] website_payment: split test to avoid iframe issue

### DIFF
--- a/addons/website_payment/static/tests/tours/donation.js
+++ b/addons/website_payment/static/tests/tours/donation.js
@@ -1,7 +1,9 @@
 /** @odoo-module */
 
+import { registry } from "@web/core/registry";
 import wTourUtils from '@website/js/tours/tour_utils';
 
+// First part of the tour
 wTourUtils.registerWebsitePreviewTour('donation_snippet_edition', {
     test: true,
     url: '/',
@@ -12,60 +14,67 @@ wTourUtils.registerWebsitePreviewTour('donation_snippet_edition', {
             name: "Donation"
         }),
         ...wTourUtils.clickOnSave(),
+]);
+
+// Second part of the tour
+registry.category('web_tour.tours').add('donation_snippet_use', {
+    test: true,
+    url: '/',
+    steps: () => [
         // -- Testing the minimum amount --
         {
             content: "Enter a negative custom amount, testing the minimum amount",
-            trigger: ":iframe #s_donation_amount_input",
+            trigger: "#s_donation_amount_input",
             run: "edit 1",
         },
         {
             content: "Donate with custom amount set",
-            trigger: ":iframe .s_donation_donate_btn",
+            trigger: ".s_donation_donate_btn",
             run: "click",
         },
         {
             content: "Check if alert-danger element exists",
-            trigger: ":iframe p.alert-danger",
+            trigger: "p.alert-danger",
         },
         // -- End of testing the minimum amount --
         {
             content: "Enter a custom amount",
-            trigger: ":iframe #s_donation_amount_input",
+            trigger: "#s_donation_amount_input",
             run: "edit 55",
         },
         {
             content: "Donate with custom amount set",
-            trigger: ":iframe .s_donation_donate_btn",
+            trigger: ".s_donation_donate_btn",
             run: "click",
         },
         {
             content: "Check if custom amount radio input is selected",
-            trigger: ":iframe input#other_amount:checked",
+            trigger: "input#other_amount:checked",
             run: () => {}, // This is a check
         },
         {
             content: "Check if custom amount radio input has value 55",
-            trigger: ':iframe input#other_amount[value="55.0"]',
+            trigger: 'input#other_amount[value="55.0"]',
             run: () => {}, // This is a check
         },
         {
             content: "Select the amount of 25",
-            trigger: ":iframe input#amount_1",
+            trigger: "input#amount_1",
             run: "click",
         },
         {
             content: "Verify that amount_1 is checked",
-            trigger: ":iframe input#amount_1:checked",
+            trigger: "input#amount_1:checked",
             run: () => {}, // This is a check
         },
         {
             content: "Verify that other_amount is not checked",
-            trigger: ":iframe input#other_amount:not(:checked)",
+            trigger: "input#other_amount:not(:checked)",
             run: () => {}, // This is a check
         },
         {
             content: "Change custom amount to 67",
-            trigger: ":iframe input[name='o_donation_amount'][type='number']",
+            trigger: "input[name='o_donation_amount'][type='number']",
             run: function(action) {
                 const input = action.anchor;
                 input.value = "67";
@@ -75,19 +84,19 @@ wTourUtils.registerWebsitePreviewTour('donation_snippet_edition', {
         },
         {
             content: "Select the custom amount radio button",
-            trigger: ":iframe input#other_amount",
+            trigger: "input#other_amount",
             run: "click",
         },
         {
             content: "Submit the donation form",
-            trigger: ":iframe button[name='o_payment_submit_button']",
+            trigger: "button[name='o_payment_submit_button']",
             run: "click",
         },
         {
             content: "Verify that the amount displayed is 67",
-            trigger: ':iframe span.oe_currency_value:contains("67.00")',
+            trigger: 'span.oe_currency_value:contains("67.00")',
             run: () => {}, // This is a check
             timeout: 10000  // Make sure the payment process animation is finished
         },
-    ]
-);
+    ],
+});

--- a/addons/website_payment/static/tests/tours/donation.js
+++ b/addons/website_payment/static/tests/tours/donation.js
@@ -23,7 +23,7 @@ registry.category('web_tour.tours').add('donation_snippet_use', {
     steps: () => [
         // -- Testing the minimum amount --
         {
-            content: "Enter a negative custom amount, testing the minimum amount",
+            content: "Enter a custom amount smaller than the minimum, testing the minimum amount",
             trigger: "#s_donation_amount_input",
             run: "edit 1",
         },
@@ -50,12 +50,10 @@ registry.category('web_tour.tours').add('donation_snippet_use', {
         {
             content: "Check if custom amount radio input is selected",
             trigger: "input#other_amount:checked",
-            run: () => {}, // This is a check
         },
         {
             content: "Check if custom amount radio input has value 55",
             trigger: 'input#other_amount[value="55.0"]',
-            run: () => {}, // This is a check
         },
         {
             content: "Select the amount of 25",
@@ -65,12 +63,10 @@ registry.category('web_tour.tours').add('donation_snippet_use', {
         {
             content: "Verify that amount_1 is checked",
             trigger: "input#amount_1:checked",
-            run: () => {}, // This is a check
         },
         {
             content: "Verify that other_amount is not checked",
             trigger: "input#other_amount:not(:checked)",
-            run: () => {}, // This is a check
         },
         {
             content: "Change custom amount to 67",
@@ -80,7 +76,7 @@ registry.category('web_tour.tours').add('donation_snippet_use', {
                 input.value = "67";
                 input.dispatchEvent(new Event("input", { bubbles: true }));
                 input.dispatchEvent(new Event("change", { bubbles: true }));
-            }
+            },
         },
         {
             content: "Select the custom amount radio button",
@@ -95,8 +91,7 @@ registry.category('web_tour.tours').add('donation_snippet_use', {
         {
             content: "Verify that the amount displayed is 67",
             trigger: 'span.oe_currency_value:contains("67.00")',
-            run: () => {}, // This is a check
-            timeout: 10000  // Make sure the payment process animation is finished
+            timeout: 10000, // Make sure the payment process animation is finished
         },
     ],
 });

--- a/addons/website_payment/tests/test_snippets.py
+++ b/addons/website_payment/tests/test_snippets.py
@@ -17,3 +17,4 @@ class TestSnippets(odoo.tests.HttpCase):
         demo_provider.write({'state': 'test'})
         self.env.ref('base.user_admin').partner_id.country_id = self.env.ref('base.be')
         self.start_tour("/?enable_editor=1", "donation_snippet_edition", login='admin')
+        self.start_tour("/", "donation_snippet_use", login="portal")


### PR DESCRIPTION
On slow networks, users or runbot may click checkboxes before the
JavaScript is fully loaded by the lazy loader, causing event handlers
to not be attached.

Fix: Split the test into two separate tours. One while logged in for
donation configuration, and another while logged out to test it, since
the issue does not occur when the iframe is not present.

**Tested with a custom multi-build and the test do not fail anymore**

runbot-77224