### PR TITLE
[IMP] base_import: add import local media using web file input

### DIFF
--- a/addons/base_import/static/src/binary_file_manager.js
+++ b/addons/base_import/static/src/binary_file_manager.js
@@ -1,0 +1,91 @@
+import { Mutex } from "@web/core/utils/concurrency";
+import { checkFileSize } from "@web/core/utils/files";
+
+export class BinaryFileManager {
+    constructor(resModel, fields, parameters, context, orm, notificationService) {
+        this.resModel = resModel;
+        this.fields = [".id", ...fields];
+        this.parameters = parameters;
+
+        this.context = context;
+        this.orm = orm;
+        this.notificationService = notificationService;
+
+        this.maxBatchSize = this.parameters.maxBatchSize * 0.95; // 0.95 for not calculated payload overhead
+        this.delayAfterEachBatch = this.parameters.delayAfterEachBatch * 1000;
+
+        this.dataToSend = {};
+
+        this.mutex = new Mutex();
+    }
+
+    async addFile(id, field, file) {
+        let data = await this._readFile(file);
+        if (typeof data === "string" && data.startsWith("data:")) {
+            // Remove data:image/*;base64,
+            data = data.split(",")[1];
+        }
+        const dataSize = data.length;
+        if (!checkFileSize(dataSize, this.notificationService)) {
+            return;
+        }
+
+        if (this.getCurrentSize() + dataSize >= this.maxBatchSize) {
+            await this.mutex.exec(async () => await this._send());
+        }
+        if (!(id in this.dataToSend)) {
+            this.dataToSend[id] = Array(this.fields.length);
+            this.dataToSend[id][0] = id;
+        }
+        const indexOfField = this.fields.indexOf(field, 1);
+        this.dataToSend[id][indexOfField] = data;
+    }
+
+    async sendLastPayload() {
+        if (Object.keys(this.dataToSend).length > 0) {
+            await this.mutex.exec(async () => await this._send());
+        }
+    }
+
+    async _send() {
+        await new Promise((resolve) => {
+            setTimeout(resolve, this.delayAfterEachBatch);
+        });
+        const data = Object.values(this.dataToSend);
+        this.dataToSend = {};
+        const context = {
+            ...this.context,
+            import_file: true,
+            tracking_disable: this.parameters.tracking_disable,
+            name_create_enabled_fields: this.parameters.name_create_enabled_fields || {},
+            import_set_empty_fields: this.parameters.import_set_empty_fields || [],
+            import_skip_records: this.parameters.import_skip_records || [],
+        };
+        let res;
+        try {
+            res = await this.orm.call(this.resModel, "load", [], {
+                fields: this.fields,
+                data,
+                context,
+            });
+        } catch (error) {
+            console.error(error);
+            return { error };
+        }
+        return res;
+    }
+
+    _readFile(file) {
+        return new Promise((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onerror = (event) => reject(event);
+            reader.onabort = (event) => reject(event);
+            reader.onload = (event) => resolve(event.target.result);
+            reader.readAsDataURL(file);
+        });
+    }
+
+    getCurrentSize() {
+        return JSON.stringify(this.dataToSend).length;
+    }
+}

--- a/addons/base_import/static/src/import_action/import_action.js
+++ b/addons/base_import/static/src/import_action/import_action.js
@@ -239,6 +239,10 @@ export class ImportAction extends Component {
     isFieldSet(column) {
         return column.fieldInfo != null;
     }
+
+    get hasBinaryFields() {
+        return this.model.columns.some((column) => column.fieldInfo?.type === "binary");
+    }
 }
 
 registry.category("actions").add("import", ImportAction);

--- a/addons/base_import/static/src/import_action/import_action.xml
+++ b/addons/base_import/static/src/import_action/import_action.xml
@@ -16,8 +16,8 @@
                         resModel="this.resModel"
                         route="this.uploadFilesRoute"
                     >
-                        <button t-if="isPreviewing" type="button" class="btn btn-secondary">Load File</button>
-                        <button t-else="" type="button" class="btn btn-primary o_import_file">Upload File</button>
+                        <button t-if="isPreviewing" type="button" class="btn btn-secondary">Load Data File</button>
+                        <button t-else="" type="button" class="btn btn-primary o_import_file">Upload Data File</button>
                     </FileInput>
                     <button t-on-click="() => this.exit()" type="button" class="btn btn-secondary">Cancel</button>
                 </t>
@@ -30,6 +30,9 @@
                         isBatched="isBatched"
                         onOptionChanged.bind="onOptionChanged"
                         onReload.bind="reload"
+                        hasBinaryFields="hasBinaryFields"
+                        binaryFilesParams="model.binaryFilesParams"
+                        onBinaryFilesParamsChanged.bind="(name, value) => model.onBinaryFilesParamsChanged(name, value)"
                     />
                     <ImportDataContent
                         columns="model.columns"

--- a/addons/base_import/static/src/import_data_sidepanel/import_data_sidepanel.js
+++ b/addons/base_import/static/src/import_data_sidepanel/import_data_sidepanel.js
@@ -2,6 +2,7 @@
 
 import { Component } from "@odoo/owl";
 import { CheckBox } from "@web/core/checkbox/checkbox";
+import { _t } from "@web/core/l10n/translation";
 import { DocumentationLink } from "@web/views/widgets/documentation_link/documentation_link";
 
 export class ImportDataSidepanel extends Component {
@@ -15,6 +16,9 @@ export class ImportDataSidepanel extends Component {
         isBatched: { type: Boolean, optional: true },
         onOptionChanged: { type: Function },
         onReload: { type: Function },
+        hasBinaryFields: { type: Boolean },
+        binaryFilesParams: { type: Object },
+        onBinaryFilesParamsChanged: { type: Function },
     };
 
     get fileName() {
@@ -39,5 +43,14 @@ export class ImportDataSidepanel extends Component {
     // Start at row 1 = skip 0 lines
     onLimitChange(ev) {
         this.props.onOptionChanged("skip", ev.target.value ? ev.target.value - 1 : 0);
+    }
+
+    get binaryFilesLabel() {
+        const files = this.props.binaryFilesParams.binaryFiles.value;
+        const number = Object.keys(files).length;
+        if (number > 0) {
+            return _t("%(number)s file(s) selected", { number });
+        }
+        return _t("No file selected");
     }
 }

--- a/addons/base_import/static/src/import_data_sidepanel/import_data_sidepanel.scss
+++ b/addons/base_import/static/src/import_data_sidepanel/import_data_sidepanel.scss
@@ -1,5 +1,23 @@
 .o_import_data_sidepanel {
     min-width: 15rem;
-    width: 15rem;
+    max-width: 350px;
     overflow-y: auto;
+
+    .o_import_grid {
+        display: grid;
+        grid-template-columns: repeat(3, auto);
+
+        .o_grid_span_2 {
+            grid-column: span 2;
+        }
+    }
+
+    .o_import_file input {
+        display: inline-block;
+        width: 6ch;
+
+        &:not(:valid) {
+            background-color: $danger-bg-subtle;
+        }
+    }
 }

--- a/addons/base_import/static/src/import_data_sidepanel/import_data_sidepanel.xml
+++ b/addons/base_import/static/src/import_data_sidepanel/import_data_sidepanel.xml
@@ -3,7 +3,7 @@
     <t t-name="ImportDataSidepanel">
         <div class="o_import_data_sidepanel p-3 bg-view">
             <div class="pb-4">
-                <h4>Imported file</h4>
+                <h4>Data to import</h4>
                 <div class="mb-2 d-flex align-items-center">
                     <i class="fa fa-file white me-2"></i>
                     <div class="fst-italic truncate"><t t-esc="fileName"/></div>
@@ -76,14 +76,57 @@
                     </div>
                 </div>
             </div>
-            <div class="pt-3 pb-4 border-top">
-                <h4>Help</h4>
-                <t t-foreach="props.importTemplates" t-as="template" t-key="template">
-                    <a class="d-block my-2" t-att-href="template.template" aria-label="Download" data-tooltip="Download">
-                        <i class="fa fa-download"/> <span><t t-esc="template.label"/></span>
-                    </a>
-                </t>
-                <DocumentationLink path="'/applications/general/export_import_data.html'" icon="'fa-external-link'" label.translate="Go to Import FAQ"/>
+            <div t-if="props.hasBinaryFields" class="pt-3 pb-4 border-top o_import_file">
+                <h4>Files to import</h4>
+                <div class="o_import_grid gap-1">
+                    <!-- First row-->
+                    <div class="o_import_grid_col">
+                        <label>
+                            <span class="btn btn-sm btn-primary">Upload your files</span>
+                            <input type="file" multiple="multiple" hidden="hidden"
+                                   t-on-change="(event) => this.props.onBinaryFilesParamsChanged('binaryFiles', event.target.files)"/>
+                        </label>
+                    </div>
+                    <div class="o_import_grid_col o_grid_span_2">
+                        <t t-esc="binaryFilesLabel"/>
+                    </div>
+
+                    <!-- Second row-->
+                    <t t-if="env.debug">
+                        <div class="o_import_grid_col">
+                            <label for="o_input_maxSizePerBatch">Max size per batch</label>
+                            <sup t-if="props.binaryFilesParams.maxSizePerBatch.help" class="text-info p-1 cursor-default" t-att-data-tooltip="props.binaryFilesParams.maxSizePerBatch.help" t-esc="'?'"/>
+                        </div>
+                        <div class="o_import_grid_col">
+                                <input type="number"
+                                       id="o_input_maxSizePerBatch"
+                                       t-att-value="props.binaryFilesParams.maxSizePerBatch.value"
+                                       t-att-max="props.binaryFilesParams.maxSizePerBatch.max"
+                                       t-att-min="props.binaryFilesParams.maxSizePerBatch.min"
+                                       t-on-change="(event) => this.props.onBinaryFilesParamsChanged('maxSizePerBatch', event.target.value)"/>
+                        </div>
+                        <div class="o_import_grid_col">
+                            <label for="o_input_maxSizePerBatch">Mb</label>
+                        </div>
+
+                        <!-- Third row-->
+                        <div class="o_import_grid_col">
+                            <label for="o_input_delayAfterEachBatch">Delay after each batch</label>
+                            <sup t-if="props.binaryFilesParams.delayAfterEachBatch.help" class="text-info p-1 cursor-default" t-att-data-tooltip="props.binaryFilesParams.delayAfterEachBatch.help" t-esc="'?'"/>
+                        </div>
+                        <div class="o_import_grid_col">
+                                <input type="number"
+                                       id="o_input_delayAfterEachBatch"
+                                       t-att-value="props.binaryFilesParams.delayAfterEachBatch.value"
+                                       t-att-min="props.binaryFilesParams.delayAfterEachBatch.min"
+                                       t-on-change="(event) => this.props.onBinaryFilesParamsChanged('delayAfterEachBatch', event.target.value)"/>
+                        </div>
+                        <div class="o_import_grid_col">
+                            <label for="o_input_delayAfterEachBatch">seconds</label>
+                        </div>
+                    </t>
+                </div>
+
             </div>
             <div t-if="env.debug" class="o_import_debug_options pt-3 pb-4 border-top">
                 <h4>Advanced</h4>
@@ -95,6 +138,15 @@
                 <CheckBox value="props.options.advanced" onChange.bind="(isChecked) => this.props.onOptionChanged('advanced', isChecked)">
                     Allow matching with subfields
                 </CheckBox>
+            </div>
+            <div class="pt-3 pb-4 border-top">
+                <h4>Help</h4>
+                <t t-foreach="props.importTemplates" t-as="template" t-key="template">
+                    <a class="d-block my-2" t-att-href="template.template" aria-label="Download" data-tooltip="Download">
+                        <i class="fa fa-download"/> <span><t t-esc="template.label"/></span>
+                    </a>
+                </t>
+                <DocumentationLink path="'/applications/general/export_import_data.html'" icon="'fa-external-link'" label.translate="Go to Import FAQ"/>
             </div>
         </div>
     </t>

--- a/addons/web/static/src/core/utils/files.js
+++ b/addons/web/static/src/core/utils/files.js
@@ -3,7 +3,7 @@ import { useService } from "@web/core/utils/hooks";
 import { session } from "@web/session";
 import { _t } from "@web/core/l10n/translation";
 
-const DEFAULT_MAX_FILE_SIZE = 128 * 1024 * 1024;
+export const DEFAULT_MAX_FILE_SIZE = 128 * 1024 * 1024;
 
 /**
  * @param {Services["notification"]} notificationService


### PR DESCRIPTION
This commit aims to add the support to upload medias (images in most case) when we import data from CSV/ODF/XLSX. This would help user on the SAAS as they have no access to the odoo shell or the database to upload medias in batch.

This commit, use the HTML input[1] with type="file" and multiple so the user can select the files to upload.

First the method is like before it create/update the record in python. Then in HTML/JavaScript we check if we need to upload files selected by the users in the input.

Technical note:
To upload a lot a medias in batch we use also the load method on the model but first in JavaScript we convert all files to base64 on the fly.

[1]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file

task-4077715

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
