### PR TITLE
[IMP] web: /json needs export permission

### DIFF
--- a/addons/web/controllers/home.py
+++ b/addons/web/controllers/home.py
@@ -177,7 +177,8 @@ class Home(http.Controller):
     def robots(self, **kwargs):
         return "User-agent: *\nDisallow: /\n"
 
-    @http.route('/json/<path:subpath>', auth='public', type='http', readonly=True)
+    # for /json, the route should work in a browser, therefore type=http
+    @http.route('/json/<path:subpath>', auth='user', type='http', readonly=True)
     def web_json(self, subpath, **kwargs):
         return request.redirect(
             f'/json/18.0/{subpath}?{urlencode(kwargs)}',
@@ -186,6 +187,9 @@ class Home(http.Controller):
 
     @http.route('/json/18.0/<path:subpath>', auth='user', type='http', readonly=True)
     def web_json_18_0(self, subpath, view_type=None, limit=0, offset=0):
+        if not request.env.user.has_group('base.group_allow_export'):
+            raise AccessError(_("You need export permissions to use the /json route"))
+
         try:
             limit = int(limit)
             offset = int(offset)

--- a/odoo/addons/test_http/tests/test_webjson.py
+++ b/odoo/addons/test_http/tests/test_webjson.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import html
 from base64 import b64encode
+from odoo.fields import Command
 from odoo.tests import tagged
 from odoo.tools import file_open
 from .test_common import TestHttpBase
@@ -48,6 +49,24 @@ class TestHttpWebJson_18_0(TestHttpBase):
         self.assertIn("You are not allowed to access", res.text)
         self.assertEqual(len(capture.output), 1)
         self.assertIn("You are not allowed to access", capture.output[0])
+
+    def test_webjson_access_export(self):
+        # a simple call
+        url = f'/json/18.0/test_http.stargate/{self.earth.id}'
+        self.authenticate('demo', 'demo')
+        res = self.url_open(url)
+        res.raise_for_status()
+
+        # remove export permssion
+        group_export = self.env.ref('base.group_allow_export')
+        self.user_demo.write({'groups_id': [Command.unlink(group_export.id)]})
+
+        # check that demo has no access to /json
+        with self.assertLogs('odoo.http', 'WARNING') as capture:
+            res = self.url_open(url)
+            self.assertIn("need export permissions", res.text)
+            self.assertEqual(res.status_code, 403)
+            self.assertIn("need export permissions", capture.output[0])
 
     def test_webjson_bad_stuff(self):
         self.authenticate('demo', 'demo')


### PR DESCRIPTION
The route allows to easily export data, so limit it to users that have export permissions.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
