### PR TITLE
[IMP] account: rework account lock dates rework

### DIFF
--- a/addons/account/models/account_lock_exception.py
+++ b/addons/account/models/account_lock_exception.py
@@ -10,7 +10,10 @@ class AccountLockException(models.Model):
     _name = "account.lock_exception"
     _description = "Account Lock Exception"
 
-    active = fields.Boolean('Active', default=True)
+    active = fields.Boolean(
+        string='Active',
+        default=True,
+    )
     state = fields.Selection(
         selection=[
             ('active', 'Active'),
@@ -39,7 +42,7 @@ class AccountLockException(models.Model):
     )
     # An exception without `end_datetime` is valid forever
     end_datetime = fields.Datetime(
-        'End Date',
+        string='End Date',
     )
 
     # Lock date fields; c.f. res.company
@@ -54,11 +57,11 @@ class AccountLockException(models.Model):
         help="The date the Tax Lock Date is set to by this exception. If no date is set the lock date is not changed.",
     )
     sale_lock_date = fields.Date(
-        string='Lock Sales',
+        string='Sales Lock Date',
         help="The date the Sale Lock Date is set to by this exception. If no date is set the lock date is not changed.",
     )
     purchase_lock_date = fields.Date(
-        string='Lock Purchases',
+        string='Purchase Lock Date',
         help="The date the Purchase Lock Date is set to by this exception. If no date is set the lock date is not changed.",
     )
 

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -532,7 +532,7 @@ class ResCompany(models.Model):
                           (soft_lock_date_field, '<', company[soft_lock_date_field]),
                           ('company_id', '=', company.id),
                         ],
-                        order=f'{soft_lock_date_field} asc',
+                        order='lock_date asc NULLS FIRST',
                         limit=1,
                     )
                 if exception:

--- a/addons/account/views/account_lock_exception_views.xml
+++ b/addons/account/views/account_lock_exception_views.xml
@@ -40,12 +40,12 @@
                                 </group>
                                 <group>
                                     <div colspan="2" class="o_wrap_label">
-                                        <span class="o_form_label">Changed Lock Dates:</span>
+                                        <span class="o_form_label">Changed Lock Date:</span>
                                     </div>
-                                    <field name="sale_lock_date" readonly="True" invisible="not sale_lock_date"/>
-                                    <field name="purchase_lock_date" readonly="True" invisible="not purchase_lock_date"/>
-                                    <field name="tax_lock_date" readonly="True" invisible="not tax_lock_date"/>
-                                    <field name="fiscalyear_lock_date" readonly="True" invisible="not fiscalyear_lock_date"/>
+                                    <field name="sale_lock_date" readonly="True" invisible="lock_date_field != 'sale_lock_date'"/>
+                                    <field name="purchase_lock_date" readonly="True" invisible="lock_date_field != 'purchase_lock_date'"/>
+                                    <field name="tax_lock_date" readonly="True" invisible="lock_date_field != 'tax_lock_date'"/>
+                                    <field name="fiscalyear_lock_date" readonly="True" invisible="lock_date_field != 'fiscalyear_lock_date'"/>
                                 </group>
                             </group>
                         </div>

--- a/addons/account/views/account_lock_exception_views.xml
+++ b/addons/account/views/account_lock_exception_views.xml
@@ -42,10 +42,16 @@
                                     <div colspan="2" class="o_wrap_label">
                                         <span class="o_form_label">Changed Lock Date:</span>
                                     </div>
-                                    <field name="sale_lock_date" readonly="True" invisible="lock_date_field != 'sale_lock_date'"/>
-                                    <field name="purchase_lock_date" readonly="True" invisible="lock_date_field != 'purchase_lock_date'"/>
-                                    <field name="tax_lock_date" readonly="True" invisible="lock_date_field != 'tax_lock_date'"/>
-                                    <field name="fiscalyear_lock_date" readonly="True" invisible="lock_date_field != 'fiscalyear_lock_date'"/>
+
+                                    <div class="o_wrap_label">
+                                        <field name="lock_date_field" class="o_form_label o_form_label_readonly" nolabel="1" readonly="True"/>
+                                    </div>
+                                    <div>
+                                        <field name="lock_date" nolabel="1" class="oe_inline" readonly="True"/>
+                                        <i class="text-muted">
+                                        (from <field name="company_lock_date" class="oe_inline" readonly="True"/>)
+                                        </i>
+                                    </div>
                                 </group>
                             </group>
                         </div>


### PR DESCRIPTION
### commit messages

#### [FIX] account: fix account.lock_exception field definitions
Some field definitions have been updated to be more consistent in style
with the other definitions.

Some field names have been updated to be the same as on the company.
(And not the same as on the Lock Dates Wizard.)



#### [IMP] account: single lock date per exception
We want to create 1 exception per lock date change (and not bundle
multiple lock date changes in a single exception).
This i.e. allows for more granularity when revoking exceptions.

In this commit we adjust 'account.lock_exception' model s.t.
it can only store 1 lock date.

The model change also allows us to easier remove a lock date with an
exception (and not just decrease it).
This was forbidden in the Lock Dates Wizard previously.

The Lock Dates Wizard is adjusted in the related enterprise PR.



#### [IMP] account: improve exception auditing
This commit improves the exception auditing in 2 ways
- The form view now displays the original date too (and not just the
  new / exceptional date)
- The button to show a restricted audit trail regarding changes during the
  exception was improved. See below for details

The exception form view provides a button to open the audit trail
restricted to messages that were created during the time the exception
was valid.
But this can also contain (many) changes that did not need an exception at all.

After this commit the audit trail is restricted further to accounting dates
in the "excepted period". The "excepted period" starts at the minimal
excepted date and ends at the the maximal original lock date.
E.g. when the Sale Lock Date was changed from 2024-02-01 to 2024-01-01
and the Purchase Lock Date was changed from 2024-03-01 to 2024-02-01
we regard the time period 2024-01-01 to 2024-03-01.

Messages are shown when
- the accounting date of the record is currently inside the "excepted period"
- the messages is regarding an accounting date change from or into the
  "excepted period"

This should find all moves that were changed during the exception
and only show moves for which we needed an exception.

For this to work the original lock date is stored on an exception (field `company_lock_date`).
When a lock date is changed all active exceptions for that lock date get revoked and
recreated with the new lock date.

### task info
related: task-3891414 (lock dates rework)
enterprise PR: https://github.com/odoo/enterprise/pull/69954
