### PR TITLE
[FIX] account_edi_ubl_cii: Fill the company_registry if no SIRET

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
@@ -159,7 +159,7 @@ class AccountEdiXmlCII(models.AbstractModel):
         else:
             seller_siret = invoice.company_id.company_registry
 
-        buyer_siret = False
+        buyer_siret = invoice.commercial_partner_id.company_registry
         if 'siret' in invoice.commercial_partner_id._fields and invoice.commercial_partner_id.siret:
             buyer_siret = invoice.commercial_partner_id.siret
         template_values = {


### PR DESCRIPTION
In Factur-X, it is sometimes required to specify the SIRET (using the node `SpecifiedLegalOrganization`).

The SIRET is a field appearing when l10n_fr is installed. In addition, in 17.0, it only appears if the current company has the French CoA installed. Hence, it is not possible to specify a SIRET on a French partner if the company is Belgian, for instance.

To fix this, we also use the company_registry to fill the SIRET node in the xml. In master, we intend to remove the SIRET field, as we should have used the company_registry from the beginning instead.

opw-4174309