### PR TITLE
[FIX] web_editor: DOMPurify is missing

### DIFF
--- a/addons/web_editor/__manifest__.py
+++ b/addons/web_editor/__manifest__.py
@@ -140,6 +140,7 @@ Odoo Web Editor widget.
             'web_editor/static/lib/jquery-cropper/jquery-cropper.js',
             'web_editor/static/lib/jQuery.transfo.js',
             'web_editor/static/lib/webgl-image-filter/webgl-image-filter.js',
+            'html_editor/static/lib/DOMpurify.js',
 
             # odoo-editor
             'web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js',


### PR DESCRIPTION
Since the PR odoo/odoo#177577, we use the latest version of DOMPurify which is in the html_editor. We forgot to import it into the use cases when the old editor is instantiated on its own in the frontend using loadWysiwygFromTextarea. This commit will therefore add it to the ‘web_editor.assets_wysiwyg’ bundle.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
