### PR TITLE
[IMP] website: improve `s_striped, *` snippet

### DIFF
--- a/addons/website/views/snippets/s_striped.xml
+++ b/addons/website/views/snippets/s_striped.xml
@@ -11,7 +11,7 @@
                     <p class="lead" style="text-align: center;">Learn about the key decisions that have shaped our identity.</p>
                 </div>
                 <div class="col-lg-8 offset-lg-2 pt24 pb24">
-                    <img class="img img-fluid" src="/web/image/website.s_text_cover_default_image" alt=""/>
+                    <img class="img img-fluid" src="/web/image/website.s_text_cover_default_image" style="width: 100% !important;" alt=""/>
                 </div>
             </div>
         </div>

--- a/addons/website/views/snippets/s_striped_center_top.xml
+++ b/addons/website/views/snippets/s_striped_center_top.xml
@@ -14,9 +14,9 @@
                         <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg"><t t-esc="cta_btn_text">Get started</t></a>
                     </p>
                 </div>
-                <div class="col-lg-12 pb24" style="text-align: center;">
-                    <figure class="figure">
-                        <img src="/web/image/website.s_picture_default_image" class="figure-img img-fluid rounded" alt=""/>
+                <div class="col-lg-10 offset-lg-1 pb24" style="text-align: center;">
+                    <figure class="figure w-100">
+                        <img src="/web/image/website.s_picture_default_image" class="figure-img img-fluid rounded" style="width: 100% !important;" alt=""/>
                         <figcaption class="figure-caption text-600">Crafted with precision and care</figcaption>
                     </figure>
                 </div>

--- a/addons/website/views/snippets/s_striped_top.xml
+++ b/addons/website/views/snippets/s_striped_top.xml
@@ -7,7 +7,7 @@
         <div class="container">
             <div class="row">
                 <div class="col-lg-6 pt24 pb24 order-lg-0" style="order: 2;">
-                    <img class="img img-fluid" src="/web/image/website.s_striped_top_default_image" alt=""/>
+                    <img class="img img-fluid" src="/web/image/website.s_striped_top_default_image" style="width: 100% !important;" alt=""/>
                 </div>
                 <div class="col-lg-6 pt24 pb24 order-lg-0" style="order: 1;">
                     <h1>Experience the Future of Innovation in Every Interaction</h1>


### PR DESCRIPTION
Before this commit, in the `s_striped_centertop` snippet the image was displayed in a full-width 12-column layout and the image was centered but did not filled the full width of its container.

This commit improves the layout by changing the column width to a 10-column layout with 1-column offset for better centering. Additionally, the image width is now explicitly set to 100% to ensure it scales properly within its container, improving visual consistency across themes. It also sets it to 100% in `s_striped` and `s_striped_top` snippets.

task-4179589
Part of task-4077427

related-to: https://github.com/odoo/design-themes/pull/904

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
