### PR TITLE
[FIX] point_of_sale: ensure draft order are canceled upon table release

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -953,6 +953,10 @@ export class PosStore extends Reactive {
         };
     }
 
+    getOrderIdsToDelete() {
+        return [...this.pendingOrder.delete];
+    }
+
     removePendingOrder(order) {
         this.pendingOrder["create"].delete(order.id);
         this.pendingOrder["write"].delete(order.id);
@@ -971,6 +975,11 @@ export class PosStore extends Reactive {
     postSyncAllOrders(orders) {}
     async syncAllOrders(options = {}) {
         try {
+            const orderIdsToDelete = this.getOrderIdsToDelete();
+            if (orderIdsToDelete.length > 0) {
+                await this.deleteOrders([], orderIdsToDelete);
+            }
+
             const { orderToCreate, orderToUpdate, paidOrdersNotSent } = this.getPendingOrder();
             const orders = [...orderToCreate, ...orderToUpdate, ...paidOrdersNotSent];
 


### PR DESCRIPTION
Before this commit, clearing all orderlines and releasing a table did not cancel the draft order, leaving it accessible upon reopening the table.

opw-4167214

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
