### PR TITLE
[FIX] account_edi_ubl_cii: partner information missing

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -582,7 +582,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         vat = self._find_value(f'.//cac:Accounting{role}Party/cac:Party//cbc:CompanyID[string-length(text()) > 5]', tree)
         phone = self._find_value(f'.//cac:Accounting{role}Party/cac:Party//cbc:Telephone', tree)
         mail = self._find_value(f'.//cac:Accounting{role}Party/cac:Party//cbc:ElectronicMail', tree)
-        name = self._find_value(f'.//cac:Accounting{role}Party/cac:Party//cbc:Name', tree)
+        name = self._find_value(f'.//cac:Accounting{role}Party/cac:Party//cbc:Name', tree) or \
+            self._find_value(f'.//cac:Accounting{role}Party/cac:Party//cbc:RegistrationName', tree)
         country_code = self._find_value(f'.//cac:Accounting{role}Party/cac:Party//cac:Country//cbc:IdentificationCode', tree)
         self._import_retrieve_and_fill_partner(invoice, name=name, phone=phone, mail=mail, vat=vat, country_code=country_code)
 


### PR DESCRIPTION
When uploading a bill via xml, if the file does not contain the node
'Name` in accounting parties informations, we don't set the partner at
all on the bill.
With this commit,  if the node `Name` is missing, we fallback to the
node `RegistrationName`.

opw-4154071
