### PR TITLE
[FIX] website: fix dragging last block of a table of content

### DIFF
--- a/addons/website/static/src/snippets/s_table_of_content/options.js
+++ b/addons/website/static/src/snippets/s_table_of_content/options.js
@@ -83,7 +83,7 @@ options.registry.TableOfContent = options.Class.extend({
      * @returns {Object}
      */
     _getTocAndHeadingId(headingEl) {
-        const match = /^table_of_content_heading_(\d+)_(\d+)$/.exec(headingEl.getAttribute("id"));
+        const match = /^table_of_content_heading_(\d+)_(\d+)$/.exec(headingEl && headingEl.getAttribute("id"));
         if (match) {
             return { tocId: parseInt(match[1]), headingId: parseInt(match[2]) };
         }


### PR DESCRIPTION
Since [1], a traceback appears when we drag the last block of a table of content into another one.

Drag and drop two tables of content on the website page
One by one, drag and drop the blocks from the second table to the first one
traceback for the last one...

This commit resolves the issue

[1]:https://github.com/odoo/odoo/commit/6cd9606e285741b59042b9674bf6682273c43a69

task-4144022