### PR TITLE
[FIX] website: fix tests when website is not installed

### DIFF
--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -18,16 +18,17 @@ class UtilPerf(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        # remove menu containing a slug url (only website_helpdesk normally), to
-        # avoid the menu cache being disabled, which would increase sql queries
-        cls.env['website.menu'].search([
-            ('url', '=like', '/%/%-%'),
-        ]).unlink()
-        # if website_livechat is installed before another module, the
-        # get_livechat_channel_info add unrelated query for the current test.
-        # So we disable it.
-        if 'channel_id' in cls.env['website']:
-            cls.env['website'].search([]).channel_id = False
+        if 'website' in cls.env:
+            # remove menu containing a slug url (only website_helpdesk normally), to
+            # avoid the menu cache being disabled, which would increase sql queries
+            cls.env['website.menu'].search([
+                ('url', '=like', '/%/%-%'),
+            ]).unlink()
+            # if website_livechat is installed before another module, the
+            # get_livechat_channel_info add unrelated query for the current test.
+            # So we disable it.
+            if 'channel_id' in cls.env['website']:
+                cls.env['website'].search([]).channel_id = False
 
     def _get_url_hot_query(self, url, cache=True, query_list=False):
         """ This method returns the number of SQL Queries used inside a request.


### PR DESCRIPTION
When running Appointment as single app, we have to make sure that test does not use any external models like 'website.menu'.

fixes runbot build error [73105](https://runbot.odoo.com/web#id=73105&menu_id=424&cids=1&action=573&model=runbot.build.error&view_type=form)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
