### PR TITLE
[FIX] website: avoid page template to crash at preview removed

### DIFF
--- a/addons/website/static/src/components/dialog/add_page_dialog.js
+++ b/addons/website/static/src/components/dialog/add_page_dialog.js
@@ -195,6 +195,10 @@ export class AddPageTemplatePreview extends Component {
             for (const imgEl of lazyLoadedImgEls) {
                 imgEl.setAttribute("loading", "lazy");
             }
+            if (!this.previewRef.el) {
+                // Stop the process when preview is removed
+                return;
+            }
             // Wait for fonts.
             await iframeEl.contentDocument.fonts.ready;
             holderEl.classList.remove("o_loading");


### PR DESCRIPTION
[FIX] website: avoid page template to crash at preview removed

Steps to reproduce:
- On the website, click on "New" then "Page" to create a new page.
- On the blank page, click on "Use this template".
- Insert a file name (e.g. `rte_translator.xml`) and click on 'Create'.

-> If the last operation was fast enough a traceback of type `TypeError:
Cannot read properties of null (reading 'fonts')` can occur.
Note that to be able to reproduce the problem, a delay may have to be
added in the `onceAllImagesLoaded` method and the operations of file
name insertion and page creation have to be quite quick (you can for
example use the `rte_translator` test tour).

Since [this commit], it is possible to create new pages from templates.
The problem here is that the template preview is removed before the
`onMounted()` operation of the `AddPageTemplatePreview` component
finished. Due to it, the content document of the preview iframe is not
set and trying to search for its `fonts` leads to an error. This commit
fixes this issue by ensuring that the component has not been destroyed
before continuing its `onMounted()`  process.

[this commit]: https://github.com/odoo/odoo/commit/e0796020ee0c3188e1e9d9fa077de73a2211c6f7
