### PR TITLE
[IMP] hr_holidays: Update "by type" report to separate between `Time Off Requests` and `Allocations`.

### DIFF
--- a/addons/hr_holidays/__manifest__.py
+++ b/addons/hr_holidays/__manifest__.py
@@ -67,8 +67,12 @@ A synchronization with an internal agenda (Meetings of the CRM module) is also p
     'assets': {
         'web.assets_backend': [
             'hr_holidays/static/src/**/*',
+            ('remove', 'hr_holidays/static/src/views/graph/**'),
             # Don't include dark mode files in light mode
             ('remove', 'hr_holidays/static/src/**/*.dark.scss'),
+        ],
+        'web.assets_backend_lazy': [
+            'hr_holidays/static/src/views/graph/**',
         ],
         "web.assets_web_dark": [
             'hr_holidays/static/src/**/*.dark.scss',

--- a/addons/hr_holidays/i18n/hr_holidays.pot
+++ b/addons/hr_holidays/i18n/hr_holidays.pot
@@ -957,6 +957,8 @@ msgid "Back on %s"
 msgstr ""
 
 #. module: hr_holidays
+#. odoo-javascript
+#: code:addons/hr_holidays/static/src/views/graph/hr_holidays_graph_renderer.js:0
 #: model:ir.ui.menu,name:hr_holidays.menu_hr_holidays_balance
 msgid "Balance"
 msgstr ""

--- a/addons/hr_holidays/report/hr_leave_report.py
+++ b/addons/hr_holidays/report/hr_leave_report.py
@@ -1,7 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
-from odoo import api, fields, models, tools, _
-from odoo.osv import expression
+from odoo import fields, models, tools
 
 
 class HrLeaveReport(models.Model):

--- a/addons/hr_holidays/report/hr_leave_report.py
+++ b/addons/hr_holidays/report/hr_leave_report.py
@@ -66,8 +66,8 @@ class HrLeaveReport(models.Model):
                 inner join hr_employee as employee on (allocation.employee_id = employee.id)
                 where employee.active IS True
                 union all select
-                    request.id as leave_id,
                     null as allocation_id,
+                    request.id as leave_id,
                     request.employee_id as employee_id,
                     request.private_name as name,
                     (request.number_of_days * -1) as number_of_days,

--- a/addons/hr_holidays/report/hr_leave_reports.xml
+++ b/addons/hr_holidays/report/hr_leave_reports.xml
@@ -53,8 +53,9 @@
         <field name="name">report.hr.holidays.report.leave_all.graph</field>
         <field name="model">hr.leave.report</field>
         <field name="arch" type="xml">
-            <graph string="Time off Summary" sample="1">
+            <graph string="Time off Summary" sample="1" stacked="1" js_class="hr_holidays_graph">
                 <field name="employee_id" type="row"/>
+                <field name="leave_type" type="col"/>
                 <field name="number_of_days" string="Duration (Days)" type="measure"/>
                 <field name="number_of_hours" string="Duration (Hours)"/>
             </graph>

--- a/addons/hr_holidays/static/src/views/graph/hr_holidays_graph_controller.xml
+++ b/addons/hr_holidays/static/src/views/graph/hr_holidays_graph_controller.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="hr_holidays.HrHolidaysGraphView.Buttons" t-inherit="web.GraphView.Buttons">
+        <!--The bar chart will always be stacked. So the stack button is of no use-->
+        <xpath expr="//div[hasclass('btn-group')][3]" position="replace"/>
+    </t>
+
+</templates>

--- a/addons/hr_holidays/static/src/views/graph/hr_holidays_graph_model.js
+++ b/addons/hr_holidays/static/src/views/graph/hr_holidays_graph_model.js
@@ -1,0 +1,73 @@
+/** @odoo-module **/
+
+import { GraphModel } from "@web/views/graph/graph_model";
+import { sortBy } from "@web/core/utils/arrays";
+
+export class HrHolidaysGraphModel extends GraphModel {
+    async load(searchParams) {
+        if (searchParams.groupBy.length != 0 && !searchParams.groupBy.includes('leave_type')){
+            searchParams.groupBy.push('leave_type');
+        }
+        await super.load(...arguments);
+    }
+
+    _getLineOverlayDataset() {
+        // Given that there are at least 2 stacks one for allocation and one for time off
+        // then there shouldn't be a lineOverlay. 
+        return null;
+    }
+
+    /**
+     * Eventually filters and sort data points.
+     * @protected
+     * @returns {Object[]}
+     */
+    _getProcessedDataPoints() {
+        const {fields, domains, groupBy, mode, order } = this.metaData;
+        this.allocation_label = fields['leave_type'].selection.find((selection) => selection[0] === 'allocation')[1]
+        this.timeoff_label = fields['leave_type'].selection.find((selection) => selection[0] === 'request')[1]
+
+        let processedDataPoints = [];
+        if (mode === "bar") {
+            processedDataPoints = this.dataPoints.filter(
+                (dataPoint) => dataPoint.labels[0] !== this._getDefaultFilterLabel(groupBy[0])
+            );
+
+            if (order !== null && domains.length === 1 && groupBy.length > 0) {
+                const groupedDataPoints = {};
+                for (const dataPt of processedDataPoints) {
+                    const key = dataPt.labels[0]; // = x-axis value under the current assumptions
+                    if (!groupedDataPoints[key]) {
+                        groupedDataPoints[key] = [];
+                    }
+                    groupedDataPoints[key].push(dataPt);
+                }
+
+                const groups = Object.values(groupedDataPoints);
+                let datapointsWithAllocation = new Set( 
+                    groups.flat()
+                    .map(dataPoint => {
+                        if (dataPoint.labels[dataPoint.labels.length - 1] === this.allocation_label){
+                            return dataPoint.labels.slice(0, -1).join('/');
+                        }
+                        return false;
+                    })
+                    .filter(label => label !== false)
+                )
+
+                const groupTotal = (group) => group.reduce((sum, dataPt) => {
+                    if (datapointsWithAllocation.has(dataPt.labels.slice(0, -1).join('/'))){
+                        return sum + dataPt.value;
+                    }
+                    return sum;
+                }, 0);
+
+                processedDataPoints = sortBy(groups, groupTotal, order.toLowerCase()).flat();
+            } 
+            else {
+                processedDataPoints = super._getProcessedDataPoints();
+            }
+            return processedDataPoints;
+        }
+    }
+}

--- a/addons/hr_holidays/static/src/views/graph/hr_holidays_graph_renderer.js
+++ b/addons/hr_holidays/static/src/views/graph/hr_holidays_graph_renderer.js
@@ -1,0 +1,103 @@
+/** @odoo-module **/
+
+import { _t } from "@web/core/l10n/translation";
+
+import { GraphRenderer } from "@web/views/graph/graph_renderer";
+import { groupBy } from "@web/core/utils/arrays";
+
+
+export class HrHolidaysGraphRenderer extends GraphRenderer {
+    delimiter = ' / ';
+
+    getBarChartData() {
+
+        let data = super.getBarChartData();
+        for (let index = 0; index < data.datasets.length; ++index) {
+            const dataset = data.datasets[index];
+            // dataset.label takes the form 'Mitchell Admin / Paid Time Off / Allocation'.
+            if (dataset.label.split(this.delimiter).includes(this.model.allocation_label)){
+                dataset.stack = this.model.allocation_label;
+            }
+            else if (dataset.label.split(this.delimiter).includes(this.model.timeoff_label)){
+                dataset.stack = this.model.timeoff_label;
+            }
+        }
+
+        if (!(data.datasets.every(dataset => dataset.stack === this.model.allocation_label)
+            || data.datasets.every(dataset => dataset.stack === this.model.timeoff_label))){
+            let balanceDatasets = this._computeBalanceDatasets(data);
+            data.datasets.push(...balanceDatasets);
+        }
+
+        // Change time off data to +ve values to be better visualized in the graph view.
+        for (let dataset of data.datasets.filter(dataset => dataset.stack === this.model.timeoff_label)){
+            dataset.data = dataset.data.map(datapoint => -datapoint);
+        }
+        return data;
+    }
+
+    _computeBalanceDatasets(data) {
+        this.balance_label = _t('Balance')
+        const datasetsByLabel = groupBy(data.datasets, 
+            (dataset) => dataset.label.split(this.delimiter)
+            .map(labelPart => labelPart === this.model.allocation_label || labelPart === this.model.timeoff_label ? this.balance_label : labelPart)
+            .join(this.delimiter)
+        );
+        const balanceDatasets = Object.entries(datasetsByLabel).map(([label, datasets]) =>
+            this._initializeBalanceDatasetFrom(datasets, label)
+        );
+        return balanceDatasets;
+    }
+
+    _initializeBalanceDatasetFrom(datasets, label){
+        let dataset = datasets[0];
+        let backgroundColor = datasets.filter(dataset => dataset.stack === this.model.allocation_label)[0]?.backgroundColor;
+        if (!backgroundColor){
+            backgroundColor = dataset.backgroundColor;
+        }
+
+        let balanceDataset = {
+            'trueLabels': dataset.trueLabels,
+            'stack': this.balance_label,
+            'originIndex': dataset.originIndex,
+            'label': label,
+            'backgroundColor': backgroundColor,
+            'borderRadius': dataset.borderRadius,
+            'cumulatedStart': dataset.cumulatedStart,
+        };
+ 
+        balanceDataset.domains = dataset.domains.map(domain => 
+            domain.map(condition => 
+                condition.includes('leave_type')
+                ? ['leave_type', 'in', ['allocation', 'request']]
+                : condition
+            )
+        ); 
+
+        /* Because the balanceDataset includes both `Allocation` and `Time Off` records: {"leave_type":"allocation"} and {"leave_type":"request"} are removed from identifiers.
+        For example: the identifier "[{"employee_id":[1,"Mitchell Admin"]},{"leave_type":"allocation"}]" becomes "[{"employee_id":[1,"Mitchell Admin"]}]" */
+        balanceDataset.identifiers = new Set([...dataset.identifiers].map(identifier => 
+                JSON.stringify( 
+                    JSON.parse(identifier) // The output is an array of objects.
+                    .filter(identifierObject => !identifierObject.hasOwnProperty('leave_type'))
+                )
+            )
+        );
+
+        balanceDataset.data = new Array(balanceDataset.trueLabels.length).fill(0);
+        const allocation_datasets = datasets.filter(dataset => dataset.stack === this.model.allocation_label)
+        for (let allocation_dataset of allocation_datasets){
+            for (let i = 0; i < allocation_dataset.data.length; i++){
+                balanceDataset.data[i] += allocation_dataset.data[i];
+            }
+        }
+        const timeoff_datasets = datasets.filter(dataset => dataset.stack === this.model.timeoff_label)
+        for (let timeoff_dataset of timeoff_datasets){
+            for (let i = 0; i < timeoff_dataset.data.length; i++){
+                if (balanceDataset.data[i] != 0)
+                    balanceDataset.data[i] += timeoff_dataset.data[i];
+            }
+        }
+        return balanceDataset;
+    }
+}

--- a/addons/hr_holidays/static/src/views/graph/hr_holidays_graph_view.js
+++ b/addons/hr_holidays/static/src/views/graph/hr_holidays_graph_view.js
@@ -1,0 +1,13 @@
+/** @odoo-module **/
+
+import { graphView } from "@web/views/graph/graph_view";
+import { registry } from "@web/core/registry";
+import { HrHolidaysGraphModel } from "./hr_holidays_graph_model";
+import { HrHolidaysGraphRenderer } from "./hr_holidays_graph_renderer";
+
+registry.category("views").add("hr_holidays_graph", {
+    ...graphView,
+    Model: HrHolidaysGraphModel,
+    Renderer: HrHolidaysGraphRenderer,
+    buttonTemplate: "hr_holidays.HrHolidaysGraphView.Buttons",
+});


### PR DESCRIPTION
The "by type" report in the time off app is not clear. There are positive values representing allocated days and negative values representing time off. These values are summed together in reporting which causes inability to compare between time off types.

These changes:
1. Split allocations from time off requests by using stacked bar chart. Allocations will have their own stack and time 
off requests will have a seperate stack.

  2. Adjusts the values representing time off to be positive.

This will enable users to use the reporting features and to compare between time off types in terms of number of allocated days and number of hours taken as leaves.

task-4014251