### PR TITLE
[FIX] hw_drivers: fix browser refresh

### DIFF
--- a/addons/hw_drivers/browser.py
+++ b/addons/hw_drivers/browser.py
@@ -29,6 +29,7 @@ class Browser:
         self.url = url
         # helpers.get_version returns a string formatted as: <L|W><version> (L: Linux, W: Windows)
         self.browser = 'chromium-browser' if float(helpers.get_version()[1:]) >= MIN_IMAGE_VERSION else 'firefox'
+        self.browser_process_name = 'chromium' if self.browser == 'chromium-browser' else self.browser
         self._x_screen = _x_screen
         self._set_environment(env)
         self.kiosk_args = [
@@ -86,7 +87,7 @@ class Browser:
         """close the browser"""
         # Kill browser instance (can't `instance.pkill()` as we can't keep the instance after Odoo service restarts)
         # We need to terminate it because Odoo will create a new instance each time it is restarted.
-        subprocess.run(['pkill', self.browser.split('-')[0]], check=False)
+        subprocess.run(['pkill', self.browser_process_name], check=False)
 
     def xdotool_keystroke(self, keystroke):
         """
@@ -97,7 +98,7 @@ class Browser:
             'xdotool', 'search',
             '--sync', '--onlyvisible',
             '--screen', self._x_screen,
-            '--class', self.browser,
+            '--class', self.browser_process_name,
             'key', keystroke,
         ], check=False)
 
@@ -110,7 +111,7 @@ class Browser:
             'xdotool', 'search',
             '--sync', '--onlyvisible',
             '--screen', self._x_screen,
-            '--class', self.browser,
+            '--class', self.browser_process_name,
             'type', text,
         ], check=False)
 


### PR DESCRIPTION
The browser helper class uses the `xdotool`
command to send keypresses to the browser.
However for Chromium, it is using the wrong
process name causing the keystrokes not to
be received.

The symptom of this is the Pairing Code does
not disappear after 5 minutes as intended,
leaving an invalid code on the screen.

This PR fixes the issue by using the correct
process name for Chromium.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
