### PR TITLE
[IMP] mail: remove xml file for wrapping template

### DIFF
--- a/addons/mail/static/src/discuss/core/common/discuss_notification_settings_client_action.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_notification_settings_client_action.js
@@ -1,4 +1,4 @@
-import { Component } from "@odoo/owl";
+import { Component, xml } from "@odoo/owl";
 import { registry } from "@web/core/registry";
 
 import { DiscussNotificationSettings } from "@mail/discuss/core/common/discuss_notification_settings";
@@ -6,7 +6,11 @@ import { DiscussNotificationSettings } from "@mail/discuss/core/common/discuss_n
 export class DiscussNotificationSettingsClientAction extends Component {
     static components = { DiscussNotificationSettings };
     static props = ["*"];
-    static template = "mail.DiscussNotificationSettingsClientAction";
+    static template = xml`
+        <div class="o-mail-DiscussNotificationSettingsClientAction mx-3 my-2">
+            <DiscussNotificationSettings/>
+        </div>
+    `;
 }
 
 registry

--- a/addons/mail/static/src/discuss/core/common/discuss_notification_settings_client_action.xml
+++ b/addons/mail/static/src/discuss/core/common/discuss_notification_settings_client_action.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<templates xml:space="preserve">
-
-    <t t-name="mail.DiscussNotificationSettingsClientAction">
-        <div class="o-mail-DiscussNotificationSettingsClientAction mx-3 my-2">
-            <DiscussNotificationSettings/>
-        </div>
-    </t>
-</templates>


### PR DESCRIPTION
This PR removes the discuss_notification_settings_client_action.xml file. This template is simple enough to be embedded in the javascript file, avoiding xml boilerplate.
