### PR TITLE
[IMP] hr_recruitment_skills: create new field which shows the matching score

### DIFF
--- a/addons/hr_recruitment/views/res_config_settings_views.xml
+++ b/addons/hr_recruitment/views/res_config_settings_views.xml
@@ -25,7 +25,7 @@
                         <block title="In-App Purchases" name="recruitment_in_app_purchases">
                             <setting id="sms" string="Send SMS" documentation="/applications/marketing/sms_marketing/pricing/pricing_and_faq.html" help="Send texts to your contacts">
                             </setting>
-                            <setting id="recruitment_extract_settings" string="Résumé Digitization (OCR)" company_dependent="1" help="Digitize your résumé to extract name and email automatically." title="Use OCR to fill data from a picture of the Résumr or the file itself">
+                            <setting id="recruitment_extract_settings" string="Résumé Digitization (OCR)" company_dependent="1" help="Digitize your résumé to extract name, email and the skills automatically." title="Use OCR to fill data from a picture of the Résumr or the file itself">
                                 <field name="module_hr_recruitment_extract" widget="upgrade_boolean"/>
                             </setting>
                         </block>

--- a/addons/hr_recruitment_skills/models/hr_applicant.py
+++ b/addons/hr_recruitment_skills/models/hr_applicant.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import fields, models, api, _
+from odoo.exceptions import UserError
 
 
 class HrApplicant(models.Model):
@@ -8,3 +9,49 @@ class HrApplicant(models.Model):
 
     candidate_skill_ids = fields.One2many(related="candidate_id.candidate_skill_ids", readonly=False)
     skill_ids = fields.Many2many(related="candidate_id.skill_ids", readonly=False)
+    matching_score = fields.Float(string="Matching Score", compute="_compute_matching_score", search="_search_matching_score",
+        help="The Matching Score reflects the match between the job positions's skills and those found in the applicant's resume.")
+    expected_skill_ids = fields.Many2many(related="job_id.skill_ids")
+
+    @api.depends('skill_ids', 'job_id.skill_ids')
+    def _compute_matching_score(self):
+        for applicant in self:
+            if not applicant.job_id.skill_ids:
+                applicant.matching_score = 0.0
+            else:
+                matching_skill_ids = applicant.job_id.skill_ids & applicant.skill_ids
+                applicant.matching_score = (len(matching_skill_ids) / len(applicant.job_id.skill_ids))
+
+    def _search_matching_score(self, operator, value):
+        if operator in ('like', 'ilike', 'not ilike', 'not like') or isinstance(value, bool):
+            raise UserError(_('Operation not supported'))
+        query = f"""
+            SELECT ha.id
+              FROM hr_applicant AS ha
+              JOIN hr_job AS hj ON hj.id = ha.job_id
+              LEFT JOIN hr_candidate AS hc ON hc.id = ha.candidate_id
+              LEFT JOIN hr_candidate_skill AS hcs ON hcs.candidate_id = hc.id
+              LEFT JOIN hr_job_hr_skill_rel AS hjs ON hjs.hr_job_id = hj.id
+              LEFT JOIN hr_skill AS hs ON hs.id = hjs.hr_skill_id
+              LEFT JOIN (
+                SELECT hr_job_id, COUNT(hr_skill_id) AS total_required_skills
+                  FROM hr_job_hr_skill_rel
+              GROUP BY hr_job_id
+              ) AS required_skills ON required_skills.hr_job_id = ha.job_id
+              LEFT JOIN (
+                    SELECT ha.id AS applicant_id, COUNT(DISTINCT hcs.skill_id) AS total_matched_skills
+                      FROM hr_applicant AS ha
+                      JOIN hr_candidate AS hc ON hc.id = ha.candidate_id
+                      JOIN hr_candidate_skill AS hcs ON hcs.candidate_id = hc.id
+                      JOIN hr_job_hr_skill_rel AS hjs ON hjs.hr_job_id = ha.job_id
+                     WHERE hcs.skill_id = hjs.hr_skill_id
+                  GROUP BY ha.id
+              ) AS matched_skills ON matched_skills.applicant_id = ha.id
+             WHERE ha.job_id IS NOT NULL
+          GROUP BY ha.id, required_skills.total_required_skills, matched_skills.total_matched_skills
+            HAVING
+                COALESCE((matched_skills.total_matched_skills * 100.0) / required_skills.total_required_skills, 0) {operator} {value}
+        """
+        self.env.cr.execute(query)
+        applicant_ids = [applicant[0] for applicant in self.env.cr.fetchall()]
+        return [('id', 'in', applicant_ids)]

--- a/addons/hr_recruitment_skills/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment_skills/views/hr_applicant_views.xml
@@ -5,6 +5,9 @@
         <field name="model">hr.applicant</field>
         <field name="inherit_id" ref="hr_recruitment.hr_applicant_view_form"/>
         <field name="arch" type="xml">
+            <field name="categ_ids" position="after">
+                <field name="matching_score" invisible="not expected_skill_ids" widget="percentage"/>
+            </field>
             <notebook position="inside">
                 <page string="Skills">
                     <div class="row ms-2">


### PR DESCRIPTION
In this PR, a new field named "matching score" is created. 
This field will display the matching score between the skills required for the job position and the applicant's skills.
The matching score field will not be displayed if the job position has no expected skills.

Task-4163423





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
