### PR TITLE
[IMP] sales_team,*: simplify kanban archs

### DIFF
--- a/addons/crm/views/crm_team_views.xml
+++ b/addons/crm/views/crm_team_views.xml
@@ -245,56 +245,49 @@
             <field name="arch" type="xml">
                 <data>
                     <xpath expr="//templates" position="before">
-                        <field name="alias_id"/>
                         <field name="alias_name"/>
                         <field name="alias_domain"/>
                         <field name="use_opportunities"/>
                         <field name="use_leads"/>
                     </xpath>
 
-                    <xpath expr="//div[hasclass('o_primary')]" position="after">
-                        <div t-if="record.alias_name.value and record.alias_domain.value">
+                    <xpath expr="//field[@name='name']" position="after">
+                        <div class="ms-2" t-if="record.alias_name.value and record.alias_domain.value">
                             <span t-translation="off"><i class="fa fa-envelope-o" aria-label="Leads" title="Leads" role="img"></i>&amp;nbsp; <field name="alias_id"/></span>
                         </div>
                     </xpath>
 
                     <xpath expr="//t[@name='first_options']" position="after">
                         <div class="row" t-if="record.lead_unassigned_count.raw_value">
-                            <div class="col-8">
-                                <a name="%(crm_case_form_view_salesteams_lead)d" type="action" context="{'search_default_unassigned_leads': 1}">
-                                    <field name="lead_unassigned_count" class="me-1"/>
-                                    <t t-if="record.lead_unassigned_count.raw_value == 1">Unassigned Lead</t>
-                                    <t t-else="">Unassigned Leads</t>
-                                </a>
-                            </div>
+                            <a class="col-8" name="%(crm_case_form_view_salesteams_lead)d" type="action" context="{'search_default_unassigned_leads': 1}">
+                                <field name="lead_unassigned_count" class="me-1"/>
+                                <t t-if="record.lead_unassigned_count.raw_value == 1">Unassigned Lead</t>
+                                <t t-else="">Unassigned Leads</t>
+                            </a>
                         </div>
                         <div class="row" t-if="record.opportunities_count.raw_value">
-                            <div class="col-8">
-                                <a name="%(crm_case_form_view_salesteams_opportunity)d" type="action" context="{'search_default_open_opportunities': True}"> <!-- context="{'search_default_probability': NOT or < 100}" -->
-                                    <field name="opportunities_count" class="me-1"/>
-                                    <t t-if="record.opportunities_count.raw_value == 1">Open Opportunity</t>
-                                    <t t-else="">Open Opportunities</t>
-                                </a>
-                            </div>
+                            <a class="col-8" name="%(crm_case_form_view_salesteams_opportunity)d" type="action" context="{'search_default_open_opportunities': True}"> <!-- context="{'search_default_probability': NOT or < 100}" -->
+                                <field name="opportunities_count" class="me-1"/>
+                                <t t-if="record.opportunities_count.raw_value == 1">Open Opportunity</t>
+                                <t t-else="">Open Opportunities</t>
+                            </a>
                             <div class="col-4 text-end text-truncate">
                                 <field name="opportunities_amount" widget="monetary" options="{'currency_field': 'currency_id'}"/>
                             </div>
                         </div>
                         <div class="row" t-if="record.opportunities_overdue_count.raw_value">
-                            <div class="col-8">
-                                <a name="%(crm_lead_action_team_overdue_opportunity)d" type="action">
-                                    <field name="opportunities_overdue_count" class="me-1"/>
-                                    <t t-if="record.opportunities_overdue_count.raw_value == 1">Overdue Opportunity</t>
-                                    <t t-else="">Overdue Opportunities</t>
-                                </a>
-                            </div>
+                            <a class="col-8" name="%(crm_lead_action_team_overdue_opportunity)d" type="action">
+                                <field name="opportunities_overdue_count" class="me-1"/>
+                                <t t-if="record.opportunities_overdue_count.raw_value == 1">Overdue Opportunity</t>
+                                <t t-else="">Overdue Opportunities</t>
+                            </a>
                              <div class="col-4 text-end text-truncate">
                                 <field name="opportunities_overdue_amount" widget="monetary" options="{'currency_field': 'currency_id'}"/>
                             </div>
                         </div>
                     </xpath>
 
-                    <xpath expr="//div[hasclass('o_kanban_manage_view')]/h5[hasclass('o_kanban_card_manage_title')]" position="after">
+                    <xpath expr="//div[@name='manage_view']/h5[hasclass('o_kanban_card_manage_title')]" position="after">
                         <div t-if="record.use_leads.raw_value" groups="crm.group_use_lead">
                             <a name="%(crm_case_form_view_salesteams_lead)d" type="action">
                                 Leads
@@ -307,7 +300,7 @@
                         </div>
                     </xpath>
 
-                    <xpath expr="//div[hasclass('o_kanban_manage_new')]/h5[hasclass('o_kanban_card_manage_title')]" position="after">
+                    <xpath expr="//div[@name='manage_new']/h5[hasclass('o_kanban_card_manage_title')]" position="after">
                         <div t-if="record.use_leads.raw_value" groups="crm.group_use_lead">
                             <a name="%(crm_lead_action_open_lead_form)d" type="action">
                                 Leads
@@ -320,7 +313,7 @@
                         </div>
                     </xpath>
 
-                    <xpath expr="//div[hasclass('o_kanban_manage_reports')]/h5[hasclass('o_kanban_card_manage_title')]" position="after">
+                    <xpath expr="//div[@name='manage_reports']/h5[hasclass('o_kanban_card_manage_title')]" position="after">
                         <div t-if="record.use_leads.raw_value" groups="crm.group_use_lead">
                             <a name="%(action_report_crm_lead_salesteam)d" type="action">
                                 Leads
@@ -333,7 +326,7 @@
                         </div>
                     </xpath>
 
-                    <xpath expr="//div[hasclass('o_kanban_manage_reports')]/div[@name='o_team_kanban_report_separator']" position="after">
+                    <xpath expr="//div[@name='manage_reports']/div[@name='o_team_kanban_report_separator']" position="after">
                         <div t-if="record.use_opportunities.raw_value">
                             <a name="%(crm.crm_activity_report_action_team)d" type="action">
                                 Activities

--- a/addons/pos_sale/views/sales_team_views.xml
+++ b/addons/pos_sale/views/sales_team_views.xml
@@ -37,14 +37,12 @@
         <field name="arch" type="xml">
         <data>
             <xpath expr="//t[@name='first_options']" position="before">
-                <div class="row" t-if="record.pos_sessions_open_count.raw_value" groups="point_of_sale.group_pos_user">
-                    <div class="col-8">
-                        <a name="%(pos_session_action_from_crm_team)d" type="action">
-                            <field name="pos_sessions_open_count"/>
-                            <t t-if="record.pos_sessions_open_count.raw_value == 1">Session Running</t>
-                            <t t-else="">Sessions Running</t>
-                        </a>
-                    </div>
+                <div class="row" groups="point_of_sale.group_pos_user">
+                    <a class="col-8" name="%(pos_session_action_from_crm_team)d" type="action">
+                        <field class="me-1" name="pos_sessions_open_count"/>
+                        <t t-if="record.pos_sessions_open_count.raw_value == 1">Session Running</t>
+                        <t t-else="">Sessions Running</t>
+                    </a>
                     <div class="col-4 text-end">
                         <field name="pos_order_amount_total" widget="monetary"/>
                     </div>

--- a/addons/sale/views/crm_team_views.xml
+++ b/addons/sale/views/crm_team_views.xml
@@ -99,37 +99,31 @@
 
             <xpath expr="//t[@name='second_options']" position="after">
                 <div class="row" t-if="record.quotations_count.raw_value">
-                    <div class="col">
-                        <a name="%(action_quotations_salesteams)d" type="action" context="{'search_default_draft': True, 'search_default_sent': True}">
-                            <field name="quotations_count" class="me-1"/>
-                            <t t-if="record.quotations_count.raw_value == 1">Quotation</t>
-                            <t t-else="">Quotations</t>
-                        </a>
-                    </div>
-                    <div class="col-auto text-truncate">
-                        <field name="quotations_amount" widget="monetary"/>
-                    </div>
+                    <a class="col" name="%(action_quotations_salesteams)d" type="action" context="{'search_default_draft': True, 'search_default_sent': True}">
+                        <field name="quotations_count" class="me-1"/>
+                        <t t-if="record.quotations_count.raw_value == 1">Quotation</t>
+                        <t t-else="">Quotations</t>
+                    </a>
+                    <field class="col-auto text-truncate" name="quotations_amount" widget="monetary"/>
                 </div>
                 <div class="row" name="orders_to_invoice" t-if="record.sales_to_invoice_count.raw_value">
-                    <div class="col-8">
-                        <a name="%(action_orders_to_invoice_salesteams)d" type="action">
-                            <field name="sales_to_invoice_count" class="me-1"/>
-                            <t t-if="record.sales_to_invoice_count.raw_value == 1">Order to Invoice</t>
-                            <t t-else="">Orders to Invoice</t>
-                        </a>
-                    </div>
+                    <a class="col-8" name="%(action_orders_to_invoice_salesteams)d" type="action">
+                        <field name="sales_to_invoice_count" class="me-1"/>
+                        <t t-if="record.sales_to_invoice_count.raw_value == 1">Order to Invoice</t>
+                        <t t-else="">Orders to Invoice</t>
+                    </a>
                 </div>
             </xpath>
 
-            <xpath expr="//div[hasclass('o_kanban_primary_bottom')]" position="after">
+            <xpath expr="//div[@name='o_kanban_primary_bottom']" position="after">
                 <t groups="sales_team.group_sale_manager">
-                    <div class="col-12 o_kanban_primary_bottom bottom_block">
+                    <div class="col-12 o_dashboard_bottom_block mt-2">
                         <field name="invoiced" widget="sales_team_progressbar" title="Invoicing" options="{'current_value': 'invoiced', 'max_value': 'invoiced_target', 'editable': true, 'edit_max_value': true, 'on_change': 'update_invoiced_target'}"/>
                     </div>
                 </t>
             </xpath>
 
-            <xpath expr="//div[hasclass('o_kanban_manage_view')]" position="inside">
+            <xpath expr="//div[@name='manage_view']" position="inside">
                 <div>
                     <a name="%(action_orders_salesteams)d" type="action">Sales Orders</a>
                 </div>

--- a/addons/sales_team/static/src/scss/crm_team_views.scss
+++ b/addons/sales_team/static/src/scss/crm_team_views.scss
@@ -1,5 +1,12 @@
 .o_crm_team_kanban .o_kanban_renderer {
     --KanbanRecord-width: 400px;
+
+    .o_dashboard_bottom_block {
+        border-top: 1px solid map-get($grays, '300');
+        background-color: map-get($grays, '200');
+        padding-top: var(--KanbanRecord-padding-v);
+        padding-bottom: var(--KanbanRecord-padding-v);
+    }
 }
 
 .o_crm_team_member_kanban .o_kanban_renderer {

--- a/addons/sales_team/views/crm_team_views.xml
+++ b/addons/sales_team/views/crm_team_views.xml
@@ -125,28 +125,22 @@
         <field name="model">crm.team</field>
         <field name="priority">10</field>
         <field name="arch" type="xml">
-            <kanban class="o_kanban_dashboard o_crm_team_kanban" create="0" can_open="0" sample="1">
-                <field name="name"/>
-                <field name="user_id"/>
-                <field name="member_ids"/>
-                <field name="color"/>
-                <field name="currency_id"/>
-                <field name="is_favorite"/>
+            <kanban class="o_crm_team_kanban" highlight_color="color" create="0" can_open="0" sample="1">
                 <templates>
                     <t t-name="kanban-menu">
                         <div class="container">
                             <div class="row">
-                                <div class="col-4 o_kanban_card_manage_section o_kanban_manage_view">
+                                <div name="manage_view" class="col-4">
                                     <h5 role="menuitem" class=" o_kanban_card_manage_title">
                                         <span>View</span>
                                     </h5>
                                 </div>
-                                <div class="col-4 o_kanban_card_manage_section o_kanban_manage_new">
+                                <div name="manage_new" class="col-4">
                                     <h5 role="menuitem" class="o_kanban_card_manage_title">
                                         <span>New</span>
                                     </h5>
                                 </div>
-                                <div class="col-4 o_kanban_card_manage_section o_kanban_manage_reports">
+                                <div name="manage_reports" class="col-4">
                                     <h5 role="menuitem" class="o_kanban_card_manage_title">
                                         <span>Reporting</span>
                                     </h5>
@@ -156,7 +150,7 @@
 
                             <div t-if="widget.editable" class="o_kanban_card_manage_settings row" groups="sales_team.group_sale_manager">
                                 <div role="menuitem" aria-haspopup="true" class="col-8">
-                                    <ul class="oe_kanban_colorpicker" data-field="color" role="menu"/>
+                                    <field name="color" widget="kanban_color_picker"/>
                                 </div>
                                 <div role="menuitem" class="col-4">
                                     <a class="dropdown-item" type="edit">Configuration</a>
@@ -164,36 +158,26 @@
                             </div>
                         </div>
                     </t>
-                    <t t-name="kanban-box">
-                        <div t-attf-class="#{!selection_mode ? kanban_color(record.color.raw_value) : ''}">
-                            <div t-attf-class="o_kanban_card_header">
-                                <div class="o_kanban_card_header_title">
-                                    <div class="o_primary o_text_overflow"><field name="name"/></div>
-                                </div>
+                    <t t-name="kanban-card">
+                        <field name="name" class="fw-bold text-truncate fs-4 ms-2"/>
+                        <div class="row mt-3 px-2">
+                            <div class="col-4" name="to_replace_in_sale_crm">
+                                <button type="object" class="btn text-wrap btn-primary" name="action_primary_channel_button"><field name="dashboard_button_name"/></button>
                             </div>
-                            <div class="container o_kanban_card_content">
-                                <div class="row o_kanban_card_upper_content">
-                                    <div class="col-4 o_kanban_primary_left" name="to_replace_in_sale_crm">
-                                        <button type="object" class="btn btn-primary" name="action_primary_channel_button"><field name="dashboard_button_name"/></button>
-                                    </div>
-                                    <div class="col-8 o_kanban_primary_right" style="padding-bottom:0;">
-                                        <t name="first_options"/>
-                                        <t name="second_options"/>
-                                        <t name="third_options"/>
-                                    </div>
-                                </div>
-                                <div class="row">
-                                    <div class="col-12 o_kanban_primary_bottom">
-                                        <t t-call="SalesTeamDashboardGraph"/>
-                                    </div>
-                                </div>
+                            <div class="col-8 mb-2 text-truncate">
+                                <t name="first_options"/>
+                                <t name="second_options"/>
+                                <t name="third_options"/>
+                            </div>
+                        </div>
+                        <div class="row px-2 mt-auto mb-n2">
+                            <div name="o_kanban_primary_bottom" class="col-12">
+                                <t t-call="SalesTeamDashboardGraph"/>
                             </div>
                         </div>
                     </t>
                     <t t-name="SalesTeamDashboardGraph">
-                        <div t-if="record.dashboard_graph_data.raw_value" class="o_sales_team_kanban_graph_section">
-                            <field name="dashboard_graph_data" widget="dashboard_graph" t-att-graph_type="'bar'"/>
-                        </div>
+                        <field t-if="record.dashboard_graph_data.raw_value" name="dashboard_graph_data" widget="dashboard_graph" t-att-graph_type="'bar'"/>
                     </t>
                 </templates>
             </kanban>

--- a/addons/website_sale/views/crm_team_views.xml
+++ b/addons/website_sale/views/crm_team_views.xml
@@ -8,15 +8,11 @@
         <field name="arch" type="xml">
             <data>
                 <xpath expr="//t[@name='third_options']" position="after">
-                    <div class="row" t-if="record.abandoned_carts_count.raw_value">
-                        <div class="col-8">
-                            <div>
-                                <a name="get_abandoned_carts" type="object">
-                                    <field name="abandoned_carts_count" class="me-1"/>
-                                    Abandoned Carts to Recover
-                                </a>
-                            </div>
-                        </div>
+                    <div class="row">
+                        <a class="col-8" name="get_abandoned_carts" type="object">
+                            <field name="abandoned_carts_count" class="me-1"/>
+                            Abandoned Carts to Recover
+                        </a>
                         <div class="col-4 text-end">
                             <field name="abandoned_carts_amount" widget="monetary"/>
                         </div>


### PR DESCRIPTION
\* = [crm, pos_sale, sale, website_sale]

In this commit we have simplified the kanban arch for the sales_team module dashboard and other modules inheriting the dashboard. The goal is to simplify them, make them easier to read and use bootstrap utility classnames.

- Previously, we used kanban-box, but now we are using kanban-card instead.
- Deprecated oe_kanban_global_click and oe_kanban_global_click_edit.
- More use of <field/> tags
- Removed the oe_kanban_colorpicker class and replaced it with the kanban_color_picker widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- kanban_image from rendering context, is deprecated so we use <field name=... widget=image/> instead
- kanban_color, kanban_getcolor and kanban_getcolorname are deprecated use new attribute highlight_color=color_field_name on root node

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
