### PR TITLE
[FIX] crm: avoid modification of contact email

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -183,7 +183,8 @@ class Lead(models.Model):
     title = fields.Many2one('res.partner.title', string='Title', compute='_compute_title', readonly=False, store=True)
     email_from = fields.Char(
         'Email', tracking=40, index=True,
-        compute='_compute_email_from', inverse='_inverse_email_from', readonly=False, store=True)
+        compute='_compute_email_from', inverse='_inverse_email_from', readonly=False, store=True,
+        help='Email address of the contact if there is any matching this email address.')
     phone = fields.Char(
         'Phone', tracking=50,
         compute='_compute_phone', inverse='_inverse_phone', readonly=False, store=True)

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -167,7 +167,8 @@
                                         title="This email is blacklisted for mass mailings. Click to unblacklist."
                                         type="object" context="{'default_email': email_from}" groups="base.group_user"
                                         attrs="{'invisible': [('is_blacklisted', '=', False)]}"/>
-                                    <field name="email_from" string="Email" widget="email"/>
+                                    <field name="email_from" string="Email" widget="email" 
+                                        attrs="{'readonly': [('partner_id', '!=', False)]}"/>
                                     <span class="fa fa-exclamation-triangle text-warning oe_edit_only"
                                         title="By saving this change, the customer email will also be updated."
                                         attrs="{'invisible': [('partner_email_update', '=', False)]}"/>


### PR DESCRIPTION
When the 'email' (email_from) field match a known contact, the 'customer' (partner_id) field is auto-filled.
However, the 'email' (email_from) remains editable, modifying the email address of the contact.

This could lead to confusion when accessing the contact and seeing on the chatter the email modification done by different users not really knowing that changing the email field on the lead would also change the email on the contact.

opw-4147470