### PR TITLE
[FIX] analytic: prevents override timesheet

### DIFF
--- a/addons/analytic/tests/test_analytic_account.py
+++ b/addons/analytic/tests/test_analytic_account.py
@@ -217,6 +217,11 @@ class TestAnalyticAccount(TransactionCase):
         """
         Test that an analytic account defined in a parent company is accessible in its branches (children)
         """
+        # timesheet adds a rule to forcer a project_id; account overrides it
+        timesheet_group = self.env.ref('hr_timesheet.group_hr_timesheet_user', raise_if_not_found=False)
+        if timesheet_group:
+            self.env.user.groups_id -= timesheet_group
+
         self.analytic_account_1.company_id = self.company_data
         self.env['account.analytic.line'].create({
             'name': 'company specific account',


### PR DESCRIPTION
Steps to reproduce:
- install only `timesheet_grid`
- run `test_analytic_account_branches`

Issue:
An access error is raised

Cause:
https://github.com/odoo/odoo/blob/8029b467dacaf9e34b21db52b148a2963efb29e4/addons/hr_timesheet/security/hr_timesheet_security.xml#L33-L44
So the analytic line should have a project_id set.

Solution:
Unlkink the groupe if existing

runbot-97783