### PR TITLE
[FIX] html_editor: traceback on escape to discard image transformation

### DIFF
--- a/addons/html_editor/static/src/main/media/image_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_plugin.js
@@ -290,7 +290,11 @@ export class ImagePlugin extends Plugin {
         }
     }
 
-    onSelectionChange() {
+    onSelectionChange(selectionData) {
+        const { anchorNode, focusNode } = selectionData.documentSelection;
+        if (!anchorNode && !focusNode) {
+            return;
+        }
         this.closeImageTransformation();
     }
 
@@ -349,12 +353,15 @@ export class ImagePlugin extends Plugin {
         if (registry.category("main_components").contains("ImageTransformation")) {
             return;
         }
+        Promise.resolve().then(() => {
+            this.document.getSelection()?.removeAllRanges();
+        });
         registry.category("main_components").add("ImageTransformation", {
             Component: ImageTransformation,
             props: {
                 image,
                 document: this.document,
-                destroy: this.closeImageTransformation,
+                destroy: () => this.closeImageTransformation(),
                 onChange: () => this.dispatch("ADD_STEP"),
             },
         });

--- a/addons/html_editor/static/tests/image.test.js
+++ b/addons/html_editor/static/tests/image.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { click, queryOne, waitFor, waitUntil } from "@odoo/hoot-dom";
+import { click, press, queryOne, waitFor, waitUntil } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { setupEditor } from "./_helpers/editor";
 import { contains } from "@web/../tests/web_test_helpers";
@@ -306,6 +306,26 @@ test("Image transformation dissapear when selection change", async () => {
     for (const transfoContainer of transfoContainers) {
         transfoContainer.remove();
     }
+});
+
+test("Image transformation disappear on escape", async () => {
+    await setupEditor(`
+        <img class="img-fluid test-image" src="${base64Img}">
+    `);
+    click("img.test-image");
+    await waitFor(".o-we-toolbar");
+    let toolbar = document.querySelectorAll(".o-we-toolbar");
+    expect(toolbar.length).toBe(1);
+    click(".o-we-toolbar button[name='image_transform']");
+    await animationFrame();
+    toolbar = document.querySelectorAll(".o-we-toolbar");
+    expect(toolbar.length).toBe(0);
+    let transfoContainers = document.querySelectorAll(".transfo-container");
+    expect(transfoContainers.length).toBe(1);
+    press("escape");
+    await animationFrame();
+    transfoContainers = document.querySelectorAll(".transfo-container");
+    expect(transfoContainers.length).toBe(0);
 });
 
 test("Can delete an image", async () => {


### PR DESCRIPTION
### Steps to Reproduce:

- Open the to-do app
- Add an image (/image, upload an image)
- Select the image
- Click the Transform button
- Press the Escape key, and a traceback occurs

### Desired behavior after PR is merged:

- Clicking the image transform button in `toolbar` clears the image
selection and enables the image transformation.
- Removes the `active` class from the image transformation button.

task-4184571