### PR TITLE
[FIX] account_edi_ubl_cii: prevent an error when confirm an invoice

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -153,7 +153,8 @@ class AccountEdiCommon(models.AbstractModel):
         customer = invoice.commercial_partner_id
 
         # add Norway, Iceland, Liechtenstein
-        european_economic_area = self.env.ref('base.europe').country_ids.mapped('code') + ['NO', 'IS', 'LI']
+        europe_country_group = self.env.ref('base.europe', raise_if_not_found=False)
+        european_economic_area = europe_country_group and europe_country_group.country_ids.mapped('code') + ['NO', 'IS', 'LI']
 
         if customer.country_id.code == 'ES' and customer.zip:
             if customer.zip[:2] in ('35', '38'):  # Canary
@@ -170,7 +171,7 @@ class AccountEdiCommon(models.AbstractModel):
             else:
                 return create_dict(tax_category_code='S')  # standard VAT
 
-        if supplier.country_id.code in european_economic_area and supplier.vat:
+        if european_economic_area and supplier.country_id.code in european_economic_area and supplier.vat:
             if tax.amount != 0:
                 # otherwise, the validator will complain because G and K code should be used with 0% tax
                 return create_dict(tax_category_code='S')


### PR DESCRIPTION
Currently, An error is generated when confirming an invoice, and Country Group  name  Europe is not available

Steps to reproduce:

- Install an 'account_reports' module.
- Navigate to Contacts / Configuration / Localization / Country Group, And Delete the country group name 'Europe'.
- Create a new tax, add name, amount, and set tax scope as goods.
- Create an invoice and confirm it.

```ValueError: External ID not found in the system: base.europe```

An error occurs when the system tries to retrieve an external id of the country group name Europe at [1], but it is not available.

Link [1]: https://github.com/odoo/odoo/blob/64a4ca83cd9b2f208c555942346bb62e31825266/addons/account_edi_ubl_cii/models/account_edi_common.py#L155-L156

To handle this issue, add 'raise_if_not_found=False' in ref() so that when country group name Europe is not available it will return a None value instead of traceback.

Sentry-5851989243

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
