### PR TITLE
[FIX] l10n_it_edi: prevent generation of XML if document type is not set

### DIFF
--- a/addons/l10n_it_edi/i18n/l10n_it_edi.pot
+++ b/addons/l10n_it_edi/i18n/l10n_it_edi.pot
@@ -686,6 +686,13 @@ msgstr ""
 
 #. module: l10n_it_edi
 #. odoo-python
+#: code:addons/l10n_it_edi/models/account_move.py:0
+#, python-format
+msgid "Please fill out the Document Type field in the Electronic Invoicing tab."
+msgstr ""
+
+#. module: l10n_it_edi
+#. odoo-python
 #: code:addons/l10n_it_edi/models/account_edi_proxy_user.py:0
 #, python-format
 msgid ""

--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -1236,6 +1236,9 @@ class AccountMove(models.Model):
             if moves := pa_moves.filtered(lambda move: not move.l10n_it_origin_document_type and move.l10n_it_cig and move.l10n_it_cup):
                 message = _("CIG/CUP fields of partner(s) are present, please fill out Origin Document Type field in the Electronic Invoicing tab.")
                 errors['move_missing_origin_document_field'] = build_error(message=message, records=moves)
+        if moves := self.filtered(lambda move: not move.l10n_it_document_type):
+            message = _("Please fill out the Document Type field in the Electronic Invoicing tab.")
+            errors['move_missing_document_type'] = build_error(message=message, records=moves)
         return errors
 
     def _l10n_it_edi_export_taxes_check(self):

--- a/addons/l10n_it_edi/tests/test_edi_export.py
+++ b/addons/l10n_it_edi/tests/test_edi_export.py
@@ -230,7 +230,7 @@ class TestItEdiExport(TestItEdi):
                 }),
             ],
         })
-        self.assertEqual(['partner_address_missing'], list(invoice._l10n_it_edi_export_data_check().keys()))
+        self.assertEqual(['partner_address_missing', 'move_missing_document_type'], list(invoice._l10n_it_edi_export_data_check().keys()))
 
     def test_invoice_non_domestic_simplified(self):
         invoice = self.env['account.move'].with_company(self.company).create({
@@ -246,7 +246,7 @@ class TestItEdiExport(TestItEdi):
                 }),
             ],
         })
-        self.assertEqual(['partner_address_missing'], list(invoice._l10n_it_edi_export_data_check().keys()))
+        self.assertEqual(['partner_address_missing', 'move_missing_document_type'], list(invoice._l10n_it_edi_export_data_check().keys()))
 
     def test_invoice_zero_percent_taxes(self):
         tax_zero_percent_hundred_percent_repartition = self.env['account.tax'].with_company(self.company).create({


### PR DESCRIPTION
# Issue:
When creating a vendor bill for a non EU partner, setting the tax to "22% G RC (Goods)" and generating the XML file, checking the generated XML file gives the error: "Tipo Documento must not be empty."

# Steps to reproduce:
- create a vendor bill with a non EU partner
- add a product with tax "22% G RC (Goods)"
- post the bill
- click Send Tax Integration
- check the generated XML file using an online checker like www.fatturacheck.it
- it will show the error "Tipo Documento must not be empty."

# Solution:
- The document type is usually computed. However, in this specific case, it cannot be computed because it does not meet any of the conditions in the computation logic. Additionally, there is no safeguard to prevent the generation of the XML file if the document type is not set.
- A check has been added to prevent XML generation when the document type is not set, ensuring the document type is always correctly provided before XML generation.

opw-4182531

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
