### PR TITLE
[FIX] web: isolate the click event within daterange picker container

### DIFF
--- a/addons/web/static/src/views/fields/daterange/daterange_field.js
+++ b/addons/web/static/src/views/fields/daterange/daterange_field.js
@@ -42,6 +42,10 @@ export class DateRangeField extends Component {
                     window.$(el).on("hide.daterangepicker", this.onPickerHide.bind(this));
 
                     this.pickerContainer.dataset.name = this.props.name;
+
+                    this.pickerContainer.addEventListener('click', function(event) {
+                        event.stopPropagation();
+                    });
                 }
 
                 return () => {

--- a/doc/cla/individual/chaule.md
+++ b/doc/cla/individual/chaule.md
@@ -1,0 +1,11 @@
+Vietnam, 2024-09-12
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Le Bao Chau lebaochau97@gmail.com https://github.com/chaule97


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- When using the daterange widget in the tree view, we observed that pressing the next or previous buttons automatically discards the edit/update action.
- The cause is that in Tree View use ListRenderer Component, they write event trigger document [click](https://github.com/odoo/odoo/blob/16.0/addons/web/static/src/views/list/list_renderer.js#L84). If we click outside `ListRenderer.Rows`, the function [onGlobalClick](https://github.com/odoo/odoo/blob/16.0/addons/web/static/src/views/list/list_renderer.js#L1603) will be triggered and discard the edit/update action.
- To avoid this issue, we will isolate the click event within the daterange picker container. By doing this, clicks inside the daterange picker container will not trigger events in the outer container.

![image](https://github.com/user-attachments/assets/4c714e58-4f0d-4544-9c6d-23077966b1a2)
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
