### PR TITLE
[IMP] website: add missing fallback images for industries

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -862,6 +862,12 @@ class Website(models.Model):
             fallback_create_missing_industry_image('s_quadrant_default_image_2', 'library_image_10')
             fallback_create_missing_industry_image('s_quadrant_default_image_3', 'library_image_13')
             fallback_create_missing_industry_image('s_quadrant_default_image_4', 'library_image_05')
+            fallback_create_missing_industry_image('s_sidegrid_default_image_1', 'library_image_03')
+            fallback_create_missing_industry_image('s_sidegrid_default_image_2', 'library_image_10')
+            fallback_create_missing_industry_image('s_sidegrid_default_image_3', 'library_image_13')
+            fallback_create_missing_industry_image('s_sidegrid_default_image_4', 'library_image_05')
+            fallback_create_missing_industry_image('s_cta_box_default_image', 'library_image_02')
+            fallback_create_missing_industry_image('s_image_punchy_default_image', 's_cover_default_image')
 
         except Exception:
             pass


### PR DESCRIPTION
This commit adds missing fallback images for new snippets within the industries.

As we introduce more and more snippets to the website builder, we need to ensure that the default images will fallback on an existing one if none is defined.

task-4180003
part of task-4177975

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
