### PR TITLE
[IMP] project: simplify task stage creation check in kanban view

### DIFF
--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_renderer.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_renderer.js
@@ -23,15 +23,11 @@ export class ProjectTaskKanbanRenderer extends KanbanRenderer {
 
     canCreateGroup() {
         // This restrict the creation of project stages to the kanban view of a given project
-        return super.canCreateGroup() && (this.isProjectTasksContext() == this.props.list.isGroupedByStage
-            && this.isProjectManager || this.props.list.groupByField.name === 'personal_stage_type_id');
-    }
-
-    isProjectTasksContext() {
         return (
-            ["project.project", "project.task.type.delete.wizard"].includes(
-                this.props.list.context.active_model
-            ) && !!this.props.list.context.default_project_id
+            super.canCreateGroup() &&
+            ((!!this.props.list.context.default_project_id == this.props.list.isGroupedByStage &&
+                this.isProjectManager) ||
+                this.props.list.groupByField.name === "personal_stage_type_id")
         );
     }
 }

--- a/addons/project/static/tests/project_task_groupby.test.js
+++ b/addons/project/static/tests/project_task_groupby.test.js
@@ -1,9 +1,20 @@
 import { beforeEach, expect, test } from "@odoo/hoot";
-import { mountView } from "@web/../tests/web_test_helpers";
+import { mountView, quickCreateKanbanColumn } from "@web/../tests/web_test_helpers";
 
 import { defineProjectModels, ProjectTask } from "./project_models";
 
 defineProjectModels();
+
+const kanbanViewParams = {
+    resModel: "project.task",
+    type: "kanban",
+    arch: `<kanban default_group_by="stage_id" js_class="project_task_kanban">
+                <templates>
+                    <t t-name="card"/>
+                </templates>
+            </kanban>`,
+};
+
 beforeEach(() => {
     ProjectTask._records = [
         {
@@ -48,47 +59,57 @@ test("project.task (tree): check group label for no deadline", async () => {
 
 test("project.task (kanban): check group label for no project", async () => {
     await mountView({
-        resModel: "project.task",
-        type: "kanban",
-        arch: `
-            <kanban js_class="project_task_kanban" default_group_by="project_id">
-                <templates>
-                    <t t-name="card"/>
-                </templates>
-            </kanban>
-        `,
+        ...kanbanViewParams,
+        groupBy: ["project_id"],
     });
     expect(".o_column_title").toHaveText("🔒 Private\n(1)");
 });
 
 test("project.task (kanban): check group label for no assignees", async () => {
     await mountView({
-        resModel: "project.task",
-        type: "kanban",
-        arch: `
-            <kanban js_class="project_task_kanban" default_group_by="user_ids">
-                <templates>
-                    <t t-name="card"/>
-                </templates>
-            </kanban>
-        `,
+        ...kanbanViewParams,
+        groupBy: ["user_ids"],
     });
     expect(".o_column_title").toHaveText("👤 Unassigned\n(1)");
 });
 
 test("project.task (kanban): check group label for no deadline", async () => {
     await mountView({
-        resModel: "project.task",
-        type: "kanban",
-        arch: `
-            <kanban js_class="project_task_kanban" default_group_by="date_deadline">
-                <templates>
-                    <t t-name="card"/>
-                </templates>
-            </kanban>
-        `,
+        ...kanbanViewParams,
+        groupBy: ["date_deadline"],
     });
     expect(".o_column_title").toHaveText("None\n(1)");
+});
+
+test("project.task (kanban): Can create stage if we are in tasks of specific project", async () => {
+    await mountView({
+        ...kanbanViewParams,
+        context: {
+            default_project_id: 1,
+        },
+    });
+    expect(".o_column_quick_create").toHaveCount(1, {
+        message: "should have a quick create column",
+    });
+    expect(".o_kanban_add_column").toHaveCount(1, {
+        message: "Add column button should be visible",
+    });
+    await quickCreateKanbanColumn();
+    expect(".o_column_quick_create input").toHaveCount(1, {
+        message: "the input should be visible",
+    });
+});
+
+test("project.task (kanban): Cannot create stage if we are not in tasks of specific project", async () => {
+    await mountView({
+        ...kanbanViewParams,
+    });
+    expect(".o_column_quick_create").toHaveCount(0, {
+        message: "quick create column should not be visible",
+    });
+    expect(".o_kanban_add_column").toHaveCount(0, {
+        message: "Add column button should not be visible",
+    });
 });
 
 test("project.task (pivot): check group label for no project", async () => {

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -205,7 +205,6 @@
             <field name="view_mode">kanban,list,form,calendar,pivot,graph,activity</field>
             <field name="domain">[('project_id', '=', active_id), ('display_in_project', '=', True)]</field>
             <field name="context">{
-                'active_model': 'project.project',
                 'default_project_id': active_id,
                 'show_project_update': True,
                 'search_default_open_tasks': 1,


### PR DESCRIPTION
- Remove the use of `active_model`​ in the context of `act_project_project_2_project_task_all` action.

task-4134660


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
