### PR TITLE
[FIX] web_editor: fix custom colors in colorpicker

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -1818,6 +1818,7 @@ const ColorpickerUserValueWidget = SelectUserValueWidget.extend({
         if (wysiwyg) {
             options.document = this.$target[0].ownerDocument;
             options.getTemplate = wysiwyg.getColorpickerTemplate.bind(wysiwyg);
+            options.getEditableCustomColors = wysiwyg.colorPalettesProps?.background?.getEditableCustomColors;
         }
         this.colorPaletteWrapper?.destroy();
         const sidebarDocument = this.colorPaletteEl.ownerDocument;

--- a/addons/website/static/tests/tours/website_custom_colors_picking.js
+++ b/addons/website/static/tests/tours/website_custom_colors_picking.js
@@ -1,0 +1,99 @@
+/** @odoo-module **/
+
+import wTourUtils from "@website/js/tours/tour_utils";
+
+const CUSTOM_COLOR_1 = '#ABCDEF';   // foreground 
+const CUSTOM_COLOR_2 = '#654321';   // background 
+
+wTourUtils.registerWebsitePreviewTour("website_custom_colors_picking", {
+    test: true,
+    url: '/',
+    edition: true,
+}, () => [
+    wTourUtils.dragNDrop({id: 's_text_block', name: 'Text'}),
+    {
+        content: "Click on the text block first paragraph",
+        trigger: 'iframe .s_text_block p',
+    },
+    {
+        content: "Open the foreground colorpicker",
+        trigger: '#toolbar:not(.oe-floating) #oe-text-color',
+    },
+    {
+        content: "Go to the 'Custom' tab",
+        trigger: '.o_we_colorpicker_switch_pane_btn[data-target="custom-colors"]',
+    },
+    {
+        content: "Input the custom color 1",
+        trigger: '.o_hex_input',
+        run: `text_blur ${CUSTOM_COLOR_1}`,
+    },
+    {
+        content: "Open the background colorpicker",
+        trigger: '.o_we_user_value_widget[data-color-prefix="bg-"]',
+    },
+    {
+        content: "Go to the 'Custom' tab",
+        trigger: '.o_we_colorpicker_switch_pane_btn[data-target="custom-colors"]',
+    },
+    {
+        content: "Input the custom color 2",
+        trigger: '.o_hex_input',
+        run: `text_blur ${CUSTOM_COLOR_2}`,
+    },
+    ...wTourUtils.clickOnSave(),
+    ...wTourUtils.clickOnEditAndWaitEditMode(),
+    wTourUtils.dragNDrop({id: 's_title', name: 'Title'}),
+    {
+        content: "Click on the text of the title block",
+        trigger: 'iframe .s_title h2',
+    },
+    {
+        content: "Open the foreground colorpicker",
+        trigger: '#toolbar:not(.oe-floating) #oe-text-color',
+    },
+    {
+        content: "Go to the 'Custom' tab",
+        trigger: '.o_we_colorpicker_switch_pane_btn[data-target="custom-colors"]',
+    },
+    {
+        content: "Check if the custom color 1 & 2 can be applied (foreground)",
+        trigger: '.dropdown-menu.colorpicker-menu.show .colorpicker',
+        run: function (actions) {
+            const customColorButton1 = this.$anchor[0].querySelector(`button[style="background-color:${CUSTOM_COLOR_1};"]`);
+            if (!customColorButton1) {
+                console.error("The custom color button for the color 1 is missing for foreground colorpicker");
+                return;
+            }
+            const customColorButton2 = this.$anchor[0].querySelector(`button[style="background-color:${CUSTOM_COLOR_2};"]`);
+            if (!customColorButton2) {
+                console.error("The custom color button for the color 2 is missing for foreground colorpicker");
+                return;
+            }
+        },
+    },
+    {
+        content: "Open the background colorpicker",
+        trigger: '.o_we_user_value_widget[data-color-prefix="bg-"]',
+    },
+    {
+        content: "Go to the 'Custom' tab",
+        trigger: '.o_we_colorpicker_switch_pane_btn[data-target="custom-colors"]',
+    },
+    {
+        content: "Check if the custom color 1 & 2 can be applied (background)",
+        trigger: '.o_we_user_value_widget.o_we_so_color_palette.o_we_widget_opened .colorpicker',
+        run: function (actions) {
+            const customColorButton1 = this.$anchor[0].querySelector(`button[style="background-color:${CUSTOM_COLOR_1};"]`);
+            if (!customColorButton1) {
+                console.error("The custom color button for the color 1 is missing for background colorpicker");
+                return;
+            }
+            const customColorButton2 = this.$anchor[0].querySelector(`button[style="background-color:${CUSTOM_COLOR_2};"]`);
+            if (!customColorButton2) {
+                console.error("The custom color button for the color 2 is missing for background colorpicker");
+                return;
+            }
+        },
+    },
+]);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -709,3 +709,6 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_header_color_and_undo_redo_issues(self):
         self.start_tour("/", "undo_redo_header_oriented_issue", login="admin")
+
+    def test_website_custom_colors_picking(self):
+        self.start_tour('/', 'website_custom_colors_picking', login='admin')


### PR DESCRIPTION
Before this commit, the colorpalette for the background color would
not display custom colors already on the page. The issue appeared in
17.0 and worked in 16.0 before the conversion of wysiwyg to owl.
github.com/https://github.com/odoo/odoo/pull/118966

The "getEditableCustomColors" method was not forwarded and therefore
we used the default function, returning nothing.

Steps to reproduce the issue:
- Add a snippet
- Set the background / font color of the snippet to a custom color
- Add another snippet
- Open the colorpicker for the text color
(The colorpicker have access to the custom color set above)
- Open the colorpicker for the background color
(The colorpicker does not have access to the custom color set above)

task-3806989