### PR TITLE
[FIX] account: Pay button in account.move list view should work on drafts

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -511,7 +511,7 @@
                       expand="context.get('expand', False)"
                       sample="1">
                     <header>
-                        <button name="action_register_payment" type="object" string="Pay"
+                        <button name="action_force_register_payment" type="object" string="Pay"
                             groups="account.group_account_user"
                             invisible="context.get('default_move_type') not in ('out_invoice', 'out_refund', 'out_receipt', 'in_invoice', 'in_refund','in_receipt')"/>
                     </header>
@@ -1915,7 +1915,7 @@ if records:
             <field name="groups_id" eval="[(4, ref('account.group_account_invoice'))]"/>
             <field name="binding_model_id" ref="account.model_account_move" />
             <field name="state">code</field>
-            <field name="binding_view_types">list,form</field>
+            <field name="binding_view_types">form</field>
             <field name="code">
 if records:
     action = records.action_force_register_payment()


### PR DESCRIPTION
Since https://github.com/odoo/odoo/commit/3ccdd62bb9ce2f623e31f2e82aa1d5b35afe9d95, we allow to register payments on draft moves via the cog menu. This is true for the form view. However, for the list view, this should be possible from the existing Pay button, and not via the cog menu.

task-id: none
