### PR TITLE
[IMP] Cash_moves : clean pop-up and allow it at closing

### DIFF
--- a/addons/point_of_sale/static/src/app/navbar/cash_move_popup/cash_move_popup.js
+++ b/addons/point_of_sale/static/src/app/navbar/cash_move_popup/cash_move_popup.js
@@ -12,7 +12,7 @@ import { Input } from "@point_of_sale/app/generic_components/inputs/input/input"
 export class CashMovePopup extends Component {
     static template = "point_of_sale.CashMovePopup";
     static components = { Input, Dialog };
-    static props = ["confirmKey?", "close"];
+    static props = ["confirmKey?", "close", "getPayload?"];
     setup() {
         super.setup();
         this.notification = useService("notification");

--- a/addons/point_of_sale/static/src/app/navbar/cash_move_popup/cash_move_popup.xml
+++ b/addons/point_of_sale/static/src/app/navbar/cash_move_popup/cash_move_popup.xml
@@ -20,14 +20,14 @@
                     getRef="(ref) => this.inputRef = ref" />
             </div>
             <div class="form-floating">
-                <textarea class="form-control" placeholder="Leave a reason here" name="reason" id="reason" t-model="state.reason" style="height:100px;" />
+                <textarea class="form-control cash-reason" placeholder="Leave a reason here" name="reason" id="reason" t-model="state.reason" style="height:100px;" />
                 <label for="reason">Reason</label>
             </div>
             <t t-set-slot="footer">
                 <button class="button confirm btn btn-lg lh-lg btn-primary"
                     t-on-click="confirm"
-                    t-att-disabled="!env.utils.isValidFloat(state.amount)">
-                    Confirm <span t-esc="format(state.amount)"/>
+                    t-att-disabled="!env.utils.isValidFloat(state.amount) or !state.reason">
+                    Confirm
                 </button>
                 <button class="button cancel btn btn-lg lh-lg btn-secondary" t-on-click="props.close">
                     Discard

--- a/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.js
+++ b/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.js
@@ -41,6 +41,11 @@ export class ClosePosPopup extends Component {
         this.state.payments[this.props.default_cash_details.id].counted = count.toString();
         this.setManualCashInput(count);
     }
+    async cashMove() {
+        await this.pos.cashMove();
+        this.dialog.closeAll();
+        this.pos.closeSession();
+    }
     getInitialState() {
         const initialState = { notes: "", payments: {} };
         if (this.pos.config.cash_control) {

--- a/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.xml
+++ b/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.xml
@@ -90,6 +90,8 @@
                 <div class="w-100 d-flex justify-content-between flex-wrap gap-2">
                     <button class="button highlight btn btn-primary" t-att-disabled="!canConfirm()" t-on-click="confirm" t-att-class="{'btn-lg': !this.ui.isSmall}">Close Register</button>
                     <button class="button btn btn-secondary" t-att-disabled="!canCancel()" t-on-click="cancel" t-att-class="{'btn-lg': !this.ui.isSmall}">Discard</button>
+                    <button class="button btn btn-lg btn-secondary" t-on-click="() => this.cashMove()">Cash In/Out</button>
+
                     <!-- Download Sale Details -->
                     <button class="button icon btn btn-secondary ms-auto"
                         t-on-click="downloadSalesReport"

--- a/addons/point_of_sale/static/src/app/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.js
@@ -9,10 +9,7 @@ import {
     SaleDetailsButton,
     handleSaleDetails,
 } from "@point_of_sale/app/navbar/sale_details_button/sale_details_button";
-import { CashMovePopup } from "@point_of_sale/app/navbar/cash_move_popup/cash_move_popup";
 import { Component, onMounted, useState } from "@odoo/owl";
-import { ClosePosPopup } from "@point_of_sale/app/navbar/closing_popup/closing_popup";
-import { _t } from "@web/core/l10n/translation";
 import { ProductScreen } from "@point_of_sale/app/screens/product_screen/product_screen";
 import { Input } from "@point_of_sale/app/generic_components/inputs/input/input";
 import { isBarcodeScannerSupported } from "@web/core/barcode/barcode_video_scanner";
@@ -65,10 +62,6 @@ export class Navbar extends Component {
     getOrderTabs() {
         return this.pos.get_open_orders().filter((order) => !order.table_id);
     }
-    onCashMoveButtonClick() {
-        this.hardwareProxy.openCashbox(_t("Cash in / out"));
-        this.dialog.add(CashMovePopup);
-    }
 
     get orderCount() {
         return this.pos.get_open_orders().length;
@@ -78,15 +71,6 @@ export class Navbar extends Component {
         return `/scoped_app?app_id=point_of_sale&app_name=${encodeURIComponent(
             this.pos.config.display_name
         )}&path=${encodeURIComponent(`pos/ui?config_id=${this.pos.config.id}`)}`;
-    }
-
-    async closeSession() {
-        const info = await this.pos.getClosePosInfo();
-        await this.pos.data.resetIndexedDB();
-
-        if (info) {
-            this.dialog.add(ClosePosPopup, info);
-        }
     }
 
     toggleProductView() {

--- a/addons/point_of_sale/static/src/app/navbar/navbar.xml
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.xml
@@ -48,7 +48,7 @@
                                 <DropdownItem onSelected="() => this.pos.onTicketButtonClick()">
                                     Orders <span t-if="orderCount gt 0" class="badge text-bg-info rounded-pill py-1 ms-2 float-end" t-esc="orderCount"/>
                                 </DropdownItem>
-                                <DropdownItem t-if="showCashMoveButton" onSelected="() => this.onCashMoveButtonClick()">
+                                <DropdownItem t-if="showCashMoveButton" onSelected="() => this.pos.cashMove()">
                                     Cash In/Out
                                 </DropdownItem>
                                 <DropdownItem t-if="showToggleProductView" onSelected="() => this.toggleProductView()">
@@ -63,7 +63,7 @@
                                 <DropdownItem onSelected="() => pos.closePos()">
                                     Backend
                                 </DropdownItem>
-                                <DropdownItem onSelected="() => this.closeSession()">
+                                <DropdownItem onSelected="() => this.pos.closeSession()">
                                     Close Register
                                 </DropdownItem>
                                 <DropdownItem t-if="this.env.debug" onSelected="() => debug.toggleWidget()">

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -32,6 +32,8 @@ import { getTaxesAfterFiscalPosition, getTaxesValues } from "../models/utils/tax
 import { QRPopup } from "@point_of_sale/app/utils/qr_code_popup/qr_code_popup";
 import { ActionScreen } from "@point_of_sale/app/screens/action_screen";
 import { FormViewDialog } from "@web/views/view_dialogs/form_view_dialog";
+import { CashMovePopup } from "@point_of_sale/app/navbar/cash_move_popup/cash_move_popup";
+import { ClosePosPopup } from "../navbar/closing_popup/closing_popup";
 
 const { DateTime } = luxon;
 
@@ -260,7 +262,18 @@ export class PosStore extends Reactive {
         this.computeProductPricelistCache();
         await this.processProductAttributes();
     }
+    cashMove() {
+        this.hardwareProxy.openCashbox(_t("Cash in / out"));
+        return makeAwaitable(this.dialog, CashMovePopup);
+    }
+    async closeSession() {
+        const info = await this.getClosePosInfo();
+        await this.data.resetIndexedDB();
 
+        if (info) {
+            this.dialog.add(ClosePosPopup, info);
+        }
+    }
     async processProductAttributes() {
         const productIds = new Set();
         const productTmplIds = new Set();

--- a/addons/point_of_sale/static/tests/tours/chrome_tour.js
+++ b/addons/point_of_sale/static/tests/tours/chrome_tour.js
@@ -14,6 +14,7 @@ registry.category("web_tour.tours").add("ChromeTour", {
             Dialog.confirm("Open Register"),
             Chrome.clickMenuButton(),
             Chrome.clickMenuDropdownOption("Cash In/Out"),
+            Chrome.fillTextArea(".cash-reason", "MOBT"),
             Dialog.confirm(),
             Chrome.clickMenuButton(),
 

--- a/addons/point_of_sale/static/tests/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/chrome_util.js
@@ -62,3 +62,10 @@ export function clickBtn(name) {
         run: "click",
     };
 }
+export function fillTextArea(target, value) {
+    return {
+        content: `Fill text area with ${value}`,
+        trigger: `textarea${target}`,
+        run: `edit ${value}`,
+    };
+}


### PR DESCRIPTION
Description of the issue/feature this PR addresses: 

Improve UI and UX

Current behavior before PR:

Desired behavior after PR is merged:

- make 'reason' required
- remove amount on confirm button
- bring method at closing


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
