### PR TITLE
[FIX] stock_account: don't write in constrains

### DIFF
--- a/addons/mrp_account/models/product.py
+++ b/addons/mrp_account/models/product.py
@@ -122,9 +122,5 @@ class ProductCategory(models.Model):
         help="""This account will be used as a valuation counterpart for both components and final products for manufacturing orders.
                 If there are any workcenter/employee costs, this value will remain on the account once the production is completed.""")
 
-    def write(self, vals):
-        return super(ProductCategory, self.with_context(product_category_mrp_account_write=True)).write(vals)
-
     def _get_stock_account_property_field_names(self):
-        mrp_value = ['property_stock_account_production_cost_id'] if self.property_stock_account_production_cost_id or not self.env.context.get('product_category_mrp_account_write') else []
-        return super()._get_stock_account_property_field_names() + mrp_value
+        return super()._get_stock_account_property_field_names() + ['property_stock_account_production_cost_id']

--- a/addons/stock_landed_costs/models/account_move.py
+++ b/addons/stock_landed_costs/models/account_move.py
@@ -75,4 +75,8 @@ class AccountMoveLine(models.Model):
         return layers.filtered(lambda svl: not svl.stock_landed_cost_id)
 
     def _eligible_for_cogs(self):
-        return super()._eligible_for_cogs() or (self.product_id.type == 'service' and self.product_id.landed_cost_ok)
+        return super()._eligible_for_cogs() or (
+            self.product_id.type == "service"
+            and self.product_id.landed_cost_ok
+            and self.product_id.valuation == "real_time"
+        )


### PR DESCRIPTION
This commit stops setting valuation accounts on product category inside the constrains method on those very accounts. This will avoid potential recursion issue and let the user set himself those accounts.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
