### PR TITLE
[FIX] point_of_sale: handle missing l10n_in_hsn_code gracefully

### DIFF
--- a/addons/l10n_in_pos/static/src/overrides/models/pos_order_line.js
+++ b/addons/l10n_in_pos/static/src/overrides/models/pos_order_line.js
@@ -4,7 +4,7 @@ import { patch } from "@web/core/utils/patch";
 
 patch(PosOrderline.prototype, {
     setup(vals) {
-        this.l10n_in_hsn_code = this.product_id.l10n_in_hsn_code;
+        this.l10n_in_hsn_code = this.product_id.l10n_in_hsn_code || "";
         return super.setup(...arguments);
     },
     getDisplayData() {


### PR DESCRIPTION
Before this commit, adding a product without the l10n_in_hsn_code field to an order would cause an error, as the system expected this field to be a string.

opw-4183959

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
