### PR TITLE
[FIX] stock: trigger push rules from sub-location

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1004,15 +1004,18 @@ Please change the quantity done or the rounding precision of your unit of measur
 
             # if the move is a returned move, we don't want to check push rules, as returning a returned move is the only decent way
             # to receive goods without triggering the push rules again (which would duplicate chained operations)
-            domain = [('location_src_id', '=', move.location_dest_id.id), ('action', 'in', ('push', 'pull_push'))]
             # first priority goes to the preferred routes defined on the move itself (e.g. coming from a SO line)
             warehouse_id = move.warehouse_id or move.picking_id.picking_type_id.warehouse_id
             if move.location_dest_id.company_id == self.env.company:
-                rule = self.env['procurement.group']._search_rule(move.route_ids, move.product_packaging_id, move.product_id, warehouse_id, domain)
+                rule = self.env['procurement.group']._get_push_rule(move.product_id, move.location_dest_id, {
+                    'route_ids': move.route_ids, 'product_packaging_id': move.product_packaging_id, 'warehouse_id': warehouse_id
+                })
             else:
                 procurement_group = self.env['procurement.group'].sudo()
                 move = move.with_context(allowed_companies=self.env.user.company_ids.ids)
-                rule = procurement_group._search_rule(move.route_ids, move.product_packaging_id, move.product_id, False, domain)
+                rule = procurement_group._get_push_rule(move.product_id, move.location_dest_id, {
+                    'route_ids': move.route_ids, 'product_packaging_id': move.product_packaging_id, 'warehouse_id': False
+                })
             # Make sure it is not returning the return
             if rule and (not move.origin_returned_move_id or move.origin_returned_move_id.location_dest_id.id != rule.location_dest_id.id):
                 new_move = rule._run_push(move)

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -566,6 +566,18 @@ class ProcurementGroup(models.Model):
         return domain
 
     @api.model
+    def _get_push_rule(self, product_id, location_dest_id, values):
+        """ Find a push rule for the location_dest_id, with a fallback to the parent locations if none could be found.
+        """
+        found_rule = self.env['stock.rule']
+        location = location_dest_id
+        while (not found_rule) and location:
+            domain = [('location_src_id', '=', location.id), ('action', 'in', ('push', 'pull_push'))]
+            found_rule = self._search_rule(values.get('route_ids'), values.get('product_packaging_id'), product_id, values.get('warehouse_id'), domain)
+            location = location.location_id
+        return found_rule
+
+    @api.model
     def _get_moves_to_assign_domain(self, company_id):
         moves_domain = [
             ('state', 'in', ['confirmed', 'partially_available']),

--- a/addons/stock/tests/test_move2.py
+++ b/addons/stock/tests/test_move2.py
@@ -2815,6 +2815,39 @@ class TestRoutes(TestStockCommon):
         self.assertEqual(move_line[0].product_uom_qty, self.product_uom_qty, 'Quantities does not match')
         self.assertEqual(move_line[1].product_uom_qty, self.product_uom_qty, 'Quantities does not match')
 
+    def test_pick_ship_from_subloc(self):
+        """ Checks that if a picking is sent to a sublocation of its original destination during the pick->ship route,
+        it will still trigger the push rule from the sublocation as well to continue the route.
+        """
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        warehouse.delivery_steps = 'pick_ship'
+        subloc = self.env['stock.location'].create({
+            'name': 'Fancy Spot',
+            'location_id': warehouse.wh_output_stock_loc_id.id,
+            'usage': 'internal',
+        })
+
+        # Create first move from Stock -> Output
+        pick_move = self.env['stock.move'].create({
+            'name': 'pick',
+            'picking_type_id': warehouse.pick_type_id.id,
+            'location_id': warehouse.lot_stock_id.id,
+            'product_id': self.product1.id,
+            'product_uom_qty': 1
+        })
+        pick_move._action_confirm()
+        self.assertEqual(pick_move.location_dest_id, warehouse.wh_output_stock_loc_id)
+
+        # Change destination of picking to sublocation of Output & Validate the picking
+        pick_move.write({'quantity': 1, 'picked': True})
+        pick_move.picking_id.location_dest_id = subloc
+        pick_move.picking_id._action_done()
+
+        # Output -> Customer rule should trigger, creating the next step
+        self.assertEqual(pick_move.location_dest_id, subloc)
+        self.assertEqual(len(pick_move.move_dest_ids), 1)
+        self.assertEqual(pick_move.move_dest_ids.location_id, subloc)
+
     def test_push_rule_on_move_1(self):
         """ Create a route with a push rule, force it on a move, check that it is applied.
         """


### PR DESCRIPTION
The changes made in #156437 had the purpose of adding more flexibility in the moves, being able the re-route them on the fly, without having to bother with the whole chain being already created.

And while the search for pull rules properly look for parent location if no rule is found within the givin location, it wasn't the case yet for push rules.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
