### PR TITLE
[FIX] Allow claim multiple rewards from a coupon

### DIFF
--- a/addons/website_sale_loyalty/controllers/main.py
+++ b/addons/website_sale_loyalty/controllers/main.py
@@ -94,8 +94,7 @@ class WebsiteSale(main.WebsiteSale):
             if reward_sudo in rewards:
                 coupon = coupon_
                 if code == coupon.code and (
-                    (program_sudo.trigger == 'with_code' and program_sudo.program_type != 'promo_code')
-                    or (program_sudo.trigger == 'auto' and program_sudo.applies_on == 'future')
+                    (program_sudo.trigger == 'auto' and program_sudo.applies_on == 'future')
                 ):
                     return self.pricelist(code, **post)
         if coupon:


### PR DESCRIPTION
**When creating a coupon loyalty program with multiple rewards you won't be able to claim any reward in the cart view of the webiste.
In the controller route where the claim form is submitting, the self.pricelist() function is always called when claming a reward. This occurs because the program is created with a program trigger == 'with_code' and causes the apply_rewards() function to never be called.
**

Impacted versions:
 
 - 17.0
 
Steps to reproduce:
 
 1. create a loyalty program with program type == 'coupons'
 2. create a rule and add 2 rewards for the loyalty program and generate the coupons.
 3. on the website add to your cart the products that meet the rule created earlier
 4. on the cart view apply de coupon code and then click on any of the claim buttons
 
Current behavior:
 
 - The form is submitted but nothing happens, the rewards remain unclaimed.
 
Expected behavior:
 
 - The reward selected should be added to the cart.
