### PR TITLE
[FIX] pos*: improve handling of split orders in kitchen display

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -254,7 +254,7 @@ export class PosOrder extends Base {
         // Checks whether an orderline has been deleted from the order since it
         // was last sent to the preparation tools. If so we delete it to the changes.
         for (const [key, change] of Object.entries(this.last_order_preparation_change)) {
-            if (!this.models["pos.order.line"].getBy("uuid", change.uuid)) {
+            if (key !== "splitted" && !this.models["pos.order.line"].getBy("uuid", change.uuid)) {
                 delete this.last_order_preparation_change[key];
             }
         }

--- a/addons/point_of_sale/static/src/app/models/utils/order_change.js
+++ b/addons/point_of_sale/static/src/app/models/utils/order_change.js
@@ -11,6 +11,9 @@ export const changesToOrder = (
         : Object.values(order.last_order_preparation_change);
 
     for (const lineChange of changes) {
+        if ("splitted" in lineChange) {
+            continue;
+        }
         if (lineChange["quantity"] > 0 && !cancelled) {
             toAdd.push(lineChange);
         } else {
@@ -78,7 +81,10 @@ export const getOrderChanges = (order, skipped = false, orderPreparationCategori
     // Checks whether an orderline has been deleted from the order since it
     // was last sent to the preparation tools. If so we add this to the changes.
     for (const [lineKey, lineResume] of Object.entries(order.last_order_preparation_change)) {
-        if (!order.models["pos.order.line"].getBy("uuid", lineResume["uuid"])) {
+        if (
+            lineKey !== "splitted" &&
+            !order.models["pos.order.line"].getBy("uuid", lineResume["uuid"])
+        ) {
             if (!changes[lineKey]) {
                 changes[lineKey] = {
                     uuid: lineResume["uuid"],

--- a/addons/pos_restaurant/models/pos_config.py
+++ b/addons/pos_restaurant/models/pos_config.py
@@ -44,7 +44,8 @@ class PosConfig(models.Model):
             last_order_preparation_change = json.loads(line.order_id.last_order_preparation_change)
             prep_change = {}
             for line_uuid in last_order_preparation_change:
-                prep_change[last_order_preparation_change[line_uuid]['uuid']] = last_order_preparation_change[line_uuid]
+                if line_uuid != "splitted":
+                    prep_change[last_order_preparation_change[line_uuid]['uuid']] = last_order_preparation_change[line_uuid]
             quantity_changed = 0
             if line.uuid in prep_change:
                 quantity_changed = line.qty - prep_change[line.uuid]['quantity']

--- a/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
+++ b/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
@@ -29,6 +29,10 @@ export class SplitBillScreen extends Component {
         return Object.values(this.priceTracker).reduce((a, b) => a + b, 0);
     }
 
+    get qtyTrackerLength() {
+        return Object.values(this.qtyTracker).filter((l) => l > 0).length;
+    }
+
     onClickLine(line) {
         const lines = line.getAllLinesInCombo();
 

--- a/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.xml
+++ b/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.xml
@@ -29,7 +29,10 @@
                             </span>
                         </div>
                         <div class="pay-button">
-                            <div class="button btn btn-lg btn-primary py-3 py-lg-5 w-100" t-on-click="createSplittedOrder">
+                            <div class="button btn btn-lg btn-primary py-3 py-lg-5 w-100"
+                                t-att-class="{'disabled btn-light' : this.qtyTrackerLength == 0}"
+                                t-on-click="createSplittedOrder"
+                            >
                                 <span>Split Order</span>
                             </div>
                         </div>


### PR DESCRIPTION
pos*: point_of_sale, pos_restaurant, pos_preparation_display

before this commit:
==============
- splitted order lines were not sent to the kitchen display upon splitting order
- there was no widget to distinguish split order lines.

after this commit:
==============
- ensure that split orders are sent to the preparation display if any of the
  original order lines are sent there.
- standardize the splitting process to ensure consistency between the
  order widget and the kitchen display.
- added a fix to disable the split order button on the split bill screen
  when no items are selected.

task - 4114041