### PR TITLE
[FIX] html_editor:  show tooltip on remove format button when disbaled

### DIFF
--- a/addons/html_editor/static/src/main/toolbar/toolbar.scss
+++ b/addons/html_editor/static/src/main/toolbar/toolbar.scss
@@ -30,6 +30,16 @@
                 border-top-right-radius: 0;
                 border-bottom-right-radius: 0;
             }
+
+            &.disabled {
+                pointer-events: auto;
+                cursor: auto;
+                &:active {
+                    border-color: var(--btn-disabled-border-color);
+                    background-color: var(--btn-disabled-bg);;
+                    color: var(--btn-disabled-color);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Issue:
======
hover over remove format button when disabled
doesn't show tooltip.

Origin of the issue:
====================
Since the disabled button will have the class .disabled which will add
`pointer-events:none` to the button so when hovering nothing happens.

Solution:
=========
- Add `pointer-events:auto` to show the tooltip on hover.
- Add `cursor:auto` to show the usual cursor and not the pointer when
  hover.
- Style the `.disabled:active` button the same as the `.disabled` so
  that clicking on the button doesn't change the style which gives the
  impressions that something happened.