### PR TITLE
[FIX] website: avoid overflow hidden in masonry snippet

### DIFF
--- a/addons/website/static/src/snippets/s_masonry_block/001.scss
+++ b/addons/website/static/src/snippets/s_masonry_block/001.scss
@@ -2,7 +2,6 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
-    overflow: hidden;
 }
 
 .s_masonry_block[data-vcss='001'] .row.o_grid_mode {


### PR DESCRIPTION
A new CSS `overflow: hidden` rule was added by [1] to hide an issue about background layers which can be reproduced that way:

- Drag and drop a Masonry snippet.
- Select any item of the snippet.
- Through the inner item's options, add an image.
- Set a border radius and apply a color filter.
- Color filter extends beyond the rounded corners of the block.

This is a known bug, which unfortunately has no acceptable solution yet. PR such as [2] is trying to solve that issue. Meanwhile, using the `overflow: hidden` CSS rule is not a solution at the moment: indeed, it means that anything you put inside those masonry boxes will not be visible as soon as it overflows the box. Including typing text.

Anyways, we have future development plans meant to improve that grid mode behavior but using `overflow: hidden` is a bad practice anyway. Let's remove it and find a solution for the long-existing issue described above later.

Note: there are also many other `overflow: hidden` rules in the codebase that we might want to remove in the future. But those are older and more complicated, and not so easily breaking things as in grid mode.

[1]: https://github.com/odoo/odoo/commit/4660f06e6835347769d925cedd4bd5035b609c7b
[2]: https://github.com/odoo/odoo/pull/163466

task-3358501