### PR TITLE
[FIX] mail: broken template

### DIFF
--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -1430,10 +1430,13 @@ class MailComposer(models.TransientModel):
             if self.composition_mode == 'comment' and not self.composition_batch:
                 res_ids = self._evaluate_res_ids()
                 rendering_res_ids = res_ids or [0]
-                self[composer_fname] = self.template_id._generate_template(
-                    rendering_res_ids,
-                    {template_fname},
-                )[rendering_res_ids[0]][template_fname]
+                try:
+                    self[composer_fname] = self.template_id._generate_template(
+                        rendering_res_ids,
+                        {template_fname},
+                    )[rendering_res_ids[0]][template_fname]
+                except UserError:
+                    self[composer_fname] = None
             else:
                 self[composer_fname] = self.template_id[template_fname]
         return self[composer_fname]

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -1430,13 +1430,10 @@ class MailComposer(models.TransientModel):
             if self.composition_mode == 'comment' and not self.composition_batch:
                 res_ids = self._evaluate_res_ids()
                 rendering_res_ids = res_ids or [0]
-                try:
-                    self[composer_fname] = self.template_id._generate_template(
-                        rendering_res_ids,
-                        {template_fname},
-                    )[rendering_res_ids[0]][template_fname]
-                except UserError:
-                    self[composer_fname] = None
+                self[composer_fname] = self.template_id._generate_template(
+                    rendering_res_ids,
+                    {template_fname},
+                )[rendering_res_ids[0]][template_fname]
             else:
                 self[composer_fname] = self.template_id[template_fname]
         return self[composer_fname]


### PR DESCRIPTION
If sale order confirmation template was broken in some way eg. field no longer exists in the model. When mail confirmation was send it caused an error and additionaly, Sale Order was not confirmed even when transaction was done, which could result in customers paying multiple times for the same Sale Order.

Now, in case of faulty template, email still will be send, but without the template body.

opw-3957553

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
