### PR TITLE
[MOV] spreadsheet_dashboard{_1}: move Marketing dashboard group

### DIFF
--- a/addons/spreadsheet_dashboard/data/dashboard.xml
+++ b/addons/spreadsheet_dashboard/data/dashboard.xml
@@ -31,4 +31,9 @@
         <field name="sequence">400</field>
     </record>
 
+    <record id="spreadsheet_dashboard_group_marketing" model="spreadsheet.dashboard.group">
+        <field name="name">Marketing</field>
+        <field name="sequence">600</field>
+    </record>
+
 </odoo>

--- a/addons/spreadsheet_dashboard_event_sale/data/dashboards.xml
+++ b/addons/spreadsheet_dashboard_event_sale/data/dashboards.xml
@@ -1,14 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <record id="spreadsheet_dashboard_group_marketing" model="spreadsheet.dashboard.group">
-        <field name="name">Marketing</field>
-        <field name="sequence">600</field>
-    </record>
 
     <record id="spreadsheet_dashboard_events" model="spreadsheet.dashboard">
         <field name="name">Events</field>
         <field name="spreadsheet_binary_data" type="base64" file="spreadsheet_dashboard_event_sale/data/files/events_dashboard.json"/>
-        <field name="dashboard_group_id" ref="spreadsheet_dashboard_event_sale.spreadsheet_dashboard_group_marketing"/>
+        <field name="dashboard_group_id" ref="spreadsheet_dashboard.spreadsheet_dashboard_group_marketing"/>
         <field name="group_ids" eval="[Command.link(ref('event.group_event_manager'))]"/>
         <field name="sequence">60</field>
         <field name="is_published">True</field>


### PR DESCRIPTION
1: spreadsheet_dashboard_event_sale

This commit prepares the ground for the new email marketing dashboard. It moves the Marketing category from the spreadsheet_dashboard_event_sale module to the spreadsheet_dashboard module.

Task: 4179584

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
