### PR TITLE
[IMP] base_setup, website_membership: add tooltip to "World Map" toggle

### DIFF
--- a/addons/base_setup/views/res_config_settings_views.xml
+++ b/addons/base_setup/views/res_config_settings_views.xml
@@ -161,7 +161,10 @@
                                     <div class="mt16 text-warning"><strong>Save</strong> this page and come back here to set up the feature.</div>
                                 </div>
                             </setting>
-                            <setting string="Geolocation" help="Geolocate your partners" id="base_geolocalize">
+                            <setting string="Geolocation"
+                                     help="Geolocate your partners"
+                                     id="base_geolocalize"
+                                     documentation="https://www.odoo.com/documentation/17.0/applications/general/integrations/geolocation.html">
                                 <field name="module_base_geolocalize"/>
                                 <div class="content-group" invisible="not module_base_geolocalize" name="base_geolocalize_warning">
                                     <div class="mt16 text-warning"><strong>Save</strong> this page and come back here to choose your Geo Provider.</div>

--- a/addons/website_membership/views/snippets.xml
+++ b/addons/website_membership/views/snippets.xml
@@ -11,7 +11,8 @@
             <we-checkbox string="World Map"
                          data-customize-website-views="website_membership.opt_index_google_map"
                          data-no-preview="true"
-                         data-reload="/"/>
+                         data-reload="/"
+                         title="Ensure you add your Google API Key in your settings to enable the feature"/>
         </div>
     </xpath>
 </template>


### PR DESCRIPTION
Specification:
- Add a tooltip : "Ensure you add your Google API Key in your settings to enable the feature"
- Add a link to the documentation

Before this commit:
- Both things do not exist.

After this commit:

- First spec is handled by "title" attribute and now tooltip is visible.
- Second spec is handled by "documentation" attribute and now link is added.

task-4113153




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
