### PR TITLE
[PERF] point_of_sale: eliminate unnecessary connect operations

### DIFF
--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -903,15 +903,6 @@ export function createRelatedModels(modelDefs, modelClasses = {}, indexes = {}) 
                             }
                         }
                     }
-                    // Connect existing records in case of post-loading
-                    if (name.includes("<-")) {
-                        const toConnect = Object.values(records[field.relation]).filter(
-                            (r) => r.raw[field.inverse_name] === rawRec.id
-                        );
-                        for (const rec of toConnect) {
-                            connect(field, recorded, rec);
-                        }
-                    }
                 }
 
                 modelToSetup.push({ raw: rawRec, record: recorded });


### PR DESCRIPTION
Before this commit, connecting a `<-` field unnecessarily attempted to link the record to the reversed field, which was not required. This additional search operation increased the time complexity of the connection process, leading to performance inefficiencies.

opw-4169060

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
