### PR TITLE
[IMP] web: add 'form' to form view's breadcrumb tooltip

### DIFF
--- a/addons/web/static/src/search/breadcrumbs/breadcrumbs.xml
+++ b/addons/web/static/src/search/breadcrumbs/breadcrumbs.xml
@@ -23,7 +23,8 @@
                             </button>
                             <t t-set-slot="content">
                                 <t t-foreach="collapsedBreadcrumbs" t-as="breadcrumb" t-key="breadcrumb.jsId">
-                                    <DropdownItem onSelected="breadcrumb.onSelected" attrs="{ href: breadcrumb.url}">
+                                    <DropdownItem onSelected="breadcrumb.onSelected"
+                                                  attrs="{ href: breadcrumb.url, 'data-tooltip': 'Back to &quot;' + breadcrumb.name + '&quot;' + (breadcrumb.isFormView ? ' form' : '')}">
                                         <t t-call="web.Breadcrumb.Name"/>
                                     </DropdownItem>
                                 </t>
@@ -32,7 +33,7 @@
                     </li>
                     <t t-foreach="visiblePathBreadcrumbs" t-as="breadcrumb" t-key="breadcrumb.jsId">
                         <li class="breadcrumb-item d-inline-flex min-w-0" t-att-class="{ o_back_button: breadcrumb_last }" t-att-data-hotkey="breadcrumb_last and 'b'" t-on-click.prevent="breadcrumb.onSelected">
-                            <a t-att-href="breadcrumb.url" class="fw-bold text-truncate" t-att-data-tooltip="'Back to &quot;' + breadcrumb.name + '&quot;'"><t t-call="web.Breadcrumb.Name"/></a>
+                            <a t-att-href="breadcrumb.url" class="fw-bold text-truncate" t-att-data-tooltip="'Back to &quot;' + breadcrumb.name + '&quot;' + (breadcrumb.isFormView ? ' form' : '')"><t t-call="web.Breadcrumb.Name"/></a>
                         </li>
                     </t>
                 </ol>

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -250,7 +250,7 @@ export function makeActionManager(env, router = _router) {
             const key = JSON.stringify(actionInfo);
             keys.push(key);
             if (displayName) {
-                breadcrumbCache[key] = displayName;
+                breadcrumbCache[key] = { display_name: displayName };
             }
             if (key in breadcrumbCache) {
                 continue;
@@ -267,19 +267,19 @@ export function makeActionManager(env, router = _router) {
                 });
             }
         }
-        const displayNames = await Promise.all(keys.map((k) => breadcrumbCache[k]));
+        const results = await Promise.all(keys.map((k) => breadcrumbCache[k]));
         const controllersToRemove = [];
-        for (const [controller, displayName] of zip(controllers, displayNames)) {
-            if (typeof displayName === "string") {
-                controller.displayName = displayName;
+        for (const [controller, res] of zip(controllers, results)) {
+            if ("display_name" in res) {
+                controller.displayName = res.display_name;
             } else {
                 controllersToRemove.push(controller);
-                if (displayName?.error) {
+                if ("error" in res) {
                     console.warn(
                         "The following element was removed from the breadcrumb and from the url.\n",
                         controller.state,
                         "\nThis could be because the action wasn't found or because the user doesn't have the right to access to the record, the original error is :\n",
-                        displayName.error
+                        res.error
                     );
                 }
             }

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -429,6 +429,9 @@ export function makeActionManager(env, router = _router) {
                     get name() {
                         return controller.displayName;
                     },
+                    get isFormView() {
+                        return controller.props?.type === "form";
+                    },
                     get url() {
                         return stateToUrl(controller.state);
                     },

--- a/addons/web/static/tests/_framework/mock_server/mock_server.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_server.js
@@ -967,13 +967,18 @@ export class MockServer {
             if (actionId) {
                 const action = this.getAction(actionId);
                 if (resId) {
-                    return this.env[action.res_model].read([resId], ["display_name"])[0]
-                        .display_name;
+                    return {
+                        display_name: this.env[action.res_model].read([resId], ["display_name"])[0]
+                            .display_name,
+                    };
                 }
-                return action.name;
+                return { display_name: action.name };
             } else if (model) {
                 if (resId) {
-                    return this.env[model].read([resId], ["display_name"])[0].display_name;
+                    return {
+                        display_name: this.env[model].read([resId], ["display_name"])[0]
+                            .display_name,
+                    };
                 }
                 throw new Error("Actions with a model should also have a resId");
             }

--- a/addons/web/static/tests/legacy/helpers/mock_server.js
+++ b/addons/web/static/tests/legacy/helpers/mock_server.js
@@ -788,13 +788,15 @@ export class MockServer {
             if (action_id) {
                 const act = this.mockLoadAction({ action_id });
                 if (resId) {
-                    return this.mockRead(act.res_model, [[resId], ["display_name"]])[0]
-                        .display_name;
+                    return {
+                        display_name: this.mockRead(act.res_model, [[resId], ["display_name"]])[0]
+                            .display_name,
+                    };
                 }
-                return act.name;
+                return { display_name: act.name };
             } else if (model) {
                 if (resId) {
-                    return this.models[model].records[resId].display_name;
+                    return { display_name: this.models[model].records[resId].display_name };
                 }
                 throw new Error("Actions with a model should also have a resId");
             }

--- a/addons/web/static/tests/webclient/actions/load_state.test.js
+++ b/addons/web/static/tests/webclient/actions/load_state.test.js
@@ -27,7 +27,7 @@ import { redirect } from "@web/core/utils/urls";
 import { ControlPanel } from "@web/search/control_panel/control_panel";
 import { _t } from "@web/core/l10n/translation";
 import { user } from "@web/core/user";
-import { queryAllTexts, queryFirst } from "@odoo/hoot-dom";
+import { queryAllAttributes, queryAllTexts, queryFirst } from "@odoo/hoot-dom";
 
 describe.current.tags("desktop");
 
@@ -1288,6 +1288,14 @@ describe(`new urls`, () => {
             "Second record",
             "Partners Action 28",
             "First record",
+        ]);
+        expect(`.o-overlay-container .dropdown-menu a`).toHaveAttribute(
+            "data-tooltip",
+            'Back to "Partners Action 27"'
+        );
+        expect(queryAllAttributes(".o_breadcrumb li.breadcrumb-item a", "data-tooltip")).toEqual([
+            'Back to "Second record" form',
+            'Back to "Partners Action 28"',
         ]);
     });
 


### PR DESCRIPTION
This commit adds the 'form' suffix in tooltips displayed when hovering
breadcrumb entries related to form views. Note that this commit also
adds a tooltip on collapsed breadcrumb items.

task-id: 4070508

----------

[REF] web: uniformize load_breadcrumbs API

This commit corrects the `load_breadcrumb` controller API.
Before this commit, the controller returned an array containing
strings (the display_name if it was found) and/or objects when
errors occurred.
Now the controller always returns an array of objects, with keys
"display_name" or "error".
This commit also opens the door for future improvements of the API
without breaking the retro-compatibility.
