### PR TITLE
[FIX] point_of_sale: fix order state after payment

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -348,7 +348,8 @@ export class PaymentScreen extends Component {
                 );
 
                 if (printResult && this.pos.config.iface_print_skip_screen) {
-                    this.currentOrder.set_screen_data({ name: "ReceiptScreen" });
+                    this.currentOrder.uiState.screen_data["value"] = "";
+                    this.currentOrder.uiState.locked = true;
                     this.pos.add_new_order();
                     nextScreen = "ProductScreen";
                 }


### PR DESCRIPTION
When automatic receipt printing is set, the order screen_state wasn't correctly set. This commit fixes the issue by setting the screen_state to empty string after the payment is done.
