### PR TITLE
[FIX] account: consider subsequent tax and tags only when next tax is_base_affected is True

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -979,6 +979,8 @@ class AccountTax(models.Model):
             if batch['include_base_amount']:
                 for next_batch in ascending_batches[i + 1:]:
                     for next_tax_data in next_batch['taxes']:
+                        if not next_tax_data['is_base_affected']:
+                            continue
                         subsequent_tax_ids.append(next_tax_data['id'])
                         if include_caba_tags or next_tax_data['tax_exigibility'] != 'on_payment':
                             for tag_id in next_tax_data[base_tags_field]:

--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -303,6 +303,9 @@ export const accountTaxHelpers = {
             if (batch.include_base_amount) {
                 for (const next_batch of ascending_batches.toSpliced(0, i + 1)) {
                     for (const next_tax_data of next_batch.taxes) {
+                        if (!next_tax_data.is_base_affected) {
+                            continue;
+                        }
                         subsequent_tax_ids.push(next_tax_data.id);
                         if (include_caba_tags || next_tax_data.tax_exigibility !== "on_payment") {
                             for (const tag_id of next_tax_data[base_tags_field]) {

--- a/addons/account/tests/test_invoice_taxes.py
+++ b/addons/account/tests/test_invoice_taxes.py
@@ -734,3 +734,82 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
             'credit': 10.0,
             'debit': 0,
         }])
+
+    def test_is_base_affected(self):
+        include_base_amount_true_tax = self.env['account.tax'].create({
+            'name': 'Test 5 set affect Base of Subsequent Taxes',
+            'amount_type': 'percent',
+            'amount': 5,
+            'include_base_amount': True,
+            'sequence': 1,
+            'invoice_repartition_line_ids': [
+                (0, 0, {
+                    'repartition_type': 'base',
+                    'tag_ids': [(6, 0, self.base_tag_pos.ids)],
+                }),
+                (0, 0, {
+                    'repartition_type': 'tax',
+                    'tag_ids': [(6, 0, self.tax_tag_pos.ids)],
+                }),
+            ],
+            'refund_repartition_line_ids': [
+                (0, 0, {
+                    'repartition_type': 'base',
+                    'tag_ids': [(6, 0, self.base_tag_neg.ids)],
+                }),
+                (0, 0, {
+                    'repartition_type': 'tax',
+                    'tag_ids': [(6, 0, self.tax_tag_neg.ids)],
+                }),
+            ],
+        })
+
+        # No Base Affected by Previous Taxes
+        is_base_affected_false_tax = include_base_amount_true_tax.copy({
+            'name': 'Test 10 Not set Base Affected by Previous Taxes',
+            'amount': 10,
+            'is_base_affected': False,
+            'sequence': 3,
+        })
+        invoice = self._create_invoice([
+            (100, include_base_amount_true_tax + is_base_affected_false_tax),
+        ])
+        self.assertRecordValues(invoice.line_ids.filtered('tax_line_id'), [
+            {
+                'tax_ids': [],
+                'tax_tag_ids': self.tax_tag_pos.ids,
+                'tax_base_amount': 100,
+                'balance': -5,
+            },
+            {
+                'tax_ids': [],
+                'tax_tag_ids': self.tax_tag_pos.ids,
+                'tax_base_amount': 100,
+                'balance': -10,
+            },
+        ])
+
+        # No Base Affected by Previous Taxes
+        is_base_affected_true_tax = include_base_amount_true_tax.copy({
+            'name': 'Test 10 set Base Affected by Previous Taxes',
+            'amount': 10,
+            'is_base_affected': True,
+            'sequence': 2,
+        })
+        invoice = self._create_invoice([
+            (100, include_base_amount_true_tax + is_base_affected_true_tax),
+        ])
+        self.assertRecordValues(invoice.line_ids.filtered('tax_line_id'), [
+            {
+                'tax_ids': is_base_affected_true_tax.ids,
+                'tax_tag_ids': self.tax_tag_pos.ids + self.base_tag_pos.ids,
+                'tax_base_amount': 100,
+                'balance': -5,
+            },
+            {
+                'tax_ids': [],
+                'tax_tag_ids': self.tax_tag_pos.ids,
+                'tax_base_amount': 105,
+                'balance': -10.5,
+            },
+        ])


### PR DESCRIPTION
we have the same functionality before this commit https://github.com/odoo/odoo/commit/ab0bdf0192120671010634978f202da35ddfc79f


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
