### PR TITLE
[FIX] base: prevent device logs for wkhtmltopdf

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -6,10 +6,11 @@ from urllib.parse import urlparse
 
 from odoo import api, fields, models, tools, SUPERUSER_ID, _
 from odoo.exceptions import UserError, AccessError, RedirectWarning
+from odoo.service import security
 from odoo.tools.safe_eval import safe_eval, time
 from odoo.tools.misc import find_in_path, ustr
 from odoo.tools import check_barcode_encoding, config, is_html_empty, parse_version, split_every
-from odoo.http import request
+from odoo.http import request, root
 from odoo.osv.expression import NEGATIVE_TERM_OPERATORS, FALSE_DOMAIN
 
 import io
@@ -524,12 +525,23 @@ class IrActionsReport(models.Model):
 
         files_command_args = []
         temporary_files = []
+        temp_session = None
 
         # Passing the cookie to wkhtmltopdf in order to resolve internal links.
         if request and request.db:
+            # Create a temporary session which will not create device logs
+            temp_session = root.session_store.new()
+            temp_session.update({
+                **request.session,
+                '_trace_disable': True,
+            })
+            if temp_session.uid:
+                temp_session.session_token = security.compute_session_token(temp_session, self.env)
+            root.session_store.save(temp_session)
+
             base_url = self._get_report_url()
             domain = urlparse(base_url).hostname
-            cookie = f'session_id={request.session.sid}; HttpOnly; domain={domain}; path=/;'
+            cookie = f'session_id={temp_session.sid}; HttpOnly; domain={domain}; path=/;'
             cookie_jar_file_fd, cookie_jar_file_path = tempfile.mkstemp(suffix='.txt', prefix='report.cookie_jar.tmp.')
             temporary_files.append(cookie_jar_file_path)
             with closing(os.fdopen(cookie_jar_file_fd, 'wb')) as cookie_jar_file:
@@ -600,6 +612,9 @@ class IrActionsReport(models.Model):
                     _logger.warning('wkhtmltopdf: %s' % err)
         except:
             raise
+        finally:
+            if temp_session:
+                root.session_store.delete(temp_session)
 
         with open(pdf_report_path, 'rb') as pdf_document:
             pdf_content = pdf_document.read()

--- a/odoo/addons/test_http/tests/test_device.py
+++ b/odoo/addons/test_http/tests/test_device.py
@@ -272,6 +272,15 @@ class TestDevice(TestHttpBase):
         self.assertNotIn('191.0.1.41', device_chrome.linked_ip_addresses)
         self.assertIn('191.0.1.41', device_firefox.linked_ip_addresses)
 
+    def test_detection_no_trace_mechanism(self):
+        session = self.authenticate(self.user_admin.login, self.user_admin.login)
+        session._trace_disable = True
+        odoo.http.root.session_store.save(session)
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-user-rw')
+        devices, logs = self.get_devices_logs(self.user_admin)
+        self.assertEqual(len(devices), 0)
+        self.assertEqual(len(logs), 0)
+
     # --------------------
     # DELETION
     # --------------------


### PR DESCRIPTION
Issue:
------
During pdf generation, wkhtmltopdf creates device logs via a request. The user agent of this request is:
```
Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/534.34 (KHTML, like Gecko) wkhtmltopdf Safari/534.34.
```
The result is that a `Linux - Safari` device log is created.

Solution:
---------
This must be prevented using the `_disable_trace` server-side mechanism of the session object.

However, we don't want to add this flag to the session currently used by the user in order to continue generating logs even during report generation for activities performed in parallel.

The possibility of creating a temporary session on the filesystem which is a copy of the current session with the `_trace_disable` flag is a good solution.