### PR TITLE
[FIX] website: fix the new "Image Gallery" design indicators

### DIFF
--- a/addons/website/views/new_page_template_templates.xml
+++ b/addons/website/views/new_page_template_templates.xml
@@ -995,9 +995,9 @@ overridden by modules), because:
     </xpath>
     <xpath expr="//div[hasclass('carousel-indicators')]" position="replace">
         <div class="carousel-indicators">
-            <div data-bs-target="#slideshow_sample" data-bs-slide-to="0" style="background-image: url(/web/image/website.s_company_team_image_1)" class="active"/>
-            <div data-bs-target="#slideshow_sample" data-bs-slide-to="1" style="background-image: url(/web/image/website.s_company_team_image_2)"/>
-            <div data-bs-target="#slideshow_sample" data-bs-slide-to="2" style="background-image: url(/web/image/website.s_company_team_image_3)"/>
+            <button data-bs-target="#slideshow_sample" data-bs-slide-to="0" style="background-image: url(/web/image/website.s_company_team_image_1)" class="active"/>
+            <button data-bs-target="#slideshow_sample" data-bs-slide-to="1" style="background-image: url(/web/image/website.s_company_team_image_2)"/>
+            <button data-bs-target="#slideshow_sample" data-bs-slide-to="2" style="background-image: url(/web/image/website.s_company_team_image_3)"/>
         </div>
     </xpath>
 </template>

--- a/addons/website/views/snippets/s_image_gallery.xml
+++ b/addons/website/views/snippets/s_image_gallery.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <template id="s_image_gallery" name="Image Gallery">
-    <section class="s_image_gallery o_slideshow s_image_gallery_indicators_rounded pt24 pb24 s_image_gallery_controllers_outside s_image_gallery_controllers_outside_arrows_right s_image_gallery_indicators_dots s_image_gallery_arrows_default" data-vcss="002" data-columns="3">
+    <section class="s_image_gallery o_slideshow pt24 pb24 s_image_gallery_controllers_outside s_image_gallery_controllers_outside_arrows_right s_image_gallery_indicators_dots s_image_gallery_arrows_default" data-vcss="002" data-columns="3">
         <div class="o_container_small overflow-hidden">
             <div id="slideshow_sample" class="carousel carousel-dark slide" data-bs-ride="true">
                 <div class="carousel-inner">


### PR DESCRIPTION
In commit [1], the "Image Gallery" snippet has been redesigned and with it, two issues have been introduced:

1) In order to have dots by default as carousel indicators, the class `s_image_gallery_indicators_dots` corresponding to this option has been added on the snippet. However, the old class setting them as rounded miniatures (`s_image_gallery_indicators_rounded`) was not removed. This resulted in the widget state of the "Indicators" option being incorrect, as it displays "Rounded Miniature" while we visually have dots.

Steps to reproduce:
- Drop an "Image Gallery" snippet and click on it. => The "Indicators" option does not match with the indicators, as they are dots and not rounded miniatures.

2) As a part of the redesign, the carousel indicators are now `<button>` elements and not `<li>` anymore. However, in one of the new page templates, these indicators were wrongly set as `<div>`. While it is inconsistent, it also made the options linked to the indicators have no effect for this specific carousel, because the rules target buttons.

Steps to reproduce:
- Add a new page by selecting the last template of the last column in the "Team" section.
- Click on the "Image Gallery" snippet.
- Change the style of the indicators with the "Indicators" option. => It has no effect.

This commit fixes these issues, by removing the "rounded miniatures" class and by setting buttons instead in the corresponding templates.

[1]: https://github.com/odoo/odoo/commit/9042b1cae7b630b20e0670788b7a4ed9e4c97609

Related to task-3654328