### PR TITLE
[FIX] spreadsheet: properly handle boolean values in lists

### DIFF
--- a/addons/spreadsheet/static/src/list/list_data_source.js
+++ b/addons/spreadsheet/static/src/list/list_data_source.js
@@ -156,7 +156,7 @@ export default class ListDataSource extends OdooViewsDataSource {
                 return value ? value[1] : "";
             }
             case "boolean":
-                return record[fieldName] ? "TRUE" : "FALSE";
+                return record[fieldName] ? true : false;
             case "date":
                 return record[fieldName] ? toNumber(this._formatDate(record[fieldName])) : "";
             case "datetime":

--- a/addons/spreadsheet/static/tests/lists/list_plugin_test.js
+++ b/addons/spreadsheet/static/tests/lists/list_plugin_test.js
@@ -45,8 +45,8 @@ QUnit.module("spreadsheet > list plugin", {}, () => {
 
     QUnit.test("Boolean fields are correctly formatted", async (assert) => {
         const { model } = await createSpreadsheetWithList({ columns: ["bar"] });
-        assert.strictEqual(getCellValue(model, "A2"), "TRUE");
-        assert.strictEqual(getCellValue(model, "A5"), "FALSE");
+        assert.strictEqual(getCellValue(model, "A2"), true);
+        assert.strictEqual(getCellValue(model, "A5"), false);
     });
 
     QUnit.test("properties field displays property display names", async (assert) => {
@@ -416,7 +416,7 @@ QUnit.module("spreadsheet > list plugin", {}, () => {
         const { model } = await createSpreadsheetWithList();
         const [listId] = model.getters.getListIds();
         assert.deepEqual(model.getters.getListDefinition(listId).domain, []);
-        assert.strictEqual(getCellValue(model, "B2"), "TRUE");
+        assert.strictEqual(getCellValue(model, "B2"), true);
         model.dispatch("UPDATE_ODOO_LIST_DOMAIN", {
             listId,
             domain: [["foo", "in", [55]]],
@@ -428,7 +428,7 @@ QUnit.module("spreadsheet > list plugin", {}, () => {
         await waitForDataSourcesLoaded(model);
         assert.deepEqual(model.getters.getListDefinition(listId).domain, []);
         await waitForDataSourcesLoaded(model);
-        assert.strictEqual(getCellValue(model, "B2"), "TRUE");
+        assert.strictEqual(getCellValue(model, "B2"), true);
         model.dispatch("REQUEST_REDO");
         assert.deepEqual(model.getters.getListDefinition(listId).domain, [["foo", "in", [55]]]);
         await waitForDataSourcesLoaded(model);


### PR DESCRIPTION
The method returning a list field value based on its type did not properly handle the boolean fields. It would return the string "TRUE" and "FALSE" which are interpreted as strings by the evaluation process.

task-418257

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
