### PR TITLE
[FIX] project: impossible to change the sequence of project

### DIFF
--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -262,8 +262,11 @@
             <field name="inherit_id" ref="project.view_project"/>
             <field name="mode">primary</field>
             <field name="arch" type="xml">
+                <xpath expr="//tree" position="attributes">
+                    <attribute name="default_order">sequence, name, id</attribute>
+                </xpath>
                 <field name="sequence" position="attributes">
-                    <attribute name="invisible">0</attribute>
+                    <attribute name="column_invisible">0</attribute>
                     <attribute name="widget">handle</attribute>
                 </field>
             </field>


### PR DESCRIPTION
* STEP TO REPRODUCE: go to configuration -> project -> switch to list view -> can't change sequence of project
* REASON: in project.view_project_config we use invisible instead of column_invisible and the default_order in tree are "is_favorite desc, sequence, name, id" not like in v16 are "sequence, name, id"
* SOLUTION: Change invisible -> column_invisible and change default_order of project config view to "sequence, name, id"

Close https://github.com/odoo/odoo/issues/176961