### PR TITLE
[FIX] stock: display report warning in red

### DIFF
--- a/addons/stock/static/src/scss/stock_forecasted.scss
+++ b/addons/stock/static/src/scss/stock_forecasted.scss
@@ -1,5 +1,5 @@
 .o_stock_forecasted_page {
-    .o_report_replenishment {
+    .table {
         .o_grid_warning {
             background-color: #f4cccc;
         }


### PR DESCRIPTION
### Steps to reproduce:

- Create a storable product with 0 unit in stock
- Create and confirm a Sale order for 1 unit fo that product
- Create and confirm a Purchase Order for 1 unit of that product and an expected date further than the delivery date.
- Click on the chart icon on the pol to be redirected to the forecast

### Expected behavior:

The line should be displayed in red since the PO is late just as in 16.0 as the cell has the "".o_grid_warning" class.

### Current behavior:

It is not.

### Cause of the issue:

The `o_report_replenishment` class does not exist in 17.0 and the `table` class is used instead the html of the report so that the css file is not defining the color of the `o_warning` class correctly anymore.

opw-4161304
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
