### PR TITLE
[FIX] website: fix traceback when opening website homepage

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -110,7 +110,7 @@ class Website(Home):
 
         # Fallback on first accessible menu
         def is_reachable(menu):
-            return menu.is_visible and menu.url not in ('/', '', '#') and not menu.url.startswith(('/?', '/#', ' '))
+            return menu.is_visible and menu.url and menu.url not in ('/', '', '#') and not menu.url.startswith(('/?', '/#', ' '))
 
         reachable_menus = top_menu.child_id.filtered(is_reachable)
         if reachable_menus:


### PR DESCRIPTION
Currently, a traceback is occurring when the user redirects to the homepage having no URL.

To reproduce this issue:

1) Install the Website and enable debugger mode
2) Remove the URL for the homepage from the configuration/menus
3) Unpublish the home website page from sites/pages
4) Create a user having no access rights of `Editor and Designer`
5) Login with the new user and open the website

Error:- 
```
AttributeError: 'bool' object has no attribute 'startswith'
```

As we can see, a URL is not a required field for the website.page. 
When the admin removes the URL, it leads to a traceback to the user,
who doesn't have the access rights for editing and designing.

As `website_page` is only available for the user having those rights.

This leads to a traceback when the `startswith` is accessing from the menu URL,
which is a Falsy value.

https://github.com/odoo/odoo/blob/92284e7df1c40aee25ae7fc5041e1aa9e132a61d/addons/website/controllers/main.py#L113

sentry-5655297758
