### PR TITLE
[FIX] point_of_sale: handle unloaded products in orderlines

### DIFF
--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -1421,7 +1421,9 @@ export class Order extends PosModel {
             this.init_from_JSON(options.json);
             const linesById = Object.fromEntries(this.orderlines.map((l) => [l.id || l.cid, l]));
             for (const line of this.orderlines) {
-                line.comboLines = line.combo_line_ids?.map((id) => linesById[id]);
+                line.comboLines = line.combo_line_ids
+                    ?.filter((id) => linesById[id])
+                    .map((id) => linesById[id]); 
                 const combo_parent_id = line.combo_parent_id?.[0] || line.combo_parent_id;
                 if (combo_parent_id) {
                     line.comboParent = linesById[combo_parent_id];


### PR DESCRIPTION
Before this commit, the PoS would fail to load if an orderline contained a product that was not loaded into the PoS. This issue could arise, for example, when category restrictions are applied after creating draft orders, preventing the PoS from loading.

opw-4119028

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
