### PR TITLE
[FIX] html_editor: icon bar shouldn't appear when selecting rating star

### DIFF
--- a/addons/html_editor/static/src/main/media/icon_plugin.js
+++ b/addons/html_editor/static/src/main/media/icon_plugin.js
@@ -16,7 +16,7 @@ export class IconPlugin extends Plugin {
                                 // All nodes should be icons, its ZWS child or its ancestors
                                 node.classList?.contains("fa") ||
                                 node.parentElement.classList.contains("fa") ||
-                                node.querySelector?.(".fa")
+                                (node.querySelector?.(".fa") && node.isContentEditable !== false)
                         ),
                 },
             ],

--- a/addons/html_editor/static/tests/icon.test.js
+++ b/addons/html_editor/static/tests/icon.test.js
@@ -2,6 +2,7 @@ import { expect, test } from "@odoo/hoot";
 import { click, waitFor } from "@odoo/hoot-dom";
 import { setupEditor } from "./_helpers/editor";
 import { animationFrame } from "@odoo/hoot-mock";
+import { setContent } from "./_helpers/selection";
 
 test("icon toolbar is displayed", async () => {
     await setupEditor(`<p><span class="fa fa-glass">[]</span></p>`);
@@ -19,6 +20,18 @@ test("icon toolbar is displayed (3)", async () => {
     await setupEditor(`<p>abc[<span class="fa fa-glass"></span>]def</p>`);
     await waitFor(".o-we-toolbar");
     expect(".btn-group[name='icon_size']").toHaveCount(1);
+});
+
+test("icon toolbar is not displayed on rating stars", async () => {
+    const { el } = await setupEditor(`<p>[<span class="fa fa-glass"></span>]</p>`);
+    await waitFor(".o-we-toolbar");
+    expect(".btn-group[name='icon_size']").toHaveCount(1);
+    setContent(
+        el,
+        `<p>\u200B<span contenteditable="false" class="o_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i>[<i class="fa fa-star-o" contenteditable="false">\u200B</i></span>]\u200B</p>`
+    );
+    await animationFrame();
+    expect(".btn-group[name='icon_size']").toHaveCount(0);
 });
 
 test("toolbar should not be namespaced for icon", async () => {


### PR DESCRIPTION
Before this commit: icon bar appears when selecting part of the rating stars
After this commit: icon bar doesn't show up on rating stars

Idealy we would want to check the contentEditable in the toolbar plugin
But since the icons are contentEditable false and the icon toolbar
exists, we want to make sure when the icon is inside a contentEditable
false node, the icon toolbar shouldn't be displayed


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
