### PR TITLE
[FIX] website: switch `s_key_benefits` layout mode to `Columns`

### DIFF
--- a/addons/website/views/snippets/s_key_benefits.xml
+++ b/addons/website/views/snippets/s_key_benefits.xml
@@ -4,16 +4,14 @@
 <template id="s_key_benefits" name="Key benefits">
     <section class="s_key_benefits pt48 pb48">
         <div class="container">
-            <div class="row o_grid_mode s_nb_column_fixed" data-row-count="11" style="column-gap: 48px;">
-                <div class="o_grid_item g-col-lg-4 g-height-1 col-lg-4" style="--grid-item-padding-x: 16px; --grid-item-padding-y: 0px; grid-area: 1 / 1 / 2 / 5; z-index: 1;">
+            <div class="row">
+                <div class="col-lg-12">
                     <p class="lead">
                         ✽&#160;&#160;What We Offer
                     </p>
-                </div>
-                <div class="o_grid_item g-col-lg-12 g-height-3 col-lg-12 pb96" style="--grid-item-padding-x: 16px; --grid-item-padding-y: 0px; grid-area: 2 / 1 / 5 / 13; z-index: 2;">
                     <h2 class="display-3-fs">Discover our<br/>main three benefits</h2>
                 </div>
-                <div class="o_grid_item g-col-lg-4 g-height-7 col-lg-4 pt48 pb24" style="--grid-item-padding-x: 16px; grid-area: 6 / 1 / 12 / 5; z-index: 3;">
+                <div class="col-lg-4 pt48 pb24">
                     <span class="display-3-fs text-o-color-1">1</span>
                     <div class="s_hr pt8 pb24" data-snippet="s_hr" data-name="Separator">
                         <hr class="w-100 mx-auto"/>
@@ -21,7 +19,7 @@
                     <h3 class="h4-fs">Fair pricing</h3>
                     <p>We provide transparent pricing that offers great value, ensuring you always get the best deal without hidden costs.</p>
                 </div>
-                <div class="o_grid_item g-col-lg-4 g-height-7 col-lg-4 pt48 pb24" style="--grid-item-padding-x: 16px; grid-area: 6 / 5 / 12 / 9; z-index: 4;">
+                <div class="col-lg-4 pt48 pb24">
                     <span class="display-3-fs text-o-color-1">2</span>
                     <div class="s_hr pt8 pb24" data-snippet="s_hr" data-name="Separator">
                         <hr class="w-100 mx-auto"/>
@@ -29,7 +27,7 @@
                     <h3 class="h4-fs">24/7 Support</h3>
                     <p>Our support team is available 24/7 to assist with any inquiries or issues, ensuring you get help whenever you need it.</p>
                 </div>
-                <div class="o_grid_item g-col-lg-4 g-height-7 col-lg-4 pt48 pb24" style="--grid-item-padding-x: 16px; grid-area: 6 / 9 / 12 / 13; z-index: 5;">
+                <div class="col-lg-4 pt48 pb24">
                     <span class="display-3-fs text-o-color-1">3</span>
                     <div class="s_hr pt8 pb24" data-snippet="s_hr" data-name="Separator">
                         <hr class="w-100 mx-auto"/>


### PR DESCRIPTION
This PR aims to switch the layout mode of the `s_key_benefits` snippet to Columns.

- requires https://github.com/odoo/design-themes/pull/925

Prior to this commit, the `s_key_benefits` snippet was using the Grid mode, which was leading to some misalignment with other snippet. We could have set the `--grid-item-padding-x` to 0px, but this would have led to another issue as we don't handle the `grid-item-padding-x` in mobile.

To prevent these issues, we switch the layout mode to Columns.

task-4188740
part of task-4077427

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
