### PR TITLE
[FIX] point_of_sale: prevent duplicate orders with auto printing

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -341,6 +341,7 @@ export class PaymentScreen extends Component {
                 );
 
                 if (printResult && this.pos.config.iface_print_skip_screen) {
+                    this.currentOrder.set_screen_data({ name: "ReceiptScreen" });
                     this.pos.add_new_order();
                     nextScreen = "ProductScreen";
                 }


### PR DESCRIPTION
Before this commit, enabling automatic printing allowed validated orders to remain in the order list, leading to potential duplicate validations when loading it. This commit addresses the issue by setting the screen data of validated orders to ReceiptScreen, preventing duplicate order validations.

opw-4149302

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
