### PR TITLE
[IMP] stock: add customer lots/SN report

### DIFF
--- a/addons/stock/__manifest__.py
+++ b/addons/stock/__manifest__.py
@@ -37,6 +37,7 @@
         'report/report_deliveryslip.xml',
         'report/report_stockinventory.xml',
         'report/report_stock_rule.xml',
+        'report/stock_lot_customer.xml',
         'report/package_templates.xml',
         'report/picking_templates.xml',
         'report/product_templates.xml',

--- a/addons/stock/models/res_partner.py
+++ b/addons/stock/models/res_partner.py
@@ -19,3 +19,10 @@ class Partner(models.Model):
         help="The stock location used as source when receiving goods from this contact.")
     picking_warn = fields.Selection(WARNING_MESSAGE, 'Stock Picking', help=WARNING_HELP, default='no-message')
     picking_warn_msg = fields.Text('Message for Stock Picking')
+
+    def action_view_stock_lots(self):
+        action = self.env['ir.actions.act_window']._for_xml_id('stock.action_lot_report')
+        all_child = self.with_context(active_test=False).search([('id', 'child_of', self.ids)])
+        action["domain"] = [("partner_id", "in", all_child.ids)]
+        action["context"] = {'search_default_filter_not_has_return': True}
+        return action

--- a/addons/stock/report/__init__.py
+++ b/addons/stock/report/__init__.py
@@ -7,3 +7,4 @@ from . import report_stock_reception
 from . import report_stock_rule
 from . import stock_traceability
 from . import product_label_report
+from . import stock_lot_customer

--- a/addons/stock/report/stock_lot_customer.py
+++ b/addons/stock/report/stock_lot_customer.py
@@ -1,0 +1,79 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class StockLotReport(models.Model):
+    _name = "stock.lot.report"
+    _description = "Customer Lot Report"
+    _rec_name = 'lot_id'
+    _auto = False
+
+    lot_id = fields.Many2one('stock.lot', 'Lot/Serial', readonly=True)
+    product_id = fields.Many2one('product.product', readonly=True)
+    partner_id = fields.Many2one('res.partner', readonly=True)
+    picking_id = fields.Many2one('stock.picking', readonly=True)
+    quantity = fields.Float(readonly=True)
+    uom_id = fields.Many2one('uom.uom', readonly=True)
+    delivery_date = fields.Datetime(readonly=True)
+    address = fields.Char(readonly=True)
+    has_return = fields.Boolean(readonly=True)
+
+    def _select(self):
+        return """
+            MIN(sml.id) AS id,
+            lot.id lot_id,
+            lot.product_id,
+            picking.partner_id,
+            picking.id picking_id,
+            sml.quantity,
+            sml.product_uom_id uom_id,
+            CONCAT_WS(', ', partner.street, partner.street2, partner.city,  partner.zip, state.name, country.code) address,
+            (SELECT COUNT(sp_return.id) FROM stock_picking sp_return WHERE sp_return.return_id = picking.id) > 0 AS has_return,
+            picking.date_done delivery_date
+        """
+
+    def _from(self):
+        return """
+            stock_lot lot
+            JOIN stock_move_line AS sml
+            ON lot.id = sml.lot_id
+            JOIN stock_picking AS picking
+            ON picking.id = sml.picking_id
+            JOIN stock_picking_type AS type
+            ON picking.picking_type_id = type.id and type.code = 'outgoing'
+            JOIN res_partner AS partner
+            ON partner.id = picking.partner_id
+            LEFT JOIN res_country_state AS state
+            ON state.id = partner.state_id
+            LEFT JOIN res_country AS country
+            ON country.id = partner.country_id
+        """
+
+    def _group_by(self):
+        return """
+            picking.id,
+            picking.partner_id,
+            lot.id,
+            lot.product_id,
+            country.code,
+            state.name,
+            partner.zip,
+            partner.city,
+            partner.street,
+            partner.street2,
+            sml.quantity,
+            sml.product_uom_id,
+            picking.date_done
+        """
+
+    def _query(self):
+        return f"""
+            SELECT {self._select()}
+              FROM {self._from()}
+          GROUP BY {self._group_by()}
+        """
+
+    @property
+    def _table_query(self):
+        return self._query()

--- a/addons/stock/report/stock_lot_customer.xml
+++ b/addons/stock/report/stock_lot_customer.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="stock_lot_customer_report_view_list" model="ir.ui.view">
+        <field name="name">stock.lot.report.view.list</field>
+        <field name="model">stock.lot.report</field>
+        <field name="arch" type="xml">
+            <list string="Lot / Serial Number" decoration-danger="has_return">
+                <field name="lot_id"/>
+                <field name="product_id"/>
+                <field name="partner_id"/>
+                <field name="picking_id"/>
+                <field name="quantity"/>
+                <field name="uom_id"/>
+                <field name="delivery_date"/>
+                <field name="address"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="action_lot_report" model="ir.actions.act_window">
+        <field name="name">Customer lots</field>
+        <field name="res_model">stock.lot.report</field>
+        <field name="view_mode">list</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No data yet!
+            </p>
+            <p>
+                Ship a lot to a customer.
+            </p>
+        </field>
+    </record>
+
+    <record id="search_customer_lot_filter" model="ir.ui.view">
+        <field name="name">Customer Lots Filter</field>
+        <field name="model">stock.lot.report</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="lot_id" string="Lot/Serial Number"/>
+                <field name="product_id"/>
+                <field name="partner_id"/>
+                <filter string="Delivery Date" name="delivery_date" date="delivery_date"/>
+                <filter string="Unreturned" name="filter_not_has_return" domain="[('has_return', '=', False)]"/>
+                <group expand="0" string="Group By">
+                    <filter name="group_by_product" string="Product" domain="[]" context="{'group_by': 'product_id'}"/>
+                    <filter name="group_by_partner" string="Address" domain="[]" context="{'group_by': 'address'}"/>
+                    <filter name="group_by_lot" string="Lot / Serial Number" domain="[]" context="{'group_by': 'lot_id'}"/>
+                    <filter name="group_by_delivery_date" string="Delivery date" domain="[]" context="{'group_by': 'delivery_date'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+</odoo>

--- a/addons/stock/security/ir.model.access.csv
+++ b/addons/stock/security/ir.model.access.csv
@@ -91,3 +91,4 @@ access_stock_picking_label_type_user,picking.label.type.user,model_picking_label
 access_stock_lot_label_layout_user,lot.label.layout.user,model_lot_label_layout,stock.group_stock_user,1,1,1,0
 access_stock_replenish_option,stock.replenishment.option,model_stock_replenishment_option,stock.group_stock_user,1,1,1,0
 access_stock_quant_relocate,access.stock.quant.relocate,model_stock_quant_relocate,stock.group_stock_manager,1,1,1,0
+access_stock_lot_report,access.stock.lot.report,model_stock_lot_report,stock.group_stock_user,1,0,0,0

--- a/addons/stock/views/res_partner_views.xml
+++ b/addons/stock/views/res_partner_views.xml
@@ -37,6 +37,16 @@
                     </group>
                 </group>
             </page>
+
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button type="object"
+                    name="action_view_stock_lots"
+                    class="oe_stat_button" icon="fa-bars" groups="stock.group_production_lot">
+                    <div class="o_stat_info">
+                        <span class="o_stat_text">Lot/Serial Numbers</span>
+                    </div>
+                </button>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
For complex products installers, we need to help them managing the warranties, maintenance and track serial numbers. We therefore add a Lot/Serial link in res.partner to access a new report listing all products delivered to this customer.

task-4196049