### PR TITLE
[FIX] uom: map missing UNSPSC codes

### DIFF
--- a/addons/uom/data/uom_data.xml
+++ b/addons/uom/data/uom_data.xml
@@ -78,7 +78,7 @@
     </record>
 
     <!-- SURFACE -->
-    <record id="uom_square_meter" model="uom.uom">
+    <record id="product_uom_square_meter" model="uom.uom">
         <field name="name">m²</field>
         <field name="category_id" ref="uom_categ_surface"/>
         <field name="factor" eval="1.0"/>
@@ -163,7 +163,7 @@
     </record>
 
     <!-- SURFACE -->
-    <record id="uom_square_foot" model="uom.uom">
+    <record id="product_uom_square_foot" model="uom.uom">
         <field name="name">ft²</field>
         <field name="category_id" ref="uom_categ_surface"/>
         <field name="factor">10.76391</field>


### PR DESCRIPTION
Problem:
The UNSPSC codes for "Square meter" and "Square foot" were not mapped correctly.

Steps to reproduce:
- Navigate to Purchase > Configuration > UoM categories > Surface.
- There is no UNSPSC Category assigned by default for these units of measure.

opw-4103838

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
