### PR TITLE
[FIX] hw_drivers: get server url error in access point mode

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -288,12 +288,14 @@ def get_ssid():
 
 @cache
 def get_odoo_server_url():
-    if platform.system() == 'Linux':
-        ap = subprocess.call(['systemctl', 'is-active', '--quiet', 'hostapd']) # if service is active return 0 else inactive
-        if not ap:
-            return False
+    """Get the URL of the linked Odoo database.
+    If the IoT Box is in access point mode, it will return ``None`` to avoid
+    connecting to the server.
 
-    return get_conf('remote_server')
+    :return: The URL of the linked Odoo database.
+    :rtype: str or None
+    """
+    return None if access_point() else get_conf('remote_server')
 
 
 def get_token():

--- a/addons/point_of_sale/tools/posbox/configuration/wireless_ap.sh
+++ b/addons/point_of_sale/tools/posbox/configuration/wireless_ap.sh
@@ -77,5 +77,6 @@ else
 	killall nginx
 	service nginx restart
 	service dnsmasq stop
+	ip addr del 10.11.12.1/24 dev wlan0 # remove the static ip
 	service odoo restart # As this file is executed on boot, this line is responsible for restarting odoo service on reboot
 fi


### PR DESCRIPTION
If the IoT Box is in access point mode, it should mean that it has no internet connection. Thus, we avoid returning the linked db url to avoid fetching it.

We used to check the access point mode with a `subprocess` call to `hostapd` service. We now check the IP, as it is set to `10.11.12.1` when in AP mode.

Task: 4182947