### PR TITLE
[FIX] sale: use the correct `report_template_id` for proforma invoices

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -850,6 +850,8 @@ class SaleOrder(models.Model):
         mail_template = self._find_mail_template()
         if mail_template and mail_template.lang:
             lang = mail_template._render_lang(self.ids)[self.id]
+        report_template_id = 'sale.action_report_pro_forma_invoice' if self.env.context.get('proforma', False) else 'sale.action_report_saleorder'
+        mail_template.report_template_ids = self.env.ref(report_template_id).ids
         ctx = {
             'default_model': 'sale.order',
             'default_res_ids': self.ids,


### PR DESCRIPTION
Problem:
The same `report_template_id` was being used for both standard and proforma invoices, leading to inconsistencies in the attachment naming.

Steps to reproduce:
- Enable Proforma invoices.
- Create a new quotation.
- Send a Proforma invoice.
- The attachment name starts with "Quotation" instead of "PRO-FORMA."

opw-4184863

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
