### PR TITLE
[FIX] product: use `field_digits` for product price fields

### DIFF
--- a/addons/product/views/product_pricelist_item_views.xml
+++ b/addons/product/views/product_pricelist_item_views.xml
@@ -78,7 +78,7 @@
                 <field name="fixed_price"
                         widget="monetary"
                         string="Price"
-                        options="{'currency_field': 'currency_id'}"
+                        options="{'currency_field': 'currency_id', 'field_digits': True}"
                         required='1'/>
                 <field name="min_quantity" colspan="4"/>
                 <field name="currency_id" column_invisible="True"/>
@@ -125,8 +125,9 @@
                                 invisible="display_applied_on == '1_product' and compute_price == 'fixed_price'"/>
                             <label for="fixed_price" invisible="compute_price != 'fixed'"/>
                             <div class="o_row" invisible="compute_price != 'fixed'" style="width: 60% !important;">
-                                <field name="fixed_price" widget="monetary"
-                                    options="{'currency_field': 'currency_id'}"/>
+                                <field name="fixed_price"
+                                    widget="monetary"
+                                    options="{'currency_field': 'currency_id', 'field_digits': True}"/>
                                 <span class="d-flex gap-2 p-0" invisible="not product_uom ">per<field
                                         name="product_uom"/></span>
                             </div>
@@ -169,7 +170,9 @@
                                 <span>%</span>
                             </div>
                             <field name="price_round" string="Round off to"/>
-                            <field name="price_surcharge" widget="monetary" options="{'currency_field': 'currency_id'}"/>
+                            <field name="price_surcharge"
+                                widget="monetary"
+                                options="{'currency_field': 'currency_id', 'field_digits': True}"/>
                             <label string="Margins" for="price_min_margin"
                                 groups="base.group_no_one"/>
                             <div class="d-flex align-items-baseline" groups="base.group_no_one">

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -304,7 +304,10 @@
                                 </div>
                                 <label for="standard_price"/>
                                 <div class="o_row">
-                                    <field name="standard_price" widget='monetary' class="oe_inline" options="{'currency_field': 'cost_currency_id'}"/>
+                                    <field name="standard_price"
+                                        class="oe_inline"
+                                        widget="monetary"
+                                        options="{'currency_field': 'cost_currency_id', 'field_digits': True}"/>
                                 </div>
                                 <field name="currency_id" invisible='1'/>
                                 <field name="cost_currency_id" invisible="1"/>


### PR DESCRIPTION
Versions
--------
- saas-17.4+

Steps
-----
1. Set product price decimal digits to 5;
2. create a price list.

Issue
-----
The field for setting a fixed price only allows for a 2 digit accuracy.

Cause
-----
When using the `monetary` widget, it defaults to the currency's decimal precision, unless the `field_digits` option is set to `True`.

This was the case for this field until commit 06d0053763cd, which refactored the pricelist displays, removing the option.

Solution
--------
In product views, set the `field_digits` option for every monetary field.

opw-4151503