### PR TITLE
[FIX] sale_project: take AAs of generated project instead of project template in SOL's distribution

### DIFF
--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -132,7 +132,7 @@ class SaleOrderLine(models.Model):
         for line in self:
             if line.display_type or line.analytic_distribution or not line.product_id:
                 continue
-            project = line.product_id.project_id or line.product_id.project_template_id or line.order_id.project_id
+            project = line.product_id.project_id or line.order_id.project_id
             distribution = project._get_analytic_distribution()
             if distribution:
                 line.analytic_distribution = distribution

--- a/addons/sale_project/tests/test_analytic_distribution.py
+++ b/addons/sale_project/tests/test_analytic_distribution.py
@@ -38,3 +38,34 @@ class TestAnalyticDistribution(HttpCase, TestSaleProjectCommon):
             {f'{account_a.id},{account_b.id}': 100},
             "The sale order line's analytic distribution should have one line containing all the accounts of the project's plans"
         )
+
+    def test_sol_analytic_distribution_project_template_service(self):
+        sale_order = self.env['sale.order'].create({'partner_id': self.partner.id})
+        sale_order_line = self.env['sale.order.line'].create({
+            'order_id': sale_order.id,
+            'product_id': self.product_delivery_manual5.id,
+        })
+        self.assertFalse(
+            sale_order_line.analytic_distribution,
+            "No default analytic distribution should be set on the SOL as no project is linked to the SO, and we do not "
+            "take the project template set on the product into account.",
+        )
+        sale_order.action_confirm()
+        self.assertEqual(
+            sale_order_line.analytic_distribution,
+            {str(sale_order.project_id.account_id.id): 100},
+            "The analytic distribution of the SOL should be set to the account of the generated project.",
+        )
+
+    def test_sol_analytic_distribution_task_in_project_service(self):
+        self.project_global.account_id = self.analytic_account_sale
+        sale_order = self.env['sale.order'].create({'partner_id': self.partner.id})
+        sale_order_line = self.env['sale.order.line'].create({
+            'order_id': sale_order.id,
+            'product_id': self.product_delivery_manual2.id,
+        })
+        self.assertEqual(
+            sale_order_line.analytic_distribution,
+            {str(self.project_global.account_id.id): 100},
+            "The analytic distribution of the SOL should be set to the account of the project set on the product.",
+        )


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. Create a service that creates a project (or project & task) based on a project template
2. Create an SO with this services and confirm it
3. The SOL and timesheets have the analytic accounts of the project template (but not the analytic accounts of the generated project)

Fix:
-------------------
When a product that creates a project (or project & task) based on a project template is added to the SO, do not set the SOL's analytic distribution by default to the project template's analytic accounts (leave it blank). When confirming the SO, the project field of the SO will automatically be set to the generated project, which will propagate its analytic accounts to the SOL's distribution.

task-4179516

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
