### PR TITLE
[FIX] web: dashboard's filter caret on hover

### DIFF
--- a/addons/web/static/src/core/record_selectors/multi_record_selector.xml
+++ b/addons/web/static/src/core/record_selectors/multi_record_selector.xml
@@ -9,14 +9,13 @@
                 value="''"
                 domain="props.domain"
                 context="props.context"
-                className="'flex-grow-1'"
+                className="'o_record_autocomplete_with_caret flex-grow-1'"
                 fieldString="props.fieldString"
                 placeholder="placeholder"
                 multiSelect="true"
                 getIds.bind="getIds"
                 update.bind="update"
             />
-            <span class="o_dropdown_button"/>
         </div>
     </t>
 

--- a/addons/web/static/src/core/record_selectors/record_selectors.scss
+++ b/addons/web/static/src/core/record_selectors/record_selectors.scss
@@ -6,4 +6,16 @@
             }
         }
     }
+
+    .o_record_autocomplete_with_caret {
+        display: flex;
+        min-width: 100%;
+
+        &:hover, &:focus-within {
+            &::after {
+                @include o-caret-down;
+                align-self: center;
+            }
+        }
+    }
 }


### PR DESCRIPTION
This commit fixes the record selector's caret positioning (displayed on hover only) by moving to be a sibling of the autocomplete's input.

Steps to reproduce:
- install Sales
- open Dashboard
- hover one of the filter in the ControlPanel => the filter's caret is displayed but on a separate line

Enterprise: https://github.com/odoo/enterprise/pull/69944

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
