### PR TITLE
[IMP] point_of_sale, pos_*: allow background payment

### DIFF
--- a/addons/l10n_es_pos/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/l10n_es_pos/static/src/overrides/components/payment_screen/payment_screen.js
@@ -34,7 +34,7 @@ patch(PaymentScreen.prototype, {
     },
     shouldDownloadInvoice() {
         return this.pos.config.is_spanish
-            ? !this.pos.get_order().is_l10n_es_simplified_invoice
+            ? !this.currentOrder.is_l10n_es_simplified_invoice
             : super.shouldDownloadInvoice();
     },
     async _postPushOrderResolve(order, order_server_ids) {

--- a/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.js
+++ b/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.js
@@ -26,11 +26,19 @@ export class OrderTabs extends Component {
         order.setBooked(true);
         this.pos.showScreen("ProductScreen");
         this.dialog.closeAll();
+        return order;
     }
     selectFloatingOrder(order) {
         this.pos.set_order(order);
         this.pos.selectedTable = null;
-        this.pos.showScreen("ProductScreen");
+        const previousOrderScreen = order.get_screen_data();
+
+        const props = {};
+        if (previousOrderScreen?.name === "PaymentScreen") {
+            props.orderUuid = order.uuid;
+        }
+
+        this.pos.showScreen(previousOrderScreen?.name || "ProductScreen", props);
         this.dialog.closeAll();
     }
     get orders() {

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -26,7 +26,9 @@ export class PaymentScreen extends Component {
         PaymentScreenPaymentLines,
         PaymentScreenStatus,
     };
-    static props = {};
+    static props = {
+        orderUuid: String,
+    };
 
     setup() {
         this.pos = usePos();
@@ -98,7 +100,7 @@ export class PaymentScreen extends Component {
         return config;
     }
     get currentOrder() {
-        return this.pos.get_order();
+        return this.pos.models["pos.order"].getBy("uuid", this.props.orderUuid);
     }
     get paymentLines() {
         return this.currentOrder.payment_ids;
@@ -107,9 +109,17 @@ export class PaymentScreen extends Component {
         return this.currentOrder.get_selected_paymentline();
     }
     async addNewPaymentLine(paymentMethod) {
+        if (this.pos.paymentTerminalInProgress && paymentMethod.use_payment_terminal) {
+            this.dialog.add(AlertDialog, {
+                title: _t("Error"),
+                body: _t("There is already an electronic payment in progress."),
+            });
+            return;
+        }
+
         // original function: click_paymentmethods
         const result = this.currentOrder.add_paymentline(paymentMethod);
-        if (!this.pos.get_order().check_paymentlines_rounding()) {
+        if (!this.currentOrder.check_paymentlines_rounding()) {
             this._display_popup_error_paymentlines_rounding();
         }
         if (result) {
@@ -168,7 +178,7 @@ export class PaymentScreen extends Component {
         } else {
             this.selectedPaymentLine.set_amount(amount);
         }
-        if (!this.pos.get_order().check_paymentlines_rounding()) {
+        if (!this.currentOrder.check_paymentlines_rounding()) {
             this._display_popup_error_paymentlines_rounding();
         }
     }
@@ -236,7 +246,7 @@ export class PaymentScreen extends Component {
     async validateOrder(isForceValidate) {
         this.numberBuffer.capture();
         if (this.pos.config.cash_rounding) {
-            if (!this.pos.get_order().check_paymentlines_rounding()) {
+            if (!this.currentOrder.check_paymentlines_rounding()) {
                 this._display_popup_error_paymentlines_rounding();
                 return;
             }
@@ -326,6 +336,7 @@ export class PaymentScreen extends Component {
         // Always show the next screen regardless of error since pos has to
         // continue working even offline.
         let nextScreen = this.nextScreen;
+        let switchScreen = false;
 
         if (
             nextScreen === "ReceiptScreen" &&
@@ -337,18 +348,26 @@ export class PaymentScreen extends Component {
                 : true;
 
             if (invoiced_finalized) {
-                const printResult = await this.pos.printReceipt();
+                this.pos.printReceipt(this.currentOrder);
 
-                if (printResult && this.pos.config.iface_print_skip_screen) {
+                if (this.pos.config.iface_print_skip_screen) {
                     this.currentOrder.uiState.screen_data["value"] = "";
                     this.currentOrder.uiState.locked = true;
-                    this.pos.add_new_order();
+                    switchScreen = this.currentOrder.uuid === this.pos.selectedOrderUuid;
                     nextScreen = "ProductScreen";
+
+                    if (switchScreen) {
+                        this.pos.add_new_order();
+                    }
                 }
             }
+        } else {
+            switchScreen = true;
         }
 
-        this.pos.showScreen(nextScreen);
+        if (switchScreen) {
+            this.pos.showScreen(nextScreen);
+        }
     }
     /**
      * This method is meant to be overriden by localization that do not want to print the invoice pdf
@@ -508,6 +527,7 @@ export class PaymentScreen extends Component {
     }
     async sendPaymentRequest(line) {
         // Other payment lines can not be reversed anymore
+        this.pos.paymentTerminalInProgress = true;
         this.numberBuffer.capture();
         this.paymentLines.forEach(function (line) {
             line.can_be_reversed = false;
@@ -523,9 +543,10 @@ export class PaymentScreen extends Component {
 
         // Automatically validate the order when after an electronic payment,
         // the current order is fully paid and due is zero.
+        this.pos.paymentTerminalInProgress = false;
         const config = this.pos.config;
         const currency = this.pos.currency;
-        const currentOrder = this.pos.get_order();
+        const currentOrder = line.pos_order_id;
         if (
             isPaymentSuccessful &&
             currentOrder.is_paid() &&

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
@@ -144,7 +144,9 @@
         <div class="paymentmethods-container mb-3" t-att-class="ui.isSmall ? 'my-2 rounded-3' : 'flex-grow-1'">
             <div class="paymentmethods  gap-1 gap-lg-2" t-att-class="{ 'd-grid p-1 gap-1 overflow-y-auto rounded-3 bg-300': ui.isSmall, 'd-flex flex-column gap-lg-2': !ui.isSmall }">
                 <t t-foreach="payment_methods_from_config" t-as="paymentMethod" t-key="paymentMethod.id">
-                    <div class="button paymentmethod btn btn-light btn-lg lh-lg flex-fill" t-on-click="() => this.addNewPaymentLine(paymentMethod)">
+                    <div class="button paymentmethod btn btn-light btn-lg lh-lg flex-fill"
+                        t-att-class="{'opacity-50': this.pos.paymentTerminalInProgress and paymentMethod.use_payment_terminal}"
+                        t-on-click="() => this.addNewPaymentLine(paymentMethod)">
                         <div class="payment-method-display d-flex align-items-center gap-2 text-wrap text-start lh-sm">
                             <img class="payment-method-icon" t-att-src="paymentMethodImage(paymentMethod.id)" />
                             <span class="payment-name" t-esc="paymentMethod.name" />

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1158,11 +1158,15 @@ export class PosStore extends Reactive {
             });
             if (confirmed) {
                 this.mobile_pane = "right";
-                this.env.services.pos.showScreen("PaymentScreen");
+                this.env.services.pos.showScreen("PaymentScreen", {
+                    orderUuid: this.selectedOrderUuid,
+                });
             }
         } else {
             this.mobile_pane = "right";
-            this.env.services.pos.showScreen("PaymentScreen");
+            this.env.services.pos.showScreen("PaymentScreen", {
+                orderUuid: this.selectedOrderUuid,
+            });
         }
     }
     async getServerOrders() {
@@ -1318,11 +1322,16 @@ export class PosStore extends Reactive {
      * @param {str} terminalName
      */
     getPendingPaymentLine(terminalName) {
-        return this.get_order().payment_ids.find(
-            (paymentLine) =>
-                paymentLine.payment_method_id.use_payment_terminal === terminalName &&
-                !paymentLine.is_done()
-        );
+        for (const order of this.models["pos.order"].getAll()) {
+            const paymentLine = order.payment_ids.find(
+                (paymentLine) =>
+                    paymentLine.payment_method_id.use_payment_terminal === terminalName &&
+                    !paymentLine.is_done()
+            );
+            if (paymentLine) {
+                return paymentLine;
+            }
+        }
     }
 
     get linesToRefund() {
@@ -1436,7 +1445,11 @@ export class PosStore extends Reactive {
     closeScreen() {
         this.addOrderIfEmpty();
         const { name: screenName } = this.get_order().get_screen_data();
-        this.showScreen(screenName);
+        const props = {};
+        if (screenName === "PaymentScreen") {
+            props.orderUuid = this.selectedOrderUuid;
+        }
+        this.showScreen(screenName, props);
     }
 
     addOrderIfEmpty() {


### PR DESCRIPTION
*: l10n_es_pos, point_of_sale, pos_adyen, pos_restaurant

Before it was not possible to leave the payment_screen during a payment. Now it is possible to leave the payment_screen and continue the payment in the background.

taskId: 4128663


