### PR TITLE
[FIX] sale: display expiration date in  portal only for quotations

### DIFF
--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -374,7 +374,7 @@
                       </t>
                       <span t-field="sale_order.date_order" t-options='{"widget": "date"}'/>
                     </div>
-                    <div class="mb-3 col-6" t-if="sale_order.validity_date">
+                    <div class="mb-3 col-6" t-if="sale_order.validity_date and sale_order.state in ['draft', 'sent']">
                         <strong>Expiration Date:</strong> <span t-field="sale_order.validity_date" t-options='{"widget": "date"}'/>
                     </div>
                 </div>


### PR DESCRIPTION
Problem: The expiration date were showing on confirmed sale orders in the customer portal.

Purpose: The expiration date should only show if the order is still a quotation in the customer portal.

Steps to Reproduce on Runbot:
1. Install Sale
2. Create a quotation with an expiration date and confirm
3. View the sale order in the customer portal view and observe that the expiration date is still displayed

opw-3926689

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
