### PR TITLE
[IMP] point_of_sale, pos_self_order: simplify kanban archs

### DIFF
--- a/addons/point_of_sale/static/src/scss/pos_dashboard.scss
+++ b/addons/point_of_sale/static/src/scss/pos_dashboard.scss
@@ -1,10 +1,7 @@
-.o_kanban_dashboard.o_pos_kanban .o_kanban_renderer.o_kanban_ungrouped {
-	.o_kanban_record {
+.o_pos_kanban .o_kanban_renderer.o_kanban_ungrouped {
+    .o_kanban_record {
         width: 500px;
-	}
-}
-.flex-grow-inf {
-	flex-grow: 9999 !important;
+    }
 }
 
 .scenario-card:hover {
@@ -17,12 +14,12 @@
     }
 }
 
-.scenario-card .img-container{
+.scenario-card .img-container {
     height: 110px;
     width: 110px;
     background-color: $o-gray-100;
 
-    .scenario-img{
+    .scenario-img {
         height: 90px;
         width: auto;
     }

--- a/addons/point_of_sale/views/point_of_sale_dashboard.xml
+++ b/addons/point_of_sale/views/point_of_sale_dashboard.xml
@@ -55,24 +55,19 @@
         <field name="name">pos.config.kanban.view</field>
         <field name="model">pos.config</field>
         <field name="arch" type="xml">
-            <kanban create="false" can_open="0" class="o_kanban_dashboard o_pos_kanban" js_class="pos_config_kanban_view">
-                <field name="current_user_id" />
+            <kanban create="false" can_open="0" class="o_pos_kanban" js_class="pos_config_kanban_view">
                 <field name="cash_control"/>
-                <field name="name"/>
                 <field name="current_session_id"/>
                 <field name="current_session_state"/>
                 <field name="access_token"/>
-                <field name="last_session_closing_date"/>
-                <field name="pos_session_username"/>
                 <field name="pos_session_state"/>
                 <field name="pos_session_duration"/>
                 <field name="currency_id"/>
-                <field name="number_of_rescue_session"/>
                 <templates>
                     <t t-name="kanban-menu">
                         <div class="container dropdown-pos-config">
                             <div class="row" style="min-width:200px">
-                                <div class="col-6 o_kanban_card_manage_section o_kanban_manage_view">
+                                <div class="col-6 o_kanban_manage_view">
                                     <h5 role="menuitem" class="o_kanban_card_manage_title">
                                         <span>View</span>
                                     </h5>
@@ -86,7 +81,7 @@
                                         <a t-attf-href="/pos_customer_display/#{record.id.value}/#{record.access_token.value}" target="_blank" style="white-space: nowrap;">Customer Display</a>
                                     </div>
                                 </div>
-                                <div class="col-6 o_kanban_card_manage_section o_kanban_manage_new">
+                                <div class="col-6">
                                     <h5 role="menuitem" class="o_kanban_card_manage_title">
                                         <span>Reporting</span>
                                     </h5>
@@ -103,74 +98,46 @@
                             </div>
                         </div>
                     </t>
-                    <t t-name="kanban-box">
-                        <div>
-                            <div class="o_kanban_card_header flex-grow-inf">
-                                <div class="o_kanban_card_header_title mb16">
-                                    <div class="o_primary o_kanban_card_header_title_name">
-                                        <t t-esc="record.name.value"/>
-                                    </div>
-                                    <t t-if="!record.current_session_id.raw_value &amp;&amp; record.pos_session_username.value">
-                                        <div class="badge text-bg-info o_kanban_inline_block">Opened by <t t-esc="record.pos_session_username.value"/></div>
-                                    </t>
-                                    <t t-if="record.pos_session_state.raw_value == 'opening_control'">
-                                        <div class="badge text-bg-info o_kanban_inline_block">Opening Control</div>
-                                    </t>
-                                    <t t-if="record.pos_session_state.raw_value == 'closing_control'">
-                                        <div class="badge text-bg-info o_kanban_inline_block">Closing Control</div>
-                                    </t>
-                                    <t t-if="record.pos_session_state.raw_value == 'opened' and record.pos_session_duration.raw_value > 1">
-                                        <div t-attf-class="badge bg-#{record.pos_session_duration.raw_value > 3 and 'danger' or 'warning'} o_kanban_inline_block"
-                                             title="The session has been opened for an unusually long period. Please consider closing.">
-                                             To Close
-                                        </div>
-                                    </t>
-                                </div>
-                            </div>
-                            <div class="container o_kanban_card_content">
-                                <div class="row">
-                                    <div class="col-6 o_kanban_primary_left">
-                                        <button t-if="record.current_session_state.raw_value != 'closing_control'" class="btn btn-primary" name="open_ui" type="object">
-                                            <t t-if="record.current_session_state.raw_value === 'opened'">Continue Selling</t>
-                                            <t t-else="">Open Register</t>
-                                        </button>
-
-                                        <button t-else="" class="btn btn-secondary" name="open_existing_session_cb" type="object">Close</button>
-
-                                    </div>
-                                    <div class="col-6 o_kanban_primary_right">
-
-                                        <div t-if="record.last_session_closing_date.value" class="row">
-                                            <div class="col-6">
-                                                <span>Closing</span>
-                                            </div>
-                                            <div class="col-6">
-                                                <span><t t-esc="record.last_session_closing_date.value"/></span>
-                                            </div>
-                                        </div>
-
-                                        <div t-if="record.last_session_closing_date.value" invisible="not cash_control" class="row">
-                                            <div class="col-6">
-                                                <span>Balance</span>
-                                            </div>
-                                            <div class="col-6">
-                                                <span><field name="last_session_closing_cash" widget="monetary"/></span>
-                                            </div>
-                                        </div>
-
-                                        <div>
-                                            <a t-if="record.number_of_rescue_session.value &gt; 0" class="oe_kanban_action oe_kanban_action_a col-12" name="open_opened_rescue_session_form" type="object">
-                                                <t t-esc="record.number_of_rescue_session.value" /> outstanding rescue session
-                                            </a>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div style="text-align:right;">
-                                    <field name="current_user_id" widget="many2one_avatar_user"/>
-                                </div>
-
+                    <t t-name="kanban-card">
+                        <div name="card_title" class="mb-4 ms-2">
+                            <field name="name" class="fw-bold fs-4 d-block"/>
+                            <div t-if="!record.current_session_id.raw_value &amp;&amp; record.pos_session_username.value" class="badge text-bg-info d-inline-block">Opened by <field name="pos_session_username"/></div>
+                            <div t-if="record.pos_session_state.raw_value == 'opening_control'" class="badge text-bg-info d-inline-block">Opening Control</div>
+                            <div t-if="record.pos_session_state.raw_value == 'closing_control'" class="badge text-bg-info d-inline-block">Closing Control</div>
+                            <div t-if="record.pos_session_state.raw_value == 'opened' and record.pos_session_duration.raw_value > 1" t-attf-class="badge bg-#{record.pos_session_duration.raw_value > 3 and 'danger' or 'warning'} d-inline-block"
+                                    title="The session has been opened for an unusually long period. Please consider closing.">
+                                    To Close
                             </div>
                         </div>
+                        <div class="row g-0 pb-4 ms-2 mt-auto">
+                            <div name="card_left" class="col-6">
+                                <button t-if="record.current_session_state.raw_value != 'closing_control'" class="btn btn-primary" name="open_ui" type="object">
+                                    <t t-if="record.current_session_state.raw_value === 'opened'">Continue Selling</t>
+                                    <t t-else="">Open Register</t>
+                                </button>
+                                <button t-else="" class="btn btn-secondary" name="open_existing_session_cb" type="object">Close</button>
+                            </div>
+                            <div class="col-6">
+                                <div t-if="record.last_session_closing_date.value" class="row">
+                                    <div class="col-6">
+                                        <span>Closing</span>
+                                    </div>
+                                    <field name="last_session_closing_date" class="col-6"/>
+                                </div>
+
+                                <div t-if="record.last_session_closing_date.value" invisible="not cash_control" class="row">
+                                    <div class="col-6">
+                                        <span>Balance</span>
+                                    </div>
+                                    <field name="last_session_closing_cash" widget="monetary" class="col-6"/>
+                                </div>
+
+                                <a t-if="record.number_of_rescue_session.value &gt; 0" class="col-12" name="open_opened_rescue_session_form" type="object">
+                                    <field name="number_of_rescue_session" /> outstanding rescue session
+                                </a>
+                            </div>
+                        </div>
+                        <field name="current_user_id" widget="many2one_avatar_user" class="mt-auto ms-auto"/>
                     </t>
                 </templates>
             </kanban>

--- a/addons/pos_self_order/views/point_of_sale_dashboard.xml
+++ b/addons/pos_self_order/views/point_of_sale_dashboard.xml
@@ -37,17 +37,17 @@
                     </a>
                 </div>
             </xpath>
-            <xpath expr="//div[hasclass('o_kanban_card_header_title_name')]" position="after">
+            <xpath expr="//field[@name='name']" position="after">
                 <field name="self_ordering_mode" invisible="1" />
                 <div class="badge text-bg-info o_kanban_inline_block me-2"
                     invisible="not self_ordering_mode == 'mobile'">
                     Self Ordering Enabled
                 </div>
             </xpath>
-            <xpath expr="//div[hasclass('o_kanban_primary_left')]" position="after">
+            <xpath expr="//div[@name='card_left']" position="after">
                 <field name="self_ordering_mode" invisible="1" />
                 <field name="current_session_id" invisible="1" />
-                <div class="col-6 o_kanban_primary_left d-flex flex-column align-items-start" invisible="not self_ordering_mode == 'kiosk'">
+                <div class="col-6 d-flex flex-column align-items-start" invisible="not self_ordering_mode == 'kiosk'">
                     <button t-if="!record.current_session_id.raw_value" class="btn btn-primary pos_open_session_btn" name="action_open_wizard" type="object">
                         Start Kiosk
                     </button>
@@ -59,7 +59,7 @@
                     </button>
                 </div>
             </xpath>
-            <xpath expr="//div[hasclass('o_kanban_primary_left')]" position="attributes">
+            <xpath expr="//div[@name='card_left']" position="attributes">
                 <field name="self_ordering_mode" invisible="1" />
                 <attribute name="invisible">self_ordering_mode == 'kiosk'</attribute>
             </xpath>


### PR DESCRIPTION
In this commit we have simplified the kanban arch for the point_of_sale module dashboard. the goal is to simplify them, make them easier to read and use bootstrap utility classnames.

- Previously, we used kanban-box, but now we are using kanban-card instead.
- Deprecated oe_kanban_global_click and oe_kanban_global_click_edit.
- More use of `<field/>` tags
- Removed the oe_kanban_colorpicker class and replaced it with the kanban_color_picker widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- kanban_image from rendering context, is deprecated so we use `<field name=... widget=image/>` instead
- kanban_color, kanban_getcolor and kanban_getcolorname are deprecated use new attribute highlight_color=color_field_name on root node

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
