### PR TITLE
[FIX] website: fix `s_cover` text readability

### DIFF
--- a/addons/website/views/snippets/s_cover.xml
+++ b/addons/website/views/snippets/s_cover.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <template id="s_cover" name="Cover">
-    <section class="s_cover parallax s_parallax_is_fixed o_cc o_cc4 pt232 pb232" data-scroll-background-ratio="1">
+    <section class="s_cover parallax s_parallax_is_fixed o_cc o_cc5 pt232 pb232" data-scroll-background-ratio="1">
         <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_cover_default_image'); background-position: 50% 75%;"/>
         <div class="o_we_bg_filter bg-black-50"/>
         <div class="container s_allow_columns">


### PR DESCRIPTION
This commit fixes a readability issue on the `s_cover` snippet.

- requires https://github.com/odoo/design-themes/pull/917

Prior to this commit, the background was set to `o_cc4` which was quite arbitrary, but could also create readability issues in some case.

As the image has a black filter on top of it, setting the `o_cc` class to `o_cc5` will ensure a readable text no matter the theme/industry.

task-4190912

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
