### PR TITLE
[IMP] purchase: PO-Bill matching improvements

### DIFF
--- a/addons/purchase/__manifest__.py
+++ b/addons/purchase/__manifest__.py
@@ -41,6 +41,7 @@
     'application': True,
     'assets': {
         'web.assets_backend': [
+            'purchase/static/src/components/**/*',
             'purchase/static/src/product_catalog/**/*',
             'purchase/static/src/toaster_button/*',
             'purchase/static/src/views/*.js',

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -582,7 +582,18 @@ class PurchaseOrder(models.Model):
                 line.product_id.product_tmpl_id.sudo().write(vals)
 
     def action_bill_matching(self):
-        return self.partner_id.action_open_purchase_matching()
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_window',
+            'name': _("Bill Matching"),
+            'res_model': 'purchase.bill.line.match',
+            'domain': [
+                ('partner_id', '=', self.partner_id.id),
+                ('company_id', 'in', self.env.company.ids),
+                ('purchase_order_id', 'in', [self.id, False]),
+            ],
+            'views': [(self.env.ref('purchase.purchase_bill_line_match_tree').id, 'list')],
+        }
 
     def _prepare_down_payment_section_values(self):
         self.ensure_one()

--- a/addons/purchase/models/res_partner.py
+++ b/addons/purchase/models/res_partner.py
@@ -66,13 +66,3 @@ class res_partner(models.Model):
     reminder_date_before_receipt = fields.Integer('Days Before Receipt', default=1, company_dependent=True,
         help="Number of days to send reminder email before the promised receipt date")
     buyer_id = fields.Many2one('res.users', string='Buyer')
-
-    def action_open_purchase_matching(self):
-        self.ensure_one()
-        return {
-            'type': 'ir.actions.act_window',
-            'name': _("Purchase Matching"),
-            'res_model': 'purchase.bill.line.match',
-            'domain': [('partner_id', '=', self.id), ('company_id', 'in', [self.env.company.id])],
-            'views': [(self.env.ref('purchase.purchase_bill_line_match_tree').id, 'list')],
-        }

--- a/addons/purchase/security/ir.model.access.csv
+++ b/addons/purchase/security/ir.model.access.csv
@@ -10,7 +10,7 @@ access_purchase_order_line_invoicing_payments_readonly,purchase.order.line,model
 access_purchase_order_line_invoicing_payments,purchase.order.line,model_purchase_order_line,account.group_account_invoice,1,1,0,0
 access_purchase_bill_line_match,purchase.bill.line.match user,model_purchase_bill_line_match,group_purchase_user,1,0,0,0
 access_purchase_bill_line_match_readonly,purchase.bill.line.match readonly,model_purchase_bill_line_match,account.group_account_readonly,1,0,0,0
-access_purchase_bill_line_match_invoicing_payments,purchase.bill.line.match invoice,model_purchase_bill_line_match,account.group_account_invoice,1,0,0,0
+access_purchase_bill_line_match_invoicing_payments,purchase.bill.line.match invoice,model_purchase_bill_line_match,account.group_account_invoice,1,1,0,0
 access_bill_to_po_wizard,bill.to.po.wizard user,model_bill_to_po_wizard,group_purchase_user,1,1,1,0
 access_purchase_order_line_portal,purchase.order.line.portal,purchase.model_purchase_order_line,base.group_portal,1,0,0,0
 access_account_tax_purchase_user,account.tax,account.model_account_tax,group_purchase_user,1,0,0,0

--- a/addons/purchase/static/src/components/monetary_field_no_zero/monetary_field_no_zero.js
+++ b/addons/purchase/static/src/components/monetary_field_no_zero/monetary_field_no_zero.js
@@ -1,0 +1,23 @@
+import { monetaryField, MonetaryField } from "@web/views/fields/monetary/monetary_field";
+import { registry } from "@web/core/registry";
+import { floatIsZero } from "@web/core/utils/numbers";
+
+export class MonetaryFieldNoZero extends MonetaryField {
+    static props = {
+        ...MonetaryField.props,
+    };
+
+    /** Override **/
+    get value() {
+        const originalValue = super.value;
+        const decimals = this.currencyDigits ? this.currencyDigits[1] : 2;
+        return floatIsZero(originalValue, decimals) ? false : originalValue;
+    }
+}
+
+export const monetaryFieldNoZero = {
+    ...monetaryField,
+    component: MonetaryFieldNoZero,
+};
+
+registry.category("fields").add("monetary_no_zero", monetaryFieldNoZero);

--- a/addons/purchase/static/src/components/open_match_line_widget/open_match_line_widget.js
+++ b/addons/purchase/static/src/components/open_match_line_widget/open_match_line_widget.js
@@ -1,0 +1,27 @@
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+import { standardFieldProps } from "@web/views/fields/standard_field_props";
+import { Component } from "@odoo/owl";
+
+class OpenMatchLineWidget extends Component {
+    static template = "purchase.OpenMatchLineWidget";
+    static props = { ...standardFieldProps };
+
+    setup() {
+        super.setup();
+        this.action = useService("action");
+    }
+
+    async openMatchLine() {
+        this.action.doActionButton({
+            type: "object",
+            resId: this.props.record.resId,
+            name: "action_open_line",
+            resModel: "purchase.bill.line.match",
+        });
+    }
+}
+
+registry.category("fields").add("open_match_line_widget", {
+    component: OpenMatchLineWidget,
+});

--- a/addons/purchase/static/src/components/open_match_line_widget/open_match_line_widget.xml
+++ b/addons/purchase/static/src/components/open_match_line_widget/open_match_line_widget.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates>
+
+    <t t-name="purchase.OpenMatchLineWidget">
+        <div t-out="props.record.data[props.name]" t-on-click.prevent.stop="openMatchLine"/>
+    </t>
+
+</templates>

--- a/addons/purchase/tests/test_purchase_downpayment.py
+++ b/addons/purchase/tests/test_purchase_downpayment.py
@@ -42,7 +42,6 @@ class TestPurchaseDownpayment(TestPurchaseToInvoiceCommon):
         generated_bill.button_cancel()
         generated_bill.unlink()
         final_bill.invoice_date = fields.Date.from_string('2019-01-02')
-        final_bill.action_post()
         self.assertFalse(final_bill.line_ids.purchase_line_id)
 
         self.env['account.move'].flush_model()

--- a/addons/purchase/views/purchase_bill_line_match_views.xml
+++ b/addons/purchase/views/purchase_bill_line_match_views.xml
@@ -7,19 +7,21 @@
             <list string="Purchase Bill Lines"
                   decoration-info="pol_id != False"
                   decoration-muted="state == 'draft'"
-                  action="action_open_line" type="object">
+                  editable="bottom" edit="1"
+                  type="object">
                 <header>
                     <button name="action_match_lines" type="object" string="Match" groups="account.group_account_invoice" class="btn btn-primary"/>
                     <button name="action_add_to_po" type="object" string="Add to PO" groups="purchase.group_purchase_user"/>
                 </header>
                 <field name="partner_id" string="Vendor" optional="hidden"/>
-                <field name="reference"/>
+                <field name="reference" widget="open_match_line_widget"/>
                 <field name="display_name" string="Product Description" decoration-it="not product_id"/>
                 <field name="product_uom_qty" string="Qty"/>
                 <field name="product_uom_id" groups="uom.group_uom" string="Unit"/>
+                <field name="product_uom_price" string="Price"/>
                 <field name="qty_invoiced" optional="hidden"/>
-                <field name="billed_amount_untaxed" widget="monetary" string="Billed"/>
-                <field name="purchase_amount_untaxed" widget="monetary" string="Purchased"/>
+                <field name="billed_amount_untaxed" widget="monetary_no_zero" sum="Total Billed" string="Billed"/>
+                <field name="purchase_amount_untaxed" widget="monetary_no_zero" sum="Total Purchased" string="Purchased"/>
                 <field name="currency_id" column_invisible="1"/>
             </list>
         </field>


### PR DESCRIPTION
This commit implements a lot of quality of life improvements after the first round of feedback on the new PO/Bill matching feature.

- domain improvements: Bill Matching only displays the lines from the
  current bill, and Purchase Matching only displays the PO lines from
  the current PO.
- PO/Bill Matching views: add price column, hide Billed/Purchased amount
  if it's zero, add totals.
- If PO line(s) is selected but not bill line, create a new bill with
  the selected POL as the lines.
- remove notification that appears when problem products is detected.
- raise error if multiple bill is detected from the selected bill lines.
- delete all unmatched selected vendor bill lines, and add all unmatched
  POL to the bill.

task-id: 4187130