### PR TITLE
[FIX] {project_}hr_expense: expense not linked to project using upload via top bar

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -577,6 +577,7 @@ class HrExpense(models.Model):
             'type': 'ir.actions.act_window',
             'views': [[False, view_type], [False, "form"]],
             'domain': [('id', 'in', expenses.ids)],
+            'context': self.env.context,
         }
 
     # ----------------------------------------

--- a/addons/hr_expense/static/src/mixins/document_upload.js
+++ b/addons/hr_expense/static/src/mixins/document_upload.js
@@ -137,7 +137,12 @@ export const ExpenseDocumentUpload = (T) => class ExpenseDocumentUpload extends 
             return;
         }
 
-        const action = await this.orm.call('hr.expense', 'create_expense_from_attachments', [attachmentIds, this.env.config.viewType]);
+        const action = await this.orm.call(
+            'hr.expense',
+            'create_expense_from_attachments',
+            [attachmentIds, this.env.config.viewType],
+            { context: this.props.context },
+        );
         await this.actionService.doAction(action);
     }
 };

--- a/addons/project_hr_expense/models/hr_expense.py
+++ b/addons/project_hr_expense/models/hr_expense.py
@@ -1,4 +1,4 @@
-from odoo import models
+from odoo import api, models
 
 
 class HrExpense(models.Model):
@@ -12,3 +12,13 @@ class HrExpense(models.Model):
             analytic_distribution = self.env['project.project'].browse(project_id)._get_analytic_distribution()
             for expense in self:
                 expense.analytic_distribution = expense.analytic_distribution or analytic_distribution
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        project_id = self.env.context.get('project_id')
+        if project_id:
+            analytic_distribution = self.env['project.project'].browse(project_id)._get_analytic_distribution()
+            if analytic_distribution:
+                for vals in vals_list:
+                    vals['analytic_distribution'] = analytic_distribution
+        return super().create(vals_list)

--- a/addons/project_hr_expense/tests/__init__.py
+++ b/addons/project_hr_expense/tests/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_analytics
 from . import test_project_profitability

--- a/addons/project_hr_expense/tests/test_analytics.py
+++ b/addons/project_hr_expense/tests/test_analytics.py
@@ -1,0 +1,45 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.hr_expense.tests.common import TestExpenseCommon
+
+
+class TestAnalytics(TestExpenseCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.project_plan, _other_plans = cls.env['account.analytic.plan']._get_all_plans()
+        cls.analytic_account1, cls.analytic_account2 = cls.env['account.analytic.account'].create([
+            {
+                'name': 'Account 1',
+                'plan_id': cls.project_plan.id,
+            },
+            {
+                'name': 'Account 2',
+                'plan_id': cls.project_plan.id,
+            },
+        ])
+        cls.project = cls.env['project.project'].create({
+            'name': 'Project',
+            'account_id': cls.analytic_account1.id,
+        })
+
+    def test_project_analytics_to_expense(self):
+        expense = self.env['hr.expense'].with_context(project_id=self.project.id).create({
+            'name': 'Expense',
+            'employee_id': self.expense_employee.id,
+            'product_id': self.product_a.id,
+        })
+        self.assertEqual(
+            expense.analytic_distribution,
+            {str(self.analytic_account1.id): 100},
+            "The analytic distribution of the created expense should be set to the account of the project specified in the context.",
+        )
+        self.project.account_id = self.analytic_account2
+        expense.analytic_distribution = False
+        expense.with_context(project_id=self.project.id)._compute_analytic_distribution()
+        self.assertEqual(
+            expense.analytic_distribution,
+            {str(self.analytic_account2.id): 100},
+            "The analytic distribution of the expense should be set to the account of the project specified in the context.",
+        )


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. Go to Expenses action in project's top bar
2. Click on "Upload"
3. It adds an expense but does not link its distribution to the analytic account of the project

Fix:
-------------------
The call that creates the expense on upload did not take the context into account. By adding the context, we can now use it to set the expense's analytic distribution to the analytic account of the project.

task-4176532

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
