### PR TITLE
[IMP] web: display and can delete default_group_by

### DIFF
--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -31,7 +31,6 @@ import { FetchRecordError } from "./errors";
  * @property {number} [countLimit]
  * @property {number} [groupsLimit]
  * @property {string[]} [defaultOrderBy]
- * @property {string[]} [defaultGroupBy]
  * @property {number} [maxGroupByDepth]
  * @property {boolean} [multiEdit]
  * @property {Object} [groupByInfo]
@@ -134,7 +133,6 @@ export class RelationalModel extends Model {
         this.initialGroupsLimit = params.groupsLimit;
         this.initialCountLimit = params.countLimit || this.constructor.DEFAULT_COUNT_LIMIT;
         this.defaultOrderBy = params.defaultOrderBy;
-        this.defaultGroupBy = params.defaultGroupBy;
         this.maxGroupByDepth = params.maxGroupByDepth;
         this.groupByInfo = params.groupByInfo || {};
         this.multiEdit = params.multiEdit;
@@ -250,10 +248,6 @@ export class RelationalModel extends Model {
 
             // groupBy
             config.groupBy = "groupBy" in params ? params.groupBy : config.groupBy;
-            // apply default groupBy if any
-            if (this.defaultGroupBy && !config.groupBy.length) {
-                config.groupBy = [this.defaultGroupBy];
-            }
             // restrict the number of groupbys if requested
             if (this.maxGroupByDepth) {
                 config.groupBy = config.groupBy.slice(0, this.maxGroupByDepth);

--- a/addons/web/static/src/search/with_search/with_search.js
+++ b/addons/web/static/src/search/with_search/with_search.js
@@ -38,6 +38,7 @@ export class WithSearch extends Component {
         hideCustomGroupBy: { type: Boolean, optional: true },
         searchMenuTypes: { type: Array, element: String, optional: true },
         canOrderByCount: { type: Boolean, optional: true },
+        defaultGroupBy: { type: Array, element: String, optional: true },
     };
 
     setup() {

--- a/addons/web/static/src/views/kanban/kanban_arch_parser.js
+++ b/addons/web/static/src/views/kanban/kanban_arch_parser.js
@@ -14,7 +14,6 @@ export class KanbanArchParser {
         const className = xmlDoc.getAttribute("class") || null;
         const canOpenRecords = exprToBoolean(xmlDoc.getAttribute("can_open"), true);
         let defaultOrder = stringToOrderBy(xmlDoc.getAttribute("default_order") || null);
-        const defaultGroupBy = xmlDoc.getAttribute("default_group_by");
         const limit = xmlDoc.getAttribute("limit");
         const countLimit = xmlDoc.getAttribute("count_limit");
         const recordsDraggable = exprToBoolean(xmlDoc.getAttribute("records_draggable"), true);
@@ -145,7 +144,6 @@ export class KanbanArchParser {
             cardColorField: xmlDoc.getAttribute("highlight_color"),
             className,
             creates,
-            defaultGroupBy,
             fieldNodes,
             widgetNodes,
             handleField,

--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -31,10 +31,6 @@ export class KanbanController extends Component {
     static components = { Layout, KanbanRenderer, MultiRecordViewButton, SearchBar, CogMenu };
     static props = {
         ...standardViewProps,
-        defaultGroupBy: {
-            validate: (dgb) => !dgb || typeof dgb === "string",
-            optional: true,
-        },
         editable: { type: Boolean, optional: true },
         forceGlobalClick: { type: Boolean, optional: true },
         onSelectionChanged: { type: Function, optional: true },
@@ -177,7 +173,7 @@ export class KanbanController extends Component {
     }
 
     get modelParams() {
-        const { resModel, archInfo, limit, defaultGroupBy } = this.props;
+        const { resModel, archInfo, limit } = this.props;
         const { activeFields, fields } = extractFieldsFromArchInfo(archInfo, this.props.fields);
 
         const cardColorField = archInfo.cardColorField;
@@ -207,7 +203,6 @@ export class KanbanController extends Component {
             limit: archInfo.limit || limit || 40,
             groupsLimit: Number.MAX_SAFE_INTEGER, // no limit
             countLimit: archInfo.countLimit,
-            defaultGroupBy,
             defaultOrderBy: archInfo.defaultOrder,
             maxGroupByDepth: 1,
             activeIdsLimit: session.active_ids_limit,

--- a/addons/web/static/src/views/kanban/kanban_view.js
+++ b/addons/web/static/src/views/kanban/kanban_view.js
@@ -20,8 +20,6 @@ export const kanbanView = {
         const { arch, relatedModels, resModel } = genericProps;
         const { ArchParser } = view;
         const archInfo = new ArchParser().parse(arch, relatedModels, resModel);
-        const defaultGroupBy =
-            genericProps.searchMenuTypes.includes("groupBy") && archInfo.defaultGroupBy;
 
         return {
             ...genericProps,
@@ -30,7 +28,6 @@ export const kanbanView = {
             Renderer: view.Renderer,
             buttonTemplate: view.buttonTemplate,
             archInfo,
-            defaultGroupBy,
         };
     },
 };

--- a/addons/web/static/src/views/kanban/progress_bar_hook.js
+++ b/addons/web/static/src/views/kanban/progress_bar_hook.js
@@ -246,8 +246,7 @@ class ProgressBarState {
 
     async _updateProgressBar() {
         const groupBy = this.model.root.groupBy;
-        const defaultGroupBy = this.model.root.defaultGroupBy;
-        if (groupBy.length || defaultGroupBy) {
+        if (groupBy.length) {
             const resModel = this.model.root.resModel;
             const domain = this.model.root.domain;
             const context = this.model.root.context;
@@ -255,7 +254,7 @@ class ProgressBarState {
             const groupsId = this.model.root.groups.map((g) => g.id).join();
             const res = await this.model.orm.call(resModel, "read_progress_bar", [], {
                 domain,
-                group_by: groupBy.length ? groupBy[0] : defaultGroupBy,
+                group_by: groupBy[0],
                 progress_bar: { colors, field, help },
                 context,
             });

--- a/addons/web/static/src/views/list/list_arch_parser.js
+++ b/addons/web/static/src/views/list/list_arch_parser.js
@@ -206,7 +206,6 @@ export class ListArchParser {
                 treeAttr.rawExpand = xmlDoc.getAttribute("expand");
                 treeAttr.decorations = getDecoration(xmlDoc);
 
-                treeAttr.defaultGroupBy = xmlDoc.getAttribute("default_group_by");
                 treeAttr.defaultOrder = stringToOrderBy(
                     xmlDoc.getAttribute("default_order") || null
                 );

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -192,7 +192,7 @@ export class ListController extends Component {
     }
 
     get modelParams() {
-        const { defaultGroupBy, rawExpand } = this.archInfo;
+        const { rawExpand } = this.archInfo;
         const { activeFields, fields } = extractFieldsFromArchInfo(
             this.archInfo,
             this.props.fields
@@ -218,7 +218,6 @@ export class ListController extends Component {
             limit: this.archInfo.limit || this.props.limit,
             countLimit: this.archInfo.countLimit,
             defaultOrderBy: this.archInfo.defaultOrder,
-            defaultGroupBy: this.props.searchMenuTypes.includes("groupBy") ? defaultGroupBy : false,
             groupsLimit: this.archInfo.groupsLimit,
             multiEdit: this.archInfo.multiEdit,
             activeIdsLimit: session.active_ids_limit,

--- a/addons/web/static/src/views/view.js
+++ b/addons/web/static/src/views/view.js
@@ -393,6 +393,9 @@ export class View extends Component {
 
         const searchMenuTypes =
             props.searchMenuTypes || descr.searchMenuTypes || this.constructor.searchMenuTypes;
+        const defaultGroupBy = archXmlDoc.hasAttribute("default_group_by")
+            ? archXmlDoc.getAttribute("default_group_by").split(",")
+            : null;
         viewProps.searchMenuTypes = searchMenuTypes;
         const canOrderByCount = descr.canOrderByCount || this.constructor.canOrderByCount;
 
@@ -433,6 +436,10 @@ export class View extends Component {
                 }
             }
             this.withSearchProps.display = display;
+        }
+
+        if (defaultGroupBy && defaultGroupBy.length) {
+            this.withSearchProps.defaultGroupBy = defaultGroupBy;
         }
 
         for (const key in this.withSearchProps) {

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -5058,7 +5058,7 @@ test.tags("desktop")("prevent drag and drop of record if save fails", async () =
 });
 
 test("kanban view with default_group_by", async () => {
-    expect.assertions(7);
+    expect.assertions(13);
 
     Partner._records[0].product_id = 1;
     Product._records.push({ id: 1, display_name: "third product" });
@@ -5094,15 +5094,25 @@ test("kanban view with default_group_by", async () => {
 
     expect(".o_kanban_renderer").toHaveClass("o_kanban_grouped");
     expect(".o_kanban_group").toHaveCount(2);
+    // open search bar in mobile
+    if (queryAll(".o_control_panel_navigation > button").length) {
+        await contains(".o_control_panel_navigation > button").click();
+    }
+    expect(`.o_searchview_facet`).toHaveCount(1);
+    expect(`.o_searchview_facet`).toHaveText("Bar");
 
     // simulate an update coming from the searchview, with another groupby given
     await toggleSearchBarMenu();
     await toggleMenuItem("GroupBy Product");
     expect(".o_kanban_group").toHaveCount(3);
+    expect(`.o_searchview_facet`).toHaveCount(1);
+    expect(`.o_searchview_facet`).toHaveText("GroupBy Product");
 
     // simulate an update coming from the searchview, removing the previously set groupby
     await contains(".o_searchview_facet .o_facet_remove").click();
     expect(".o_kanban_group").toHaveCount(2);
+    expect(`.o_searchview_facet`).toHaveCount(1);
+    expect(`.o_searchview_facet`).toHaveText("Bar");
 });
 
 test.tags("desktop")("kanban view not groupable", async () => {

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -14915,15 +14915,61 @@ test(`list view with default_group_by`, async () => {
     });
     expect(`.o_list_renderer table`).toHaveClass("o_list_table_grouped");
     expect(`.o_group_header`).toHaveCount(2);
+    // open search bar in mobile
+    if (queryAll(".o_control_panel_navigation > button").length) {
+        await contains(".o_control_panel_navigation > button").click();
+    }
+    expect(`.o_searchview_facet`).toHaveCount(1);
+    expect(`.o_searchview_facet`).toHaveText("Bar");
     expect.verifySteps(["web_read_group1"]);
 
     await selectGroup("m2m");
     expect(`.o_group_header`).toHaveCount(4);
+    expect(`.o_searchview_facet`).toHaveCount(1);
+    expect(`.o_searchview_facet`).toHaveText("M2m");
     expect.verifySteps(["web_read_group2"]);
 
     await toggleMenuItem("M2m");
     expect(`.o_group_header`).toHaveCount(2);
+    expect(`.o_searchview_facet`).toHaveCount(1);
+    expect(`.o_searchview_facet`).toHaveText("Bar");
     expect.verifySteps(["web_read_group3"]);
+});
+
+test(`list view with multi-fields default_group_by`, async () => {
+    let readGroupCount = 0;
+    onRpc("web_read_group", ({ kwargs }) => {
+        readGroupCount++;
+        expect.step(`web_read_group${readGroupCount}`);
+        switch (readGroupCount) {
+            case 1:
+                return expect(kwargs.groupby).toEqual(["foo"]);
+            case 2:
+                return expect(kwargs.groupby).toEqual(["bar"]);
+        }
+    });
+
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <list default_group_by="foo,bar">
+                <field name="bar"/>
+            </list>
+        `,
+    });
+    expect(`.o_list_renderer table`).toHaveClass("o_list_table_grouped");
+    expect(`.o_group_header`).toHaveCount(3);
+    // open search bar in mobile
+    if (queryAll(".o_control_panel_navigation > button").length) {
+        await contains(".o_control_panel_navigation > button").click();
+    }
+    expect(`.o_searchview_facet`).toHaveCount(1);
+    expect(`.o_searchview_facet`).toHaveText("Foo\n>\nBar");
+    expect.verifySteps(["web_read_group1"]);
+    await contains(`.o_group_header`).click();
+    expect(`.o_group_header`).toHaveCount(5);
+    expect.verifySteps(["web_read_group2"]);
 });
 
 test(`ungrouped list, apply filter, decrease limit`, async () => {


### PR DESCRIPTION
This commit improves the default_group_by UX by displaying it in the search facets and allowing the user to remove it when needed.

task-3895650
