### PR TITLE
[FIX] account: clean tax group display on invoice report

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -360,8 +360,9 @@
                     <t t-else="">
                         <td>
                             <span t-out="amount_by_group['tax_group_name']">Tax 15%</span>
-                            <span> on </span>
-                            <span class="text-nowrap" t-out="amount_by_group['formatted_tax_group_base_amount']">27.00</span>
+                            <span t-if="not amount_by_group['hide_base_amount']" class="text-nowrap"> on
+                                <t t-esc="amount_by_group['formatted_tax_group_base_amount']"/>
+                            </span>
                         </td>
                         <td class="text-end o_price_total">
                             <span class="text-nowrap" t-out="amount_by_group['formatted_tax_group_amount']">4.05</span>


### PR DESCRIPTION
Steps to reproduce:
- Accounting > Configuration > Taxes
- Create a tax with 'Tax Computation' as Fixed
- Invoice a product with only that fixed tax
- Print the invoice

The subtotals for fixed taxes are displayed showing 'on $__', this is inconsistent with the intent of 5f77e6588ee2a15d7bf2cb593a51f509d9e4ca9d where the change was made. We want this mention only on percentage based taxes which actually depend on the amount the tax is applied to.

i.e. '15% on $100' for percentage and just 'Fix $15' for fixed taxes.

opw-4110516

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
