### PR TITLE
[IMP] spreadsheet: add list insertion with tables

### DIFF
--- a/addons/spreadsheet/static/src/helpers/constants.js
+++ b/addons/spreadsheet/static/src/helpers/constants.js
@@ -5,8 +5,6 @@ import { _t } from "@web/core/l10n/translation";
 
 export const DEFAULT_LINES_NUMBER = 20;
 
-export const TOP_LEVEL_STYLE = { bold: true, fillColor: "#E6F2F3" };
-
 export const UNTITLED_SPREADSHEET_NAME = _t("Untitled spreadsheet");
 
 export const RELATIVE_DATE_RANGE_TYPES = [

--- a/addons/spreadsheet/static/src/list/plugins/list_core_plugin.js
+++ b/addons/spreadsheet/static/src/list/plugins/list_core_plugin.js
@@ -2,7 +2,6 @@
 
 import { CommandResult } from "../../o_spreadsheet/cancelled_reason";
 import { helpers } from "@odoo/o-spreadsheet";
-import { TOP_LEVEL_STYLE } from "../../helpers/constants";
 import { _t } from "@web/core/l10n/translation";
 import { globalFiltersFieldMatchers } from "@spreadsheet/global_filters/plugins/global_filters_core_plugin";
 import { sprintf } from "@web/core/utils/strings";
@@ -320,33 +319,6 @@ export class ListCorePlugin extends OdooCorePlugin {
             });
             col++;
         }
-        this.dispatch("SET_FORMATTING", {
-            sheetId,
-            style: TOP_LEVEL_STYLE,
-            target: [
-                {
-                    top: anchor[1],
-                    bottom: anchor[1],
-                    left: anchor[0],
-                    right: anchor[0] + columns.length - 1,
-                },
-            ],
-        });
-        this.dispatch("SET_ZONE_BORDERS", {
-            sheetId,
-            target: [
-                {
-                    top: anchor[1],
-                    bottom: anchor[1],
-                    left: anchor[0],
-                    right: anchor[0] + columns.length - 1,
-                },
-            ],
-            border: {
-                position: "external",
-                color: "#2D7E84",
-            },
-        });
     }
 
     _insertValues(sheetId, anchor, id, columns, linesNumber) {
@@ -365,21 +337,6 @@ export class ListCorePlugin extends OdooCorePlugin {
             }
             row++;
         }
-        this.dispatch("SET_ZONE_BORDERS", {
-            sheetId,
-            target: [
-                {
-                    top: anchor[1],
-                    bottom: anchor[1] + linesNumber,
-                    left: anchor[0],
-                    right: anchor[0] + columns.length - 1,
-                },
-            ],
-            border: {
-                position: "external",
-                color: "#2D7E84",
-            },
-        });
     }
 
     /**


### PR DESCRIPTION
We currently insert lists with hardcoded borders and styles. This revision adds a new UI command to:
- Split the style addition from the list datasource insertion
- replace the current style by a table

Task: 4178740

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
