### PR TITLE
[FIX] l10n_in_{sale,purchase}_stock: fix price unit compute with different currency

### DIFF
--- a/addons/l10n_in_purchase_stock/models/stock_move.py
+++ b/addons/l10n_in_purchase_stock/models/stock_move.py
@@ -10,7 +10,14 @@ class StockMove(models.Model):
         self.ensure_one()
         if line_id := self.purchase_line_id:
             if qty := line_id.product_qty:
-                return line_id.price_subtotal / qty
+                company_id = line_id.company_id
+                return line_id.currency_id._convert(
+                    line_id.price_subtotal / qty,
+                    company_id.currency_id,
+                    company_id,
+                    self.date,
+                    round=False
+                )
             return 0.00
         return super()._l10n_in_get_product_price_unit()
 

--- a/addons/l10n_in_sale_stock/models/stock_move.py
+++ b/addons/l10n_in_sale_stock/models/stock_move.py
@@ -10,7 +10,14 @@ class StockMove(models.Model):
         self.ensure_one()
         if line_id := self.sale_line_id:
             if qty := line_id.product_uom_qty:
-                return line_id.price_subtotal / qty
+                company_id = line_id.company_id
+                return line_id.currency_id._convert(
+                    line_id.price_subtotal / qty,
+                    company_id.currency_id,
+                    company_id,
+                    self.date,
+                    round=False
+                )
             return 0.00
         return super()._l10n_in_get_product_price_unit()
 


### PR DESCRIPTION
Before this commit:
While generating E-waybill from a SO/PO with different currency the price unit in E-waybill is displayed incorrect in INR, the currency conversion rate is not applied and the price unit is displayed as it is in INR which is incorrect

After this commit:
We resolve the above issue. Now the currency conversation rate is applied correctly on the price unit while generating E-waybill from SO/PO

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
