### PR TITLE
[REF] *: remove unnecessary/unwanted stuff from kanban archs

### DIFF
--- a/addons/fleet/views/fleet_vehicle_cost_views.xml
+++ b/addons/fleet/views/fleet_vehicle_cost_views.xml
@@ -267,7 +267,7 @@
                 <templates>
                     <t t-name="kanban-card">
                         <div class="flex-row">
-                            <field name="vehicle_id" widget="image" options="{'preview_image': 'image_128'}" t-att-alt="record.vehicle_id.value" class="float-start col-2 pe-2"/>
+                            <field name="vehicle_id" widget="image" options="{'preview_image': 'image_128'}" class="float-start col-2 pe-2"/>
                             <div class="col-10 pe-2 text-truncate">
                                 <field class="fw-bolder" name="vehicle_id"/>
                                 <span t-attf-class="float-end badge #{['todo', 'running'].indexOf(record.state.raw_value) > -1 ? 'text-bg-secondary' : ['cancelled'].indexOf(record.state.raw_value) > -1 ? 'text-bg-danger' : 'text-bg-success'}">

--- a/addons/gamification/views/gamification_goal_views.xml
+++ b/addons/gamification/views/gamification_goal_views.xml
@@ -156,7 +156,7 @@
                     <t t-name="kanban-card" class="text-center">
                         <field class="fw-bold fs-4" name="definition_id" />
                         <div class="d-flex justify-content-center mt-3">
-                            <field class="o_image_24_cover me-1 rounded" name="user_id" widget="image" options="{'preview_image': 'avatar_128'}" t-att-title="record.user_id.value" t-att-alt="record.user_id.value"/>
+                            <field class="o_image_24_cover me-1 rounded" name="user_id" widget="image" options="{'preview_image': 'avatar_128'}"/>
                             <field name="user_id" class="fw-bold"/>
                         </div>
                         <div class="pt-3 fs-1 fw-bolder">

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -372,8 +372,6 @@
                             <field name="employee_id"
                                 widget="image"
                                 options="{'preview_image': 'avatar_128'}"
-                                t-att-title="record.employee_id.value"
-                                t-att-alt="record.employee_id.value"
                                 class="o_image_64_cover float-start mr4"/>
                         </aside>
                         <main class="w-100 ps-3">

--- a/addons/lunch/views/lunch_product_views.xml
+++ b/addons/lunch/views/lunch_product_views.xml
@@ -149,7 +149,7 @@
                 <templates>
                     <t t-name="kanban-card" class="flex-row">
                         <aside class="o_kanban_aside_full d-none d-md-block">
-                            <field name="image_128" widget="image" t-att-alt="record.id.value"/>
+                            <field name="image_128" widget="image" alt="Product Image"/>
                         </aside>
                         <main>
                             <div class="d-flex">

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -364,7 +364,8 @@
                                 <field name="production_id"/> - <field name="name"/>
                             </div>
                             <div class="o_kanban_workorder_date h5">
-                                <span class="d-flex" t-esc="record.date_start.value or record.production_date.value"/>
+                                <field name="date_start"/>
+                                <field t-if="!record.date_start.raw_value" name="production_date"/>
                             </div>
                             <div class="h2 ms-2">
                                 <span t-attf-class="badge #{['progress'].indexOf(record.state.raw_value) > -1 ? 'text-bg-warning' : ['ready', 'waiting', 'pending'].indexOf(record.state.raw_value) > -1 ? 'text-bg-primary' : ['done'].indexOf(record.state.raw_value) > -1 ? 'text-bg-success' : 'text-bg-danger'}">

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -488,7 +488,7 @@
                             </div>
                             <footer class="fs-6 pt-0">
                                 <div class="d-flex">
-                                    <field name="name" class="me-1"/> <t t-esc="record.date_order.value and record.date_order.value.split(' ')[0] or False"/>
+                                    <field name="name" class="me-1"/> <field name="date_order" options="{'show_time': false}"/>
                                     <field name="activity_ids" widget="kanban_activity" class="ms-1"/>
                                 </div>
                                 <field name="state" widget="label_selection" options="{'classes': {'draft': 'default', 'cancel': 'default', 'done': 'success', 'approved': 'warning'}}" class="ms-auto"/>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -53,7 +53,7 @@
                                     <field name="json_popover" nolabel="1" widget="stock_rescheduling_popover" invisible="not json_popover"/>
                                 </div>
                                 <div class="d-flex ms-auto mt-1 align-items-center">
-                                    <t t-esc="record.scheduled_date.value and record.scheduled_date.value.split(' ')[0] or False"/>
+                                    <field name="scheduled_date" options="{'show_time': false}"/>
                                     <field name="user_id" widget="many2one_avatar_user" invisible="not user_id" readonly="state in ['cancel', 'done']" class="ms-1"/>
                                 </div>
                             </footer>


### PR DESCRIPTION
*fleet,hr_holidays,mrp,purchase,stock,website

Kanban archs are being converted to a simpler API [1]. This is a long process that requires rewritting/reviewing all kanban archs. This commit is a followup of those simplications and aims at fixing some leftovers that have been forgotten/that we didn't see on review:

 - do not use t-esc to display a field, use the <field> tag instead (t-esc still works for now, but by convention and for the sake of consistency with the form view, we encourage using <field>)
 - t-att-alt on many2one fields with image widget is useless, the correct alt attribute is already generated by the widget.

In particular:
 - some t-esc were done on datetime fields to not display the time, we can use a classic <field> with show_time option set to false
 - in website, t-esc was used because we manipulated the displayed string, but it didn't seem useful (couldn't see any change before/after).
 - t-att-alt and t-att-title removed from <field widget="image"/> as the first one is useless and the second doesn't work (and the name was displayed next to the image anyway).

[1] task~3992107

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
