### PR TITLE
[FIX] l10n_es_edi_facturae: restore item descritpion

### DIFF
--- a/addons/l10n_es_edi_facturae/models/account_move.py
+++ b/addons/l10n_es_edi_facturae/models/account_move.py
@@ -304,7 +304,7 @@ class AccountMove(models.Model):
                 'ReceiverTransactionReference': receiver_transaction_reference,
                 'FileReference': self.ref[:20] if self.ref else False,
                 'FileDate': fields.Date.context_today(self),
-                'ItemDescription': line.product_id.display_name or line.name,
+                'ItemDescription': line.name,
                 'Quantity': line.quantity,
                 'UnitOfMeasure': line.product_uom_id.l10n_es_edi_facturae_uom_code,
                 'UnitPriceWithoutTax': line.currency_id.round(price_before_discount / line.quantity if line.quantity else 0.),


### PR DESCRIPTION
Steps to reproduce:
- Switch to ES company
- Products > Sales tab > Add sales description
- Invoice that product > Confirm
- Send & Print > Tick 'Generate Facturae edi file'
- Download the xml facturae file
- ItemDescription only contains the product name

We expect the ItemDescription to contain the product's sale description as well, which is the behavior of versions 17.2 and prior. The change was introduced in 4f325ef620263c27e095eb49026a677ac617a0ee.

opw-4181520

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
