### PR TITLE
[FIX] point_of_sale: restore visibility of ship-later button

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
@@ -117,7 +117,7 @@
                     <i class="fa me-2" t-attf-class="{{ currentOrder.is_to_invoice() ? 'fa-check-square text-action' : 'fa-square-o' }}" /> 
                 </button>
             </div>
-            <div t-if="(pos.config.iface_tipproduct and pos.config.tip_product_id) or pos.config.iface_cashdrawer" class="d-flex flex-column gap-2 w-100">
+            <div t-if="(pos.config.iface_tipproduct and pos.config.tip_product_id) or pos.config.iface_cashdrawer or pos.config.ship_later" class="d-flex flex-column gap-2 w-100">
                 <button t-if="pos.config.iface_tipproduct and pos.config.tip_product_id" class="button btn btn-light btn-lg d-flex justify-content-between align-items-baseline w-100 lh-lg" t-att-class="{ 'highlight active text-action': currentOrder.get_tip() }"
                     t-on-click="addTip">
                     <span t-attf-class="{{currentOrder.get_tip() ? 'me-auto' : 'mx-auto' }}"><i class="fa fa-heart me-2" />Tip</span>

--- a/addons/point_of_sale/static/tests/tours/payment_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/payment_screen_tour.js
@@ -69,6 +69,9 @@ registry.category("web_tour.tours").add("PaymentScreenTour2", {
             ProductScreen.addOrderline("Letter Tray", "1", "10"),
             ProductScreen.clickPayButton(),
 
+            // check that ship later button is present
+            { trigger: ".payment-buttons button:contains('Ship Later')" },
+
             PaymentScreen.enterPaymentLineAmount("Bank", "99"),
             // trying to put 99 as an amount should throw an error. We thus confirm the dialog.
             Dialog.confirm(),

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -676,7 +676,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'split_transactions': False,
             'company_id': self.env.company.id,
         })
-        self.main_pos_config.write({'payment_method_ids': [(6, 0, bank_pm.ids)]})
+        self.main_pos_config.write({'payment_method_ids': [(6, 0, bank_pm.ids)], 'ship_later': True})
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PaymentScreenTour2', login="pos_user")
 


### PR DESCRIPTION
Steps to reproduce:

1. Activate the Ship Later setting in any config.
2. Open session of that config.
3. Add an item in the order and go to payment screen.
4. [ISSUE] The ship later button is not present.

Fix:

In this commit, we are restoring the visibility of the ship later button which was accidentally hidden in the later UI revamp:
1bc90a18807c43206c4620d7faad2579a3a61fc9.

