### PR TITLE
[FIX] stock: unreserve backwards on qty decrease

### DIFF
--- a/addons/mrp/static/tests/tours/mrp_sm_sml_synchronization.js
+++ b/addons/mrp/static/tests/tours/mrp_sm_sml_synchronization.js
@@ -55,10 +55,10 @@ registry.category("web_tour.tours").add('test_manufacturing_and_byproduct_sm_to_
         { trigger: ".o_data_row > td:contains('10')" },
         {
             trigger: ".o_field_widget[name=quantity] input",
-            run: 'text 7',
+            run: 'text 8',
         },
         { trigger: ".fa-list" },
-        { trigger: ".o_list_footer .o_list_number > span:contains('7')" },
+        { trigger: ".o_list_footer .o_list_number > span:contains('8')" },
         { trigger: ".o_form_button_save" },
         ...stepUtils.saveForm(),
     ]

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -4306,5 +4306,5 @@ class TestMrpSynchronization(HttpCase):
         self.start_tour(url, "test_manufacturing_and_byproduct_sm_to_sml_synchronization", login="admin", timeout=100)
         self.assertEqual(mo.move_raw_ids.quantity, 7)
         self.assertEqual(mo.move_raw_ids.move_line_ids.quantity, 7)
-        self.assertEqual(mo.move_byproduct_ids.quantity, 7)
+        self.assertEqual(mo.move_byproduct_ids.quantity, 8)
         self.assertEqual(len(mo.move_byproduct_ids.move_line_ids), 2)

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -360,7 +360,9 @@ class StockMove(models.Model):
     def _set_quantity(self):
         def _process_decrease(move, quantity):
             mls_to_unlink = set()
-            for ml in move.move_line_ids:
+            # Since the move lines might have been created in a certain order to respect
+            # a removal strategy, they need to be unreserved in the opposite order
+            for ml in reversed(move.move_line_ids.sorted('id')):
                 if float_is_zero(quantity, precision_rounding=move.product_uom.rounding):
                     break
                 qty_ml_dec = min(ml.quantity, ml.product_uom_id._compute_quantity(quantity, ml.product_uom_id, round=False))

--- a/addons/stock/tests/test_move2.py
+++ b/addons/stock/tests/test_move2.py
@@ -2520,6 +2520,92 @@ class TestSinglePicking(TestStockCommon):
         self.assertEqual(picking.move_ids.quantity, 6.0)
         self.assertTrue(sml.picked)
 
+    def test_unreservation_on_qty_decrease(self):
+        """
+        Check that the move_lines are unreserved backwards on qty
+        decrease to respect lifo/fifo/... removal strategies
+        """
+        tracked_product = self.env['product.product'].create({
+            'name': "Lovely Product",
+            'type': 'product',
+            'tracking': 'lot',
+        })
+        # Use the removal strategy by alphabetical order of locations
+        closest_strategy = self.env['product.removal'].search([('method', '=', 'closest')])
+        tracked_product.categ_id.removal_strategy_id = closest_strategy
+        lot_count = 5
+        lots = self.env['stock.lot'].create([
+            {
+                'product_id': tracked_product.id,
+                'name': f'LOT00{1 + i}'
+            }
+            for i in range(lot_count)
+        ])
+        locations = self.env['stock.location'].create([
+            {
+                'name': f'Shell {lot_count - i}',
+                'usage': 'internal',
+                'location_id': self.stock_location,
+            }
+            for i in range(lot_count)
+        ])
+        for i in range(lot_count):
+            self.env['stock.quant']._update_available_quantity(tracked_product, locations[i], 10.0, lot_id=lots[i])
+        delivery = self.env['stock.picking'].create({
+            'name': 'Lovely Delivery',
+            'location_id': self.stock_location,
+            'location_dest_id': self.customer_location,
+            'picking_type_id': self.picking_type_out,
+            'move_ids': [
+                Command.create({
+                    'name': 'Lovely Move',
+                    'product_id': tracked_product.id,
+                    'product_uom_qty': 50,
+                    'location_id': self.stock_location,
+                    'location_dest_id': self.customer_location,
+                    'product_uom': tracked_product.uom_id.id,
+                })
+            ]
+        })
+        delivery.picking_type_id.reservation_method = 'at_confirm'
+        delivery.action_confirm()
+        self.assertEqual(delivery.move_line_ids.mapped(lambda sml: (sml.location_id.name, sml.lot_id.name, sml.quantity)), [
+            ('Shell 1', 'LOT005', 10.0),
+            ('Shell 2', 'LOT004', 10.0),
+            ('Shell 3', 'LOT003', 10.0),
+            ('Shell 4', 'LOT002', 10.0),
+            ('Shell 5', 'LOT001', 10.0),
+        ])
+        # Decrease the quantity to 45 units
+        with Form(delivery) as delivery_form:
+            with delivery_form.move_ids_without_package.edit(0) as move:
+                move.quantity = 45
+        self.assertEqual(delivery.move_line_ids.mapped(lambda sml: (sml.location_id.name, sml.lot_id.name, sml.quantity)), [
+            ('Shell 1', 'LOT005', 10.0),
+            ('Shell 2', 'LOT004', 10.0),
+            ('Shell 3', 'LOT003', 10.0),
+            ('Shell 4', 'LOT002', 10.0),
+            ('Shell 5', 'LOT001', 5.0),
+        ])
+        # Decrease the quantity to 25 units
+        with Form(delivery) as delivery_form:
+            with delivery_form.move_ids_without_package.edit(0) as move:
+                move.quantity = 25
+        self.assertEqual(delivery.move_line_ids.mapped(lambda sml: (sml.location_id.name, sml.lot_id.name, sml.quantity)), [
+            ('Shell 1', 'LOT005', 10.0),
+            ('Shell 2', 'LOT004', 10.0),
+            ('Shell 3', 'LOT003', 5.0),
+        ])
+        # Decrease the quantity to 12 units
+        with Form(delivery) as delivery_form:
+            with delivery_form.move_ids_without_package.edit(0) as move:
+                move.quantity = 12
+        self.assertEqual(delivery.move_line_ids.mapped(lambda sml: (sml.location_id.name, sml.lot_id.name, sml.quantity)), [
+            ('Shell 1', 'LOT005', 10.0),
+            ('Shell 2', 'LOT004', 2.0),
+        ])
+
+
 class TestStockUOM(TestStockCommon):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
### Steps to reproduce:

- Create a product tracked by lot and register 4 lots of 10 units in stock : LOT001, LOT002, LOT003, LOT004
- Inventory > Configuration > Products > Product Categories
- Change the Removal strategy of the "All" category to LIFO
- Create and confirm a delivery order for 40 units of your product
> Move lines are created for reservation in order LOT003, LOT002, LOT001
- Do not click on the detailed operation to see these LOTS and decrease the quantity of the move to 15 units

### Expected behavior:

Since the lines were created respecting the removal strategy, they should be removed accordingly from the last one created to the first created > LOT001 and LOT002 should be removed and 5 units should be decreased from LOT003

### Current behavior:

LOT004 and LOT004 are removed and 5 units is removed from LOT002

### Cause of the issue:

On qty decrease, the `_process_decrease` of the `set_quantity` is called to decrease the qties on the associated sml and to unlink the one resulting with a 0 qty. However, the loop used to make this action is not based on the reversed order of creation of the lines but on their order itself.

#### Note:

This doe snot solve the issue for complex removal strategy that would require a complete recompute of the reservation on qty decrease such as "use the minimal amount of packages".

### Note 2:

An other issue exists when you increase the demand of the move instead of decreasing it: while the qty done is increased no assignments are done so that a move line without lot id would be created to fulfill the increase of qty. This is because the `_action_assign` can not be triggered again in this process increase since the stockpocalypse the line was even commented here:
https://github.com/odoo/odoo/blob/9f364cde276b8b3be73c30617515bd55a9f25aba/addons/stock/models/stock_move.py#L376-L378 he reason is that if an `_action_assign` was performed instead and if the units were not in stock to fulfill it the qty would only be increased by the available qty and the desired flow would be bloqued. THe behavior is being improved in master (18.0+) but the required change of the `_process_increase` is to risky to be applied in stable.

co-authored by @naja628

opw-4074174 and opw-4071479
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
