### PR TITLE
[FIX] website_sale: show vat number in website address

### DIFF
--- a/addons/l10n_pe_website_sale/__manifest__.py
+++ b/addons/l10n_pe_website_sale/__manifest__.py
@@ -20,6 +20,9 @@
         "web.assets_frontend": [
             "l10n_pe_website_sale/static/src/js/website_sale.js",
         ],
+        'web.assets_tests': [
+            'l10n_pe_website_sale/static/tests/tours/website_sale_address.js',
+        ],
     },
     "installable": True,
     "auto_install": True,

--- a/addons/l10n_pe_website_sale/static/tests/tours/website_sale_address.js
+++ b/addons/l10n_pe_website_sale/static/tests/tours/website_sale_address.js
@@ -1,0 +1,40 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import tourUtils from "@website_sale/js/tours/tour_utils";
+
+registry.category("web_tour.tours").add('update_the_address_for_peru_company', {
+    test: true,
+    url: '/shop',
+    steps: () => [
+        ...tourUtils.addToCart({ productName: "Test Product" }),
+        tourUtils.goToCart({ quantity: 1 }),
+        {
+            content: "Go to checkout",
+            trigger: "a:contains('Checkout')",
+            run: "click",
+        },
+        {
+            content: "Fill vat",
+            trigger: 'input[name="vat"]',
+            run: "text 111111111111",
+        },
+        {
+            content: "Fill city",
+            trigger: 'input[name="city"]',
+            run: "text Scranton",
+        },
+        {
+            content: "Save address",
+            trigger: 'a:contains("Save address")',
+            run: "click",
+        },
+        {
+            content: "Add new billing address",
+            trigger: '.all_billing a[href^="/shop/address?mode=billing"]:contains("Add address")',
+            run: "click",
+        },
+        ...tourUtils.fillAdressForm(),
+        ...tourUtils.payWithTransfer(),
+    ],
+});

--- a/addons/l10n_pe_website_sale/tests/__init__.py
+++ b/addons/l10n_pe_website_sale/tests/__init__.py
@@ -1,0 +1,2 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import test_l10n_pe_website_sale

--- a/addons/l10n_pe_website_sale/tests/test_l10n_pe_website_sale.py
+++ b/addons/l10n_pe_website_sale/tests/test_l10n_pe_website_sale.py
@@ -1,0 +1,41 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import HttpCase, tagged
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestWebsiteSalePe(HttpCase):
+
+    def test_change_address(self):
+        if self.env['ir.module.module']._get('payment_custom').state != 'installed':
+            self.skipTest("Transfer provider is not installed")
+
+        transfer_provider = self.env.ref('payment.payment_provider_transfer')
+        transfer_provider.write({
+            'state': 'enabled',
+            'is_published': True,
+        })
+        transfer_provider._transfer_ensure_pending_msg_is_set()
+        self.env['product.product'].create({
+            'name': 'Test Product',
+            'standard_price': 70.0,
+            'list_price': 70.0,
+            'website_published': True,
+        })
+        # Avoid Shipping/Billing address page (Needed when test is run without demo data)
+        country_us_id = self.env['ir.model.data']._xmlid_to_res_id('base.us')
+        country_us_state_id = self.env['ir.model.data']._xmlid_to_res_id('base.state_us_39')
+        self.env.ref('base.partner_admin').write({
+            'street': '215 Vine St',
+            'city': 'Scranton',
+            'zip': '18503',
+            'country_id': country_us_id,
+            'state_id': country_us_state_id,
+            'phone': '+1 555-555-5555',
+            'email': 'admin@yourcompany.example.com',
+        })
+        country_peru = self.env.ref('base.pe')
+        self.env.company.account_fiscal_country_id = country_peru
+        self.env.company.country_id = country_peru
+        self.env['website'].get_current_website().company_id = self.env.company.id
+        self.start_tour("/", 'update_the_address_for_peru_company', login="admin", watch=True)


### PR DESCRIPTION
Issue:
======
We can't save address in website of latam company (peru for example)

Steps to reproduce the issue:
=============================
- Install ecommerce and peru localization
- Change the company of the website to the peru company
- Go to website add anything to cart and checkout
- Edit the address
- Save
- Required fields missing even though there is no field with red showing
  a warning.

Origin of the issue:
====================
In the template of the address of `l10n_pe_website_sale` we show the
`partner_info` using an xpath on `vat`. But in the common template we
show the VAT number on condition so when that condition is false we will
have some mandatory fields missing because we didn't show them in the
address form.

Solution:
=========
backport of https://github.com/odoo/odoo/commit/3a2eb31de39c9da162ef1bc53deb88a4c6b841f6

opw-4148782