### PR TITLE
[FIX] website_sale_loyalty: remove erroneous `else`

### DIFF
--- a/addons/website_sale_loyalty/static/src/js/website_sale_loyalty_delivery.js
+++ b/addons/website_sale_loyalty/static/src/js/website_sale_loyalty_delivery.js
@@ -2,7 +2,6 @@
 
 import publicWidget from "@web/legacy/js/public/public_widget";
 
-
 publicWidget.registry.websiteSaleDelivery.include({
     //--------------------------------------------------------------------------
     // Private
@@ -22,8 +21,8 @@ publicWidget.registry.websiteSaleDelivery.include({
                 cart_summary_discount_line.innerHTML = this.result.new_amount_delivery_discount;
             }
         }
-        else if (this.result.new_amount_order_discounted) {
-             const cart_summary_discount_line = document.querySelector(
+        if (this.result.new_amount_order_discounted) {
+            const cart_summary_discount_line = document.querySelector(
                 '[data-reward-type="discount"]'
             );
             if (cart_summary_discount_line) {

--- a/addons/website_sale_loyalty/static/tests/tours/test_website_sale_free_shipping_discount_line.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_website_sale_free_shipping_discount_line.js
@@ -1,11 +1,11 @@
 /** @odoo-module **/
 
 import { registry } from "@web/core/registry";
-import wsTourUtils from '@website_sale/js/tours/tour_utils';
+import wsTourUtils from "@website_sale/js/tours/tour_utils";
 
-registry.category("web_tour.tours").add('check_shipping_discount', {
+registry.category("web_tour.tours").add("check_shipping_discount", {
     test: true,
-    url: '/shop?search=Plumbus',
+    url: "/shop?search=Plumbus",
     steps: () => [
         {
             content: "select Plumbus",
@@ -20,21 +20,18 @@ registry.category("web_tour.tours").add('check_shipping_discount', {
             content: "click on 'Add to Cart' button",
             trigger: '#product_detail form[action^="/shop/cart/update"] #add_to_cart',
         },
-        wsTourUtils.goToCart({quantity: 3}),
+        wsTourUtils.goToCart({ quantity: 3 }),
+        wsTourUtils.goToCheckout(),
         {
-            content: "go to checkout",
-            trigger: 'a[href="/shop/checkout?express=1"]',
+            content: "select delivery1",
+            trigger: "li label:contains(delivery1)",
         },
         {
-            content: "select delivery with rule",
-            trigger: 'li label:contains("delivery with rule")',
-        },
-        {
-            trigger: ".accordion-button"
+            trigger: ".accordion-button",
         },
         {
             content: "check if delivery price is correct'",
-            trigger: 'label:contains("delivery with rule") + span.o_wsale_delivery_badge_price:contains(100.00)',
+            trigger: "label:contains(delivery1) + span[name=price]:contains(100.00)",
             isCheck: true,
         },
         {
@@ -43,8 +40,44 @@ registry.category("web_tour.tours").add('check_shipping_discount', {
             isCheck: true,
         },
         {
-            content: "check if delivery price is correct'",
+            content: "check if shipping discount is correct",
             trigger: "[data-reward-type='shipping'] .oe_currency_value:contains('-﻿75.00')",
+            isCheck: true,
+        },
+        {
+            content: "enter eWallet code",
+            trigger: "form[name=coupon_code] input",
+            run: "text infinite-money-glitch",
+        },
+        {
+            trigger: "form[name=coupon_code] .a-submit",
+        },
+        {
+            content: "wait for accordion to collapse, then reopen",
+            trigger: ".accordion-button.collapsed",
+        },
+        {
+            content: "check eWallet discount",
+            trigger: "[data-reward-type=discount] .oe_currency_value:contains(373.75)",
+            isCheck: true,
+        },
+        {
+            content: "select delivery2",
+            trigger: "li label:contains(delivery2)",
+        },
+        {
+            content: "check for eWallet update after shipping cost change",
+            trigger: "[data-reward-type=discount] .oe_currency_value:contains(345.00)",
+            isCheck: true,
+        },
+        {
+            content: "check if new delivery price is correct'",
+            trigger: "label:contains(delivery2) + span[name=price]:contains(10.00)",
+            isCheck: true,
+        },
+        {
+            content: "check if new shipping discount is correct'",
+            trigger: "[data-reward-type=shipping] .oe_currency_value:contains(-﻿10.00)",
             isCheck: true,
         },
     ],


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Create a coupon with free shipping reward;
2. create an eWallet with enough points for a free purchase;
3. create at least 2 shipping methods with different prices;
4. in eCommerce, add a product to cart, and go to checkout;
5. apply coupon;
6. go to payment & apply eWallet;
7. switch between shipping methods.

Issue
-----
The eWallet amount on the right doesn't get updated after changing shipping costs.

Cause
-----
Commit e08449e42a01 allowed for eWallet to update after changes, using a `_handleCarrierUpdateResultBadge` override.

Commit 453c6169e080 merged the `_handleCarrierUpdateResult` & `_handleCarrierUpdateResultBadge` methods. Because of an `else` that was left in by accident, it either displays a shipping discount *or* it updates the eWallet.

Solution
--------
Remove the stray `else` so that the conditional branches are no longer mutually exclusive.

opw-4150258
