### PR TITLE
[IMP] {sale_,}project: small improvements in project form

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -365,7 +365,7 @@ class ProjectProject(models.Model):
     def _compute_access_instruction_message(self):
         for project in self:
             if project.privacy_visibility == 'portal':
-                project.access_instruction_message = _('Grant portal users access to your project by adding them as followers (the tasks of the project are not included). To grant access to tasks to a portal user, add them as followers for these tasks.')
+                project.access_instruction_message = _('To give portal users access to your project, add them as followers. For task access, add them as followers for each task.')
             elif project.privacy_visibility == 'followers':
                 project.access_instruction_message = _('Grant employees access to your project or tasks by adding them as followers. Employees automatically get access to the tasks they are assigned to.')
             else:

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -85,31 +85,31 @@
                         <page name="settings" string="Settings">
                             <group>
                                 <group>
-                                    <field name="privacy_visibility" widget="radio"/>
-                                    <span colspan="2" class="text-muted o_row ps-1" invisible="access_instruction_message == ''">
-                                        <i class="fa fa-lightbulb-o"/>&amp;nbsp;<field class="d-inline" name="access_instruction_message" nolabel="1"/>
-                                    </span>
-                                    <span colspan="2" class="text-muted o_row ps-1" invisible="privacy_visibility_warning == ''">
-                                        <i class="fa fa-warning"/>&amp;nbsp;<field class="d-inline" name="privacy_visibility_warning" nolabel="1"/>
-                                    </span>
-                                </group>
-                                <group>
-                                    <div name="alias_def" colspan="2" class="pb-2">
-                                        <!-- Always display the whole alias in edit mode. It depends in read only -->
-                                        <!-- Need to add alias_id in view for getting alias_domain_id by default -->
-                                        <field name="alias_id" invisible="1"/>
-                                        <label for="alias_name" class="fw-bold o_form_label" string="Create tasks by sending an email to"/>
-                                        <field name="alias_email" class="oe_read_only d-inline" widget="email" readonly="1" invisible="not alias_name" />
-                                        <span class="oe_edit_only o_row">
-                                            <field name="alias_name" placeholder="alias"/>@
-                                            <field name="alias_domain_id" class="oe_inline" placeholder="e.g. mycompany.com"
-                                                   options="{'no_create': True, 'no_open': True}"/>
-                                        </span>
+                                    <!-- Always display the whole alias in edit mode. It depends in read only -->
+                                    <!-- Need to add alias_id in view for getting alias_domain_id by default -->
+                                    <field name="alias_id" invisible="1"/>
+                                    <label for="alias_name" string="Email Alias"/>
+                                    <field name="alias_email" widget="email" readonly="1" nolabel="1" groups="!project.group_project_manager"/>
+                                    <div class="d-inline-flex" groups="project.group_project_manager">
+                                        <field name="alias_name" placeholder="alias"/>@
+                                        <field name="alias_domain_id" placeholder="e.g. mycompany.com"
+                                            options="{'no_create': True, 'no_open': True}"/>
                                     </div>
                                     <!-- the alias contact must appear when the user start typing and it must disappear
                                         when the string is deleted. -->
                                     <field name="alias_contact" class="oe_inline" string="Accept Emails From"
                                            invisible="not alias_email"/>
+                                    <field name="privacy_visibility" widget="radio"/>
+                                    <span colspan="2" class="text-muted o_row ps-1" invisible="access_instruction_message == ''">
+                                        <i class="fa fa-lightbulb-o pe-2" title="Info"/><field class="d-inline" name="access_instruction_message" nolabel="1"/>
+                                    </span>
+                                    <span colspan="2" class="text-muted o_row ps-1" invisible="privacy_visibility_warning == ''">
+                                        <i class="fa fa-warning pe-2" title="Warning"/><field class="d-inline" name="privacy_visibility_warning" nolabel="1"/>
+                                    </span>
+                                </group>
+                                <group name="analytic">
+                                    <div class="o_horizontal_separator text-uppercase fw-bolder small mb-3" groups="analytic.group_analytic_accounting">analytic</div>
+                                    <field name="account_id" groups="analytic.group_analytic_accounting"/>
                                 </group>
                                 <group name="extra_settings">
                                 </group>
@@ -151,13 +151,6 @@
                                             </div>
                                         </setting>
                                     </div>
-                                </group>
-                            </group>
-                        </page>
-                        <page name="analytic" string="Analytic" groups="analytic.group_analytic_accounting">
-                            <group>
-                                 <group>
-                                    <field name="account_id"/>
                                 </group>
                             </group>
                         </page>

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -118,7 +118,7 @@
                     </div>
                 </group>
             </xpath>
-            <xpath expr="//page[@name='settings']//field[@name='privacy_visibility']" position="before">
+            <xpath expr="//group[@name='analytic']//div" position="before">
                 <field name="reinvoiced_sale_order_id" invisible="not allow_billable or not partner_id"/>
                 <label for="sale_line_id" invisible="not allow_billable or not partner_id"/>
                 <div 


### PR DESCRIPTION
- Removed the 'Analytic' notebook and moved the analytic plans to a dedicated 'Analytic' section within the 'Settings' notebook.
- Made the 'Analytic' section title invisible when the user lacks the access rights to view the fields underneath.
- Moved the 'Visibility' field to be placed under the 'Email Alias' field.
- Renamed the 'Create tasks by sending an email to' label to 'Email Alias' and aligned the input field to the right of the label.
- Updated the tooltip for portal user access: "To give portal users access to your project, add them as followers. For task access, add them as followers for each task."

task-4188338



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
