### PR TITLE
[FIX] point_of_sale: ensure correct display of all order lines in the report

### DIFF
--- a/addons/point_of_sale/report/pos_order_report.py
+++ b/addons/point_of_sale/report/pos_order_report.py
@@ -40,19 +40,30 @@ class PosOrderReport(models.Model):
 
     def _select(self):
         return """
+            -- The purpose of this CTE is to map each "pos_order_line" to the "payment_method_id" corresponding to its "pos_order"
+            -- considering we always show the first "payment_method_id"
+            WITH payment_method_by_order_line AS (
+                SELECT
+                    pol.id AS pos_order_line_id,
+                    (array_agg(pm.payment_method_id))[1] AS payment_method_id
+                FROM pos_order_line pol
+                LEFT JOIN pos_order po ON (po.id = pol.order_id)
+                LEFT JOIN pos_payment pm ON (pm.pos_order_id=po.id)
+                GROUP BY pol.id
+            )
             SELECT
-                MIN(l.id) AS id,
-                COUNT(*) AS nbr_lines,
+                l.id AS id,
+                1 AS nbr_lines, -- number of lines in order line is always 1
                 s.date_order AS date,
-                SUM(l.qty) AS product_qty,
-                SUM(l.qty * l.price_unit / CASE COALESCE(s.currency_rate, 0) WHEN 0 THEN 1.0 ELSE s.currency_rate END) AS price_sub_total,
-                SUM(ROUND((l.price_subtotal_incl) / CASE COALESCE(s.currency_rate, 0) WHEN 0 THEN 1.0 ELSE s.currency_rate END, cu.decimal_places)) AS price_total,
-                SUM((l.qty * l.price_unit) * (l.discount / 100) / CASE COALESCE(s.currency_rate, 0) WHEN 0 THEN 1.0 ELSE s.currency_rate END) AS total_discount,
+                l.qty AS product_qty,
+                l.qty * l.price_unit / COALESCE(NULLIF(s.currency_rate, 0), 1.0) AS price_sub_total,
+                ROUND((l.price_subtotal_incl) / COALESCE(NULLIF(s.currency_rate, 0), 1.0), cu.decimal_places) AS price_total,
+                (l.qty * l.price_unit) * (l.discount / 100) / COALESCE(NULLIF(s.currency_rate, 0), 1.0) AS total_discount,
                 CASE
-                    WHEN SUM(l.qty * u.factor) = 0 THEN NULL
-                    ELSE (SUM(l.qty*l.price_unit / CASE COALESCE(s.currency_rate, 0) WHEN 0 THEN 1.0 ELSE s.currency_rate END)/SUM(l.qty * u.factor))::decimal
+                    WHEN l.qty * u.factor = 0 THEN NULL
+                    ELSE (l.qty*l.price_unit / COALESCE(NULLIF(s.currency_rate, 0), 1.0))/(l.qty * u.factor)::decimal
                 END AS average_price,
-                SUM(cast(to_char(date_trunc('day',s.date_order) - date_trunc('day',s.create_date),'DD') AS INT)) AS delay_validation,
+                cast(to_char(date_trunc('day',s.date_order) - date_trunc('day',s.create_date),'DD') AS INT) AS delay_validation,
                 s.id as order_id,
                 s.partner_id AS partner_id,
                 s.state AS state,
@@ -66,7 +77,7 @@ class PosOrderReport(models.Model):
                 s.pricelist_id,
                 s.session_id,
                 s.account_move IS NOT NULL AS invoiced,
-                SUM(l.price_subtotal - COALESCE(l.total_cost,0) / CASE COALESCE(s.currency_rate, 0) WHEN 0 THEN 1.0 ELSE s.currency_rate END) AS margin,
+                l.price_subtotal - COALESCE(l.total_cost,0) / COALESCE(NULLIF(s.currency_rate, 0), 1.0) AS margin,
                 pm.payment_method_id AS payment_method_id
         """
 
@@ -80,23 +91,11 @@ class PosOrderReport(models.Model):
                 LEFT JOIN pos_session ps ON (s.session_id=ps.id)
                 LEFT JOIN res_company co ON (s.company_id=co.id)
                 LEFT JOIN res_currency cu ON (co.currency_id=cu.id)
-                LEFT JOIN pos_payment pm ON (pm.pos_order_id=s.id)
-                LEFT JOIN pos_payment_method ppm ON (pm.payment_method_id=ppm.id)
+                LEFT JOIN payment_method_by_order_line pm ON (pm.pos_order_line_id=l.id)
         """
 
     def _group_by(self):
-        return """
-            GROUP BY
-                s.id, s.date_order, s.partner_id,s.state, pt.categ_id,
-                s.user_id, s.company_id, s.sale_journal,
-                s.pricelist_id, s.account_move, s.create_date, s.session_id,
-                l.product_id,
-                pt.categ_id,
-                p.product_tmpl_id,
-                ps.config_id,
-                pm.payment_method_id,
-                ppm.id
-        """
+        return ""
 
     def init(self):
         tools.drop_view_if_exists(self._cr, self._table)
@@ -104,7 +103,6 @@ class PosOrderReport(models.Model):
             CREATE OR REPLACE VIEW %s AS (
                 %s
                 %s
-                %s
             )
-        """ % (self._table, self._select(), self._from(), self._group_by())
+        """ % (self._table, self._select(), self._from())
         )

--- a/addons/point_of_sale/tests/test_report_session.py
+++ b/addons/point_of_sale/tests/test_report_session.py
@@ -112,3 +112,76 @@ class TestReportSession(TestPoSCommon):
 
         pdf = self.env['ir.actions.report']._render_qweb_pdf('point_of_sale.sale_details_report', res_ids=session_id_2)
         self.assertTrue(pdf)
+
+    def test_report_listing(self):
+        product1 = self.create_product('Product 1', self.categ_basic, 150)
+        product2 = self.create_product('Product 2', self.categ_basic, 150)
+
+        cash_payment_method = self.env['pos.payment.method'].create({
+            'name': 'Cash',
+            'receivable_account_id': self.company_data['default_account_receivable'].id,
+            'journal_id': self.company_data['default_journal_cash'].id,
+            'company_id': self.env.company.id,
+        })
+        bank_payment_method = self.env['pos.payment.method'].create({
+            'name': 'Bank',
+            'journal_id': self.company_data['default_journal_bank'].id,
+            'receivable_account_id': self.company_data['default_account_receivable'].id,
+            'company_id': self.env.company.id,
+        })
+        self.config.write({'payment_method_ids': [(4, bank_payment_method.id), (4, cash_payment_method.id)]})
+
+        self.open_new_session()
+        session = self.pos_session
+
+        self.tax_sale_a['amount'] = 10
+        order = self.env['pos.order'].create({
+            'session_id': session.id,
+            'lines': [(0, 0, {
+                'name': "TR/0001",
+                'product_id': product1.id,
+                'price_unit': 150,
+                'discount': 0,
+                'qty': 1.0,
+                'price_subtotal': 150,
+                'tax_ids': [(6, 0, self.tax_sale_a.ids)],
+                'price_subtotal_incl': 165,
+            }), (0, 0, {
+                'name': "TR/0001",
+                'product_id': product2.id,
+                'price_unit': 150,
+                'discount': 0,
+                'qty': 1.0,
+                'price_subtotal': 150,
+                'tax_ids': [(6, 0, self.tax_sale_a.ids)],
+                'price_subtotal_incl': 165,
+            })],
+            'amount_total': 330.0,
+            'amount_tax': 30.0,
+            'amount_paid': 0.0,
+            'amount_return': 0.0,
+        })
+        payment_context = {"active_ids": order.ids, "active_id": order.id}
+
+        order_payment = self.env['pos.make.payment'].with_context(**payment_context).create([{
+            'amount': am,
+            'payment_method_id': pm
+        } for am in [65, 100] for pm in [cash_payment_method.id, bank_payment_method.id]])
+        for payment in order_payment:
+            payment.with_context(**payment_context).check()
+
+        order_report_lines = self.env['report.pos.order'].sudo().search([('order_id', '=', order.id)])
+
+        self.assertEqual(len(order_report_lines), 2)
+        self.assertEqual(order_report_lines[0].payment_method_id.id, order_report_lines[1].payment_method_id.id)
+
+        for order in order_report_lines:
+            self.assertEqual(order.price_total, 165.0)
+            self.assertEqual(order.nbr_lines, 1)
+            self.assertEqual(order.product_qty, 1)
+
+        order_report_lines_count_product1 = self.env['report.pos.order'].sudo().search_count([('product_id', '=', product1.id)])
+        order_report_lines_count_product2 = self.env['report.pos.order'].sudo().search_count([('product_id', '=', product2.id)])
+
+        self.assertEqual(order_report_lines_count_product1, 1)
+        self.assertEqual(order_report_lines_count_product2, 1)


### PR DESCRIPTION
Problem:
The query generating the report view has several issues:
- The ID for the POS order line is set using `MIN(l.id) AS id`, which causes only the first order line for each order to be displayed, instead of all order lines.
- For mapping the `payment_method_id`, the query uses `order_id`, which results in duplicated records. When multiple payment methods are used for a single order (as in the given ticket), the report shows an order line for each payment method. Consequently, all aggregations are multiplied by the number of `payment_method_id` entries for that order.

Steps to reproduce:

- Open POS.
- Add two products with different quantities.
- Use two different payment methods during checkout.
- Go to the orders report of that shop.
- In the list, click on the order you just created.
- Notice that many values are incorrectly multiplied by the number of `payment_method_id` entries.

opw-4171674

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
