### PR TITLE
[I18N] account_edi_ubl_cii_tax_extension: add new stable module

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -54,6 +54,14 @@ type          = PO
 minimum_perc  = 0
 resource_name = account_edi_ubl_cii
 
+[o:odoo:p:odoo-16:r:account_edi_ubl_cii_tax_extension]
+file_filter   = addons/account_edi_ubl_cii_tax_extension/i18n/<lang>.po
+source_file   = addons/account_edi_ubl_cii_tax_extension/i18n/account_edi_ubl_cii_tax_extension.pot
+source_lang   = en
+type          = PO
+minimum_perc  = 0
+resource_name = account_edi_ubl_cii_tax_extension
+
 [o:odoo:p:odoo-16:r:account_fleet]
 file_filter   = addons/account_fleet/i18n/<lang>.po
 source_file   = addons/account_fleet/i18n/account_fleet.pot


### PR DESCRIPTION
Add `account_edi_ubl_cii_tax_extension` module to transifex.
Pot file already added in original PR that adds in new module into stable.

Orig PR: https://github.com/odoo/odoo/pull/176221
opw-4061329