### PR TITLE
[IMP] website: reintroduce double events in `s_timeline`

### DIFF
--- a/addons/website/static/src/snippets/s_timeline/options.js
+++ b/addons/website/static/src/snippets/s_timeline/options.js
@@ -27,8 +27,9 @@ options.registry.Timeline = options.Class.extend({
      */
     timelineCard(previewMode, widgetValue, params) {
         const timelineRowEl = this.$target[0].closest(".s_timeline_row");
-        timelineRowEl.classList.toggle("flex-md-row-reverse");
-        timelineRowEl.classList.toggle("flex-md-row");
-        this.$target[0].classList.toggle("text-md-end");
+        const timelineCardEls = timelineRowEl.querySelectorAll(".s_timeline_card");
+        const firstContentEl = timelineRowEl.querySelector(".s_timeline_content");
+        timelineRowEl.append(firstContentEl);
+        timelineCardEls.forEach(card => card.classList.toggle("text-md-end"));
     },
 });

--- a/addons/website/views/snippets/s_timeline.xml
+++ b/addons/website/views/snippets/s_timeline.xml
@@ -20,41 +20,46 @@
                                 <small class="text-muted">13/06/2019</small>
                                 <h3 class="h4-fs card-title">First Feature</h3>
                                 <p class="card-text">A timeline is a graphical representation on which important events are marked.</p>
-                                <a href="#" class="btn btn-primary">See more</a>
                             </div>
                         </div>
                     </div>
                     <div class="s_timeline_content w-0 w-md-100 h-0"/>
                 </div>
-                <div class="s_timeline_row position-relative d-flex gap-md-5 flex-column flex-md-row-reverse pb-4" data-name="Milestone">
+                <div class="s_timeline_row position-relative d-flex gap-md-5 flex-column flex-md-row pb-4" data-name="Milestone">
                     <div class="s_timeline_line position-absolute top-0 bottom-0 w-0 mb-1 border-start pe-none"/>
                     <span class="s_timeline_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none text-o-color-1" contenteditable="false"/>
                     <div class="s_timeline_content w-100 ps-4 ps-md-0">
-                        <div class="s_timeline_card s_card card my-0 me-auto" style="border-width: 0px !important;" data-vxml="001" data-snippet="s_card" data-name="Milestone Event">
+                        <div class="s_timeline_card s_card card my-0 me-auto text-md-end" style="border-width: 0px !important;" data-vxml="001" data-snippet="s_card" data-name="Milestone Event">
                             <div class="card-body">
                                 <small class="text-muted">21/03/2021</small>
                                 <h3 class="h4-fs card-title">Second Feature</h3>
                                 <p class="card-text">A timeline is a graphical representation on which important events are marked.</p>
-                                <a href="#" class="btn btn-primary">See more</a>
                             </div>
                         </div>
                     </div>
-                    <div class="s_timeline_content w-0 w-md-100 h-0"/>
+                    <div class="s_timeline_content w-100 ps-4 ps-md-0">
+                        <div class="s_timeline_card s_card card my-0 me-auto" style="border-width: 0px !important;" data-vxml="001" data-snippet="s_card" data-name="Milestone Event">
+                            <div class="card-body">
+                                <small class="text-muted">21/03/2021</small>
+                                <h3 class="h4-fs card-title">Third Feature</h3>
+                                <p class="card-text">A timeline is a visual display that highlights significant events in chronological order.</p>
+                            </div>
+                        </div>
+                    </div>
                 </div>
                 <div class="s_timeline_row position-relative d-flex flex-column flex-md-row gap-md-5 pb-4" data-name="Milestone">
                     <div class="s_timeline_line position-absolute top-0 bottom-0 w-0 mb-1 border-start pe-none"/>
                     <span class="s_timeline_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none text-o-color-1" contenteditable="false"/>
+                    <div class="s_timeline_content w-0 w-md-100 h-0"/>
                     <div class="s_timeline_content w-100 ps-4 ps-md-0">
-                        <div class="s_timeline_card s_card card my-0 ms-auto text-md-end" style="border-width: 0px !important;" data-vxml="001" data-snippet="s_card" data-name="Milestone Event">
+                        <div class="s_timeline_card s_card card my-0 ms-auto" style="border-width: 0px !important;" data-vxml="001" data-snippet="s_card" data-name="Milestone Event">
                             <div class="card-body">
                                 <small class="text-muted">25/12/2024</small>
                                 <h3 class="h4-fs card-title">Latest Feature</h3>
                                 <p class="card-text">A timeline is a graphical representation on which important events are marked.</p>
-                                <a href="#" class="btn btn-primary">See more</a>
                             </div>
                         </div>
                     </div>
-                    <div class="s_timeline_content w-0 w-md-100 h-0"/>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Since commit 48545a60ddc4a50bc792318ed6cd20cfb20b5c55, we can no longer have two events in the same line.

This commit reintroduces double events in a row to increase layout possibilities for the user.

This commit also removes primary buttons to simplify the layout.

task-4189342
Part of task-3619705

| Header | Header |
|--------|--------|
| ![Capture d’écran 2024-09-16 à 17 08 54](https://github.com/user-attachments/assets/014c8ff3-8d88-4793-af1b-8d61ecf4c886) | ![Capture d’écran 2024-09-16 à 17 30 37](https://github.com/user-attachments/assets/831e0d86-03c1-452c-9214-f8b931fc350d) |

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
