### PR TITLE
[FIX] sale_crm: leads to form view instead of list view in "My Quotations"

### DIFF
--- a/addons/sale_crm/views/sale_order_views.xml
+++ b/addons/sale_crm/views/sale_order_views.xml
@@ -32,7 +32,7 @@
     <menuitem
         id="sale_order_menu_quotations_crm"
         name="My Quotations"
-        action="sale.action_quotations"
+        action="sale.action_quotations_with_onboarding"
         parent="crm.crm_menu_sales"
         sequence="2"/>
 


### PR DESCRIPTION
In version 17.4, "My Quotations" (in the CRM module) opens a new quotation in the form view, rather than displaying a list of all quotations.

Steps to reproduce the issue:
Go to the CRM module.
Navigate to Sales -> My Quotations.

This fix ensures that the "My Quotations" menu correctly opens the list view of all quotations.

OPW-4150236

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
