### PR TITLE
[FIX] point_of_sale: subtotal not ignored by serialize

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1200,9 +1200,9 @@ class PosOrderLine(models.Model):
     price_unit = fields.Float(string='Unit Price', digits=0)
     qty = fields.Float('Quantity', digits='Product Unit of Measure', default=1)
     price_subtotal = fields.Float(string='Tax Excl.', digits=0,
-        readonly=True, store=True, compute='_compute_amount_line_all')
+        readonly=True, required=True)
     price_subtotal_incl = fields.Float(string='Tax Incl.', digits=0,
-        readonly=True, store=True, compute='_compute_amount_line_all')
+        readonly=True, required=True)
     price_extra = fields.Float(string="Price extra")
     price_type = fields.Selection([
         ('original', 'Original'),
@@ -1319,15 +1319,22 @@ class PosOrderLine(models.Model):
         if self.filtered(lambda x: x.order_id.state not in ["draft", "cancel"]):
             raise UserError(_("You can only unlink PoS order lines that are related to orders in new or cancelled state."))
 
-    @api.depends('price_unit', 'tax_ids', 'qty', 'discount', 'product_id')
+    @api.onchange('price_unit', 'tax_ids', 'qty', 'discount', 'product_id')
+    def _onchange_amount_line_all(self):
+        for line in self:
+            res = line._compute_amount_line_all()
+            line.update(res)
+
     def _compute_amount_line_all(self):
-        for orderline in self:
-            fpos = orderline.order_id.fiscal_position_id
-            tax_ids_after_fiscal_position = fpos.map_tax(orderline.tax_ids)
-            price = orderline.price_unit * (1 - (orderline.discount or 0.0) / 100.0)
-            taxes = tax_ids_after_fiscal_position.compute_all(price, orderline.order_id.currency_id, orderline.qty, product=orderline.product_id, partner=orderline.order_id.partner_id)
-            orderline.price_subtotal_incl = taxes['total_included']
-            orderline.price_subtotal = taxes['total_excluded']
+        self.ensure_one()
+        fpos = self.order_id.fiscal_position_id
+        tax_ids_after_fiscal_position = fpos.map_tax(self.tax_ids)
+        price = self.price_unit * (1 - (self.discount or 0.0) / 100.0)
+        taxes = tax_ids_after_fiscal_position.compute_all(price, self.order_id.currency_id, self.qty, product=self.product_id, partner=self.order_id.partner_id)
+        return {
+            'price_subtotal_incl': taxes['total_included'],
+            'price_subtotal': taxes['total_excluded'],
+        }
 
     @api.onchange('product_id')
     def _onchange_product_id(self):

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -131,6 +131,10 @@ export class PosOrder extends Base {
         this.amount_tax = this.get_total_tax();
         this.amount_total = this.get_total_with_tax();
         this.amount_return = this.get_change();
+        this.lines.forEach((line) => {
+            line.price_subtotal = line.get_price_without_tax();
+            line.price_subtotal_incl = line.get_price_with_tax();
+        });
     }
 
     // NOTE args added [unwatchedPrinter]

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -578,6 +578,9 @@ class TestUi(TestPointOfSaleHttpCommon):
         n_paid = self.env['pos.order'].search_count([('state', '=', 'paid')])
         self.assertEqual(n_invoiced, 1, 'There should be 1 invoiced order.')
         self.assertEqual(n_paid, 2, 'There should be 2 paid order.')
+        last_order = self.env['pos.order'].search([])[-1]
+        self.assertEqual(last_order.lines[0].price_subtotal, 12.0)
+        self.assertEqual(last_order.lines[0].price_subtotal_incl, 12.0)
 
     def test_04_product_configurator(self):
         # Making one attribute inactive to verify that it doesn't show

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -607,6 +607,7 @@ export class SelfOrder extends Reactive {
         }
 
         try {
+            this.currentOrder.recomputeOrderData();
             const data = await rpc(
                 `/pos-self-order/process-order/${this.config.self_ordering_mode}`,
                 {


### PR DESCRIPTION
This reverts commit 76f06383d405e129a00bd4fffa3943d68dccec46.

When serializing an object from the PoS computed fields are ignored, and this caused issues because `price_subtotal_incl` is needed in `_merge_order_lines`.

This also fix the issue of the reverted commit in another and add a test
for it.

opw-4171641
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
