### PR TITLE
[FIX] point_of_sale: Raise error on `stock.picking`  only when deactivating

### DIFF
--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -168,6 +168,8 @@ class StockPickingType(models.Model):
     @api.constrains('active')
     def _check_active(self):
         for picking_type in self:
+            if picking_type.active:
+                continue
             pos_config = self.env['pos.config'].sudo().search([('picking_type_id', '=', picking_type.id)], limit=1)
             if pos_config:
                 raise ValidationError(_("You cannot archive '%s' as it is used by a POS configuration '%s'.", picking_type.name, pos_config.name))


### PR DESCRIPTION
The active flag [can be included](https://github.com/odoo/odoo/blob/17.0/addons/mrp/models/stock_warehouse.py#L259-L277) in the values to update when calling function `_create_or_update_sequences_and_picking_types`, for example [during upgrades](https://github.com/odoo/upgrade/blob/master/migrations/stock/saas~17.3.1.1/end-migrate.py#L16).

This will raise the Validation Error even if the flag is being kept as active.

upg-2034998

