### PR TITLE
[FIX] calendar: uninvited admins edit non-private events

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -289,11 +289,14 @@ class Meeting(models.Model):
     def _compute_user_can_edit(self):
         for event in self:
             # By default, only current attendees and the organizer can edit the event.
-            editor_candidates = event.partner_ids.user_ids + event.user_id
+            editor_candidates = set(event.partner_ids.user_ids + event.user_id)
             # Right before saving the event, old partners must be able to save changes.
             if event._origin:
-                editor_candidates += event._origin.partner_ids.user_ids
-            event.user_can_edit = self.env.user.id in editor_candidates.ids
+                editor_candidates |= set(event._origin.partner_ids.user_ids)
+            # Non-private events must be editable by uninvited administrators.
+            if self.env.user.has_group('base.group_system') and event.privacy != 'private':
+                editor_candidates.add(self.env.user)
+            event.user_can_edit = self.env.user in editor_candidates
 
     @api.depends('attendee_ids')
     def _compute_invalid_email_partner_ids(self):


### PR DESCRIPTION
This commit allows uninvited admins to edit non-private events (public, confidential). It was a needed change since administrators might have to change the event information of these types of events day to day. A re-work of the compute methods will be made on master followed by the addition of the proper ACL rules for handling calendar events.

task-4182649