### PR TITLE
[FIX] mail: update activity view after creating multiple activities

### DIFF
--- a/addons/mail/static/src/js/views/activity/activity_controller.js
+++ b/addons/mail/static/src/js/views/activity/activity_controller.js
@@ -78,9 +78,12 @@ var ActivityController = BasicController.extend({
                 const messaging = await owl.Component.env.services.messaging.get();
                 const thread = messaging.models['Thread'].insert({ id: resIds[0], model: this.model.modelName });
                 await messaging.openActivityForm({ thread });
-                this.trigger_up('reload');
             },
-        });
+        },
+        {
+            onClose: () => this.trigger_up("reload"),
+        }
+    );
     },
     /**
      * @private


### PR DESCRIPTION
Before this commit:
When a user creates multiple scheduled activities and clicks the "Close" button the newly created activities are not updated in the activity view.

After this commit:
When a user creates multiple scheduled activities and clicks the "Close" button, the newly created activities should update and visible in the activity view.

Task-4057815