### PR TITLE
[FIX] web_editor: fix hotkey functionality for html fields in form view

### DIFF
--- a/addons/web_editor/static/src/js/editor/toolbar.js
+++ b/addons/web_editor/static/src/js/editor/toolbar.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { useActiveElement, utils as uiUtils } from "@web/core/ui/ui_service";
+import { utils as uiUtils } from "@web/core/ui/ui_service";
 import { ColorPalette } from "@web_editor/js/wysiwyg/widgets/color_palette";
 
 import {
@@ -81,7 +81,6 @@ export class Toolbar extends Component {
     }
 
     setup() {
-        useActiveElement("toolbarRef");
         onMounted(() => {
             for (const [colorType, ref] of Object.entries(this.colorDropdownRef)) {
                 const dropdown = ref.el;

--- a/addons/web_editor/static/src/xml/editor.xml
+++ b/addons/web_editor/static/src/xml/editor.xml
@@ -6,7 +6,7 @@
 
     <!-- Editor toolbar -->
     <t t-name="web_editor.toolbar">
-        <div id="toolbar" class="oe-toolbar oe-floating" t-ref="toolbarRef">
+        <div id="toolbar" class="oe-toolbar oe-floating">
             <div t-if="props.showStyle" id="style" t-attf-class="btn-group {{ props.dropDirection }}">
                 <button type="button" class="btn dropdown-toggle"
                     data-bs-toggle="dropdown" data-bs-original-title="Text style" tabindex="-1" aria-expanded="false">

--- a/addons/web_editor/static/tests/html_field_tests.js
+++ b/addons/web_editor/static/tests/html_field_tests.js
@@ -248,51 +248,6 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
         assert.strictEqual(editable.innerHTML, `<p>first</p>`);
     });
 
-    QUnit.module("List view interactions with the HtmlField");
-
-    QUnit.test("use the toolbar in a list view", async (assert) => {
-        const expectedValue = `<p>t<span class="h2-fs">e</span>st</p>`;
-        serverData.models.partner.records = [
-            { id: 1, txt: "<p>first</p>" },
-        ];
-        const htmlFieldPromise = makeDeferred();
-        patchWithCleanup(HtmlField.prototype, {
-            async startWysiwyg() {
-                await super.startWysiwyg(...arguments);
-                htmlFieldPromise.resolve(this);
-            }
-        });
-        await makeView({
-            type: "list",
-            resId: 1,
-            resModel: "partner",
-            serverData,
-            arch: `
-                <tree editable="top">
-                    <field name="txt" widget="html"/>
-                </tree>`,
-            mockRPC(route, args) {
-                if (args.method === "web_save" && args.model === 'partner') {
-                    assert.equal(args.args[1].txt, expectedValue);
-                    assert.step("web_save");
-                }
-            }
-        });
-        await click(target.querySelector(".o_data_row [name=txt]"));
-        const htmlField = await htmlFieldPromise;
-        const editable = htmlField.wysiwyg.odooEditor.editable;
-        const textInput = editable.querySelector(".note-editable p");
-        textInput.innerText = "test";
-        const pText = $(textInput).contents()[0];
-        Wysiwyg.setRange(pText, 1, pText, 2);
-        await nextTick();
-        // We need to skip the visibility check, because the toolbar is not visible unless we run the test in debug mode
-        await click(document, "#font-size button", { skipVisibilityCheck: true });
-        await click(document, "#font-size a[data-value='21']", { skipVisibilityCheck: true });
-        await click(target.querySelector(".btn-primary.o_list_button_save"));
-        assert.verifySteps(["web_save"]);
-    });
-
     QUnit.module('Sandboxed Preview');
 
     QUnit.test("complex html is automatically in sandboxed preview mode", async (assert) => {

--- a/addons/web_editor/static/tests/test_wysiwyg_collaboration.js
+++ b/addons/web_editor/static/tests/test_wysiwyg_collaboration.js
@@ -13,7 +13,6 @@ import { makeTestEnv } from "@web/../tests/helpers/mock_env";
 import { makeFakeNotificationService } from "@web/../tests/helpers/mock_services";
 import { mount, getFixture } from "@web/../tests/helpers/utils";
 import { registry } from "@web/core/registry";
-import { uiService } from "@web/core/ui/ui_service";
 
 export function makeSpy(obj, functionName) {
     const spy = {
@@ -153,23 +152,6 @@ export async function createPeers(peers) {
 
     let lastGeneratedId = 0;
 
-    registry.category("services").add("notification", makeFakeNotificationService(), {
-        force: true,
-    });
-    registry.category("services").add("popover", { start: () => ({}) }, {
-        force: true,
-    });
-    registry.category("services").add("ui", uiService, {
-        force: true,
-    });
-    const env = await makeTestEnv({
-        mockRPC(route) {
-            if (route === "/web/dataset/call_kw/res.users/read") {
-                return [{ id: 0, name: "admin" }];
-            }
-        }
-    });
-
     for (const peerId of peers) {
         const iframe = document.createElement('iframe');
         if (navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
@@ -182,6 +164,20 @@ export async function createPeers(peers) {
         iframe.contentDocument.body.innerHTML = `<div class="peer_wysiwyg_wrapper client_${peerId}"></div>`;
         const peerWysiwygWrapper = iframe.contentDocument.querySelector('.peer_wysiwyg_wrapper');
         iframe.contentWindow.$ = $;
+
+        registry.category("services").add("notification", makeFakeNotificationService(), {
+            force: true,
+        });
+        registry.category("services").add("popover", { start: () => ({  }) }, {
+            force: true,
+        });
+        const env = await makeTestEnv({
+            mockRPC(route) {
+                if (route === "/web/dataset/call_kw/res.users/read") {
+                    return [{ id: 0, name: "admin" }];
+                }
+            }
+        });
 
         const wysiwyg = await mount(Wysiwyg, peerWysiwygWrapper, {
             env,


### PR DESCRIPTION
before this commit:
The hotkey functionality is not working as expected when an HTML field is present in the form view. This issue arises because the useActiveElement method sets the target to the editor toolbar in this [commit](https://github.com/odoo/odoo/pull/178189/commits/2c40feca689d6050f746393b28d1238c9ba891ad), which interferes with the hotkey's intended ActiveElement behavior and causes it to break.

after this commit:
The hotkey will work as expected in the form view

Task-4181924