### PR TITLE
[FIX] stock_account: use the correct accounts for adjustment & scrap

### DIFF
--- a/addons/point_of_sale/tests/test_pos_stock_account.py
+++ b/addons/point_of_sale/tests/test_pos_stock_account.py
@@ -266,5 +266,5 @@ class TestPoSStock(TestPoSCommon):
         refund_payment.with_context(**payment_context).check()
 
         self.pos_session.action_pos_session_validate()
-        expense_account_move_line = self.env['account.move.line'].search([('account_id', '=', self.expense_account.id)])
+        expense_account_move_line = self.env['account.move.line'].search([('account_id', '=', self.expense_account.id), ('product_id', '=', False)])
         self.assertEqual(expense_account_move_line.balance, 0.0, "Expense account should be 0.0")

--- a/addons/purchase_mrp/tests/test_anglo_saxon_valuation.py
+++ b/addons/purchase_mrp/tests/test_anglo_saxon_valuation.py
@@ -16,7 +16,7 @@ class TestAngloSaxonValuationPurchaseMRP(AccountTestInvoicingCommon):
         super().setUpClass()
         cls.vendor01 = cls.env['res.partner'].create({'name': "Super Vendor"})
 
-        cls.stock_input_account, cls.stock_output_account, cls.stock_valuation_account, cls.expense_account, cls.stock_journal = _create_accounting_data(cls.env)
+        cls.stock_input_account, cls.stock_output_account, cls.stock_valuation_account, cls.expense_account, cls.income_account, cls.stock_journal = _create_accounting_data(cls.env)
         cls.avco_category = cls.env['product.category'].create({
             'name': 'AVCO',
             'property_cost_method': 'average',

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -536,10 +536,15 @@ class StockMove(models.Model):
         return svl_vals_list
 
     def _get_src_account(self, accounts_data):
-        return self.location_id.valuation_out_account_id.id or accounts_data['stock_input'].id
+        if self.location_id.usage == 'inventory':
+            return self.location_id.valuation_in_account_id.id or accounts_data['income'].id
+        else:
+            return self.location_id.valuation_out_account_id.id or accounts_data['stock_input'].id
 
     def _get_dest_account(self, accounts_data):
-        if not self.location_dest_id.usage in ('production', 'inventory'):
+        if self.location_dest_id.usage == 'inventory':
+            return self.location_dest_id.valuation_out_account_id.id or accounts_data['expense'].id
+        elif not self.location_dest_id.usage in ('production', 'inventory'):
             return accounts_data['stock_output'].id
         else:
             return self.location_dest_id.valuation_in_account_id.id or accounts_data['stock_output'].id

--- a/addons/stock_account/tests/test_account_move.py
+++ b/addons/stock_account/tests/test_account_move.py
@@ -18,6 +18,7 @@ class TestAccountMoveStockCommon(AccountTestInvoicingCommon):
             cls.stock_output_account,
             cls.stock_valuation_account,
             cls.expense_account,
+            cls.income_account,
             cls.stock_journal,
         ) = _create_accounting_data(cls.env)
 

--- a/addons/stock_account/tests/test_lot_valuation.py
+++ b/addons/stock_account/tests/test_lot_valuation.py
@@ -84,7 +84,7 @@ class TestLotValuation(TestStockValuationCommon):
 
     def test_real_time_valuation(self):
         """ Test account move lines contains lot """
-        self.stock_input_account, self.stock_output_account, self.stock_valuation_account, self.expense_account, self.stock_journal = _create_accounting_data(self.env)
+        self.stock_input_account, self.stock_output_account, self.stock_valuation_account, self.expense_account, self.income_account, self.stock_journal = _create_accounting_data(self.env)
         self.product1.categ_id.write({
             'property_stock_account_input_categ_id': self.stock_input_account.id,
             'property_stock_account_output_categ_id': self.stock_output_account.id,

--- a/addons/stock_account/tests/test_stock_valuation_layer_revaluation.py
+++ b/addons/stock_account/tests/test_stock_valuation_layer_revaluation.py
@@ -11,7 +11,7 @@ class TestStockValuationLayerRevaluation(TestStockValuationCommon):
     @classmethod
     def setUpClass(cls):
         super(TestStockValuationLayerRevaluation, cls).setUpClass()
-        cls.stock_input_account, cls.stock_output_account, cls.stock_valuation_account, cls.expense_account, cls.stock_journal = _create_accounting_data(cls.env)
+        cls.stock_input_account, cls.stock_output_account, cls.stock_valuation_account, cls.expense_account, cls.income_account, cls.stock_journal = _create_accounting_data(cls.env)
         cls.product1.write({
             'property_account_expense_id': cls.expense_account.id,
         })

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -39,12 +39,18 @@ def _create_accounting_data(env):
         'account_type': 'expense',
         'reconcile': True,
     })
+    income_account = env['account.account'].create({
+        'name': 'Income Account',
+        'code': 'IncomeAccount',
+        'account_type': 'income',
+        'reconcile': True,
+    })
     stock_journal = env['account.journal'].create({
         'name': 'Stock Journal',
         'code': 'STJTEST',
         'type': 'general',
     })
-    return stock_input_account, stock_output_account, stock_valuation_account, expense_account, stock_journal
+    return stock_input_account, stock_output_account, stock_valuation_account, expense_account, income_account, stock_journal
 
 
 class TestStockValuationBase(TransactionCase):
@@ -77,7 +83,7 @@ class TestStockValuationBase(TransactionCase):
             'group_ids': [(6, 0, [cls.env.ref('stock.group_stock_user').id])]
         })
 
-        cls.stock_input_account, cls.stock_output_account, cls.stock_valuation_account, cls.expense_account, cls.stock_journal = _create_accounting_data(cls.env)
+        cls.stock_input_account, cls.stock_output_account, cls.stock_valuation_account, cls.expense_account, cls.income_account, cls.stock_journal = _create_accounting_data(cls.env)
         cls.product1.categ_id.write({
             'property_stock_account_input_categ_id': cls.stock_input_account.id,
             'property_stock_account_output_categ_id': cls.stock_output_account.id,
@@ -87,6 +93,7 @@ class TestStockValuationBase(TransactionCase):
         cls.product1.categ_id.property_valuation = 'real_time'
         cls.product2.categ_id.property_valuation = 'real_time'
         cls.product1.write({
+            'property_account_income_id': cls.income_account.id,
             'property_account_expense_id': cls.expense_account.id,
         })
 
@@ -105,14 +112,14 @@ class TestStockValuationBase(TransactionCase):
             ('account_id', '=', self.stock_valuation_account.id),
         ], order='date, id')
 
-    def _make_in_move(self, product, quantity, unit_cost=None, location_dest_id=False, picking_type_id=False):
+    def _make_in_move(self, product, quantity, unit_cost=None, location_id=False, location_dest_id=False, picking_type_id=False):
         """ Helper to create and validate a receipt move.
         """
         unit_cost = unit_cost or product.standard_price
         in_move = self.env['stock.move'].create({
             'name': 'in %s units @ %s per unit' % (str(quantity), str(unit_cost)),
             'product_id': product.id,
-            'location_id': self.env.ref('stock.stock_location_suppliers').id,
+            'location_id': location_id or self.env.ref('stock.stock_location_suppliers').id,
             'location_dest_id': location_dest_id or self.env.ref('stock.stock_location_stock').id,
             'product_uom': self.env.ref('uom.product_uom_unit').id,
             'product_uom_qty': quantity,
@@ -128,14 +135,14 @@ class TestStockValuationBase(TransactionCase):
 
         return in_move.with_context(svl=True)
 
-    def _make_out_move(self, product, quantity):
+    def _make_out_move(self, product, quantity, location_dest_id=False):
         """ Helper to create and validate a delivery move.
         """
         out_move = self.env['stock.move'].create({
             'name': 'out %s units' % str(quantity),
             'product_id': product.id,
             'location_id': self.env.ref('stock.stock_location_stock').id,
-            'location_dest_id': self.env.ref('stock.stock_location_customers').id,
+            'location_dest_id': location_dest_id or self.env.ref('stock.stock_location_customers').id,
             'product_uom': self.env.ref('uom.product_uom_unit').id,
             'product_uom_qty': quantity,
             'picking_type_id': self.env.ref('stock.picking_type_out').id,
@@ -4383,3 +4390,32 @@ class TestStockValuation(TestStockValuationBase):
                 {'quantity': -2.0, 'remaining_qty': 0.0, 'value': -30.0, 'remaining_value': 0.0},
             ]
         )
+
+    def test_positive_stock_adjustment_valuation(self):
+        accounts_data = self.product1.product_tmpl_id.get_product_accounts()
+        inventory_adjustment_loc = self.env['stock.location'].search(
+            [('usage', '=', 'inventory'), ('company_id', '=', self.env.company.id)], limit=1
+        )
+        self.product1.standard_price = 10
+        inventory_gain_move = self._make_in_move(self.product1, 10, location_id=inventory_adjustment_loc.id)
+        self.assertTrue(inventory_gain_move.stock_valuation_layer_ids)
+        self.assertEqual(len(inventory_gain_move.stock_valuation_layer_ids.account_move_id.line_ids), 2)
+        debit_line = inventory_gain_move.stock_valuation_layer_ids.account_move_id.line_ids.filtered(lambda l: l.debit > 0)
+        credit_line = inventory_gain_move.stock_valuation_layer_ids.account_move_id.line_ids.filtered(lambda l: l.credit > 0)
+        self.assertEqual(debit_line.account_id, accounts_data['stock_valuation'])
+        self.assertEqual(credit_line.account_id, accounts_data['income'])
+
+    def test_negative_stock_adjustment_valuation(self):
+        accounts_data = self.product1.product_tmpl_id.get_product_accounts()
+        inventory_adjustment_loc = self.env['stock.location'].search(
+            [('usage', '=', 'inventory'), ('company_id', '=', self.env.company.id)], limit=1
+        )
+        self.product1.standard_price = 10
+        self._make_in_move(self.product1, 10)
+        inventory_loss_move = self._make_out_move(self.product1, 5, location_dest_id=inventory_adjustment_loc.id)
+        self.assertTrue(inventory_loss_move.stock_valuation_layer_ids)
+        self.assertEqual(len(inventory_loss_move.stock_valuation_layer_ids.account_move_id.line_ids), 2)
+        debit_line = inventory_loss_move.stock_valuation_layer_ids.account_move_id.line_ids.filtered(lambda l: l.debit > 0)
+        credit_line = inventory_loss_move.stock_valuation_layer_ids.account_move_id.line_ids.filtered(lambda l: l.credit > 0)
+        self.assertEqual(debit_line.account_id, accounts_data['expense'])
+        self.assertEqual(credit_line.account_id, accounts_data['stock_valuation'])

--- a/addons/stock_account/tests/test_stockvaluationlayer.py
+++ b/addons/stock_account/tests/test_stockvaluationlayer.py
@@ -1005,7 +1005,7 @@ class TestStockValuationChangeValuation(TestStockValuationCommon):
     @classmethod
     def setUpClass(cls):
         super(TestStockValuationChangeValuation, cls).setUpClass()
-        cls.stock_input_account, cls.stock_output_account, cls.stock_valuation_account, cls.expense_account, cls.stock_journal = _create_accounting_data(cls.env)
+        cls.stock_input_account, cls.stock_output_account, cls.stock_valuation_account, cls.expense_account, cls.income_account, cls.stock_journal = _create_accounting_data(cls.env)
         cls.product1.categ_id.property_valuation = 'real_time'
         cls.product1.write({
             'property_account_expense_id': cls.expense_account.id,


### PR DESCRIPTION
This commit fixes the automatic valuation of stock adjustments and scraps stock moves. The valuation logic will be as follows: the expense account will be debited in case of negative adjustment or scraps (if an outgoing account is specified on the adjustment or scrap location, it will be used instead for each scenario respectively). The category stock valuation account will be credited in both cases. In case of positive adjustment, the general income account will be credited (or the location incoming valuation account if defined) and the stock valuation account will be debited.

Task-4013809

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
