### PR TITLE
[FIX] html_editor: show header 1 name correctly in toolbar

### DIFF
--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -17,7 +17,7 @@ import { DIRECTIONS } from "@html_editor/utils/position";
 import { _t } from "@web/core/l10n/translation";
 import { FontSelector } from "./font_selector";
 
-const fontItems = [
+export const fontItems = [
     {
         name: _t("Header 1 Display 1"),
         tagName: "h1",

--- a/addons/html_editor/static/src/main/font/font_selector.js
+++ b/addons/html_editor/static/src/main/font/font_selector.js
@@ -40,13 +40,15 @@ export class FontSelector extends Component {
             return item.tagName === tagName;
         });
 
+        const matchingItemsWitoutExtraClass = matchingItems.filter((item) => !item.extraClass);
+
         if (!matchingItems.length) {
             return "Normal";
         }
 
         return (
             matchingItems.find((item) => block.classList.contains(item.extraClass)) ||
-            matchingItems[0]
+            (matchingItemsWitoutExtraClass.length && matchingItemsWitoutExtraClass[0])
         ).name;
     }
 

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -15,7 +15,7 @@ import {
 } from "@odoo/hoot-dom";
 import { advanceTime, animationFrame, tick } from "@odoo/hoot-mock";
 import { contains, patchTranslations, patchWithCleanup } from "@web/../tests/web_test_helpers";
-import { fontSizeItems } from "../src/main/font/font_plugin";
+import { fontSizeItems, fontItems } from "../src/main/font/font_plugin";
 import { Plugin } from "../src/plugin";
 import { MAIN_PLUGINS } from "../src/plugin_sets";
 import { convertNumericToUnit, getCSSVariableValue, getHtmlStyle } from "../src/utils/formatting";
@@ -213,6 +213,28 @@ test("toolbar works: can select font", async () => {
     await contains(".o_font_selector_menu .dropdown-item:contains('Header 2')").click();
     expect(getContent(el)).toBe("<h2>[test]</h2>");
     expect(".o-we-toolbar [name='font']").toHaveText("Header 2");
+});
+
+test("toolbar works: show the right font name", async () => {
+    await setupEditor("<p>[test]</p>");
+    await waitFor(".o-we-toolbar");
+    for (const item of fontItems) {
+        await contains(".o-we-toolbar [name='font'] .dropdown-toggle").click();
+        const name = item.name.toString();
+        let selector = `.o_font_selector_menu .dropdown-item:contains('${name}')`;
+        for (const tempItem of fontItems) {
+            // we need to exclude the font names which have the current name as a substring.
+            if (tempItem === item) {
+                continue;
+            }
+            const tempItemName = tempItem.name.toString();
+            if (tempItemName.includes(name)) {
+                selector += `:not(:contains(${tempItemName}))`;
+            }
+        }
+        await contains(selector).click();
+        expect(".o-we-toolbar [name='font']").toHaveText(name);
+    }
 });
 
 test("toolbar works: can select font size", async () => {


### PR DESCRIPTION
Before this commit:

Selecting header 1 in the font dropdown will show header 1 display 1 which is wrong. They are 2 different fonts.

After this commit: Now every selected font show its corresponding name.

Added a test to check the flow for all possible fonts.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
