### PR TITLE
[FIX] base: fix test_signaling_01_multiple

### DIFF
--- a/odoo/addons/base/tests/test_ormcache.py
+++ b/odoo/addons/base/tests/test_ormcache.py
@@ -7,7 +7,7 @@ from threading import Thread, Barrier
 
 
 @tagged('-at_install', 'post_install')
-class TestOrmcache(TransactionCase):
+class TestOrmCache(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -15,6 +15,10 @@ class TestOrmcache(TransactionCase):
             raise AssertionError('Registry should not be invalidated when starting this test')
         # this test verifies the actual side effects of signaling changes
         cls._signal_changes_patcher.stop()
+        # if something invalidate the cache or registry before test_signaling_01_multiple, 
+        # the test may fail the first time but succeed on retry
+        # disabling autoretry to avoid hidding "real" errrors
+        cls._retry = False
 
     def test_ormcache(self):
         """ Test the effectiveness of the ormcache() decorator. """

--- a/odoo/addons/base/tests/test_ormcache.py
+++ b/odoo/addons/base/tests/test_ormcache.py
@@ -13,9 +13,12 @@ class TestOrmCache(TransactionCase):
         super().setUpClass()
         if cls.registry.registry_invalidated:
             raise AssertionError('Registry should not be invalidated when starting this test')
+        if cls.registry.cache_invalidated:
+            raise AssertionError('Cache should not be invalidated when starting this test')
+
         # this test verifies the actual side effects of signaling changes
         cls._signal_changes_patcher.stop()
-        # if something invalidate the cache or registry before test_signaling_01_multiple, 
+        # if something invalidate the cache or registry before test_signaling_01_multiple,
         # the test may fail the first time but succeed on retry
         # disabling autoretry to avoid hidding "real" errrors
         cls._retry = False

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -805,6 +805,7 @@ class TransactionCase(BaseCase):
         cls.registry = odoo.registry(get_db_name())
         cls.registry_start_invalidated = cls.registry.registry_invalidated
         cls.registry_start_sequence = cls.registry.registry_sequence
+        cls.registry_cache_sequences = dict(cls.registry.cache_sequences)
 
         def reset_changes():
             if (cls.registry_start_sequence != cls.registry.registry_sequence) or cls.registry.registry_invalidated:
@@ -815,6 +816,7 @@ class TransactionCase(BaseCase):
             with cls.muted_registry_logger:
                 cls.registry.clear_all_caches()
             cls.registry.cache_invalidated.clear()
+            cls.registry.cache_sequences = cls.registry_cache_sequences
         cls.addClassCleanup(reset_changes)
 
         def signal_changes():


### PR DESCRIPTION
The test `test_signaling_01_multiple` may fail if the sequence changed during another test. A fix was made to reset the registry sequence but the cache sequence remains an issue.

This should solve the issue by resetting the sequence at the end of each test.

The tour test_ir_model_fields_translation was used with test_signaling_01_multiple to reproduce the issue.

Auto retry is also disabled on this test to avoid the same issue in the future.