### PR TITLE
[FIX] point_of_sale, pos_event: fix performance and bugs

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -189,6 +189,9 @@ class PosSession(models.Model):
 
         pricelist_item_domain = [
             '|',
+            ('company_id', '=', False),
+            ('company_id', '=', self.company_id.id),
+            '|',
             '&', ('product_id', '=', False), ('product_tmpl_id', 'in', product_tmpl_ids),
             ('product_id', 'in', product_ids)]
 

--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -209,7 +209,7 @@ class ProductProduct(models.Model):
             'available_quantity': self.with_context({'warehouse_id': w.id}).qty_available,
             'forecasted_quantity': self.with_context({'warehouse_id': w.id}).virtual_available,
             'uom': self.uom_name}
-            for w in self.env['stock.warehouse'].search([])]
+            for w in self.env['stock.warehouse'].search([('company_id', '=', config.company_id.id)])]
 
         if config.picking_type_id.warehouse_id:
             # Sort the warehouse_list, prioritizing config.picking_type_id.warehouse_id

--- a/addons/pos_event/models/event_registration.py
+++ b/addons/pos_event/models/event_registration.py
@@ -11,7 +11,7 @@ class EventRegistration(models.Model):
 
     @api.model
     def _load_pos_data_domain(self, data):
-        return [('event_ticket_id', 'in', [ticket['id'] for ticket in data['event.event.ticket']['data']])]
+        return False
 
     @api.model
     def _load_pos_data_fields(self, config_id):

--- a/addons/pos_event/models/event_registration_answer.py
+++ b/addons/pos_event/models/event_registration_answer.py
@@ -13,4 +13,4 @@ class EventRegistrationAnswer(models.Model):
 
     @api.model
     def _load_pos_data_domain(self, data):
-        return [('question_id', 'in', [quest['id'] for quest in data['event.question']['data']])]
+        return False

--- a/addons/pos_event/models/event_ticket.py
+++ b/addons/pos_event/models/event_ticket.py
@@ -8,9 +8,12 @@ class EventTicket(models.Model):
 
     @api.model
     def _load_pos_data_domain(self, data):
-        return [('event_id.is_finished', '=', False),
+        return [
+            ('event_id.is_finished', '=', False),
+            ('event_id.company_id', '=', data['pos.config']['data'][0]['company_id']),
             '|', ('end_sale_datetime', '>=', fields.Datetime.now()), ('end_sale_datetime', '=', False),
-            '|', ('start_sale_datetime', '<=', fields.Datetime.now()), ('start_sale_datetime', '=', False)]
+            '|', ('start_sale_datetime', '<=', fields.Datetime.now()), ('start_sale_datetime', '=', False)
+        ]
 
     @api.model
     def _load_pos_data_fields(self, config_id):


### PR DESCRIPTION
- pos_event: it tries to load all registrations and answers for events, which is not needed and makes the POS unable to load when you have events with a lot of attendees.
- pos_event: it tries to get the tickets of events of all companies, but doesn't have access to taxes on thoses products, so raise issues.
- point_of_sale: when you get info of a products, it takes all warehouses of any company, but cannot access locations of other companies. So we restrict to current company.
- point_of_sale: when it loads pricelists, it tries to get pricelists items of other company, which makes no sense and raises errors.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
