### PR TITLE
[FIX] base_automation: show `filter_domain` in debug mode

### DIFF
--- a/addons/base_automation/i18n/base_automation.pot
+++ b/addons/base_automation/i18n/base_automation.pot
@@ -490,7 +490,7 @@ msgstr ""
 #: model:ir.model.fields,help:base_automation.field_base_automation__filter_pre_domain
 msgid ""
 "If present, this condition must be satisfied before the update of the "
-"record."
+"record. Not checked on record creation."
 msgstr ""
 
 #. module: base_automation

--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import datetime
@@ -6,7 +5,6 @@ import logging
 import traceback
 from collections import defaultdict
 from uuid import uuid4
-
 from dateutil.relativedelta import relativedelta
 
 from odoo import _, api, exceptions, fields, models
@@ -64,6 +62,7 @@ TIME_TRIGGERS = [
     'on_time_created',
     'on_time_updated',
 ]
+
 
 def get_webhook_request_payload():
     if not request:
@@ -182,7 +181,8 @@ class BaseAutomation(models.Model):
         string='Before Update Domain',
         compute='_compute_filter_pre_domain',
         readonly=False, store=True,
-        help="If present, this condition must be satisfied before the update of the record.")
+        help="If present, this condition must be satisfied before the update of the record. "
+             "Not checked on record creation.")
     filter_domain = fields.Char(
         string='Apply on',
         help="If present, this condition must be satisfied before executing the automation rule.",
@@ -221,6 +221,7 @@ class BaseAutomation(models.Model):
                       action_names=', '.join(failing_actions.mapped('name'))
                      )
                 )
+
     @api.depends("trigger", "webhook_uuid")
     def _compute_url(self):
         for automation in self:

--- a/addons/base_automation/views/base_automation_views.xml
+++ b/addons/base_automation/views/base_automation_views.xml
@@ -88,9 +88,19 @@
                                        options="{'model': 'model_name', 'in_dialog': True}"
                                        invisible="trigger == 'on_webhook'"
                                 />
-                                <label for="filter_domain" invisible="trigger not in ['on_create_or_write', 'on_change', 'on_unlink']"/>
-                                <label for="filter_domain" string="Extra Conditions" invisible="trigger not in ['on_time', 'on_time_created', 'on_time_updated']"/>
+                                <field name="filter_domain" widget="domain" groups="base.group_no_one"
+                                    options="{'model': 'model_name', 'in_dialog': True}"
+                                    invisible="trigger == 'on_webhook'"
+                                />
+                                <label for="filter_domain" groups="!base.group_no_one"
+                                    invisible="trigger not in ['on_create_or_write', 'on_change', 'on_unlink']"
+                                />
+                                <label for="filter_domain" groups="!base.group_no_one"
+                                    string="Extra Conditions"
+                                    invisible="trigger not in ['on_time', 'on_time_created', 'on_time_updated']"
+                                />
                                 <field name="filter_domain" nolabel="1" widget="domain"
+                                    groups="!base.group_no_one"
                                     options="{'model': 'model_name', 'in_dialog': False, 'foldable': True}"
                                     invisible="trigger not in ['on_create_or_write', 'on_change', 'on_unlink', 'on_time', 'on_time_created', 'on_time_updated']"
                                 />


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Enter debug mode;
2. create an Automation Rule;
3. select Task as model;
4. set trigger to Stage is set to New;
5. set domain to a specific customer;
6. add send email as action;
7. create a task.

Issue
-----
Email is sent after task creation, regardless of the customer.

Cause
-----
The triggers added to 0a744accc2aa automatically compute the `filter_domain` value, and hide the field in view. With debug mode enabled, the `filter_pre_domain` field is still visible & editable.

The newly added triggers are applied on both create & update, while `filter_pre_domain` is only applied on update. This leads to confusion when clients add a domain which appears to be ignored, as the selected trigger is immediately hit on creation.

Solution
--------
1. Specify in the help string that `filter_pre_domain` is ignored on creation.
2. When entering debug mode, also show the `filter_domain` field, allowing users to further modify the domain computed by the selected trigger, and helping to distinguish itself from `filter_pre_domain`.

opw-3928082