### PR TITLE
[FIX] mail: remove company_ids One2many field from Group By search

### DIFF
--- a/addons/mail/views/mail_alias_domain_views.xml
+++ b/addons/mail/views/mail_alias_domain_views.xml
@@ -60,12 +60,6 @@
                 <field name="name"/>
                 <field name="bounce_alias"/>
                 <field name="catchall_alias"/>
-                <field name="company_ids" groups="base.group_multi_company"/>
-                <group expand="0" string="Group By">
-                    <filter string="Company" name="group_by_company_ids"
-                        domain="[]" context="{'group_by': 'company_ids'}"
-                        groups="base.group_multi_company"/>
-                </group>
             </search>
         </field>
     </record>


### PR DESCRIPTION
Currently, an exception is generated when the user tries to group by copmany in Alias Domain.

Error:
`psycopg2.errors.UndefinedColumn: column mail_alias_domain.company_ids does not exist`

This is because the search view of the `mail.alias.domain` model is used group by company_ids field, which is One2many.

This commit will fix above issue by removing the company_ids from the group since we can't group by records with multiple record set fields.

sentry-5774171054

