### PR TITLE
[FIX] sale_stock: check warehouse handle multi company deliveries

### DIFF
--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -103,8 +103,17 @@ class SaleOrder(models.Model):
     def _check_warehouse(self):
         """ Ensure that the warehouse is set in case of storable products """
         orders_without_wh = self.filtered(lambda order: order.state not in ('draft', 'cancel') and not order.warehouse_id)
-        if any(l for l in orders_without_wh.order_line if l.product_id.type == 'consu'):
-            raise UserError(_('You must define a warehouse on a sale order with goods.'))
+        other_company = set()
+        for order_line in orders_without_wh.order_line:
+            if order_line.product_id.type != 'consu':
+                continue
+            if order_line.route_id.company_id and order_line.route_id.company_id != order_line.company_id:
+                other_company.add(order_line.route_id.company_id.id)
+                continue
+            self.env['stock.warehouse'].with_company(order_line.order_id.company_id)._warehouse_redirect_warning()
+        other_company_warehouses = self.env['stock.warehouse'].search([('company_id', 'in', list(other_company))])
+        if any(c not in other_company_warehouses.company_id.ids for c in other_company):
+            raise UserError(_("You must have a warehouse for line using a delivery in different company."))
 
     def write(self, values):
         if values.get('order_line') and self.state == 'sale':

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -166,7 +166,7 @@ class Warehouse(models.Model):
     @api.model
     def _warehouse_redirect_warning(self):
         warehouse_action = self.env.ref('stock.action_warehouse_form')
-        msg = _('Please create a warehouse for this company.')
+        msg = _('Please create a warehouse for company %s.', self.env.company.display_name)
         if not self.env.user.has_group('stock.group_stock_manager'):
             raise UserError('Please contact your administrator to configure your warehouse.')
         raise RedirectWarning(msg, warehouse_action.id, _('Go to Warehouses'))


### PR DESCRIPTION
Use case to reproduce:
- Company A -> Has a warehouse
- Branch A -> No warehouse.
- Set the delivery company A route as sale order line selectable
- Create a SO in Branch A
- Create a line and set the route "delivery Company A"
- Confirm

Current Behavior:
Error saying there is no warehouse in the current company.

Expected Behavior:
Delivery in Company A

It happens because doesn't check if the delivery is in the current company. This commit complete the check to do a proper check if it uses route from other companies

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
