### PR TITLE
[FIX] web: support extra HTTP headers in RPC service

### DIFF
--- a/addons/web/static/src/core/network/rpc_service.js
+++ b/addons/web/static/src/core/network/rpc_service.js
@@ -96,7 +96,11 @@ export function jsonrpc(env, rpcId, url, params, settings = {}) {
         });
         // configure and send request
         request.open("POST", url);
-        request.setRequestHeader("Content-Type", "application/json");
+        const headers = settings.headers || {};
+        headers["Content-Type"] = "application/json";
+        for (let [header, value] of Object.entries(headers)) {
+            request.setRequestHeader(header, value);
+        }
         request.send(JSON.stringify(data));
     });
     /**

--- a/addons/web/static/tests/core/network/rpc_service_tests.js
+++ b/addons/web/static/tests/core/network/rpc_service_tests.js
@@ -268,3 +268,25 @@ QUnit.test("trigger a ConnectionLostError when response isn't json parsable", as
         assert.ok(e instanceof ConnectionLostError);
     }
 });
+
+QUnit.test("rpc can send additional headers", async (assert) => {
+    assert.expect(1);
+    const MockXHR = makeMockXHR(null, function () {
+        assert.deepEqual(this._requestHeaders, {
+            "Content-Type": "application/json",
+            Hello: "World",
+        });
+    });
+    function HeaderCollectingMockXHR() {
+        const ret = MockXHR();
+        ret._requestHeaders = {};
+        ret.setRequestHeader = function(header, value) {
+            ret._requestHeaders[header] = value;
+        };
+        return ret;
+    }
+    patchWithCleanup(browser, { XMLHttpRequest: HeaderCollectingMockXHR }, { pure: true });
+
+    const env = await makeTestEnv({ serviceRegistry });
+    await env.services.rpc("/test/", null, { headers: { Hello: 'World' } });
+});


### PR DESCRIPTION
JQuery ajax was supporting extra headers sent along with the HTTP request, but this was no longer possible with the new RPC service. With this commit, we reintroduce this feature, so that extra HTTP headers can be specified by the caller.