### PR TITLE
[FIX] l10n_ar: AFIP Type change after company creation

### DIFF
--- a/addons/l10n_ar/models/account_chart_template.py
+++ b/addons/l10n_ar/models/account_chart_template.py
@@ -43,3 +43,18 @@ class AccountChartTemplate(models.AbstractModel):
             company.account_purchase_tax_id = self.env['account.tax']
 
         return res
+
+    def try_loading(self, template_code, company, install_demo=False):
+        # During company creation load template code corresponding to the AFIP Responsibility
+        if not company:
+            return
+        if isinstance(company, int):
+            company = self.env['res.company'].browse([company])
+        if company.country_code == 'AR' and not company.chart_template:
+            match = {
+                self.env.ref('l10n_ar.res_RM'): 'ar_base',
+                self.env.ref('l10n_ar.res_IVAE'): 'ar_ex',
+                self.env.ref('l10n_ar.res_IVARI'): 'ar_ri',
+            }
+            template_code = match.get(company.l10n_ar_afip_responsibility_type_id, template_code)
+        return super().try_loading(template_code, company, install_demo)


### PR DESCRIPTION
Create a company:
- Name: Any
- Country: Argentina
- AFIP Responsibility Type: IVA Responsable Inscripto

Save

Issue: Company AFIP Type will be set back to Responsable Monotributo
This occurs because when company is created the system will try to
load the coa.
The COA to load is currently determined only by the country of the new company,
and the default for new Argentina companies is 'Responsable Monotributo'
Then, the AFIP Type is changed to match the CoA

In order to take into account the company settings when loading the CoA
we check via context if we are operating on a company and load the
template matching the AFIP Type

opw-4175351