### PR TITLE
[FIX] point_of_sale: block sale of archived product variants

### DIFF
--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -154,6 +154,8 @@ class ProductProduct(models.Model):
             for tax in taxes:
                 taxes_by_company[tax.company_id.id].add(tax.id)
 
+        loaded_product_tmpl_ids = list({p['product_tmpl_id'] for p in products})
+        archived_combinations = self._get_archived_combinations_per_product_tmpl_id(loaded_product_tmpl_ids)
         different_currency = config_id.currency_id != self.env.company.currency_id
         for product in products:
             if different_currency:
@@ -162,6 +164,17 @@ class ProductProduct(models.Model):
 
             if len(taxes_by_company) > 1 and len(product['taxes_id']) > 1:
                 product['taxes_id'] = filter_taxes_on_company(product['taxes_id'], taxes_by_company)
+
+            if archived_combinations.get(product['product_tmpl_id']):
+                product['_archived_combinations'] = archived_combinations[product['product_tmpl_id']]
+
+    def _get_archived_combinations_per_product_tmpl_id(self, product_tmpl_ids):
+        archived_combinations = {}
+        for product in self.env['product.product'].with_context(active_test=False).search([('product_tmpl_id', 'in', product_tmpl_ids), ('active', '=', False)]):
+            if not archived_combinations.get(product.product_tmpl_id.id):
+                archived_combinations[product.product_tmpl_id.id] = []
+            archived_combinations[product.product_tmpl_id.id].append(product.product_template_attribute_value_ids.ids)
+        return archived_combinations
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_active_pos_session(self):

--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -194,5 +194,17 @@ export class ProductProduct extends Base {
         const fields = ["barcode", "default_code"];
         return fields.some((field) => this[field] && this[field].includes(searchWord));
     }
+
+    _isArchivedCombination(attributeValueIds) {
+        for (const archivedCombination of this._archived_combinations) {
+            const ptavCommon = archivedCombination.filter((ptav) =>
+                attributeValueIds.includes(ptav)
+            );
+            if (ptavCommon.length === attributeValueIds.length) {
+                return true;
+            }
+        }
+        return false;
+    }
 }
 registry.category("pos_available_models").add(ProductProduct.pythonModel, ProductProduct);

--- a/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.js
@@ -184,4 +184,21 @@ export class ProductConfiguratorPopup extends Component {
         this.props.getPayload(this.computePayload());
         this.props.close();
     }
+    isArchivedCombination() {
+        const variantAttributeValueIds = this.getVariantAttributeValueIds();
+        if (variantAttributeValueIds.length === 0) {
+            return false;
+        }
+        return this.props.product._isArchivedCombination(variantAttributeValueIds);
+    }
+    getVariantAttributeValueIds() {
+        const attribute_value_ids = [];
+        this.state.payload.forEach((att_component) => {
+            const { valueIds } = att_component.getValue();
+            if (att_component.attributeLine.attribute_id.create_variant === "always") {
+                attribute_value_ids.push(valueIds);
+            }
+        });
+        return attribute_value_ids.flat();
+    }
 }

--- a/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.xml
@@ -122,6 +122,9 @@
     <t t-name="point_of_sale.ProductConfiguratorPopup">
         <Dialog title="'Attribute selection'">
             <div t-ref="input-area">
+                <div t-if="isArchivedCombination()" class="alert alert-warning mt-3">
+                    <span>This option or combination of options is not available</span>
+                </div>
                 <div t-foreach="this.props.product.attribute_line_ids" t-as="attributeLine" t-key="attributeLine.id" class="attribute mb-3">
                     <div class="attribute_name mb-2 fw-bolder" t-esc="attributeLine.attribute_id.name"/>
                     <RadioProductAttribute t-if="attributeLine.attribute_id.display_type === 'radio'" attributeLine="attributeLine"/>
@@ -133,7 +136,12 @@
             </div>
             <t t-set-slot="footer">
                 <div class="d-flex w-100 justify-content-start gap-2">
-                    <button class="btn btn-primary o-default-button" t-on-click="confirm">Ok</button>
+                    <button 
+                        class="btn btn-primary o-default-button"
+                        t-att-class="{'disabled': isArchivedCombination()}"
+                        t-on-click="confirm">
+                        Ok
+                    </button>
                     <button class="btn btn-secondary o-default-button" t-on-click="close">Discard</button>
                 </div>
             </t>


### PR DESCRIPTION
Before this commit, users could inadvertently sell an archived product variant by selecting its attribute combination in the product configurator popup.

opw-4171604

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
