### PR TITLE
[FIX] web: duplicate include archived button

### DIFF
--- a/addons/web/static/src/core/tree_editor/tree_editor.xml
+++ b/addons/web/static/src/core/tree_editor/tree_editor.xml
@@ -148,6 +148,7 @@
         <t t-if="isTree(node.value)">
             <TreeEditor t-props="props"
                 update="(value) => this.updateLeafValue(node, value)"
+                slots="{}"
                 isSubTree="true"
                 tree="node.value"
                 resModel="getResModel(node)"

--- a/addons/web/static/tests/core/domain_selector/domain_selector.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector.test.js
@@ -2136,6 +2136,22 @@ test(`any operator (edit) test defaultValue => defaultCondition`, async () => {
     expect(getCurrentPath(1)).toBe("Country");
 });
 
+test(`any operator with include archived`, async () => {
+    Partner._fields.active = fields.Boolean({
+        string: "Active",
+        searchable: true,
+    });
+    await makeDomainSelector({
+        readonly: false,
+        isDebugMode: true,
+        domain: `[("product_id", "any", [("name", "=", "Mancester City")])]`,
+    });
+    expect(SELECTORS.condition).toHaveCount(2);
+    expect('.form-switch label:contains("Include archived")').toHaveCount(1, {
+        message: "Sub TreeEditor shouldn't add another checkbox",
+    });
+});
+
 test(`any/not any operator (readonly)`, async () => {
     const toTest = [
         {


### PR DESCRIPTION
This commit fixes a bug where the include archived checkbox button would be duplicated when the "any" operator would be used. This was due to the fact that using this operator would spawn a sub TreeEditor component inside of itself carrying most of its props including the include archived Checkbox slot from the domain selector which was supposed to be unique. The fix is therefore to empty the slots from the sub TreeEditor component.
