### PR TITLE
[IMP] website: allow the user to load more themes

### DIFF
--- a/addons/base_import/static/src/import_block_ui.xml
+++ b/addons/base_import/static/src/import_block_ui.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
+    <!-- TODO should re-use the blockUI template of web -->
     <t t-name="base_import.BlockUI">
         <div class="o_blockUI fixed-top d-flex justify-content-center align-items-center flex-column vh-100 bg-black-50">
             <div class="o_spinner mb-4">

--- a/addons/web/static/src/core/ui/block_ui.js
+++ b/addons/web/static/src/core/ui/block_ui.js
@@ -9,17 +9,25 @@ export class BlockUI extends Component {
     };
 
     static template = xml`
-        <div t-att-class="state.blockUI ? 'o_blockUI fixed-top d-flex justify-content-center align-items-center flex-column vh-100' : ''">
-          <t t-if="state.blockUI">
-            <div class="o_spinner mb-4">
-                <img src="/web/static/img/spin.svg" alt="Loading..."/>
+        <t t-if="state.blockState === BLOCK_STATES.UNBLOCKED">
+            <div/>
+        </t>
+        <t t-else="">
+            <t t-set="visiblyBlocked" t-value="state.blockState === BLOCK_STATES.VISIBLY_BLOCKED"/>
+            <div class="o_blockUI fixed-top d-flex justify-content-center align-items-center flex-column vh-100"
+                 t-att-class="visiblyBlocked ? '' : 'o_blockUI_invisible'">
+                <t t-if="visiblyBlocked">
+                    <div class="o_spinner mb-4">
+                        <img src="/web/static/img/spin.svg" alt="Loading..."/>
+                    </div>
+                    <div class="o_message text-center px-4">
+                        <t t-esc="state.line1"/><br/>
+                        <t t-esc="state.line2"/>
+                    </div>
+                </t>
             </div>
-            <div class="o_message text-center px-4">
-                <t t-esc="state.line1"/> <br/>
-                <t t-esc="state.line2"/>
-            </div>
-          </t>
-        </div>`;
+        </t>
+    `;
 
     setup() {
         this.messagesByDuration = [
@@ -50,8 +58,9 @@ export class BlockUI extends Component {
                 l1: _t("Maybe you should consider reloading the application by pressing F5..."),
             },
         ];
+        this.BLOCK_STATES = { UNBLOCKED: 0, BLOCKED: 1, VISIBLY_BLOCKED: 2 };
         this.state = useState({
-            blockUI: false,
+            blockState: this.BLOCK_STATES.UNBLOCKED,
             line1: "",
             line2: "",
         });
@@ -72,7 +81,15 @@ export class BlockUI extends Component {
     }
 
     block(ev) {
-        this.state.blockUI = true;
+        const showBlockedUI = () => (this.state.blockState = this.BLOCK_STATES.VISIBLY_BLOCKED);
+        const delay = ev.detail?.delay;
+        if (delay) {
+            this.state.blockState = this.BLOCK_STATES.BLOCKED;
+            this.showBlockedUITimer = setTimeout(showBlockedUI, delay);
+        } else {
+            showBlockedUI();
+        }
+
         if (ev.detail?.message) {
             this.state.line1 = ev.detail.message;
         } else {
@@ -81,7 +98,8 @@ export class BlockUI extends Component {
     }
 
     unblock() {
-        this.state.blockUI = false;
+        this.state.blockState = this.BLOCK_STATES.UNBLOCKED;
+        clearTimeout(this.showBlockedUITimer);
         clearTimeout(this.msgTimer);
         this.state.line1 = "";
         this.state.line2 = "";

--- a/addons/web/static/src/core/ui/block_ui.scss
+++ b/addons/web/static/src/core/ui/block_ui.scss
@@ -1,9 +1,11 @@
 .o_blockUI {
-	cursor: wait;
-	-webkit-backdrop-filter: blur(2px);
-	backdrop-filter: blur(2px);
-	background: rgba(#000, .5);
-	color: #fff;
-	// NOTE: The value of the z-index below mirrors the $zindex-tooltip one
-	z-index: 1070 !important;
+    cursor: wait;
+    z-index: $zindex-popover !important;
+
+    &:not(.o_blockUI_invisible) {
+        -webkit-backdrop-filter: blur(2px);
+        backdrop-filter: blur(2px);
+        background: rgba(#000, .5);
+        color: #fff;
+    }
 }

--- a/addons/web/static/src/core/ui/ui_service.js
+++ b/addons/web/static/src/core/ui/ui_service.js
@@ -154,9 +154,12 @@ export const uiService = {
         let blockCount = 0;
         function block(data) {
             blockCount++;
+            // TODO could probably be improved to handle multiple block demands
+            // but that have different messages and delays
             if (blockCount === 1) {
                 bus.trigger("BLOCK", {
                     message: data?.message,
+                    delay: data?.delay,
                 });
             }
         }

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -480,7 +480,7 @@ class Website(models.Model):
         return r
 
     @api.model
-    def configurator_recommended_themes(self, industry_id, palette):
+    def configurator_recommended_themes(self, industry_id, palette, result_nbr_max=3):
         Module = request.env['ir.module.module']
         domain = Module.get_themes_domain()
         domain = AND([[('name', '!=', 'theme_default')], domain])
@@ -488,7 +488,10 @@ class Website(models.Model):
         client_themes_img = {t: get_manifest(t).get('images_preview_theme', {}) for t in client_themes if get_manifest(t)}
         themes_suggested = self._website_api_rpc(
             '/api/website/2/configurator/recommended_themes/%s' % (industry_id if industry_id > 0 else ''),
-            {'client_themes': client_themes_img}
+            {
+                'client_themes': client_themes_img,
+                'result_nbr_max': result_nbr_max,
+            }
         )
         process_svg = self.env['website.configurator.feature']._process_svg
         for theme in themes_suggested:

--- a/addons/website/static/src/client_actions/configurator/configurator.js
+++ b/addons/website/static/src/client_actions/configurator/configurator.js
@@ -464,7 +464,7 @@ export class ThemeSelectionScreen extends ApplyConfiguratorScreen {
         onMounted(async () => {
             // Add a loading effect during the loading of the images inside the
             // svgs.
-            this.uiService.block();
+            this.uiService.block({delay: 400});
             this.state.themes.forEach((theme, idx) => {
                 // Transform the text svg into a svg element.
                 const svgEl = new DOMParser().parseFromString(theme.svg, 'image/svg+xml').documentElement;

--- a/addons/website/static/src/client_actions/configurator/configurator.scss
+++ b/addons/website/static/src/client_actions/configurator/configurator.scss
@@ -4,6 +4,9 @@
     $input-font-size: 40%;
 
     .o_configurator_screen {
+        // ==== Variables
+        --ConfiguratorPreview-height: MIN(70vh, 560px);
+        --ConfiguratorSmallPreview-height: MIN(60vh, 500px);
 
         // ==== Animations
         @keyframes configuratorFadeIn{
@@ -12,11 +15,11 @@
         }
 
         @keyframes theme_screenshot_scroll {
-            to { transform: translate3d(0, -24%, 0)}
+            to { transform: translate3d(0, calc((100% - var(--ConfiguratorPreview-height)) * -1), 0)}
         }
 
         @keyframes theme_screenshot_scroll_small {
-            to { transform: translate3d(0, -31.5%, 0)}
+            to { transform: translate3d(0, calc((100% - var(--ConfiguratorSmallPreview-height)) * -1), 0)}
         }
 
         // ==== General Components
@@ -336,18 +339,21 @@
             }
 
             .theme_preview {
-                padding-top: 65%;
+                @include media-breakpoint-down(lg) {
+                    --ConfiguratorPreview-height: 300px;
+                    --ConfiguratorSmallPreview-height: var(--ConfiguratorPreview-height);
+                }
+
+                height: var(--ConfiguratorPreview-height);
                 box-shadow: $box-shadow-sm;
 
                 @include media-breakpoint-up(lg) {
-                    padding-top: 200%;
-
                     &:hover {
                         transform: translate3d(0,-10px,0);
                     }
 
                     &.small {
-                        padding-top: 180%;
+                        height: var(--ConfiguratorSmallPreview-height);
                     }
                 }
 

--- a/addons/website/static/src/client_actions/configurator/configurator.xml
+++ b/addons/website/static/src/client_actions/configurator/configurator.xml
@@ -193,7 +193,7 @@
 
 <t t-name="website.Configurator.ThemeSelectionScreen">
     <div class="o_configurator_screen h-100 d-flex flex-column o_theme_selection_screen">
-        <div class="o_configurator_odoo_logo mt-4 ms-5" style="height: 31px; width: 99px;"/>
+        <div class="o_configurator_odoo_logo flex-shrink-0 mt-4 ms-5" style="height: 31px; width: 99px;"/>
         <div class="o_configurator_screen_content d-flex flex-column flex-grow-1 align-items-center">
             <div class="m-auto w-100 w-md-75 w-xl-100">
                 <div class="o_configurator_typing_text text-center mt-4 mb-lg-4">Choose your favorite <b>Theme</b>
@@ -231,6 +231,29 @@
                             </t>
                         </div>
                     </div>
+                    <t t-if="showViewMoreThemesButton">
+                        <p style="text-align: center;">
+                            <button class="btn btn-primary btn-lg px-4 py-2 center-block" t-on-click="getMoreThemes" t-ref="extraThemesButton">View more themes</button>
+                        </p>
+                    </t>
+                    <t t-elif="state.extraThemes.length" t-foreach="[...Array(Math.ceil(state.extraThemes.length/3)).keys()]" t-as="nbrExtraRow" t-key="nbrExtraRow">
+                        <div class="row pb-4 pt-5">
+                            <t t-foreach="[...Array(3).keys()]" t-as="nbrExtraCol" t-key="nbrExtraCol">
+                                <div class="col-12 col-lg-4 d-flex align-items-end mb-4 mb-lg-0">
+                                    <t t-set="extraThemeId" t-value="nbrExtraRow * 3 + nbrExtraCol"/>
+                                    <t t-set="extraThemeName" t-value="getExtraThemeName(extraThemeId)"/>
+                                    <t t-if="extraThemeName">
+                                        <div class="theme_preview border rounded position-relative w-100 small o_configurator_show_fast">
+                                            <h6 class="theme_preview_tip text-center text-muted">Click to select</h6>
+                                            <!-- Force LTR to prevent SVG issues in RTL languages -->
+                                            <div class="theme_svg_container rounded overflow-hidden" t-ref="ExtraThemePreview{{extraThemeId}}" dir="ltr"/>
+                                            <div class="button_area" t-on-click="() => this.chooseTheme(extraThemeName)"/>
+                                        </div>
+                                    </t>
+                                </div>
+                            </t>
+                        </div>
+                    </t>
                 </div>
             </div>
         </div>

--- a/addons/website/static/src/client_actions/website_preview/website_preview.xml
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
+
+<!-- TODO should re-use the blockUI template of web -->
 <t t-name="website.BlockPreview">
     <div class="o_blockUI o_block_preview position-fixed d-flex justify-content-center align-items-center flex-column h-100 w-100 bg-black-50">
         <div class="o_spinner mb-4">


### PR DESCRIPTION
[IMP] website: allow the user to load more themes

This commit adds a 'View more Themes' button in the "Theme" selection
page of the website configurator. If clicked, more themes are loaded and
the user can choose from 27 of them.

This commit also solves a small visual problem and keeps the size of the
odoo logo when more themes are loaded.

Steps to reproduce:
- Create a new website and go on the theme selection screen.
- Click on the "View more themes" button.

-> The odoo logo becomes very small.

IAP PR: https://github.com/odoo/iap-apps/pull/889
task-4184418


--------------------------------------------------------------------------------------------------------------------------------------------------------

[IMP] website: adjust configurator preview scroll animation

Prior to this commit, the preview scrolling animation used fixed values.
But since the theme redesign, image previews now have different heights.
Depending on this height, the scrolling animation may display an empty
space or not go all the way to the end of the screenshot.
This commit adjusts the scrolling animation to match the height of
selected theme previews.

task-4177975
