### PR TITLE
[FIX] Stock : Remove the very confusing self variable in lambda

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1240,7 +1240,7 @@ class Picking(models.Model):
         """
         self._check_company()
 
-        todo_moves = self.move_ids.filtered(lambda self: self.state in ['draft', 'waiting', 'partially_available', 'assigned', 'confirmed'])
+        todo_moves = self.move_ids.filtered(lambda mv: mv.state in ['draft', 'waiting', 'partially_available', 'assigned', 'confirmed'])
         for picking in self:
             if picking.owner_id:
                 picking.move_ids.write({'restrict_partner_id': picking.owner_id.id})


### PR DESCRIPTION
The using of self variable in lambda method will erase the global scope variable self used to refere to picking recordset and it is very confusing,we have replaced them with mv as the variable refere to moves to be done






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
