### PR TITLE
[FIX] account, purchase: accrued entry returned order

### DIFF
--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -185,7 +185,7 @@ class AccruedExpenseRevenue(models.TransientModel):
                         l.qty_to_invoice,
                         0,
                         precision_rounding=l.product_uom.rounding,
-                    ) == 1
+                    ) != 0
                 )
                 for order_line in lines:
                     if is_purchase:

--- a/addons/sale/tests/test_accrued_sale_orders.py
+++ b/addons/sale/tests/test_accrued_sale_orders.py
@@ -101,6 +101,7 @@ class TestAccruedSaleOrders(AccountTestInvoicingCommon):
         # delivered products invoiced, nothing to invoice left
         self.sale_order.with_context(default_invoice_date=self.wizard.date)._create_invoices().action_post()
         with self.assertRaises(UserError):
+            self.env['account.move.line']._invalidate_cache()
             self.wizard.create_entries()
         self.assertTrue(self.wizard.display_amount)
 


### PR DESCRIPTION
When returning a purchase/sale order, we can not create
accrued entry for the returned order

Steps:

- Create a purchase order
- Receive product
- Create and confirm bill
- Set received quantity to 0
- From the action menu, select "Accrued Expense Entry"
-> There is no line, it should be a line for the vendor credit not

This is because we filter the order lines to get only the lines
that have a positive quantity to invoice, in that case the quantity
to invoice is negative and should be taken into account

opw-4176706
