### PR TITLE
[FIX] l10n_es_edi_sii: give 0% tax in tax details

### DIFF
--- a/addons/l10n_es_edi_sii/models/account_edi_format.py
+++ b/addons/l10n_es_edi_sii/models/account_edi_format.py
@@ -210,6 +210,11 @@ class AccountEdiFormat(models.Model):
             tax_details_info['NoSujeta']['ImportePorArticulos7_14_Otros'] = round(sign * base_amount_not_subject, 2)
         if not invoice.company_id.currency_id.is_zero(base_amount_not_subject_loc) and invoice.is_sale_document():
             tax_details_info['NoSujeta']['ImporteTAIReglasLocalizacion'] = round(sign * base_amount_not_subject_loc, 2)
+        if not tax_details_info and invoice.is_sale_document():
+            if any(t['l10n_es_type'] == 'no_sujeto' for t in tax_details['tax_details'].values()):
+                tax_details_info['NoSujeta']['ImportePorArticulos7_14_Otros'] = 0
+            if any(t['l10n_es_type'] == 'no_sujeto_loc' for t in tax_details['tax_details'].values()):
+                tax_details_info['NoSujeta']['ImporteTAIReglasLocalizacion'] = 0
 
         return {
             'tax_details_info': tax_details_info,


### PR DESCRIPTION
**Current behavior:**
An invoice with offsetting lines (total == 0.00) with 0% tax will prevent the invoice from being processed by the SII Llevanza de libros registro (ES).

**Expected behavior:**
The invoice can be processed.

**Steps to reproduce:**
1. Create an invoice from a Spanish company to, e.g., a Belgian company

2. Create 2 invoice lines for the same product, one for positive 10 euros, the other for negative 10 euros

3. Add the `0% EU S (Services)` tax to both invoice lines

4. Confirm the invoice, then try to process the document

5. Observe the error about not having a tax scope set, even though the scope is set in the tax settings

**Cause of the issue:**
When an invoice in in this state, it goes through the `_l10n_es_edi_get_invoices_tax_details_info()` method without a value for the `TipoDesglose` EDI node, causing the exception.

**Fix:**
If there are taxes present but no values for the `TipoDesglose` node filled at the end of the method, add them (respectively, based on the tax type) with a value == 0.

opw-4083107