### PR TITLE
[REF] hr_payroll: move data to demo

### DIFF
--- a/addons/hr_contract/data/hr_contract_data.xml
+++ b/addons/hr_contract/data/hr_contract_data.xml
@@ -2,24 +2,10 @@
 <odoo>
     <data noupdate="1">
         <!-- Structure Type -->
-        <record id="structure_type_employee" model="hr.payroll.structure.type">
-            <field name="name">Employee</field>
+        <record id="structure_type_default" model="hr.payroll.structure.type">
+            <field name="name">Default Structure Type</field>
             <field name="country_id" eval="False"/>
-        </record>
-        <record id="structure_type_worker" model="hr.payroll.structure.type">
-            <field name="name">Worker</field>
-            <field name="country_id" eval="False"/>
-        </record>
-
-        <record id="structure_type_employee_cp200_pfi" model="hr.payroll.structure.type">
-            <field name="name">CP200 PFI: Belgian Employee</field>
-            <field name="default_resource_calendar_id" ref="resource.resource_calendar_std"/>
-            <field name="country_id" ref="base.be"/>
-        </record>
-        <record id="structure_type_employee_cp200" model="hr.payroll.structure.type">
-            <field name="name">CP200: Belgian Employee</field>
-            <field name="default_resource_calendar_id" ref="resource.resource_calendar_std"/>
-            <field name="country_id" ref="base.be"/>
+            <field name="active">False</field>
         </record>
 
         <!-- Contract-related subtypes for messaging / Chatter -->

--- a/addons/hr_contract/data/hr_contract_demo.xml
+++ b/addons/hr_contract/data/hr_contract_demo.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <record id="structure_type_employee_cp200_pfi" model="hr.payroll.structure.type">
-        <field name="default_resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
+    <!-- Structure Type -->
+    <record id="structure_type_employee" model="hr.payroll.structure.type">
+        <field name="name">Employee</field>
+        <field name="country_id" eval="False"/>
     </record>
-
-    <record id="structure_type_employee_cp200" model="hr.payroll.structure.type">
-        <field name="default_resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
+    <record id="structure_type_worker" model="hr.payroll.structure.type">
+        <field name="name">Worker</field>
+        <field name="country_id" eval="False"/>
     </record>
 
     <data noupdate="1">

--- a/addons/hr_contract/models/hr_payroll_structure_type.py
+++ b/addons/hr_contract/models/hr_payroll_structure_type.py
@@ -9,6 +9,7 @@ class HrPayrollStructureType(models.Model):
     _description = 'Salary Structure Type'
 
     name = fields.Char('Salary Structure Type')
+    active = fields.Boolean(default=True)
     default_resource_calendar_id = fields.Many2one(
         'resource.calendar', 'Default Working Hours',
         default=lambda self: self.env.company.resource_calendar_id)


### PR DESCRIPTION
There is a lot of data in payroll which will probably never be used in a real case scenario since you always use the payroll app with a localization.

The only case where you use the standalone payroll is for BA demos, so these data should be moved in demo data instead of being in prod.

Task: 4167714
