### PR TITLE
[IMP] account: x2many_buttons, allow to open in a new tab

### DIFF
--- a/addons/account/static/src/components/account_move_business_doc_action/account_move_open_entries.js
+++ b/addons/account/static/src/components/account_move_business_doc_action/account_move_open_entries.js
@@ -1,0 +1,43 @@
+/** @odoo-module **/
+import { registry } from "@web/core/registry";
+export async function openJournalEntries(env, action) {
+    let ids = [];
+    if (action.params.ids) {
+        ids = action.params.ids;
+    } else if (action.context.params.resId) {
+        ids = [action.context.params.resId];
+    } else if (action.context.params.ids) {
+        if (Number.isInteger(action.context.params.ids)) {
+            ids = [action.context.params.ids];
+        } else {
+            ids = action.context.params.ids.split(",").map((s) => parseInt(s));
+        }
+    }
+
+    let actionToDo;
+    if (ids.length === 1) {
+        actionToDo = await env.services.orm.call(
+            "account.move",
+            "action_open_business_doc",
+            [ids[0]],
+            {}
+        );
+    } else {
+        actionToDo = await env.services.action.loadAction("account.action_move_journal_line");
+        Object.assign(actionToDo, {
+            domain: [["id", "in", ids]],
+            views: [
+                [false, "list"],
+                [false, "form"],
+            ],
+            context: {
+                list_view_ref: "account.view_duplicated_moves_tree_js",
+            },
+        });
+        if (action.params.name) {
+            actionToDo.display_name = action.params.name;
+        }
+    }
+    return env.services.action.doAction(actionToDo);
+}
+registry.category("actions").add("action_open_journal_entries", openJournalEntries);

--- a/addons/account/static/src/components/x2many_buttons/x2many_buttons.js
+++ b/addons/account/static/src/components/x2many_buttons/x2many_buttons.js
@@ -14,32 +14,19 @@ class X2ManyButtons extends Component {
     };
 
     setup() {
-        this.orm = useService("orm");
         this.action = useService("action");
     }
 
-    async openTreeAndDiscard() {
-        const ids = this.currentField.currentIds;
+    async onClick(ids) {
         await this.props.record.discard();
-        this.action.doAction({
-            name: this.props.treeLabel,
-            type: "ir.actions.act_window",
-            res_model: "account.move",
-            views: [
-                [false, "list"],
-                [false, "form"],
-            ],
-            domain: [["id", "in", ids]],
-            context: {
-                form_view_ref: "account.view_duplicated_moves_tree_js",
+        await this.action.doAction({
+            type: "ir.actions.client",
+            tag: "action_open_journal_entries",
+            params: {
+                name: this.props.treeLabel,
+                ids: ids,
             },
         });
-    }
-
-    async openFormAndDiscard(id) {
-        const action = await this.orm.call(this.currentField.resModel, "action_open_business_doc", [id], {});
-        await this.props.record.discard();
-        this.action.doAction(action);
     }
 
     get currentField() {

--- a/addons/account/static/src/components/x2many_buttons/x2many_buttons.xml
+++ b/addons/account/static/src/components/x2many_buttons/x2many_buttons.xml
@@ -3,14 +3,18 @@
     <t t-name="account.X2ManyButtons">
         <div class="d-flex align-items-center">
             <t t-foreach="this.currentField.records.slice(0, 3)" t-as="record" t-key="record.id">
-                <button class="btn btn-link p-0"
-                        t-on-click="() => this.openFormAndDiscard(record.resId)"
+                <a t-att-href="`/odoo/journal-entries/${record.resId}`"
+                        t-on-click.prevent="() => this.onClick([record.resId])"
                         t-att-data-hotkey="`shift+${record_index + 1}`"
                         t-out="record.data.display_name"/>
                 <span t-if="!record_last" class="pe-1">,</span>
             </t>
             <t t-if="this.currentField.count gt 3">
-                <button class="btn btn-link p-0" t-on-click="() => this.openTreeAndDiscard()" data-hotkey="shift+4">... (View all)</button>
+                <a t-att-href="`/odoo/journal-entries?ids=${this.currentField.currentIds.join(',')}`"
+                    t-on-click.prevent="() => this.onClick(this.currentField.currentIds)"
+                    data-hotkey="shift+4">
+                        ... (View all)
+                </a>
             </t>
         </div>
     </t>

--- a/addons/account/static/tests/legacy/x2many_buttons_tests.js
+++ b/addons/account/static/tests/legacy/x2many_buttons_tests.js
@@ -62,7 +62,7 @@ QUnit.module("Fields", (hooks) => {
             type: "form",
         });
         assert.containsOnce(target, ".o_field_x2many_buttons", "should have rendered a x2many_buttons field");
-        assert.strictEqual(target.querySelectorAll(".o_field_x2many_buttons button").length, 2, "buttons should be rendered");
+        assert.strictEqual(target.querySelectorAll(".o_field_x2many_buttons a").length, 2, "buttons should be rendered");
     });
 
     QUnit.test("component rendering: exactly 3 records on field", async function (assert) {
@@ -76,7 +76,7 @@ QUnit.module("Fields", (hooks) => {
             type: "form",
         });
         assert.containsOnce(target, ".o_field_x2many_buttons", "should have rendered a x2many_buttons field");
-        assert.strictEqual(target.querySelectorAll(".o_field_x2many_buttons button").length, 3, "buttons should be rendered");
+        assert.strictEqual(target.querySelectorAll(".o_field_x2many_buttons a").length, 3, "buttons should be rendered");
     });
 
     QUnit.test("component rendering: more than 3 records on field", async function (assert) {
@@ -90,7 +90,7 @@ QUnit.module("Fields", (hooks) => {
             type: "form",
         });
         assert.containsOnce(target, ".o_field_x2many_buttons", "should have rendered a x2many_buttons field");
-        const buttons = target.querySelectorAll(".o_field_x2many_buttons button");
+        const buttons = target.querySelectorAll(".o_field_x2many_buttons a");
         assert.strictEqual(buttons.length, 4, "buttons should be rendered");
         assert.strictEqual(buttons[3].innerText, "... (View all)", "The 4th button should be the view all one");
     });
@@ -133,7 +133,7 @@ QUnit.module("Fields", (hooks) => {
 
         await editInput(target, "[name='ref'] input", "new ref");
         assert.strictEqual(target.querySelector("[name='ref'] input").value, "new ref", "should have edited the input");
-        await click(target.querySelector(".o_field_x2many_buttons button"));
+        await click(target.querySelector(".o_field_x2many_buttons a"));
         assert.strictEqual(target.querySelector("[name='ref'] input").value, "b1", "should have discarded the input");
         assert.verifySteps(["action_open_business_doc"])
     });
@@ -151,24 +151,19 @@ QUnit.module("Fields", (hooks) => {
         patchWithCleanup(form.env.services.action, {
             doAction(action) {
                 assert.deepEqual(action, {
-                    domain: [["id", "in", [1,2,3,4,5]]],
-                    name: "Duplicated Bills",
-                    res_model: "account.move",
-                    type: "ir.actions.act_window",
-                    views: [
-                        [false, "list"],
-                        [false, "form"],
-                    ],
-                    context: {
-                        form_view_ref: "account.view_duplicated_moves_tree_js",
-                    }
+                    params:{
+                        ids: [1, 2, 3, 4, 5],
+                        name: "Duplicated Bills",
+                    },
+                    tag: "action_open_journal_entries",
+                    type: "ir.actions.client",
                 });
             }
         });
         const x2mbuttons = target.querySelector(".o_field_x2many_buttons");
         await editInput(target, "[name='ref'] input", "new ref");
         assert.strictEqual(target.querySelector("[name='ref'] input").value, "new ref", "should have edited the input");
-        await click(x2mbuttons.querySelectorAll("button")[3]);
+        await click(x2mbuttons.querySelectorAll("a")[3]);
         assert.strictEqual(target.querySelector("[name='ref'] input").value, "b6", "should have discarded the input");
     });
 });

--- a/addons/account/views/account_menuitem.xml
+++ b/addons/account/views/account_menuitem.xml
@@ -68,4 +68,9 @@
             </menuitem>
         </menuitem>
     </menuitem>
+    <record id="ir_actions_open_journal_entries" model="ir.actions.client">
+        <field name="name">Open Journal Entries</field>
+        <field name="path">journal-entries</field>
+        <field name="tag">action_open_journal_entries</field>
+    </record>
 </odoo>


### PR DESCRIPTION
The feature "This document might be a duplicate of ..." displays a list of links to invoices or payments that could be duplicates of the current document.

As the goal is to compare multiple similar documents, it would be cool to open them in different tabs to ease their comparison. To be able to compare the documents side by side.

This is what this revision does, while keeping the exact same style and behavior.

Using a link instead of a button, with as href `/odoo/[model]/[id]` is the same strategy used by the regular many2one fields: https://github.com/odoo/odoo/blob/33206fd1941ae1aeccc32789189ad61111556eb3/addons/web/static/src/views/fields/many2one/many2one_field.xml#L31 As well as that `get_formview_action`:
https://github.com/odoo/odoo/blob/33206fd1941ae1aeccc32789189ad61111556eb3/addons/web/static/src/views/fields/many2one/many2one_field.js#L250

However, in this case, we do not know exactly which model to open. If the move is an invoice, it should be account.move, if it's a payment, it's should be account.payment.
This is the role of the method `action_open_business_doc`, as well as the role of the view list `view_duplicated_moves_tree_js` to open the right form according to what kind of accounting document the move is.

The client action added allows to have an URL which can store the id/ids of account.move to open,
hence providing the possibility to open the duplicates in a new tab with an `<a href="..."/>` link.
It uses the strategy already in place to call `action_open_business_doc` if it's a single document, to load the right form view according to the kind of accounting document,
or to load the list `account.view_duplicated_moves_tree_js` which takes care of the same thing for multiple documents.