### PR TITLE
[FIX] product: reformat the demo data for sales description

### DIFF
--- a/addons/product/data/product_demo.xml
+++ b/addons/product/data/product_demo.xml
@@ -550,11 +550,7 @@
         <record id="desk_organizer" model="product.product">
             <field name="list_price">5.10</field>
             <field name="name">Desk Organizer</field>
-            <field name="description_sale">
-                The desk organiser is perfect for storing all kinds of small things and since the 5
-                boxes are loose, you can move and place them in the way that suits you and your
-                things best.
-            </field>
+            <field name="description_sale">The desk organiser is perfect for storing all kinds of small things and since the 5 boxes are loose, you can move and place them in the way that suits you and your things best.</field>
             <field name="default_code">FURN_0001</field>
             <field name="barcode">2300001000008</field>
             <field name="weight">0.01</field>


### PR DESCRIPTION
The sales description for Desk Organizer seems to be incorrectly displayed due to multiple lines in xml.
