### PR TITLE
[FIX] pos_self_order: redirect to product page when draft order

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/landing_page/landing_page.js
+++ b/addons/pos_self_order/static/src/app/pages/landing_page/landing_page.js
@@ -81,7 +81,7 @@ export class LandingPage extends Component {
     }
 
     clickMyOrder() {
-        this.router.navigate(this.draftOrder.length > 0 ? "cart" : "orderHistory");
+        this.router.navigate(this.draftOrder.length > 0 ? "product_list" : "orderHistory");
     }
 
     clickCustomLink(link) {


### PR DESCRIPTION
On the self order, if you cancel a payment you're redirected to the landing page. But if you click on "My Order" you redirected to the cart and you are not able to add new products to your order because you can't acces the product page.

Steps to reproduce:
-------------------
* Install self_order and the demo online payment method
* Setup the self order to use the online payment method, and pay after each
* Open the mobile menu
* Make a new order, add some product go to pay but cancel payment
* You're taken back to the landing page
* Click on my order
> Observation: You're redirected to the cart page and cannot add any new
product to the order

Note:
---------------
Impossible to write a tour as when paying the tour setup is lost

opw-4069046
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
