### PR TITLE
[FIX] web_editor: correct the selection to draw a peer selection

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -1866,8 +1866,17 @@ export class OdooEditor extends EventTarget {
             focusOffset = 0;
         }
 
-        [anchorNode, anchorOffset] = getDeepestPosition(anchorNode, anchorOffset);
-        [focusNode, focusOffset] = getDeepestPosition(focusNode, focusOffset);
+        if (anchorNode.isConnected && focusNode.isConnected) {
+            [anchorNode, anchorOffset] = getDeepestPosition(anchorNode, anchorOffset);
+            [focusNode, focusOffset] = getDeepestPosition(focusNode, focusOffset);
+        } else {
+            // TODO: This is a stable fix for drawing an incorrect selection in
+            // a niche case. The root cause will be fixed in master.
+            anchorNode = this.editable.children[0];
+            focusNode = this.editable.children[0];
+            anchorOffset = 0;
+            focusOffset = 0;
+        }
 
         const direction = getCursorDirection(
             anchorNode,


### PR DESCRIPTION
Prior to this commit, attempting to draw a peer's selection within an element that was not present in the DOM would result in a crash.

Under certain race conditions, it is possible for an element to exist outside of the DOM. To enhance resilience and prevent crashes, this commit adjusts the selection as necessary to ensure it can be drawn correctly.

task-4143889
