### PR TITLE
[FIX] html_editor: restore selection not inEditable

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -126,6 +126,7 @@ export class SelectionPlugin extends Plugin {
     });
 
     setup() {
+        this.canApplySelectionToDocument = true;
         this.resetSelection();
         this.addDomListener(this.document, "selectionchange", this.updateActiveSelection);
         this.addDomListener(this.editable, "mousedown", (ev) => {
@@ -432,15 +433,38 @@ export class SelectionPlugin extends Plugin {
         [focusNode, focusOffset] = normalizeFakeBR(focusNode, focusOffset);
         const selection = this.document.getSelection();
         if (selection) {
-            if (
-                selection.anchorNode !== anchorNode ||
-                selection.focusNode !== focusNode ||
-                selection.anchorOffset !== anchorOffset ||
-                selection.focusOffset !== focusOffset
-            ) {
-                selection.setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset);
+            if (this.canApplySelectionToDocument) {
+                if (
+                    selection.anchorNode !== anchorNode ||
+                    selection.focusNode !== focusNode ||
+                    selection.anchorOffset !== anchorOffset ||
+                    selection.focusOffset !== focusOffset
+                ) {
+                    selection.setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset);
+                }
+                this.activeSelection = this.makeActiveSelection(selection, true);
+            } else {
+                let range = new Range();
+                range.setStart(anchorNode, anchorOffset);
+                range.setEnd(focusNode, focusOffset);
+                if (anchorNode !== focusNode || anchorOffset !== focusOffset) {
+                    // Check if the direction is correct
+                    if (range.collapsed) {
+                        range = new Range();
+                        range.setEnd(anchorNode, anchorOffset);
+                        range.setStart(focusNode, focusOffset);
+                    }
+                }
+
+                this.activeSelection = this.makeActiveSelection({
+                    anchorNode,
+                    anchorOffset,
+                    focusNode,
+                    focusOffset,
+                    getRangeAt: () => range,
+                    rangeCount: 1,
+                });
             }
-            this.activeSelection = this.makeActiveSelection(selection, true);
         }
 
         return this.activeSelection;
@@ -475,16 +499,12 @@ export class SelectionPlugin extends Plugin {
         const anchor = { node: selection.anchorNode, offset: selection.anchorOffset };
         const focus = { node: selection.focusNode, offset: selection.focusOffset };
 
-        let documentSelectionToRestore;
-        if (!selectionData.documentSelectionIsInEditable) {
-            documentSelectionToRestore = selectionData.documentSelection;
-        }
+        this.canApplySelectionToDocument = selectionData.documentSelectionIsInEditable;
         return {
             restore: () => {
                 if (selection.isDefault) {
                     return;
                 }
-                // update the active selection
                 this.setSelection(
                     {
                         anchorNode: anchor.node,
@@ -494,14 +514,7 @@ export class SelectionPlugin extends Plugin {
                     },
                     { normalize: false }
                 );
-
-                if (documentSelectionToRestore && documentSelectionToRestore.anchorNode) {
-                    const { anchorNode, anchorOffset, focusNode, focusOffset } =
-                        documentSelectionToRestore;
-                    this.document
-                        .getSelection()
-                        .setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset);
-                }
+                this.canApplySelectionToDocument = true;
             },
             update(callback) {
                 callback(anchor);

--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -78,10 +78,7 @@ export class ToolbarPlugin extends Plugin {
             case "CONTENT_UPDATED":
                 if (this.overlay.isOpen) {
                     const selectionData = this.shared.getSelectionData();
-                    if (
-                        !selectionData.documentSelectionIsInEditable ||
-                        selectionData.editableSelection.isCollapsed
-                    ) {
+                    if (selectionData.editableSelection.isCollapsed) {
                         this.overlay.close();
                     } else {
                         this.updateButtonsStates(selectionData.editableSelection);

--- a/addons/html_editor/static/tests/selection.test.js
+++ b/addons/html_editor/static/tests/selection.test.js
@@ -1,12 +1,14 @@
 import { describe, expect, test } from "@odoo/hoot";
-import { press, queryFirst } from "@odoo/hoot-dom";
+import { getActiveElement, press, queryFirst, queryOne } from "@odoo/hoot-dom";
 import { animationFrame, tick } from "@odoo/hoot-mock";
+import { Component, xml } from "@odoo/owl";
 import { patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { useAutofocus } from "@web/core/utils/hooks";
 import { Plugin } from "../src/plugin";
 import { MAIN_PLUGINS } from "../src/plugin_sets";
 import { setupEditor } from "./_helpers/editor";
 import { getContent } from "./_helpers/selection";
-import { tripleClick } from "./_helpers/user_actions";
+import { insertText, tripleClick } from "./_helpers/user_actions";
 
 test("getEditableSelection should work, even if getSelection returns null", async () => {
     const { editor } = await setupEditor("<p>a[b]</p>");
@@ -157,4 +159,54 @@ test("press 'ctrl+a' in 'contenteditable' should only select his content", async
     expect(getContent(el)).toBe(
         `<div contenteditable="false"><p contenteditable="true">[ab]</p><p contenteditable="true">cd</p></div>`
     );
+});
+
+test("restore a selection when you are not in the editable shouldn't move the focus", async () => {
+    class TestInput extends Component {
+        static template = xml`<input t-ref="input" t-att-value="'eee'" class="test"/>`;
+        static props = ["*"];
+
+        setup() {
+            useAutofocus({ refName: "input", mobile: true });
+        }
+    }
+
+    class TestPlugin extends Plugin {
+        static name = "test";
+        static dependencies = ["overlay"];
+        static resources = (p) => ({
+            powerboxItems: [
+                {
+                    category: "widget",
+                    name: "Test",
+                    action() {
+                        p.showOverlay();
+                    },
+                },
+            ],
+        });
+
+        setup() {
+            this.overlay = this.shared.createOverlay(TestInput);
+        }
+
+        showOverlay() {
+            this.overlay.open({
+                props: {},
+            });
+        }
+    }
+
+    const { editor } = await setupEditor("<p>te[]st</p>", {
+        config: { Plugins: [...MAIN_PLUGINS, TestPlugin] },
+    });
+    insertText(editor, "/test");
+    press("enter");
+    await animationFrame();
+    expect(getActiveElement()).toBe(queryOne("input.test"));
+
+    // Something trigger restore
+    const cursors = editor.shared.preserveSelection();
+    cursors.restore();
+    expect(getActiveElement()).toBe(queryOne("input.test"));
 });

--- a/addons/html_editor/static/tests/tags.test.js
+++ b/addons/html_editor/static/tests/tags.test.js
@@ -435,7 +435,7 @@ describe("to blockquote", () => {
         expect(getContent(el)).toBe("<p>abcd</p>");
 
         setTag("h1")(editor);
-        expect(getContent(el)).toBe("<h1>ab[]cd</h1>");
+        expect(getContent(el)).toBe("<h1>abcd</h1>");
     });
 
     test("setTag should work when we move the selection outside of the editor", async () => {


### PR DESCRIPTION
The goal of this commit is that when we are outside the editor (for example in the input of an overlay) and something executes preserveSelection + restore then the focus must not change. It must stay in the ovelay input.

We therefore need to ensure that any setSelection called between preserveSelection and restore updtate the activeSelection without modifying the document selection, so as not to modify the focus.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
