### PR TITLE
[FIX] pos_self_order: kitchen order ticket in kiosk self order

### DIFF
--- a/addons/pos_online_payment_self_order/static/src/self_order_service.js
+++ b/addons/pos_online_payment_self_order/static/src/self_order_service.js
@@ -15,14 +15,8 @@ patch(SelfOrder.prototype, {
                 (o) => o.access_token === data["pos.order"][0].access_token
             );
             if (status === "success" && !this.currentOrder.access_token && order) {
-                this.finalizeOrder(order.access_token);
+                this.confirmationPage("order", this.config.self_ordering_mode, order.access_token);
             }
-        });
-    },
-    finalizeOrder(accessToken) {
-        this.router.navigate("confirmation", {
-            orderAccessToken: accessToken,
-            screenMode: "order",
         });
     },
     getOnlinePaymentUrl(

--- a/addons/pos_self_order/static/scss/pos_self_order.scss
+++ b/addons/pos_self_order/static/scss/pos_self_order.scss
@@ -1,8 +1,0 @@
-.multiprint-flex {
-    display: flex;
-    margin-bottom: 10px;
-}
-
-.multiprint-flex .product-quantity {
-    margin-right: 50px;
-}

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -290,13 +290,13 @@ export class SelfOrder extends Reactive {
             newLine.delete();
         }
     }
-    async confirmationPage(screen_mode, device) {
+    async confirmationPage(screen_mode, device, access_token = "") {
         this.router.navigate("confirmation", {
-            orderAccessToken: this.currentOrder.access_token,
+            orderAccessToken: access_token || this.currentOrder.access_token,
             screenMode: screen_mode,
         });
         if (device === "kiosk") {
-            this.printKioskChanges();
+            this.printKioskChanges(access_token);
         }
     }
 
@@ -444,8 +444,8 @@ export class SelfOrder extends Reactive {
         return new HWPrinter({ url });
     }
 
-    _getKioskPrintingCategoriesChanges(categories) {
-        return this.currentOrder.lines.filter((orderline) =>
+    _getKioskPrintingCategoriesChanges(order, categories) {
+        return order.lines.filter((orderline) =>
             categories.some((category) =>
                 this.models["product.product"]
                     .get(orderline.product_id.id)
@@ -455,22 +455,27 @@ export class SelfOrder extends Reactive {
         );
     }
 
-    async printKioskChanges() {
+    async printKioskChanges(access_token = "") {
         const d = new Date();
         let hours = "" + d.getHours();
         hours = hours.length < 2 ? "0" + hours : hours;
         let minutes = "" + d.getMinutes();
         minutes = minutes.length < 2 ? "0" + minutes : minutes;
+        const order = access_token
+            ? this.models["pos.order"].find((o) => o.access_token === access_token)
+            : this.currentOrder;
+
         for (const printer of this.kitchenPrinters) {
             const orderlines = this._getKioskPrintingCategoriesChanges(
+                order,
                 Object.values(printer.config.product_categories_ids)
             );
             if (orderlines) {
                 const printingChanges = {
                     new: orderlines,
-                    tracker: this.currentOrder.table_stand_number,
-                    trackingNumber: this.currentOrder.tracking_number || "unknown number",
-                    name: this.currentOrder.pos_reference || "unknown order",
+                    tracker: order.table_stand_number,
+                    trackingNumber: order.tracking_number || "unknown number",
+                    name: order.pos_reference || "unknown order",
                     time: {
                         hours,
                         minutes,

--- a/addons/pos_self_order/static/src/app/store/order_change_receipt_template.xml
+++ b/addons/pos_self_order/static/src/app/store/order_change_receipt_template.xml
@@ -14,16 +14,14 @@
                 </div>
             </t>
             <br />
-            <br />
             <div class="pos-receipt-title">
                 NEW
                 <t t-esc='changes.time.hours'/>:<t t-esc='changes.time.minutes'/>
             </div>
             <br />
-            <br />
             <t t-foreach="changes.new" t-as="change" t-key="change_index">
-                <div class="multiprint-flex">
-                    <span class="product-quantity" t-esc="change.qty"/>
+                <div class="product-details d-flex">
+                    <span class="product-quantity me-5 mb-1" t-esc="change.qty"/>
                     <span class="product-name" t-esc="change.full_product_name"/>
                 </div>
                 <t t-if="change.customer_note">


### PR DESCRIPTION
Before this commit:
===================
- The kitchen order ticket was not printing correctly when the kiosk was
  configured with online payment, the ticket printed with incomplete or
  incorrect details.

After this ticket:
================
- The kitchen order ticket now prints correctly when using kiosk self order.
- Ticket layout has been improved, with proper margin and padding adjustments
  for better readability.

Task- 4182015