### PR TITLE
[FIX] hw_drivers: open chromium without signing in

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
@@ -83,8 +83,9 @@ class DisplayDriver(Driver):
         # Kill browser instance (can't `instance.pkill()` as we can't keep the instance after Odoo service restarts)
         # We need to terminate it because Odoo will create a new instance each time it is restarted.
         subprocess.run(['pkill', self.browser.split('-')[0]], check=False)
-        # --log-level=3 to avoid useless log messages
-        subprocess.Popen([self.browser, self.url, '--start-fullscreen', '--log-level=3'], env=browser_env)
+        # --log-level=3 to avoid useless log messages, --bwsi to use chromium without signing in
+        browser_args = ['--start-fullscreen', '--log-level=3', '--bwsi']
+        subprocess.Popen([self.browser, self.url, *browser_args], env=browser_env)
 
         # To remove when everyone is on version >= 24.08: chromium has '--start-fullscreen' option
         if self.browser == 'firefox':


### PR DESCRIPTION
It appears that `chromium-browser` sometimes asks for user to sign in, displaying an unwanted popup instead of the IoT Box display homepage.
We fix this by adding `--bwsi` argument to the command line.
