### PR TITLE
[FIX] account_edi_ubl_cii: add constraint on the delivery address

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -410,6 +410,9 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
                 constraints.update({f'cen_en16931_{role}_vat_country_code': _(
                     "The VAT of the %s should be prefixed with its country code.", role)})
 
+        if invoice.partner_shipping_id:
+            # [BR-57]-Each Deliver to address (BG-15) shall contain a Deliver to country code (BT-80).
+            constraints['cen_en16931_delivery_address'] = self._check_required_fields(invoice.partner_shipping_id, 'country_id')
         return constraints
 
     def _invoice_constraints_peppol_en16931_ubl(self, invoice, vals):


### PR DESCRIPTION
The country is a mandatory field on the delivery address.

Xpath:
cac:Delivery/cac:DeliveryLocation/cac:Address/cac:Country/cbc:IdentificationCode

"[BR-57]-Each Deliver to address (BG-15) shall contain a Deliver to country code (BT-80)."

opw-4139689