### PR TITLE
[IMP] account: improve exception auditing

### DIFF
--- a/addons/account/models/account_lock_exception.py
+++ b/addons/account/models/account_lock_exception.py
@@ -54,11 +54,11 @@ class AccountLockException(models.Model):
         help="The date the Tax Lock Date is set to by this exception. If no date is set the lock date is not changed.",
     )
     sale_lock_date = fields.Date(
-        string='Lock Sales',
+        string='Sales Lock Date',
         help="The date the Sale Lock Date is set to by this exception. If no date is set the lock date is not changed.",
     )
     purchase_lock_date = fields.Date(
-        string='Lock Purchases',
+        string='Purchase Lock Date',
         help="The date the Purchase Lock Date is set to by this exception. If no date is set the lock date is not changed.",
     )
 

--- a/addons/account/views/account_lock_exception_views.xml
+++ b/addons/account/views/account_lock_exception_views.xml
@@ -42,10 +42,38 @@
                                     <div colspan="2" class="o_wrap_label">
                                         <span class="o_form_label">Changed Lock Dates:</span>
                                     </div>
-                                    <field name="sale_lock_date" readonly="True" invisible="not sale_lock_date"/>
-                                    <field name="purchase_lock_date" readonly="True" invisible="not purchase_lock_date"/>
-                                    <field name="tax_lock_date" readonly="True" invisible="not tax_lock_date"/>
-                                    <field name="fiscalyear_lock_date" readonly="True" invisible="not fiscalyear_lock_date"/>
+
+                                    <label for="sale_lock_date" invisible="not sale_lock_date"/>
+                                    <div invisible="not sale_lock_date">
+                                        <field name="sale_lock_date" class="oe_inline" readonly="True"/>
+                                        <i class="text-muted">
+                                        (from <field name="company_sale_lock_date" class="oe_inline" readonly="True" invisible="not sale_lock_date"/>)
+                                        </i>
+                                    </div>
+
+                                    <label for="purchase_lock_date" invisible="not purchase_lock_date"/>
+                                    <div invisible="not purchase_lock_date">
+                                        <field name="purchase_lock_date" class="oe_inline" readonly="True" invisible="not purchase_lock_date"/>
+                                        <i class="text-muted">
+                                        (from <field name="company_purchase_lock_date" class="oe_inline" readonly="True" invisible="not purchase_lock_date"/>)
+                                        </i>
+                                    </div>
+
+                                    <label for="tax_lock_date" invisible="not tax_lock_date"/>
+                                    <div invisible="not tax_lock_date">
+                                        <field name="tax_lock_date" class="oe_inline" readonly="True" invisible="not tax_lock_date"/>
+                                        <i class="text-muted">
+                                        (from <field name="company_tax_lock_date" class="oe_inline" readonly="True" invisible="not tax_lock_date"/>)
+                                        </i>
+                                    </div>
+
+                                    <label for="fiscalyear_lock_date" invisible="not fiscalyear_lock_date"/>
+                                    <div invisible="not fiscalyear_lock_date">
+                                        <field name="fiscalyear_lock_date" class="oe_inline" readonly="True" invisible="not fiscalyear_lock_date"/>
+                                        <i class="text-muted">
+                                        (from <field name="company_fiscalyear_lock_date" class="oe_inline" readonly="True" invisible="not fiscalyear_lock_date"/>)
+                                        </i>
+                                    </div>
                                 </group>
                             </group>
                         </div>


### PR DESCRIPTION
(additional misc fix: fix field names)

This commit improves the exception auditing in 2 ways
- The form view now displays the original date too (and not just the
  new / exceptional date)
- The button to show a restricted audit trail regarding changes during the
  exception was improved. See below for details

The exception form view provides a button to open the audit trail
restricted to messages that were created during the time the exception
was valid.
But this can also contain (many) changes that did not need an exception at all.

After this commit the audit trail is restricted further to accounting dates
in the "excepted period". The "excepted period" starts at the minimal
excepted date and ends at the the maximal original lock date.
E.g. when the Sale Lock Date was changed from 2024-02-01 to 2024-01-01
and the Purchase Lock Date was changed from 2024-03-01 to 2024-02-01
we regard the time period 2024-01-01 to 2024-03-01.

Messages are shown when
- the accounting date of the record is currently inside the "excepted period"
- the messages is regarding an accounting date change from or into the
  "excepted period"

This should find all moves that were changed during the exception
and only show moves for which we needed an exception.

related: task-3891414 (lock dates rework)