### PR TITLE
[FIX] project: fix traceback if there is no filter domain while grouping project

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1211,7 +1211,7 @@ class Task(models.Model):
         })
         filtered_domain = _change_operator(filtered_domain)
         if not filtered_domain:
-            return False
+            return self.env[comodel]
         if additional_domain:
             filtered_domain = expression.AND([filtered_domain, additional_domain])
         return self.env[comodel].search(filtered_domain, order=order)


### PR DESCRIPTION
Currently a traceback may arises when there is no `filter_domain`, 
while the user tries to group projects.

Error:- 

```
AttributeError: 'bool' object has no attribute '_name'
  File "odoo/models.py", line 6643, in __and__
    if self._name != other._name:
TypeError: unsupported operand types in: project.project(2,) & False
  File "odoo/http.py", line 2383, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1913, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1976, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1943, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2187, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 227, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 757, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 35, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 459, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/web/models/models.py", line 242, in web_read_group
    groups = self._web_read_group(domain, fields, groupby, limit, offset, orderby, lazy)
  File "addons/web/models/models.py", line 268, in _web_read_group
    groups = self.read_group(domain, fields, groupby, offset=offset, limit=limit,
  File "addons/project/models/project_task.py", line 1982, in read_group
    return super().read_group(domain, fields, groupby, offset, limit, orderby, lazy)
  File "odoo/models.py", line 2800, in read_group
    rows_dict = self._read_group_fill_results(
  File "odoo/models.py", line 2247, in _read_group_fill_results
    values = group_expand(self, groups, domain).sudo()
  File "home/odoo/src/enterprise/saas-17.4/industry_fsm/models/project_task.py", line 194, in _group_expand_project_ids
    res &= search_on_comodel
  File "odoo/models.py", line 6648, in __and__
    raise TypeError(f"unsupported operand types in: {self} & {other!r}")
```
This is because of the recent changes from the below commit

Commit:- https://github.com/odoo/odoo/pull/172973/commits/600b379c91059bfce5ebf6c53a9d282a07e5c640

When the `_search_on_comodel` method returns `False` if there is no `filter_domain`,
it leads to a traceback because `&` is used between an empty recordset and a False.

https://github.com/odoo/enterprise/blob/ce508a604bf70af06347e43000f25426473fb867/industry_fsm/models/project_task.py#L149-L151

We can resolve this issue by returning an empty record, Instead of returning False.

sentry-5836960027

