### PR TITLE
[REF] html_editor: remove isDefault in selection

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -218,7 +218,6 @@ export class SelectionPlugin extends Plugin {
                 direction: DIRECTIONS.RIGHT,
                 textContent: () => "",
                 intersectsNode: () => false,
-                isDefault: true,
             };
         } else {
             range = selection.getRangeAt(0);
@@ -261,7 +260,6 @@ export class SelectionPlugin extends Plugin {
                 direction,
                 textContent: () => (range.collapsed ? "" : selection.toString()),
                 intersectsNode: (node) => range.intersectsNode(node),
-                isDefault: false,
             };
         }
 
@@ -503,9 +501,6 @@ export class SelectionPlugin extends Plugin {
         this.canApplySelectionToDocument = selectionData.documentSelectionIsInEditable;
         return {
             restore: () => {
-                if (selection.isDefault) {
-                    return;
-                }
                 this.setSelection(
                     {
                         anchorNode: anchor.node,


### PR DESCRIPTION
In the odoo/odoo#179985 PR, we forgot to remove the concept of isDefault, which is no longer necessary thanks to canApplySelectionToDocument. We therefore forgot to set canApplySelectionToDocument to true during the restore when it was the default selection.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
