### PR TITLE
[FIX] account: account_root search fails in multicompany

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1817,7 +1817,7 @@ class AccountMoveLine(models.Model):
             return {}
 
         # Override in order to not read the complete move line table and use the index instead
-        query_account = self.env['account.account']._search([('company_ids', 'in', self.env.companies.ids)])
+        query_account = self.env['account.account']._search([('company_ids', 'in', self.env.companies.ids), ('code', '!=', False)])
         account_code_alias = self.env['account.account']._field_to_sql('account_account', 'code', query_account)
 
         query_line = self._search(domain, limit=1)


### PR DESCRIPTION
To reproduce:
Have a company with 2 different CoA (Belgian/USA for instance) 
Go on Balance Sheet
Audit a line

=> Traceback

We should enforce that we don't have a bool when using accumulate




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
