### PR TITLE
[FIX] point_of_sale: remove payment_method groupby on report.pos.order

### DIFF
--- a/addons/point_of_sale/report/pos_order_report.py
+++ b/addons/point_of_sale/report/pos_order_report.py
@@ -36,7 +36,14 @@ class PosOrderReport(models.Model):
     pricelist_id = fields.Many2one('product.pricelist', string='Pricelist', readonly=True)
     session_id = fields.Many2one('pos.session', string='Session', readonly=True)
     margin = fields.Float(string='Margin', readonly=True)
-    payment_method_id = fields.Many2one('pos.payment.method', string='Payment Method', readonly=True)
+    payment_method_ids = fields.One2many('pos.payment.method', string="Payment Methods", compute='_compute_payments', search='_search_payment_method_ids')
+
+    def _compute_payments(self):
+        for pos_line in self:
+            pos_line.payment_method_ids = pos_line.order_id.payment_ids.payment_method_id
+
+    def _search_payment_method_ids(self, operator, value):
+        return [('order_id.payment_ids.payment_method_id', operator, value)]
 
     def _select(self):
         return """
@@ -66,8 +73,7 @@ class PosOrderReport(models.Model):
                 s.pricelist_id,
                 s.session_id,
                 s.account_move IS NOT NULL AS invoiced,
-                SUM(l.price_subtotal - COALESCE(l.total_cost,0) / CASE COALESCE(s.currency_rate, 0) WHEN 0 THEN 1.0 ELSE s.currency_rate END) AS margin,
-                pm.payment_method_id AS payment_method_id
+                SUM(l.price_subtotal - COALESCE(l.total_cost,0) / CASE COALESCE(s.currency_rate, 0) WHEN 0 THEN 1.0 ELSE s.currency_rate END) AS margin
         """
 
     def _from(self):
@@ -80,8 +86,6 @@ class PosOrderReport(models.Model):
                 LEFT JOIN pos_session ps ON (s.session_id=ps.id)
                 LEFT JOIN res_company co ON (s.company_id=co.id)
                 LEFT JOIN res_currency cu ON (co.currency_id=cu.id)
-                LEFT JOIN pos_payment pm ON (pm.pos_order_id=s.id)
-                LEFT JOIN pos_payment_method ppm ON (pm.payment_method_id=ppm.id)
         """
 
     def _group_by(self):
@@ -93,9 +97,7 @@ class PosOrderReport(models.Model):
                 l.product_id,
                 pt.categ_id,
                 p.product_tmpl_id,
-                ps.config_id,
-                pm.payment_method_id,
-                ppm.id
+                ps.config_id
         """
 
     def init(self):

--- a/addons/point_of_sale/tests/test_report_pos_order.py
+++ b/addons/point_of_sale/tests/test_report_pos_order.py
@@ -104,3 +104,44 @@ class TestReportPoSOrder(TestPoSCommon):
 
         self.assertEqual(reports[0].margin, 135)
         self.assertEqual(reports[0].price_total, 135)
+
+    def test_report_pos_order_3(self):
+        """Test order with multiple payments"""
+
+        product1 = self.create_product('Product 1', self.categ_basic, 150)
+
+        self.open_new_session()
+        session = self.pos_session
+        self.env['pos.order'].create({
+            'session_id': session.id,
+            'lines': [
+                (0, 0, {
+                    'name': "OL/0001",
+                    'product_id': product1.id,
+                    'price_unit': 150,
+                    'discount': 0,
+                    'qty': 1.0,
+                    'price_subtotal': 150,
+                    'price_subtotal_incl': 150,
+                })
+            ],
+            'amount_total': 150.0,
+            'amount_tax': 0.0,
+            'amount_paid': 0.0,
+            'amount_return': 0.0,
+            'payment_ids': [
+                (0, 0, {
+                    'payment_method_id': self.cash_pm1.id,
+                    'amount': 100,
+                }),
+                (0, 0, {
+                    'payment_method_id': self.cash_pm1.id,
+                    'amount': 50,
+                })
+            ]
+        })
+
+        # PoS Orders have negative IDs to avoid conflict, so reports[0] will correspond to the newest order
+        reports = self.env['report.pos.order'].sudo().search([('product_id', '=', product1.id)], order='id')
+
+        self.assertEqual(reports[0].product_qty, 1.0)

--- a/addons/point_of_sale/views/pos_order_report_view.xml
+++ b/addons/point_of_sale/views/pos_order_report_view.xml
@@ -58,12 +58,12 @@
                     <field name="partner_id"/>
                     <field name="product_id"/>
                     <field name="product_categ_id"/>
+                    <field name="payment_method_ids"/>
                     <group expand="1" string="Group By">
                         <filter string="User" name="User" context="{'group_by':'user_id'}"/>
                         <filter string="Point of Sale" name="pos" context="{'group_by':'config_id'}"/>
                         <filter string="Product" name="product" context="{'group_by':'product_id'}"/>
                         <filter string="Product Category" name="product_category" context="{'group_by':'product_categ_id'}"/>
-                        <filter string="Payment Method" name="payment_method" context="{'group_by':'payment_method_id'}"/>
                         <separator/>
                         <filter string="Order Date" name="order_month" context="{'group_by':'date:month'}"/>
                     </group>


### PR DESCRIPTION
This commit will correct the report.pos.order lines having double or more amounts due to a join on payment methods.

See recent pull:
https://github.com/odoo/odoo/pull/166528
This PR added payment methods to the POS report by joining the payments from the order. It does not regard workflows with multiple payments or cash payments. In these scenarios, an order will have multiple payment records and joining on these causes the pos.order.line to be counted twice, once for each payment.

Steps:
1. Open a POS session and add any item to order
2. In the payment screen, attach two payments
 - Can be done manually by making separate partial payments
 - If using cash register, add a cash payment larger than amount. This will result in a second (negative) payment for change
3. Go to POS Order Report analysis (best viewed in pivot) and locate relevant order
4. The report line will have 2x quantity and total price

The reason for this is that payment_ids is a O2M field. We cannot do a left join on this because it will create a duplicate line for each payment. The duplicate lines are then grouped and summed, resulting in bad amounts.

The aim of this fix is to remove the join on payments and refactor it into a computed O2M field. However, this means that we can no longer group by payment methods so a search method was added to allow filtering, instead.

opw-4141426


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
