### PR TITLE
[IMP] point_of_sale, pos_self_order: Store applied pricelist item on Orderline

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1291,6 +1291,7 @@ class PosOrderLine(models.Model):
         store=True, readonly=False)
     price_unit = fields.Float(string='Unit Price', digits=0)
     qty = fields.Float('Quantity', digits='Product Unit of Measure', default=1)
+    pricelist_item_id = fields.Many2one('product.pricelist.item')
     price_subtotal = fields.Float(string='Tax Excl.', digits=0,
         readonly=True, required=True)
     price_subtotal_incl = fields.Float(string='Tax Incl.', digits=0,
@@ -1333,7 +1334,7 @@ class PosOrderLine(models.Model):
     @api.model
     def _load_pos_data_fields(self, config_id):
         return [
-            'qty', 'attribute_value_ids', 'custom_attribute_value_ids', 'price_unit', 'skip_change', 'uuid', 'price_subtotal', 'price_subtotal_incl', 'order_id', 'note', 'price_type',
+            'qty', 'pricelist_item_id', 'attribute_value_ids', 'custom_attribute_value_ids', 'price_unit', 'skip_change', 'uuid', 'price_subtotal', 'price_subtotal_incl', 'order_id', 'note', 'price_type',
             'product_id', 'discount', 'tax_ids', 'pack_lot_ids', 'customer_note', 'refunded_qty', 'price_extra', 'full_product_name', 'refunded_orderline_id', 'combo_parent_id', 'combo_line_ids', 'combo_item_id', 'refund_orderline_ids'
         ]
 

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -394,12 +394,15 @@ export class PosOrder extends Base {
         );
 
         for (const line of lines_to_recompute) {
-            const newPrice = line.product_id.get_price(
+            const { price, pricelist_item } = line.product_id.get_price(
                 pricelist,
                 line.get_quantity(),
-                line.get_price_extra()
+                line.get_price_extra(),
+                false,
+                true // Get pricelist_item
             );
-            line.set_unit_price(newPrice);
+            line.set_unit_price(price);
+            line.set_pricelist_item(pricelist_item);
         }
 
         const attributes_prices = {};

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -242,13 +242,15 @@ export class PosOrderline extends Base {
 
         // just like in sale.order changing the qty will recompute the unit price
         if (!keep_price && this.price_type === "original") {
-            this.set_unit_price(
-                this.product_id.get_price(
-                    this.order_id.pricelist_id,
-                    this.get_quantity(),
-                    this.get_price_extra()
-                )
+            const { price, pricelist_item } = this.product_id.get_price(
+                this.order_id.pricelist_id,
+                this.get_quantity(),
+                this.get_price_extra(),
+                false,
+                true // Get pricelist_item
             );
+            this.set_unit_price(price);
+            this.set_pricelist_item(pricelist_item);
         }
 
         this.setDirty();
@@ -340,6 +342,12 @@ export class PosOrderline extends Base {
         this.set_quantity(this.get_quantity() + orderline.get_quantity());
     }
 
+    set_pricelist_item(item) {
+        if (typeof item !== "undefined") {
+            this.pricelist_item_id = item;
+        }
+    }
+
     set_unit_price(price) {
         const parsed_price = !isNaN(price)
             ? price
@@ -351,6 +359,10 @@ export class PosOrderline extends Base {
             this.models["decimal.precision"].find((dp) => dp.name === "Product Price").digits
         );
         this.setDirty();
+    }
+
+    get_pricelist_item() {
+        return this.pricelist_item_id;
     }
 
     get_unit_price() {

--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -116,7 +116,7 @@ export class ProductProduct extends Base {
     // product.pricelist.item records are loaded with a search_read
     // and were automatically sorted based on their _order by the
     // ORM. After that they are added in this order to the pricelists.
-    get_price(pricelist, quantity, price_extra = 0, recurring = false) {
+    get_price(pricelist, quantity, price_extra = 0, recurring = false, get_pricelist_item = false) {
         // In case of nested pricelists, it is necessary that all pricelists are made available in
         // the POS. Display a basic alert to the user in the case where there is a pricelist item
         // but we can't load the base pricelist to get the price when calling this method again.
@@ -135,7 +135,7 @@ export class ProductProduct extends Base {
         let price = this.lst_price + (price_extra || 0);
         const rule = rules.find((rule) => !rule.min_quantity || quantity >= rule.min_quantity);
         if (!rule) {
-            return price;
+            return get_pricelist_item ? { price: price, pricelist_item: rule } : price;
         }
 
         if (rule.base === "pricelist") {
@@ -171,7 +171,7 @@ export class ProductProduct extends Base {
         // being used further. Note that this cannot happen here,
         // because it would cause inconsistencies with the backend for
         // pricelist that have base == 'pricelist'.
-        return price;
+        return get_pricelist_item ? { price: price, pricelist_item: rule } : price;
     }
 
     getImageUrl() {

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -813,17 +813,29 @@ export class PosStore extends Reactive {
 
         // Handle price unit
         if (!values.product_id.isCombo() && vals.price_unit === undefined) {
-            values.price_unit = values.product_id.get_price(order.pricelist_id, values.qty);
-        }
-        const isScannedProduct = opts.code && opts.code.type === "product";
-        if (values.price_extra && !isScannedProduct) {
-            const price = values.product_id.get_price(
+            const { price, pricelist_item } = values.product_id.get_price(
                 order.pricelist_id,
                 values.qty,
-                values.price_extra
+                0,
+                false,
+                true // Get pricelist_item
+            );
+            values.price_unit = price;
+            values.pricelist_item_id = pricelist_item;
+        }
+
+        const isScannedProduct = opts.code && opts.code.type === "product";
+        if (values.price_extra && !isScannedProduct) {
+            const { price, pricelist_item } = values.product_id.get_price(
+                order.pricelist_id,
+                values.qty,
+                values.price_extra,
+                false,
+                true // Get pricelist_item
             );
 
             values.price_unit = price;
+            values.pricelist_item_id = pricelist_item;
         }
 
         const line = this.data.models["pos.order.line"].create({ ...values, order_id: order });

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -271,13 +271,16 @@ export class SelfOrder extends Reactive {
         }
 
         if (values.price_extra > 0) {
-            const price = values.product_id.get_price(
+            const { price, pricelist_item } = values.product_id.get_price(
                 this.currentOrder.pricelist_id,
                 values.qty,
-                values.price_extra
+                values.price_extra,
+                false,
+                true // Get pricelist_item
             );
 
             values.price_unit = price;
+            values.pricelist_item_id = pricelist_item;
         }
 
         const newLine = this.models["pos.order.line"].create(values);

--- a/doc/cla/individual/QuocDuong1306.md
+++ b/doc/cla/individual/QuocDuong1306.md
@@ -1,0 +1,11 @@
+Vietnam, 2024-07-24
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Quoc Duong duongquoctran1306@gmail.com https://github.com/QuocDuong1306


### PR DESCRIPTION
Currently, the applied pricelist item on an Orderline is not stored in the Point of Sale (POS) model.

Proposed Change:

This PR stores the applied `pricelist item` on the Orderline whenever a new price is determined for a product based on the selected `pricelist`. Doing so, we enable other modules to use this information, for example, if we want to show it on the show a distinctive mark on the Receipt whenever a specific type of pricelist item has been applied.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
