### PR TITLE
[FIX] web_editor, website: prevent error when deleting image

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -5590,7 +5590,7 @@ registry.ReplaceMedia = SnippetOptionWidget.extend({
      */
     _computeWidgetState(methodName, params) {
         const parentEl = this.$target[0].parentElement;
-        const linkEl = parentEl.tagName === 'A' ? parentEl : null;
+        const linkEl = parentEl && parentEl.tagName === 'A' ? parentEl : null;
         switch (methodName) {
             case 'setLink': {
                 return linkEl ? 'true' : '';

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -1116,7 +1116,8 @@ options.registry.ReplaceMedia.include({
         URLWidgetEl.title = _t("Hint: Type '/' to search an existing page and '#' to link to an anchor.");
         oldURLWidgetEl.replaceWith(URLWidgetEl);
 
-        const hrefValue = this.$target[0].parentElement.getAttribute('href');
+        const parentEl = this.$target[0].parentElement;
+        const hrefValue = parentEl ? parentEl.getAttribute("href") : null;
         if (!hrefValue || !hrefValue.startsWith('/')) {
             return;
         }


### PR DESCRIPTION
Steps to reproduce:

- Navigate to website et open the editor.
- Drop an "Images Wall" block in the web editor.
- Delete the images one by one.
- Issue: At some point, a traceback occurs: `this.$target[0].parentElement` is null.

The error is triggered since [1] when trying to access parentElement of a deleted image, which is null.

This commit resolves the issue by ensuring that the parentElement attribute is only accessed when it is not null, preventing the traceback when deleting images from the "Images Wall" block.

[1]: https://github.com/odoo/odoo/commit/7c8323e816062f44f940a0bee2b69a11510b09db

task-4149807
