### PR TITLE
[FIX] hr_timesheet: correct employee domain

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -48,7 +48,7 @@ class AccountAnalyticLine(models.Model):
     def _domain_employee_id(self):
         domain = [('company_id', 'in', self._context.get('allowed_company_ids'))]
         if not self.env.user.has_group('hr_timesheet.group_hr_timesheet_approver'):
-            domain = expression.AND([domain, ('user_id', '=', self.env.user.id)])
+            domain = expression.AND([domain, [('user_id', '=', self.env.user.id)]])
         return domain
 
     task_id = fields.Many2one(


### PR DESCRIPTION
Issue
-----
Traceback when selecting the employee of a timesheet with a user having limited timesheets rights.

Change
-----
Provide a domain in the correct form to `expression.AND`

opw-4163104
