### PR TITLE
[FIX] web: do not translate empty string

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
@@ -1,4 +1,3 @@
-import { _t } from "@web/core/l10n/translation";
 import { getLocalWeekNumber, is24HourFormat } from "@web/core/l10n/dates";
 import { localization } from "@web/core/l10n/localization";
 import { renderToString } from "@web/core/utils/render";
@@ -70,7 +69,7 @@ export class CalendarCommonRenderer extends Component {
     get options() {
         return {
             allDaySlot: true,
-            allDayContent: _t(""),
+            allDayContent: "",
             dayHeaderFormat: this.env.isSmall
                 ? SHORT_SCALE_TO_HEADER_FORMAT[this.props.model.scale]
                 : SCALE_TO_HEADER_FORMAT[this.props.model.scale],


### PR DESCRIPTION
Trying to extract the translation of an empty string will throw a warning (https://github.com/python-babel/babel/blob/master/babel/messages/extract.py#L356) (Can be observed in `test_only` logs of bundle
`testing post_install from auth_totp to microsoft_outlook`)

This commit removes the translation of the empty string.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
