### PR TITLE
[IMP] core: add warning on writing no store no inverse field

### DIFF
--- a/addons/crm/tests/test_crm_lead_assignment.py
+++ b/addons/crm/tests/test_crm_lead_assignment.py
@@ -526,8 +526,12 @@ class TestLeadAssign(TestLeadAssignCommon):
             'assignment_max': 30,
         })
 
-        sales_team_4_m1.lead_month_count = 30
-        sales_team_4_m1.lead_day_count = 2
+        with self.env.protecting(  # Avoid warning because fields are cannot write normally.
+            (sales_team_4_m1._fields['lead_day_count'], sales_team_4_m1._fields['lead_month_count']),
+            sales_team_4_m1,
+        ):
+            sales_team_4_m1.lead_month_count = 30
+            sales_team_4_m1.lead_day_count = 2
         leads.team_id = sales_team_4.id
 
         members_data = sales_team_4._assign_and_convert_leads()

--- a/addons/google_calendar/tests/test_sync_odoo2google.py
+++ b/addons/google_calendar/tests/test_sync_odoo2google.py
@@ -934,8 +934,8 @@ class TestSyncOdoo2GoogleMail(TestTokenAccess, TestSyncGoogle, MailCommon):
         organizer1 = self.users[0]
         organizer2 = self.users[1]
         user_root = self.env.ref('base.user_root')
-        organizer1.google_calendar_token = 'abc'
-        organizer2.google_calendar_token = False
+        organizer1.res_users_settings_id.google_calendar_token = 'abc'
+        organizer2.res_users_settings_id.google_calendar_token = False
         event_values = {
             'name': "Event",
             'start': datetime(2020, 1, 15, 8, 0),

--- a/addons/mail/models/mail_tracking_duration_mixin.py
+++ b/addons/mail/models/mail_tracking_duration_mixin.py
@@ -27,10 +27,10 @@ class MailTrackingDurationMixin(models.AbstractModel):
                 tracked_field = fields.Many2one('tracked.model', tracking=True)
         """
 
-        field = self.env['ir.model.fields'].sudo().search_fetch([
+        field = self.env['ir.model.fields'].sudo().search([
             ('model', '=', self._name),
             ('name', '=', self._track_duration_field),
-        ], ['id'], limit=1)
+        ], limit=1)
 
         if (
             self._track_duration_field not in self._track_get_fields()

--- a/addons/mail/tests/mail_tracking_duration_mixin_case.py
+++ b/addons/mail/tests/mail_tracking_duration_mixin_case.py
@@ -67,7 +67,7 @@ class MailTrackingDurationMixinCase(MailCommon):
             records (recordset): all the records that need to be asserted
             record_to_tracking_dic (list): A list of tuples mapping records to their respective tracking dictionaries.
         """
-        records._compute_duration_tracking()
+        records.invalidate_recordset(['duration_tracking'])
         for record, tracking_dic in record_to_tracking_dic:
             self.assertDictEqual(dict(tracking_dic), record.duration_tracking)
 

--- a/addons/mail_plugin/models/res_partner.py
+++ b/addons/mail_plugin/models/res_partner.py
@@ -65,4 +65,6 @@ class ResPartner(models.Model):
                         'iap_search_domain': vals.get('iap_search_domain'),
                     } for partner in missing_partners
                 ])
+            vals.pop('iap_enrich_info', None)
+            vals.pop('iap_search_domain', None)
         return res

--- a/odoo/addons/base/tests/test_ir_actions.py
+++ b/odoo/addons/base/tests/test_ir_actions.py
@@ -294,11 +294,12 @@ ZeroDivisionError: division by zero""" % self.test_server_action.id
         self.assertEqual(self.test_partner.country_id.name, 'TestUpdatedCountry', 'ir_actions_server: country name should have been updated through relation')
 
         # update a readonly field
-        self.action.write({
-            'state': 'object_write',
-            'update_path': 'country_id.image_url',
-            'value': "/base/static/img/country_flags/be.png",
-        })
+        with mute_logger('odoo.models'):
+            self.action.write({
+                'state': 'object_write',
+                'update_path': 'country_id.image_url',
+                'value': "/base/static/img/country_flags/be.png",
+            })
         self.assertEqual(self.test_partner.country_id.image_url, "/base/static/img/country_flags/ty.png", 'ir_actions_server: country flag has this value before the update')
         run_res = self.action.with_context(self.context).run()
         self.assertFalse(run_res, 'ir_actions_server: update record action correctly finished should return False')

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -4102,7 +4102,7 @@ class TestSelectionUpdates(TransactionCase):
         related_record = self.env[self.MODEL_BASE].create({'my_selection': 'foo'})
         with self.assertQueryCount(2):  # defaults (readonly related field), INSERT
             record = self.env[self.MODEL_RELATED].create({'selection_id': related_record.id})
-        with self.assertQueryCount(0):
+        with self.assertQueryCount(0), mute_logger('odoo.models'):
             record.related_selection = 'bar'
 
     def test_selection_related(self):

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4520,6 +4520,10 @@ class BaseModel(metaclass=MetaModel):
             field = self._fields.get(fname)
             if not field:
                 raise ValueError("Invalid field %r on model %r" % (fname, self._name))
+
+            if not field.store and not field.inverse:
+                _logger.warning("Write on non store or inverse field: %r", field)
+
             field_values.append((field, value))
             if field.inverse:
                 if field.type in ('one2many', 'many2many'):


### PR DESCRIPTION
ONLY TO TEST, runbot will be yellow.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
