### PR TITLE
[IMP] account: account prefix analytic distribution

### DIFF
--- a/addons/account/views/account_analytic_distribution_model_views.xml
+++ b/addons/account/views/account_analytic_distribution_model_views.xml
@@ -8,7 +8,8 @@
             <field name="arch" type="xml">
                 <data>
                     <xpath expr="//field[@name='partner_id']" position="before">
-                            <field name="account_prefix" optional="show"/>
+                        <field name="prefix_placeholder" column_invisible="1"/> <!-- Needed for the char_with_placeholder_field widget -->
+                        <field name="account_prefix" string="Accounts Prefixes" optional="show" widget="char_with_placeholder_field" options="{'placeholder_field': 'prefix_placeholder'}"/>
                     </xpath>
                     <xpath expr="//field[@name='company_id']" position="before">
                             <field name="product_id" optional="show"/>
@@ -25,7 +26,8 @@
             <field name="arch" type="xml">
                 <data>
                     <xpath expr="//field[@name='partner_category_id']" position="after">
-                            <field name="account_prefix"/>
+                        <field name="prefix_placeholder" invisible="1"/> <!-- Needed for the char_with_placeholder_field widget -->
+                        <field name="account_prefix" string="Accounts Prefixes" widget="char_with_placeholder_field" options="{'placeholder_field': 'prefix_placeholder'}"/>
                     </xpath>
                     <xpath expr="//field[@name='company_id']" position="before">
                             <field name="product_id"/>


### PR DESCRIPTION
Suppose our user wants to set a default analytic distribution for accounts 610003, 620003 and 602004. He currently needs to duplicate the analytic distribution model 3 times. The idea is to allow him specifying the distribution only once and to parse the Accounts Prefixes field, where those prefixes will be separated properly.

This commit will also add a dynamic placeholder

task: 4178861




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
