### PR TITLE
[IMP] pos_event: add support for badge printers

### DIFF
--- a/addons/pos_event/models/event_event.py
+++ b/addons/pos_event/models/event_event.py
@@ -14,4 +14,4 @@ class Event(models.Model):
     @api.model
     def _load_pos_data_fields(self, config_id):
         return ['id', 'name', 'seats_available', 'event_ticket_ids', 'registration_ids', 'seats_limited', 'write_date',
-                'question_ids', 'general_question_ids', 'specific_question_ids']
+                'question_ids', 'general_question_ids', 'specific_question_ids', 'badge_format']

--- a/addons/pos_event/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/pos_event/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -19,7 +19,35 @@ patch(ReceiptScreen.prototype, {
         ]);
     },
     async printEventBadge() {
-        const registrations = this.pos.get_order().eventRegistrations.map((reg) => reg.id);
-        await this.report.doAction("event.action_report_event_registration_badge", [registrations]);
+        const registrations = this.pos.get_order().eventRegistrations;
+
+        const smallBadgeRegistrations = registrations.filter(
+            (reg) => reg.event_id.badge_format === "96x82"
+        );
+        const largeBadgeRegistrations = registrations.filter(
+            (reg) => reg.event_id.badge_format === "96x134"
+        );
+        const nonBadgePrinterRegistrations = registrations.filter(
+            (reg) => !["96x82", "96x134"].includes(reg.event_id.badge_format)
+        );
+
+        if (nonBadgePrinterRegistrations.length > 0) {
+            await this.report.doAction(
+                "event.action_report_event_registration_badge",
+                nonBadgePrinterRegistrations.map((reg) => reg.id)
+            );
+        }
+        if (largeBadgeRegistrations.length > 0) {
+            await this.report.doAction(
+                "event.action_report_event_registration_badge_96x134",
+                largeBadgeRegistrations.map((reg) => reg.id)
+            );
+        }
+        if (smallBadgeRegistrations.length > 0) {
+            await this.report.doAction(
+                "event.action_report_event_registration_badge_96x82",
+                smallBadgeRegistrations.map((reg) => reg.id)
+            );
+        }
     },
 });

--- a/addons/pos_event/static/src/app/screens/receipt_screen/receipt_screen.xml
+++ b/addons/pos_event/static/src/app/screens/receipt_screen/receipt_screen.xml
@@ -9,7 +9,7 @@
                         <i t-attf-class="fa {{doPrintEventFull.status === 'loading' ? 'fa-fw fa-spin fa-circle-o-notch' : 'fa-print'}} me-1" />Print Full Page Ticket
                     </button>
                     <button class="o-event-badge button print btn btn-md btn-secondary w-50 py-3" t-on-click="() => doPrintEventBadge.call()">
-                        <i t-attf-class="fa {{doPrintEventBadge.status === 'loading' ? 'fa-fw fa-spin fa-circle-o-notch' : 'fa-print'}} me-1" />Print Foldable Badge
+                        <i t-attf-class="fa {{doPrintEventBadge.status === 'loading' ? 'fa-fw fa-spin fa-circle-o-notch' : 'fa-print'}} me-1" />Print Badge
                     </button>
                 </div>
             </t>


### PR DESCRIPTION
Epson badge printers have recently been added to the Event app, but they use new reports and so can't currently be used via pos_event.

This PR adds support for printing the correct reports based on the event's badge format, which will allow printing on the badge printer assuming the report has been linked.

Related enterprise PR: https://github.com/odoo/enterprise/pull/69953

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
