### PR TITLE
[FIX] point_of_sale: prevent recalculation of `extra_price`

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -705,8 +705,8 @@ export class PosStore extends Reactive {
         if (!values.product_id.isCombo() && vals.price_unit === undefined) {
             values.price_unit = values.product_id.get_price(order.pricelist_id, values.qty);
         }
-
-        if (values.price_extra) {
+        const isScannedProduct = opts.code && opts.code.type === "product";
+        if (values.price_extra && !isScannedProduct) {
             const price = values.product_id.get_price(
                 order.pricelist_id,
                 values.qty,


### PR DESCRIPTION
Problem:
The calculation of the extra price for product variants is being applied twice:
- In the product model:
https://github.com/odoo/odoo/blob/b966f2acc15503eafdbc4bda0d7733adcd635208/addons/product/models/product_product.py#L283
- In the point of sale store:
https://github.com/odoo/odoo/blob/b966f2acc15503eafdbc4bda0d7733adcd635208/addons/point_of_sale/static/src/app/store/pos_store.js#L588-L595
https://github.com/odoo/odoo/blob/b966f2acc15503eafdbc4bda0d7733adcd635208/addons/point_of_sale/static/src/app/store/pos_store.js#L709-L717

In the case of a barcode-scanned product, the extra price is already included in the price, so we should avoid adding it again.

Steps to reproduce:

- Create a product with 2 variants, each having an extra price.
- Add a barcode to each variant.
- Open PoS and scan the barcode of any variant.
- The extra price is added twice.

opw-4177407

I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)