### PR TITLE
[IMP] base: make an unallowed files exception text more explicit

### DIFF
--- a/odoo/addons/base/models/ir_asset.py
+++ b/odoo/addons/base/models/ir_asset.py
@@ -343,7 +343,8 @@ class IrAsset(models.Model):
         if addon_manifest:
             if addon not in installed:
                 # Assert that the path is in the installed addons
-                raise Exception(f"Unallowed to fetch files from addon {addon} for file {path_def}")
+                raise Exception(f"""Unallowed to fetch files from addon {addon} for file {path_def}. """
+                                f"""Addon {addon} is not installed""")
             addons_path = addon_manifest['addons_path']
             full_path = os.path.normpath(os.sep.join([addons_path, *path_parts]))
             # forbid escape from the current addon


### PR DESCRIPTION
While working on a support ticket, I was faced with this exception handling: https://github.com/odoo/odoo/blob/49061347c181b1a451435bc363bb9508db8b6fab/odoo/addons/base/models/ir_asset.py#L344-L346

It might be nitpicky, but given the if condition, the exception error text could be more explicit about the fact that it's raised because the files in question being from an uninstalled addon/module.

This might fast track troubleshooting without having to dive into the source code to understand why the error is being raised.

There is always the possibility that I might be missing some context or other scenarios where this error could be raised.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
