### PR TITLE
[IMP] account: Made redirect action more generic

### DIFF
--- a/addons/account/wizard/account_validate_account_move.py
+++ b/addons/account/wizard/account_validate_account_move.py
@@ -71,6 +71,8 @@ class ValidateAccountMove(models.TransientModel):
                 "name": "Depending Action",
                 "params": {
                     "depending_action": exception.args[0],
+                    "message": _("It seems there is some depending closing move to be posted"),
+                    "button_text": _("Depending moves"),
                 },
                 'context': {
                     'dialog_size': 'medium',


### PR DESCRIPTION
Currently the redirect action component is only configured for the tax closing depending move.

The goal here is to make it generic so we can have a different message and button text


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
