### PR TITLE
[FIX] *: fix incorrect URLs in Templates

### DIFF
--- a/addons/hr_recruitment_survey/views/survey_templates_statistics.xml
+++ b/addons/hr_recruitment_survey/views/survey_templates_statistics.xml
@@ -4,7 +4,7 @@
     <template id="hr_recruitment_survey_button_form_view" inherit_id="survey.survey_button_form_view">
         <xpath expr="//div[hasclass('survey_button_form_view_hook')]" position="inside">
             <a t-if="(env.user.has_group('hr_recruitment.group_hr_recruitment_manager') and survey.survey_type == 'recruitment')"
-                t-attf-href="/odoo/action-hr_recruitment_survey.survey_survey_action_recruitment/{survey.id}"
+                t-attf-href="/odoo/action-hr_recruitment_survey.survey_survey_action_recruitment/{{survey.id}}"
                 class="ms-2">
                 <i class="oi oi-fw oi-arrow-right"/>Go to Recruitment
             </a>

--- a/addons/mass_mailing/views/mailing_templates_portal_management.xml
+++ b/addons/mass_mailing/views/mailing_templates_portal_management.xml
@@ -10,7 +10,7 @@
                             <p>
                                 Mailing Reports have been turned off for all users. <br/>
                                 If needed, they can be turned back on from the
-                                <a t-if="menu_id" t-attf-href="/odoo?menu_id={menu_id}">
+                                <a t-if="menu_id" t-attf-href="/odoo?menu_id={{menu_id}}">
                                     Settings Menu.
                                 </a>
                                 <t t-else="">

--- a/addons/microsoft_outlook/views/templates.xml
+++ b/addons/microsoft_outlook/views/templates.xml
@@ -6,7 +6,7 @@
             <div class="alert alert-warning w-50 mx-auto" role="alert">
                 <t t-esc="error"/>
                 <br/>
-                <a t-attf-href="/odoo/{model_name}/{rec_id}">
+                <a t-attf-href="/odoo/{{model_name}}/{{rec_id}}">
                     Go back to your mail server
                 </a>
             </div>

--- a/addons/survey/views/survey_templates_management.xml
+++ b/addons/survey/views/survey_templates_management.xml
@@ -13,7 +13,7 @@
                     <h1 class="mt32">403: Forbidden</h1>
                     <p>The page you were looking for could not be authorized.</p>
                     <p>Maybe you were looking for
-                        <a t-attf-href="/odoo/action-survey.action_survey_form/{survey.id}">this page</a> ?
+                        <a t-attf-href="/odoo/action-survey.action_survey_form/{{survey.id}}">this page</a> ?
                     </p>
                 </div>
             </div>
@@ -99,7 +99,7 @@
         <div t-ignore="true" class="alert alert-info p-2 border-0 rounded-0 d-print-none css_editable_mode_hidden mb-0 text-center">
             <p class="mb-1">This is a Test Survey Entry.</p>
             <div class="survey_button_form_view_hook d-inline-block">
-                <a t-if="env.user.has_group('survey.group_survey_user')" t-attf-href="/odoo/action-survey.action_survey_form/{survey.id}">
+                <a t-if="env.user.has_group('survey.group_survey_user')" t-attf-href="/odoo/action-survey.action_survey_form/{{survey.id}}">
                     <i class="oi oi-fw oi-arrow-right"/>Go to Survey</a>
             </div>
         </div>

--- a/addons/website_blog/views/website_blog_components.xml
+++ b/addons/website_blog/views/website_blog_components.xml
@@ -307,7 +307,7 @@ Display a sidebar beside the post content.
             <t t-else="">
                 <div class="mb-4 bg-100 py-2 px-3 border" groups="website.group_website_designer">
                     <h6 class="text-muted"><em>No tags defined</em></h6>
-                    <a role="menuitem" t-attf-href="/odoo/action-{action}/{main_object.id}?menu_id={menu or main_object.env.ref('website.menu_website_configuration').id}"
+                    <a role="menuitem" t-attf-href="/odoo/action-{{action}}/{{main_object.id}}?menu_id={{menu or main_object.env.ref('website.menu_website_configuration').id}}"
                         title='Edit in backend' id="edit-in-backend">Add some</a>
                 </div>
             </t>

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -391,7 +391,7 @@
 
 <!-- Button to configure Tickets -->
 <template id="registration_configure_tickets_button" name="Registration Configure Ticket Button">
-    <a t-attf-class="o_not_editable text-nowrap {{linkClasses or '' }}" t-attf-href="/odoo/event.event/{event.id}?menu_id={backend_menu_id}" role="link"  title="Configure event tickets">
+    <a t-attf-class="o_not_editable text-nowrap {{linkClasses or '' }}" t-attf-href="/odoo/event.event/{{event.id}}?menu_id={{backend_menu_id}}" role="link"  title="Configure event tickets">
         <i class="fa fa-gear me-1" role="img" aria-label="Configure" title="Configure event tickets"/><em>Configure Tickets</em>
     </a>
 </template>

--- a/addons/website_event_booth/views/event_booth_templates.xml
+++ b/addons/website_event_booth/views/event_booth_templates.xml
@@ -29,7 +29,7 @@
                             <p>This event is not open to exhibitors registration at this time.</p>
                             <p>Check our <a href="/event" title="List of Future Events" aria-label="Link to list of future events">list of future events</a>.</p>
                             <div class="o_not_editable my-3" groups="event.group_event_manager">
-                                <a class="btn o_wevent_cta mb-4" target="_blank" t-attf-href="/odoo/event.event/{event.id}">
+                                <a class="btn o_wevent_cta mb-4" target="_blank" t-attf-href="/odoo/event.event/{{event.id}}">
                                     <span class="fa fa-gear me-1"/> Configure Booths
                                 </a>
                             </div>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2876,7 +2876,7 @@
                 'bg-danger'}">
                 <div class="card-header">
                     <a role="button" groups="base.group_system" class="btn btn-sm btn-link text-white float-end" target="_blank" aria-label="Edit" title="Edit"
-                            t-attf-href="/odoo/action-payment.action_payment_provider/{tx_sudo.provider_id.id}">
+                            t-attf-href="/odoo/action-payment.action_payment_provider/{{tx_sudo.provider_id.id}}">
                         <i class="fa fa-pencil"></i>
                     </a>
                     <t t-if="tx_sudo.state == 'pending'">

--- a/addons/website_sale_slides/views/website_slides_templates.xml
+++ b/addons/website_sale_slides/views/website_slides_templates.xml
@@ -83,7 +83,7 @@
         <div t-if="channel.enroll == 'payment' and not channel.product_id.is_published"
             class="alert alert-info" role="alert" groups="website_slides.group_website_slides_officer">
             This course cannot be bought because its linked product
-            <a t-attf-href="/odoo/action-website_sale.product_template_action_website/{channel.product_id.product_tmpl_id.id}"
+            <a t-attf-href="/odoo/action-website_sale.product_template_action_website/{{channel.product_id.product_tmpl_id.id}}"
                 class="alert-link" t-out="channel.product_id.name"/>
             is not published.
         </div>

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -631,7 +631,7 @@
             </t>
             <span t-if="channel.can_publish" class="d-none d-md-flex">
                 <a t-if="slide.slide_category == 'article'" class="mx-2 o_text_link text-primary o_not_editable" target="_blank" t-attf-href="/slides/slide/#{slug(slide)}?enable_editor=1" title="Edit"><span class="fa fa-pencil"/></a>
-                <a t-else="" class="mx-2 o_text_link text-primary o_not_editable" target="_blank" t-attf-href="/odoo/action-{slide_action}/{slide.id}" title="Edit in backend"><span class="fa fa-pencil"/></a>
+                <a t-else="" class="mx-2 o_text_link text-primary o_not_editable" target="_blank" t-attf-href="/odoo/action-{{slide_action}}/{{slide.id}}" title="Edit in backend"><span class="fa fa-pencil"/></a>
                 <a href="#" t-att-data-slide-id="slide.id" class="o_text_link text-danger mx-2 o_wslides_js_slide_archive o_not_editable" title="Delete"><span class="fa fa-trash"/></a>
             </span>
         </div>


### PR DESCRIPTION
Since the migration from the old URLs to the new user-friendly URLs, some typos were introduced in the templates. The syntax of the parameters of the Qweb dynamic attributes was not respected. This leads to incorrectly generated URLs.

task-id 3820230