### PR TITLE
[IMP] core: typing

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1,4 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from __future__ import annotations
 
 import logging
 import re

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -4,30 +4,32 @@
 """ High-level objects for fields. """
 from __future__ import annotations
 
-from collections import defaultdict
-from datetime import date, datetime, time
-from operator import attrgetter
-from xmlrpc.client import MAXINT
 import ast
 import base64
+import binascii
 import copy
 import contextlib
-import binascii
 import enum
 import itertools
 import json
 import logging
+import typing
 import uuid
 import warnings
+from collections import defaultdict
+from datetime import date, datetime, time
+from difflib import get_close_matches, unified_diff
+from hashlib import sha256
+from operator import attrgetter
+from xmlrpc.client import MAXINT
 
 import psycopg2
 import pytz
 from markupsafe import Markup, escape as markup_escape
 from psycopg2.extras import Json as PsycopgJson
-from difflib import get_close_matches, unified_diff
-from hashlib import sha256
 
-from .models import check_property_field_value_name
+from .api import ContextType, DomainType, IdType, NewId, ValuesType
+from .models import BaseModel, check_property_field_value_name
 from .netsvc import ColoredFormatter, GREEN, RED, DEFAULT, COLOR_PATTERN
 from .tools import (
     float_repr, float_round, float_compare, float_is_zero, human_size,
@@ -45,8 +47,8 @@ from .tools.translate import html_translate
 from odoo.exceptions import CacheMiss
 from odoo.osv import expression
 
-import typing
-from odoo.api import ContextType, DomainType, IdType, NewId, M, T
+T = typing.TypeVar("T")
+M = typing.TypeVar("M", bound=BaseModel)
 
 
 DATE_LENGTH = len(date.today().strftime(DATE_FORMAT))
@@ -4195,7 +4197,7 @@ class Command(enum.IntEnum):
     SET = 6
 
     @classmethod
-    def create(cls, values: dict):
+    def create(cls, values: ValuesType) -> tuple[Command, typing.Literal[0], ValuesType]:
         """
         Create new records in the comodel using ``values``, link the created
         records to ``self``.
@@ -4213,7 +4215,7 @@ class Command(enum.IntEnum):
         return (cls.CREATE, 0, values)
 
     @classmethod
-    def update(cls, id: int, values: dict):
+    def update(cls, id: int, values: ValuesType) -> tuple[Command, int, ValuesType]:
         """
         Write ``values`` on the related record.
 
@@ -4222,7 +4224,7 @@ class Command(enum.IntEnum):
         return (cls.UPDATE, id, values)
 
     @classmethod
-    def delete(cls, id: int):
+    def delete(cls, id: int) -> tuple[Command, int, typing.Literal[0]]:
         """
         Remove the related record from the database and remove its relation
         with ``self``.
@@ -4236,7 +4238,7 @@ class Command(enum.IntEnum):
         return (cls.DELETE, id, 0)
 
     @classmethod
-    def unlink(cls, id: int):
+    def unlink(cls, id: int) -> tuple[Command, int, typing.Literal[0]]:
         """
         Remove the relation between ``self`` and the related record.
 
@@ -4250,7 +4252,7 @@ class Command(enum.IntEnum):
         return (cls.UNLINK, id, 0)
 
     @classmethod
-    def link(cls, id: int):
+    def link(cls, id: int) -> tuple[Command, int, typing.Literal[0]]:
         """
         Add a relation between ``self`` and the related record.
 
@@ -4259,7 +4261,7 @@ class Command(enum.IntEnum):
         return (cls.LINK, id, 0)
 
     @classmethod
-    def clear(cls):
+    def clear(cls) -> tuple[Command, typing.Literal[0], typing.Literal[0]]:
         """
         Remove all records from the relation with ``self``. It behaves like
         executing the `unlink` command on every record.
@@ -4269,7 +4271,7 @@ class Command(enum.IntEnum):
         return (cls.CLEAR, 0, 0)
 
     @classmethod
-    def set(cls, ids: list):
+    def set(cls, ids: list[int]) -> tuple[Command, typing.Literal[0], list[int]]:
         """
         Replace the current relations of ``self`` by the given ones. It behaves
         like executing the ``unlink`` command on every removed relation then

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4807,14 +4807,12 @@ class BaseModel(metaclass=MetaModel):
 
     @api.model_create_multi
     def create(self, vals_list: list[ValuesType]) -> Self:
-        """ create(vals_list) -> records
-
-        Creates new records for the model.
+        """Creates new records for the model.
 
         The new records are initialized using the values from the list of dicts
         ``vals_list``, and if necessary those from :meth:`~.default_get`.
 
-        :param Union[list[dict], dict] vals_list:
+        :param vals_list:
             values for the model's fields, as a list of dictionaries::
 
                 [{'field_name': field_value, ...}, ...]


### PR DESCRIPTION
odoo/odoo#177609 added a bunch of typing, but that has a few issues:

- `create` is not defined as taking a lone dict, which is the most common way to use it by an order of magnitude, so 9 cases out of 10 are marked as incorrect when trying to typecheck creates at least in pycharm, add ~~the relevant overloads (they don't seem to work correctly when create is being overridden tho)~~ proper typing to the decorators[^1][^2].
- The `M` typevar is not relevant to `api.py` (or its users), move it to `fields.py` where it makes sense
- ~~Try to define the set of writeable values more precisely than `Any`, though it remains somewhat dodgy~~.

[^1]: overloads "worked" but had to be repeated on every overload of the method which sucked (as overloading `create` is pretty normal)
[^2]: so it still doesn't work in pycharm as it apparently doesn't understand typed decorators (at least not generic ones), it seems to work fine in mypy and pyright though which hit that it's the right solution