### PR TITLE
[IMP] account: Add field currency_code

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -441,6 +441,7 @@ class AccountMove(models.Model):
         required=True,
         compute='_compute_currency_id', inverse='_inverse_currency_id', store=True, readonly=False, precompute=True,
     )
+    currency_code = fields.Char(related='currency_id.name', string="Currency code")
     invoice_currency_rate = fields.Float(
         string='Currency Rate',
         compute='_compute_invoice_currency_rate', store=True, precompute=True,


### PR DESCRIPTION
During SEPA Direct Debit refactoring, the need to check a move or payment currency to be in Euros
arose.

We add the related field to the base account module, as it may be required by other child modules later

task-id: 3722517



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
