### PR TITLE
[FIX] stock: collection of 18.0 bugfixes for mrp

### DIFF
--- a/addons/stock/static/src/stock_forecasted/forecasted_header.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_header.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 import { useService } from "@web/core/utils/hooks";
 import { formatFloat } from "@web/views/fields/formatters";
-import { Component } from "@odoo/owl";
+import { Component, markup } from "@odoo/owl";
 
 export class ForecastedHeader extends Component {
     static template = "stock.ForecastedHeader";
@@ -17,6 +17,9 @@ export class ForecastedHeader extends Component {
     async _onClickInventory(){
         const context = this._getActionContext();
         const action = await this.orm.call('stock.quant', 'action_view_quants', [], { context });
+        if (action.help) {
+            action.help = markup(action.help);
+        }
         return this.action.doAction(action);
     }
 

--- a/addons/stock/static/src/views/search/stock_orderpoint_search_panel.js
+++ b/addons/stock/static/src/views/search/stock_orderpoint_search_panel.js
@@ -10,6 +10,7 @@ export class StockOrderpointSearchPanel extends SearchPanel {
     setup() {
         super.setup(...arguments);
         this.globalVisibilityDays = useState({value: 0});
+        this.state.sidebarExpanded = false;
     }
 
     async applyGlobalVisibilityDays(ev) {


### PR DESCRIPTION
Various v18 bugfixes for MRP before the feature freeze.
Current behaviour:
1. HTML help string markup for empty reports don't get parsed in some cases (such as the forecasted inventory report).
2. Replenishments sidepanel is expanded by default.

Desired behaviour:
1. HTML help string markup gets parsed for every report view.
2. Replenishments sidepanel is collapsed by default.

Task ID: [4154879](https://www.odoo.com/odoo/966/tasks/4154879)