### PR TITLE
[FIX] barcodes: remove usage of jQuery in barcode service

### DIFF
--- a/addons/barcodes/static/src/barcode_service.js
+++ b/addons/barcodes/static/src/barcode_service.js
@@ -110,8 +110,12 @@ export const barcodeService = {
             if (ev.key === "Unidentified") {
                 return;
             }
-            if ($(document.activeElement).not('input:text, textarea, [contenteditable], ' +
-                '[type="email"], [type="number"], [type="password"], [type="tel"], [type="search"]').length) {
+            if (
+                !document.activeElement.matches(
+                    'input, [type="text"], textarea, [contenteditable], ' +
+                        '[type="email"], [type="number"], [type="password"], [type="tel"], [type="search"]'
+                )
+            ) {
                 barcodeInput.focus();
             }
             keydownHandler(ev);


### PR DESCRIPTION
On chrome mobile, when going in the pos self order and trying to do a search on the products you would get a traceback. This was happening because jQuery was not defined.

Steps to reproduce:
-------------------
* Install pos_self_order and barcodes
* Open the PoS on a chrome mobile device (use browserstack)
* Try to do a search on the products page
> Observation: You get a traceback

Why the fix:
------------
jQuery is not always defined, so we remove the use of jQuery.

opw-4107823
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
