### PR TITLE
[FIX] website: increase the duration limit of all snippets test

### DIFF
--- a/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
+++ b/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
@@ -127,7 +127,7 @@ registry.category("web_tour.tours").add("snippets_all_drag_and_drop", {
             // safety check, otherwise the test might "break" one day and
             // receive no steps. The test would then not test anything anymore
             // without us noticing it.
-            if (steps.length < 220) {
+            if (steps.length < 500) {
                 console.error(`This test is not behaving as it should, got only ${steps.length} steps.`);
             }
             unpatchWysiwygAdapter = patchWysiwygAdapter();

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -45,7 +45,7 @@ class TestSnippets(HttpCase):
                 'name': 'My Mail Group',
                 'alias_name': 'my_mail_group',
             })
-        self.start_tour(f"/odoo/action-website.website_preview?{path}", "snippets_all_drag_and_drop", login='admin', timeout=300)
+        self.start_tour(f"/odoo/action-website.website_preview?{path}", "snippets_all_drag_and_drop", login='admin', timeout=600)
 
     def test_04_countdown_preview(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_countdown', login='admin')


### PR DESCRIPTION
Given the addition of many new snippets in Website, we need to increase the duration limit of the "snippets_all_drag_and_drop" test. This test was introduced by this commit [1].

[1]: https://github.com/odoo/odoo/commit/460d5ecb926c13a79ba363f8f86442433d91bf6f

task-4077427