### PR TITLE
[FIX] l10n_vn: Fix repartition line tag

### DIFF
--- a/addons/l10n_vn/data/template/account.tax-vn.csv
+++ b/addons/l10n_vn/data/template/account.tax-vn.csv
@@ -38,7 +38,7 @@
 "tax_import","Import Tax","Import Tax","Import Tax","5.0","percent","purchase","tax_group_import","base","invoice","+tax_import_base","","True","Thuế nhập khẩu"
 "","","","","","","","","tax","invoice","+tax_import","chart3333","",""
 "","","","","","","","","base","refund","-tax_import_base","","",""
-"","","","","","","","","tax","refund","+tax_import","chart3333","",""
+"","","","","","","","","tax","refund","-tax_import","chart3333","",""
 "tax_sale_vat10","10%","Value Added Tax (VAT) 10%","Value Added Tax (VAT) 10%","10.0","percent","sale","tax_group_10","base","invoice","+Untaxed sales of goods and services taxed 10%","","False","Thuế GTGT phải nộp 10%"
 "","","","","","","","","tax","invoice","+VAT on sales of goods and services 10%","chart33311","",""
 "","","","","","","","","base","refund","-Untaxed sales of goods and services taxed 10%","","",""


### PR DESCRIPTION
refund tag should start with `-`

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
