### PR TITLE
[IMP] bus: add state property and statechange event

### DIFF
--- a/addons/bus/static/src/workers/websocket_worker.js
+++ b/addons/bus/static/src/workers/websocket_worker.js
@@ -11,7 +11,7 @@ import { debounce, Deferred } from "@bus/workers/websocket_worker_utils";
 /**
  * Type of action that can be sent from the client to the worker.
  *
- * @typedef {'add_channel' | 'delete_channel' | 'force_update_channels' | 'initialize_connection' | 'send' | 'leave' | 'stop' | 'start'} WorkerAction
+ * @typedef {'add_channel' | 'delete_channel' | 'force_update_channels' | 'initialize_connection' | 'send' | 'leave' | 'stop' | 'start' | 'readyState'} WorkerAction
  */
 
 export const WEBSOCKET_CLOSE_CODES = Object.freeze({
@@ -153,6 +153,8 @@ export class WebsocketWorker {
                 return this._forceUpdateChannels();
             case "initialize_connection":
                 return this._initializeConnection(client, data);
+            case "readyState":
+                return client.postMessage({ type: "readyState", data: this.websocket?.readyState })
         }
     }
 

--- a/doc/cla/individual/abichinger.md
+++ b/doc/cla/individual/abichinger.md
@@ -1,0 +1,11 @@
+Austria, 2024-09-16
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Andreas Bichinger andreas.bichinger@gmail.com https://github.com/abichinger


### PR DESCRIPTION
I would like to display a warning, if the websocket of the shared worker is disconnected,
but I have not found a straight forward way to get the state of the websocket.

Adding listeners for all emits (`connect`, `disconnect`, `reconnect`, `reconnecting`) is not sufficient, because If you open a second tab, no event may be sent at all.

If this PR is merged the state of the websocket can be accessed like this:
```js
let state = bus.state;
bus_service.addEventListener("statechange", ({detail: newState}) => {
  state = newState;
  if (state !== bus.CONNECTED) {
    console.warn("WebSocket is not connected")
  } 
});
```




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
