### PR TITLE
[FIX] base_automation: Account for group changes in old_values

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -742,7 +742,7 @@ class BaseAutomation(models.Model):
                 pre = {a: a._filter_pre(records) for a in automations}
                 # read old values before the update
                 old_values = {
-                    record.id: {field_name: record[field_name] for field_name in vals}
+                    record.id: {field_name: record[field_name] for field_name in vals if field_name in record._fields}
                     for record in records
                 }
                 # call original method


### PR DESCRIPTION
Currently if there is any automation rule set to trigger on save on res.users, an error will be thrown any time there is a change made to the groups on a user. This is due to the changed field being a sel_groups... field which does not actually exist on the res.users model. To circumvent this, logic has been added to identify when a field is a selection group field, and pull the correct existing group from the groups_id field on the record using set logic.

OPW: 4152636

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
