### PR TITLE
[FIX] hr_expense: correct monetary value on expense dashboard

### DIFF
--- a/addons/hr_expense/static/src/components/expense_dashboard.js
+++ b/addons/hr_expense/static/src/components/expense_dashboard.js
@@ -1,7 +1,7 @@
 /** @odoo-module */
 
 import { useService } from '@web/core/utils/hooks';
-import session from 'web.session';
+import { formatMonetary } from "@web/views/fields/formatters";
 
 const { Component, onWillStart, useState } = owl;
 
@@ -22,16 +22,7 @@ export class ExpenseDashboard extends Component {
     }
 
     renderMonetaryField(value, currency_id) {
-        value = value.toFixed(2);
-        const currency = session.get_currency(currency_id);
-        if (currency) {
-            if (currency.position === "after") {
-                value += currency.symbol;
-            } else {
-                value = currency.symbol + value;
-            }
-        }
-        return value;
+        return formatMonetary(value, { currencyId: currency_id});;
     }
 }
 ExpenseDashboard.template = 'hr_expense.ExpenseDashboard';


### PR DESCRIPTION
* Before this commit: the monetary value is always fix with 2 decimal and no thousand separator at all like 1000000 instead of 1.000.000
* After this commit correctly display thousand separator and of course the decimal and currency symbol simply using formatMonetary method

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
