### PR TITLE
[FIX] base: fix traceback when the user gives wrong company in partner

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -470,7 +470,7 @@ class Partner(models.Model):
         companies = self.env['res.company'].search_fetch([('partner_id', 'in', partners.ids)], ['partner_id'])
         for company in companies:
             if company != company.partner_id.company_id:
-                raise (_('The company assigned to this partner does not match the company this partner represents.'))
+                raise ValidationError(_('The company assigned to this partner does not match the company this partner represents.'))
 
     def copy_data(self, default=None):
         default = dict(default or {})


### PR DESCRIPTION
After the below commit, a traceback arises because of the exception is directly raised instead from the BaseException.

Error:- 

```
TypeError: exceptions must derive from BaseException
  File "odoo/http.py", line 2383, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1913, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1976, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1943, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2187, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 227, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 757, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 35, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 459, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/web/models/models.py", line 71, in web_save
    self.write(vals)
  File "addons/snailmail/models/res_partner.py", line 26, in write
    return super(ResPartner, self).write(vals)
  File "addons/partner_autocomplete/models/res_partner.py", line 229, in write
    res = super(ResPartner, self).write(values)
  File "addons/mail_plugin/models/res_partner.py", line 44, in write
    res = super(ResPartner, self).write(vals)
  File "odoo/addons/base/models/res_partner.py", line 754, in write
    result = result and super(Partner, self).write(vals)
  File "addons/mail/models/mail_activity_mixin.py", line 249, in write
    return super(MailActivityMixin, self).write(vals)
  File "addons/mail/models/mail_thread.py", line 331, in write
    result = super(MailThread, self).write(values)
  File "odoo/models.py", line 4582, in write
    real_recs._validate_fields(vals, inverse_fields)
  File "odoo/models.py", line 1513, in _validate_fields
    check(self)
  File "odoo/addons/base/models/res_partner.py", line 473, in _check_partner_company
    raise (_('The company assigned to this partner does not match the company this partner represents.'))
```

Commit:- https://github.com/odoo/odoo/pull/177221/commits/060f7240d8711b90073fdd1339ed43d6fa59249d

After this commit a `ValidationError` is raised instead of a direct exception to prevent the traceback.

sentry-5850002187
