### PR TITLE
[FIX] gamification: fix traceback when user deletes a module having gamification record

### DIFF
--- a/addons/gamification/models/gamification_goal_definition.py
+++ b/addons/gamification/models/gamification_goal_definition.py
@@ -33,7 +33,7 @@ class GoalDefinition(models.Model):
         ('progress', "Progressive (using numerical values)"),
         ('boolean', "Exclusive (done or not-done)"),
     ], default='progress', string="Displayed as", required=True)
-    model_id = fields.Many2one('ir.model', string='Model')
+    model_id = fields.Many2one('ir.model', string='Model', ondelete='cascade')
     model_inherited_ids = fields.Many2many('ir.model', related='model_id.inherited_model_ids')
     field_id = fields.Many2one(
         'ir.model.fields', string='Field to Sum',


### PR DESCRIPTION
Currently, a traceback occurs when the user deletes a module which is having a gamification goal record.

To reproduce this issue:

1) Install `sale` and `gamification`
2) Create a new `gamification challenge` record
3) Create a new `goal` in the gamification challenge 
4) Make sure the goal has the definition as `Automatic: sum on a field` 
5) Select the model as `account`
6) Uninstall the invoicing module and start the `challenge` of that gamification.

Error:- 
```
KeyError: False
```

The value of the model_id became `False` when the user deletes a module used in goal.

This leads to a traceback as model_id is used for the reference of obj 

https://github.com/odoo/odoo/blob/d9603e93d2ab5e0b9fd1948dfd3e3bee20ede599/addons/gamification/models/gamification_goal.py#L164-L165

We can resolve this issue by adding `ondelete='cascade'` in the field
definition. Where the record will be deleted if the corresponding model is 
uninstalled.  

sentry-4089991441
