### PR TITLE
[FIX] account: Fix reco model partner matching with newline

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -795,7 +795,11 @@ class AccountReconcileModel(models.Model):
 
         for partner_mapping in self.partner_mapping_line_ids:
             match_payment_ref = re.match(partner_mapping.payment_ref_regex, st_line.payment_ref) if partner_mapping.payment_ref_regex else True
-            match_narration = re.match(partner_mapping.narration_regex, tools.html2plaintext(st_line.narration or '').rstrip()) if partner_mapping.narration_regex else True
+            match_narration = re.match(
+                partner_mapping.narration_regex,
+                tools.html2plaintext(st_line.narration or '').rstrip(),
+                flags=re.DOTALL   # Ignore '/n' set by online sync.
+            ) if partner_mapping.narration_regex else True
 
             if match_payment_ref and match_narration:
                 return partner_mapping.partner_id

--- a/addons/account/tests/test_reconciliation_matching_rules.py
+++ b/addons/account/tests/test_reconciliation_matching_rules.py
@@ -1125,6 +1125,20 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
                 self.bank_line_2.id: no_match_result,
             }, self.bank_st)
 
+            # More complex matching to match something from bank sync data.
+            # Note: the indentation is done with multiple \n to mimic the bank sync behavior. Keep them for this test!
+            rule.partner_mapping_line_ids.write({'narration_regex': ".*coincoin.*"})
+            self.bank_line_1.write({'narration': """
+                {
+                    "informations": "coincoin turlututu tsoin tsoin",
+                }
+            """})
+
+            self._check_statement_matching(rule, {
+                self.bank_line_1.id: match_result,
+                self.bank_line_2.id: no_match_result,
+            }, self.bank_st)
+
     def test_partner_name_in_communication(self):
         self.invoice_line_1.partner_id.write({'name': "Archibald Haddock"})
         self.bank_line_1.write({'partner_id': None, 'payment_ref': '1234//HADDOCK-Archibald'})


### PR DESCRIPTION
In a reconciliation model with partner mapping, the search criterion can be enclosed in `.*` regexp expression bypass only searching the beginning of the transaction notes.

The issue lies when there are one or more `\n` linebreak character in the notes as this character is not part of the regexp metacharacter `.`, resulting in no match.

Adding the flag `re.DOTALL` to the `re.match()` function allows to match `.` with `\n` which will then produce the desired outcome.

This is already fixed in more recent version, this PR is just backporting that fix to Odoo 15.

opw-4173733
