### PR TITLE
[IMP] sale_project: hide type field in product form when creating SOL on the fly

### DIFF
--- a/addons/sale_project/views/product_views.xml
+++ b/addons/sale_project/views/product_views.xml
@@ -29,4 +29,17 @@
         </field>
     </record>
 
+    <record id="product_template_form_view_inherit_sale_project" model="ir.ui.view">
+        <field name="name">product.template.sale.project.form</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="sale.product_template_form_view"/>
+        <field name="mode">primary</field>
+        <field name="priority">999</field>
+        <field name="arch" type="xml">
+            <field name="type" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+        </field>
+    </record>
+
 </odoo>

--- a/addons/sale_project/views/sale_order_line_views.xml
+++ b/addons/sale_project/views/sale_order_line_views.xml
@@ -28,6 +28,7 @@
                 <attribute name="context">{
                     'default_type': 'service',
                     'default_service_policy': 'ordered_prepaid',
+                    'form_view_ref': 'sale_project.product_template_form_view_inherit_sale_project',
                 }</attribute>
             </field>
         </field>


### PR DESCRIPTION
**Improvement**

When creating a SOL on the fly within a project/task, users can also create or edit products. To avoid errors from selecting non-service products, the type field is now hidden in the product form during this process, ensuring only service products are created.

task-4179188