### PR TITLE
[FIX] base_import: redirect to same import screen page on reload

### DIFF
--- a/addons/base_import/static/src/import_action/import_action.js
+++ b/addons/base_import/static/src/import_action/import_action.js
@@ -31,10 +31,13 @@ export class ImportAction extends Component {
         this.resModel = this.props.action.params.model;
         this.model = useImportModel({
             env: this.env,
-            resModel: this.resModel,
+            resModel: this.resModel || this.props.action.params.res_model,
             context: this.props.action.params.context || {},
             orm: this.orm,
         });
+        if (this.model.resModel) {
+            this.props.updateActionState({ res_model: this.model.resModel });
+        }
 
         this.state = useState({
             filename: undefined,


### PR DESCRIPTION
- Go to CRM app
- Click on the action menu --> Import records --> Import screen will appear
- Reload the page a traceback will occur which will disappear quickly (you can see it in console)
- It redirects you back to the kanban view which is not correct

Before this commit, on reloading the import screen page a traceback was occuring which redirects back to the kanban/list view. This occurs because the ImportAction lost the current model at reload (resModel).

Now, the ImportAction will update the state of action using updateActionState prop, to add the resModel to the url (as a query param), and be able to restore the full state at reload.

Task-3959254

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
