### PR TITLE
[FIX] web, *: remove fa icons in Install App button

### DIFF
--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -360,7 +360,7 @@
 
     <menuitem
         id="menu_event_registration_desk"
-        name="Kiosk Mode"
+        name="Registration Desk"
         sequence="30"
         action="event_action_install_kiosk_pwa"
         parent="event.event_main_menu"

--- a/addons/web/static/src/webclient/actions/action_install_kiosk_pwa.xml
+++ b/addons/web/static/src/webclient/actions/action_install_kiosk_pwa.xml
@@ -1,13 +1,13 @@
 <templates>
 
     <t t-name="web.ActionInstallKioskPWA">
-        <div class="my-3 px-3 py-2">
+        <div class="text-center my-3">
             <div class="fs-2 mb-2">From your Kiosk, open this URL:</div>
             <i class="fa fa-share-square-o me-1 mb-3"/><a t-att-href="url" target="_blank" t-esc="url"></a>
         </div>
         <footer class="border-top d-flex p-3 justify-content-center justify-content-md-end flex-wrap gap-1 w-100">
             <button class="btn btn-secondary" special="cancel" t-on-click="() => this.dialog.closeAll()">Close</button>
-            <a class="btn btn-primary" t-att-href="installURL" target="_blank"><i class="fa fa-download me-1"/>Install App</a>
+            <a class="btn btn-primary" t-att-href="installURL" target="_blank">Install App</a>
         </footer>
     </t>
 

--- a/addons/web/static/src/webclient/user_menu/user_menu_items.js
+++ b/addons/web/static/src/webclient/user_menu/user_menu_items.js
@@ -105,7 +105,7 @@ export function odooAccountItem(env) {
 }
 
 function installPWAItem(env) {
-    let description = _t("Install app");
+    let description = _t("Install App");
     let callback = () => env.services.pwa.show();
     let show = () => env.services.pwa.isAvailable;
     const currentApp = env.services.menu.getCurrentApp();


### PR DESCRIPTION
*: events

To stay consistent with the lack of icons in other areas, we remove the icon that was added in this button.

We also rename the "Kiosk Mode" button to "Registration Desk" in events, as it was named before.

task-4160938