### PR TITLE
[16.0][REF] stock_account: Add _get_qty_taken_on_candidate()

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -332,6 +332,9 @@ class ProductProduct(models.Model):
         candidates_domain = self._get_fifo_candidates_domain(company)
         return self.env["stock.valuation.layer"].sudo().search(candidates_domain)
 
+    def _get_qty_taken_on_candidate(self, qty_to_take_on_candidates, candidate):
+        return min(qty_to_take_on_candidates, candidate.remaining_qty)
+
     def _run_fifo(self, quantity, company):
         self.ensure_one()
 
@@ -341,7 +344,7 @@ class ProductProduct(models.Model):
         new_standard_price = 0
         tmp_value = 0  # to accumulate the value taken on the candidates
         for candidate in candidates:
-            qty_taken_on_candidate = min(qty_to_take_on_candidates, candidate.remaining_qty)
+            qty_taken_on_candidate = self._get_qty_taken_on_candidate(qty_to_take_on_candidates, candidate)
 
             candidate_unit_cost = candidate.remaining_value / candidate.remaining_qty
             new_standard_price = candidate_unit_cost


### PR DESCRIPTION
This change allows us to practically revive the 'real price' costing
method via customization, specifically using the
stock_valuation_fifo_lot OCA module. By making `qty_taken_on_candidate`
adjustable in the `_run_fifo()` method, we can fine-tune the FIFO
calculation to better suit real price costing needs.

@qrtl QT4650

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
