### PR TITLE
[FIX] web: lazy controller for server actions

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -214,31 +214,13 @@ export function makeActionManager(env, router = _router) {
         if (state.action && state.resId && controllers.at(-1)?.action?.id === state.action) {
             // When loading the state on a form view, we will need to load the action for it,
             // and this will give us the display name of the corresponding multi-record view in
-            // the breadcrumb. By calling _loadAction preemptively, we can in some cases avoid
+            // the breadcrumb.
+            // By marking the last controller as a lazyController, we can in some cases avoid
             // _loadBreadcrumbs from doing any network request as the breadcrumbs may only contain
             // the form view and the multi-record view.
-            const { actionRequest, options } = _getActionParams();
-            const [bcControllers, action] = await Promise.all([
-                _loadBreadcrumbs(controllers.slice(0, -1)),
-                _loadAction(actionRequest, options.additionalContext).then((action) =>
-                    _preprocessAction(action, options.additionalContext)
-                ),
-            ]);
-
-            // If the current action is a Window action and has a multi-record view, we add the last
-            // controller to the breadcrumb controllers.
-            if (
-                action.type === "ir.actions.act_window" &&
-                action.views.some((view) => view[1] !== "form" && view[1] !== "search")
-            ) {
-                controllers.at(-1).displayName = action.display_name || action.name || "";
-                controllers.at(-1).action = action;
-                return [...bcControllers, controllers.at(-1)];
-            }
-
-            // If the current action doesn't have a multi-record view, or is not a Window action,
-            // we don't need to add the last controller to the breadcrumb controllers
-            return bcControllers;
+            const bcControllers = await _loadBreadcrumbs(controllers.slice(0, -1));
+            controllers.at(-1).lazy = true;
+            return [...bcControllers, controllers.at(-1)];
         }
         return _loadBreadcrumbs(controllers);
     }
@@ -1109,6 +1091,25 @@ export function makeActionManager(env, router = _router) {
             ..._getViewInfo(view, action, views, options.props),
         };
         action.controllers[view.type] = controller;
+
+        const newStackLastController = options.newStack?.at(-1);
+        if (newStackLastController?.lazy) {
+            const multiView = action.views.find(
+                (view) => view[1] !== "form" && view[1] !== "search"
+            );
+            if (multiView) {
+                // If the current action has a multi-record view, we add the last
+                // controller to the breadcrumb controllers.
+                delete newStackLastController.lazy;
+                newStackLastController.displayName = action.display_name || action.name || "";
+                newStackLastController.action = action;
+                newStackLastController.props.type = multiView[1];
+            } else {
+                // If the current action doesn't have a multi-record view,
+                // we don't need to add the last controller to the breadcrumb controllers
+                options.newStack.splice(-1);
+            }
+        }
 
         return _updateUI(controller, options);
     }


### PR DESCRIPTION
Before this commit when opening a CRM Lead from the URL, the breadcrumb
doesn't show the multi-record controller. This occurs, because the CRM
action is a server action that returns a window action, and the lazy
controller is never created.

Now, the lazy controller is correctly created also for the server
actions.