### PR TITLE
[IMP] mail: start call confirm popover

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -57,6 +57,7 @@ export class ChatWindow extends Component {
         this.ui = useState(useService("ui"));
         this.contentRef = useRef("content");
         this.threadActions = useThreadActions();
+        this.root = useRef("root");
 
         useChildSubEnv({
             closeActionPanel: () => this.threadActions.activeAction?.close(),

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -11,6 +11,7 @@
         }"
         t-on-keydown="onKeydown"
         tabindex="1"
+        t-ref="root"
     >
         <div class="o-mail-ChatWindow-header d-flex align-items-center flex-shrink-0 bg-100 z-1" t-on-click="onClickHeader" t-att-class="{ 'cursor-pointer': !ui.isSmall and thread, 'pt-2': !thread }">
             <t t-if="threadActions.actions.length > 3">
@@ -30,7 +31,7 @@
                             <t t-else="" t-set="actions" t-value="threadActions.actions.slice(1, -2)"/>
                             <DropdownItem t-foreach="actions" t-as="action" t-key="action.id"
                                 class="'o-mail-ChatWindow-command btn rounded-0 d-flex align-items-center px-2 py-2 m-0'"
-                                attrs="{ title: action.name }"
+                                attrs="{ title: action.name, name: action.id }"
                                 onSelected="() => action.onSelect()"
                             >
                                 <i t-att-class="action.icon"/>
@@ -101,7 +102,10 @@
 </t>
 
 <t t-name="mail.ChatWindow.dropdownAction">
-    <button class="o-mail-ChatWindow-command btn d-flex p-2 opacity-75 opacity-100-hover" t-att-class="itemClass" t-att-title="action.name" t-on-click.stop="() => action.onSelect()"><i t-att-class="action.icon"/></button>
+    <button class="o-mail-ChatWindow-command btn d-flex opacity-75 opacity-100-hover" t-attf-class="#{itemClass}" t-att-title="action.name" t-att-name="action.id" t-on-click.stop="() => action.onSelect()" t-att-class="{
+        'o-active': action.isActive,
+        'p-2': !ui.isSmall,
+    }"><i t-att-class="ui.isSmall ? action.iconLarge : action.icon"/></button>
 </t>
 
 <t t-name="mail.ChatWindow.headerContent">

--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -47,6 +47,7 @@ threadActionsRegistry
             return component.props.chatWindow;
         },
         icon: "oi fa-fw oi-close",
+        iconLarge: "oi fa-fw fa-lg oi-close",
         name: _t("Close Chat Window (ESC)"),
         open(component) {
             component.close();

--- a/addons/mail/static/src/discuss/call/common/call_confirmation.js
+++ b/addons/mail/static/src/discuss/call/common/call_confirmation.js
@@ -1,0 +1,19 @@
+import { Component, useState } from "@odoo/owl";
+
+import { useService } from "@web/core/utils/hooks";
+
+export class CallConfirmation extends Component {
+    static props = ["thread", "close?"];
+    static template = "discuss.CallConfirmation";
+
+    setup() {
+        super.setup();
+        this.ui = useState(useService("ui"));
+        this.store = useState(useService("mail.store"));
+    }
+
+    proceed() {
+        this.store.rtc.toggleCall(this.props.thread);
+        this.props.close?.();
+    }
+}

--- a/addons/mail/static/src/discuss/call/common/call_confirmation.scss
+++ b/addons/mail/static/src/discuss/call/common/call_confirmation.scss
@@ -1,0 +1,8 @@
+.o-mail-CallConfirmation button {
+    --bg-opacity: .15;
+    --border-opacity: .5;
+
+    &:hover {
+        filter: brightness(1.25);
+    }
+}

--- a/addons/mail/static/src/discuss/call/common/call_confirmation.xml
+++ b/addons/mail/static/src/discuss/call/common/call_confirmation.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="discuss.CallConfirmation">
+        <div class="o-mail-CallConfirmation d-flex align-items-center justify-content-center p-2">
+            <span class="fw-bolder fst-italic text-muted" t-att-class="{ 'fs-5': ui.isSmall }">Start Call?</span>
+            <span class="me-2"/>
+            <div class="btn-group" t-att-class="{ 'btn-group-small': !ui.isSmall }">
+                <button class="btn btn-light border-success bg-success text-success" t-att-class="{ 'px-2 py-0': !ui.isSmall }" t-on-click="() => this.proceed()"><i class="fa fa-phone" t-att-class="{ 'fa-lg': ui.isSmall }"/></button>
+                <button class="btn btn-light border-danger bg-danger text-danger" t-att-class="{ 'px-2 py-0': !ui.isSmall }" t-on-click="() => this.props.close()"><i class="oi oi-close" t-att-class="{ 'fa-lg': ui.isSmall }"/></button>
+            </div>
+        </div>
+    </t>
+
+</templates>

--- a/addons/mail/static/src/discuss/call/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/call/common/thread_actions.js
@@ -4,7 +4,9 @@ import { CallSettings } from "@mail/discuss/call/common/call_settings";
 import { useComponent, useState } from "@odoo/owl";
 
 import { _t } from "@web/core/l10n/translation";
+import { usePopover } from "@web/core/popover/popover_hook";
 import { useService } from "@web/core/utils/hooks";
+import { CallConfirmation } from "./call_confirmation";
 
 threadActionsRegistry
     .add("call", {
@@ -16,13 +18,24 @@ threadActionsRegistry
         icon: "fa fa-fw fa-phone",
         iconLarge: "fa fa-fw fa-lg fa-phone",
         name: _t("Start a Call"),
-        open(component) {
-            component.rtc.toggleCall(component.thread);
+        open(component, action) {
+            if (!component.thread.rtcSessions.length) {
+                action.popover.open(component.root.el.querySelector(`[name="${action.id}"]`), {
+                    thread: component.thread,
+                });
+            } else {
+                component.rtc.toggleCall(component.thread);
+            }
         },
+        panelOuterClass: "shadow-sm m-1",
         sequence: 10,
-        setup() {
+        setup(action) {
             const component = useComponent();
             component.rtc = useState(useService("discuss.rtc"));
+            action.popover = usePopover(CallConfirmation, {
+                onClose: () => action.close(),
+                popoverClass: action.panelOuterClass,
+            });
         },
     })
     .add("settings", {


### PR DESCRIPTION
With this commit, when a conversation has no ongoing call, clicking on call thread action asks confirmation to start the call.

Start a call invites all members to join the call, and since the button is a quick action, it's also too easy to click on it by mistake.

To remedy to misclick in mobile, the chat window quick actions are also bigger.

<img width="358" alt="Screenshot 2024-09-12 at 21 04 23" src="https://github.com/user-attachments/assets/9902d2c6-ffb9-4628-b694-909c745cb854">

