### PR TITLE
[FIX] mail: reload_on_attachment should not close attachment box

### DIFF
--- a/addons/mail/static/src/chatter/web/chatter_patch.js
+++ b/addons/mail/static/src/chatter/web/chatter_patch.js
@@ -128,7 +128,8 @@ patch(Chatter.prototype, {
                 } else {
                     this.state.showAttachmentLoading = false;
                     this.state.isAttachmentBoxOpened =
-                        this.props.isAttachmentBoxVisibleInitially && this.attachments.length > 0;
+                        this.state.isAttachmentBoxOpened ||
+                        (this.props.isAttachmentBoxVisibleInitially && this.attachments.length > 0);
                 }
                 return () => browser.clearTimeout(this.loadingAttachmentTimeout);
             },


### PR DESCRIPTION
**Current behavior before PR:**

prior to this PR after posting an attachment, if the attachment box was opened it closes after the reload.

**Desired behavior after PR is merged:**

this PR addresses this issue by updating the behavior to ensure that the attachment box remains open even after the reload.

task-4161477

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
