### PR TITLE
[FIX] web: fix creating m2m in form view add child's changes

### DIFF
--- a/addons/web/static/src/model/relational_model/static_list.js
+++ b/addons/web/static/src/model/relational_model/static_list.js
@@ -875,6 +875,10 @@ export class StaticList extends DataPoint {
                     // on a view button in the x2many dialog), so replace the CREATE command by a
                     // LINK
                     commands.push([LINK, record.resId]);
+                } else if (command[0] === UPDATE && record.evalContext.id && record._virtualId) {
+                    // while adding a new record in x2many dialog, saving the parent record can lead to 
+                    // dirty state of children record to be saved with virtualId while previously saved.
+                    continue;
                 } else {
                     const values = record._getChanges(record._changes, { withReadonly });
                     if (command[0] === CREATE || Object.keys(values).length) {


### PR DESCRIPTION
When adding a m2m record in a form view, although record is correctly add and virtual record should no longer be part of `web_save`, trigger save on parent/main record still has changes left from children's records.

This fixes issue #178541 




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
