### PR TITLE
[IMP] html_editor: enable scrolling for long images in cropper

### DIFF
--- a/addons/html_editor/static/src/main/media/image_crop.js
+++ b/addons/html_editor/static/src/main/media/image_crop.js
@@ -232,6 +232,7 @@ export class ImageCrop extends Component {
         if (rect.top < viewportTop || viewportBottom - rect.bottom < 100) {
             await scrollTo(this.media, {
                 behavior: "smooth",
+                isAnchor: true,
                 ...(scrollable && { scrollable }),
             });
         }


### PR DESCRIPTION
### Steps to reproduce:

- Insert a long image (/image, upload an image).
- Try to crop the image.
- Observe that you are unable to scroll to view the full image

### Description of the issue/feature this PR addresses:

- The cropper wrapper would scroll to the bottom if the image was too long, causing a negative offset from the top.

### Desired behavior after PR is merged:

- The cropper wrapper now scrolls to the top, allowing scrolling to view the entire image.

task-3787418