### PR TITLE
[FIX] point_of_sale: use ir.sequence for order reference

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -103,7 +103,7 @@ export class PosOrder extends Base {
             rounding_applied: this.get_rounding_applied(),
             tax_details: this.get_tax_details(),
             change: this.amount_return,
-            name: this.name,
+            name: this.pos_reference,
             invoice_id: null, //TODO
             cashier: this.employee_id?.name || this.user_id?.name,
             date: formatDateTime(parseUTCString(this.date_order)),
@@ -171,7 +171,7 @@ export class PosOrder extends Base {
                     cancelled: changes["cancelled"],
                     table_name: this.table_id?.name,
                     floor_name: this.table_id?.floor_id?.name,
-                    name: this.name || "unknown order",
+                    name: this.pos_reference || "unknown order",
                     time: {
                         hours,
                         minutes,

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -631,7 +631,7 @@ export class TicketScreen extends Component {
                 modelField: "tracking_number",
             },
             RECEIPT_NUMBER: {
-                repr: (order) => order.name,
+                repr: (order) => order.pos_reference,
                 displayName: _t("Receipt Number"),
                 modelField: "pos_reference",
             },

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -66,7 +66,7 @@
                                         <div><t t-esc="getDate(order)"></t></div>
                                     </div>
                                     <div class="col wide p-2">
-                                        <div><t t-esc="order.name"></t></div>
+                                        <div><t t-esc="order.pos_reference"></t></div>
                                     </div>
                                     <div class="col wide p-2">
                                         <div><t t-esc="order.tracking_number"></t></div>
@@ -97,7 +97,7 @@
                                 <div class="mobileOrderList order-row" t-att-class="{ 'highlight bg-primary text-white': isHighlighted(order) }"
                                     t-on-click="() => this.onClickOrder(order)" t-on-dblclick="() =>  order.uiState.locked ? ()=>{} : this._setOrder(order)" >
                                     <div class="col p-2 d-flex justify-content-between align-items-center">
-                                        <div><t t-esc="order.name"></t> / <t t-esc="order.tracking_number"></t></div>
+                                        <div><t t-esc="order.pos_reference"></t> / <t t-esc="order.tracking_number"></t></div>
                                         <div><t t-esc="getTotal(order)"></t></div>
                                     </div>
                                     <div class="col p-2 d-flex justify-content-between align-items-center">

--- a/addons/pos_online_payment/tests/test_frontend.py
+++ b/addons/pos_online_payment/tests/test_frontend.py
@@ -210,7 +210,7 @@ class TestUi(AccountTestInvoicingCommon, OnlinePaymentCommon):
 
         create_result = self.env['pos.order'].with_user(self.pos_user).sync_from_ui([order_data])
         self.assertEqual(len(current_session.order_ids), 1)
-        order_id = next(result_order_data for result_order_data in create_result['pos.order'] if result_order_data['name'] == order_pos_reference)['id']
+        order_id = next(result_order_data for result_order_data in create_result['pos.order'] if result_order_data['pos_reference'] == order_pos_reference)['id']
 
         order = self.env['pos.order'].search([('id', '=', order_id)])
         self.assertEqual(order.state, 'draft')

--- a/addons/pos_self_order/static/src/overrides/models/pos_store.js
+++ b/addons/pos_self_order/static/src/overrides/models/pos_store.js
@@ -28,7 +28,7 @@ patch(PosStore.prototype, {
 patch(PosOrder.prototype, {
     setup() {
         super.setup(...arguments);
-        if (this.name.startsWith("Self-Order")) {
+        if (this.pos_reference?.startsWith("Self-Order")) {
             this.tracking_number = "S" + this.tracking_number;
         }
     },


### PR DESCRIPTION
Before this commit, the receipt number was incorrectly used as the order reference. This commit ensures that the order reference is correctly generated from the ir.sequence, aligning with the intended design.

opw-4165620

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
