### PR TITLE
[IMP] mail: message reactions in order

### DIFF
--- a/addons/mail/models/mail_message_reaction.py
+++ b/addons/mail/models/mail_message_reaction.py
@@ -32,6 +32,7 @@ class MailMessageReaction(models.Model):
             data = {
                 "content": content,
                 "count": len(reactions),
+                "sequence": min(reactions.ids),
                 "personas": Store.many_ids(reactions.guest_id)
                 + Store.many_ids(reactions.partner_id),
                 "message": Store.one_id(message_id),

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -119,7 +119,14 @@ export class Message extends Record {
      * @type {() => {} | undefined}
      */
     postFailRedo = undefined;
-    reactions = Record.many("MessageReactions", { inverse: "message" });
+    reactions = Record.many("MessageReactions", {
+        inverse: "message",
+        /**
+         * @param {import("models").MessageReactions} r1
+         * @param {import("models").MessageReactions} r2
+         */
+        sort: (r1, r2) => r1.sequence - r2.sequence,
+    });
     notifications = Record.many("Notification", { inverse: "message" });
     recipients = Record.many("Persona");
     thread = Record.one("Thread");

--- a/addons/mail/static/src/core/common/message_reactions_model.js
+++ b/addons/mail/static/src/core/common/message_reactions_model.js
@@ -16,6 +16,8 @@ export class MessageReactions extends Record {
     content;
     /** @type {number} */
     count;
+    /** @type {number} */
+    sequence;
     personas = Record.many("Persona");
     message = Record.one("Message");
 

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -1816,6 +1816,34 @@ test("Click on view reactions shows the reactions on the message", async () => {
     await contains(".o-mail-MessageReactionMenu", { text: "😅1" });
 });
 
+test("Reactions are ordered by id", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_type: "channel",
+        name: "channel1",
+    });
+    pyEnv["mail.message"].create({
+        body: "Hello world",
+        res_id: channelId,
+        message_type: "comment",
+        model: "discuss.channel",
+        reaction_ids: [
+            pyEnv["mail.message.reaction"].create({
+                content: "🔰",
+                partner_id: serverState.partnerId,
+            }),
+            pyEnv["mail.message.reaction"].create({
+                content: "🔢",
+                partner_id: serverState.partnerId,
+            }),
+        ],
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-MessageReaction:eq(0)", { text: "🔰" });
+    await contains(".o-mail-MessageReaction:eq(1)", { text: "🔢" });
+});
+
 test("discuss - bigger font size when there is only emoji", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({

--- a/addons/mail/static/tests/mock_server/mock_models/mail_message_reaction.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_message_reaction.js
@@ -26,6 +26,7 @@ export class MailMessageReaction extends models.ServerModel {
             const data = {
                 content: content,
                 count: reactionGroup.length,
+                sequence: Math.min(reactionGroup.map((reaction) => reaction.id)),
                 personas: mailDataHelpers.Store.many_ids(guests).concat(
                     mailDataHelpers.Store.many_ids(partners)
                 ),

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -1442,18 +1442,24 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         partner_0 = self.users[0].partner_id.id
         partner_1 = self.users[1].partner_id.id
         partner_2 = self.users[2].partner_id.id
+        reactions_0 = last_message.sudo().reaction_ids.filtered(lambda r: r.content == "👍")
+        reactions_1 = last_message.sudo().reaction_ids.filtered(lambda r: r.content == "😁")
+        reactions_2 = last_message.sudo().reaction_ids.filtered(lambda r: r.content == "😊")
+        reactions_3 = last_message.sudo().reaction_ids.filtered(lambda r: r.content == "😏")
         if channel == self.channel_general:
             return [
                 {
                     "content": "👍",
                     "count": 1,
                     "message": last_message.id,
+                    "sequence": min(reactions_0.ids),
                     "personas": [{"id": partner_2, "type": "partner"}],
                 },
                 {
                     "content": "😁",
                     "count": 2,
                     "message": last_message.id,
+                    "sequence": min(reactions_1.ids),
                     "personas": [
                         {"id": partner_2, "type": "partner"},
                         {"id": partner_1, "type": "partner"},
@@ -1463,6 +1469,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                     "content": "😊",
                     "count": 3,
                     "message": last_message.id,
+                    "sequence": min(reactions_2.ids),
                     "personas": [
                         {"id": partner_2, "type": "partner"},
                         {"id": partner_1, "type": "partner"},
@@ -1476,12 +1483,14 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                     "content": "😁",
                     "count": 1,
                     "message": last_message.id,
+                    "sequence": min(reactions_1.ids),
                     "personas": [{"id": partner_2, "type": "partner"}],
                 },
                 {
                     "content": "😊",
                     "count": 3,
                     "message": last_message.id,
+                    "sequence": min(reactions_2.ids),
                     "personas": [
                         {"id": partner_2, "type": "partner"},
                         {"id": partner_1, "type": "partner"},
@@ -1492,6 +1501,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                     "content": "😏",
                     "count": 2,
                     "message": last_message.id,
+                    "sequence": min(reactions_3.ids),
                     "personas": [
                         {"id": partner_1, "type": "partner"},
                         {"id": partner_0, "type": "partner"},


### PR DESCRIPTION
This commit ensures that message reactions are displayed in chronological order, from the earliest to the most recent when getting the data from the server.

https://github.com/odoo/enterprise/pull/70042

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
