### PR TITLE
[FIX] base: ir.ui.view: fix order inconsistency from name

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -158,7 +158,7 @@
         <record id="view_move_line_tree" model="ir.ui.view">
             <field name="name">account.move.line.list</field>
             <field name="model">account.move.line</field>
-            <field eval="100" name="priority"/>
+            <field eval="10" name="priority"/>
             <field name="arch" type="xml">
                 <list name="move_line_tree" string="Journal Items" create="false" edit="true" expand="context.get('expand', False)" multi_edit="1" sample="1">
                     <field name="move_id" column_invisible="True"/>

--- a/addons/product/views/product_template_views.xml
+++ b/addons/product/views/product_template_views.xml
@@ -3,6 +3,7 @@
     <record id="product_template_tree_view" model="ir.ui.view">
         <field name="name">product.template.product.list</field>
         <field name="model">product.template</field>
+        <field name="priority">10</field>
         <field name="arch" type="xml">
             <list string="Product" multi_edit="1" sample="1">
             <header>


### PR DESCRIPTION
The name is used to add information to the view such as a description, it is nonsense to use it to look up the default view. Inheritance is also done with priority and id.

The problem being revealed when renaming tree to list: https://github.com/odoo/odoo/pull/159909