### PR TITLE
[FIX] product, sale_pdf_quote_builder: fix error when configure dynamic fields  

### DIFF
--- a/addons/product/i18n/product.pot
+++ b/addons/product/i18n/product.pot
@@ -2118,6 +2118,15 @@ msgid ""
 msgstr ""
 
 #. module: product
+#. odoo-python
+#: code:addons/product/models/product_document.py:0
+msgid ""
+"Please upload a pdf File.\n"
+"\n"
+" Invalid file: %s"
+msgstr ""
+
+#. module: product
 #: model:ir.model.fields.selection,name:product.selection__res_config_settings__product_weight_in_lbs__1
 msgid "Pounds"
 msgstr ""

--- a/addons/product/models/product_document.py
+++ b/addons/product/models/product_document.py
@@ -32,6 +32,15 @@ class ProductDocument(models.Model):
                     attachment.url
                 ))
 
+    @api.onchange('datas')
+    def _onchange_datas(self):
+        for attachment in self:
+            attachment_name = attachment.ir_attachment_id.name
+            if attachment.datas and not attachment_name.endswith('pdf'):
+                raise ValidationError(_(
+                    "Please upload a pdf File.\n\n Invalid file: %s", attachment_name
+                ))
+
     #=== CRUD METHODS ===#
 
     @api.model_create_multi

--- a/addons/sale_pdf_quote_builder/i18n/sale_pdf_quote_builder.pot
+++ b/addons/sale_pdf_quote_builder/i18n/sale_pdf_quote_builder.pot
@@ -311,6 +311,12 @@ msgid ""
 msgstr ""
 
 #. module: sale_pdf_quote_builder
+#. odoo-python
+#: code:addons/sale_pdf_quote_builder/utils.py:0
+msgid "Unable to read the File Content or %s."
+msgstr ""
+
+#. module: sale_pdf_quote_builder
 #: model_terms:ir.ui.view,arch_db:sale_pdf_quote_builder.dynamic_fields_wizard
 msgid "Validate"
 msgstr ""

--- a/addons/sale_pdf_quote_builder/utils.py
+++ b/addons/sale_pdf_quote_builder/utils.py
@@ -7,6 +7,11 @@ from odoo import _
 from odoo.exceptions import ValidationError
 from odoo.tools import pdf
 
+try:
+    from PyPDF2.errors import PdfReadError
+except ImportError:
+    from PyPDF2.utils import PdfReadError
+
 
 def _ensure_document_not_encrypted(document):
     if pdf.PdfFileReader(io.BytesIO(document), strict=False).isEncrypted:
@@ -24,6 +29,9 @@ def _get_form_fields_from_pdf(pdf_data):
     :return: set of form fields that are in the pdf.
     :rtype: set
     """
-    reader = pdf.PdfFileReader(io.BytesIO(base64.b64decode(pdf_data)))
+    try:
+        reader = pdf.PdfFileReader(io.BytesIO(base64.b64decode(pdf_data)))
+    except PdfReadError as e:
+        raise ValidationError(_("Unable to read the File Content or %s.", e))
 
     return set(reader.getFields() or '')

--- a/addons/sale_pdf_quote_builder/views/product_document_views.xml
+++ b/addons/sale_pdf_quote_builder/views/product_document_views.xml
@@ -10,6 +10,7 @@
                 <button
                     name="action_open_dynamic_fields_wizard"
                     type="object"
+                    invisible="type == 'url'"
                     string="Configure dynamic fields"
                     help="Configure the path to fill the form fields."
                     class="btn-link"


### PR DESCRIPTION
Currently, an error occurs when configuring dynamic fields in the product document and file content is empty or the URL which is given as a file content not valid.

Step to produce:

- Install the 'sale_pdf_quote_builder' module.
- Navigate to Sales / Products / Product Variants.
- Click on the Documents button, And create a new product document.
- Add a name and set a type as URL and add an invalid URL with the right
URL domains like https://xyz.odoo.com/.
- Click on 'Configure dynamic fields'.

```EmptyFileError: Cannot read an empty file```

An error occurs when the system tries to read file content through the PDF file reader at [1]. But it is empty.

Link [1]:https://github.com/odoo/odoo/blob/ce73a1e19f19526b59bde9cebe2751102e2d8b27/addons/sale_pdf_quote_builder/utils.py#L27

Add validation for file content on the product.document to only accept PDF file and also add a try-except block to raise a validation error if an error occurs during PDF file reading, Additionally hide the 'Configure Dynamic Fields' button if a type is set to 'URL'.

Sentry-5795555265