### PR TITLE
[IMP] contacts,mail,web: Revamp debug menu

### DIFF
--- a/addons/contacts/static/tests/tours/debug_menu_set_defaults.js
+++ b/addons/contacts/static/tests/tours/debug_menu_set_defaults.js
@@ -29,7 +29,7 @@
             },
             {
                 content: "Click the Set Defaults menu",
-                trigger: '.dropdown-item:contains(Set Defaults)',
+                trigger: '.dropdown-item:contains(Set Default Values)',
                 run: "click",
             },
             {

--- a/addons/mail/static/src/js/tools/debug_manager.js
+++ b/addons/mail/static/src/js/tools/debug_manager.js
@@ -6,7 +6,7 @@ export function manageMessages({ component, env }) {
     if (!resId) {
         return null; // No record
     }
-    const description = _t("Manage Messages");
+    const description = _t("Messages");
     return {
         type: "item",
         description,
@@ -29,7 +29,8 @@ export function manageMessages({ component, env }) {
                 },
             });
         },
-        sequence: 325,
+        sequence: 130,
+        section: "record",
     };
 }
 

--- a/addons/mail/static/tests/legacy/web/debug_menu_tests.js
+++ b/addons/mail/static/tests/legacy/web/debug_menu_tests.js
@@ -46,12 +46,12 @@ test("Manage Messages", async (assert) => {
     await click(target, ".o_debug_manager .dropdown-toggle");
     const dropdownItems = target.querySelectorAll(".dropdown-menu .dropdown-item");
     assert.strictEqual(dropdownItems.length, 1);
-    assert.strictEqual(dropdownItems[0].innerText.trim(), "Manage Messages");
+    assert.strictEqual(dropdownItems[0].innerText.trim(), "Messages");
 
     await click(dropdownItems[0]);
     await assertSteps(["message_read"]);
     assert.strictEqual(
         target.querySelector(".o_breadcrumb .active > span").innerText.trim(),
-        "Manage Messages"
+        "Messages"
     );
 });

--- a/addons/web/static/src/@types/registries/debug_registry.d.ts
+++ b/addons/web/static/src/@types/registries/debug_registry.d.ts
@@ -19,6 +19,7 @@ declare module "registries" {
         Component: typeof Component;
         props: object;
         sequence: number;
+        section?: string;
     }
 
     interface DebugItem {
@@ -27,20 +28,22 @@ declare module "registries" {
         description: string;
         href?: string;
         sequence: number;
+        section?: string;
     }
 
-    interface DebugSeparator {
-        type: "separator";
-        sequence: number;
-    }
-
-    type DebugRegistryItemShapeResult = DebugComponent | DebugItem | DebugSeparator | null;
+    type DebugRegistryItemShapeResult = DebugComponent | DebugItem | null;
 
     export type DebugRegistryItemShape = (params: DebugRegistryItemShapeParams) => DebugRegistryItemShapeResult;
 
     export type DebugRegistryCategories = Record<string, DebugRegistryItemShape>;
 
+    export interface DebugSectionRegistryItemShape {
+        label: string;
+        sequence: number;
+    };
+
     interface GlobalRegistryCategories {
         debug: RegistryData<DebugRegistryItemShape, DebugRegistryCategories>;
+        debug_section: DebugSectionRegistryItemShape;
     }
 }

--- a/addons/web/static/src/core/debug/debug_menu.xml
+++ b/addons/web/static/src/core/debug/debug_menu.xml
@@ -4,23 +4,27 @@
     <t t-name="web.DebugMenu">
         <div class="o_debug_manager">
             <Dropdown
-                beforeOpen="getElements"
+                beforeOpen.bind="loadGroupedItems"
                 position="'bottom-end'"
             >
                 <button t-att-class="`o-dropdown--narrow ${env.inDialog?'btn btn-link':''}`">
                     <i class="fa fa-bug" role="img" aria-label="Open developer tools"/>
                 </button>
                 <t t-set-slot="content">
-                    <t t-foreach="elements" t-as="element" t-key="element_index">
-                        <DropdownItem
-                            t-if="element.type == 'item'"
-                            onSelected="element.callback"
-                            attrs="{ href: element.href }"
-                        >
-                            <t t-esc="element.description"/>
-                        </DropdownItem>
-                        <div t-if="element.type == 'separator'" role="separator" class="dropdown-divider"/>
-                        <t t-if="element.type == 'component'" t-component="element.Component" t-props="element.props"/>
+                    <t t-foreach="sectionEntries" t-as="entry" t-key="entry[0]">
+                        <div class="dropdown-menu_group dropdown-header">
+                            <t t-esc="getSectionLabel(entry[0])"/>
+                        </div>
+                        <t t-foreach="entry[1]" t-as="element" t-key="element_index">
+                            <DropdownItem
+                                t-if="element.type == 'item'"
+                                onSelected="element.callback"
+                                attrs="{ href: element.href }"
+                            >
+                                <span t-att-style="entry[0] and 'padding-left: 12px;'" t-esc="element.description"/>
+                            </DropdownItem>
+                            <t t-if="element.type == 'component'" t-component="element.Component" t-props="element.props"/>
+                        </t>
                     </t>
                 </t>
             </Dropdown>

--- a/addons/web/static/src/core/debug/debug_menu_basic.js
+++ b/addons/web/static/src/core/debug/debug_menu_basic.js
@@ -1,8 +1,21 @@
 import { useEnvDebugContext } from "./debug_context";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { _t } from "@web/core/l10n/translation";
+import { groupBy, sortBy } from "@web/core/utils/arrays";
 
 import { Component } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+
+const debugSectionRegistry = registry.category("debug_section");
+
+debugSectionRegistry
+    .add("record", { label: _t("Record"), sequence: 10 })
+    .add("records", { label: _t("Records"), sequence: 10 })
+    .add("ui", { label: _t("User Interface"), sequence: 20 })
+    .add("security", { label: _t("Security"), sequence: 30 })
+    .add("testing", { label: _t("Testing"), sequence: 40 })
+    .add("tools", { label: _t("Tools"), sequence: 50 });
 
 export class DebugMenuBasic extends Component {
     static template = "web.DebugMenu";
@@ -11,11 +24,21 @@ export class DebugMenuBasic extends Component {
         DropdownItem,
     };
     static props = {};
+
     setup() {
-        const debugContext = useEnvDebugContext();
-        // Needs to be bound to this for use in template
-        this.getElements = async () => {
-            this.elements = await debugContext.getItems(this.env);
-        };
+        this.debugContext = useEnvDebugContext();
+    }
+
+    async loadGroupedItems() {
+        const items = await this.debugContext.getItems(this.env);
+        const sections = groupBy(items, (item) => item.section || "");
+        this.sectionEntries = sortBy(
+            Object.entries(sections),
+            ([section]) => debugSectionRegistry.get(section, { sequence: 50 }).sequence
+        );
+    }
+
+    getSectionLabel(section) {
+        return debugSectionRegistry.get(section, { label: section }).label;
     }
 }

--- a/addons/web/static/src/core/debug/debug_menu_items.js
+++ b/addons/web/static/src/core/debug/debug_menu_items.js
@@ -4,37 +4,32 @@ import { router } from "@web/core/browser/router";
 import { registry } from "@web/core/registry";
 import { user } from "@web/core/user";
 
-function activateAssetsDebugging({ env }) {
-    return {
-        type: "item",
-        description: _t("Activate Assets Debugging"),
-        callback: () => {
-            router.pushState({ debug: "assets" }, { reload: true });
-        },
-        sequence: 410,
-    };
-}
-
 function activateTestsAssetsDebugging({ env }) {
+    if (String(router.current.debug).includes("tests")) {
+        return;
+    }
+
     return {
         type: "item",
-        description: _t("Activate Tests Assets Debugging"),
+        description: _t("Activate Test Mode"),
         callback: () => {
             router.pushState({ debug: "assets,tests" }, { reload: true });
         },
-        sequence: 420,
+        sequence: 580,
+        section: "tools",
     };
 }
 
 export function regenerateAssets({ env }) {
     return {
         type: "item",
-        description: _t("Regenerate Assets Bundles"),
+        description: _t("Regenerate Assets"),
         callback: async () => {
             await env.services.orm.call("ir.attachment", "regenerate_assets_bundles");
             browser.location.reload();
         },
-        sequence: 430,
+        sequence: 550,
+        section: "tools",
     };
 }
 
@@ -48,26 +43,26 @@ function becomeSuperuser({ env }) {
         callback: () => {
             browser.open(becomeSuperuserURL, "_self");
         },
-        sequence: 440,
+        sequence: 560,
+        section: "tools",
     };
 }
 
 function leaveDebugMode() {
     return {
         type: "item",
-        description: _t("Leave the Developer Tools"),
+        description: _t("Leave Debug Mode"),
         callback: () => {
             router.pushState({ debug: 0 }, { reload: true });
         },
-        sequence: 450,
+        sequence: 650,
     };
 }
 
 registry
     .category("debug")
     .category("default")
-    .add("activateAssetsDebugging", activateAssetsDebugging)
     .add("regenerateAssets", regenerateAssets)
     .add("becomeSuperuser", becomeSuperuser)
-    .add("leaveDebugMode", leaveDebugMode)
-    .add("activateTestsAssetsDebugging", activateTestsAssetsDebugging);
+    .add("activateTestsAssetsDebugging", activateTestsAssetsDebugging)
+    .add("leaveDebugMode", leaveDebugMode);

--- a/addons/web/static/src/core/debug/debug_menu_items.xml
+++ b/addons/web/static/src/core/debug/debug_menu_items.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.DebugMenu.SetDefaultDialog">
-        <Dialog title.translate="Set Defaults">
+        <Dialog title.translate="Set Default Values">
             <table style="width: 100%">
                 <tr>
                     <td>
@@ -62,7 +62,7 @@
     </t>
 
     <t t-name="web.DebugMenu.GetMetadataDialog">
-        <Dialog title.translate="View Metadata">
+        <Dialog title.translate="Metadata">
             <table class="table table-sm table-striped">
                 <tr>
                     <th>ID:</th>

--- a/addons/web/static/src/core/debug/debug_providers.js
+++ b/addons/web/static/src/core/debug/debug_providers.js
@@ -30,21 +30,21 @@ commandProviderRegistry.add("debug", {
                     browser.open("/web/tests/next?debug=assets");
                 },
                 category: "debug",
-                name: _t("Run unit tests"),
+                name: _t("Run Unit Tests"),
             });
             result.push({
                 action() {
                     browser.open("/web/tests?debug=assets");
                 },
                 category: "debug",
-                name: _t("Run QUnit tests (legacy)"),
+                name: _t("Run QUnit Tests (legacy)"),
             });
             result.push({
                 action() {
                     browser.open("/web/tests/mobile?debug=assets");
                 },
                 category: "debug",
-                name: _t("Run QUnit mobile tests (legacy)"),
+                name: _t("Run QUnit Mobile Tests (legacy)"),
             });
         } else {
             const debugKey = "debug";

--- a/addons/web/static/src/webclient/actions/debug_items.js
+++ b/addons/web/static/src/webclient/actions/debug_items.js
@@ -4,39 +4,19 @@ import { registry } from "@web/core/registry";
 
 const debugRegistry = registry.category("debug");
 
-function actionSeparator({ action }) {
-    if (!action.id || !action.res_model) {
-        return null;
-    }
-    return {
-        type: "separator",
-        sequence: 100,
-    };
-}
-
-function accessSeparator({ accessRights, action }) {
-    const { canSeeModelAccess, canSeeRecordRules } = accessRights;
-    if (!action.res_model || (!canSeeModelAccess && !canSeeRecordRules)) {
-        return null;
-    }
-    return {
-        type: "separator",
-        sequence: 200,
-    };
-}
-
 function editAction({ action, env }) {
     if (!action.id) {
         return null;
     }
-    const description = _t("Edit Action");
+    const description = _t("Action");
     return {
         type: "item",
         description,
         callback: () => {
             editModelDebug(env, description, action.type, action.id);
         },
-        sequence: 110,
+        sequence: 220,
+        section: "ui",
     };
 }
 
@@ -44,7 +24,7 @@ function viewFields({ action, env }) {
     if (!action.res_model) {
         return null;
     }
-    const description = _t("View Fields");
+    const description = _t("Fields");
     return {
         type: "item",
         description,
@@ -68,7 +48,8 @@ function viewFields({ action, env }) {
                 },
             });
         },
-        sequence: 130,
+        sequence: 250,
+        section: "ui",
     };
 }
 
@@ -76,10 +57,10 @@ function ViewModel({ action, env }) {
     if (!action.res_model) {
         return null;
     }
-    const modelName = action.res_model
+    const modelName = action.res_model;
     return {
         type: "item",
-        description: _t("View Model: %s", modelName),
+        description: _t("Model: %s", modelName),
         callback: async () => {
             const modelId = (
                 await env.services.orm.search("ir.model", [["model", "=", modelName]], {
@@ -88,7 +69,8 @@ function ViewModel({ action, env }) {
             )[0];
             editModelDebug(env, modelName, "ir.model", modelId);
         },
-        sequence: 120,
+        sequence: 210,
+        section: "ui",
     };
 }
 
@@ -96,7 +78,7 @@ function manageFilters({ action, env }) {
     if (!action.res_model) {
         return null;
     }
-    const description = _t("Manage Filters");
+    const description = _t("Filters");
     return {
         type: "item",
         description,
@@ -116,7 +98,8 @@ function manageFilters({ action, env }) {
                 },
             });
         },
-        sequence: 140,
+        sequence: 260,
+        section: "ui",
     };
 }
 
@@ -124,7 +107,7 @@ function viewAccessRights({ accessRights, action, env }) {
     if (!action.res_model || !accessRights.canSeeModelAccess) {
         return null;
     }
-    const description = _t("View Access Rights");
+    const description = _t("Access Rights");
     return {
         type: "item",
         description,
@@ -148,7 +131,8 @@ function viewAccessRights({ accessRights, action, env }) {
                 },
             });
         },
-        sequence: 210,
+        sequence: 350,
+        section: "security",
     };
 }
 
@@ -159,7 +143,7 @@ function viewRecordRules({ accessRights, action, env }) {
     const description = _t("Model Record Rules");
     return {
         type: "item",
-        description: _t("View Record Rules"),
+        description: _t("Record Rules"),
         callback: async () => {
             const modelId = (
                 await env.services.orm.search("ir.model", [["model", "=", action.res_model]], {
@@ -180,17 +164,16 @@ function viewRecordRules({ accessRights, action, env }) {
                 },
             });
         },
-        sequence: 220,
+        sequence: 360,
+        section: "security",
     };
 }
 
 debugRegistry
     .category("action")
-    .add("actionSeparator", actionSeparator)
     .add("editAction", editAction)
     .add("viewFields", viewFields)
     .add("ViewModel", ViewModel)
     .add("manageFilters", manageFilters)
-    .add("accessSeparator", accessSeparator)
     .add("viewAccessRights", viewAccessRights)
     .add("viewRecordRules", viewRecordRules);

--- a/addons/web/static/src/webclient/clickbot/clickbot_loader.js
+++ b/addons/web/static/src/webclient/clickbot/clickbot_loader.js
@@ -11,11 +11,12 @@ export async function startClickEverywhere(xmlId, light, currentState) {
 export function runClickTestItem({ env }) {
     return {
         type: "item",
-        description: _t("Run Click Everywhere Test"),
+        description: _t("Run Click Everywhere"),
         callback: () => {
             startClickEverywhere();
         },
-        sequence: 30,
+        sequence: 460,
+        section: "testing",
     };
 }
 

--- a/addons/web/static/src/webclient/debug/debug_items.js
+++ b/addons/web/static/src/webclient/debug/debug_items.js
@@ -3,36 +3,15 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { SelectCreateDialog } from "@web/views/view_dialogs/select_create_dialog";
 
-function runHootItem() {
+function runUnitTests() {
     const href = "/web/tests/next?debug=assets";
     return {
         type: "item",
-        description: _t("Run unit tests"),
+        description: _t("Run Unit Tests"),
         href,
         callback: () => browser.open(href),
-        sequence: 10,
-    };
-}
-
-function runJSTestsItem() {
-    const href = "/web/tests?debug=assets";
-    return {
-        type: "item",
-        description: _t("Run QUnit tests (legacy)"),
-        href,
-        callback: () => browser.open(href),
-        sequence: 20,
-    };
-}
-
-function runJSTestsMobileItem() {
-    const href = "/web/tests/mobile?debug=assets";
-    return {
-        type: "item",
-        description: _t("Run QUnit mobile tests (legacy)"),
-        href,
-        callback: () => browser.open(href),
-        sequence: 30,
+        sequence: 450,
+        section: "testing",
     };
 }
 
@@ -68,23 +47,13 @@ export function openViewItem({ env }) {
                 onSelected,
             });
         },
-        sequence: 40,
-    };
-}
-
-// This separates the items defined above from global items that aren't webclient-only
-function globalSeparator() {
-    return {
-        type: "separator",
-        sequence: 400,
+        sequence: 540,
+        section: "tools",
     };
 }
 
 registry
     .category("debug")
     .category("default")
-    .add("runHootItem", runHootItem)
-    .add("runJSTestsItem", runJSTestsItem)
-    .add("runJSTestsMobileItem", runJSTestsMobileItem)
-    .add("globalSeparator", globalSeparator)
+    .add("runHootItem", runUnitTests)
     .add("openViewItem", openViewItem);

--- a/addons/web/static/src/webclient/debug/profiling/profiling_item.scss
+++ b/addons/web/static/src/webclient/debug/profiling/profiling_item.scss
@@ -1,9 +1,8 @@
-.o_debug_manager {
-    .o_debug_profiling_item {
-        cursor: auto;
-    }
+.o_debug_profiling_item {
+    cursor: auto;
+    padding-left: 12px;
 
-    .form-switch {
+    .o_profiling_switch .form-switch {
         cursor: pointer;
     }
 }

--- a/addons/web/static/src/webclient/debug/profiling/profiling_service.js
+++ b/addons/web/static/src/webclient/debug/profiling/profiling_service.js
@@ -60,27 +60,17 @@ export const profilingService = {
             }
         }
 
-        function profilingSeparator() {
-            return {
-                type: "separator",
-                sequence: 500,
-            };
-        }
-
         function profilingItem() {
             return {
                 type: "component",
                 Component: ProfilingItem,
                 props: { bus },
-                sequence: 510,
+                sequence: 570,
+                section: "tools",
             };
         }
 
-        registry
-            .category("debug")
-            .category("default")
-            .add("profilingSeparator", profilingSeparator)
-            .add("profilingItem", profilingItem);
+        registry.category("debug").category("default").add("profilingItem", profilingItem);
 
         return {
             state,

--- a/addons/web/static/tests/core/debug/debug_manager.test.js
+++ b/addons/web/static/tests/core/debug/debug_manager.test.js
@@ -66,6 +66,7 @@ describe.tags("desktop")("DebugMenu", () => {
                         expect.step("callback item_1");
                     },
                     sequence: 10,
+                    section: "a",
                 };
             })
             .add("item_2", () => {
@@ -76,6 +77,7 @@ describe.tags("desktop")("DebugMenu", () => {
                         expect.step("callback item_2");
                     },
                     sequence: 5,
+                    section: "a",
                 };
             })
             .add("item_3", () => {
@@ -85,16 +87,8 @@ describe.tags("desktop")("DebugMenu", () => {
                     callback: () => {
                         expect.step("callback item_3");
                     },
+                    section: "b",
                 };
-            })
-            .add("separator", () => {
-                return {
-                    type: "separator",
-                    sequence: 20,
-                };
-            })
-            .add("separator_2", () => {
-                return null;
             })
             .add("item_4", () => {
                 return null;
@@ -102,12 +96,12 @@ describe.tags("desktop")("DebugMenu", () => {
         await mountWithCleanup(DebugMenuParent);
         await contains("button.dropdown-toggle").click();
         expect(".dropdown-menu .dropdown-item").toHaveCount(3);
-        expect(".dropdown-divider").toHaveCount(1);
+        expect(".dropdown-menu .dropdown-menu_group").toHaveCount(2);
         const children = [...queryOne(".dropdown-menu").children] || [];
-        expect(children.map((el) => el.tagName)).toEqual(["SPAN", "SPAN", "DIV", "SPAN"]);
-        const items = [...queryAll(".dropdown-menu .dropdown-item")] || [];
-        expect(queryAllTexts(items)).toEqual(["Item 2", "Item 1", "Item 3"]);
+        expect(children.map((el) => el.tagName)).toEqual(["DIV", "SPAN", "SPAN", "DIV", "SPAN"]);
+        expect(queryAllTexts(children)).toEqual(["a", "Item 2", "Item 1", "b", "Item 3"]);
 
+        const items = [...queryAll(".dropdown-menu .dropdown-item")] || [];
         for (const item of items) {
             click(item);
         }
@@ -232,7 +226,7 @@ describe.tags("desktop")("DebugMenu", () => {
         await contains("button.dropdown-toggle").click();
         expect(".dropdown-menu .dropdown-item").toHaveCount(1);
         const item = queryOne(".dropdown-menu .dropdown-item");
-        expect(item).toHaveText("Regenerate Assets Bundles");
+        expect(item).toHaveText("Regenerate Assets");
         click(item);
         await animationFrame();
         expect.verifySteps(["ir.attachment/regenerate_assets_bundles", "reloadPage"]);
@@ -283,7 +277,7 @@ describe.tags("desktop")("DebugMenu", () => {
         });
 
         await contains(".o_debug_manager button").click();
-        await contains(".dropdown-menu .dropdown-item:contains('Get View')").click();
+        await contains(".dropdown-menu .dropdown-item:contains('Computed Arch')").click();
         expect(".modal").toHaveCount(1);
         expect(".modal-body").toHaveText(`<list><field name="name"/></list>`);
     });
@@ -306,7 +300,7 @@ describe.tags("desktop")("DebugMenu", () => {
             views: [[false, "pivot"]],
         });
         await contains(".o_debug_manager button").click();
-        await contains(".dropdown-menu .dropdown-item:contains('Edit View: Pivot')").click();
+        await contains(".dropdown-menu .dropdown-item:contains('View: Pivot')").click();
 
         expect(".breadcrumb-item").toHaveCount(1);
         expect(".o_breadcrumb .active").toHaveCount(1);
@@ -337,7 +331,7 @@ describe.tags("desktop")("DebugMenu", () => {
             views: [[false, "list"]],
         });
         await contains(".o_debug_manager button").click();
-        await contains(".dropdown-menu .dropdown-item:contains('Edit SearchView')").click();
+        await contains(".dropdown-menu .dropdown-item:contains('SearchView')").click();
         expect(".breadcrumb-item").toHaveCount(1);
         expect(".o_breadcrumb .active").toHaveCount(1);
         expect(".o_breadcrumb .active").toHaveText("Edit View");
@@ -363,7 +357,7 @@ describe.tags("desktop")("DebugMenu", () => {
             views: [[false, "list"]],
         });
         await contains(".o_debug_manager button").click();
-        await contains(".dropdown-menu .dropdown-item:contains('Edit SearchView')").click();
+        await contains(".dropdown-menu .dropdown-item:contains('SearchView')").click();
         expect(".breadcrumb-item").toHaveCount(1);
         expect(".o_breadcrumb .active").toHaveCount(1);
         expect(".o_breadcrumb .active").toHaveText("Edit View");
@@ -387,7 +381,7 @@ describe.tags("desktop")("DebugMenu", () => {
         });
 
         await contains(".o_dialog .o_debug_manager button").click();
-        expect(".dropdown-menu .dropdown-item:contains('Edit SearchView')").toHaveCount(0);
+        expect(".dropdown-menu .dropdown-item:contains('SearchView')").toHaveCount(0);
     });
 
     test("set defaults: basic rendering", async () => {
@@ -411,7 +405,7 @@ describe.tags("desktop")("DebugMenu", () => {
             views: [[24, "form"]],
         });
         await contains(".o_debug_manager button").click();
-        await contains(".dropdown-menu .dropdown-item:contains('Set Defaults')").click();
+        await contains(".dropdown-menu .dropdown-item:contains('Set Default Values')").click();
         expect(".modal").toHaveCount(1);
         expect(".modal select#formview_default_fields").toHaveCount(1);
         expect(".modal #formview_default_fields option").toHaveCount(2);
@@ -445,7 +439,7 @@ describe.tags("desktop")("DebugMenu", () => {
             views: [[25, "form"]],
         });
         await contains(".o_debug_manager button").click();
-        await contains(".dropdown-menu .dropdown-item:contains('Set Defaults')").click();
+        await contains(".dropdown-menu .dropdown-item:contains('Set Default Values')").click();
         expect(".modal").toHaveCount(1);
         await contains(".modal .modal-footer button").click();
         expect(".modal").toHaveCount(0);
@@ -478,7 +472,7 @@ describe.tags("desktop")("DebugMenu", () => {
             views: [[26, "form"]],
         });
         await contains(".o_debug_manager button").click();
-        await contains(".dropdown-menu .dropdown-item:contains('Set Defaults')").click();
+        await contains(".dropdown-menu .dropdown-item:contains('Set Default Values')").click();
         expect(".modal").toHaveCount(1);
 
         await contains(".modal #formview_default_fields").select("name");
@@ -518,11 +512,8 @@ describe.tags("desktop")("DebugMenu", () => {
             views: [[false, "form"]],
         });
         await contains(".o_debug_manager button").click();
-        await contains(".dropdown-menu .dropdown-item:contains('View Raw Record Data')").click();
-        expect(".modal").toHaveCount(1);
-        expect(".modal-body pre").toHaveText(
-            '{\n "create_date": "2019-03-11 09:30:00",\n "display_name": "custom1",\n "id": 1,\n "name": "custom1",\n "write_date": "2019-03-11 09:30:00"\n}'
-        );
+        await contains(".dropdown-menu .dropdown-item:contains(/^Data/)").click();
+        expect(browser.location.pathname).toBe("/json/m-custom/1");
     });
 
     test("view metadata: basic rendering", async () => {
@@ -557,7 +548,7 @@ describe.tags("desktop")("DebugMenu", () => {
             views: [[false, "form"]],
         });
         await contains(".o_debug_manager button").click();
-        await contains(".dropdown-menu .dropdown-item:contains('View Metadata')").click();
+        await contains(".dropdown-menu .dropdown-item:contains('Metadata')").click();
         expect(".modal").toHaveCount(1);
         const contentModal = queryAll(".modal-body table tr th, .modal-body table tr td");
         expect(queryAllTexts(contentModal)).toEqual([
@@ -643,7 +634,7 @@ describe.tags("desktop")("DebugMenu", () => {
                 views: [[18, "form"]],
             });
             await contains(".o_debug_manager button").click();
-            await contains(".dropdown-menu .dropdown-item:contains('Set Defaults')").click();
+            await contains(".dropdown-menu .dropdown-item:contains('Set Default Values')").click();
             expect(".modal").toHaveCount(1);
 
             await contains(".modal #formview_default_fields").select(field_name);
@@ -687,8 +678,7 @@ describe.tags("desktop")("DebugMenu", () => {
         });
 
         await contains(".o_debug_manager button").click();
-        expect(queryAll(".dropdown-menu .dropdown-item")[0]).toHaveText("View Model: res.partner");
-        await contains(".dropdown-menu .dropdown-item:contains('View Model:')").click();
+        await contains(".dropdown-menu .dropdown-item:contains('Model:')").click();
 
         expect(".breadcrumb-item").toHaveCount(1);
         expect(".o_breadcrumb .active").toHaveCount(1);

--- a/addons/web/static/tests/webclient/actions/window_action.test.js
+++ b/addons/web/static/tests/webclient/actions/window_action.test.js
@@ -2332,9 +2332,9 @@ test("debugManager is active for views", async () => {
     onRpc("has_access", () => true);
     await mountWithCleanup(WebClient);
     await getService("action").doAction(1);
-    expect(".o-dropdown--menu .o-dropdown-item:contains('Edit View: Kanban')").toHaveCount(0);
+    expect(".o-dropdown--menu .o-dropdown-item:contains('View: Kanban')").toHaveCount(0);
     await contains(".o_debug_manager .dropdown-toggle").click();
-    expect(".o-dropdown--menu .o-dropdown-item:contains('Edit View: Kanban')").toHaveCount(1);
+    expect(".o-dropdown--menu .o-dropdown-item:contains('View: Kanban')").toHaveCount(1);
 });
 
 test.tags("desktop")("reload a view via the view switcher keep state", async () => {


### PR DESCRIPTION
This commit reworks the debug menu by organising the items by section, renaming some items and reordering them.
The menu "Data" (previously "View Raw Record Data") now redirects to the /json route of the current view.

task-4055746