### PR TITLE
[FIX] mail: send message in chatter should respect user/customer language

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -549,7 +549,7 @@ class Channel(models.Model):
         the noise. """
         groups = super(Channel, self)._notify_get_groups(msg_vals=msg_vals)
         for (index, (group_name, group_func, group_data)) in enumerate(groups):
-            if group_name != 'customer':
+            if 'customer' not in group_name:
                 groups[index] = (group_name, lambda partner: False, group_data)
         return groups
 

--- a/addons/mail/models/mail_followers.py
+++ b/addons/mail/models/mail_followers.py
@@ -124,7 +124,8 @@ SELECT DISTINCT ON (pid) * FROM (
            partner.active as active,
            partner.partner_share as pshare,
            users.notification_type AS notif,
-           array_agg(groups_rel.gid) AS groups
+           array_agg(groups_rel.gid) AS groups,
+           partner.lang
       FROM res_partner partner
  LEFT JOIN res_users users ON users.partner_id = partner.id
                           AND users.active
@@ -145,7 +146,8 @@ ORDER BY pid, notif
 SELECT partner.id as pid,
     partner.active as active, partner.partner_share as pshare,
     users.notification_type AS notif,
-    array_agg(groups_rel.gid) FILTER (WHERE groups_rel.gid IS NOT NULL) AS groups
+    array_agg(groups_rel.gid) FILTER (WHERE groups_rel.gid IS NOT NULL) AS groups,
+    partner.lang
 FROM res_partner partner
     LEFT JOIN res_users users ON users.partner_id = partner.id AND users.active
     LEFT JOIN res_groups_users_rel groups_rel ON groups_rel.uid = users.id

--- a/addons/mail/wizard/mail_resend_message.py
+++ b/addons/mail/wizard/mail_resend_message.py
@@ -63,9 +63,9 @@ class MailResendMessage(models.TransientModel):
                 record = self.env[message.model].browse(message.res_id) if message.is_thread_message() else self.env['mail.thread']
 
                 email_partners_data = []
-                for pid, active, pshare, notif, groups in self.env['mail.followers']._get_recipient_data(None, 'comment', False, pids=to_send.ids):
+                for pid, active, pshare, notif, groups, lang in self.env['mail.followers']._get_recipient_data(None, 'comment', False, pids=to_send.ids):
                     if pid and notif == 'email' or not notif:
-                        pdata = {'id': pid, 'share': pshare, 'active': active, 'notif': 'email', 'groups': groups or []}
+                        pdata = {'id': pid, 'share': pshare, 'active': active, 'notif': 'email', 'groups': groups or [], lang: lang}
                         if not pshare and notif:  # has an user and is not shared, is therefore user
                             email_partners_data.append(dict(pdata, type='user'))
                         elif pshare and notif:  # has an user and is shared, is therefore portal

--- a/addons/mail/wizard/mail_wizard_invite.py
+++ b/addons/mail/wizard/mail_wizard_invite.py
@@ -72,8 +72,8 @@ class Invite(models.TransientModel):
                 })
                 partners_data = []
                 recipient_data = self.env['mail.followers']._get_recipient_data(document, 'comment', False, pids=new_partners.ids)
-                for pid, active, pshare, notif, groups in recipient_data:
-                    pdata = {'id': pid, 'share': pshare, 'active': active, 'notif': 'email', 'groups': groups or []}
+                for pid, active, pshare, notif, groups, lang in recipient_data:
+                    pdata = {'id': pid, 'share': pshare, 'active': active, 'notif': 'email', 'groups': groups or [], lang: lang}
                     if not pshare and notif:  # has an user and is not shared, is therefore user
                         partners_data.append(dict(pdata, type='user'))
                     elif pshare and notif:  # has an user and is shared, is therefore portal

--- a/addons/sms/models/mail_followers.py
+++ b/addons/sms/models/mail_followers.py
@@ -15,10 +15,10 @@ class Followers(models.Model):
                 sms_pids = pids
             res = super(Followers, self)._get_recipient_data(records, message_type, subtype_id, pids=pids)
             new_res = []
-            for pid, active, pshare, notif, groups in res:
+            for pid, active, pshare, notif, groups, lang in res:
                 if pid and pid in sms_pids:
                     notif = 'sms'
-                new_res.append((pid, active, pshare, notif, groups))
+                new_res.append((pid, active, pshare, notif, groups, lang))
             return new_res
         else:
             return super(Followers, self)._get_recipient_data(records, message_type, subtype_id, pids=pids)

--- a/addons/sms/wizard/sms_resend.py
+++ b/addons/sms/wizard/sms_resend.py
@@ -86,9 +86,9 @@ class SMSResend(models.TransientModel):
             numbers = [r.sms_number for r in self.recipient_ids if r.resend and not r.partner_id]
 
             rdata = []
-            for pid, active, pshare, notif, groups in self.env['mail.followers']._get_recipient_data(record, 'sms', False, pids=pids):
+            for pid, active, pshare, notif, groups, lang in self.env['mail.followers']._get_recipient_data(record, 'sms', False, pids=pids):
                 if pid and notif == 'sms':
-                    rdata.append({'id': pid, 'share': pshare, 'active': active, 'notif': notif, 'groups': groups or [], 'type': 'customer' if pshare else 'user'})
+                    rdata.append({'id': pid, 'share': pshare, 'active': active, 'notif': notif, 'groups': groups or [], 'lang': lang, 'type': 'customer' if pshare else 'user'})
             if rdata or numbers:
                 record._notify_record_by_sms(
                     self.mail_message_id, rdata, check_existing=True,

--- a/addons/test_mail/tests/test_mail_followers.py
+++ b/addons/test_mail/tests/test_mail_followers.py
@@ -180,7 +180,7 @@ class BaseFollowersTest(TestMailCommon):
         """
         users = self.user_admin + self.user_employee + self.user_portal
         recipient_data = self.env['mail.followers']._get_recipient_data(self.env['mail.thread'], False, False, pids=users.partner_id.ids)
-        groups = {pid: set(groups) for pid, _, _, _, groups in recipient_data}
+        groups = {pid: set(groups) for pid, _, _, _, groups, _ in recipient_data}
 
         self.assertEqual(groups[self.user_admin.partner_id.id], set(self.user_admin.groups_id.ids), "User Admin groups are not correctly fetched")
         self.assertEqual(groups[self.user_employee.partner_id.id], set(self.user_employee.groups_id.ids), "User Employee groups are not correctly fetched")


### PR DESCRIPTION
* STEP TO REPRODUCE: user 1 use English, user 2 use Vietnamese -> Go to any record like a Partner record, add follow for both user 1 and user 2 -> Send message in English environment -> Go to mail box of user 1, mail body and button url display English which is correct but mail body and button url in mail box of user 2 are also display in English which is not
correct while it should be in Vietnamese
* REASON: the system currently always use language in self.env.context
* SOLUTION: use language of partner instead

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
