### PR TITLE
[IMP] core: bearer authorization header

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -476,7 +476,8 @@ class Users(models.Model):
           - { 'uid': 32, 'auth_method': 'webauthn',      'mfa': 'skip'    }
         :rtype: dict
         """
-        assert credential['type'] == 'password' and credential['password']
+        if not (credential['type'] == 'password' and credential['password']):
+            raise AccessDenied()
         self.env.cr.execute(
             "SELECT COALESCE(password, '') FROM res_users WHERE id=%s",
             [self.env.user.id]

--- a/odoo/addons/test_http/controllers.py
+++ b/odoo/addons/test_http/controllers.py
@@ -51,6 +51,12 @@ class TestHttp(http.Controller):
         assert request.env.cr.readonly == str2bool(readonly)
         return "Tek'ma'te"
 
+    @http.route('/test_http/greeting-bearer', type='http', auth='bearer', readonly=_readonly)
+    def greeting_bearer(self, readonly=True):
+        assert request.env.user, "ORM should be initialized"
+        assert request.env.cr.readonly == str2bool(readonly)
+        return f"Tek'ma'te; user={request.env.user.login}"
+
     @http.route('/test_http/wsgi_environ', type='http', auth='none')
     def wsgi_environ(self):
         environ = {

--- a/odoo/addons/test_http/tests/test_greeting.py
+++ b/odoo/addons/test_http/tests/test_greeting.py
@@ -1,18 +1,21 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
+import datetime
 
 from odoo.tests import tagged
 from odoo.tests.common import new_test_user
+from odoo.tools import mute_logger
 
 from .test_common import TestHttpBase
+from .test_webjson import CSRF_USER_HEADERS
 
 
 @tagged('post_install', '-at_install')
 class TestHttpGreeting(TestHttpBase):
+
     def test_greeting0_matrix(self):
         new_test_user(self.env, 'jackoneill', context={'lang': 'en_US'})
         test_matrix = [
-            # path, database, login, expected_code, expected_re_pattern
+            # path, database, login, expected_code, expected_pattern
             ('/test_http/greeting', False, None, 200, r"Tek'ma'te"),
             ('/test_http/greeting', True, None, 200, r"Tek'ma'te"),
             ('/test_http/greeting', True, 'public', 200, r"Tek'ma'te"),
@@ -29,6 +32,10 @@ class TestHttpGreeting(TestHttpBase):
             ('/test_http/greeting-user', True, None, 303, r".*/web/login.*"),
             ('/test_http/greeting-user', True, 'public', 303, r".*/web/login.*"),
             ('/test_http/greeting-user', True, 'jackoneill', 200, r"Tek'ma'te"),
+            ('/test_http/greeting-bearer', False, None, 404, r"Not Found"),
+            ('/test_http/greeting-bearer', True, None, 401, r".*Unauthorized.*"),
+            ('/test_http/greeting-bearer', True, 'public', 401, r".*Unauthorized.*"),
+            ('/test_http/greeting-bearer', True, 'jackoneill', 200, r"Tek'ma'te"),
         ]
 
         for path, withdb, login, expected_code, expected_pattern in test_matrix:
@@ -38,7 +45,7 @@ class TestHttpGreeting(TestHttpBase):
                         self.authenticate(None, None)
                     elif login:
                         self.authenticate(login, login)
-                    res = self.db_url_open(path, allow_redirects=False)
+                    res = self.db_url_open(path, allow_redirects=False, headers=CSRF_USER_HEADERS)
                 else:
                     res = self.nodb_url_open(path, allow_redirects=False)
 
@@ -47,6 +54,45 @@ class TestHttpGreeting(TestHttpBase):
 
                 if withdb and login:
                     self.logout(keep_db=False)
+
+        # create job with an apikey
+        joe = new_test_user(self.env, 'joe', context={'lang': 'en_US'})
+        joe = joe.with_user(joe)
+        key_expiration = datetime.datetime.now() + datetime.timedelta(days=0.5)
+        key = joe.env['res.users.apikeys']._generate('rpc', 'test', key_expiration)
+        for path, authorization, expected_code, expected_pattern in [
+            ('/test_http/greeting-bearer', None, 401, r".*Unauthorized.*"),
+            ('/test_http/greeting-bearer', 'invalid', 401, r".*Unauthorized.*"),
+            ('/test_http/greeting-bearer', "Bearer invalidkey2345", 401, r".Unauthorized"),
+            ('/test_http/greeting-bearer', f"Bearer {key}", 200, r"Tek'ma'te.*=joe"),
+            ('/test_http/greeting-user', f"Bearer {key}", 303, r".*/web/login.*"),
+        ]:
+            with self.subTest(path=path, authorization=authorization):
+                headers = {"Authorization": authorization} if authorization else None
+                res = self.db_url_open(path, headers=headers, allow_redirects=False)
+
+                self.assertRegex(res.text, expected_pattern)
+                self.assertEqual(res.status_code, expected_code)
+                self.logout()
+
+        with self.subTest("jackoneill with joe's token"):
+            self.authenticate("jackoneill", "jackoneill")
+            with mute_logger('odoo.http'):
+                res = self.db_url_open(
+                    '/test_http/greeting-bearer',
+                    headers={"Authorization": f"Bearer {key}"},
+                )
+            self.assertEqual(res.status_code, 403)
+            self.assertRegex(res.text, r".*does not match the used apikey")
+            self.logout(keep_db=False)
+
+        with self.subTest("joe with no Sec- headers"):
+            self.authenticate("jackoneill", "jackoneill")
+            with mute_logger('odoo.http'):
+                res = self.db_url_open('/test_http/greeting-bearer')
+            self.assertEqual(res.status_code, 403)
+            self.assertRegex(res.text, r".*Authorization.*headers")
+            self.logout(keep_db=False)
 
     def test_greeting1_headers_nodb(self):
         res = self.nodb_url_open('/test_http/greeting')

--- a/odoo/addons/test_http/tests/test_webjson.py
+++ b/odoo/addons/test_http/tests/test_webjson.py
@@ -7,6 +7,12 @@ from odoo.tools import file_open
 from .test_common import TestHttpBase
 
 CT_HTML = 'text/html; charset=utf-8'
+CSRF_USER_HEADERS = {
+    "Sec-Fetch-Dest": "document",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-Site": 'none',
+    "Sec-Fetch-User": "?1",
+}
 
 
 @tagged('-at_install', 'post_install')
@@ -20,11 +26,22 @@ class TestHttpWebJson_18_0(TestHttpBase):
             cls.gizeh_data = file.read()
             cls.gizeh_b64 = b64encode(cls.gizeh_data).decode()
 
+    def url_open_json(self, url, *, expected_code=0):
+        url = f"/json/18.0{url}"
+        res = self.url_open(url, headers=CSRF_USER_HEADERS)
+        if expected_code is None:
+            pass
+        elif expected_code:
+            self.assertEqual(res.status_code, expected_code)
+        else:
+            # expected=0, raise for status
+            res.raise_for_status()
+        return res
+
     def test_webjson_access_error(self):
         self.authenticate('demo', 'demo')
         with self.assertLogs('odoo.http', 'WARNING') as capture:
-            res = self.url_open('/json/18.0/settings')
-            self.assertEqual(res.status_code, 403)
+            res = self.url_open_json('/settings', expected_code=403)
             self.assertEqual(res.headers['Content-Type'], 'text/html; charset=utf-8')
         self.assertIn("You are not allowed to access", res.text)
         self.assertEqual(len(capture.output), 1)
@@ -36,15 +53,14 @@ class TestHttpWebJson_18_0(TestHttpBase):
             self.skipTest("crm is not installed")
 
         self.authenticate('demo', 'demo')
-        self.url_open('/json/18.0/crm').raise_for_status()
+        self.url_open_json('/crm')
 
         self.env['ir.model.access'].search([
             ('model_id', '=', action_crm.model_id.id)
         ]).perm_read = False
 
         with self.assertLogs('odoo.http', 'WARNING') as capture:
-            res = self.url_open('/json/18.0/crm')
-            self.assertEqual(res.status_code, 403)
+            res = self.url_open_json('/crm', expected_code=403)
             self.assertEqual(res.headers['Content-Type'], 'text/html; charset=utf-8')
         self.assertIn("You are not allowed to access", res.text)
         self.assertEqual(len(capture.output), 1)
@@ -52,10 +68,9 @@ class TestHttpWebJson_18_0(TestHttpBase):
 
     def test_webjson_access_export(self):
         # a simple call
-        url = f'/json/18.0/test_http.stargate/{self.earth.id}'
+        url = f'/test_http.stargate/{self.earth.id}'
         self.authenticate('demo', 'demo')
-        res = self.url_open(url)
-        res.raise_for_status()
+        res = self.url_open_json(url)
 
         # remove export permssion
         group_export = self.env.ref('base.group_allow_export')
@@ -63,46 +78,40 @@ class TestHttpWebJson_18_0(TestHttpBase):
 
         # check that demo has no access to /json
         with self.assertLogs('odoo.http', 'WARNING') as capture:
-            res = self.url_open(url)
+            res = self.url_open_json(url, expected_code=403)
             self.assertIn("need export permissions", res.text)
-            self.assertEqual(res.status_code, 403)
             self.assertIn("need export permissions", capture.output[0])
 
     def test_webjson_bad_stuff(self):
         self.authenticate('demo', 'demo')
 
         with self.subTest(bad='action'):
-            res = self.url_open('/json/18.0/idontexist')
-            self.assertEqual(res.status_code, 400)
+            res = self.url_open_json('/idontexist', expected_code=400)
             self.assertEqual(res.headers['Content-Type'], CT_HTML)
             self.assertIn(
                 "expected action at word 1 but found “idontexist”", res.text)
 
         with self.subTest(bad='active_id'):
-            res = self.url_open('/json/18.0/5/test_http.stargate')
-            self.assertEqual(res.status_code, 400)
+            res = self.url_open_json('/5/test_http.stargate', expected_code=400)
             self.assertEqual(res.headers['Content-Type'], CT_HTML)
             self.assertIn("expected action at word 1 but found “5”", res.text)
 
         with self.subTest(bad='record_id'):
-            res = self.url_open('/json/18.0/test_http.stargate/1/2')
-            self.assertEqual(res.status_code, 400)
+            res = self.url_open_json('/test_http.stargate/1/2', expected_code=400)
             self.assertEqual(res.headers['Content-Type'], CT_HTML)
             self.assertIn("expected action at word 3 but found “2”", res.text)
 
         with self.subTest(bad='view_type'):
             error = "No default view of type 'idontexist' could be found!"
             with self.assertLogs('odoo.http', 'WARNING') as capture:
-                res = self.url_open('/json/18.0/res.users?view_type=idontexist')
-                self.assertEqual(res.status_code, 400)
+                res = self.url_open_json('/res.users?view_type=idontexist', expected_code=400)
                 self.assertEqual(res.headers['Content-Type'], CT_HTML)
                 self.assertIn(error, html.unescape(res.text))
             self.assertEqual(capture.output, [f"WARNING:odoo.http:{error}"])
 
     def test_webjson_form(self):
         self.authenticate('demo', 'demo')
-        res = self.url_open(f'/json/18.0/test_http.stargate/{self.earth.id}')
-        res.raise_for_status()
+        res = self.url_open_json(f'/test_http.stargate/{self.earth.id}')
         self.assertEqual(res.json(), {
             'id': self.earth.id,
             'name': self.earth.name,
@@ -115,8 +124,7 @@ class TestHttpWebJson_18_0(TestHttpBase):
 
     def test_webjson_form_subtree(self):
         self.authenticate('demo', 'demo')
-        res = self.url_open(f'/json/18.0/test_http.galaxy/{self.milky_way.id}')
-        res.raise_for_status()
+        res = self.url_open_json(f'/test_http.galaxy/{self.milky_way.id}')
         self.assertEqual(
             res.json(),
             self.milky_way.web_read({
@@ -130,9 +138,8 @@ class TestHttpWebJson_18_0(TestHttpBase):
 
     def test_webjson_form_viewtype_list(self):
         self.authenticate('demo', 'demo')
-        url = f'/json/18.0/test_http.stargate/{self.earth.id}'
-        res = self.url_open(f'{url}?view_type=list')
-        res.raise_for_status()
+        url = f'/test_http.stargate/{self.earth.id}'
+        res = self.url_open_json(f'{url}?view_type=list')
         self.assertEqual(res.json(), {
             'id': self.earth.id,
             'name': self.earth.name,
@@ -141,8 +148,7 @@ class TestHttpWebJson_18_0(TestHttpBase):
 
     def test_webjson_tree(self):
         self.authenticate('demo', 'demo')
-        res = self.url_open('/json/18.0/test_http.stargate')
-        res.raise_for_status()
+        res = self.url_open_json('/test_http.stargate')
         self.assertEqual(
             res.json(),
             self.env['test_http.stargate']
@@ -151,28 +157,25 @@ class TestHttpWebJson_18_0(TestHttpBase):
 
     def test_webjson_tree_limit_offset(self):
         self.authenticate('demo', 'demo')
-        url = '/json/18.0/test_http.stargate'
+        url = '/test_http.stargate'
         stargates = (
             self.env['test_http.stargate']
                 .web_search_read([], {'name': {}, 'sgc_designation': {}})
         )['records']
 
-        res_limit = self.url_open(f'{url}?limit=1')
-        res_limit.raise_for_status()
+        res_limit = self.url_open_json(f'{url}?limit=1')
         self.assertEqual(res_limit.json(), {
             'length': len(stargates),
             'records': stargates[:1]
         })
 
-        res_offset = self.url_open(f'{url}?offset=1')
-        res_offset.raise_for_status()
+        res_offset = self.url_open_json(f'{url}?offset=1')
         self.assertEqual(res_offset.json(), {
             'length': len(stargates),
             'records': stargates[1:]
         })
 
-        res_limit_offset = self.url_open(f'{url}?limit=1&offset=1')
-        res_limit_offset.raise_for_status()
+        res_limit_offset = self.url_open_json(f'{url}?limit=1&offset=1')
         self.assertEqual(res_limit_offset.json(), {
             'length': len(stargates),
             'records': stargates[1:2]

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -680,6 +680,12 @@ def route(route=None, **routing):
 
         * ``'user'``: The user must be authenticated and the current
           request will be executed using the rights of the user.
+        * ``'bearer'``: The user is authenticated using an "Authorization"
+          request header, using the Bearer scheme with an API token.
+          The request will be executed with the permissions of the
+          corresponding user. If the header is missing, the request
+          must belong to an authentication session, as for the "user"
+          authentication method.
         * ``'public'``: The user may or may not be authenticated. If he
           isn't, the current request will be executed using the shared
           Public user.


### PR DESCRIPTION
Be able to authenticate a request using the "Authorization" HTTP header. We will match a bearer token to the apikeys of users only when
- http.route(security='bearer')
- the session is not already linked to any user

task-3987268


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
