### PR TITLE
[FIX] l10n_din5008*: use `date` widget when displaying dates

### DIFF
--- a/addons/l10n_din5008/report/din5008_base_document_layout.xml
+++ b/addons/l10n_din5008/report/din5008_base_document_layout.xml
@@ -11,15 +11,15 @@
                         </tr>
                         <tr>
                             <td>Invoice Date:</td>
-                            <td><t t-out="company.l10n_din5008_invoice_date"/></td>
+                            <td><t t-out="company.l10n_din5008_invoice_date" t-options="{'widget': 'date'}"/></td>
                         </tr>
                         <tr>
                             <td>Due Date:</td>
-                            <td><t t-out="company.l10n_din5008_due_date"/></td>
+                            <td><t t-out="company.l10n_din5008_due_date" t-options="{'widget': 'date'}"/></td>
                         </tr>
                         <tr>
                             <td>Delivery Date:</td>
-                            <td><t t-out="company.l10n_din5008_delivery_date"/></td>
+                            <td><t t-out="company.l10n_din5008_delivery_date" t-options="{'widget': 'date'}"/></td>
                         </tr>
                         <tr>
                             <td>Reference:</td>

--- a/addons/l10n_din5008/report/din5008_report.xml
+++ b/addons/l10n_din5008/report/din5008_report.xml
@@ -197,15 +197,15 @@
                             </tr>
                             <tr t-if="o.invoice_date">
                                 <td>Invoice Date</td>
-                                <td><t t-out="o.invoice_date"/></td>
+                                <td><t t-out="o.invoice_date" t-options="{'widget': 'date'}"/></td>
                             </tr>
                             <tr t-if="o.invoice_date_due">
                                 <td>Invoice Date Due</td>
-                                <td><t t-out="o.invoice_date_due"/></td>
+                                <td><t t-out="o.invoice_date_due" t-options="{'widget': 'date'}"/></td>
                             </tr>
                             <tr t-if="o.delivery_date">
                                 <td>Delivery Date</td>
-                                <td><t t-out="o.delivery_date"/></td>
+                                <td><t t-out="o.delivery_date" t-options="{'widget': 'date'}"/></td>
                             </tr>
                             <tr t-if="o.invoice_origin">
                                 <td>Source</td>

--- a/addons/l10n_din5008_purchase/report/din5008_purchase_order_templates.xml
+++ b/addons/l10n_din5008_purchase/report/din5008_purchase_order_templates.xml
@@ -21,11 +21,11 @@
                         </tr>
                         <tr t-if="o.date_approve">
                             <td>Order Date:</td>
-                            <td><t t-out="o.date_approve"/></td>
+                            <td><t t-out="o.date_approve" t-options="{'widget': 'date'}"/></td>
                         </tr>
                         <tr t-if="o.date_order">
                             <td>Order Deadline:</td>
-                            <td><t t-out="o.date_order"/></td>
+                            <td><t t-out="o.date_order" t-options="{'widget': 'date'}"/></td>
                         </tr>
                         <tr t-if="o.incoterm_id">
                             <td>Incoterm:</td>

--- a/addons/l10n_din5008_repair/report/din5008_repair_templates.xml
+++ b/addons/l10n_din5008_repair/report/din5008_repair_templates.xml
@@ -15,7 +15,7 @@
                         </tr>
                         <tr>
                             <td>Printing Date:</td>
-                            <td><t t-out="o.l10n_din5008_printing_date"/></td>
+                            <td><t t-out="o.l10n_din5008_printing_date" t-options="{'widget': 'date'}"/></td>
                         </tr>
                     </table>
                 </div>

--- a/addons/l10n_din5008_sale/report/din5008_sale_templates.xml
+++ b/addons/l10n_din5008_sale/report/din5008_sale_templates.xml
@@ -12,11 +12,11 @@
                             </tr>
                             <tr t-if="doc.date_order">
                                 <td>Quotation Date:</td>
-                                <td><t t-out="doc.date_order"/></td>
+                                <td><t t-out="doc.date_order" t-options="{'widget': 'date'}"/></td>
                             </tr>
                             <tr t-if="doc.validity_date">
                                 <td>Expiration:</td>
-                                <td><t t-out="doc.validity_date"/></td>
+                                <td><t t-out="doc.validity_date" t-options="{'widget': 'date'}"/></td>
                             </tr>
                         </t>
                         <t t-else="">
@@ -26,7 +26,7 @@
                             </tr>
                             <tr t-if="doc.date_order">
                                 <td>Order Date:</td>
-                                <td><t t-out="doc.date_order"/></td>
+                                <td><t t-out="doc.date_order" t-options="{'widget': 'date'}"/></td>
                             </tr>
                         </t>
                         <tr t-if="doc.client_order_ref">


### PR DESCRIPTION
Versions
--------
- saas-17.4+

Steps
-----
1. Set document layout to DIN5008;
2. create an invoice;
3. print invoice.

Issue
-----
Dates are formatted as YYYY-MM-DD, regardless of date formatting preferences.

Cause
-----
Commit 6d36b380315 moved DIN5008 formatting logic from Python to XML. In doing so, dates were no longer getting formatted.

Solution
--------
Add the `date` widget to the XML fields to format them accordingly.

opw-4172138

Enterprise PR: https://github.com/odoo/enterprise/pull/70142