### PR TITLE
[FIX] web_editor : add list item after enter at end of pre inside list

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/enter.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/enter.js
@@ -15,6 +15,7 @@ import {
     toggleClass,
     isVisible,
     nodeSize,
+    setSelection,
 } from '../utils/utils.js';
 
 Text.prototype.oEnter = function (offset) {
@@ -173,6 +174,11 @@ HTMLPreElement.prototype.oEnter = function (offset) {
         this.insertBefore(lineBreak, this.childNodes[offset]);
         setCursorEnd(lineBreak);
     } else {
+        if (this.parentElement.nodeName === 'LI') {
+            setSelection(this.parentElement, childNodeIndex(this) + 1);
+            HTMLLIElement.prototype.oEnter.call(this.parentElement, ...arguments);
+            return;
+        }
         const node = document.createElement('p');
         this.parentNode.insertBefore(node, this.nextSibling);
         fillEmpty(node);

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
@@ -3650,6 +3650,13 @@ X[]
                         contentAfter: '<pre><p>abc</p><p>def</p></pre><p>[]<br></p>',
                     });
                 });
+                it('should insert a new list item after the pre inside a list item', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<ul><li><pre>abc[]</pre></li></ul>',
+                        stepFunction: insertParagraphBreak,
+                        contentAfter: '<ul><li><pre>abc</pre></li><li>[]<br></li></ul>',
+                    });
+                });
             });
             describe('Blockquote', () => {
                 it('should insert a new line within the blockquote', async () => {


### PR DESCRIPTION
Issue:
======
`enter` command doesnt work properly for `pre` element inside list element.

Steps to reproduce the issue:
=============================
- Add a list
- Add a code block with `/code`
- Add sone text
- Put the cursor at the end of the text
- click `enter`
- It adds a `br` element and puts the selection at the start.

Origin of the issue:
====================
The `oEnter` function of the `pre` element is triggered which adds a `p` element just after the `pre` element inside the same `li` element. Now in sanitiwe we unwrap the p elements inside `li` which leaves us with only a `br` after the `pre`. Since we put the selection at the start of the newly added then removed `p` element, the final selection will not behave correctly.

Solution:
=========
We single out the case when the parent element of the `pre` is a `li` and treat it as a break inside a `li`.

task-4187676