### PR TITLE
[FIX] mail, im_livechat: download files crashes with guest user

### DIFF
--- a/addons/im_livechat/static/src/embed/common/disabled_features.js
+++ b/addons/im_livechat/static/src/embed/common/disabled_features.js
@@ -1,19 +1,11 @@
 /* @odoo-module */
 
-import { messageActionsRegistry } from "@mail/core/common/message_actions";
 import { threadActionsRegistry } from "@mail/core/common/thread_actions";
 import { Thread } from "@mail/core/common/thread_model";
 import { ThreadService } from "@mail/core/common/thread_service";
 
 import { patch } from "@web/core/utils/patch";
 import { SESSION_STATE } from "./livechat_service";
-
-const downloadFilesAction = messageActionsRegistry.get("download_files");
-patch(downloadFilesAction, {
-    condition(component) {
-        return component.message.originThread.type !== "livechat" && super.condition(component);
-    },
-});
 
 patch(Thread.prototype, {
     get hasMemberList() {

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -78,7 +78,8 @@ messageActionsRegistry
         sequence: 90,
     })
     .add("download_files", {
-        condition: (component) => component.message.attachments.length > 1,
+        condition: (component) =>
+            component.message.attachments.length > 1 && component.store.self?.user?.isInternalUser,
         icon: "fa-download",
         title: _t("Download Files"),
         onClick: (component) =>


### PR DESCRIPTION
Download files are restricted to the internal users by acl. This commit adapts the UI so the feature would not be available for non-internal users.

Steps to reproduce:

- Go to a public channel as a guest
- Send a message with multiple attachments
- Try to download all of them by clicking on Download Files in the message action menu
- It crashes with Forbidden error

