### PR TITLE
[IMP] hr_recruitment: must have fixes

### DIFF
--- a/addons/hr_recruitment/models/hr_candidate.py
+++ b/addons/hr_recruitment/models/hr_candidate.py
@@ -148,6 +148,7 @@ class HrCandidate(models.Model):
                     WHERE c.id != sub.id
                      AND ((coalesce(c.email_normalized, '') <> '' AND sub.email_normalized = c.email_normalized)
                        OR (coalesce(c.partner_phone_sanitized, '') <> '' AND c.partner_phone_sanitized = sub.partner_phone_sanitized))
+                      AND c.company_id = sub.company_id
                 ) AS similar_candidates
             FROM hr_candidate AS c
             WHERE id IN %(ids)s
@@ -172,6 +173,7 @@ class HrCandidate(models.Model):
             domain = expression.OR([domain, [('email_normalized', '=', self.email_normalized)]])
         if self.partner_phone_sanitized:
             domain = expression.OR([domain, [('partner_phone_sanitized', '=', self.partner_phone_sanitized)]])
+        domain = expression.AND([domain, [('company_id', '=', self.company_id.id)]])
         return domain
 
     def _compute_attachment_count(self):

--- a/addons/hr_recruitment/security/hr_recruitment_security.xml
+++ b/addons/hr_recruitment/security/hr_recruitment_security.xml
@@ -66,9 +66,29 @@
         <field name="groups" eval="[(4, ref('hr_recruitment.group_hr_recruitment_interviewer'))]"/>
     </record>
 
+    <record id="hr_candidate_interviewer_rule" model="ir.rule">
+        <field name="name">Candidate Interviewer</field>
+        <field name="model_id" ref="model_hr_candidate"/>
+        <field name="domain_force">[
+            '|',
+                ('applicant_ids.job_id.interviewer_ids', 'in', user.id),
+                ('applicant_ids.interviewer_ids', 'in', user.id),
+        ]</field>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+        <field name="groups" eval="[(4, ref('hr_recruitment.group_hr_recruitment_interviewer'))]"/>
+    </record>
+
     <record id="hr_applicant_user_rule" model="ir.rule">
         <field name="name">User: All Applicants</field>
         <field name="model_id" ref="model_hr_applicant"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('hr_recruitment.group_hr_recruitment_user'))]"/>
+    </record>
+
+    <record id="hr_candidate_user_rule" model="ir.rule">
+        <field name="name">User: All Candidates</field>
+        <field name="model_id" ref="model_hr_candidate"/>
         <field name="domain_force">[(1, '=', 1)]</field>
         <field name="groups" eval="[(4, ref('hr_recruitment.group_hr_recruitment_user'))]"/>
     </record>

--- a/addons/hr_recruitment/security/ir.model.access.csv
+++ b/addons/hr_recruitment/security/ir.model.access.csv
@@ -3,6 +3,7 @@ access_hr_job_interviewer,hr.job.interviewer,hr.model_hr_job,group_hr_recruitmen
 access_hr_job_user,hr.job user,model_hr_job,group_hr_recruitment_user,1,1,1,1
 hr.access_hr_job_user,hr.job user,model_hr_job,hr.group_hr_user,1,0,0,0
 access_hr_applicant_interviewer,hr.applicant.interviewer,model_hr_applicant,group_hr_recruitment_interviewer,1,1,0,0
+access_hr_candidate_interviewer,hr.candidate.interviewer,model_hr_candidate,group_hr_recruitment_interviewer,0,1,0,0
 access_hr_applicant_user,hr.applicant.user,model_hr_applicant,group_hr_recruitment_user,1,1,1,1
 access_hr_candidate_user,hr.candidate.user,model_hr_candidate,group_hr_recruitment_user,1,1,1,1
 access_hr_recruitment_stage_interviewer,hr.recruitment.stage.interviewer,model_hr_recruitment_stage,group_hr_recruitment_interviewer,1,0,0,0

--- a/addons/hr_recruitment/tests/test_recruitment.py
+++ b/addons/hr_recruitment/tests/test_recruitment.py
@@ -41,9 +41,9 @@ class TestRecruitment(TransactionCase):
                 'email_from': 'laure.poiret@aol.ru',
             },
         ])
-        self.assertEqual(dup1.similar_candidates_count, 1)
-        self.assertEqual(dup2.similar_candidates_count, 1)
-        self.assertEqual(no_dup.similar_candidates_count, 0)
+        self.assertEqual(dup1.candidate_id.similar_candidates_count, 1)
+        self.assertEqual(dup2.candidate_id.similar_candidates_count, 1)
+        self.assertEqual(no_dup.candidate_id.similar_candidates_count, 0)
 
     def test_similar_candidates_count(self):
         """ Test that we find same candidates based on simmilar mail,
@@ -90,11 +90,11 @@ class TestRecruitment(TransactionCase):
                 }).id,
             },
         ])
-        self.assertEqual(A.similar_candidates_count, 2)  # C, D
-        self.assertEqual(B.similar_candidates_count, 1)  # D, F
-        self.assertEqual(C.similar_candidates_count, 1)  # A, D
-        self.assertEqual(D.similar_candidates_count, 2)  # A, B, C
-        self.assertEqual(E.similar_candidates_count, 0)  # Should not match with G
+        self.assertEqual(A.candidate_id.similar_candidates_count, 2)  # C, D
+        self.assertEqual(B.candidate_id.similar_candidates_count, 1)  # D, F
+        self.assertEqual(C.candidate_id.similar_candidates_count, 1)  # A, D
+        self.assertEqual(D.candidate_id.similar_candidates_count, 2)  # A, B, C
+        self.assertEqual(E.candidate_id.similar_candidates_count, 0)  # Should not match with G
 
     def test_application_no_partner_duplicate(self):
         """ Test that when applying, the existing partner

--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -82,14 +82,6 @@
                             <span class="o_stat_text">Employee</span>
                         </div>
                     </button>
-                    <button name="action_open_similar_candidates"
-                            class="oe_stat_button"
-                            icon="fa-pencil"
-                            type="object"
-                            context="{'active_test': False}"
-                            invisible="similar_candidates_count == 0">
-                        <field name="similar_candidates_count" widget="statinfo" string="Similar Candidates"/>
-                    </button>
                     <button name="action_open_other_applications"
                             class="oe_stat_button"
                             icon="fa-pencil"
@@ -269,6 +261,7 @@
                 <group expand="0" string="Group By">
                     <filter string="Job" name="job" domain="[]" context="{'group_by': 'job_id'}"/>
                     <filter string="Stage" name="stage" domain="[]" context="{'group_by': 'stage_id'}"/>
+                    <filter string="Candidate" name="candidate" domain="[]" context="{'group_by': 'candidate_id'}"/>
                     <filter string="Responsible" name="responsible" domain="[]"  context="{'group_by': 'user_id'}"/>
                     <filter string="Creation Date" name="creation_date" context="{'group_by': 'create_date'}"/>
                     <filter string="Hiring Date" name="hired_date" context="{'group_by': 'date_closed'}"/>
@@ -310,7 +303,7 @@
         <field name="arch" type="xml">
             <form>
                 <group>
-                    <field name="candidate_id" placeholder="e.g. John Doe"/>
+                    <field name="candidate_id" options="{'no_create_edit': True}" placeholder="e.g. John Doe"/>
                     <field name="job_id" options="{'no_open': True}"/>
                     <field name="company_id" invisible="1"/>
                 </group>

--- a/addons/hr_recruitment/views/hr_candidate_views.xml
+++ b/addons/hr_recruitment/views/hr_candidate_views.xml
@@ -9,7 +9,7 @@
                 <field name="email_normalized" invisible="1"/>
                 <field name="partner_phone_sanitized" invisible="1"/>
                 <header>
-                    <button string="Create Employee" name="create_employee_from_candidate" type="object" data-hotkey="q" groups="hr_recruitment.group_hr_recruitment_user"
+                    <button string="Create Employee" name="create_employee_from_candidate" type="object" data-hotkey="q" groups="hr.group_hr_user"
                             class="o_create_employee" invisible="employee_id or not active"/>
                 </header>
                 <sheet>
@@ -35,7 +35,7 @@
                         </button>
                         <button name="action_open_similar_candidates"
                                 class="oe_stat_button"
-                                icon="fa-pencil"
+                                icon="fa-users"
                                 type="object"
                                 context="{'active_test': False}"
                                 invisible="similar_candidates_count == 0">


### PR DESCRIPTION
This pr adds various fixes and improvements to recruitment.
- The `Similar Candidates` smart button counter now displays accurate numbers when in a multi company environment. Before it would search across companies for candidates, often making the number higher than actual similar candidates in the selected company leading to confusion and despair.
- Since the split of the applicant model into applications and candidates, interviewers could no longer edit any information on a application (a candidate by extension) they were assigned to. This has been fixed with new access rules, allowing interviewers to edit candidates, but only through the application form.
- Some buttons/fields are now hidden/read-only if you don't have access to them.
- The`Other Applications` smart button now also displays applications by similar candidates, not only applications by the viewed candidate.
- The `All applications` view now allows grouping by `Candidate`.
- A bug in `Applicant Analysis` which cause archived applicants to still be counted as hired was fixed.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
