### PR TITLE
[FIX] website: remove `fs-5` class from `s_features` icons

### DIFF
--- a/addons/website/views/snippets/s_features.xml
+++ b/addons/website/views/snippets/s_features.xml
@@ -13,7 +13,7 @@
                     <div class="s_hr pt-4 pb32">
                         <hr class="w-100 mx-auto"/>
                     </div>
-                    <i class="s_features_icon fa fa-paper-plane-o mb-3 rounded fs-5 bg-o-color-3" role="img"/>
+                    <i class="s_features_icon fa fa-paper-plane-o mb-3 rounded bg-o-color-3" role="img"/>
                     <div class="overflow-hidden">
                         <h3 class="h5-fs">Reliability</h3>
                         <p>Consistent performance and uptime ensure efficient, reliable service with minimal interruptions and quick response times.</p>
@@ -23,7 +23,7 @@
                     <div class="s_hr pt-4 pb32">
                         <hr class="w-100 mx-auto"/>
                     </div>
-                    <i class="s_features_icon fa fa-credit-card mb-3 rounded fs-5 bg-o-color-3" role="img"/>
+                    <i class="s_features_icon fa fa-credit-card mb-3 rounded bg-o-color-3" role="img"/>
                     <div class="overflow-hidden">
                         <h3 class="h5-fs">Performance</h3>
                         <p>Speed and efficiency ensure tasks are completed quickly and resources are used optimally, enhancing productivity and satisfaction.</p>
@@ -33,7 +33,7 @@
                     <div class="s_hr pt-4 pb32">
                         <hr class="w-100 mx-auto"/>
                     </div>
-                    <i class="s_features_icon fa fa-flag-o mb-3 rounded fs-5 bg-o-color-3" role="img"/>
+                    <i class="s_features_icon fa fa-flag-o mb-3 rounded bg-o-color-3" role="img"/>
                     <div class="overflow-hidden">
                         <h3 class="h5-fs">Scalability</h3>
                         <p>Growth capability is a system's ability to scale and adapt, meeting increasing demands and evolving needs for long-term success.</p>


### PR DESCRIPTION
This commit removes a `fs-5` that was added on icons within the `s_features` snippet.

- requires https://github.com/odoo/design-themes/pull/918

Currently, the size of icons are handled in two different ways :

1) if the icon has a `rounded` class, we have a CSS property setting the width to a certain size.

2) if the icon doesn't have the `rounded` class, it uses the default behaviour, meaning the `fa-*x` class will set a font-size. In this case, as there was a `fs-*` class applied, it prevented the icon to scale.

This commit fixes the issue by removing the extra class.

task-4182400

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
