### PR TITLE
[FIX] mrp: fix deleting a maufacturing order component from form view

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -866,8 +866,11 @@ class MrpProduction(models.Model):
                 location_source = self.env['stock.location'].browse(vals.get('location_src_id'))
                 warehouse_id = location_source.warehouse_id.id
             for move_vals in vals[move_str]:
-                command, _id, field_values = move_vals
-                if command == Command.CREATE and not field_values.get('warehouse_id', False):
+                command = move_vals[0]
+                if command != Command.CREATE:
+                    continue
+                field_values = move_vals[2]
+                if not field_values.get('warehouse_id', False):
                     field_values['warehouse_id'] = warehouse_id
 
         if vals.get('picking_type_id'):


### PR DESCRIPTION
Steps to reproduce:
- Create an MO and confirm it.
- Remove any component (`move_raw_ids`).
- Save the form.

Expected behavior:
The component should be removed.

Current behavior:
A traceback appears.

This is because the `write` of the `mrp_production` always tries to destructure the value of `move_raw_ids` into a `Command` tuple of three elements, which is not the case when deleting on of the components, where the tuple consists only of two elements: the `DELETE` constant and the id of the removed record (no values element).

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
