### PR TITLE
[IMP] website: add a link to analytics page in the Plausible settings

### DIFF
--- a/addons/website/views/res_config_settings_views.xml
+++ b/addons/website/views/res_config_settings_views.xml
@@ -201,6 +201,15 @@
                                 </div>
                             </div>
                             <div invisible="not has_plausible_shared_key">
+                                <button
+                                    type="action"
+                                    name="%(website.backend_dashboard)d"
+                                    string=" See Analytics Report"
+                                    class="btn-link fw-normal border-0"
+                                    icon="oi-arrow-right d-inline me-auto"
+                                />
+                            </div>
+                            <div invisible="not has_plausible_shared_key">
                                 <widget
                                     class="oe_link"
                                     name="documentation_link"


### PR DESCRIPTION
Added a "See Analytics Report" link in the Plausible settings that redirects users to the Website > Reporting > Analytics page. This enhancement provides a direct path to the analytics report, making it easier for users to access and enable the feature.

task-3597041