### PR TITLE
[FIX] auth_password_policy_signup: error on password reset page

### DIFF
--- a/addons/auth_password_policy_signup/static/src/js/signup_policy.js
+++ b/addons/auth_password_policy_signup/static/src/js/signup_policy.js
@@ -7,7 +7,7 @@ import PasswordMeter from "@auth_password_policy_signup/js/password_meter";
 const signupForm = document.querySelector('.oe_signup_form, .oe_reset_password_form');
 if (signupForm) {
     const password = document.querySelector("[type=password][minlength]");
-    const minlength = Number(password.getAttribute("minlength"));
+    const minlength = password ? Number(password.getAttribute("minlength")) : NaN;
     if (!isNaN(minlength)) {
         const meter = new PasswordMeter(null, new ConcretePolicy({minlength}), recommendations);
         meter.insertAfter(password);


### PR DESCRIPTION
This commit fixes an error appearing on the password reset page when no    
password field is present (cf. the first step asking for the user's email).     
    
Steps to reproduce:    
- with the `auth_password_policy_signup` module installed    
- from the login page, click on "reset password"    
- the page asking for the user email is displayed    
=> `TypeError: Cannot read properties of null (reading 'getAttribute')`    
    
opw-4184038    


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
