### PR TITLE
[FIX] l10n_sg: tax report adapted to changes in generic P&L

### DIFF
--- a/addons/l10n_sg/data/account_tax_report_data.xml
+++ b/addons/l10n_sg/data/account_tax_report_data.xml
@@ -180,7 +180,7 @@
                             <record id="account_tax_report_line_revenues_accounting_period_formula" model="account.report.expression">
                                 <field name="label">balance</field>
                                 <field name="engine">aggregation</field>
-                                <field name="formula">OPINC.balance</field>
+                                <field name="formula">REV.balance</field>
                                 <field name="subformula">cross_report</field>
                             </record>
                         </field>


### PR DESCRIPTION
OPINC (Operating Income) has been replaced by REV (Revenue), still filtering the same journal items ([('account_id.account_type', '=', 'income')])

See odoo/enterprise#69959





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
