### PR TITLE
[FIX] web_editor: prevent URL conversion when editing tabs

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/sanitize.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/sanitize.js
@@ -97,6 +97,10 @@ export function areSimilarElements(node, node2) {
  * @returns {String|null}
  */
 function deduceURLfromLabel(link) {
+    // Skip modifying the href for Bootstrap tabs.
+    if (link && link.getAttribute("role") === "tab") {
+        return;
+    }
     const label = link.innerText.trim().replace(ZERO_WIDTH_CHARS_REGEX, '');
     // Check first for e-mail.
     let match = label.match(EMAIL_REGEX);


### PR DESCRIPTION
Steps to reproduce the issue :
- Open web editor
- Drag and drop the Tab building block
- Rename the first tab "email@gmail.com" or "example.com"
- Switch to the second tab and switch back to the first one.

Issue: The content of the first tab don't appears anymore when switching
tabs. In 17.2 and above the same problem appears with the tel protocol,
so '123' is converted to tel://123.

Cause: The href attribute of the tab link is incorrectly converted to a
mail protocol (mailto:email@gmail.com), an http protocol
(https://example.com/) or since 17.2, a tel protocol due to the
deduceURLfromLabel() function introduced in [1].

This commit addresses the issue by disabling the conversion of URL,
mail, and tel protocols when an anchor tag includes a role="tab"
attribute, ensuring that the tab functionality remains intact. Only
anchor links (href="#...") are allowed for tabs.

[1]: https://github.com/odoo/odoo/commit/a903a3114b335fcd9c69b1c74a68838f2cef3e36

opw-4165676
