### PR TITLE
[IMP] payment_adyen: add event url field

### DIFF
--- a/addons/pos_adyen/models/pos_payment_method.py
+++ b/addons/pos_adyen/models/pos_payment_method.py
@@ -26,6 +26,13 @@ class PosPaymentMethod(models.Model):
     adyen_test_mode = fields.Boolean(help='Run transactions in the test environment.', groups='base.group_erp_manager')
 
     adyen_latest_response = fields.Char(copy=False, groups='base.group_erp_manager') # used to buffer the latest asynchronous notification from Adyen.
+    adyen_event_url = fields.Char(
+        string="Event URL",
+        help="This URL needs to be pasted on Adyen's portal terminal settings.",
+        readonly=True,
+        store=False,
+        default=lambda self: f"{self.get_base_url()}/pos_adyen/notification",
+    )
 
     @api.model
     def _load_pos_data_fields(self, config_id):

--- a/addons/pos_adyen/views/pos_payment_method_views.xml
+++ b/addons/pos_adyen/views/pos_payment_method_views.xml
@@ -9,6 +9,7 @@
                 <!-- Adyen -->
                 <field name="adyen_api_key" invisible="use_payment_terminal != 'adyen'" required="use_payment_terminal == 'adyen'" password="True"/>
                 <field name="adyen_terminal_identifier" invisible="use_payment_terminal != 'adyen'" required="use_payment_terminal == 'adyen'"/>
+                <field name="adyen_event_url" invisible="use_payment_terminal != 'adyen'" widget="CopyClipboardChar"/>
                 <field name="adyen_test_mode" invisible="use_payment_terminal != 'adyen'" required="use_payment_terminal == 'adyen'"/>
             </xpath>
         </field>


### PR DESCRIPTION
Clients using Adyen as a payment provider could forget pasting the event url on Adyen's website or type it wrong.  
As a result, when a payment was accepted/refused/..., Odoo could not recieve the information, and ended up stuck.

By adding this field, users will be less likely to forget to paste the URL, and the copy-paste process will be more convenient.

Task: 4173725