### PR TITLE
[IMP] mrp: simplify kanban archs

### DIFF
--- a/addons/mrp/static/src/scss/mrp_workorder_kanban.scss
+++ b/addons/mrp/static/src/scss/mrp_workorder_kanban.scss
@@ -1,25 +1,23 @@
-.o_kanban_dashboard{
-    &.o_mrp_workorder_kanban {
-        .o_kanban_record {
+.o_mrp_workorder_kanban {
+    .o_kanban_record {
+        flex-basis: 40%;
+        @include media-breakpoint-down(lg) {
+            flex-basis: 100%
+        }
+    }
+    .o_kanban_group .o_kanban_record_top {
+        flex-direction: column;
+    }
+    .o_kanban_record_top {
+        justify-content: space-between;
+        .o_kanban_workorder_title {
             flex-basis: 40%;
-            @include media-breakpoint-down(lg) {
-                flex-basis: 100%
-            }
         }
-        .o_kanban_group .o_kanban_record_top {
-            flex-direction: column;
-        }
-        .o_kanban_record_top {
-            justify-content: space-between;
-            .o_kanban_workorder_title {
-                flex-basis: 40%;
-            }
-            .o_kanban_workorder_status {
-                flex-basis: 20%;
-            }
+        .o_kanban_workorder_status {
+            flex-basis: 20%;
         }
     }
-    &.o_workcenter_kanban {
-        --KanbanRecord-width: 400px;
-    }
+}
+.o_workcenter_kanban {
+    --KanbanRecord-width: 400px;
 }

--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -149,9 +149,7 @@
             <field name="name">mrp.workcenter.kanban</field>
             <field name="model">mrp.workcenter</field>
             <field name="arch" type="xml">
-                <kanban class="o_kanban_dashboard o_workcenter_kanban" create="0" can_open="0" sample="1">
-                    <field name="name"/>
-                    <field name="color"/>
+                <kanban highlight_color="color" class="o_workcenter_kanban" create="0" can_open="0" sample="1">
                     <field name="workorder_count"/>
                     <field name="working_state"/>
                     <field name="oee_target"/>
@@ -159,7 +157,7 @@
                         <t t-name="kanban-menu">
                             <div class="container">
                                 <div class="row">
-                                    <div class="col-6 o_kanban_card_manage_section o_kanban_manage_view">
+                                    <div class="col-6">
                                         <h5 role="menuitem" class="o_kanban_card_manage_title">
                                             <span>Actions</span>
                                         </h5>
@@ -167,7 +165,7 @@
                                             <a name="action_work_order" type="object">Plan Orders</a>
                                         </div>
                                     </div>
-                                    <div class="col-6 o_kanban_card_manage_section o_kanban_manage_new">
+                                    <div class="col-6">
                                         <h5 role="menuitem" class="o_kanban_card_manage_title">
                                             <span>Reporting</span>
                                         </h5>
@@ -187,103 +185,71 @@
 
                                 <div t-if="widget.editable" class="o_kanban_card_manage_settings row">
                                     <div role="menuitem" aria-haspopup="true" class="col-8">
-                                        <ul role="menu" class="oe_kanban_colorpicker" data-field="color"/>
+                                        <field name="color" widget="kanban_color_picker"/>
                                     </div>
                                     <div role="menuitem" class="col-4">
-                                        <a type="edit">Settings</a>
+                                        <a type="open">Settings</a>
                                     </div>
                                 </div>
                             </div>
                         </t>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="#{!selection_mode ? kanban_color(record.color.raw_value) : ''}">
-                                <div t-attf-class="o_kanban_card_header o_kanban_record_top">
-                                    <div class="o_kanban_record_headings o_kanban_card_header_title">
-                                        <span class="o_primary ml8" style="display: inline-block">
-                                            <field name="name"/>
-                                        </span>
+                        <t t-name="kanban-card">
+                            <field name="name" class="fw-bold fs-4 ms-2"/>
+                            <div class="row mt-3 pb-3">
+                                <div class="col-6">
+                                    <div class="btn-group p-1" name="o_wo">
+                                        <button t-if="record.workorder_count.raw_value &gt; 0" class="btn btn-primary" name="action_work_order" type="object" context="{'search_default_ready': 1, 'search_default_progress': 1, 'desktop_list_view': 1, 'search_default_workcenter_id': id}">
+                                            <span>WORK ORDERS</span>
+                                        </button>
+                                        <button t-if="record.workorder_count.raw_value &lt;= 0" class="btn btn-warning" name="%(act_product_mrp_production_workcenter)d" type="action">
+                                            <span>PLAN ORDERS</span>
+                                        </button>
                                     </div>
                                 </div>
-                                <div class="container o_kanban_card_content">
-                                    <div class="row mb16">
-                                        <div class="col-6 o_kanban_primary_left">
-                                            <div class="btn-group" name="o_wo">
-                                            <t t-if="record.workorder_count.raw_value &gt; 0">
-                                                <button class="btn btn-primary" name="action_work_order" type="object" context="{'search_default_ready': 1, 'search_default_progress': 1, 'desktop_list_view': 1, 'search_default_workcenter_id': id}">
-                                                    <span>WORK ORDERS</span>
-                                                </button>
-                                            </t>
-                                            <t  t-if="record.workorder_count.raw_value &lt;= 0">
-                                                <button class="btn btn-warning" name="%(act_product_mrp_production_workcenter)d" type="action">
-                                                    <span>PLAN ORDERS</span>
-                                                </button>
-                                            </t>
-                                            </div>
-                                        </div>
-                                        <div class="col-6 o_kanban_primary_right">
-                                            <div class="row" t-if="record.workorder_ready_count.raw_value &gt; 0">
-                                                <div class="col-8">
-                                                    <a name="action_work_order" type="object" context="{'search_default_ready': 1}">
-                                                        To Launch
-                                                    </a>
-                                                </div>
-                                                <div class="col-4 text-end">
-                                                    <field name="workorder_ready_count"/>
-                                                </div>
-                                            </div>
-                                            <div class="row" t-if="record.workorder_progress_count.raw_value &gt; 0">
-                                                <div class="col-8">
-                                                    <a name="action_work_order" type="object" context="{'search_default_progress': 1}">
-                                                        In Progress
-                                                    </a>
-                                                </div>
-                                                <div class="col-4 text-end">
-                                                    <field name="workorder_progress_count"/>
-                                                </div>
-                                            </div>
-                                            <div class="row" t-if="record.workorder_late_count.raw_value &gt; 0">
-                                                <div class="col-8">
-                                                    <a name="action_work_order" type="object" context="{'search_default_late': 1}">
-                                                        Late
-                                                    </a>
-                                                </div>
-                                                <div class="col-4 text-end">
-                                                    <field name="workorder_late_count"/>
-                                                </div>
-                                            </div>
-                                            <div class="row" t-if="record.oee.raw_value &gt; 0">
-                                                <div class="col-6">
-                                                    <a name="%(mrp_workcenter_productivity_report_oee)d" type="action">
-                                                        OEE
-                                                    </a>
-                                                </div>
-                                                <div class="col-6 text-end">
-                                                    <span t-att-class="record.oee_target.raw_value and (record.oee.raw_value &lt; record.oee_target.raw_value) and 'text-danger' or (record.oee.raw_value &gt; record.oee_target.raw_value) and 'text-success' or 'text-warning'">
-                                                        <strong>
-                                                            <field name="oee" widget="integer"/>%
-                                                        </strong>
-                                                    </span>
-                                                </div>
-                                            </div>
-                                        </div>
+                                <div class="col-6">
+                                    <div class="row" t-if="record.workorder_ready_count.raw_value &gt; 0">
+                                        <a name="action_work_order" class="col-8" type="object" context="{'search_default_ready': 1}">
+                                            To Launch
+                                        </a>
+                                        <field name="workorder_ready_count" class="col-4 text-end"/>
                                     </div>
-                                    <div class="row">
-                                        <div class="col-12 o_kanban_primary_left" style="position:absolute; bottom:10px;" name="wc_stages">
-                                            <a name="%(act_mrp_block_workcenter)d" type="action" class="o_status float-end"
-                                                title="No workorder currently in progress. Click to mark work center as blocked."
-                                                aria-label="No workorder currently in progress. Click to mark work center as blocked."
-                                                invisible="working_state in ('blocked', 'done')"/>
-                                            <a name="unblock" type="object" class=" o_status o_status_red float-end"
-                                                title="Workcenter blocked, click to unblock."
-                                                aria-label="Workcenter blocked, click to unblock."
-                                                invisible="working_state in ('normal', 'done')"/>
-                                            <a name="%(act_mrp_block_workcenter)d" type="action" class="o_status o_status_green float-end"
-                                                title="Work orders in progress. Click to block work center."
-                                                aria-label="Work orders in progress. Click to block work center."
-                                                invisible="working_state in ('normal', 'blocked')"/>
+                                    <div class="row" t-if="record.workorder_progress_count.raw_value &gt; 0">
+                                        <a name="action_work_order" class="col-8" type="object" context="{'search_default_progress': 1}">
+                                            In Progress
+                                        </a>
+                                        <field name="workorder_progress_count" class="col-4 text-end"/>
+                                    </div>
+                                    <div class="row" t-if="record.workorder_late_count.raw_value &gt; 0">
+                                        <a name="action_work_order" class="col-8" type="object" context="{'search_default_late': 1}">
+                                            Late
+                                        </a>
+                                        <field name="workorder_late_count" class="col-4 text-end"/>
+                                    </div>
+                                    <div class="row" t-if="record.oee.raw_value &gt; 0">
+                                        <a name="%(mrp_workcenter_productivity_report_oee)d" class="col-6" type="action">
+                                            OEE
+                                        </a>
+                                        <div class="col-6">
+                                            <span t-att-class="record.oee_target.raw_value and (record.oee.raw_value &lt; record.oee_target.raw_value) and 'text-danger d-flex float-end fw-bolder' or (record.oee.raw_value &gt; record.oee_target.raw_value) and 'text-success d-flex float-end fw-bolder' or 'text-warning d-flex float-end fw-bolder'">
+                                                <field name="oee" widget="integer"/>%
+                                            </span>
                                         </div>
                                     </div>
                                 </div>
+                            </div>
+                            <div class="ms-auto" name="wc_stages">
+                                <a name="%(act_mrp_block_workcenter)d" type="action" class="o_status float-end"
+                                    title="No workorder currently in progress. Click to mark work center as blocked."
+                                    aria-label="No workorder currently in progress. Click to mark work center as blocked."
+                                    invisible="working_state in ('blocked', 'done')"/>
+                                <a name="unblock" type="object" class=" o_status o_status_red float-end"
+                                    title="Workcenter blocked, click to unblock."
+                                    aria-label="Workcenter blocked, click to unblock."
+                                    invisible="working_state in ('normal', 'done')"/>
+                                <a name="%(act_mrp_block_workcenter)d" type="action" class="o_status o_status_green float-end"
+                                    title="Work orders in progress. Click to block work center."
+                                    aria-label="Work orders in progress. Click to block work center."
+                                    invisible="working_state in ('normal', 'blocked')"/>
                             </div>
                         </t>
                     </templates>

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -352,61 +352,39 @@
         <field name="name">mrp.production.work.order.kanban</field>
         <field name="model">mrp.workorder</field>
         <field name="arch" type="xml">
-            <kanban class="o_kanban_dashboard o_mrp_workorder_kanban" create="0" sample="1">
-                <field name="name"/>
-                <field name="production_id"/>
-                <field name="state" readonly="1"/>
-                <field name="is_user_working"/>
+            <kanban class="o_mrp_workorder_kanban" create="0" sample="1">
                 <field name="working_user_ids"/>
-                <field name="last_working_user_id"/>
                 <field name="working_state"/>
-                <field name="workcenter_id"/>
-                <field name="product_id"/>
-                <field name="qty_remaining"/>
-                <field name="qty_production"/>
                 <field name="date_start"/>
                 <field name="production_date"/>
-                <field name="product_uom_id" force_save="1"/>
-                <field name="finished_lot_id"/>
-                <field name="operation_id"/>
                 <templates>
-                    <t t-name="kanban-box">
-                        <div class="oe_kanban_global_click">
-                            <div class="o_kanban_card_header o_kanban_record_top">
-                                <div class="o_kanban_workorder_title">
-                                    <h4 class="o_primary">
-                                        <span><t t-out="record.production_id.value"/></span> - <span><t t-out="record.name.value"/></span>
-                                    </h4>
-                                </div>
-                                <div class="o_kanban_workorder_date">
-                                    <h5><span class="d-flex" t-esc="record.date_start.value or record.production_date.value"/></h5>
-                                </div>
-                                <div>
-                                    <h2 class="ml8">
-                                        <span t-attf-class="badge #{['progress'].indexOf(record.state.raw_value) > -1 ? 'text-bg-warning' : ['ready', 'waiting', 'pending'].indexOf(record.state.raw_value) > -1 ? 'text-bg-primary' : ['done'].indexOf(record.state.raw_value) > -1 ? 'text-bg-success' : 'text-bg-danger'}">
-                                            <t t-out="record.state.value"/>
-                                        </span>
-                                    </h2>
-                                </div>
+                    <t t-name="kanban-card">
+                        <div class="d-flex o_kanban_record_top">
+                            <div class="o_kanban_workorder_title h4">
+                                <field name="production_id"/> - <field name="name"/>
                             </div>
-                            <div class="o_kanban_record_bottom">
-                                <h5 class="oe_kanban_bottom_left">
-                                    <span><t t-out="record.product_id.value"/>, </span> <span><t t-out="record.qty_production.value"/> <t t-out="record.product_uom_id.value"/><t t-if="record.finished_lot_id.value">, </t></span><span t-if="record.finished_lot_id.value" t-out="record.finished_lot_id.value"/>
-                                </h5>
-                                <div class="o_kanban_workorder_status">
-                                    <div class="o_kanban_record_bottom">
-                                        <div class="oe_kanban_bottom_right" t-if="record.state.raw_value == 'progress'">
-                                            <span t-if="record.working_state.raw_value != 'blocked' and record.working_user_ids.raw_value.length > 0"><i class="fa fa-play" role="img" aria-label="Run" title="Run"/></span>
-                                            <span t-if="record.working_state.raw_value != 'blocked' and record.working_user_ids.raw_value.length == 0 and record.last_working_user_id.raw_value"><i class="fa fa-pause" role="img" aria-label="Pause" title="Pause"/></span>
-                                            <span t-if="record.working_state.raw_value == 'blocked' and (record.working_user_ids.raw_value.length == 0 or record.last_working_user_id.raw_value)"><i class="fa fa-stop" role="img" aria-label="Stop" title="Stop"/></span>
-                                            <t name="user_avatar" t-if="record.last_working_user_id.raw_value">
-                                                <img t-att-src="kanban_image('res.users', 'avatar_128', record.last_working_user_id.raw_value)" class="oe_kanban_avatar o_avatar rounded" alt="Avatar"/>
-                                            </t>
-                                        </div>
-                                    </div>
-                                </div>
+                            <div class="o_kanban_workorder_date h5">
+                                <span class="d-flex" t-esc="record.date_start.value or record.production_date.value"/>
+                            </div>
+                            <div class="h2 ms-2">
+                                <span t-attf-class="badge #{['progress'].indexOf(record.state.raw_value) > -1 ? 'text-bg-warning' : ['ready', 'waiting', 'pending'].indexOf(record.state.raw_value) > -1 ? 'text-bg-primary' : ['done'].indexOf(record.state.raw_value) > -1 ? 'text-bg-success' : 'text-bg-danger'}">
+                                    <field name="state"/>
+                                </span>
                             </div>
                         </div>
+                        <footer>
+                            <h5>
+                                <field name="product_id"/>, <field name="qty_production" class="ms-1"/> <field name="product_uom_id"/><t t-if="record.finished_lot_id.value">, </t> <field t-if="record.finished_lot_id.value" name="finished_lot_id" class="ms-1"/>
+                            </h5>
+                            <div class="o_kanban_workorder_status d-flex ms-auto" t-if="record.state.raw_value == 'progress'">
+                                <span t-if="record.working_state.raw_value != 'blocked' and record.working_user_ids.raw_value.length > 0"><i class="fa fa-play fs-6" role="img" aria-label="Run" title="Run"/></span>
+                                <span t-if="record.working_state.raw_value != 'blocked' and record.working_user_ids.raw_value.length == 0 and record.last_working_user_id.raw_value"><i class="fa fa-pause" role="img" aria-label="Pause" title="Pause"/></span>
+                                <span t-if="record.working_state.raw_value == 'blocked' and (record.working_user_ids.raw_value.length == 0 or record.last_working_user_id.raw_value)"><i class="fa fa-stop" role="img" aria-label="Stop" title="Stop"/></span>
+                                <t name="user_avatar" t-if="record.last_working_user_id.raw_value">
+                                    <field name="last_working_user_id" widget="image" options="{'preview_image': 'avatar_128'}" class="ms-1" alt="Avatar"/>
+                                </t>
+                            </div>
+                        </footer>
                     </t>
                 </templates>
             </kanban>


### PR DESCRIPTION
In this commit we have simplified the kanban arch for the mrp module dashboard. the goal is to simplify them, make them easier to read and use bootstrap utility classnames.

- Previously, we used kanban-box, but now we are using kanban-card instead.
- Deprecated oe_kanban_global_click and oe_kanban_global_click_edit.
- More use of <field/> tags
- Removed the oe_kanban_colorpicker class and replaced it with the kanban_color_picker widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- kanban_image from rendering context, is deprecated so we use <field name=... widget=image/> instead
- kanban_color, kanban_getcolor and kanban_getcolorname are deprecated use new attribute highlight_color=color_field_name on root node

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
