### PR TITLE
[FIX] base_automation: records not filtered on creation

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -724,8 +724,9 @@ class BaseAutomation(models.Model):
                 # call original method
                 records = create.origin(self.with_env(automations.env), vals_list, **kw)
                 # check postconditions, and execute actions on the records that satisfy them
+                pre = {a: a._filter_pre(records) for a in automations}
                 for automation in automations.with_context(old_values=None):
-                    automation._process(automation._filter_post(records, feedback=True))
+                    automation._process(automation._filter_post(pre[automation], feedback=True))
                 return records.with_env(self.env)
 
             return create


### PR DESCRIPTION
Current behaviour:
---
Automation rules don't take the filter_pre_domain into account when creating the record 
the rule is based on, thus processing the automation rule bypassing the domain.

Steps to reproduce:
---
1. Install CRM
2. Go to settings > CRM > activate Leads
3. In technical > Automation Rules
4. Create a new rule, model Lead/Opportunity
5. Set trigger "Stage is set to New"
6. Set domain as: [("email_from", "=", "djsergser")]
7. Add a "Send email" action
8. Save the automation rule
9. Go to CRM > Leads > Create a new lead > Save
10. Email is in log notes NB: Email should not have been sent

Cause of the issue:
---
filter_pre_domain no taken into account when creating.

opw-4114553

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
