### PR TITLE
[FIX] mail: prevent the error when the field name is not found in the model

### DIFF
--- a/addons/mail/models/mail_tracking_value.py
+++ b/addons/mail/models/mail_tracking_value.py
@@ -46,7 +46,7 @@ class MailTracking(models.Model):
             if not tracking.field_id:
                 return env.is_system()
             model_field = env[tracking.field_id.model]._fields.get(tracking.field_id.name)
-            return model_field.is_accessible(env)
+            return model_field.is_accessible(env) if model_field else False
 
         return self.filtered(has_field_access)
 


### PR DESCRIPTION
This error occurs when we modify the ``Level Weight`` in ``Partner Assignment`` within Contacts, then uninstall the ``Website`` module, and subsequently attempt to access the modified contact again.

Steps to reproduce:
- Install the ``website_crm_partner_assign`` module
- Change the ``Level Weight`` in ``Partner Assignment`` in Contacts
- Now uninstall the ``Website`` module
- Now open the changed contact again

Traceback: 
``AttributeError: 'NoneType' object has no attribute 'is_accessible'``

The error in [1] occurred because the field name from ``tracking.field_id.name`` was not found in ``tracking.field_id.model``.

[1]- https://github.com/odoo/odoo/blob/d9d0b1c66dd608e475bdb7d29c162b6251b0f329/addons/mail/models/mail_tracking_value.py#L48-L49

sentry-5664351482

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
