### PR TITLE
[IMP] web: /json redirect for multiple views

### DIFF
--- a/addons/web/controllers/__init__.py
+++ b/addons/web/controllers/__init__.py
@@ -6,6 +6,7 @@ from . import database
 from . import dataset
 from . import domain
 from . import export
+from . import json
 from . import home
 from . import model
 from . import pivot

--- a/addons/web/controllers/home.py
+++ b/addons/web/controllers/home.py
@@ -2,23 +2,16 @@
 
 import json
 import logging
-from http import HTTPStatus
-from urllib.parse import urlencode
 
-import psycopg2.errors
-from werkzeug.exceptions import BadRequest
-
-import odoo
+import odoo.exceptions
 import odoo.modules.registry
 from odoo import http
 from odoo.exceptions import AccessError
 from odoo.http import request
 from odoo.service import security
-from odoo.tools.safe_eval import safe_eval
 from odoo.tools.translate import _
 from .utils import (
     ensure_db,
-    get_action_triples,
     _get_login_redirect_url,
     is_user_internal,
 )
@@ -177,79 +170,3 @@ class Home(http.Controller):
     @http.route(['/robots.txt'], type='http', auth="none")
     def robots(self, **kwargs):
         return "User-agent: *\nDisallow: /\n"
-
-    # for /json, the route should work in a browser, therefore type=http
-    @http.route('/json/<path:subpath>', auth='bearer', type='http', readonly=True)
-    def web_json(self, subpath, **kwargs):
-        return request.redirect(
-            f'/json/18.0/{subpath}?{urlencode(kwargs)}',
-            HTTPStatus.TEMPORARY_REDIRECT
-        )
-
-    @http.route('/json/18.0/<path:subpath>', auth='bearer', type='http', readonly=True)
-    def web_json_18_0(self, subpath, view_type=None, limit=0, offset=0):
-        if not request.env.user.has_group('base.group_allow_export'):
-            raise AccessError(_("You need export permissions to use the /json route"))
-
-        try:
-            limit = int(limit)
-            offset = int(offset)
-        except ValueError as exc:
-            raise BadRequest(exc.args[0])
-        context = dict(request.env.context)
-
-        def get_action_triples_():
-            try:
-                yield from get_action_triples(request.env, subpath, start_pos=1)
-            except ValueError as exc:
-                raise BadRequest(exc.args[0])
-
-        # Hack for OXP. We are not sure yet if we wanna run all server
-        # actions, but we are sure we want to run those ones. TODO: find
-        # a better way to do it.
-        allowed_server_action_paths = {'crm'}
-
-        for active_id, action, record_id in get_action_triples_():
-            if action.sudo().path in allowed_server_action_paths:
-                try:
-                    action = request.env['ir.actions.act_window'].new(
-                        action.sudo(False).run())
-                except psycopg2.errors.ReadOnlySqlTransaction as e:
-                    # never retry on RO connection, just leave
-                    raise AccessError() from e
-            if action._name != 'ir.actions.act_window':
-                e = f"{action._name} are not supported server-side"
-                raise BadRequest(e)
-            context.update(safe_eval(action.context, dict(
-                action._get_eval_context(action),
-                active_id=active_id,
-                context=context,
-            )))
-
-        if not view_type:
-            if record_id:
-                view_type = 'form'
-            else:
-                view_type = action.view_mode.split(',')[0]
-
-        model = request.env[action.res_model].with_context(context)
-        view = model.get_view(view_type=view_type)
-        spec = model._get_fields_spec(view)
-
-        if record_id:
-            res = model.browse(int(record_id)).web_read(spec)[0]
-        else:
-            domain = safe_eval(action.domain or '[]', dict(
-                action._get_eval_context(action),
-                context=context,
-                active_id=active_id,
-                allowed_company_ids=[1],
-            ))
-            res = model.web_search_read(
-                domain,
-                spec,
-                limit=limit or action.limit,
-                offset=offset,
-            )
-
-        return request.make_json_response(res)

--- a/addons/web/controllers/json.py
+++ b/addons/web/controllers/json.py
@@ -1,0 +1,97 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import logging
+from http import HTTPStatus
+from urllib.parse import urlencode
+
+import psycopg2.errors
+from werkzeug.exceptions import BadRequest
+
+from odoo import http
+from odoo.exceptions import AccessError
+from odoo.http import request
+from odoo.tools.safe_eval import safe_eval
+from odoo.tools.translate import _
+
+from .utils import get_action_triples
+
+_logger = logging.getLogger(__name__)
+
+
+class WebJsonController(http.Controller):
+
+    # for /json, the route should work in a browser, therefore type=http
+    @http.route('/json/<path:subpath>', auth='bearer', type='http', readonly=True)
+    def web_json(self, subpath, **kwargs):
+        return request.redirect(
+            f'/json/18.0/{subpath}?{urlencode(kwargs)}',
+            HTTPStatus.TEMPORARY_REDIRECT
+        )
+
+    @http.route('/json/18.0/<path:subpath>', auth='bearer', type='http', readonly=True)
+    def web_json_18_0(self, subpath, view_type=None, limit=0, offset=0):
+        if not request.env.user.has_group('base.group_allow_export'):
+            raise AccessError(_("You need export permissions to use the /json route"))
+
+        try:
+            limit = int(limit)
+            offset = int(offset)
+        except ValueError as exc:
+            raise BadRequest(exc.args[0])
+        context = dict(request.env.context)
+
+        def get_action_triples_():
+            try:
+                yield from get_action_triples(request.env, subpath, start_pos=1)
+            except ValueError as exc:
+                raise BadRequest(exc.args[0])
+
+        # Hack for OXP. We are not sure yet if we wanna run all server
+        # actions, but we are sure we want to run those ones. TODO: find
+        # a better way to do it.
+        allowed_server_action_paths = {'crm'}
+
+        for active_id, action, record_id in get_action_triples_():
+            if action.sudo().path in allowed_server_action_paths:
+                try:
+                    action = request.env['ir.actions.act_window'].new(
+                        action.sudo(False).run())
+                except psycopg2.errors.ReadOnlySqlTransaction as e:
+                    # never retry on RO connection, just leave
+                    raise AccessError() from e
+            if action._name != 'ir.actions.act_window':
+                e = f"{action._name} are not supported server-side"
+                raise BadRequest(e)
+            context.update(safe_eval(action.context, dict(
+                action._get_eval_context(action),
+                active_id=active_id,
+                context=context,
+            )))
+
+        if not view_type:
+            if record_id:
+                view_type = 'form'
+            else:
+                view_type = action.view_mode.split(',')[0]
+
+        model = request.env[action.res_model].with_context(context)
+        view = model.get_view(view_type=view_type)
+        spec = model._get_fields_spec(view)
+
+        if record_id:
+            res = model.browse(int(record_id)).web_read(spec)[0]
+        else:
+            domain = safe_eval(action.domain or '[]', dict(
+                action._get_eval_context(action),
+                context=context,
+                active_id=active_id,
+                allowed_company_ids=[1],
+            ))
+            res = model.web_search_read(
+                domain,
+                spec,
+                limit=limit or action.limit,
+                offset=offset,
+            )
+
+        return request.make_json_response(res)

--- a/addons/web/controllers/json.py
+++ b/addons/web/controllers/json.py
@@ -1,17 +1,23 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import ast
 import logging
+from collections import defaultdict
+from datetime import date
 from http import HTTPStatus
 from urllib.parse import urlencode
 
 import psycopg2.errors
+from dateutil.relativedelta import relativedelta
+from lxml import etree
 from werkzeug.exceptions import BadRequest
 
 from odoo import http
 from odoo.exceptions import AccessError
 from odoo.http import request
+from odoo.models import regex_object_name
+from odoo.osv import expression
 from odoo.tools.safe_eval import safe_eval
-from odoo.tools.translate import _
 
 from .utils import get_action_triples
 
@@ -29,88 +35,300 @@ class WebJsonController(http.Controller):
         )
 
     @http.route('/json/1/<path:subpath>', auth='bearer', type='http', readonly=True)
-    def web_json_1(self, subpath, view_type=None, limit=0, offset=0):
+    def web_json_1(self, subpath, **kwargs):
         """Simple JSON representation of the views.
 
+        Get the JSON representation of the action/view as it would be shown
+        in the web client for the same /odoo `subpath`.
+
         Behaviour:
-        - we have a `record_id` (form view) and we `web_read` the spec
-        - otherwise `web_search_read`
+        - When, the action resolves to a pair (Action, id), `form` view_type.
+          Otherwise when it resolves to (Action, None), use the given view_type
+          or the preferred one.
+        - View form uses `web_read`.
+        - If a groupby is given, use a read group.
+          Views pivot, graph redirect to a canonical URL with a groupby.
+        - Otherwise use a search read.
+        - If any parameter is missing, redirect to the canonical URL (one where
+          all parameters are set).
 
         :param subpath: Path to the (window) action to execute
         :param view_type: View type from which we generate the parameters
+        :param domain: The domain for searches
         :param offset: Offset for search
         :param limit: Limit for search
+        :param groupby: Comma-separated string; when set, executes a `web_read_group`
+                        and groups by the given fields
+        :param fields: Comma-separates aggregates for the "group by" query
+        :param start_date: When applicable, minimum date (inclusive bound)
+        :param end_date: When applicable, maximum date (exclusive bound)
         """
+        if not request.env.user.has_group('base.group_allow_export'):
+            raise AccessError(request.env._("You need export permissions to use the /json route"))
+
+        # redirect when the computed kwargs and the kwargs from the URL are different
+        param_list = set(kwargs)
+
+        def check_redirect():
+            # when parameters were added, redirect
+            if set(param_list) == set(kwargs):
+                return None
+            # for domains, make chars as safe
+            encoded_kwargs = urlencode(kwargs, safe="()[], '\"")
+            return request.redirect(
+                f'/json/1/{subpath}?{encoded_kwargs}',
+                HTTPStatus.TEMPORARY_REDIRECT
+            )
+
+        # Get the action
         env = request.env
-        if not env.user.has_group('base.group_allow_export'):
-            raise AccessError(_("You need export permissions to use the /json route"))
-
-        try:
-            limit = int(limit)
-            offset = int(offset)
-        except ValueError as exc:
-            raise BadRequest(exc.args[0])
-        context = dict(env.context)
-
-        def get_action_triples_():
-            try:
-                yield from get_action_triples(env, subpath, start_pos=1)
-            except ValueError as exc:
-                raise BadRequest(exc.args[0])
-
-        for active_id, action, record_id in get_action_triples_():
-            action_sudo = action.sudo()
-            if action_sudo.usage == 'ir_actions_server' and action_sudo.path:
-                try:
-                    with action.pool.cursor(readonly=True) as ro_cr:
-                        if not ro_cr.readonly:
-                            ro_cr.connection.set_session(readonly=True)
-                        assert ro_cr.readonly
-                        action_data = action.with_env(action.env(cr=ro_cr)).run()
-                except psycopg2.errors.ReadOnlySqlTransaction as e:
-                    # never retry on RO connection, just leave
-                    raise AccessError(env._("Read-only action allowed")) from e
-                except ValueError as e:
-                    # safe_eval wraps the error into a ValueError (as str)
-                    if "ReadOnlySqlTransaction" in e.args[0]:
-                        raise AccessError(env._("Read-only action allowed")) from e
-                    raise
-                # transform data into a new record
-                action = env[action_data['type']]
-                action = action.new(action_data, origin=action.browse(action_data.pop('id')))
-            if action._name != 'ir.actions.act_window':
-                e = f"{action._name} are not supported server-side"
-                raise BadRequest(e)
-            context.update(safe_eval(action.context, dict(
-                action._get_eval_context(action),
-                active_id=active_id,
-                context=context,
-            )))
-
-        if not view_type:
-            if record_id:
-                view_type = 'form'
-            else:
-                view_type = action.view_mode.split(',')[0]
-
+        action, context, eval_context, record_id = self._get_action(subpath)
         model = env[action.res_model].with_context(context)
-        view = model.get_view(view_type=view_type)
+
+        # Get the view
+        view_type = kwargs.get('view_type')
+        if not view_type and record_id:
+            view_type = 'form'
+        view_id, view_type = get_view_id_and_type(action, view_type)
+        view = model.get_view(view_id, view_type)
         spec = model._get_fields_spec(view)
 
-        if record_id:
+        # Simple case: form view with record
+        if view_type == 'form' or record_id:
+            if redirect := check_redirect():
+                return redirect
+            if not record_id:
+                raise BadRequest(env._("Missing record id"))
             res = model.browse(int(record_id)).web_read(spec)[0]
+            return request.make_json_response(res)
+
+        # Find domain and limits
+        domains = [safe_eval(action.domain or '[]', eval_context)]
+        if 'domain' in kwargs:
+            # for the user-given domain, use only literal-eval instead of safe_eval
+            user_domain = ast.literal_eval(kwargs.get('domain') or '[]')
+            domains.append(user_domain)
         else:
-            domain = safe_eval(action.domain or '[]', dict(
-                action._get_eval_context(action),
-                context=context,
-                active_id=active_id,
-                allowed_company_ids=[1],
-            ))
+            default_domain = get_default_domain(model, action, context, eval_context)
+            if default_domain and default_domain != expression.TRUE_DOMAIN:
+                kwargs['domain'] = repr(default_domain)
+            domains.append(default_domain)
+        try:
+            limit = int(kwargs.get('limit', 0)) or action.limit
+            offset = int(kwargs.get('offset', 0))
+        except ValueError as exc:
+            raise BadRequest(exc.args[0]) from exc
+        if 'offset' not in kwargs:
+            kwargs['offset'] = offset
+        if 'limit' not in kwargs:
+            kwargs['limit'] = limit
+
+        # Additional info from the view
+        view_tree = etree.fromstring(view['arch'])
+
+        # Add date domain for some view types
+        if view_type in ('calendar', 'gantt', 'cohort'):
+            try:
+                start_date = date.fromisoformat(kwargs['start_date'])
+                end_date = date.fromisoformat(kwargs['end_date'])
+            except ValueError as exc:
+                raise BadRequest(exc.args[0]) from exc
+            except KeyError:
+                start_date = end_date = None
+            date_domain = get_date_domain(start_date, end_date, view_tree)
+            domains.append(date_domain)
+            if 'start_date' not in kwargs or end_date not in kwargs:
+                kwargs.update({
+                    'start_date': date_domain[0][2].isoformat(),
+                    'end_date': date_domain[1][2].isoformat(),
+                })
+
+        # Add explicitly activity fields for an activity view
+        if view_type == 'activity':
+            domains.append([('activity_ids', '!=', False)])
+            # add activity fields
+            for field_name, field in model._fields.items():
+                if field_name.startswith('activity_') and field_name not in spec and field.is_accessible(env):
+                    spec[field_name] = {}
+
+        # Group by
+        groupby, fields = get_groupby(view_tree, kwargs.get('groupby'), kwargs.get('fields'))
+        if groupby is not None and not kwargs.get('groupby'):
+            # add arguments to kwargs
+            kwargs['groupby'] = ','.join(groupby)
+            if 'fields' not in kwargs and fields:
+                kwargs['fields'] = ','.join(fields)
+        if groupby is None and fields:
+            # add fields to the spec
+            for field in fields:
+                spec.setdefault(field, {})
+
+        # Last checks before the query
+        if redirect := check_redirect():
+            return redirect
+        domain = expression.AND(domains)
+        # Reading a group or a list
+        if groupby:
+            res = model.web_read_group(
+                domain,
+                fields=fields or ['__count'],
+                groupby=groupby,
+                limit=limit,
+                lazy=False,
+            )
+            # pop '__domain' key
+            for value in res['groups']:
+                del value['__domain']
+        else:
             res = model.web_search_read(
                 domain,
                 spec,
-                limit=limit or action.limit,
+                limit=limit,
                 offset=offset,
             )
-
         return request.make_json_response(res)
+
+    def _get_action(self, subpath):
+        def get_action_triples_():
+            try:
+                yield from get_action_triples(request.env, subpath, start_pos=1)
+            except ValueError as exc:
+                raise BadRequest(exc.args[0]) from exc
+
+        context = dict(request.env.context)
+        active_id, action, record_id = list(get_action_triples_())[-1]
+        action = action.sudo()
+        if action.usage == 'ir_actions_server' and action.path:
+            # force read-only evaluation of action_data
+            try:
+                with action.pool.cursor(readonly=True) as ro_cr:
+                    if not ro_cr.readonly:
+                        ro_cr.connection.set_session(readonly=True)
+                    assert ro_cr.readonly
+                    action_data = action.with_env(action.env(cr=ro_cr, su=False)).run()
+            except psycopg2.errors.ReadOnlySqlTransaction as e:
+                # never retry on RO connection, just leave
+                raise AccessError(action.env._("Unsupported server action")) from e
+            except ValueError as e:
+                # safe_eval wraps the error into a ValueError (as str)
+                if "ReadOnlySqlTransaction" not in e.args[0]:
+                    raise
+                raise AccessError(action.env._("Unsupported server action")) from e
+            # transform data into a new record
+            action = action.env[action_data['type']]
+            action = action.new(action_data, origin=action.browse(action_data.pop('id')))
+        if action._name != 'ir.actions.act_window':
+            e = f"{action._name} are not supported server-side"
+            raise BadRequest(e)
+        eval_context = dict(
+            action._get_eval_context(action),
+            active_id=active_id,
+            context=context,
+        )
+        # update the context and return
+        context.update(safe_eval(action.context, eval_context))
+        return action, context, eval_context, record_id
+
+
+def get_view_id_and_type(action, view_type: str | None) -> tuple[int | None, str]:
+    """Extract the view id from the action"""
+    assert action._name == 'ir.actions.act_window'
+    view_modes = action.view_mode.split(',')
+    if not view_type:
+        view_type = view_modes[0]
+    for view_id, action_view_type in action.views:
+        if view_type == action_view_type:
+            break
+    else:
+        if view_type not in view_modes:
+            raise BadRequest(request.env._(
+                "Invalid view type '%(view_type)s' for action id=%(action)s",
+                view_type=view_type,
+                action=action.id,
+            ))
+        view_id = False
+    return view_id, view_type
+
+
+def get_default_domain(model, action, context, eval_context):
+    for ir_filter in model.env['ir.filters'].get_filters(model._name, action._origin.id):
+        if ir_filter['is_default']:
+            default_domain = safe_eval(ir_filter['domain'], eval_context)
+            break
+    else:
+        def filters_from_context():
+            view_tree = None
+            for key, value in context.items():
+                if key.startswith('search_default_') and value:
+                    filter_name = key[15:]
+                    if not regex_object_name.match(filter_name):
+                        raise ValueError(model.env._("Invalid default search filter name for %s", key))
+                    if view_tree is None:
+                        view = model.get_view(action.search_view_id.id, 'search')
+                        view_tree = etree.fromstring(view['arch'])
+                    if (element := view_tree.find(Rf'.//filter[@name="{filter_name}"]')) is not None:
+                        # parse the domain
+                        if domain := element.attrib.get('domain'):
+                            yield domain
+                        # not parsing context['group_by']
+
+        default_domain = expression.AND(
+            safe_eval(domain, eval_context)
+            for domain in filters_from_context()
+        )
+    return default_domain
+
+
+def get_date_domain(start_date, end_date, view_tree):
+    if not start_date or not end_date:
+        start_date = date.today() + relativedelta(day=1)
+        end_date = start_date + relativedelta(months=1)
+    date_field = view_tree.attrib.get('date_start')
+    if not date_field:
+        raise ValueError("Could not find the date field in the view")
+    return [(date_field, '>=', start_date), (date_field, '<', end_date)]
+
+
+def get_groupby(view_tree, groupby=None, fields=None):
+    """Parse the given groupby and fields and fallback to the view if not provided.
+
+    Return the groupby as a list when given.
+    Otherwise find groupby and fields from the view.
+
+    :param view_tree: The xml tree of the view
+    :param groupby: string or None
+    :param fields: string or None
+    """
+    if groupby:
+        groupby = groupby.split(',')
+    if fields:
+        fields = fields.split(',')
+    else:
+        fields = None
+    if groupby is not None:
+        return groupby, fields
+
+    if view_tree.tag in ('pivot', 'graph'):
+        # extract groupby from the view if we don't have any
+        field_by_type = defaultdict(list)
+        for element in view_tree.findall(r'./field'):
+            field_name = element.attrib.get('name')
+            if element.attrib.get('invisible', '') in ('1', 'true'):
+                field_by_type['invisible'].append(field_name)
+            else:
+                field_by_type[element.attrib.get('type', 'normal')].append(field_name)
+            # not reading interval from the attribute
+        groupby = [
+            *field_by_type.get('row', ()),
+            *field_by_type.get('col', ()),
+            *field_by_type.get('normal', ()),
+        ]
+        if fields is None:
+            fields = field_by_type.get('measure', [])
+        return groupby, fields
+    if view_tree.attrib.get('default_group_by'):
+        # in case the kanban view (or other) defines a default grouping
+        # return the field name so it is added to the spec
+        field = view_tree.attrib.get('default_group_by')
+        return (None, [field] if field else [])
+    return None, None

--- a/odoo/addons/test_http/__manifest__.py
+++ b/odoo/addons/test_http/__manifest__.py
@@ -4,7 +4,7 @@
     'version': '1.0',
     'category': 'Hidden/Tests',
     'description': """A module to test HTTP""",
-    'depends': ['base', 'web', 'web_tour'],
+    'depends': ['base', 'web', 'web_tour', 'mail'],
     'installable': True,
     'data': [
         'data.xml',

--- a/odoo/addons/test_http/data.xml
+++ b/odoo/addons/test_http/data.xml
@@ -47,18 +47,23 @@
             <field name="galaxy_id" ref="test_http.milky_way"/>
             <field name="glyph_attach" type="base64" file="test_http/static/src/img/gizeh.png"/>
             <field name="glyph_inline" type="base64" file="test_http/static/src/img/gizeh.png"/>
+            <field name="last_use_date">2020-03-15</field>
         </record>
 
         <record id="abydos" model="test_http.stargate">
             <field name="name">Abydos</field>
             <field name="address">r7fwcu</field>
             <field name="galaxy_id" ref="test_http.milky_way"/>
+            <field name="availability">0.91</field>
+            <field name="last_use_date">2020-03-04</field>
         </record>
 
         <record id="dakara" model="test_http.stargate">
             <field name="name">Dakara</field>
             <field name="address">gs38x4</field>
             <field name="galaxy_id" ref="test_http.milky_way"/>
+            <field name="availability">0.95</field>
+            <field name="last_use_date">2020-01-04</field>
         </record>
 
         <record id="lantea" model="test_http.stargate">
@@ -66,6 +71,7 @@
             <field name="address">u6iz7d</field>
             <field name="galaxy_id" ref="test_http.pegasus"/>
             <field name="has_galaxy_crystal" eval="True"/>
+            <field name="last_use_date">2020-01-08</field>
         </record>
 
         <record id="athos" model="test_http.stargate">

--- a/odoo/addons/test_http/models.py
+++ b/odoo/addons/test_http/models.py
@@ -10,6 +10,7 @@ PEGASUS_REGIONS = ['M4R', 'P3Y', 'M6R']
 class Stargate(models.Model):
     _name = 'test_http.stargate'
     _description = 'Stargate'
+    _inherit = ['mail.thread', 'mail.activity.mixin']
 
     name = fields.Char(required=True, store=True, compute='_compute_name', readonly=False)
     address = fields.Char(required=True)
@@ -21,7 +22,8 @@ class Stargate(models.Model):
     glyph_related = fields.Image('Glyph 128', related='glyph_attach', max_width=128, max_height=128)
     glyph_compute = fields.Image(compute='_compute_glyph_compute')
     galaxy_picture = fields.Image(related='galaxy_id.picture', attachment=True, store=False)
-
+    availability = fields.Float(default=0.99, aggregator="avg")
+    last_use_date = fields.Date()
 
     _sql_constraints = [
         ('address_length', 'CHECK(LENGTH(address) = 6)', "Local addresses have 6 glyphs"),

--- a/odoo/addons/test_http/tests/test_webjson.py
+++ b/odoo/addons/test_http/tests/test_webjson.py
@@ -2,6 +2,9 @@
 import html
 from base64 import b64encode
 
+from datetime import date
+
+from odoo.api import Environment
 from odoo.fields import Command
 from odoo.tests import tagged
 from odoo.tools import file_open, mute_logger
@@ -15,6 +18,19 @@ CSRF_USER_HEADERS = {
     "Sec-Fetch-Site": 'none',
     "Sec-Fetch-User": "?1",
 }
+
+
+def read_group_list(model, domain=None, groupby=(), fields=('__count',)):
+    result = model.web_read_group(domain or [], groupby=groupby, fields=fields, lazy=False)
+    # transform result:
+    # - tuple into list
+    # - pop '__domain'
+    for group in result['groups']:
+        del group['__domain']
+        for k, v in group.items():
+            if isinstance(v, tuple):
+                group[k] = list(v)
+    return result
 
 
 @tagged('-at_install', 'post_install')
@@ -40,8 +56,13 @@ class TestHttpWebJson_1(TestHttpBase):
             res.raise_for_status()
         return res
 
-    def test_webjson_access_error(self):
+    def authenticate_demo(self):
         self.authenticate('demo', 'demo')
+        user = self.user_demo
+        return Environment(self.env.cr, user.id, {'lang': user.lang, 'tz': user.tz})
+
+    def test_webjson_access_error(self):
+        self.authenticate_demo()
         with self.assertLogs('odoo.http', 'WARNING') as capture:
             res = self.url_open_json('/settings', expected_code=403)
             self.assertEqual(res.headers['Content-Type'], 'text/html; charset=utf-8')
@@ -50,11 +71,11 @@ class TestHttpWebJson_1(TestHttpBase):
         self.assertIn("You are not allowed to access", capture.output[0])
 
     def test_webjson_access_error_crm(self):
-        action_crm = self.env['ir.actions.server'].search([('path', '=', 'crm')])
+        action_crm = self.env['ir.actions.server'].sudo().search([('path', '=', 'crm')])
         if not action_crm:
             self.skipTest("crm is not installed")
 
-        self.authenticate('demo', 'demo')
+        self.authenticate_demo()
         self.url_open_json('/crm')
 
         self.env['ir.model.access'].search([
@@ -71,7 +92,7 @@ class TestHttpWebJson_1(TestHttpBase):
     def test_webjson_access_export(self):
         # a simple call
         url = f'/test_http.stargate/{self.earth.id}'
-        self.authenticate('demo', 'demo')
+        self.authenticate_demo()
         res = self.url_open_json(url)
 
         # remove export permssion
@@ -85,7 +106,7 @@ class TestHttpWebJson_1(TestHttpBase):
             self.assertIn("need export permissions", capture.output[0])
 
     def test_webjson_bad_stuff(self):
-        self.authenticate('demo', 'demo')
+        self.authenticate_demo()
 
         with self.subTest(bad='action'):
             res = self.url_open_json('/idontexist', expected_code=400)
@@ -104,15 +125,13 @@ class TestHttpWebJson_1(TestHttpBase):
             self.assertIn("expected action at word 3 but found “2”", res.text)
 
         with self.subTest(bad='view_type'):
-            error = "No default view of type 'idontexist' could be found!"
-            with self.assertLogs('odoo.http', 'WARNING') as capture:
-                res = self.url_open_json('/res.users?view_type=idontexist', expected_code=400)
-                self.assertEqual(res.headers['Content-Type'], CT_HTML)
-                self.assertIn(error, html.unescape(res.text))
-            self.assertEqual(capture.output, [f"WARNING:odoo.http:{error}"])
+            error = "Invalid view type 'idontexist'"
+            res = self.url_open_json('/res.users?view_type=idontexist', expected_code=400)
+            self.assertEqual(res.headers['Content-Type'], CT_HTML)
+            self.assertIn(error, html.unescape(res.text))
 
     def test_webjson_form(self):
-        self.authenticate('demo', 'demo')
+        self.authenticate_demo()
         res = self.url_open_json(f'/test_http.stargate/{self.earth.id}')
         self.assertEqual(res.json(), {
             'id': self.earth.id,
@@ -125,11 +144,11 @@ class TestHttpWebJson_1(TestHttpBase):
         })
 
     def test_webjson_form_subtree(self):
-        self.authenticate('demo', 'demo')
+        env = self.authenticate_demo()
         res = self.url_open_json(f'/test_http.galaxy/{self.milky_way.id}')
         self.assertEqual(
             res.json(),
-            self.milky_way.web_read({
+            self.milky_way.with_env(env).web_read({
                 'name': {},
                 'stargate_ids': {'fields': {
                     'name': {},
@@ -139,7 +158,7 @@ class TestHttpWebJson_1(TestHttpBase):
         )
 
     def test_webjson_form_viewtype_list(self):
-        self.authenticate('demo', 'demo')
+        self.authenticate_demo()
         url = f'/test_http.stargate/{self.earth.id}'
         res = self.url_open_json(f'{url}?view_type=list')
         self.assertEqual(res.json(), {
@@ -148,20 +167,20 @@ class TestHttpWebJson_1(TestHttpBase):
             'sgc_designation': self.earth.sgc_designation,
         })
 
-    def test_webjson_tree(self):
-        self.authenticate('demo', 'demo')
+    def test_webjson_list(self):
+        env = self.authenticate_demo()
         res = self.url_open_json('/test_http.stargate')
         self.assertEqual(
             res.json(),
-            self.env['test_http.stargate']
+            env['test_http.stargate']
                 .web_search_read([], {'name': {}, 'sgc_designation': {}})
         )
 
-    def test_webjson_tree_limit_offset(self):
-        self.authenticate('demo', 'demo')
+    def test_webjson_list_limit_offset(self):
+        env = self.authenticate_demo()
         url = '/test_http.stargate'
         stargates = (
-            self.env['test_http.stargate']
+            env['test_http.stargate']
                 .web_search_read([], {'name': {}, 'sgc_designation': {}})
         )['records']
 
@@ -183,10 +202,134 @@ class TestHttpWebJson_1(TestHttpBase):
             'records': stargates[1:2]
         })
 
+    def test_webjson_list_domain(self):
+        env = self.authenticate_demo()
+        domain = [("address", "like", "gs38")]
+        res = self.url_open_json(f'/test_http.stargate?domain={domain!r}')
+        self.assertEqual(
+            res.json(),
+            env['test_http.stargate']
+                .web_search_read(domain, {'name': {}, 'sgc_designation': {}})
+        )
+
+    def test_webjson_list_domain_default_filter(self):
+        action_domain = [('availability', '>', 0.95)]
+        self.env.ref('test_http.action_window_stargate').domain = action_domain
+        env = self.authenticate_demo()
+
+        res = self.url_open_json('/test_http.stargate')
+        self.assertEqual(
+            res.json()["length"],
+            env['test_http.stargate'].search_count(action_domain),
+        )
+
+        user_domain = [('address', 'ilike', 'a')]
+        env['ir.filters'].create({
+            'domain': user_domain,
+            'model_id': 'test_http.stargate',
+            'name': 'Some def filter',
+            'is_default': True,
+        })
+        res = self.url_open_json('/test_http.stargate')
+        self.assertEqual(
+            res.json()["length"],
+            env['test_http.stargate'].search_count(action_domain + user_domain),
+        )
+        self.assertIn("ilike", res.url, "URL should contain a user domain")
+        self.assertNotIn(action_domain[0][0], res.url, "URL should not contain a domain with action domain")
+
+    def test_webjson_list_args(self):
+        env = self.authenticate_demo()
+        # create a default filter
+        domain = [("name", "ilike", "earth")]
+        self.env['ir.filters'].create({
+            'name': 'my filter',
+            'is_default': True,
+            'domain': domain,
+            'model_id': 'test_http.stargate',
+        })
+        res = self.url_open_json('/test_http.stargate')
+        self.assertEqual(
+            res.json(),
+            env['test_http.stargate']
+                .web_search_read(domain, {'name': {}, 'sgc_designation': {}})
+        )
+        # we should find one redirect with the domain in the URL
+        [hist] = res.history
+        self.assertEqual(hist.status_code, 307)
+        str_domain = str(domain).replace(' ', '+')
+        self.assertIn("limit=80", res.url)
+        self.assertIn(f"domain={str_domain}", res.url)
+
+    def test_webjson_pivot(self):
+        env = self.authenticate_demo()
+        res = self.url_open_json('/test_http.stargate?view_type=pivot')
+        self.assertEqual(
+            res.json(),
+            read_group_list(
+                env['test_http.stargate'], [], ['galaxy_id', 'has_galaxy_crystal'], ['availability']),
+        )
+
+        res = self.url_open_json('/test_http.stargate?view_type=pivot&groupby=has_galaxy_crystal&fields=availability:min')
+        self.assertEqual(
+            res.json(),
+            read_group_list(env['test_http.stargate'], [], ['has_galaxy_crystal'], ['availability:min']),
+        )
+
+        user_domain = [('availability', '>=', 0.95)]
+        env['ir.filters'].create({
+            'domain': user_domain,
+            'model_id': 'test_http.stargate',
+            'name': 'Some def filter',
+            'is_default': True,
+        })
+        res = self.url_open_json('/test_http.stargate?view_type=pivot&groupby=has_galaxy_crystal&fields=availability:min')
+        self.assertEqual(
+            res.json(),
+            read_group_list(env['test_http.stargate'], user_domain, ['has_galaxy_crystal'], ['availability:min']),
+        )
+
+    def test_webjson_graph(self):
+        env = self.authenticate_demo()
+        res = self.url_open_json('/test_http.stargate?view_type=graph')
+        self.assertEqual(
+            res.json(),
+            read_group_list(env['test_http.stargate'], [], ['galaxy_id']),
+        )
+
+    def test_webjson_activity(self):
+        env = self.authenticate_demo()
+        env['test_http.stargate'].search([], limit=1).activity_schedule(summary='test')
+        res = self.url_open_json('/test_http.stargate?view_type=activity')
+        # check that we have at least the following fields
+        expected_fields = ["activity_ids", "activity_summary", "activity_user_id", "galaxy_id"]
+        self.assertEqual(
+            sorted(field_name for field_name in res.json()["records"][0] if field_name in expected_fields),
+            expected_fields,
+        )
+
+    def test_webjson_calendar(self):
+        env = self.authenticate_demo()
+        today = date.today()
+        start_date_iso = today.replace(day=1).isoformat()
+        # check that we have the date in the URL
+        res = self.url_open_json('/test_http.stargate?view_type=calendar')
+        self.assertIn(f"start_date={start_date_iso}", res.url)
+        # check that we can filter using the date
+        last_date = max(
+            env['test_http.stargate'].search([('last_use_date', '!=', False)])
+            .mapped('last_use_date')
+        )
+        res = self.url_open_json(f'/test_http.stargate?view_type=calendar&domain=[]&start_date={last_date.isoformat()}&end_date=2099-01-01')
+        self.assertEqual(
+            res.json()["length"],
+            env['test_http.stargate'].search_count([('last_use_date', '>=', last_date)]),
+        )
+
     def test_webjson_readonly(self):
-        self.authenticate('demo', 'demo')
+        env = self.authenticate_demo()
         # test that we can write
-        self.env.ref('test_http.earth').copy()
+        env.ref('test_http.earth').copy()
         # create the action that executes the same write
         self.env['ir.actions.server'].create({
             'name': 'test write',
@@ -198,4 +341,4 @@ class TestHttpWebJson_1(TestHttpBase):
         # test that is does NOT work
         with mute_logger("odoo.http", "odoo.sql_db"):
             res = self.url_open_json('/test_webjson_readonly', expected_code=403)
-            self.assertIn("Read-only action allowed", res.text)
+            self.assertIn("Unsupported server action", res.text)

--- a/odoo/addons/test_http/views.xml
+++ b/odoo/addons/test_http/views.xml
@@ -70,4 +70,49 @@
             </form>
         </field>
     </record>
+
+    <record id="test_http_stargate_pivot" model="ir.ui.view">
+        <field name="model">test_http.stargate</field>
+        <field name="arch" type="xml">
+            <pivot string="Stargate">
+                <field name="galaxy_id" type="row"/>
+                <field name="has_galaxy_crystal" type="col"/>
+                <field name="availability" type="measure"/>
+            </pivot>
+        </field>
+    </record>
+
+    <record id="test_http_stargate_graph" model="ir.ui.view">
+        <field name="model">test_http.stargate</field>
+        <field name="arch" type="xml">
+            <graph string="Stargate">
+                <field name="galaxy_id"/>
+            </graph>
+        </field>
+    </record>
+
+    <record id="test_http_stargate_activity" model="ir.ui.view">
+        <field name="model">test_http.stargate</field>
+        <field name="arch" type="xml">
+            <activity string="Stargate">
+                <field name="galaxy_id"/>
+            </activity>
+        </field>
+    </record>
+
+    <record id="test_http_stargate_calendar" model="ir.ui.view">
+        <field name="model">test_http.stargate</field>
+        <field name="arch" type="xml">
+            <calendar string="Stargate" create="0" date_start="last_use_date">
+                <field name="galaxy_id"/>
+            </calendar>
+        </field>
+    </record>
+
+    <record id="action_window_stargate" model="ir.actions.act_window">
+        <field name="name">Stargate</field>
+        <field name="res_model">test_http.stargate</field>
+        <field name="view_mode">list,form,pivot,graph,activity,calendar</field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
Handle additional parameters like the domain and default values from multiple view types: kanban, graph, pivot, calendar, activity.

The code is moved to a separate file because it is a specific feature of Odoo and should not be in the same file as the default `/odoo` route.

task-3987268

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
