### PR TITLE
[FIX] {sale_,}stock: allow intercompany dropships

### DIFF
--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -243,13 +243,18 @@ class SaleOrderLine(models.Model):
             'route_ids': self.route_id,
             'warehouse_id': self.order_id.warehouse_id or False,
             'partner_id': self.order_id.partner_shipping_id.id,
-            'location_final_id': self.order_id.partner_shipping_id.property_stock_customer,
+            'location_final_id': self._get_location_final(),
             'product_description_variants': self.with_context(lang=self.order_id.partner_id.lang)._get_sale_order_line_multiline_description_variants(),
             'company_id': self.order_id.company_id,
             'product_packaging_id': self.product_packaging_id,
             'sequence': self.sequence,
         })
         return values
+
+    def _get_location_final(self):
+        # Can be overriden for inter-company transactions.
+        self.ensure_one()
+        return self.order_id.partner_shipping_id.property_stock_customer
 
     def _get_qty_procurement(self, previous_product_uom_qty=False):
         self.ensure_one()
@@ -309,7 +314,7 @@ class SaleOrderLine(models.Model):
     def _create_procurements(self, product_qty, procurement_uom, origin, values):
         self.ensure_one()
         return [self.env['procurement.group'].Procurement(
-            self.product_id, product_qty, procurement_uom, self.order_id.partner_shipping_id.property_stock_customer,
+            self.product_id, product_qty, procurement_uom, self._get_location_final(),
             self.product_id.display_name, origin, self.order_id.company_id, values)]
 
     def _action_launch_stock_rule(self, previous_product_uom_qty=False):

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -205,9 +205,12 @@ class StockMove(models.Model):
                 location_dest = move.picking_id.location_dest_id
             elif move.picking_type_id:
                 location_dest = move.picking_type_id.default_location_dest_id
-            customer_loc, __ = self.env['stock.warehouse']._get_partner_locations()
-            if location_dest and move.location_final_id and (move.location_final_id._child_of(location_dest) or
-               (location_dest._child_of(customer_loc) and move.partner_id and move.location_final_id._child_of(move.partner_id.property_stock_customer))):
+            is_move_to_interco_transit = False
+            if self.env.user.has_group('base.group_multi_company') and location_dest:
+                customer_loc, __ = self.env['stock.warehouse']._get_partner_locations()
+                inter_comp_location = self.env.ref('stock.stock_location_inter_company', raise_if_not_found=False)
+                is_move_to_interco_transit = location_dest._child_of(customer_loc) and move.location_final_id == inter_comp_location
+            if location_dest and move.location_final_id and (move.location_final_id._child_of(location_dest) or is_move_to_interco_transit):
                 # Force the location_final as dest in the following cases:
                 # - The location_final is a sublocation of destination -> Means we reached the end
                 # - The location dest is an out location (i.e. Customers) but the final dest is different (e.g. Inter-Company transfers)


### PR DESCRIPTION
Since #156437, the moves can have a final location representing their final endpoint. This causes some issues for inter-company transactions, as they are meant to deliver to/pick from the 'Inter-Company Transit' location.

This means that for sale orders meant to other companies, they are always supposed to deliver their goods there:
- Normal delivery: CompA/Stock -> ICT, ICT -> CompB/Stock
- Dropship: CompA/Stock -> ICT, ICT -> Customer

But this opens a few issues, as the compA SO's `partner_shipping_id` is the customer itself, meaning that the final location would end up as Customers, which we want to avoid.

Also, to accomodate both these cases, we need to add a bit complexity computation of the location_dest of a move. We consider that if the location_dest is Customers but its final is ICT, then we apply the ICT.

opw-4163612

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
