### PR TITLE
[FIX] web: fix unexpected behavior of userId

### DIFF
--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -182,7 +182,7 @@ class Http(models.AbstractModel):
             'is_system': user._is_system() if session_uid else False,
             'is_public': user._is_public(),
             'is_website_user': user._is_public() if session_uid else False,
-            'uid': session_uid,
+            'uid': session_uid or False,
             'is_frontend': True,
             'profile_session': request.session.profile_session,
             'profile_collectors': request.session.profile_collectors,


### PR DESCRIPTION
Versions:
------------
18.0

Steps to Reproduce:
----------------------------
1. Send user's document for sign.
2. Now sign the document without login
3. you will get access right error, after signing

Issue:
----------
session expiration popup appears unexpectedly.

Cause:
------------
due to recent improvements, the userId is not being retrieved as expected null is being retrieved instead of false.

Solution:
------------
pass uid false if there nothing found.

task-4178827
