### PR TITLE
[FIX] {purchase_,}stock: Fix cross-dock with new push rules

### DIFF
--- a/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
+++ b/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
@@ -533,8 +533,8 @@ class MrpSubcontractingPurchaseTest(TestMrpSubcontractingCommon):
         self.env.company.po_lead = 5
         self.env.company.days_to_purchase = 5
 
-        rule = self.env['stock.rule'].search([('action', '=', 'buy')], limit=1)
-        (self.finished | self.comp1 | self.comp2).route_ids = [(6, None, [rule.route_id.id])]
+        buy_route_id = self.ref('purchase_stock.route_warehouse0_buy')
+        (self.finished | self.comp1 | self.comp2).route_ids = [(6, None, [buy_route_id])]
         self.comp2_bom.active = False
         self.env['product.supplierinfo'].create({
             'product_tmpl_id': self.finished.product_tmpl_id.id,

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -81,6 +81,13 @@ class StockWarehouse(models.Model):
             result[warehouse.id].update(warehouse._get_receive_rules_dict())
         return result
 
+    def _get_receive_rules_dict(self):
+        rules = super()._get_receive_rules_dict()
+        customer_loc, __ = self._get_partner_locations()
+        # Sets the right order for new warehouses: buy then push.
+        rules['crossdock'].insert(0, self.Routing(self.env['stock.location'], customer_loc, self.in_type_id, 'buy'))
+        return rules
+
     def _get_routes_values(self):
         routes = super(StockWarehouse, self)._get_routes_values()
         routes.update(self._get_receive_routes_values('buy_to_resupply'))

--- a/addons/purchase_stock/tests/test_routes.py
+++ b/addons/purchase_stock/tests/test_routes.py
@@ -1,3 +1,4 @@
+from odoo import Command
 from odoo.tests import Form, TransactionCase
 
 
@@ -66,3 +67,63 @@ class TestRoutes(TransactionCase):
 
         wh.reception_steps = 'two_steps'
         self.assertEqual(wh.reception_steps, 'two_steps')
+
+    def test_cross_dock_with_purchase(self):
+        customer_loc, supplier_loc = self.env['stock.warehouse']._get_partner_locations()
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        warehouse.write({'reception_steps': 'two_steps', 'delivery_steps': 'pick_ship'})
+
+        partner = self.env['res.partner'].create({'name': 'Vendor'})
+        product = self.env['product.product'].create({
+            'name': 'Cross-Dockable',
+            'is_storable': True,
+            'route_ids': [Command.link(warehouse.crossdock_route_id.id)],
+            'seller_ids': [Command.create({'partner_id': partner.id})],
+        })
+
+        # Create a procurement for an Out using that should use the cross-dock route
+        group = self.env['procurement.group'].create({'name': 'Test-cross-dock'})
+        self.env['procurement.group'].run([self.env['procurement.group'].Procurement(
+            product, 5, self.env.ref('uom.product_uom_unit'), customer_loc,
+            product.name, '/', self.env.company, {'warehouse_id': warehouse, 'group_id': group})
+        ])
+
+        # No move should be created, instead should have created a Purchase Order
+        receipt_move = self.env['stock.move'].search([('group_id', '=', group.id)])
+        self.assertFalse(receipt_move)
+        purchase_order = self.env['purchase.order'].search([('group_id', '=', group.id)])
+        self.assertEqual(purchase_order.partner_id, partner)
+        purchase_order.button_confirm()
+
+        receipt_move = purchase_order.picking_ids.move_ids
+        self.assertRecordValues(receipt_move, [{
+            'location_id': supplier_loc.id,
+            'location_dest_id': warehouse.wh_input_stock_loc_id.id,
+            'location_final_id': customer_loc.id,
+            'picking_type_id': warehouse.in_type_id.id,
+        }])
+
+        # Validate the chain
+        receipt_move.write({'picked': True})
+        receipt_move._action_done()
+
+        cross_dock_move = receipt_move.move_dest_ids
+        self.assertRecordValues(cross_dock_move, [{
+            'location_id': warehouse.wh_input_stock_loc_id.id,
+            'location_dest_id': warehouse.wh_output_stock_loc_id.id,
+            'location_final_id': customer_loc.id,
+            'picking_type_id': warehouse.xdock_type_id.id,
+        }])
+        cross_dock_move.write({'picked': True})
+        cross_dock_move._action_done()
+
+        delivery_move = cross_dock_move.move_dest_ids
+        self.assertRecordValues(delivery_move, [{
+            'location_id': warehouse.wh_output_stock_loc_id.id,
+            'location_dest_id': customer_loc.id,
+            'location_final_id': customer_loc.id,
+            'picking_type_id': warehouse.out_type_id.id,
+        }])
+        delivery_move.write({'picked': True})
+        delivery_move._action_done()
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(product, customer_loc), 5)

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -589,10 +589,6 @@ class Warehouse(models.Model):
                     'company_id': self.company_id.id,
                     'sequence': 20,
                 },
-                'rules_values': {
-                    'active': True,
-                    'procure_method': 'make_to_order'
-                }
             }
         }
 
@@ -796,8 +792,8 @@ class Warehouse(models.Model):
                     self.Routing(warehouse.wh_input_stock_loc_id, warehouse.wh_qc_stock_loc_id, warehouse.qc_type_id, 'push'),
                     self.Routing(warehouse.wh_qc_stock_loc_id, warehouse.lot_stock_id, warehouse.store_type_id, 'push')],
                 'crossdock': [
-                    self.Routing(warehouse.wh_input_stock_loc_id, warehouse.wh_output_stock_loc_id, warehouse.xdock_type_id, 'pull'),
-                    self.Routing(warehouse.wh_output_stock_loc_id, customer_loc, warehouse.out_type_id, 'pull')],
+                    self.Routing(supplier_loc, customer_loc, warehouse.in_type_id, 'pull'),
+                    self.Routing(warehouse.wh_input_stock_loc_id, warehouse.wh_output_stock_loc_id, warehouse.xdock_type_id, 'push')],
                 'ship_only': [self.Routing(warehouse.lot_stock_id, customer_loc, warehouse.out_type_id, 'pull')],
                 'pick_ship': [
                     self.Routing(warehouse.lot_stock_id, customer_loc, warehouse.pick_type_id, 'pull'),
@@ -824,6 +820,7 @@ class Warehouse(models.Model):
             'three_steps': [
                 self.Routing(self.wh_input_stock_loc_id, self.wh_qc_stock_loc_id, self.qc_type_id, 'push'),
                 self.Routing(self.wh_qc_stock_loc_id, self.lot_stock_id, self.store_type_id, 'push')],
+            'crossdock': [self.Routing(self.wh_input_stock_loc_id, self.wh_output_stock_loc_id, self.xdock_type_id, 'push')],
         }
 
     def _get_inter_warehouse_route_values(self, supplier_warehouse):

--- a/addons/stock/tests/test_move2.py
+++ b/addons/stock/tests/test_move2.py
@@ -3229,6 +3229,55 @@ class TestRoutes(TestStockCommon):
         pushed_move = move1.move_dest_ids
         self.assertEqual(pushed_move.location_dest_id.id, push_location_2.id)
 
+    def test_cross_dock(self):
+        customer_loc = self.env['stock.location'].browse(self.customer_location)
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        warehouse.write({'reception_steps': 'two_steps', 'delivery_steps': 'pick_ship'})
+        self.product1.write({
+            'route_ids': [Command.link(warehouse.crossdock_route_id.id)]
+        })
+
+        # Create a procurement for an Out using that should use the cross-dock route
+        group = self.env['procurement.group'].create({'name': 'Test-cross-dock'})
+        self.env['procurement.group'].run([self.env['procurement.group'].Procurement(
+            self.product1, 5, self.uom_unit, customer_loc,
+            self.product1.name, '/', self.env.company, {'warehouse_id': warehouse, 'group_id': group})
+        ])
+
+        # Fetch the reception move that was created
+        receipt_move = self.env['stock.move'].search([('group_id', '=', group.id)])
+        self.assertRecordValues(receipt_move, [{
+            'location_id': self.supplier_location,
+            'location_dest_id': warehouse.wh_input_stock_loc_id.id,
+            'location_final_id': self.customer_location,
+            'picking_type_id': warehouse.in_type_id.id,
+        }])
+
+        # Validate the chain
+        receipt_move.write({'picked': True})
+        receipt_move._action_done()
+
+        cross_dock_move = receipt_move.move_dest_ids
+        self.assertRecordValues(cross_dock_move, [{
+            'location_id': warehouse.wh_input_stock_loc_id.id,
+            'location_dest_id': warehouse.wh_output_stock_loc_id.id,
+            'location_final_id': self.customer_location,
+            'picking_type_id': warehouse.xdock_type_id.id,
+        }])
+        cross_dock_move.write({'picked': True})
+        cross_dock_move._action_done()
+
+        delivery_move = cross_dock_move.move_dest_ids
+        self.assertRecordValues(delivery_move, [{
+            'location_id': warehouse.wh_output_stock_loc_id.id,
+            'location_dest_id': self.customer_location,
+            'location_final_id': self.customer_location,
+            'picking_type_id': warehouse.out_type_id.id,
+        }])
+        delivery_move.write({'picked': True})
+        delivery_move._action_done()
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product1, customer_loc), 5)
+
 
 class TestAutoAssign(TestStockCommon):
     def create_pick_ship(self):


### PR DESCRIPTION
With the new push rules, we need to setup a proper pull rule to start the push chain. Now it mimics what's done in other rules, setting up a pull rule with a forward destination, or a buy rule if purchase is installed.

Also required to backport b9a3f74c9a8ca1c07a8cfcf8884c6c6d3c2cecd4, as it avoids the purchase orders created through the cross-dock route to be considered as dropships, as in both cases it goes from Vendor -> Customer.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
