### PR TITLE
[IMP] mail: minor discuss style improvements

### DIFF
--- a/addons/mail/static/src/core/common/autoresize_input.scss
+++ b/addons/mail/static/src/core/common/autoresize_input.scss
@@ -8,7 +8,7 @@
             --o-input-border-color: #{$border-color};
         }
         &:focus {
-            --o-input-border-color: #{$black};
+            --o-input-border-color: #{rgba($black, .5)};
         }
     }
 }

--- a/addons/mail/static/src/core/common/chat_window.scss
+++ b/addons/mail/static/src/core/common/chat_window.scss
@@ -18,6 +18,7 @@
 }
 
 .o-mail-ChatWindow-command {
+    --btn-active-border-color: transparent;
     color: inherit !important;
     &:hover, &.o-active {
         background-color: rgba(0, 0, 0, 0.05);

--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -83,7 +83,7 @@
     top: -10000px;
 }
 
-.o-mail-Composer-compactContainer {
+.o-mail-Composer-focusBorderedStyle {
     --border-opacity: 0.75;
 
     &.o-mobile:not(:focus-within) {
@@ -91,7 +91,7 @@
     }
 
     &:has(textarea:focus) {
-        --border-opacity: 0.35;
+        --border-opacity: 0.25;
         border-color: rgba($o-action, var(--border-opacity)) !important;
     }
 }

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -11,7 +11,7 @@
                     'pb-2': extended and !props.composer.message,
                     'o-extended': extended,
                     'o-isUiSmall': ui.isSmall,
-                    'p-3': normal,
+                    'p-3 mt-1': normal,
                     'o-hasSelfAvatar': !env.inChatWindow and thread,
                     'o-focused': props.composer.isFocused,
                     'o-editing': props.composer.message,
@@ -31,15 +31,16 @@
             <div class="o-mail-Composer-coreMain d-flex flex-nowrap align-items-start flex-grow-1" t-att-class="{ 'flex-column' : extended }">
                 <div class="d-flex bg-view flex-grow-1 border"
                     t-att-class="{
-                        'o-mail-Composer-compactContainer m-1 shadow-sm border-secondary': compact and !props.composer.message,
-                        'o-mobile rounded-3': isMobileOS,
-                        'rounded-3' : normal,
-                        'rounded-3 align-self-stretch' : extended,
+                        'm-1 shadow-sm': compact and !props.composer.message,
+                        'o-mobile': isMobileOS,
+                        'rounded' : normal or extended or isMobileOS or (compact and !props.composer.message),
+                        'border-secondary o-mail-Composer-focusBorderedStyle' : normal or (compact and !props.composer.message),
+                        'align-self-stretch' : extended,
                         'flex-column': extended or props.composer.message,
                     }"
                 >
                     <div class="position-relative flex-grow-1">
-                        <textarea class="o-mail-Composer-input o-mail-Composer-inputStyle form-control bg-view border-0 rounded-3 shadow-none overflow-auto"
+                        <textarea class="o-mail-Composer-input o-mail-Composer-inputStyle form-control bg-view border-0 shadow-none overflow-auto"
                             t-ref="textarea"
                             style="height:40px;"
                             t-on-keydown="onKeydown"
@@ -67,7 +68,7 @@
                         t-att-class="{
                             'ms-1': compact and ui.isSmall,
                             'mx-1': compact and !ui.isSmall,
-                            'ms-3': normal,
+                            'ms-3 rounded-end-3': normal,
                             'mx-3 border-top p-1': extended,
                             'border-top': extended or props.composer.message,
                             'rounded': !props.composer.message,

--- a/addons/mail/static/src/core/common/message.dark.scss
+++ b/addons/mail/static/src/core/common/message.dark.scss
@@ -1,5 +1,9 @@
-.o-mail-Message.o-card {
-    background-color: mix($gray-100, $gray-200);
+.o-mail-Message {
+    --mail-Message-quickActionHover: #{$gray-300};
+
+    &.o-card {
+        background-color: mix($gray-100, $gray-200);
+    }
 }
 
 .o-mail-Message-author {

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -119,6 +119,7 @@
 }
 
 .o-mail-Message-actions {
+    --btn-active-border-color: transparent;
     z-index: $o-mail-NavigableList-zIndex - 3;
 
     &.o-expanded {
@@ -126,7 +127,7 @@
     }
 
     button:hover, .focus {
-        background-color: mix($o-gray-100, $o-gray-200) !important;
+        background-color: var(--mail-Message-quickActionHover, $gray-200) !important;
     }
 }
 

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -76,7 +76,7 @@
                                                     'o-orange border border-warning': message.bubbleColor === 'orange',
                                                     }" t-attf-class="{{ isAlignedRight ? 'rounded-start-3' : 'rounded-end-3' }}"/>
                                                 <MessageInReply t-if="message.parentMessage" message="message" onClick="props.onParentMessageClick"/>
-                                                <div class="position-relative text-break o-mail-Message-body" t-att-class="{
+                                                <div class="position-relative text-break o-mail-Message-body small" t-att-class="{
                                                             'p-1': message.is_note,
                                                             'fs-1': !state.isEditing and !env.inChatter and message.onlyEmojis,
                                                             'mb-0 py-2': !message.is_note,
@@ -153,7 +153,7 @@
                         'rounded-start-1': isStart,
                         'rounded-end-1': isEnd,
                     }"/>
-                    <button t-else="" class="btn px-1 py-0 rounded-0" t-att-title="action.title" t-att-name="action.id" t-on-click.stop="action.onClick" t-att-class="{
+                    <button t-else="" class="btn btn-sm px-1 py-0 rounded-0" t-att-title="action.title" t-att-name="action.id" t-on-click.stop="action.onClick" t-att-class="{
                         'rounded-start-1': isStart,
                         'rounded-end-1': isEnd,
                     }">
@@ -180,7 +180,7 @@
 
 
 <t t-name="mail.Message.expandAction">
-    <button class="btn rounded-0" t-att-title="expandText" t-on-click="openMobileActions" t-att-class="{
+    <button class="btn btn-sm rounded-0" t-att-title="expandText" t-on-click="openMobileActions" t-att-class="{
         'o-mail-Message-openActionMobile opacity-25 p-2 mt-n2 rounded-circle user-select-none': isMobileOS and !mobileExpanded,
         'me-n2': isMobileOS and !mobileExpanded and isAlignedRight,
         'ms-n2': isMobileOS and !mobileExpanded and !isAlignedRight,

--- a/addons/mail/static/src/core/common/message_reaction_button.xml
+++ b/addons/mail/static/src/core/common/message_reaction_button.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.MessageReactionButton">
-        <button class="btn px-1 py-0 lh-1 rounded-0" t-att-class="props.classNames" tabindex="1" t-att-title="props.action.title" aria-label="props.action.title" t-ref="emoji-picker"><i class="fa-lg" t-att-class="props.action.icon"/></button>
+        <button class="btn btn-sm px-1 py-0 lh-1 rounded-0" t-att-class="props.classNames" tabindex="1" t-att-title="props.action.title" aria-label="props.action.title" t-ref="emoji-picker"><i class="fa-lg" t-att-class="props.action.icon"/></button>
     </t>
 
 </templates>

--- a/addons/mail/static/src/core/common/search_messages_panel.xml
+++ b/addons/mail/static/src/core/common/search_messages_panel.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.SearchMessagesPanel">
-        <ActionPanel title="env.inChatter ? undefined : title" minWidth="200" initialWidth="400">
+        <ActionPanel title="env.inChatter ? undefined : title" minWidth="200" initialWidth="400" icon="'oi oi-search'">
             <div class="d-flex py-2">
                 <div class="input-group">
                     <div class="o_searchview form-control d-flex align-items-center bg-view p-0" role="search" aria-autocomplete="list">

--- a/addons/mail/static/src/core/public_web/discuss.dark.scss
+++ b/addons/mail/static/src/core/public_web/discuss.dark.scss
@@ -5,18 +5,11 @@
 .o-mail-Discuss-headerActions button {
     background-color: mix($gray-100, $gray-200);
 
-    &:not(.o-isActive):hover {
+    &:hover, &.o-isActive {
         background-color: $gray-300;
-    }
-    &.o-isActive {
-        background-color: $gray-400;
-    }
-    &.o-isActive:hover {
-        background-color: mix($gray-300, $gray-400);
     }
 }
 
 .o-mail-Discuss-headerActionsGroup {
-    --border-opacity: .1;
-    background-color: mix($gray-200, $gray-300);
+    --border-opacity: .125;
 }

--- a/addons/mail/static/src/core/public_web/discuss.scss
+++ b/addons/mail/static/src/core/public_web/discuss.scss
@@ -1,3 +1,8 @@
+.o_control_panel:has(+ .o-mail-Discuss) {
+    --border-opacity: .5;
+    --ControlPanel-border-bottom: #{$border-width solid rgba($border-color, var(--border-opacity, 1))};
+}
+
 .o-mail-Discuss-content {
     .o-mail-Thread {
         flex-grow: 1;
@@ -17,33 +22,33 @@
     max-width: 75%;
 }
 .o-mail-Discuss-header {
+    --border-opacity: .5;
+    box-shadow: 0 .125rem .25rem rgba($black, .025); // 1/3rd of box-shadow-sm
     background-color: $white;
-    box-shadow: 0px 1px 6px -3px rgba(50, 50, 50, 0.15);
 }
 
 .o-mail-Discuss-headerActions button {
     --btn-disabled-opacity: 0.25;
 
-    &:not(.o-isActive):hover {
-        background-color: $gray-200;
+    &:hover, &.o-isActive {
+        background-color: $gray-300;
     }
     &.o-isActive {
-        background-color: $gray-300;
-        outline: $border-width solid $gray-500;
-        outline-offset: -$border-width;
-    }
-    &.o-isActive:hover {
-        background-color: $gray-300;
+        color: #{var(--btn-active-color)};
     }
 }
 
 .o-mail-Discuss-headerActionsGroup {
-    --border-opacity: .05;
+    --border-opacity: .025;
     background-color: mix($gray-100, $gray-200, 75%);
 }
 
 .o-mail-Discuss-headerCountry {
     width: 24px;
+}
+
+.o-mail-Discuss-rightPanel {
+    --border-opacity: .5;
 }
 
 .o-mail-Discuss-threadAvatar {

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -6,9 +6,9 @@
     <div class="o-mail-Discuss d-flex h-100 flex-grow-1" t-att-class="{ 'flex-column align-items-center bg-view': ui.isSmall }" t-ref="root">
         <DiscussSidebar t-if="!ui.isSmall and props.hasSidebar"/>
         <div t-if="!(ui.isSmall and store.discuss.activeTab !== 'main')" class="o-mail-Discuss-content d-flex flex-column h-100 w-100 overflow-auto" t-ref="content">
-            <div class="o-mail-Discuss-header px-3 d-flex flex-shrink-0 align-items-center border-bottom z-1 flex-grow-0" t-ref="header">
+            <div class="o-mail-Discuss-header px-3 d-flex flex-shrink-0 align-items-center border-bottom border-secondary z-1 flex-grow-0" t-ref="header">
                 <t t-if="thread">
-                    <div t-if="['channel', 'group', 'chat'].includes(thread.channel_type)" class="o-mail-Discuss-threadAvatar position-relative align-self-center align-items-center mt-2 mb-2 me-2">
+                    <div t-if="['channel', 'group', 'chat'].includes(thread.channel_type)" class="o-mail-Discuss-threadAvatar position-relative align-self-center align-items-center my-1 me-2">
                         <img class="rounded" t-att-src="thread.avatarUrl" alt="Thread Image"/>
                         <FileUploader t-if="thread.is_editable" acceptedFileExtensions="'.bmp, .jpg, .jpeg, .png, .svg'" showUploadingText="false" multiUpload="false" onUploaded.bind="(data) => this.onFileUploaded(data)">
                             <t t-set-slot="toggler">
@@ -23,9 +23,9 @@
                     </t>
                     <CountryFlag t-if="thread.anonymous_country" country="thread.anonymous_country" class="'o-mail-Discuss-headerCountry border'"/>
                     <ImStatus t-if="thread.channel_type === 'chat' and thread.correspondent" className="'me-1'" member="thread.correspondent" />
-                    <div class="d-flex flex-grow-1 align-self-center align-items-center h-100 py-2">
+                    <div class="d-flex flex-grow-1 align-self-center align-items-center h-100 py-1">
                         <AutoresizeInput
-                            className="'o-mail-Discuss-threadName lead fw-bold flex-shrink-1 text-dark py-0'"
+                            className="'o-mail-Discuss-threadName fw-bolder flex-shrink-1 py-0'"
                             enabled="thread.is_editable or thread.channel_type === 'chat'"
                             onValidate.bind="renameThread"
                             value="thread.displayName"
@@ -34,7 +34,7 @@
                             <div class="flex-shrink-0 mx-2 py-2 border-start"/>
                             <t t-set="autogrowDescriptionPlaceholder">Add a description</t>
                             <AutoresizeInput
-                                className="'o-mail-Discuss-threadDescription flex-shrink-1 py-1'"
+                                className="'o-mail-Discuss-threadDescription flex-shrink-1 py-0 fw-bold text-muted small'"
                                 enabled="thread.is_editable"
                                 onValidate.bind="updateThreadDescription"
                                 placeholder="thread.is_editable ? autogrowDescriptionPlaceholder : ''"
@@ -42,8 +42,8 @@
                             />
                         </t>
                     </div>
-                    <div class="o-mail-Discuss-headerActions flex-shrink-0 d-flex align-items-center ms-1">
-                        <span t-if="partitionedActions.quick.length" class="o-mail-Discuss-headerActionsGroup btn-group border border-dark">
+                    <div class="o-mail-Discuss-headerActions flex-shrink-0 d-flex align-items-center ms-1 my-1">
+                        <span t-if="partitionedActions.quick.length" class="o-mail-Discuss-headerActionsGroup btn-group btn-group-sm border border-dark">
                             <t t-set="groupBefore" t-value="true"/>
                             <t t-foreach="partitionedActions.quick" t-as="action" t-key="action.id" t-call="mail.Discuss.action">
                                 <t t-set="action" t-value="action"/>
@@ -51,7 +51,7 @@
                         </span>
                         <t t-else="" t-set="groupBefore" t-value="false"/>
                         <span t-if="groupBefore" class="text-muted align-self-stretch ms-2 me-1"/>
-                        <span t-if="partitionedActions.other.length" class="o-mail-Discuss-headerActionsGroup btn-group border border-dark">
+                        <span t-if="partitionedActions.other.length" class="o-mail-Discuss-headerActionsGroup btn-group btn-group-sm border border-dark">
                          <t t-set="groupBefore" t-value="true"/>
                             <t t-foreach="partitionedActions.other" t-as="action" t-key="action.id" t-call="mail.Discuss.action">
                                 <t t-set="action" t-value="action"/>
@@ -60,7 +60,7 @@
                         <t t-else="" t-set="groupBefore" t-value="false"/>
                         <span t-if="groupBefore" class="text-muted align-self-stretch ms-2 me-1"/>
                         <t t-foreach="partitionedActions.group.slice().reverse()" t-as="group" t-key="group_index">
-                            <span t-if="group.length" class="o-mail-Discuss-headerActionsGroup btn-group border border-dark">
+                            <span t-if="group.length" class="o-mail-Discuss-headerActionsGroup btn-group btn-group-sm border border-dark">
                                 <t t-foreach="group" t-as="action" t-key="action.id" t-call="mail.Discuss.action">
                                     <t t-set="action" t-value="action"/>
                                 </t>
@@ -69,7 +69,7 @@
                         </t>
                         <div t-if="store.inPublicPage and !ui.isSmall" class="d-flex align-items-center">
                             <img class="o-mail-Discuss-selfAvatar mx-1 rounded-circle o_object_fit_cover flex-shrink-0" alt="Avatar" t-att-src="store.self.avatarUrl"/>
-                            <div class="lead fw-bold flex-shrink-1 text-dark">
+                            <div class="lead fw-bolder flex-shrink-1 text-dark">
                                 <t t-if="store.self.type === 'partner'" t-esc="store.self.name"/>
                                 <t t-else="">
                                     <AutoresizeInput
@@ -91,7 +91,7 @@
                             <t name="thread"><Thread thread="thread" t-key="thread.localId" jumpPresent="state.jumpThreadPresent" messageEdition="messageEdition" messageToReplyTo="messageToReplyTo"/></t>
                             <Composer t-if="thread.model !== 'mail.box' or thread.eq(messageToReplyTo.thread)" t-key="thread.localId" composer="thread.composer" autofocus="true" messageEdition="messageEdition" messageToReplyTo="messageToReplyTo" onDiscardCallback="() => messageToReplyTo.cancel()" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="messageToReplyTo?.message ? (messageToReplyTo.message.is_note ? 'note' : 'message') : undefined"/>
                         </div>
-                        <div t-if="threadActions.activeAction?.componentCondition" t-attf-class="{{ threadActions.activeAction.panelOuterClass }}" class="h-100 border-start flex-shrink-0">
+                        <div t-if="threadActions.activeAction?.componentCondition" t-attf-class="{{ threadActions.activeAction.panelOuterClass }}" class="o-mail-Discuss-rightPanel h-100 border-start border-secondary flex-shrink-0 shadow-sm z-1">
                             <t t-component="threadActions.activeAction.component" thread="thread" t-props="threadActions.activeAction.componentProps"/>
                         </div>
                     </t>
@@ -106,7 +106,7 @@
 </t>
 
 <t t-name="mail.Discuss.action">
-    <button class="btn px-1 btn-group-item btn-secondary bg-inherit m-0 border-0" t-attf-class="{{ action.isActive ? 'o-isActive' : '' }}" t-att-disabled="action.disabledCondition" t-att-title="action.name" t-att-name="action.id" t-on-click="() => action.onSelect()">
+    <button class="btn px-1 btn-group-item btn-secondary bg-inherit m-0 border-0" t-att-class="{ 'rounded-start-1': action_first, 'rounded-end-1': action_last }" t-attf-class="{{ action.isActive ? 'o-isActive' : '' }}" t-att-disabled="action.disabledCondition" t-att-title="action.name" t-att-name="action.id" t-on-click="() => action.onSelect()">
         <i t-if="action.iconLarge" t-att-class="action.iconLarge"/> <span t-if="action.text" t-esc="action.text"/>
     </button>
 </t>

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.scss
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.scss
@@ -1,5 +1,5 @@
 .o-mail-DiscussSidebar {
-    box-shadow: 1px 0px 6px -3px rgba(50, 50, 50, 0.15);
+    --border-opacity: .5;
     width: 60px;
 
     &:not(.o-compact) {

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.xml
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebar">
-        <div class="o-mail-DiscussSidebar d-flex d-print-none flex-column overflow-auto flex-shrink-0 h-100 border-end z-1 o-mail-discussSidebarBgColor" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }">
+        <div class="o-mail-DiscussSidebar d-flex d-print-none flex-column overflow-auto flex-shrink-0 h-100 border-end border-secondary z-1 o-mail-discussSidebarBgColor shadow-sm" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }">
             <div class="o-mail-DiscussSidebar-top position-sticky justify-content-center top-0 z-2 o-mail-discussSidebarBgColor" t-att-class="{ 'py-2': !store.inPublicPage, 'pt-1': store.inPublicPage }">
                 <div class="d-flex align-items-center justify-content-center" t-att-class="{ 'flex-column gap-2': store.discuss.isSidebarCompact }">
                     <t name="compact-btn">
-                        <Dropdown state="compactFloating" position="'right-middle'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-view border p-2 mx-2 my-2 min-w-0 shadow-sm'" manual="true">
+                        <Dropdown state="compactFloating" position="'right-middle'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-view border p-2 m-2 min-w-0 shadow-none'" manual="true">
                             <button class="o-mail-DiscussSidebar-compactBtn btn btn-light py-1 align-items-center justify-content-center smaller" t-att-aria-label="compactBtnText" t-att-class="{ 'ms-auto me-0': !store.discuss.isSidebarCompact, 'position-absolute': !store.discuss.isSidebarCompact and !store.inPublicPage, 'o-compact': store.discuss.isSidebarCompact }" t-on-click="() => this.store.discuss.isSidebarCompact = !this.store.discuss.isSidebarCompact" t-ref="compact-btn"><i class="oi fa-fw" t-att-class="store.discuss.isSidebarCompact ? 'oi-arrow-right' : 'oi-arrow-left'"/></button>
                             <t t-set-slot="content">
                                 <div t-ref="compact-floating">

--- a/addons/mail/static/src/core/public_web/messaging_menu.scss
+++ b/addons/mail/static/src/core/public_web/messaging_menu.scss
@@ -7,7 +7,6 @@
 
 .o-mail-MessagingMenu-list {
     background-color: var(--mail-MessagingMenu-bg, $o-view-background-color);
-    gap: map-get($spacers, 1) / 2;
 }
 
 .o-mail-MessagingMenu-navbar button.o-active {

--- a/addons/mail/static/src/core/public_web/messaging_menu.xml
+++ b/addons/mail/static/src/core/public_web/messaging_menu.xml
@@ -7,7 +7,7 @@
 
 <t t-name="mail.MessagingMenu.content">
     <div t-if="!(ui.isSmall and env.inDiscussApp and store.discuss.activeTab === 'main')" t-att-class="`${discussSystray.contentClass} o-mail-MessagingMenu`">
-        <div t-if="!env.inDiscussApp or store.discuss.activeTab !== 'main'" class="o-mail-MessagingMenu-list d-flex flex-column overflow-auto flex-grow-1 list-group list-group-flush" t-ref="notification-list">
+        <div t-if="!env.inDiscussApp or store.discuss.activeTab !== 'main'" class="o-mail-MessagingMenu-list d-flex flex-column overflow-auto flex-grow-1 list-group list-group-flush p-1 gap-1" t-ref="notification-list">
             <t t-foreach="threads" name="threads" t-as="thread" t-key="thread.localId">
                 <t t-set="message" t-value="thread.isChatChannel or (thread.channel_type === 'channel' and thread.needactionMessages.length === 0) ? thread.newestPersistentNotEmptyOfAllMessage : thread.needactionMessages.at(-1)"/>
                 <NotificationItem

--- a/addons/mail/static/src/core/public_web/notification_item.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.scss
@@ -46,7 +46,7 @@
 
 .o-mail-NotificationItem-unreadIndicator {
     color: darken($info, 5%);
-    opacity: 85%;
-    font-size: 0.5rem;
+    opacity: 75%;
+    font-size: 0.4rem;
     left: map-get($spacers, 2);
 }

--- a/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
@@ -10,7 +10,7 @@
     </t>
 
     <t t-name="mail.Mailbox">
-        <Dropdown t-if="store.discuss.isSidebarCompact" state="floating" position="'right-middle'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-view border p-2 mx-2 my-2 min-w-0 shadow-sm'" manual="true">
+        <Dropdown t-if="store.discuss.isSidebarCompact" state="floating" position="'right-middle'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-view border p-2 mx-2 my-2 min-w-0 shadow-none'" manual="true">
             <t t-call="mail.Mailbox.main"/>
             <t t-set-slot="content">
                 <div class="overflow-hidden" t-ref="floating">
@@ -27,8 +27,8 @@
             t-att-class="{
                 'bg-inherit': mailbox.notEq(store.discuss.thread),
                 'o-active': mailbox.eq(store.discuss.thread),
-                'justify-content-center position-relative': store.discuss.isSidebarCompact,
-                'py-1': !store.discuss.isSidebarCompact,
+                'py-2 justify-content-center position-relative': store.discuss.isSidebarCompact,
+                'py-0': !store.discuss.isSidebarCompact,
             }"
             t-on-click="(ev) => this.openThread(ev)"
             t-ref="root"

--- a/addons/mail/static/src/core/web/discuss_sidebar_patch.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.DiscussSidebar" t-inherit-mode="extension">
         <xpath expr="//*[@name='compact-btn']" position="before">
-            <Dropdown t-if="store.discuss.isSidebarCompact" state="meetingFloating" position="'right-middle'" menuClass="'o-mail-DiscussSidebar-floatingMenu border bg-view p-2 mx-2 my-2 min-w-0 shadow-sm'" manual="true">
+            <Dropdown t-if="store.discuss.isSidebarCompact" state="meetingFloating" position="'right-middle'" menuClass="'o-mail-DiscussSidebar-floatingMenu border bg-view p-2 mx-2 my-2 min-w-0 shadow-none'" manual="true">
                 <t t-call="mail.DiscussSidebar.startMeetingButton"/>
                 <t t-set-slot="content">
                     <div t-ref="meeting-floating">

--- a/addons/mail/static/src/discuss/core/common/action_panel.js
+++ b/addons/mail/static/src/discuss/core/common/action_panel.js
@@ -13,6 +13,7 @@ export class ActionPanel extends Component {
     static components = { ResizablePanel };
     static props = {
         title: { type: String, optional: true },
+        icon: { type: String, optional: true },
         resizable: { type: Boolean, optional: true },
         slots: { type: Object, optional: true },
         initialWidth: { type: Number, optional: true },

--- a/addons/mail/static/src/discuss/core/common/action_panel.xml
+++ b/addons/mail/static/src/discuss/core/common/action_panel.xml
@@ -13,9 +13,10 @@
     <t t-name="mail.ActionPanel.content">
         <div class="o-mail-ActionPanel-header position-sticky top-0 pt-2 pb-1 d-flex align-items-baseline gap-1 bg-inherit" t-att-class="{ 'px-1': env.inChatWindow, 'px-2': !env.inChatWindow }">
             <button t-if="env.closeActionPanel" class="btn p-1 opacity-75 opacity-100-hover text-muted" title="Close panel" t-on-click.stop="env.closeActionPanel">
-                <i class="oi oi-arrow-left fa-lg fa-fw"/>
+                <i class="oi oi-arrow-left fa-fw"/>
             </button>
-            <p t-if="props.title" class="fs-6 fw-bold text-uppercase m-0 text-muted flex-grow-1" t-esc="props.title"/>
+            <i t-if="props.icon" class="me-1 text-muted" t-att-class="props.icon"/>
+            <p t-if="props.title" class="fw-bold text-uppercase m-0 text-muted flex-grow-1 smaller" t-esc="props.title"/>
         </div>
         <div class="px-1 d-flex flex-column flex-grow-1 bg-inherit">
             <t t-slot="default"/>

--- a/addons/mail/static/src/discuss/core/common/attachment_panel.xml
+++ b/addons/mail/static/src/discuss/core/common/attachment_panel.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.AttachmentPanel">
-        <ActionPanel title.translate="Attachments" minWidth="200" initialWidth="400">
+        <ActionPanel title.translate="Attachments" minWidth="200" initialWidth="400" icon="'fa fa-paperclip'">
             <div class="d-flex flex-column py-2 flex-grow-1">
                 <div t-if="hasToggleAllowPublicUpload" class="form-check form-switch mx-4">
                     <label class="form-check-label">

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.ChannelInvitation">
-        <ActionPanel title.translate="Invite people" resizable="false">
+        <ActionPanel title.translate="Invite people" resizable="false" icon="'fa fa-user-plus'">
             <div class="d-flex flex-column flex-grow-1 bg-inherit" t-att-class="{ 'o-discuss-ChannelInvitation-has-size-constraints': props.hasSizeConstraints }">
                 <t t-if="store.self.type === 'partner'">
                     <input class="o-discuss-ChannelInvitation-search form-control lh-1 px-2 bg-view" t-ref="input" placeholder="Type the name of a person" t-on-input="onInput"/>

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -2,8 +2,8 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.ChannelMemberList">
-        <ActionPanel title.translate="Members" minWidth="200">
-            <button t-on-click="() => props.openChannelInvitePanel({ keepPrevious: env.inChatWindow })" class="btn btn-secondary m-2 mt-0">Invite a User</button>
+        <ActionPanel title.translate="Members" minWidth="200" icon="'fa fa-users'">
+            <button t-on-click="() => props.openChannelInvitePanel({ keepPrevious: env.inChatWindow })" class="btn btn-secondary btn-sm m-2 mt-1 d-flex align-items-center justify-content-center gap-2"><i class="fa fa-fw fa-user-plus"/>Invite a User</button>
             <t t-if="props.thread.onlineMembers.length > 0">
                 <h6 class="text-muted pt-2 text-uppercase smaller">
                     Online -

--- a/addons/mail/static/src/discuss/core/common/notification_settings.scss
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.scss
@@ -1,5 +1,13 @@
 .o-discuss-NotificationSettings {
 
+    button {
+        --btn-active-border-color: transparent;
+
+        &:hover {
+            background-color: $gray-200;
+        }
+    }
+
     .o-mail-NotificationSettings-submenu {
         max-width: 250px !important;
     }

--- a/addons/mail/static/src/discuss/core/common/notification_settings.xml
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.xml
@@ -2,13 +2,13 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.NotificationSettings">
-        <ActionPanel title.translate="Notification Settings">
+        <ActionPanel title.translate="Notification Settings" icon="'fa fa-bell'">
             <div class="o-discuss-NotificationSettings">
                 <div t-if="store.settings.mute_until_dt" class="d-flex flex-column alert alert-warning">
                     <span><i class="fa fa-exclamation-triangle"/> <a href="#" t-on-click="onClickServerMuted">Server is muted</a></span>
                 </div>
                 <t t-if="props.thread.mute_until_dt">
-                    <button class="btn w-100 d-flex p-1 opacity-75 opacity-100-hover" t-on-click="()=>this.setMute(false)">
+                    <button class="btn w-100 d-flex p-1 rounded-0" t-on-click="()=>this.setMute(false)">
                         <div class="d-flex flex-column flex-grow-1 px-2 py-1 w-100 rounded">
                             <span class="fs-6 fw-bold text-wrap text-start text-break">Unmute Channel</span>
                             <span class="fw-normal smaller" t-out="store.settings.getMuteUntilText(props.thread.mute_until_dt)"/>
@@ -17,8 +17,8 @@
                 </t>
                 <div t-else="" class="d-flex">
                     <Dropdown t-if="props.thread.channel_type === 'channel'" position="'right-start'" menuClass="'o-mail-NotificationSettings-submenu d-flex flex-column py-0 my-0'">
-                        <button class="btn w-100 d-flex p-1 opacity-75 opacity-100-hover">
-                            <div class="d-flex flex-grow-1 align-items-center px-2 py-1 w-100 rounded">
+                        <button class="btn btn-light bg-inherit w-100 d-flex p-1 rounded-0 border-0">
+                            <div class="d-flex flex-grow-1 align-items-center px-2 py-1 w-100">
                                 <span class="text-wrap text-start text-break">Mute Channel</span>
                                 <div class="o-discuss-NotificationSettings-separator flex-grow-1"/>
                                 <i class="oi oi-arrow-right ms-2"/>
@@ -34,27 +34,27 @@
                         <div class="d-flex align-items-center rounded px-3 py-2 m-0">
                             <span class="fs-6 fw-bold text-wrap text-start text-break">Mute Channel</span>
                         </div>
-                        <hr class="solid mx-2 my-0"/>
+                        <hr class="solid mx-2 my-1"/>
                         <t t-foreach="store.settings.MUTES" t-as="mute" t-key="mute.label">
-                            <button class="o-mail-NotificationSettings-muteDuration btn rounded d-flex align-items-center fs-6 fw-normal px-3 py-2 m-0 opacity-75 opacity-100-hover" t-att-title="mute.name" t-on-click="() => this.setMute(mute.value)" t-out="mute.name"/>
+                            <button class="o-mail-NotificationSettings-muteDuration btn rounded d-flex align-items-center fs-6 fw-normal px-3 py-2 m-0 rounded-0" t-att-title="mute.name" t-on-click="() => this.setMute(mute.value)" t-out="mute.name"/>
                         </t>
                     </div>
                 </div>
                 <t t-if="props.thread.channel_type === 'channel'">
-                    <hr class="solid mx-2 my-0"/>
-                    <button class="btn d-flex w-100 px-1 py-0 opacity-75 opacity-100-hover" t-on-click="() => store.settings.setCustomNotifications(false, props.thread)">
-                        <div class="d-flex flex-grow-1 align-items-center p-2 rounded">
+                    <hr class="solid mx-2 my-1"/>
+                    <button class="btn d-flex w-100 px-1 py-0 rounded-0" t-on-click="() => store.settings.setCustomNotifications(false, props.thread)">
+                        <div class="d-flex flex-grow-1 align-items-center px-2 py-1 rounded">
                             <div class="d-flex flex-column align-items-start">
                                 <span class="fs-6 fw-normal text-wrap text-start text-break">Use Default</span>
-                                <span class="fw-bolder smaller"><t t-out="store.settings.NOTIFICATIONS.find((n) => n.label === store.settings.channel_notifications).name"/></span>
+                                <span class="fw-bolder smaller fst-italic text-muted ms-3"><t t-out="store.settings.NOTIFICATIONS.find((n) => n.label === store.settings.channel_notifications).name"/></span>
                             </div>
                             <div class="o-discuss-NotificationSettings-separator flex-grow-1"/>
                             <input class="form-check-input" type="radio" t-att-checked="!props.thread.custom_notifications"/>
                         </div>
                     </button>
                     <t t-foreach="store.settings.NOTIFICATIONS" t-as="notif" t-key="notif.label">
-                        <button class="btn w-100 d-flex px-1 py-0 opacity-75 opacity-100-hover" t-on-click="() => store.settings.setCustomNotifications(notif.label, props.thread)">
-                            <div class="d-flex flex-grow-1 align-items-center p-2 rounded">
+                        <button class="btn w-100 d-flex px-1 py-0 rounded-0" t-on-click="() => store.settings.setCustomNotifications(notif.label, props.thread)">
+                            <div class="d-flex flex-grow-1 align-items-center px-2 py-1 rounded">
                                 <span class="fs-6 fw-normal text-wrap text-start text-break" t-esc="notif.name"/>
                                 <div class="o-discuss-NotificationSettings-separator flex-grow-1"/>
                                 <input class="form-check-input ms-2" type="radio" t-att-checked="props.thread.custom_notifications === notif.label"/>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
@@ -39,8 +39,7 @@ export class DiscussSidebarChannel extends Component {
         return {
             "bg-inherit": this.thread.notEq(this.store.discuss.thread),
             "o-active": this.thread.eq(this.store.discuss.thread),
-            "o-unread":
-                this.thread.selfMember?.message_unread_counter > 0 && !this.thread.isMuted,
+            "o-unread": this.thread.selfMember?.message_unread_counter > 0 && !this.thread.isMuted,
             "opacity-50": this.thread.isMuted,
             "position-relative justify-content-center mx-2 o-compact":
                 this.store.discuss.isSidebarCompact,

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
@@ -35,6 +35,10 @@
 
     &.o-compact {
         font-size: .65rem;
+
+        .oi-chevron-right, .oi-chevron-down {
+            font-size: .5rem;
+        }
     }
 }
 

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -3,7 +3,7 @@
     <t t-name="mail.DiscussSidebarCategories">
         <hr t-if="!store.discuss.isSidebarCompact and !store.inPublicPage" class="my-2 w-100 opacity-0 flex-shrink-0"/>
         <t t-if="hasQuickSearch">
-            <Dropdown t-if="store.discuss.isSidebarCompact" state="quickSearchFloating" position="'right-middle'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-view border mx-2 my-2 min-w-0 p-0 shadow-sm'" manual="true">
+            <Dropdown t-if="store.discuss.isSidebarCompact" state="quickSearchFloating" position="'right-middle'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-view border mx-2 my-2 min-w-0 p-0 shadow-none'" manual="true">
                 <button class="o-mail-DiscussSidebarCategories-quickSearchBtn btn btn-light d-flex align-items-center justify-content-center px-1 mx-2 bg-inherit" t-att-class="{ 'o-active': state.quickSearchVal.length }" t-on-click="() => state.floatingQuickSearchOpen = true" t-ref="quick-search-btn"><i class="fa fa-search"/></button>
                 <t t-set-slot="content">
                     <div t-att-class="{ 'p-2': !state.floatingQuickSearchOpen }" t-ref="quick-search-floating">
@@ -37,7 +37,7 @@
     </t>
 
     <t t-name="mail.DiscussSidebarCategory">
-         <Dropdown t-if="actions.length and store.discuss.isSidebarCompact" state="floating" position="'right-middle'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-view border p-2 mx-2 my-2 min-w-0 shadow-sm'" manual="true">
+         <Dropdown t-if="actions.length and store.discuss.isSidebarCompact" state="floating" position="'right-middle'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-view border p-2 mx-2 my-2 min-w-0 shadow-none'" manual="true">
             <t t-call="mail.DiscussSidebarCategory.main"/>
             <t t-set-slot="content">
                 <div class="overflow-hidden" t-ref="floating">
@@ -61,7 +61,7 @@
                 </t>
                 <t t-else="">
                     <span t-if="store.channels.status === 'fetching'" class="o-visible-short-delay"><i class="o-mail-DiscussSidebarCategory-icon smaller me-1 fa fa-fw fa-circle-o-notch fa-spin opacity-50"/></span>
-                    <i t-else="" class="o-mail-DiscussSidebarCategory-icon smaller me-1" t-att-class="category.open ? 'oi oi-chevron-down opacity-100' : 'oi oi-chevron-right opacity-50'"/>
+                    <i t-else="" class="o-mail-DiscussSidebarCategory-icon o-xsmaller me-1" t-att-class="category.open ? 'oi oi-chevron-down opacity-100' : 'oi oi-chevron-right opacity-50'"/>
                     <span class="btn-sm p-0 text-uppercase text-break fw-bolder smaller" t-att-class="{ 'opacity-50': !category.open }"><t t-esc="category.name"/></span>
                 </t>
             </button>
@@ -89,7 +89,7 @@
 
     <t t-name="mail.DiscussSidebarChannel">
         <t name="root">
-            <Dropdown t-if="store.discuss.isSidebarCompact" state="floating" position="'right-middle'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-view border p-2 mx-2 my-2 min-w-0 shadow-sm'" manual="true">
+            <Dropdown t-if="store.discuss.isSidebarCompact" state="floating" position="'right-middle'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-view border p-2 mx-2 my-2 min-w-0 shadow-none'" manual="true">
                 <t t-call="mail.DiscussSidebarChannel.main"/>
                 <t t-set-slot="content">
                     <div class="overflow-hidden" t-ref="floating">
@@ -129,7 +129,7 @@
                     <t t-component="indicators[0]" t-props="{ thread }"/>
                 </div>
             </t>
-            <span t-if="thread.selfMember?.message_unread_counter > 0 and !thread.isMuted and thread.importantCounter === 0" class="o-mail-DiscussSidebarChannel-unreadIndicator position-absolute" name="unread-indicator" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }" title="Thread has unread messages"><i class="fa fa-circle smaller"/></span>
+            <span t-if="thread.selfMember?.message_unread_counter > 0 and !thread.isMuted and thread.importantCounter === 0" class="o-mail-DiscussSidebarChannel-unreadIndicator position-absolute opacity-75" name="unread-indicator" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }" title="Thread has unread messages"><i class="fa fa-circle smaller"/></span>
             <span t-if="thread.importantCounter > 0" t-attf-class="o-mail-DiscussSidebar-badge badge rounded-pill o-discuss-badge fw-bold {{thread.isMuted ? 'o-muted' : ''}}" t-att-class="{ 'ms-1 me-2': !store.discuss.isSidebarCompact, 'position-absolute top-0 o-compact': store.discuss.isSidebarCompact }" t-esc="thread.importantCounter"/>
         </div>
     </t>

--- a/addons/mail/static/src/discuss/message_pin/common/pinned_messages_panel.xml
+++ b/addons/mail/static/src/discuss/message_pin/common/pinned_messages_panel.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="discuss.PinnedMessagesPanel">
-        <ActionPanel title.translate="Pinned Messages" minWidth="200" initialWidth="400">
+        <ActionPanel title.translate="Pinned Messages" minWidth="200" initialWidth="400" icon="'fa fa-thumb-tack'">
             <MessageCardList emptyText="emptyText" messages="props.thread.pinnedMessages" thread="props.thread" mode="'pin'"/>
         </ActionPanel>
     </t>


### PR DESCRIPTION
Using Discuss is exhausting, mostly due to harsh visuals and some items being unbalanced.

This commit makes the following improvements to make it more pleasant:

Discuss app:
- Reduced border in sidebar, header & panel
- Reduced spacing on mailboxes
- Bolder and reduced conversation name size, muted description
- Floating menu have removed shadow
- Channel unread indicator are slightly less visible
- "Invite a User" button in "Members" has "fa-user-plus" icon
- Slightly less harsh header thread actions with less border
- Composer is less rounded and has reduced border with focus effect
- Channel Notification settings dropdown has less spacing mouse hover effect, and default subtitle easier to spot at a glance
- Sidebar chevron are smaller w.r.t. the category title and icon
- Action panels show panel icon in header

Chat window and message:
- actions no longer have black bordered active visual, instead have more pronounced background effect
- Reduced message body size

Before
![before](https://github.com/user-attachments/assets/1869d2be-ac20-4360-a40c-7f1c3403a50a)

After
![after](https://github.com/user-attachments/assets/5b3da4fb-6bf4-44a1-ad21-99142d6036ad)
