### PR TITLE
[FIX] base: fix traceback when opening projects while sale uninstalled

### DIFF
--- a/odoo/addons/base/models/ir_embedded_actions.py
+++ b/odoo/addons/base/models/ir_embedded_actions.py
@@ -87,7 +87,7 @@ class IrEmbeddedActions(models.Model):
                     record.is_visible = False
 
     # Delete the filters linked to a embedded action.
-    @api.ondelete(at_uninstall=True)
+    @api.ondelete(at_uninstall=False)
     def _unlink_if_action_deletable(self):
         for record in self:
             if not record.is_deletable:


### PR DESCRIPTION
A traceback occurs when the user uninstalls the sales module and tries to open any project.

To reproduce this issue:

1) Install sales, project
2) Uninstall sales
3) Try to open any project

Error:- 

```
KeyError: 'allow_billable'
```

This is because of the new embedded action introduced in the project module.

When the user uninstalls the sale module the embedded action record of the sale needs to be deleted.

https://github.com/odoo/odoo/blob/45e75693e8ee4f8cf9af842cd2facd4f2f6356d8/odoo/addons/base/models/ir_model.py#L2480-L2485

But an exception is raised because of the unlink method triggered during the uninstallation for embedded action and an exception is raised.

https://github.com/odoo/odoo/blob/45e75693e8ee4f8cf9af842cd2facd4f2f6356d8/odoo/addons/base/models/ir_embedded_actions.py#L90-L94

Due to this, the embedded action record is stored in the `undeletable_ids`.

Later it is removed from the `module_date` and the remaining module data is deleted.

https://github.com/odoo/odoo/blob/45e75693e8ee4f8cf9af842cd2facd4f2f6356d8/odoo/addons/base/models/ir_model.py#L2524-L2531

Finally, the embedded action of the sale module is not deleted and has a domain, 
which contains `allow_billable`. This leads to the above traceback.

sentry-5677055153

