### PR TITLE
[FIX] account: use parent chart of template for branches

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -643,7 +643,9 @@ class ResCompany(models.Model):
             self.env.reset()     # clear the set of environments
             env = self.env()     # get an environment that refers to the new registry
             for company in self.filtered(lambda c: c.country_id and not c.chart_template):
-                template_code = self.env['account.chart.template']._guess_chart_template(company.country_id)
+                template_code = company.parent_id.chart_template
+                if not template_code:
+                    template_code = self.env['account.chart.template']._guess_chart_template(company.country_id)
                 if template_code != 'generic_coa':
                     @self.env.cr.precommit.add
                     def try_loading(template_code=template_code, company=company):


### PR DESCRIPTION
Issue when adding a branch for a company with a parent using "German chart of accounts SKR04" localization.

Steps to reproduce:
- Install the l10n_de and account modules.
- Create a company with the localization “German chart of accounts SKR04.”
- For this company, attempt to create a branch.

Explanation of the issue:
The _guess_chart_template function incorrectly returns the SKR03 chart template instead of SKR04 for the new branch. As a result, the _pre_reload_data function, which creates the missing xmlids, is not triggered.

Solution:
To resolve this issue, I prioritize using the chart template from the parent company if available, instead of relying on the _guess_chart_template function.

opw-4141944