### PR TITLE
[CLA] Via laurea: Remove Mantux11

### DIFF
--- a/doc/cla/corporate/via_laurea.md
+++ b/doc/cla/corporate/via_laurea.md
@@ -15,5 +15,5 @@ List of contributors:
 Gailius Kazlauskas gailius.kaz@vialaurea.lt https://github.com/gaikaz
 Donatas Valiulis donatas@vialaurea.lt https://github.com/DonatasV
 Domantas Girdžiūnas domantas@vialaurea.lt https://github.com/Du-ma
-Mantas Šniukas mantas@vialaurea.lt https://github.com/Mantux11
+Mantas Šniukas mantas@vialaurea.lt (up to 2024-09-13)
 Saulius Zilys saulius@vialaurea.lt (up to 2017-04-24)


### PR DESCRIPTION
Removing Mantux11 from our CLA




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
