### PR TITLE
[FIX] web: unable to locally login in some condition

### DIFF
--- a/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
+++ b/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
@@ -155,7 +155,7 @@ test("rendering with PWA installation request", async () => {
     });
     patchWithCleanup(browser.localStorage, {
         getItem(key) {
-            if (key === "pwa.installationState") {
+            if (key === "pwaService.installationState") {
                 step("getItem " + key);
                 // in this test, installation has not yet proceeded
                 return null;
@@ -174,7 +174,7 @@ test("rendering with PWA installation request", async () => {
     // This event must be triggered to initialize the pwa service properly
     // as if it was run by a browser supporting PWA (never triggered in a test otherwise).
     browser.dispatchEvent(new CustomEvent("beforeinstallprompt"));
-    await assertSteps(["getItem pwa.installationState"]);
+    await assertSteps(["getItem pwaService.installationState"]);
     await contains(".o-mail-MessagingMenu-counter");
     await contains(".o-mail-MessagingMenu-counter", { text: "1" });
     await click(".o_menu_systray i[aria-label='Messages']");
@@ -198,7 +198,7 @@ test("installation of the PWA request can be dismissed", async () => {
     });
     patchWithCleanup(browser.localStorage, {
         getItem(key) {
-            if (key === "pwa.installationState") {
+            if (key === "pwaService.installationState") {
                 step("getItem " + key);
                 // in this test, installation has not yet proceeded
                 return null;
@@ -206,7 +206,7 @@ test("installation of the PWA request can be dismissed", async () => {
             return super.getItem(key);
         },
         setItem(key, value) {
-            if (key === "pwa.installationState") {
+            if (key === "pwaService.installationState") {
                 step("installationState value:  " + value);
             }
             return super.setItem(key, value);
@@ -221,11 +221,11 @@ test("installation of the PWA request can be dismissed", async () => {
     // This event must be triggered to initialize the pwa service properly
     // as if it was run by a browser supporting PWA (never triggered in a test otherwise).
     browser.dispatchEvent(new CustomEvent("beforeinstallprompt"));
-    await assertSteps(["getItem pwa.installationState"]);
+    await assertSteps(["getItem pwaService.installationState"]);
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem .oi-close");
     await assertSteps([
-        "getItem pwa.installationState",
+        "getItem pwaService.installationState",
         'installationState value:  {"/odoo":"dismissed"}',
     ]);
     await click(".o_menu_systray i[aria-label='Messages']");
@@ -238,7 +238,7 @@ test("rendering with PWA installation request (dismissed)", async () => {
     });
     patchWithCleanup(browser.localStorage, {
         getItem(key) {
-            if (key === "pwa.installationState") {
+            if (key === "pwaService.installationState") {
                 step("getItem " + key);
                 // in this test, installation has been previously dismissed by the user
                 return `{"/odoo":"dismissed"}`;
@@ -250,7 +250,7 @@ test("rendering with PWA installation request (dismissed)", async () => {
     // This event must be triggered to initialize the pwa service properly
     // as if it was run by a browser supporting PWA (never triggered in a test otherwise).
     browser.dispatchEvent(new CustomEvent("beforeinstallprompt"));
-    await assertSteps(["getItem pwa.installationState"]);
+    await assertSteps(["getItem pwaService.installationState"]);
     await contains(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-MessagingMenu-counter", { count: 0 });
     await click(".o_menu_systray i[aria-label='Messages']");
@@ -263,7 +263,7 @@ test("rendering with PWA installation request (already running as PWA)", async (
     });
     patchWithCleanup(browser.localStorage, {
         getItem(key) {
-            if (key === "pwa.installationState") {
+            if (key === "pwaService.installationState") {
                 step("getItem " + key);
                 // in this test, we remove any value that could contain localStorage so the service would be allowed to prompt
                 return null;
@@ -274,7 +274,7 @@ test("rendering with PWA installation request (already running as PWA)", async (
     await start();
     // The 'beforeinstallprompt' event is not triggered here, since the
     // browser wouldn't trigger it when the app is already launched
-    await assertSteps(["getItem pwa.installationState"]);
+    await assertSteps(["getItem pwaService.installationState"]);
     await contains(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-MessagingMenu-counter", { count: 0 });
     await click(".o_menu_systray i[aria-label='Messages']");

--- a/addons/web/static/src/core/pwa/pwa_service.js
+++ b/addons/web/static/src/core/pwa/pwa_service.js
@@ -53,20 +53,22 @@ const pwaService = {
         });
 
         function _getInstallationState(scope = state.startUrl) {
-            const installationState = browser.localStorage.getItem("pwa.installationState");
+            const installationState = browser.localStorage.getItem("pwaService.installationState");
             return installationState ? JSON.parse(installationState)[scope] : "";
         }
 
         function _setInstallationState(value) {
-            const ls = JSON.parse(browser.localStorage.getItem("pwa.installationState") || "{}");
+            const ls = JSON.parse(
+                browser.localStorage.getItem("pwaService.installationState") || "{}"
+            );
             ls[state.startUrl] = value;
-            browser.localStorage.setItem("pwa.installationState", JSON.stringify(ls));
+            browser.localStorage.setItem("pwaService.installationState", JSON.stringify(ls));
         }
 
         function _removeInstallationState() {
-            const ls = JSON.parse(browser.localStorage.getItem("pwa.installationState"));
+            const ls = JSON.parse(browser.localStorage.getItem("pwaService.installationState"));
             delete ls[state.startUrl];
-            browser.localStorage.setItem("pwa.installationState", JSON.stringify(ls));
+            browser.localStorage.setItem("pwaService.installationState", JSON.stringify(ls));
         }
 
         if (state.isScopedApp) {

--- a/addons/web/static/tests/core/pwa_service.test.js
+++ b/addons/web/static/tests/core/pwa_service.test.js
@@ -44,7 +44,7 @@ test("PWA installation process", async () => {
     });
     patchWithCleanup(browser.localStorage, {
         setItem(key, value) {
-            if (key === "pwa.installationState") {
+            if (key === "pwaService.installationState") {
                 expect.step(value);
                 return null;
             }

--- a/addons/web/static/tests/views/fields/one2many_field.test.js
+++ b/addons/web/static/tests/views/fields/one2many_field.test.js
@@ -11375,7 +11375,7 @@ test("open a one2many record containing a one2many", async () => {
     });
 
     expect.verifySteps([
-        "localStorage getItem pwa.installationState", // from install_prompt service
+        "localStorage getItem pwaService.installationState",
         "localStorage getItem optional_fields,partner,form,123456789,p,list,name",
         "localStorage getItem debug_open_view,partner,form,123456789,p,list,name",
     ]);

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -9981,7 +9981,7 @@ test(`form view with inline list view with optional fields and local storage moc
 
     const localStorageKey = "partner,form,123456789,child_ids,list,bar,foo";
     expect.verifySteps([
-        "getItem pwa.installationState",
+        "getItem pwaService.installationState",
         `getItem optional_fields,${localStorageKey}`,
         `getItem debug_open_view,${localStorageKey}`,
     ]);
@@ -10046,7 +10046,7 @@ test.tags("desktop")(
 
         const localStorageKey = "partner,form,123456789,child_ids,list,bar,foo";
         expect.verifySteps([
-            "getItem pwa.installationState",
+            "getItem pwaService.installationState",
             `getItem optional_fields,${localStorageKey}`,
             `getItem debug_open_view,${localStorageKey}`,
         ]);


### PR DESCRIPTION
Since the 20298f37cf05e532c2fd5e26f1ab838cf854bb17, we convert the local storage key `pwa.installationState` from a string value "accepted" or "dismissed" to key / value system with the pwa scope as key. If you have using a browser using the legacy system, it can break the login flow since 25f59bd2fece767ed94adf6364277a663d5f5012. To prevent that error, we added a dynamic conversion of the key from the old system to the new system one.

Steps to reproduce:

- Decline the pwa prompt install from an odoo version before 20298f37cf05e532c2fd5e26f1ab838cf854bb17
- Upgrade your odoo from a version after 25f59bd2fece767ed94adf6364277a663d5f5012
- You get a JS error that's blocking you from login.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
