### PR TITLE
[IMP] base_import_module: clarify message for industry popup

### DIFF
--- a/addons/base_import_module/i18n/base_import_module.pot
+++ b/addons/base_import_module/i18n/base_import_module.pot
@@ -81,13 +81,6 @@ msgid "Created on"
 msgstr ""
 
 #. module: base_import_module
-#: model_terms:ir.ui.view,arch_db:base_import_module.view_base_module_import
-msgid ""
-"Demo data should only be used on test databases. Once they are loaded, they "
-"cannot be entirely removed!"
-msgstr ""
-
-#. module: base_import_module
 #: model:ir.model.fields,field_description:base_import_module.field_base_import_module__display_name
 msgid "Display Name"
 msgstr ""
@@ -140,11 +133,6 @@ msgid "Import Module"
 msgstr ""
 
 #. module: base_import_module
-#: model_terms:ir.ui.view,arch_db:base_import_module.view_base_module_import
-msgid "Import demo data"
-msgstr ""
-
-#. module: base_import_module
 #: model:ir.model.fields,field_description:base_import_module.field_base_import_module__with_demo
 msgid "Import demo data of module"
 msgstr ""
@@ -184,6 +172,20 @@ msgstr ""
 #. module: base_import_module
 #: model:ir.model.fields,field_description:base_import_module.field_base_import_module__write_date
 msgid "Last Updated on"
+msgstr ""
+
+#. module: base_import_module
+#: model_terms:ir.ui.view,arch_db:base_import_module.view_base_module_import
+msgid "Load demo data"
+msgstr ""
+
+#. module: base_import_module
+#. odoo-python
+#: code:addons/base_import_module/models/ir_module.py:0
+#, python-format
+msgid ""
+"Load demo data to test the industry's features with sample records. Do not "
+"load them if this is your production database."
 msgstr ""
 
 #. module: base_import_module
@@ -266,13 +268,6 @@ msgstr ""
 #: code:addons/base_import_module/models/ir_module.py:0
 #, python-format
 msgid "Studio customizations require the Odoo Studio app."
-msgstr ""
-
-#. module: base_import_module
-#. odoo-python
-#: code:addons/base_import_module/models/ir_module.py:0
-#, python-format
-msgid "The following modules will also be installed:\n"
 msgstr ""
 
 #. module: base_import_module

--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -445,7 +445,7 @@ class IrModule(models.Model):
 
     @api.model
     def _get_missing_dependencies(self, zip_data):
-        modules, unavailable_modules = self._get_missing_dependencies_modules(zip_data)
+        _modules, unavailable_modules = self._get_missing_dependencies_modules(zip_data)
         description = ''
         if unavailable_modules:
             description = _(
@@ -459,10 +459,11 @@ class IrModule(models.Model):
                 "https://www.odoo.com/pricing-plan for more information.\n"
                 "If you need Website themes, it can be downloaded from https://github.com/odoo/design-themes.\n"
             )
-        elif modules:
-            description = _("The following modules will also be installed:\n")
-            for mod in modules:
-                description += "- " + mod.shortdesc + "\n"
+        else:
+            description = _(
+                "Load demo data to test the industry's features with sample records. "
+                "Do not load them if this is your production database.",
+            )
         return description, unavailable_modules
 
     def _get_missing_dependencies_modules(self, zip_data):

--- a/addons/base_import_module/views/base_import_module_view.xml
+++ b/addons/base_import_module/views/base_import_module_view.xml
@@ -6,15 +6,12 @@
             <field name="arch" type="xml">
                 <form string="Install the application">
                     <field name="state" invisible="1"/>
-                    <p class="alert alert-danger" role="alert" invisible="not with_demo or state == 'done'">
-                        Demo data should only be used on test databases. Once they are loaded, they cannot be entirely removed!
-                    </p>
                     <p class="alert alert-warning" role="alert" invisible="state == 'done' or context.get('data_module')">Note: you can only import data modules (.xml files and static assets)</p>
                     <field name="modules_dependencies" readonly="1" nolabel="1" invisible="state == 'done'"/>
                     <group invisible="state != 'init'">
                         <field name="module_file" string="Module file (.zip)" options="{'accepted_file_extensions': '.zip'}" invisible="context.get('data_module')"/>
                         <field name="force" groups="base.group_no_one"/>
-                        <field name="with_demo" string="Import demo data"/>
+                        <field name="with_demo" string="Load demo data"/>
                     </group>
                     <group invisible="state != 'done'">
                         <field name="import_message" nolabel="1" readonly="1"/>


### PR DESCRIPTION
When installing an industry from the database, the list of dependencies to install is displayed in the dialog box. This is not clear nor necessary for the user and is therefore removed. Also, a message better alerts the user about loading demo data on a database.

task-4096849