### PR TITLE
[IMP] project, *: simplify kanban archs

### DIFF
--- a/addons/hr_timesheet/views/project_project_views.xml
+++ b/addons/hr_timesheet/views/project_project_views.xml
@@ -70,13 +70,13 @@
             <field name="inherit_id" ref="project.view_project_kanban"/>
             <field name="priority">24</field>
             <field name="arch" type="xml">
-                <field name="partner_id" position="after">
-                    <field name="allow_timesheets" invisible="1"/>
-                    <field name="remaining_hours" invisible="1"/>
-                    <field name="encode_uom_in_days" invisible="1"/>
-                    <field name="allocated_hours" invisible="1"/>
-                </field>
-                <xpath expr="//div[hasclass('o_kanban_manage_view')]" position="inside">
+                <xpath expr="//templates" position="before">
+                    <field name="allow_timesheets"/>
+                    <field name="remaining_hours"/>
+                    <field name="encode_uom_in_days"/>
+                    <field name="allocated_hours"/>
+                </xpath>
+                <xpath expr="//div[@name='card_menu_view']" position="inside">
                     <div role="menuitem" t-if="record.allow_timesheets.raw_value" groups="hr_timesheet.group_hr_timesheet_user">
                         <a name="action_project_timesheets" type="object">Timesheets</a>
                     </div>
@@ -87,8 +87,8 @@
                     <t t-set="title" t-value="'Days Remaining'" t-if="record.encode_uom_in_days.raw_value"/>
                     <t t-set="title" t-value="'Time Remaining'" t-else=""/>
                     <div t-if="record.allow_timesheets.raw_value and record.allocated_hours.raw_value &gt; 0"
-                        t-attf-class="oe_kanban_align badge border {{ badgeColor }}" t-att-title="title" groups="hr_timesheet.group_hr_timesheet_user">
-                        <field name="remaining_hours" widget="timesheet_uom"/>
+                        t-attf-class="me-1 ms-1 oe_kanban_align badge border {{ badgeColor }}" t-att-title="title" groups="hr_timesheet.group_hr_timesheet_user">
+                        <field name="remaining_hours" widget="timesheet_uom" class="p-0"/>
                     </div>
                 </xpath>
             </field>

--- a/addons/project/static/src/scss/project_dashboard.scss
+++ b/addons/project/static/src/scss/project_dashboard.scss
@@ -1,4 +1,4 @@
-.o_kanban_dashboard.o_project_kanban .o_kanban_renderer {
+.o_project_kanban .o_kanban_renderer {
 
     .o_project_kanban_main {
         max-width: 300px;

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -368,8 +368,8 @@
             <field name="name">project.project.kanban</field>
             <field name="model">project.project</field>
             <field name="arch" type="xml">
-                <kanban
-                    class="o_kanban_dashboard o_project_kanban o_emphasize_colors"
+                <kanban highlight_color="color"
+                    class="o_project_kanban"
                     js_class="project_project_kanban"
                     on_create="project.open_create_project"
                     action="action_view_tasks" type="object"
@@ -377,32 +377,18 @@
                     sample="1"
                     default_order="is_favorite desc, sequence, name, id"
                 >
-                    <field name="display_name"/>
-                    <field name="partner_id"/>
-                    <field name="color"/>
-                    <field name="open_task_count"/>
-                    <field name="milestone_count_reached"/>
-                    <field name="milestone_count"/>
                     <field name="allow_milestones"/>
-                    <field name="label_tasks"/>
-                    <field name="alias_email"/>
-                    <field name="is_favorite"/>
                     <field name="rating_count" />
-                    <field name="rating_avg"/>
-                    <field name="rating_status"/>
                     <field name="rating_active" />
-                    <field name="date"/>
                     <field name="privacy_visibility"/>
                     <field name="last_update_color"/>
-                    <field name="last_update_status"/>
-                    <field name="tag_ids"/>
                     <progressbar field="last_update_status" colors='{"on_track": "success", "at_risk": "warning", "off_track": "danger", "on_hold": "info", "done": "purple"}'/>
                     <field name="sequence" widget="handle"/>
                     <templates>
                         <t t-name="kanban-menu" groups="base.group_user">
                             <div class="container">
                                 <div class="row">
-                                    <div class="col-6 o_kanban_card_manage_section o_kanban_manage_view">
+                                    <div name="card_menu_view" class="col-6">
                                         <h5 role="menuitem" class="o_kanban_card_manage_title">
                                             <span>View</span>
                                         </h5>
@@ -413,11 +399,11 @@
                                             <a name="action_get_list_view" type="object">Milestones</a>
                                         </div>
                                     </div>
-                                    <div class="col-6 o_kanban_card_manage_section o_kanban_manage_reporting">
+                                    <div class="col-6 o_kanban_manage_reporting">
                                         <h5 role="menuitem" class="o_kanban_card_manage_title" groups="project.group_project_user">
                                             <span>Reporting</span>
                                         </h5>
-                                        <div role="menuitem" groups="project.group_project_user" class="o_kanban_task_analysis">
+                                        <div role="menuitem" groups="project.group_project_user" name="task_analysis">
                                             <a name="action_view_tasks_analysis" type="object">Tasks Analysis</a>
                                         </div>
                                         <div role="menuitem" name="project_burndown_menu" groups="project.group_project_user">
@@ -427,15 +413,15 @@
                                 </div>
                                 <div class="o_kanban_card_manage_settings row">
                                     <div role="menuitem" aria-haspopup="true" class="col-6" groups="project.group_project_manager">
-                                        <ul class="oe_kanban_colorpicker" data-field="color" role="popup"/>
+                                        <field name="color" widget="kanban_color_picker"/>
                                     </div>
                                     <div role="menuitem" class="col-6" groups="project.group_project_manager">
 
                                         <a t-if="record.privacy_visibility.raw_value == 'portal'" class="dropdown-item" role="menuitem" name="action_open_share_project_wizard" type="object">Share Project</a>
 
-                                        <a class="dropdown-item" role="menuitem" type="edit">Settings</a>
+                                        <a class="dropdown-item" role="menuitem" type="open">Settings</a>
                                     </div>
-                                    <div class="o_kanban_card_manage_section o_kanban_manage_view col-12 ps-0" groups="!project.group_project_manager">
+                                    <div class="col-12 ps-0" groups="!project.group_project_manager">
                                         <div role="menuitem" class="w-100">
                                             <a class="dropdown-item mx-0" role="menuitem" type="open">View</a>
                                         </div>
@@ -443,72 +429,66 @@
                                 </div>
                             </div>
                         </t>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="#{kanban_color(record.color.raw_value)} oe_kanban_global_click o_has_icon oe_kanban_content oe_kanban_card">
-                                <div class="o_project_kanban_main d-flex align-items-baseline gap-1">
-                                    <field name="is_favorite" widget="project_is_favorite" nolabel="1"/>
-                                    <div class="o_kanban_card_content mw-100">
-                                        <div class="o_kanban_primary_left">
-                                            <div class="o_primary me-5">
-                                                <span class="o_text_overflow" t-att-title="record.display_name.value"><t t-esc="record.display_name.value"/></span>
-                                                <span class="o_text_overflow text-muted" t-if="record.partner_id.value">
-                                                    <span class="fa fa-user me-2" aria-label="Partner" title="Partner"></span><t t-esc="record.partner_id.value"/>
-                                                </span>
-                                                <div t-if="record.date.raw_value or record.date_start.raw_value" class="text-muted o_row">
-                                                    <span class="fa fa-clock-o me-2" title="Dates"></span><field name="date_start"/>
-                                                    <i t-if="record.date.raw_value and record.date_start.raw_value" class="fa fa-long-arrow-right mx-2 oe_read_only" aria-label="Arrow icon" title="Arrow"/>
-                                                    <field name="date"/>
-                                                </div>
-                                                <div t-if="record.alias_email.value" class="text-muted text-truncate" t-att-title="record.alias_email.value">
-                                                    <span class="fa fa-envelope-o me-2" aria-label="Domain Alias" title="Domain Alias"></span><t t-esc="record.alias_email.value"/>
-                                                </div>
-                                                <div t-if="record.rating_active.raw_value and record.rating_count.raw_value &gt; 0" class="text-muted" groups="project.group_project_rating">
-                                                    <b class="me-1">
-                                                        <span style="font-weight:bold;" class="fa mt4 fa-smile-o text-success" t-if="record.rating_avg.raw_value &gt;= 3.66" title="Average Rating: Satisfied" role="img" aria-label="Happy face"/>
-                                                        <span style="font-weight:bold;" class="fa mt4 fa-meh-o text-warning" t-elif="record.rating_avg.raw_value &gt;= 2.33" title="Average Rating: Okay" role="img" aria-label="Neutral face"/>
-                                                        <span style="font-weight:bold;" class="fa mt4 fa-frown-o text-danger" t-else="" title="Average Rating: Dissatisfied" role="img" aria-label="Sad face"/>
-                                                    </b>
-                                                    <t t-if="record.rating_avg.raw_value % 1 == 0">
-                                                        <field name="rating_avg" nolabel="1" widget="float" digits="[1, 0]"/>
-                                                    </t>
-                                                    <t t-else="">
-                                                        <field name="rating_avg" nolabel="1" widget="float" digits="[1, 1]"/>
-                                                    </t> / 5
-                                                </div>
-                                                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
-                                            </div>
-                                        </div>
+                        <t t-name="kanban-card">
+                            <div class="o_project_kanban_main d-flex align-items-baseline gap-1 ms-1">
+                                <field name="is_favorite" widget="project_is_favorite" nolabel="1"/>
+                                <div class="mw-100 pb-4 me-5">
+                                    <span class="text-truncate d-block fs-4 fw-bold" t-att-title="record.display_name.value"><field name="display_name"/></span>
+                                    <span name="partner_name" class="text-truncate text-muted" t-if="record.partner_id.value">
+                                        <span class="fa fa-user me-2" aria-label="Partner" title="Partner"></span><field name="partner_id"/>
+                                    </span>
+                                    <div t-if="record.date.raw_value or record.date_start.raw_value" class="text-muted">
+                                        <span class="fa fa-clock-o me-2" title="Dates"></span><field name="date_start"/>
+                                        <i t-if="record.date.raw_value and record.date_start.raw_value" class="fa fa-long-arrow-right mx-2 oe_read_only" aria-label="Arrow icon" title="Arrow"/>
+                                        <field name="date"/>
                                     </div>
-                                </div>
-                                <div class="o_kanban_record_bottom mt-3">
-                                    <div class="oe_kanban_bottom_left">
-                                        <div class="o_project_kanban_boxes d-flex align-items-baseline">
-                                            <a class="o_project_kanban_box" name="action_view_tasks" type="object">
-                                                <div>
-                                                    <span class="o_value"><t t-esc="record.open_task_count.value"/></span>
-                                                    <span class="o_label ms-1"><t t-esc="record.label_tasks.value"/></span>
-                                                </div>
-                                            </a>
-                                            <a groups='project.group_project_milestone' t-if="record.allow_milestones and record.allow_milestones.raw_value and record.milestone_count.raw_value &gt; 0"
-                                                class="o_kanban_inline_block btn-link text-dark small"
-                                                role="button"
-                                                name="action_get_list_view"
-                                                type="object"
-                                                t-attf-title="#{record.milestone_count_reached.value} Milestones reached out of #{record.milestone_count.value}"
-                                            >
-                                                <span class="fa fa-flag me-1"/>
-                                                <t t-out="record.milestone_count_reached.value"/>/<t t-out="record.milestone_count.value"/>
-                                            </a>
-                                        </div>
-                                        <field name="activity_ids" widget="kanban_activity"/>
+                                    <div t-if="record.alias_email.value" class="text-muted text-truncate" t-att-title="record.alias_email.value">
+                                        <span class="fa fa-envelope-o me-2" aria-label="Domain Alias" title="Domain Alias"></span><field name="alias_email"/>
                                     </div>
-                                    <div class="oe_kanban_bottom_right">
-                                        <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
-                                        <field t-if="record.last_update_status.value &amp;&amp; widget.editable" name="last_update_status" widget="project_state_selection"/>
-                                        <span t-if="record.last_update_status.value &amp;&amp; !widget.editable" t-att-class="'o_status_bubble mx-0 o_color_bubble_' + record.last_update_color.value" t-att-title="record.last_update_status.value"></span>
+                                    <div t-if="record.rating_active.raw_value and record.rating_count.raw_value &gt; 0" class="d-flex text-muted" groups="project.group_project_rating">
+                                        <b class="me-1">
+                                            <span class="fa mt4 fa-smile-o fw-bolder text-success" t-if="record.rating_avg.raw_value &gt;= 3.66" title="Average Rating: Satisfied" role="img" aria-label="Happy face"/>
+                                            <span class="fa mt4 fa-meh-o fw-bolder text-warning" t-elif="record.rating_avg.raw_value &gt;= 2.33" title="Average Rating: Okay" role="img" aria-label="Neutral face"/>
+                                            <span class="fa mt4 fa-frown-o fw-bolder text-danger" t-else="" title="Average Rating: Dissatisfied" role="img" aria-label="Sad face"/>
+                                        </b>
+                                        <t t-if="record.rating_avg.raw_value % 1 == 0">
+                                            <field name="rating_avg" nolabel="1" widget="float" digits="[1, 0]"/>
+                                        </t>
+                                        <t t-else="">
+                                            <field name="rating_avg" nolabel="1" widget="float" digits="[1, 1]"/>
+                                        </t> / 5
                                     </div>
+                                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                                 </div>
                             </div>
+                            <footer class="fs-6 mt-auto pt-0 ms-1">
+                                <div class="d-flex align-items-center">
+                                    <div class="o_project_kanban_boxes d-flex align-items-baseline">
+                                        <a class="o_project_kanban_box me-1" name="action_view_tasks" type="object">
+                                            <div>
+                                                <field name="open_task_count" class="o_value"/>
+                                                <field name="label_tasks" class="ms-1"/>
+                                            </div>
+                                        </a>
+                                        <a groups='project.group_project_milestone' t-if="record.allow_milestones and record.allow_milestones.raw_value and record.milestone_count.raw_value &gt; 0"
+                                            class="d-inline-block btn-link text-dark small me-1"
+                                            role="button"
+                                            name="action_get_list_view"
+                                            type="object"
+                                            t-attf-title="#{record.milestone_count_reached.value} Milestones reached out of #{record.milestone_count.value}"
+                                        >
+                                            <span class="fa fa-flag me-1"/>
+                                            <field name="milestone_count_reached"/>/<field name="milestone_count"/>
+                                        </a>
+                                    </div>
+                                    <field name="activity_ids" widget="kanban_activity" class="ms-2"/>
+                                </div>
+                                <div class="d-flex ms-auto align-items-center">
+                                    <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]" class="me-1"/>
+                                    <field t-if="record.last_update_status.value &amp;&amp; widget.editable" name="last_update_status" widget="project_state_selection"/>
+                                    <span t-if="record.last_update_status.value &amp;&amp; !widget.editable" t-att-class="'o_status_bubble mx-0 o_color_bubble_' + record.last_update_color.value" t-att-title="record.last_update_status.value"></span>
+                                </div>
+                            </footer>
                         </t>
                     </templates>
                 </kanban>
@@ -690,7 +670,7 @@
                 <xpath expr="/kanban" position="inside">
                     <field name="id"/>
                 </xpath>
-                <xpath expr="//div[hasclass('o_kanban_task_analysis')]" position="before">
+                <xpath expr="//div[@name='task_analysis']" position="before">
                     <div role="menuitem" groups="project.group_project_user">
                         <a name="project_update_all_action" type="object" t-attf-context="{'active_id': #{record.id.raw_value} }">Dashboard</a>
                     </div>

--- a/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
+++ b/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
@@ -252,7 +252,7 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
     content: 'Go back to the kanban view the project created',
     run: "click",
 }, {
-    trigger: '.oe_kanban_global_click :contains("Project for Freeman")',
+    trigger: '.o_kanban_record:contains("Project for Freeman")',
     content: 'Open the project',
     run: "click",
 }, {

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -133,7 +133,7 @@
         <field name="inherit_id" ref="project.view_project_kanban"/>
         <field name="priority">32</field>
         <field name="arch" type="xml">
-            <xpath expr="//div[hasclass('o_kanban_manage_view')]" position="inside">
+            <xpath expr="//div[@name='card_menu_view']" position="inside">
                 <div t-if="record.allow_billable.raw_value and record.sale_order_id.raw_value and record.pricing_type.raw_value != 'task_rate'"
                     role="menuitem"
                     groups="sales_team.group_sale_salesman_all_leads">

--- a/addons/website_slides/views/slide_channel_views.xml
+++ b/addons/website_slides/views/slide_channel_views.xml
@@ -242,7 +242,7 @@
             <field name="name">slide.channel.view.kanban</field>
             <field name="model">slide.channel</field>
             <field name="arch" type="xml">
-                <kanban highlight_color="color" string="eLearning Overview" class="o_emphasize_colors o_slide_kanban o_slide_channel_kanban" edit="false" sample="1">
+                <kanban highlight_color="color" string="eLearning Overview" class="o_slide_kanban o_slide_channel_kanban" edit="false" sample="1">
                     <field name="website_published"/>
                     <templates>
                         <t t-name="kanban-menu">


### PR DESCRIPTION
*hr_timesheet,sale_timesheet,documents_project,industry_fsm_report, project_account_budget
In this commit we have simplified the kanban arch for the project module dashboard. the goal is to simplify them, make them easier to read and use bootstrap utility classnames.

- Previously, we used kanban-box, but now we are using kanban-card instead.
- Deprecated oe_kanban_global_click and oe_kanban_global_click_edit.
- More use of `<field/>` tags
- Removed the oe_kanban_colorpicker class and replaced it with the kanban_color_picker widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- kanban_image from rendering context, is deprecated so we use `<field name=... widget=image/>` instead
- kanban_color, kanban_getcolor and kanban_getcolorname are deprecated use new attribute highlight_color=color_field_name on root node

Task-3992107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
