### PR TITLE
[IMP] event{_sale}: improve barcode scanner flow to easily handle larger crowd

### DIFF
--- a/addons/event/__manifest__.py
+++ b/addons/event/__manifest__.py
@@ -58,6 +58,7 @@ Key Features
             'event/static/src/icon_selection_field/icon_selection_field.xml',
             'event/static/src/template_reference_field/*',
             'event/static/src/js/tours/**/*',
+            'event/static/src/views/*',
         ],
         'web.assets_frontend': [
             'event/static/src/js/tours/**/*',

--- a/addons/event/controllers/main.py
+++ b/addons/event/controllers/main.py
@@ -89,7 +89,7 @@ class EventController(Controller):
             }
         else:
             return {
-                'name': _('Registration Desk'),
+                'name': _('Event Registrations'),
                 'country': False,
                 'city': False,
                 'company_name': request.env.company.name,

--- a/addons/event/static/src/client_action/event_barcode.js
+++ b/addons/event/static/src/client_action/event_barcode.js
@@ -22,6 +22,8 @@ export class EventScanView extends Component {
         this.dialog = useService("dialog");
         this.notification = useService("notification");
         this.orm = useService("orm");
+        this.pwaService = useService("pwa");
+        this.home = useService("home_menu");
 
         const { default_event_id, active_model, active_id } = this.props.action.context;
         this.eventId = default_event_id || (active_model === "event.event" && active_id);
@@ -127,16 +129,6 @@ export class EventScanView extends Component {
                     search_default_confirmed: true,
                 },
             });
-        }
-    }
-
-    onClickBackToEvents() {
-        if (this.isMultiEvent) {
-            // define action from scratch instead of using existing 'action_event_view' to avoid
-            // messing with menu bar
-            this.actionService.doAction("event.action_event_view", { clearBreadcrumbs: true });
-        } else {
-            this.actionService.restore();
         }
     }
 }

--- a/addons/event/static/src/client_action/event_barcode.scss
+++ b/addons/event/static/src/client_action/event_barcode.scss
@@ -24,6 +24,33 @@
         max-width: 200px;
         max-height: 100px;
     }
+    .o_barcode_mobile_container {
+        transform: scale(2.5);
+        margin-top: 75px;
+        margin-bottom: 20px;
+
+        img {
+            height: 70px;
+        }
+
+        .o_mobile_barcode{
+            opacity: 0;
+            height: 70px;
+        }
+        .o_barcode_laser{
+            height: 2px;
+        }
+    }
+    @media (max-width: 750px) {
+        main {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            height: 50vh;
+        }
+    }
+
     @include media-breakpoint-up(md) {
         flex: 0 0 auto;
         width: 550px;
@@ -32,12 +59,25 @@
         -moz-border-radius: 10px;
         box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.6);
         font-size: 1.2em;
-        padding: 3em;
+        padding-top: 0;
+        padding-left: 1em;
+        padding-right: 1em;
+        padding-bottom: 0.75em;
     }
 }
 .o_notification_manager {
     .o_event_success {
         color: white;
         background-color: #5BC236;
+    }
+}
+
+.register_attendee{
+    justify-content: center;
+    margin-left: 40px;
+}
+@media (max-width: 750px) {
+    .register_attendee{
+        margin-left: 0px;
     }
 }

--- a/addons/event/static/src/client_action/event_barcode.xml
+++ b/addons/event/static/src/client_action/event_barcode.xml
@@ -3,35 +3,38 @@
 <templates xml:space="preserve">
 
     <t t-name="event.EventScanView">
-        <div class="o_event_barcode_bg o_home_menu_background">
-            <div class="o_event_barcode_main bg-view">
-                <a t-if="!isDisplayStandalone" href="#" class="o_event_previous_menu float-start"><i class="oi oi-chevron-left" t-on-click.prevent="() => this.onClickBackToEvents()"></i></a>
-                <div class="text-center">
-                    <h1 t-out="data.name"/>
-                    <p>
-                        <t t-if="data.city and data.country">
-                            <t t-out="data.city"/> - <t t-out="data.country"/>
-                        </t>
-                        <t t-if="data.city and !data.country" t-out="data.city"/>
-                        <t t-if="data.country and !data.city" t-out="data.country"/>
-                    </p>
-                    <h2><small>Welcome to</small> <t t-out="data.company_name"/></h2>
-                    <img t-if="data.company_id" t-attf-src="/web/image/res.company/{{data.company_id}}/logo_web" alt="Company Logo" class="o_event_barcode_company_image"/>
-                </div>
-                <div class="row">
-                    <div class="col-sm-5 mt16">
-                        <BarcodeScanner onBarcodeScanned="(ev) => this.onBarcodeScanned(ev)"/>
-                        <h5 class="mt8 mb0 text-muted">Scan a badge</h5>
+        <div class="o_event_barcode_bg o_home_menu_background h-100 w-100 pt-sm-3">
+            <div class="o_event_barcode_main container d-flex flex-column h-100 h-sm-auto bg-view shadow">
+                <header>
+                    <div class="d-flex align-items-center justify-content-between my-3">
+                        <a t-if="!isDisplayStandalone" href="#" class="o_stock_barcode_home_menu oi oi-apps me-3 text-dark" t-on-click="() => this.home.toggle(true)"/>
+                        <span class="fs-2 text-center">
+                            <t t-out="data.name"/>
+                        </span>
+                        <button t-if="pwaService.isScopedApp" class="btn btn-light fa fa-sign-out" t-on-click="logout" />
+                        <a t-elif="pwaService.isSupportedOnBrowser" data-tooltip="Install App" class="btn btn-secondary d-flex align-items-center justify-content-center" href="/scoped_app?app_id=event&amp;path=odoo" target="_blank"><b>Install</b></a>
                     </div>
-                    <div class="col-sm-2 mt32">
-                        <h4 class="mt0 mb8"><i>or</i></h4>
+                </header>
+                <main class="flex-grow-1">
+                    <div class="text-center">
+                        <p>
+                            <t t-if="data.city and data.country">
+                                <t t-out="data.city"/> - <t t-out="data.country"/>
+                            </t>
+                            <t t-if="data.city and !data.country" t-out="data.city"/>
+                            <t t-if="data.country and !data.city" t-out="data.country"/>
+                        </p>
                     </div>
-                    <div class="col-sm-5 mt16">
-                        <button class="o_event_select_attendee btn btn-primary mb16" t-on-click="() => this.onClickSelectAttendee()">
-                            <div class="mb16 mt16">Select Attendee</div>
-                        </button>
+                    <BarcodeScanner onBarcodeScanned="(ev) => this.onBarcodeScanned(ev)"/>
+                    <div class="my-5 text-center o_barcode_tap_to_scan">
+                        <h5 class="mt8 mb0 text-muted">Scan or Tap</h5>
                     </div>
-                </div>
+                </main>
+                <footer>
+                    <button class="o_event_select_attendee btn btn-primary w-100" t-on-click="() => this.onClickSelectAttendee()">
+                        <div class="fw-bolder mb16 mt16">Select Attendee</div>
+                    </button>
+                </footer>
             </div>
         </div>
     </t>

--- a/addons/event/static/src/client_action/event_registration_summary_dialog.xml
+++ b/addons/event/static/src/client_action/event_registration_summary_dialog.xml
@@ -6,25 +6,35 @@
        <Dialog size="'md'" title.translate="Home">
             <div class="row">
                 <div class="col-lg-10 w-100 fs-2">
-                    <div t-if="registrationStatus.value === 'confirmed_registration'" class="alert alert-success text-center" role="alert">
-                        <i class="fa fa-solid fa-check-circle me-2"/>
-                        <span>Successfully registered!</span>
+                    <div t-if="registrationStatus.value === 'confirmed_registration'" class="alert alert-success d-flex justify-content-between align-items-center" role="alert">
+                        <div class="register_attendee d-flex flex-fill">
+                            <i class="fa fa-solid fa-check-circle me-2 align-self-center"/>
+                            <span>Successfully registered!</span>
+                        </div>
+                        <button type="button" class="btn btn-link ms-3" t-on-click="undoRegistration">
+                            Undo
+                        </button>
                     </div>
-                    <div t-else="" class="alert alert-warning text-center" role="alert">
-                        <i class="fa fa-solid fa-exclamation-circle me-2"/>
-                        <t t-if="registrationStatus.value === 'need_manual_confirmation'">
-                            <span>This ticket is for another event!<br/>
-                            Confirm attendance?</span>
-                        </t>
-                        <t t-elif="registrationStatus.value === 'not_ongoing_event'">
-                            <span>This ticket is not for an ongoing event</span>
-                        </t>
-                        <t t-elif="registrationStatus.value === 'canceled_registration'">
-                            <span>Cancelled registration</span>
-                        </t>
-                        <t t-elif="registrationStatus.value == 'already_registered'">
-                            <span>Ticket already scanned!</span>
-                        </t>
+                    <div t-else="" class="alert alert-warning d-flex justify-content-between align-items-center" role="alert">
+                        <div class="register_attendee d-flex flex-fill">
+                            <i class="fa fa-solid fa-exclamation-circle me-2 align-self-center"/>
+                            <t t-if="registrationStatus.value === 'need_manual_confirmation'">
+                                <span>This ticket is for another event!<br/>
+                                Confirm attendance?</span>
+                            </t>
+                            <t t-elif="registrationStatus.value === 'not_ongoing_event'">
+                                <span>This ticket is not for an ongoing event</span>
+                            </t>
+                            <t t-elif="registrationStatus.value === 'canceled_registration'">
+                                <span>Cancelled registration</span>
+                            </t>
+                            <t t-elif="registrationStatus.value == 'already_registered'">
+                                <span>Ticket already scanned!</span>
+                            </t>
+                        </div>
+                        <button type="button" class="btn btn-link ms-3" t-on-click="undoRegistration">
+                            Undo
+                        </button>
                     </div>
                 </div>
             </div>
@@ -72,8 +82,7 @@
                 </div>
             </div>
             <t t-set-slot="footer">
-                <button t-if="needManualConfirmation" class="btn btn-primary" t-on-click="() => this.onRegistrationConfirm()">Confirm</button>
-                <button t-ref="continueButton" class="btn btn-primary" t-on-click="() => this.onScanNext()">Continue</button>
+                <button class="btn btn-primary" t-on-click="() => this.onRegistrationConfirm()">Continue</button>
                 <button t-att-disabled="!hasSelectedPrinter()" class="btn btn-primary" t-on-click="() => this.onRegistrationPrintPdf()">Print</button>
                 <button class="btn btn-secondary" t-on-click="() => this.onRegistrationView()">Edit</button>
             </t>

--- a/addons/event/static/src/scss/event.scss
+++ b/addons/event/static/src/scss/event.scss
@@ -30,6 +30,12 @@
             min-height: 95px;
         }
     }
+    .attendee_badge{
+        font-size: 1.2rem;
+        padding: 10px 20px;
+        margin-top: -3px;
+        margin-right: -15px;
+    }
 }
 
 .o_event_registration_view_tree {

--- a/addons/event/static/src/views/event_registration_kanban_controller.js
+++ b/addons/event/static/src/views/event_registration_kanban_controller.js
@@ -1,0 +1,54 @@
+import { kanbanView } from "@web/views/kanban/kanban_view";
+import { KanbanController } from "@web/views/kanban/kanban_controller";
+import { EventRegistrationSummaryDialog } from "@event/client_action/event_registration_summary_dialog";
+import { onMounted, onWillUnmount } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+
+export default class EventRegistrationKanbanController extends KanbanController {
+
+    setup() {
+        super.setup()
+        this.dialog = useService("dialog");
+        this.orm = useService("orm")
+        onMounted(this.hideSystray);
+        onWillUnmount(this.showSystray);
+    }
+
+    async openRecord(record, mode) {
+        const barcode = record.data.barcode
+        const eventId = record.data.event_id[0]
+
+        const result = await this.orm.call("event.registration", "register_attendee", [], {
+            barcode: barcode,
+            event_id: eventId,
+        });
+
+        this.dialog.add(
+            EventRegistrationSummaryDialog,
+            {
+                registration: result,
+                model: this.model
+            }
+        )
+    }
+
+    hideSystray() {
+        this.observer = new MutationObserver((mutations) => {
+            document.querySelector('.o_menu_systray').classList.add('d-none');
+            this.observer.disconnect();
+        });
+        this.observer.observe(document.body, { childList: true, subtree: true });
+    }
+
+    showSystray() {
+        if (document.querySelector('.o_event_attendee_kanban_view')) {
+            document.querySelector('.o_menu_systray').classList.remove('d-none');
+        }
+    }
+}
+
+registry.category("views").add("registration_dialog_kanban", {
+    ...kanbanView,
+    Controller: EventRegistrationKanbanController,
+});

--- a/addons/event/static/src/views/event_registration_list_controller.js
+++ b/addons/event/static/src/views/event_registration_list_controller.js
@@ -1,0 +1,53 @@
+import { EventRegistrationSummaryDialog } from "@event/client_action/event_registration_summary_dialog";
+import { onMounted, onWillUnmount } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+import { listView } from "@web/views/list/list_view";
+import { ListController } from "@web/views/list/list_controller";
+
+export default class EventRegistrationListController extends ListController {
+
+    setup() {
+        super.setup();
+        this.dialog = useService("dialog");
+        this.orm = useService("orm");
+
+        onMounted(this.hideSystray);
+        onWillUnmount(this.showSystray);
+    }
+
+    async openRecord(record, mode) {
+        const barcode = record.data.barcode
+        const eventId = record.data.event_id[0]
+
+        const result = await this.orm.call("event.registration", "register_attendee", [], {
+            barcode: barcode,
+            event_id: eventId,
+        });
+
+        this.dialog.add(
+            EventRegistrationSummaryDialog,
+            {
+                registration: result,
+                model: this.model
+            }
+        )
+    }
+
+    hideSystray() {
+        if (document.querySelector('.o_event_registration_view_tree')) {
+            document.querySelector('.o_menu_systray').classList.add('d-none');
+        }
+    }
+
+    showSystray() {
+        if (document.querySelector('.o_event_registration_view_tree')) {
+            document.querySelector('.o_menu_systray').classList.remove('d-none');
+        }
+    }
+}
+
+registry.category("views").add("registration_dialog_list", {
+    ...listView,
+    Controller: EventRegistrationListController,
+});

--- a/addons/event/views/event_registration_views.xml
+++ b/addons/event/views/event_registration_views.xml
@@ -8,7 +8,8 @@
         <field name="arch" type="xml">
             <list string="Registration" multi_edit="1" sample="1"
                   expand="1" default_order="create_date desc"
-                  class="o_event_registration_view_tree">
+                  class="o_event_registration_view_tree o_event_registration_attendee" js_class="registration_dialog_list">
+                <field name="barcode" column_invisible="True"/>
                 <field name="active" column_invisible="True"/>
                 <field name="create_date" optional="show" string="Registration Date"/>
                 <field name="name"/>
@@ -122,45 +123,17 @@
         <field name="model">event.registration</field>
         <field name="priority">10</field>
         <field name="arch" type="xml">
-            <kanban class="o_event_attendee_kanban_view" default_order="name, create_date desc" sample="1">
+            <kanban class="o_event_attendee_kanban_view" default_order="name, create_date desc" sample="1" js_class="registration_dialog_kanban">
                 <field name="name"/>
                 <field name="state"/>
                 <field name="active"/>
+                <field name="barcode"/>
                 <templates>
-                    <t t-name="event_attendees_kanban_icons_desktop">
-                        <div class="d-none d-md-block h-100">
-                            <div id="event_attendees_kanban_icons_desktop" class="h-100 float-end p-2 d-flex align-items-end flex-column gap-1">
-                                <t t-if="record.active.raw_value">
-                                    <a class="btn btn-md btn-secondary" string="Confirm Attendance" name="action_set_done" type="object" invisible="state == 'done'"
-                                        role="button" aria-label="Confirm Attendance Button" title="Confirm Attendance">
-                                        <i class="fa fa-check" role="img"/>
-                                    </a>
-                                    <a class="btn btn-md btn-success" string="Reset To Registered" name="action_confirm" type="object" invisible="state != 'done'"
-                                        role="button" aria-label="Reset To Registered Button" title="Reset To Registered">
-                                        <i class="fa fa-check" role="img"/>
-                                    </a>
-                                </t>
-                            </div>
-                        </div>
-                    </t>
-                    <t t-name="event_attendees_kanban_icons_mobile">
-                        <div id="event_attendees_kanban_icons_mobile" class="d-md-none d-flex align-items-end flex-column gap-1 h-100 ps-4">
-                            <t t-if="record.active.raw_value">
-                                <a class="btn btn-secondary d-flex justify-content-center align-items-center h-100 w-100"
-                                    string="Confirm Attendance" name="action_set_done" type="object" invisible="state == 'done'" role="button">
-                                    <i class="fa fa-check fa-3x" role="img" aria-label="Confirm Attendance Button" title="Confirm Attendance"/>
-                                </a>
-                                <a class="btn btn-success d-flex justify-content-center align-items-center h-100 w-100"
-                                    string="Reset To Registered" name="action_confirm" type="object" invisible="state != 'done'" role="button">
-                                    <i class="fa fa-check fa-3x" role="img" aria-label="Reset To Registered Button" title="Reset To Registered"/>
-                                </a>
-                            </t>
-                        </div>
-                    </t>
-                    <t t-name="kanban-card" class="row g-0">
+                    <t t-name="kanban-card" t-attf-class="row g-0 o_event_registration_attendee">
                         <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                         <div class="col-8 col-md-9">
                             <field class="d-block fw-bold fs-5" name="name"/>
+                            <field name="state" widget="badge" decoration-success="state == 'done'" class="position-absolute top-0 end-0 attendee_badge"/>
                             <div class="o_kanban_event_registration_event_name">
                                 <field class="text-truncate text-primary" name="event_id" invisible="context.get('default_event_id')"/>
                             </div>
@@ -174,10 +147,6 @@
                                     <field name="event_ticket_id" class="fw-bold text-truncate ms-1"/>
                                 </t>
                             </div>
-                        </div>
-                        <div id="event_attendees_kanban_icons" class="col-4 col-md-3">
-                            <t t-call="event_attendees_kanban_icons_desktop"/>
-                            <t t-call="event_attendees_kanban_icons_mobile"/>
                         </div>
                     </t>
                 </templates>
@@ -313,7 +282,7 @@
     <record id="event_registration_action_kanban" model="ir.actions.act_window">
         <field name="res_model">event.registration</field>
         <field name="name">Attendees</field>
-        <field name="view_mode">kanban,list,form,calendar,graph</field>
+        <field name="view_mode">kanban,list,form</field>
         <field name="domain">[('event_id', '=', active_id)]</field>
         <field name="context">{'default_event_id': active_id}</field>
         <field name="help" type="html">
@@ -328,7 +297,7 @@
     <record id="event_registration_action" model="ir.actions.act_window">
         <field name="res_model">event.registration</field>
         <field name="name">Attendees</field>
-        <field name="view_mode">kanban,list,form,calendar,graph</field>
+        <field name="view_mode">kanban,list,form</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 No Attendees expected yet!

--- a/addons/event_sale/views/event_registration_views.xml
+++ b/addons/event_sale/views/event_registration_views.xml
@@ -17,17 +17,6 @@
         </field>
     </record>
 
-    <record id="event_registration_view_kanban" model="ir.ui.view">
-        <field name="name">event.registration.kanban.inherit.event.sale</field>
-        <field name="model">event.registration</field>
-        <field name="inherit_id" ref="event.event_registration_view_kanban"/>
-        <field name="arch" type="xml">
-            <xpath expr="//div[hasclass('o_kanban_event_registration_event_name')]" position="inside">
-                <span invisible="context.get('default_event_id')" class="text-muted"> - </span><field name="sale_status"/>
-            </xpath>
-        </field>
-    </record>
-
     <record id="event_registration_view_graph" model="ir.ui.view">
         <field name="name">event.registration.graph.inherit.event.sale</field>
         <field name="model">event.registration</field>

--- a/addons/hr_attendance/static/src/components/kiosk_barcode/kiosk_barcode.js
+++ b/addons/hr_attendance/static/src/components/kiosk_barcode/kiosk_barcode.js
@@ -9,6 +9,7 @@ export class KioskBarcodeScanner extends BarcodeScanner {
         barcodeSource: String,
         token: String,
     };
+    static template = "hr_attendance.BarcodeScanner";
     setup() {
         super.setup();
         this.scanBarcode = () => scanBarcode(this.env, this.facingMode, this.props.token);

--- a/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.xml
+++ b/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.xml
@@ -5,7 +5,7 @@
     <img t-att-src="companyImageUrl" alt="Company Logo" class="o_hr_attendance_kiosk_company_image align-self-center"/>
 </t>
 
-<t t-inherit="barcodes.BarcodeScanner" t-inherit-mode="extension">
+<t t-name="hr_attendance.BarcodeScanner" t-inherit="barcodes.BarcodeScanner" t-inherit-mode="primary">
     <xpath expr="//div[hasclass('o_barcode_mobile_container')]" position="replace">
         <button t-if="isBarcodeScannerSupported" t-on-click="openMobileScanner" class="o_mobile_barcode btn btn-light btn-lg p-5 rounded-3">
             <i class="fa fa-3x fa-barcode mb-3"/>


### PR DESCRIPTION
**Purpose:**
Enhance the barcode scanner interface and optimize the attendee registration process for more efficient handling of large volumes of attendees.

**Specifications:**
Change barcode scanner template.
- Make barcode template same as 'stock_barcode'
- Add a dynamic title 

Modify attendees page.
- Remove check/uncheck button
- Replace payment status by status
- Keep status as a badge
- Get rid of systray in navbar
- Only keep kanban and list view
- When clicking on record, it opens a dialog box same as if barcode is scanned (kanban and list). 

Edit the dialog box which opens when user is marked attended.
- Keep status in one line.
- Add an undo button.
- Add Print and Edit buttons in footer which are 'Print Ticket' and 'Open Details' currently.

Removed a kanban view from event_sale module
- 'event_registration_view_kanban' view was no longer needed as replaced 'sales_status' wth 'status'

Mockup link: https://app.excalidraw.com/l/65VNwvy7c4X/88aC6OMVygk

Task-4159794

