### PR TITLE
[FIX] point_of_sale: display difference correctly in other languages

### DIFF
--- a/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.js
+++ b/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.js
@@ -118,7 +118,7 @@ export class ClosePosPopup extends Component {
     getDifference(paymentId) {
         const counted = this.state.payments[paymentId].counted;
         if (!this.env.utils.isValidFloat(counted)) {
-            return NaN;
+            return null;
         }
         const expectedAmount =
             paymentId === this.props.default_cash_details?.id

--- a/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.xml
+++ b/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.xml
@@ -34,7 +34,7 @@
                                         <button class="icon fa fa-money fa-lg btn btn-secondary ms-1" t-on-click="openDetailsPopup" />
                                     </td>
                                     <t t-set="diff" t-value="getDifference(props.default_cash_details.id)" />
-                                    <td t-esc="env.utils.isValidFloat(diff) ? env.utils.formatCurrency(diff) : ''"
+                                    <td t-esc="diff !== null ? env.utils.formatCurrency(diff) : ''"
                                         t-att-class="{'warning text-danger fw-bolder': !env.utils.floatIsZero(getDifference(props.default_cash_details.id))}"/>
                                 </tr>
                             </tbody>


### PR DESCRIPTION
Before this commit, when decimal separators were commas (,) instead of (.), entering a float number for the opening amount would result in the difference not being displayed in the closing popup. This issue occurred because the response from getDifference was not parsed as a float, causing checks with isValidFloat to return false.

opw-4170777

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
