### PR TITLE
[FIX] pos_loyalty: enable searching for more customers

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/components/partner_list_screen/partner_list_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/partner_list_screen/partner_list_screen.js
@@ -12,7 +12,7 @@ patch(PartnerList.prototype, {
 
     async searchPartner() {
         const res = await super.searchPartner();
-        const coupons = this.pos.fetchCoupons([
+        const coupons = await this.pos.fetchCoupons([
             ["partner_id", "in", res.map((partner) => partner.id)],
         ]);
         this.pos.computePartnerCouponIds(coupons);


### PR DESCRIPTION
A traceback appears when searching for more customers inside the shop.

Steps to reproduce:
-------------------
* Make sure you have `pos_layalty` installed
* Open shop session
* Select **Customers**
* Enter anything in the search bar
* Scroll down and select **Search more**
> Observation: Traceback -> TypeError: cards is not iterable

Why the fix:
------------
https://github.com/odoo/odoo/blob/d9d0b1c66dd608e475bdb7d29c162b6251b0f329/addons/pos_loyalty/static/src/overrides/components/partner_list_screen/partner_list_screen.js#L15-L18

`coupons` is a Promise as per:
https://github.com/odoo/odoo/blob/d9d0b1c66dd608e475bdb7d29c162b6251b0f329/addons/pos_loyalty/static/src/overrides/models/pos_store.js#L630

ad thus we cannot access any value from it:
https://github.com/odoo/odoo/blob/d9d0b1c66dd608e475bdb7d29c162b6251b0f329/addons/pos_loyalty/static/src/overrides/models/pos_store.js#L574

opw-4175319
