### PR TITLE
[FIX] project: makes sure the view project is shown in email for user

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -644,7 +644,7 @@ class Project(models.Model):
         self.ensure_one()
         portal_privacy = self.privacy_visibility == 'portal'
         for group_name, _group_method, group_data in groups:
-            if group_name in ('customer', 'user') or group_name == 'portal_customer' and not portal_privacy:
+            if group_name in ['portal', 'portal_customer'] and not portal_privacy:
                 group_data['has_button_access'] = False
         return groups
 

--- a/addons/project/tests/test_project_flow.py
+++ b/addons/project/tests/test_project_flow.py
@@ -458,13 +458,17 @@ class TestProjectFlow(TestProjectCommon, MailCommon):
         ])
         for project in projects:
             groups = project._notify_get_recipients_groups(self.env['mail.message'], False)
-            portal_customer_group = next((g for g in groups if g[0] == 'portal_customer'), False)
-            if portal_customer_group:
-                self.assertEqual(
-                    portal_customer_group[2]['has_button_access'],
-                    project.name == 'public project',
-                    "Only the public project should have its name clickable in the email sent to the customer when an email is sent via a email template set in the project stage for instance."
-                )
+            groups_per_key = {g[0]: g for g in groups}
+            for key, group in groups_per_key.items():
+                has_button_access = group[2]['has_button_access']
+                if key in ['portal', 'portal_customer']:
+                    self.assertEqual(
+                        has_button_access,
+                        project.name == 'public project',
+                        "Only the public project should have its name clickable in the email sent to the customer when an email is sent via a email template set in the project stage for instance."
+                    )
+                elif key == 'user':
+                    self.assertTrue(has_button_access)
 
     def test_private_task_search_tag(self):
         task = self.env['project.task'].create({


### PR DESCRIPTION
Before this commit, due to 715d6be, the `View Project` button in the email sent even if the receiver is an internal user, which is not really expected.

This commit makes sure the button is only hidden for the customer portal when the project is private.

X-Original-Commit: 715d6be