### PR TITLE
[FIX] point_of_sale: payment method form view structure

### DIFF
--- a/addons/point_of_sale/views/pos_payment_method_views.xml
+++ b/addons/point_of_sale/views/pos_payment_method_views.xml
@@ -8,10 +8,12 @@
                 <sheet>
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                     <field name="active" invisible="1"/>
-                    <field name="type" invisible="1" />
-                    <div class="oe_title">
-                        <label for="name"/>
-                        <h1><field name="name" placeholder="e.g. Cash" class="oe_inline"/></h1>
+                    <field name="type" invisible="1"/>
+                    <div class="d-flex justify-content-between">
+                        <div class="oe_title">
+                            <label for="name"/>
+                            <h1><field name="name" placeholder="e.g. Cash" class="oe_inline"/></h1>
+                        </div>
                         <field name="image" class="oe_avatar" widget='image'/>
                     </div>
                     <group name="Payment methods">


### PR DESCRIPTION
avatar was placed in the row under the title's one, instead of inlined with it.

**BEFORE:** 
![image](https://github.com/user-attachments/assets/193d8197-aa07-4c95-b71c-6efb12e2f67f)
**AFTER:**
 ![image](https://github.com/user-attachments/assets/4862806f-a8ac-49d5-a75b-78dff6091cb4)