### PR TITLE
[FIX] fix test_webjson_access_error_crm test

### DIFF
--- a/odoo/addons/test_http/tests/test_webjson.py
+++ b/odoo/addons/test_http/tests/test_webjson.py
@@ -33,7 +33,7 @@ class TestHttpWebJson_18_0(TestHttpBase):
     def test_webjson_access_error_crm(self):
         action_crm = self.env['ir.actions.server'].search([('path', '=', 'crm')])
         if not action_crm:
-            self.skip("crm is not installed")
+            self.skipTest("crm is not installed")
 
         self.authenticate('demo', 'demo')
         self.url_open('/json/18.0/crm').raise_for_status()


### PR DESCRIPTION
when crm is not installed, test_webjson_access_error_crm was supposed to skip a test, but was using skip instead of skipTest, which gave error. Now it's fixed.

Runbot error https://runbot.odoo.com/web#id=75057&menu_id=424&action=573&model=runbot.build.error&view_type=form




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
