### PR TITLE
[FIX] account: autopost of bills with OCR

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -957,13 +957,7 @@ class AccountJournal(models.Model):
             ).message_post(attachment_ids=attachment.ids)
 
             attachment.write({'res_model': 'account.move', 'res_id': invoice.id})
-            if (
-                invoice.company_id.autopost_bills
-                and invoice.partner_id.autopost_bills == 'always'
-                and not invoice.abnormal_amount_warning
-                and not invoice.restrict_mode_hash_table
-            ):
-                invoice.action_post()
+            invoice._autopost_bill()
 
         return all_invoices
 

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2839,6 +2839,7 @@ class AccountMove(models.Model):
             for move, vals in zip(moves, vals_list):
                 if 'tax_totals' in vals:
                     move.tax_totals = vals['tax_totals']
+            moves.is_manually_modified = False
         return moves
 
     def write(self, vals):
@@ -2847,8 +2848,6 @@ class AccountMove(models.Model):
         self._sanitize_vals(vals)
 
         for move in self:
-            if 'is_manually_modified' not in vals and not self.env.context.get('skip_is_manually_modified'):
-                move.is_manually_modified = True
             violated_fields = set(vals).intersection(move._get_integrity_hash_fields() + ['inalterable_hash'])
             if move.inalterable_hash and violated_fields:
                 raise UserError(_(
@@ -2905,6 +2904,9 @@ class AccountMove(models.Model):
         container = {'records': self | stolen_moves}
         with self.env.protecting(self._get_protected_vals(vals, self)), self._check_balanced(container):
             with self._sync_dynamic_lines(container):
+                if 'is_manually_modified' not in vals and not self.env.context.get('skip_is_manually_modified'):
+                    vals['is_manually_modified'] = True
+
                 res = super(AccountMove, self.with_context(
                     skip_account_move_synchronization=True,
                 )).write(vals)
@@ -4606,6 +4608,19 @@ class AccountMove(models.Model):
             references = [move.invoice_origin] if move.invoice_origin else []
             move._find_and_set_purchase_orders(references, move.partner_id.id, move.amount_total, timeout=timeout)
         return self
+
+    def _autopost_bill(self):
+        # Verify if the bill should be autoposted, if so, post it
+        self.ensure_one()
+        if (
+            self.company_id.autopost_bills
+            and self.partner_id
+            and self.is_purchase_document(include_receipts=True)
+            and self.partner_id.autopost_bills == 'always'
+            and not self.abnormal_amount_warning
+            and not self.restrict_mode_hash_table
+        ):
+            self.action_post()
 
     def _show_autopost_bills_wizard(self):
         if (


### PR DESCRIPTION
When uploading a bill and using the OCR, autoposting of the bill is broken.

This is because when clicking the "Refresh" button, the OCR updates the values of the bill therefore `is_manually_modified` is set to `True`.

Adding the context key `is_manually_modified` to the `_check_ocr_status` fixes this. Also, after filling all fields with the OCR, we now automatically post the bill using the helper method `_autopost_bill` of `account.move`.

task-id: none

Enterprise PR: https://github.com/odoo/enterprise/pull/70014