### PR TITLE
[FIX] product: catalog ux manual edit

### DIFF
--- a/addons/product/static/src/product_catalog/kanban_controller.js
+++ b/addons/product/static/src/product_catalog/kanban_controller.js
@@ -3,6 +3,7 @@
 import { KanbanController } from "@web/views/kanban/kanban_controller";
 import { onWillStart } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
+import { useDebounced } from "@web/core/utils/timing";
 import { _t } from "@web/core/l10n/translation";
 
 export class ProductCatalogKanbanController extends KanbanController {
@@ -14,6 +15,7 @@ export class ProductCatalogKanbanController extends KanbanController {
         this.orm = useService("orm");
         this.orderId = this.props.context.order_id;
         this.orderResModel = this.props.context.product_catalog_order_model;
+        this.backToQuotationDebounced = useDebounced(this.backToQuotation, 500)
 
         onWillStart(async () => this._defineButtonContent());
     }

--- a/addons/product/static/src/product_catalog/kanban_controller.xml
+++ b/addons/product/static/src/product_catalog/kanban_controller.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="ProductCatalogKanbanController" t-inherit="web.KanbanView" t-inherit-mode="primary">
         <xpath expr="//button[hasclass('o-kanban-button-new')]" position="replace">
-            <button t-out="this.buttonString" type="button" class="btn btn-secondary o-kanban-button-back" t-on-click="this.backToQuotation"/>
+            <button t-out="this.buttonString" type="button" class="btn btn-secondary o-kanban-button-back" t-on-click="this.backToQuotationDebounced"/>
         </xpath>
     </t>
 </templates>

--- a/addons/product/static/src/product_catalog/order_line/order_line.js
+++ b/addons/product/static/src/product_catalog/order_line/order_line.js
@@ -13,6 +13,14 @@ export class ProductCatalogOrderLine extends Component {
         warning: { type: String, optional: true},
     };
 
+    /**
+     * Focus input text when clicked
+     * @param {Event} ev 
+     */
+    _onFocus(ev) {
+        ev.target.select();
+    }
+
     //--------------------------------------------------------------------------
     // Private
     //--------------------------------------------------------------------------

--- a/addons/product/static/src/product_catalog/order_line/order_line.xml
+++ b/addons/product/static/src/product_catalog/order_line/order_line.xml
@@ -30,7 +30,9 @@
                 <input class="o_input form-control border text-center text-bg-light"
                         type="number"
                         t-att-value="quantity"
-                        t-on-change="this.env.setQuantity"/>
+                        t-on-change="this.env.setQuantity"
+                        t-on-focus="_onFocus"
+                />
                 <button class="btn btn-primary border"
                         t-on-click.stop="(ev) => this.env.increaseQuantity()">
                     <i class="fa fa-plus"/>


### PR DESCRIPTION
When a user clicks in the catalog record input to change the quantity manually the input content isn't autoselect and the user has to delete the former one to enter the desired value. Autoselecting the value seems more conveniant in the majority of cases.

Also, after one of these edits, if the user click right away in the Back to order button, the redirection to the order form will too fast and it will miss the last edition.

Current behavior before PR:

![Peek 12-09-2024 11-29](https://github.com/user-attachments/assets/7ab2d27a-5fc9-4d0c-af54-4f4bfa33c374)


Desired behavior after PR is merged:

![after](https://github.com/user-attachments/assets/e96f97a4-fb08-4b9f-bf60-45c6e0662210)


@Tecnativa
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
