### PR TITLE
 [FIX] mail: link-preview on public channel invitations

### DIFF
--- a/addons/mail/controllers/link_preview.py
+++ b/addons/mail/controllers/link_preview.py
@@ -19,7 +19,9 @@ class LinkPreviewController(http.Controller):
             return
         if clear:
             message.sudo().link_preview_ids._unlink_and_notify()
-        guest.env["mail.link.preview"].sudo()._create_from_message_and_notify(message)
+        guest.env["mail.link.preview"].sudo()._create_from_message_and_notify(
+            message, request_url=request.httprequest.url_root
+        )
 
     @http.route("/mail/link_preview/delete", methods=["POST"], type="json", auth="public")
     @add_guest_to_context


### PR DESCRIPTION
**Current behavior before PR:**

When link-preview is done on public channel invitation links it posts a guest
joined the channel​ message in the public channel.

**Desired behavior after PR is merged:**

now we are ignoring public channel invitations links for link-preview, so it
does not post guest joined the channel

backported PR: https://github.com/odoo/odoo/pull/178932 which handle's ignore link-preview.

task-4083161

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
