### PR TITLE
[FIX] sale_purchase_stock: Keep MTO link in multi-step reception

### DIFF
--- a/addons/sale_purchase_stock/models/sale_order.py
+++ b/addons/sale_purchase_stock/models/sale_order.py
@@ -12,4 +12,6 @@ class SaleOrder(models.Model):
         super(SaleOrder, self)._compute_purchase_order_count()
 
     def _get_purchase_orders(self):
-        return super(SaleOrder, self)._get_purchase_orders() | self.procurement_group_id.stock_move_ids.created_purchase_line_ids.order_id | self.procurement_group_id.stock_move_ids.move_orig_ids.purchase_line_id.order_id
+        return super()._get_purchase_orders() \
+            | self.procurement_group_id.stock_move_ids.created_purchase_line_ids.order_id \
+            | self.env['stock.move'].browse(self.procurement_group_id.stock_move_ids._rollup_move_origs()).purchase_line_id.order_id

--- a/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
+++ b/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
@@ -27,6 +27,10 @@ class TestSalePurchaseStockFlow(TransactionCase):
                 'partner_id': cls.vendor.id,
             })],
         })
+        cls.warehouse = cls.env['stock.warehouse'].create({
+            'name': 'Other Warehouse',
+            'code': 'OTH',
+        })
 
     def test_cancel_so_with_draft_po(self):
         """
@@ -153,3 +157,27 @@ class TestSalePurchaseStockFlow(TransactionCase):
         blue_po = self.env['purchase.order'].search([('partner_id', '=', blue_vendor.id)], limit=1)
         self.assertTrue(blue_po)
         self.assertRecordValues(blue_po.order_line, [{'product_id': blue_product.id, 'product_uom_qty': 3, 'price_unit': 10}])
+
+    def test_link_sale_purchase_mto_link_multi_step(self):
+        self.warehouse.reception_steps = 'two_steps'
+        sale = self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'order_line': [
+                Command.create({
+                    'name': self.mto_product.name,
+                    'product_id': self.mto_product.id,
+                    'product_uom_qty': 1,
+                    'product_uom': self.mto_product.uom_id.id,
+                }),
+            ],
+            'warehouse_id': self.warehouse.id,
+        })
+        sale.action_confirm()
+        self.assertEqual(sale.purchase_order_count, 1)
+        purchase = sale._get_purchase_orders()
+        purchase.button_confirm()
+
+        receipt = purchase.picking_ids
+        receipt.move_ids.write({'quantity': 1, 'picked': True})
+        receipt._action_done()
+        self.assertEqual(sale.purchase_order_count, 1)


### PR DESCRIPTION
With the old pull rules, pickings were created up to the last step before reception (i.e. Input in multi-step reception) which would be all in the procurement group. Then, once the purchase order is validated, then reception move would be the orig of that last step move. In this case, the link would work properly.

However, with the new push rules, the move that trigget the creation of the purchase order is no longer Input -> Stock, but the first step of delivery. This still works correctly until the first reception step is completed, but then the move_orig of the Stock -> Output is no longer Vendor -> Input, but Input -> Stock, which doesn't contain the link to the purchase order.

This means we have to rollup the orig of the move to get to the actual purchase order, regardless of the number of extra steps in between.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
