### PR TITLE
[IMP] spreadsheet: Placeholder for chart datasources

### DIFF
--- a/addons/spreadsheet/static/src/chart/plugins/odoo_chart_core_plugin.js
+++ b/addons/spreadsheet/static/src/chart/plugins/odoo_chart_core_plugin.js
@@ -4,6 +4,7 @@ import { checkFilterFieldMatching } from "@spreadsheet/global_filters/helpers";
 import { CommandResult } from "../../o_spreadsheet/cancelled_reason";
 import { Domain } from "@web/core/domain";
 import { OdooCorePlugin } from "@spreadsheet/plugins";
+import { _t } from "@web/core/l10n/translation";
 
 /**
  * @typedef {Object} Chart
@@ -11,6 +12,12 @@ import { OdooCorePlugin } from "@spreadsheet/plugins";
  *
  * @typedef {import("@spreadsheet").FieldMatching} FieldMatching
  */
+
+const CHART_PLACEHOLDER_DISPLAY_NAME = {
+    odoo_bar: _t("Odoo Bar Chart"),
+    odoo_line: _t("Odoo Line Chart"),
+    odoo_pie: _t("Odoo Pie Chart"),
+};
 
 export class OdooChartCorePlugin extends OdooCorePlugin {
     static getters = /** @type {const} */ ([
@@ -108,9 +115,9 @@ export class OdooChartCorePlugin extends OdooCorePlugin {
      * @returns {string}
      */
     getOdooChartDisplayName(chartId) {
-        return `(#${this.getOdooChartIds().indexOf(chartId) + 1}) ${
-            this.getters.getChart(chartId).title.text
-        }`;
+        const { title, type } = this.getters.getChart(chartId);
+        const name = title.text || CHART_PLACEHOLDER_DISPLAY_NAME[type];
+        return `(#${this.getOdooChartIds().indexOf(chartId) + 1}) ${name}`;
     }
 
     /**

--- a/addons/spreadsheet/static/tests/charts/model/odoo_chart_plugin.test.js
+++ b/addons/spreadsheet/static/tests/charts/model/odoo_chart_plugin.test.js
@@ -652,6 +652,23 @@ test("Remove odoo chart when sheet is deleted", async () => {
     expect(model.getters.getOdooChartIds().length).toBe(0);
 });
 
+test("Odoo chart datasource display name has a default when the chart title is empty", async () => {
+    const { model } = await createSpreadsheetWithChart({ type: "odoo_line" });
+    const sheetId = model.getters.getActiveSheetId();
+    const chartId = model.getters.getChartIds(sheetId)[0];
+    const definition = model.getters.getChartDefinition(chartId);
+    expect(model.getters.getOdooChartDisplayName(chartId)).toBe("(#1) Partners");
+    model.dispatch("UPDATE_CHART", {
+        definition: {
+            ...definition,
+            title: { text: "" },
+        },
+        id: chartId,
+        sheetId,
+    });
+    expect(model.getters.getOdooChartDisplayName(chartId)).toBe("(#1) Odoo Line Chart");
+});
+
 test("See records when clicking on a bar chart bar", async () => {
     const action = {
         domain: [


### PR DESCRIPTION
Currently, we will use the chart title to generate the related datasource display name. However, if we decide to empty the chart title, then the datasource display name will be empty as well.

This revision adds a placeholder to be used in  those cases.

task-4187464

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
