### PR TITLE
[FIX] core: overlong error messages on `assertRecordValues` failures

### DIFF
--- a/odoo/addons/test_testing_utilities/ir.model.access.csv
+++ b/odoo/addons/test_testing_utilities/ir.model.access.csv
@@ -30,3 +30,4 @@ access_ttu_root,access_ttu_root,model_ttu_root,base.group_user,1,0,0,0
 access_ttu_child,access_ttu_child,model_ttu_child,base.group_user,1,0,0,0
 access_ttu_grandchild,access_ttu_grandchild,model_ttu_grandchild,base.group_user,1,0,0,0
 access_res_config_test,access_res_config_test,test_testing_utilities.model_res_config_test,base.group_user,1,0,0,0
+access_wide,access_wide,model_test_testing_utilities_wide,,0,0,0,0

--- a/odoo/addons/test_testing_utilities/models.py
+++ b/odoo/addons/test_testing_utilities/models.py
@@ -354,3 +354,28 @@ class ResConfigTest(models.Model):
     param2 = fields.Many2one(
         'res.config',
         config_parameter="resConfigTest.parameter2")
+
+
+class Wide(models.Model):
+    _name = _description = 'test_testing_utilities.wide'
+    _log_access = False
+
+    account_id = fields.Float()
+    amount_currency = fields.Float()
+    credit = fields.Float()
+    currency_id = fields.Float()
+    date_maturity = fields.Float()
+    debit = fields.Float()
+    discount = fields.Float()
+    name = fields.Float()
+    partner_id = fields.Float()
+    price_subtotal = fields.Float()
+    price_total = fields.Float()
+    price_unit = fields.Float()
+    product_id = fields.Float()
+    product_uom_id = fields.Float()
+    quantity = fields.Float()
+    tax_base_amount = fields.Float()
+    tax_ids = fields.Float()
+    tax_line_id = fields.Float()
+    tax_tag_invert = fields.Float()

--- a/odoo/addons/test_testing_utilities/tests/test_methods.py
+++ b/odoo/addons/test_testing_utilities/tests/test_methods.py
@@ -46,6 +46,68 @@ class TestBasic(common.TransactionCase):
 
         self.assertRecordValues(r, [{'dummy': 42}])
 
+    def test_assertRecordValues_float_formatting(self):
+        # ensure diff configuration is the default
+        self.patch(self, 'maxDiff', 80 * 8)
+
+        Records = self.env['test_testing_utilities.wide']
+        names = sorted(Records._fields.keys() - {'id', 'display_name'})
+
+        d = {
+            n: float(k)
+            for k, n in enumerate(names)
+        }
+
+        values = [{**d, "name": float(i), "price_total": float(i)} for i in range(200)]
+        values[63]['quantity'] = False
+        records = Records.create(values)
+        values[63]['price_total'] = 42.0
+
+        with self.assertRaises(AssertionError) as cm:
+            self.assertRecordValues(records, values)
+
+        self.maxDiff = None
+        self.assertEqual(str(cm.exception), """\
+Lists differ: [{'ac[24051 chars]al': 42.0, 'price_unit': 11.0, 'product_id': 1[51872 chars]8.0}] != [{'ac[24051 chars]al': 63.0, 'price_unit': 11.0, 'product_id': 1[51872 chars]8.0}]
+
+First differing element 63:
+{'acc[193 chars]al': 42.0, 'price_unit': 11.0, 'product_id': 1[127 chars]18.0}
+{'acc[193 chars]al': 63.0, 'price_unit': 11.0, 'product_id': 1[127 chars]18.0}
+
+--- expected
++++ records
+@@ -1205,7 +1205,7 @@
+   'name': 63.0,
+   'partner_id': 8.0,
+   'price_subtotal': 9.0,
+-  'price_total': 42.0,
++  'price_total': 63.0,
+   'price_unit': 11.0,
+   'product_id': 12.0,
+   'product_uom_id': 13.0,
+""")
+
+        vs = {
+            k: v for k, v in values[63].items()
+            if k in ("discount", "price_subtotal", "price_total", "quantity")
+        }
+        # if the default ndiff fits into the default diff limits keep that as is
+        with self.assertRaises(AssertionError) as cm:
+            self.assertRecordValues(records[63], [vs])
+        self.assertEqual(str(cm.exception), """\
+Lists differ: [{'discount': 6.0, 'price_subtotal': 9.0, 'price_total': 42.0, 'quantity': 0.0}] != [{'discount': 6.0, 'price_subtotal': 9.0, 'price_total': 63.0, 'quantity': 0.0}]
+
+First differing element 0:
+{'discount': 6.0, 'price_subtotal': 9.0, 'price_total': 42.0, 'quantity': 0.0}
+{'discount': 6.0, 'price_subtotal': 9.0, 'price_total': 63.0, 'quantity': 0.0}
+
+- [{'discount': 6.0, 'price_subtotal': 9.0, 'price_total': 42.0, 'quantity': 0.0}]
+?                                                          ^^
+
++ [{'discount': 6.0, 'price_subtotal': 9.0, 'price_total': 63.0, 'quantity': 0.0}]
+?                                                          ^^
+""")
+
     def test_assertRaises_rollbacks(self):
         """Checks that a "correctly" executing assertRaises (where the expected
         exception has been raised and caught) will properly rollback.


### PR DESCRIPTION
odoo/odoo#178332 attempted to simplify `assertRecordValues` and clarify its messages, it failed quite significantly at the second one, fix that:

- Reformat error diffs using udiff rather than the default ndiff (which always displays the entire thing), ndiff provides either completely cutoff output (because it's very easy to get above maxDiff = 640 when comparing pprints of lists of dicts) or extremely large output as it always displays the entire thing, when comparing either lots of records or very large dicts this is unusable.

  Not quite sure how I missed that Python uses ndiff, I assume it's because a previous version did the diffing explicitly using udiff and I didn't validate it when I changed to straight `assertEqual`. `pytest` has the exact same behavior so it's not like I got confused with that. Add tests to check that the formatting is as intended (use large lists from account as basis).

  Note: for now only swap out cutoff diffs, if the caller sets `maxDiff = None` then assume they want the entire thing.

- Don't decorate the `Approx` values inside `assertRecordValues`, that formats out as differences on every failure even when those values are irrelevant. This makes the diff unreadable as basically every float value (which has rounding applied but that's most of them, in accounting anyway) gets prefixed by `~` which shows up during the diff.

  There is still an edge case if the rounding was necessary to make values match, it might be a good idea to `round` the values based on the input information in that case if that turns out to be a common problem.

