### PR TITLE
[IMP] account_accountant: allow "removing" lock dates with exception

### DIFF
--- a/addons/account/views/account_lock_exception_views.xml
+++ b/addons/account/views/account_lock_exception_views.xml
@@ -42,10 +42,10 @@
                                     <div colspan="2" class="o_wrap_label">
                                         <span class="o_form_label">Changed Lock Dates:</span>
                                     </div>
-                                    <field name="sale_lock_date" readonly="True" invisible="not sale_lock_date"/>
-                                    <field name="purchase_lock_date" readonly="True" invisible="not purchase_lock_date"/>
-                                    <field name="tax_lock_date" readonly="True" invisible="not tax_lock_date"/>
-                                    <field name="fiscalyear_lock_date" readonly="True" invisible="not fiscalyear_lock_date"/>
+                                    <field name="display_sale_lock_date" readonly="True" invisible="not sale_lock_date"/>
+                                    <field name="display_purchase_lock_date" readonly="True" invisible="not purchase_lock_date"/>
+                                    <field name="display_tax_lock_date" readonly="True" invisible="not tax_lock_date"/>
+                                    <field name="display_fiscalyear_lock_date" readonly="True" invisible="not fiscalyear_lock_date"/>
                                 </group>
                             </group>
                         </div>


### PR DESCRIPTION
Currently we do not allow removing lock dates completely with an exception (except in the special 'everyone' / 'forever' case in which we just change the actual lock date instead of creating an exception).

It was designed like this for technical reasons.
An exception stores a "new date" for all the lock date field; a missing value for a lock date field means "no change". E.g.: `exception.sale_lock_date == False` means the exception does not change the sale lock date.

After this commit we (pseudo-) allow removing a lock date with an exception. We "simulate" the removal of a lock date by setting the "new date" to a very early date. 1000-01-01 was chosen for technical reasons. It should be before any needed accounting entries. (See comment in the code).

related: task-3891414 (lock dates rework)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
