### PR TITLE
[IMP] mail, *: replace portal attachment uploader with mail uploader

### DIFF
--- a/addons/im_livechat/controllers/attachment.py
+++ b/addons/im_livechat/controllers/attachment.py
@@ -13,7 +13,9 @@ class LivechatAttachmentController(AttachmentController):
     @route()
     @add_guest_to_context
     def mail_attachment_upload(self, ufile, thread_id, thread_model, is_pending=False, **kwargs):
-        thread = request.env[thread_model].with_context(active_test=False).search([("id", "=", thread_id)])
+        thread = request.env[thread_model]._get_thread_with_access(
+            int(thread_id), mode=request.env[thread_model]._mail_post_access, **kwargs
+        )
         if not thread:
             raise NotFound()
         if (

--- a/addons/mail/controllers/attachment.py
+++ b/addons/mail/controllers/attachment.py
@@ -48,7 +48,9 @@ class AttachmentController(http.Controller):
     @http.route("/mail/attachment/upload", methods=["POST"], type="http", auth="public")
     @add_guest_to_context
     def mail_attachment_upload(self, ufile, thread_id, thread_model, is_pending=False, **kwargs):
-        thread = request.env[thread_model].with_context(active_test=False).search([("id", "=", thread_id)])
+        thread = request.env[thread_model]._get_thread_with_access(
+            int(thread_id), mode=request.env[thread_model]._mail_post_access, **kwargs
+        )
         if not thread:
             raise NotFound()
         if thread_model == "discuss.channel" and not thread.allow_public_upload and not request.env.user._is_internal():

--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -1,8 +1,5 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import base64
-import json
 import math
 import re
 
@@ -297,63 +294,6 @@ class CustomerPortal(Controller):
             'X-Frame-Options': 'SAMEORIGIN',
             'Content-Security-Policy': "frame-ancestors 'self'",
         })
-
-    @http.route('/portal/attachment/add', type='http', auth='public', methods=['POST'], website=True)
-    def attachment_add(self, name, file, thread_model, thread_id, access_token=None):
-        """Process a file uploaded from the portal chatter and create the
-        corresponding `ir.attachment`.
-
-        The attachment will be created "pending" until the associated message
-        is actually created, and it will be garbage collected otherwise.
-
-        :param name: name of the file to save.
-        :type name: string
-
-        :param file: the file to save
-        :type file: werkzeug.FileStorage
-
-        :param thread_model: name of the model of the original document.
-            To check access rights only, it will not be saved here.
-        :type thread_model: string
-
-        :param thread_id: id of the original document.
-            To check access rights only, it will not be saved here.
-        :type thread_id: int
-
-        :param access_token: access_token of the original document.
-            To check access rights only, it will not be saved here.
-        :type access_token: string
-
-        :return: attachment data {id, name, mimetype, file_size, access_token}
-        :rtype: dict
-        """
-        try:
-            self._document_check_access(thread_model, int(thread_id), access_token=access_token)
-        except (AccessError, MissingError) as e:
-            raise UserError(_("The document does not exist or you do not have the rights to access it."))
-
-        IrAttachment = request.env['ir.attachment']
-
-        # Avoid using sudo when not necessary: internal users can create attachments,
-        # as opposed to public and portal users.
-        if not request.env.user._is_internal():
-            IrAttachment = IrAttachment.sudo()
-
-        # At this point the related message does not exist yet, so we assign
-        # those specific res_model and res_is. They will be correctly set
-        # when the message is created: see `mail_message_post`,
-        # or garbage collected otherwise: see  `_garbage_collect_attachments`.
-        attachment = IrAttachment.create({
-            'name': name,
-            'datas': base64.b64encode(file.read()),
-            'res_model': 'mail.compose.message',
-            'res_id': 0,
-            'access_token': IrAttachment._generate_access_token(),
-        })
-        return request.make_response(
-            data=json.dumps(attachment.read(['id', 'name', 'mimetype', 'file_size', 'access_token'])[0]),
-            headers=[('Content-Type', 'application/json')]
-        )
 
     @http.route('/portal/attachment/remove', type='json', auth='public')
     def attachment_remove(self, attachment_id, access_token=None):

--- a/addons/portal/static/src/js/portal_composer.js
+++ b/addons/portal/static/src/js/portal_composer.js
@@ -98,11 +98,11 @@ var PortalComposer = publicWidget.Widget.extend({
     },
     _prepareAttachmentData: function (file) {
         return {
-            'name': file.name,
-            'file': file,
-            'thread_id': this.options.res_id,
-            'thread_model': this.options.res_model,
-            'access_token': this.options.token,
+            is_pending: true,
+            thread_id: this.options.res_id,
+            thread_model: this.options.res_model,
+            token: this.options.token,
+            ufile: file,
         };
     },
     /**
@@ -120,7 +120,8 @@ var PortalComposer = publicWidget.Widget.extend({
                 if (odoo.csrf_token) {
                     data.csrf_token = odoo.csrf_token;
                 }
-                post('/portal/attachment/add', data).then(function (attachment) {
+                post('/mail/attachment/upload', data).then(function (res) {
+                    let attachment = res.data["ir.attachment"][0]
                     attachment.state = 'pending';
                     self.attachments.push(attachment);
                     self._updateAttachments();

--- a/addons/portal/static/src/xml/portal_chatter.xml
+++ b/addons/portal/static/src/xml/portal_chatter.xml
@@ -67,7 +67,7 @@
                     <button t-if="showDelete and attachment.state == 'pending'" class="o_portal_chatter_attachment_delete btn btn-sm btn-outline-danger" title="Delete">
                         <i class="fa fa-times"/>
                     </button>
-                    <a t-attf-href="/web/content/#{attachment.id}?download=true&amp;access_token=#{attachment.access_token}" target="_blank" class="d-flex flex-row">
+                    <a t-attf-href="/web/content/#{attachment.id}?download=true&amp;#{attachment.access_token and 'access_token=' + attachment.access_token}" target="_blank" class="d-flex flex-row">
                         <div class='oe_attachment_embedded o_image' t-att-title="attachment.name" t-att-data-mimetype="attachment.mimetype"/>
                         <div class='o_portal_chatter_attachment_name align-self-center text-truncate' t-att-data-tooltip="attachment.name" data-tooltip-position="top">
                             <t t-esc='attachment.name'/>

--- a/addons/project/static/src/project_sharing/components/chatter/chatter_composer.js
+++ b/addons/project/static/src/project_sharing/components/chatter/chatter_composer.js
@@ -113,7 +113,8 @@ export class ChatterComposer extends Component {
     onFileUpload(files) {
         this.state.loading = false;
         this.clearErrors();
-        for (const file of files) {
+        for (const fileData of files) {
+            let file = fileData.data["ir.attachment"][0];
             file.state = 'pending';
             this.state.attachments.push(file);
         }

--- a/addons/project/static/src/project_sharing/components/portal_attach_document/portal_attach_document.js
+++ b/addons/project/static/src/project_sharing/components/portal_attach_document/portal_attach_document.js
@@ -26,7 +26,7 @@ export class PortalAttachDocument extends Component {
     static defaultProps = {
         acceptedFileExtensions: "*",
         onUpload: () => {},
-        route: "/portal/attachment/add",
+        route: "/mail/attachment/upload",
         beforeOpen: async () => true,
     };
 }

--- a/addons/project/static/src/project_sharing/components/portal_file_input/portal_file_input.js
+++ b/addons/project/static/src/project_sharing/components/portal_file_input/portal_file_input.js
@@ -35,8 +35,9 @@ export class PortalFileInput extends FileInput {
             files.map(
                 (file) =>
                     super.uploadFiles({
-                        file,
-                        name: file.name,
+                        ufile: [file],
+                        token: otherParams.access_token,
+                        is_pending: true,
                         ...otherParams,
                     })
             )

--- a/addons/website_slides/tests/test_ui_wslides.py
+++ b/addons/website_slides/tests/test_ui_wslides.py
@@ -270,18 +270,3 @@ class TestUiPublisherYoutube(HttpCaseGamification):
         })
 
         self.start_tour(self.env['website'].get_client_action_url('/slides'), 'course_publisher', login=user_demo.login)
-
-
-@tests.common.tagged('external', 'post_install', '-standard', '-at_install')
-class TestPortalComposer(TestUICommon):
-    def test_portal_composer_attachment(self):
-        """Check that the access token is returned when we upload an attachment."""
-        self.authenticate('demo', 'demo')
-        response = self.url_open('/portal/attachment/add', data={
-            'name': 'image.png',
-            'res_id': self.channel.id,
-            'res_model': 'slide.channel',
-            'csrf_token': http.WebRequest.csrf_token(self),
-        }, files={'file': ('image.png', '', 'image/png')})
-        self.assertTrue(response.ok)
-        self.assertTrue(response.json().get('access_token'))


### PR DESCRIPTION
This commit replaces `/portal/attachment/add` with `/mail/attachment/upload` 

Part of task-2828744
