### PR TITLE
[FIX] delivery: fix failing test

### DIFF
--- a/addons/delivery/tests/test_delivery_cost.py
+++ b/addons/delivery/tests/test_delivery_cost.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import datetime
 from odoo.tests import common, Form
 from odoo.tools import float_compare
 
@@ -452,6 +453,7 @@ class TestDeliveryCost(common.TransactionCase):
         })
 
         self.env['res.currency.rate'].with_company(nook_inc).create({
+            'name': datetime.date(2000, 1, 1),
             'currency_id': currency_bells.id,
             'company_rate': 0.5,
             'inverse_company_rate': 2,


### PR DESCRIPTION
In `test_base_on_rule_currency_is_converted` we create a rate for a testing currency and check that is applied, but we don't specify its name/date, so under certain conditions it will considered as applying only tomorrow and the test will fail.

runbot-97969
