### PR TITLE
[FIX] account: amount currency not correct in payment receipt

### DIFF
--- a/addons/account/views/report_payment_receipt_templates.xml
+++ b/addons/account/views/report_payment_receipt_templates.xml
@@ -64,11 +64,11 @@
                                 </tr>
                                 <!-- PAYMENTS/REVERSALS -->
                                 <tr t-foreach="inv._get_reconciled_invoices_partials()[0]" t-as="par">
-                                    <t t-set="payment" t-value="par[2].move_id"/>
-                                    <td><span t-field="payment.date"/></td>
-                                    <td><span t-field="payment.name"/></td>
-                                    <td><span t-field="payment.ref"/></td>
-                                    <t t-set="amountPayment" t-value="-payment.amount_total"/>
+                                    <t t-set="payment" t-value="par[2]"/>
+                                    <td><span t-field="payment.move_id.date"/></td>
+                                    <td><span t-field="payment.move_id.name"/></td>
+                                    <td><span t-field="payment.move_id.ref"/></td>
+                                    <t t-set="amountPayment" t-value="-par[0].amount"/>
                                     <t t-set="amountInvoice" t-value="-par[1]"/>
                                     <t t-set="currencyPayment" t-value="payment.currency_id"/>
                                     <t t-set="currencyInvoice" t-value="inv.currency_id"/>


### PR DESCRIPTION
When reconciliing and invoice with a misc entry line,
we display the amount currency of the total amount of the
entry instead of the partial.

Steps:

- With USD company currency and EUR foreign currency
- Make an invoice for 2000 EUR
- Register a payment for 1000 EUR
- Make a journal entry in USD, 3 credit lines 1000 USD each
  on the receivable account, for the invoice's partner
- Come back to the invoice and reconcile it with two misc lines
  via the outstanding credit widget
- Open the payment and print the payment receipt
-> The Amount Currency column of the misc entry lines show
   -$3000 instead of $-1000 and $-528.89 (depending of the
   current rate)

With this commit we take the debit or credit amount currency from the
partial instead of the total amount of the entry.

opw-4089534