### PR TITLE
[FIX] stock_fleet: prevent the error when try to save without Dock Location

### DIFF
--- a/addons/stock_fleet/models/stock_picking_batch.py
+++ b/addons/stock_fleet/models/stock_picking_batch.py
@@ -77,5 +77,6 @@ class StockPickingBatch(models.Model):
         if self.dock_id:
             self.move_ids.write({'location_dest_id': self.dock_id.id})
         else:
-            for picking in self:
-                picking.move_ids.write({'location_dest_id': picking.location_dest_id.id})
+            for batch in self:
+                for picking in batch.picking_ids:
+                    picking.move_ids.write({'location_dest_id': picking.location_dest_id.id})


### PR DESCRIPTION
This error occurs when attempting to save a ``Batch Transfer`` without specifying a ``Dock Location``.

Steps to reproduce:
- Install the ``stock_fleet`` module
- Activate ``Storage Locations`` in Configuration of Inventory
- Now go to ``Batch Transfers`` in Operations and Create new
- Now add ``Dock Location`` and save
- Now Remove ``Dock Location`` and save

Traceback: 
``AttributeError: 'stock.picking.batch' object has no attribute 'location_dest_id'``

The error in [1] occurred because the ``location_dest_id`` field is not part of the ``stock.picking.batch`` model but belongs to the ``stock.picking`` model.

This commit resolves the error by adding ``picking_ids``, allowing us to retrieve the ``location_dest_id``.

[1]- https://github.com/odoo/odoo/blob/45e75693e8ee4f8cf9af842cd2facd4f2f6356d8/addons/stock_fleet/models/stock_picking_batch.py#L81

sentry-5825702049

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
