### PR TITLE
[FIX] project: display project in search view when adding blocking task

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -58,7 +58,7 @@
                     <field name="user_ids" filter_domain="[('user_ids.name', 'ilike', self), ('user_ids.active', 'in', [True, False])]"/>
                 </field>
                 <field name="stage_id" position="after">
-                    <field name="project_id" string="Project" invisible="context.get('default_project_id')"/>
+                    <field name="project_id" string="Project"/>
                 </field>
                 <field name="partner_id" position="after">
                     <field name="company_id" groups="base.group_multi_company"/>
@@ -68,7 +68,7 @@
                     <filter string="Assignees" name="user" context="{'group_by': 'user_ids'}"/>
                 </filter>
                 <filter name="stage" position="after">
-                    <filter string="Project" name="project" context="{'group_by': 'project_id'}" invisible="context.get('default_project_id')"/>
+                    <filter string="Project" name="project" context="{'group_by': 'project_id'}"/>
                 </filter>
             </field>
         </record>


### PR DESCRIPTION
Before this commit, due to some changes in #153989, the project field is no longer displayed in the search view displayed in the modal displayed when the user would like to add a task as blocking task.

This commit reverts the invisible condition added on that field in the search since that change was not really needed for project sharing since project sharing feature does not really use that search view.

Steps to reproduce:
==================

1. Install project
2. Enable `Task dependencies` feature in Settings > Configuration of project app.
3. Create a project with `Task dependencies` feature enabled.
4. Add a new task in that project and click on `Add a line` in `Blocked By` tab inside the form view.
5. Search another project inside the search by taping the name of another project.

Current behavior
----------------

The project field is not in the search and so it is impossible to quickly search tasks in another project.

Expected behavior
-----------------

The project field should be displayed in the search view to be able to search tasks in another project instead of search in all projects (if the default filter is removed).
