### PR TITLE
[FIX] pos_sale: link order to sale team

### DIFF
--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -19,7 +19,7 @@ class PosOrder(models.Model):
     @api.model
     def _complete_values_from_session(self, session, values):
         values = super(PosOrder, self)._complete_values_from_session(session, values)
-        values.setdefault('crm_team_id', session.config_id.crm_team_id.id)
+        values['crm_team_id'] = values['crm_team_id'] if values.get('crm_team_id') else session.config_id.crm_team_id.id
         return values
 
     @api.depends('date_order', 'company_id')

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -263,3 +263,16 @@ registry.category("web_tour.tours").add("PosShipLaterNoDefault", {
             Utils.negateStep(PaymentScreen.shippingLaterHighlighted()),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("PosSaleTeam", {
+    test: true,
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            ProductScreen.clickDisplayedProduct("Test Product"),
+            ProductScreen.totalAmountIs("100.00"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+        ].flat(),
+});

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -735,3 +735,18 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         self.main_pos_config.write({'ship_later': True})
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosShipLaterNoDefault', login="accountman")
+
+    def test_order_sale_team(self):
+        self.env['product.product'].create({
+            'name': 'Test Product',
+            'available_in_pos': True,
+            'lst_price': 100.0,
+            'taxes_id': False,
+        })
+        sale_team = self.env['crm.team'].create({'name': 'Test team'})
+        self.main_pos_config.write({'crm_team_id': sale_team})
+        self.main_pos_config.open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosSaleTeam', login="accountman")
+        order = self.env['pos.order'].search([])
+        self.assertEqual(len(order), 1)
+        self.assertEqual(order.crm_team_id, sale_team)


### PR DESCRIPTION
Currently, if you have a sale team related to a shop, making an order will not link the sale team to the order.

Steps to reproduce:
-------------------
* Go to the **Point of sale** App
* Go into settings
* Under **Sale team** select any team
* Open the related shop session
* Make an order
* Invoice it right after paying.
* Go to the **Accounting App**
* Select **Customer** then **Invoices**
* Select the related invoice
* Select the tab **Extra info**
> Observation: The sale team is not set.

Why the fix:
------------
When generating the invoice we are supposed to set the sale team with https://github.com/odoo/odoo/blob/ce73a1e19f19526b59bde9cebe2751102e2d8b27/addons/pos_sale/models/pos_order.py#L22

With `values` a dictionnary. In saas-17.4, the key `crm_team_id` is present in the dictionnary, but is `false`.

Since `setdefault` will not perform any change to a dictionnary if the key is already present inside, the value is not set with the `crm_team_id` from the config. We do not want to change this as `values['crm_team_id']=...` as it would systematically override the value and in the case when we settle an order we still want to use the sale team associated to that order.

Why is `values['crm_team_id']` false? Because the order in the shop has the field `crm_team_id` available but it's `undefined` because not loaded to the session.
https://github.com/odoo/odoo/blob/8dd35e194e54fd364100d57b32b8aff7b5ffec35/addons/point_of_sale/static/src/app/store/pos_store.js#L993-L995

What we do with this fix is to load the value of the sale team set in config to the shop and we set the value for every new order.

opw-4151736
