### PR TITLE
[IMP] sale_management: improve SOL description logic

### DIFF
--- a/addons/sale_management/models/sale_order_line.py
+++ b/addons/sale_management/models/sale_order_line.py
@@ -17,7 +17,9 @@ class SaleOrderLine(models.Model):
         for line in self:
             if line.product_id and line.order_id.sale_order_template_id and line._use_template_name():
                 for template_line in line.order_id.sale_order_template_id.sale_order_template_line_ids:
-                    if line.product_id == template_line.product_id:
+                    if line.product_id == template_line.product_id and template_line.name:
+                        # If a specific description was set on the template, use it
+                        # Otherwise the description is handled by the super call
                         lang = line.order_id.partner_id.lang
                         line.name = template_line.with_context(lang=lang).name + line.with_context(lang=lang)._get_sale_order_line_multiline_description_variants()
                         break

--- a/addons/sale_management/models/sale_order_template_line.py
+++ b/addons/sale_management/models/sale_order_template_line.py
@@ -39,10 +39,8 @@ class SaleOrderTemplateLine(models.Model):
 
     name = fields.Text(
         string="Description",
-        compute='_compute_name',
-        store=True, readonly=False, precompute=True,
-        required=True,
-        translate=True)
+        translate=True,
+    )
 
     product_uom_id = fields.Many2one(
         comodel_name='uom.uom',
@@ -62,13 +60,6 @@ class SaleOrderTemplateLine(models.Model):
         ('line_note', "Note")], default=False)
 
     #=== COMPUTE METHODS ===#
-
-    @api.depends('product_id')
-    def _compute_name(self):
-        for option in self:
-            if not option.product_id:
-                continue
-            option.name = option.product_id.get_product_multiline_description_sale()
 
     @api.depends('product_id')
     def _compute_product_uom_id(self):
@@ -103,11 +94,13 @@ class SaleOrderTemplateLine(models.Model):
         :rtype: dict
         """
         self.ensure_one()
-        return {
+        vals = {
             'display_type': self.display_type,
-            'name': self.name,
             'product_id': self.product_id.id,
             'product_uom_qty': self.product_uom_qty,
             'product_uom': self.product_uom_id.id,
             'sequence': self.sequence,
         }
+        if self.name:
+            vals['name'] = self.name
+        return vals

--- a/addons/sale_management/tests/test_sale_order.py
+++ b/addons/sale_management/tests/test_sale_order.py
@@ -33,6 +33,7 @@ class TestSaleOrder(SaleManagementCommon):
             {
                 'name': 'Product 1',
                 'lst_price': cls.pub_product_price,
+                'description_sale': "This is a product description"
             }, {
                 'name': 'Optional product',
                 'lst_price': cls.pub_option_price,
@@ -351,3 +352,47 @@ class TestSaleOrder(SaleManagementCommon):
         # after changing the quantity of the product, the price unit should not be recomputed
         sale_order_with_option.order_line.product_uom_qty = 10
         self.assertEqual(sale_order_with_option.sale_order_option_ids.price_unit, 10)
+
+    def test_product_description_no_template_description(self):
+        """
+        Test case for when the product has a description, but the quotation template line does not.
+        The final sale order line should use the product's description.
+        """
+        quotation_template_no_description = self.empty_order_template
+        quotation_template_no_description.sale_order_template_line_ids = [
+            Command.create({
+                'product_id': self.product_1.id,
+                'name': False,
+            }),
+        ]
+        sale_order = self.empty_order
+        sale_order.sale_order_template_id = quotation_template_no_description
+        sale_order._onchange_sale_order_template_id()
+        self.assertEqual(
+            sale_order.order_line[0].name,
+            f"{self.product_1.name}\n{self.product_1.description_sale}",
+            "Sale order line should use product's description when no quotation template \
+            description is set."
+        )
+
+    def test_product_description_with_template_description(self):
+        """
+        Test case for when both the product and the quotation template line have descriptions.
+        The final sale order line should use the template's description.
+        """
+        quotation_template_with_description = self.empty_order_template
+        quotation_template_with_description.sale_order_template_line_ids = [
+            Command.create({
+                'product_id': self.product_1.id,
+                'name': "This is a template description",
+            }),
+        ]
+        sale_order = self.empty_order
+        sale_order.sale_order_template_id = quotation_template_with_description
+        sale_order._onchange_sale_order_template_id()
+        self.assertEqual(
+            sale_order.order_line[0].name,
+            quotation_template_with_description.sale_order_template_line_ids[0].name,
+            "The sale order line should use the quotation template's description when both \
+            product and the quotation template descriptions are set."
+        )


### PR DESCRIPTION
Before:
When a product is added to a quotation template, the description is generated based on the current product name and sale description and then saved on the template. This means that if the product sales description changes in the future, it will not be updated on the template. As a result, any new sales order created from the template will have the old version of the description.

After:
- By default, the description in the quotation template remains empty.
- When creating a sale order line (SOL) from the template, the product description is computed dynamically using the current product name and sales description.
- If a custom sales description is provided in the template, then it will be used in the SOL instead of computing the new one.

task-4169433