### PR TITLE
[FIX] point_of_sale: allow session opening with unloaded products

### DIFF
--- a/addons/point_of_sale/static/src/app/models/data_service.js
+++ b/addons/point_of_sale/static/src/app/models/data_service.js
@@ -147,7 +147,8 @@ export class PosData extends Reactive {
             );
         }
 
-        const results = this.models.loadData(data, [], true);
+        const missing = await this.missingRecursive(data);
+        const results = this.models.loadData(missing, [], true);
         for (const [model, data] of Object.entries(results)) {
             for (const record of data) {
                 if (record.raw.JSONuiState) {


### PR DESCRIPTION
Before this commit, changing a product's category, causing it to not load, would result in errors when loading orderlines from IndexedDB due to undefined product_id. This fix ensures missing products are loaded when retrieving orders from IndexedDB.

opw-4185964

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
