### PR TITLE
[FIX] sale: only create discount product if allowed

### DIFF
--- a/addons/sale/i18n/sale.pot
+++ b/addons/sale/i18n/sale.pot
@@ -844,7 +844,8 @@ msgid ""
 "e.g. this option can be useful to share Product description files.\n"
 "Confirmed order: the document will be sent to and accessible by customers.\n"
 "e.g. this option can be useful to share User Manual or digital content bought on ecommerce. \n"
-"Inside quote: The document will be included in the pdf of the quotation between the header pages and the quote table. "
+"Inside quote: The document will be included in the pdf of the quotation \n"
+"and sale order between the header pages and the quote table. "
 msgstr ""
 
 #. module: sale
@@ -4543,6 +4544,16 @@ msgstr ""
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.view_sale_advance_payment_inv
 msgid "There are existing"
+msgstr ""
+
+#. module: sale
+#. odoo-python
+#: code:addons/sale/wizard/sale_order_discount.py:0
+#, python-format
+msgid ""
+"There does not seem to be any discount product configured for this company "
+"yet. You can either use a per-line discount, or ask an administrator to "
+"grant the discount the first time."
 msgstr ""
 
 #. module: sale

--- a/addons/sale/wizard/sale_order_discount.py
+++ b/addons/sale/wizard/sale_order_discount.py
@@ -68,9 +68,21 @@ class SaleOrderDiscount(models.TransientModel):
         self.ensure_one()
         discount_product = self.company_id.sale_discount_product_id
         if not discount_product:
-            self.company_id.sudo().sale_discount_product_id = self.env['product.product'].sudo().create(
-                self._prepare_discount_product_values()
-            )
+            if (
+                self.env['product.product'].check_access_rights('create', raise_exception=False)
+                and self.company_id.check_access_rights('write', raise_exception=False)
+                and self.company_id._filter_access_rules_python('write')
+                and self.company_id.check_field_access_rights('write', ['sale_discount_product_id'])
+            ):
+                self.company_id.sale_discount_product_id = self.env['product.product'].create(
+                    self._prepare_discount_product_values()
+                )
+            else:
+                raise ValidationError(_(
+                    "There does not seem to be any discount product configured for this company yet."
+                    " You can either use a per-line discount, or ask an administrator to grant the"
+                    " discount the first time."
+                ))
             discount_product = self.company_id.sale_discount_product_id
         return discount_product
 


### PR DESCRIPTION
The issue was recently fixed with a sudo, but it allowed standard salesman/users to
create discount products and update the company, which ideally shouldn't happen.

Since a single use of the wizard by the admin will properly create the discount product,
we prefer to encourage the user to request the admin to do it first instead of
bypassing the standard access rights.

opw-4048403

