### PR TITLE
[IMP] web_editor,website: remove banner from website

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/powerbox/Powerbox.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/powerbox/Powerbox.js
@@ -20,6 +20,7 @@ function cycle(num, max) {
  *     fontawesome: string; // a fontawesome class name
  *     callback: () => void; // to execute when the command is picked
  *     isDisabled?: () => boolean; // return true to disable the command
+ *     keywords: Array<String> // to add synonyms for command
  * }
  */
 
@@ -347,7 +348,9 @@ export class Powerbox {
                     this._context.filteredCommands = this._context.commands.filter(command => {
                         const commandText = (command.category + ' ' + command.name);
                         const commandDescription = command.description.replace(/\s/g, '');
-                        return commandText.match(fuzzyRegex) || commandDescription.match(exactRegex);
+                        return commandText.match(fuzzyRegex)
+                            || commandDescription.match(exactRegex)
+                            || command.keywords?.some(keyword => exactRegex.test(keyword));
                     });
                 } else {
                     this._context.filteredCommands = this._context.commands;

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -2449,6 +2449,33 @@ export class Wysiwyg extends Component {
             },
         }
     }
+    /**
+     * Retrieves an array of banner command objects, each representing a specific
+     * type of banner (info, success, warning, danger) that can be inserted.
+     * Each banner command contains detail such as the label, type, icon,
+     * description, and priority.
+     *
+     * @returns {Array}
+     */
+    _getBannerCommands() {
+        return [
+            this._getBannerCommand(_t("Banner Info"), "info", "fa-info-circle", _t("Insert an info banner"), 24),
+            this._getBannerCommand(_t("Banner Success"), "success", "fa-check-circle", _t("Insert a success banner"), 23),
+            this._getBannerCommand(_t("Banner Warning"), "warning", "fa-exclamation-triangle", _t("Insert a warning banner"), 22),
+            this._getBannerCommand(_t("Banner Danger"), "danger", "fa-exclamation-circle", _t("Insert a danger banner"), 21)
+        ];
+    }
+    /**
+     * Returns an array containing a banner category object with a
+     * name and priority value.
+     *
+     * @returns {Array}
+     */
+    _getBannerCategory() {
+        return [
+            { name: _t("Banners"), priority: 65 }
+        ];
+    }
     _insertSnippetMenu() {
         return this.snippetsMenu.insertBefore(this.$el);
     }
@@ -2494,12 +2521,9 @@ export class Wysiwyg extends Component {
     }
     _getPowerboxOptions() {
         const editorOptions = this.options;
-        const categories = [{ name: _t('Banners'), priority: 65 },];
+        const categories = [...this._getBannerCategory()];
         const commands = [
-            this._getBannerCommand(_t('Banner Info'), 'info', 'fa-info-circle', _t('Insert an info banner'), 24),
-            this._getBannerCommand(_t('Banner Success'), 'success', 'fa-check-circle', _t('Insert a success banner'), 23),
-            this._getBannerCommand(_t('Banner Warning'), 'warning', 'fa-exclamation-triangle', _t('Insert a warning banner'), 22),
-            this._getBannerCommand(_t('Banner Danger'), 'danger', 'fa-exclamation-circle', _t('Insert a danger banner'), 21),
+            ...this._getBannerCommands(),
             {
                 category: _t('Structure'),
                 name: _t('Quote'),

--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -328,6 +328,12 @@ export class WysiwygAdapterComponent extends Wysiwyg {
         this._setObserver();
         this.odooEditor.observerActive();
     }
+    _getBannerCommands() {
+        return [];
+    }
+    _getBannerCategory() {
+        return [];
+    }
     /**
      * Stop the widgets and save the content.
      *
@@ -784,6 +790,7 @@ export class WysiwygAdapterComponent extends Wysiwyg {
                 priority: 100,
                 description: _t('Insert an alert snippet'),
                 fontawesome: 'fa-info',
+                keywords: ["banner", "info", "success", "warning", "danger"],
                 isDisabled: () => !this.odooEditor.isSelectionInBlockRoot(),
                 callback: () => {
                     snippetCommandCallback('.oe_snippet_body[data-snippet="s_alert"]');

--- a/addons/website/static/tests/tours/powerbox_snippet.js
+++ b/addons/website/static/tests/tours/powerbox_snippet.js
@@ -1,0 +1,80 @@
+/** @odoo-module **/
+
+import wTourUtils from "@website/js/tours/tour_utils";
+
+wTourUtils.registerWebsitePreviewTour("website_powerbox_snippet", {
+    edition: true,
+    test: true,
+}, () => [
+    wTourUtils.dragNDrop({
+        id: "s_text_block",
+        name: "Text",
+    }), {
+        content: "Check if s_text_block snippet is inserted",
+        trigger: "iframe .s_text_block",
+        run: () => {},
+    }, {
+        content: "Select the last paragraph",
+        trigger: "iframe .s_text_block p:last-child",
+    }, {
+        content: "Show the powerbox",
+        trigger: "iframe .s_text_block p:last-child",
+        run: function(actions) {
+            actions.text(`/`, this.$anchor[0]);
+            const wrapwrapEl = this.$anchor[0].closest("#wrapwrap");
+            wrapwrapEl.dispatchEvent(
+                new InputEvent("input", {
+                    inputType: "insertText",
+                    data: "/",
+                })
+            );
+        },
+    }, {
+        content: "Initially alert snippet should be present in the powerbox",
+        trigger: ".oe-powerbox-wrapper .oe-powerbox-commandName:contains('Alert')",
+        run: () => {},
+    }, {
+        content: "Change the content to '/table' so that alert snippet should not be present in the powerbox",
+        trigger: "iframe .s_text_block p:last-child",
+        run: function() {
+            const wrapwrapEl = this.$anchor[0].closest("#wrapwrap");
+            this.$anchor[0].textContent = "/table";
+            wrapwrapEl.ownerDocument.dispatchEvent(
+                new KeyboardEvent('keyup', {
+                    key: 'DummyKey',
+                    code: 'KeyDummy',
+                    cancelable: true,
+                })
+            );
+        },
+    }, {
+        content: "Alert snippet should not be present in the powerbox",
+        trigger: ".oe-powerbox-wrapper .oe-powerbox-commandName:not(:contains('Alert'))",
+        run: () => {},
+    }, {
+        content: "Change the content to '/banner'",
+        trigger: "iframe .s_text_block p:last-child",
+        run: function() {
+            const wrapwrapEl = this.$anchor[0].closest("#wrapwrap");
+            this.$anchor[0].textContent = "/banner";
+            wrapwrapEl.ownerDocument.dispatchEvent(
+                new KeyboardEvent('keyup', {
+                    key: 'DummyKey',
+                    code: 'KeyDummy',
+                    cancelable: true,
+                })
+            );
+        },
+    }, {
+        content: "Alert snippet should be present in the powerbox",
+        trigger: ".oe-powerbox-wrapper .oe-powerbox-commandName:contains('Alert')",
+        run: () => {},
+    }, {
+        content: "Click on the alert snippet",
+        trigger: ".oe-powerbox-wrapper .oe-powerbox-commandName:contains('Alert')",
+    }, {
+        content: "Check if s_alert snippet is inserted",
+        trigger: "iframe .s_alert",
+        run: () => {},
+    }
+]);


### PR DESCRIPTION
This commit removes four banner-related commands: Banner Info, Banner Success, Banner Warning, and Banner Danger. These commands have been removed in favor of using the Alert command, which offers the same functionality through a fully customizable Alert snippet. Now, when users search for terms like 'Banner', 'Info', 'Success', 'Warning' or 'Danger', the Alert command will appear in the Powerbox instead of the previous banner commands.


task-3572344


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
