### PR TITLE
[FIX] l10n_sa_edi: show clear error on zatca xml processing

### DIFF
--- a/addons/l10n_sa_edi/models/account_edi_format.py
+++ b/addons/l10n_sa_edi/models/account_edi_format.py
@@ -148,10 +148,7 @@ class AccountEdiFormat(models.Model):
         """
         xml_content, errors = self.env['account.edi.xml.ubl_21.zatca']._export_invoice(invoice)
         if errors:
-            return {
-                'error': _("Could not generate Invoice UBL content: %s") % ", \n".join(errors),
-                'blocking_level': 'error'
-            }
+            raise UserError(_("Could not generate Invoice UBL content: %s", ", \n".join(errors)))
         return self._l10n_sa_postprocess_zatca_template(xml_content)
 
     def _l10n_sa_submit_einvoice(self, invoice, signed_xml, PCSID_data):
@@ -223,7 +220,10 @@ class AccountEdiFormat(models.Model):
         self.ensure_one()
 
         # Prepare UBL invoice values and render XML file
-        unsigned_xml = xml_content or self._l10n_sa_generate_zatca_template(invoice)
+        try:
+            unsigned_xml = xml_content or self._l10n_sa_generate_zatca_template(invoice)
+        except UserError as e:
+            return ({'error': e.args[0], 'blocking_level': 'error'}, xml_content)
 
         # Load PCISD data and X509 certificate
         try:


### PR DESCRIPTION
Before this commit:
If the ZATCA xml template generator encounters an error, it returns the error message itself to the calling method that expects xml content. The xml processing then crashes with a traceback that doesn't indicate where the issue is.

After this commit:
The ZATCA xml template generator raises the error with a clear error message that allows the user to easily fix it themselves.

opw-4081849

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
