### PR TITLE
[FIX] mail, im_livechat: download files crashes with guest user

### DIFF
--- a/addons/im_livechat/static/src/embed/common/disabled_features.js
+++ b/addons/im_livechat/static/src/embed/common/disabled_features.js
@@ -1,15 +1,7 @@
-import { messageActionsRegistry } from "@mail/core/common/message_actions";
 import { threadActionsRegistry } from "@mail/core/common/thread_actions";
 import { Thread } from "@mail/core/common/thread_model";
 
 import { patch } from "@web/core/utils/patch";
-
-const downloadFilesAction = messageActionsRegistry.get("download_files");
-patch(downloadFilesAction, {
-    condition(component) {
-        return component.message.thread.channel_type !== "livechat" && super.condition(component);
-    },
-});
 
 patch(Thread.prototype, {
     get hasMemberList() {

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -175,7 +175,8 @@ messageActionsRegistry
         sequence: 90,
     })
     .add("download_files", {
-        condition: (component) => component.message.attachment_ids.length > 1,
+        condition: (component) =>
+            component.message.attachment_ids.length > 1 && component.store.self.isInternalUser,
         icon: "fa-download",
         title: _t("Download Files"),
         onClick: (component) =>


### PR DESCRIPTION
Download files are restricted to the internal users by acl. This commit adapts 
the UI so the feature would not be available for non-internal users.

Steps to reproduce:
- Go to a public channel as a guest
- Send a message with multiple attachments
- Try to download all of them by clicking on `Download Files` in the message 
action menu
- It crashes with Forbidden error