### PR TITLE
[IMP] website: adjust configurator preview scroll animation

### DIFF
--- a/addons/website/static/src/client_actions/configurator/configurator.scss
+++ b/addons/website/static/src/client_actions/configurator/configurator.scss
@@ -4,6 +4,9 @@
     $input-font-size: 40%;
 
     .o_configurator_screen {
+        // ==== Variables
+        --ConfiguratorPreview-height: MIN(70vh, 560px);
+        --ConfiguratorSmallPreview-height: MIN(60vh, 500px);
 
         // ==== Animations
         @keyframes configuratorFadeIn{
@@ -12,11 +15,11 @@
         }
 
         @keyframes theme_screenshot_scroll {
-            to { transform: translate3d(0, -24%, 0)}
+            to { transform: translate3d(0, calc((100% - var(--ConfiguratorPreview-height)) * -1), 0)}
         }
 
         @keyframes theme_screenshot_scroll_small {
-            to { transform: translate3d(0, -31.5%, 0)}
+            to { transform: translate3d(0, calc((100% - var(--ConfiguratorSmallPreview-height)) * -1), 0)}
         }
 
         // ==== General Components
@@ -336,18 +339,21 @@
             }
 
             .theme_preview {
-                padding-top: 65%;
+                @include media-breakpoint-down(lg) {
+                    --ConfiguratorPreview-height: 300px;
+                    --ConfiguratorSmallPreview-height: var(--ConfiguratorPreview-height);
+                }
+
+                height: var(--ConfiguratorPreview-height);
                 box-shadow: $box-shadow-sm;
 
                 @include media-breakpoint-up(lg) {
-                    padding-top: 200%;
-
                     &:hover {
                         transform: translate3d(0,-10px,0);
                     }
 
                     &.small {
-                        padding-top: 180%;
+                        height: var(--ConfiguratorSmallPreview-height);
                     }
                 }
 


### PR DESCRIPTION
Prior to this commit, the preview scrolling animation used fixed values. But since the theme redesign, image previews now have different heights. Depending on this height, the scrolling animation may display an empty space or not go all the way to the end of the screenshot. This commit adjusts the scrolling animation to match the height of selected theme previews.

task-4177975

| Before | After |
|--------|--------|
| ![Capture d’écran 2024-09-13 à 16 52 19](https://github.com/user-attachments/assets/75116c75-0a5e-4c4c-aad0-9783bbadc94c) | ![Capture d’écran 2024-09-13 à 16 51 43](https://github.com/user-attachments/assets/3e1b0549-3e66-4dcc-8385-c7dc5a14bc4e) |

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
