### PR TITLE
[IMP] l10n_ro_edi: show document index, rename state display

### DIFF
--- a/addons/l10n_ro_edi/models/ciusro_document.py
+++ b/addons/l10n_ro_edi/models/ciusro_document.py
@@ -53,19 +53,22 @@ class L10nRoEdiDocument(models.Model):
     invoice_id = fields.Many2one(comodel_name='account.move', required=True)
     state = fields.Selection(
         selection=[
-            ('invoice_sending', 'Sending'),
-            ('invoice_sending_failed', 'Error'),
             ('invoice_sent', 'Sent'),
+            ('invoice_sending_failed', 'Error'),
+            ('invoice_validated', 'Validated'),
         ],
         string='E-Factura Status',
         required=True,
+        help="""Sent -> Successfully sent to the SPV, waiting for validation.
+                Validated -> Sent & validated by the SPV.
+                Error -> Sending error or validation error from the SPV.""",
     )
     datetime = fields.Datetime(default=fields.Datetime.now, required=True)
     attachment_id = fields.Many2one(comodel_name='ir.attachment')
     message = fields.Char()
-    key_loading = fields.Char()         # To be used to fetch the status of previously sent XML
-    key_signature = fields.Char()       # Received from a successful response: to be saved for government purposes
-    key_certificate = fields.Char()     # Received from a successful response: to be saved for government purposes
+    key_loading = fields.Char(string="E-Factura Index")  # To be used to fetch the status of previously sent XML
+    key_signature = fields.Char()    # Received from a successful response: to be saved for government purposes
+    key_certificate = fields.Char()  # Received from a successful response: to be saved for government purposes
 
     @api.model
     def _request_ciusro_send_invoice(self, company, xml_data, move_type='out_invoice'):
@@ -180,7 +183,7 @@ class L10nRoEdiDocument(models.Model):
         """ Fetch the latest response from E-Factura about the XML sent """
         self.ensure_one()
         # Do the batch fetch process on a single invoice/document
-        self.invoice_id._l10n_ro_edi_fetch_invoice_sending_documents()
+        self.invoice_id._l10n_ro_edi_fetch_invoice_sent_documents()
 
     def action_l10n_ro_edi_download_signature(self):
         """ Download the received successful signature XML file from E-Factura """

--- a/addons/l10n_ro_edi/views/account_move_views.xml
+++ b/addons/l10n_ro_edi/views/account_move_views.xml
@@ -8,13 +8,10 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <xpath expr="//div[@name='journal_div']" position="after">
-                <label for="l10n_ro_edi_state"
+                <field name="l10n_ro_edi_state"
                        invisible="not l10n_ro_edi_state or state == 'draft' or move_type in ('in_invoice', 'in_refund')"/>
-                <div name="l10n_ro_edi_div"
-                     class="d-flex"
-                     invisible="not l10n_ro_edi_state or state == 'draft' or move_type in ('in_invoice', 'in_refund')">
-                    <field name="l10n_ro_edi_state" class="oe_inline"/>
-                </div>
+                <field name="l10n_ro_edi_index"
+                       invisible="not l10n_ro_edi_index or state == 'draft' or move_type in ('in_invoice', 'in_refund')"/>
             </xpath>
 
             <!-- CIUS-RO Documents Tab -->
@@ -25,17 +22,18 @@
                     <field name="l10n_ro_edi_document_ids">
                         <list create="false" delete="false" edit="false" no_open="1"
                               decoration-danger="state == 'invoice_sending_failed'"
-                              decoration-warning="state == 'invoice_sending'"
-                              decoration-success="state == 'invoice_sent'">
+                              decoration-warning="state == 'invoice_sent'"
+                              decoration-success="state == 'invoice_validated'">
                             <field name="message" column_invisible="1"/>
                             <field name="attachment_id" column_invisible="1"/>
                             <field name="datetime"/>
                             <field name="state" widget="account_document_state"/>
+                            <field name="key_loading"/>
 
                             <button name="action_l10n_ro_edi_fetch_status"
                                     type="object"
                                     string="Fetch status"
-                                    invisible="state != 'invoice_sending'"/>
+                                    invisible="state != 'invoice_sent'"/>
                             <button name="action_l10n_ro_edi_download_signature"
                                     type="object"
                                     string="Download"
@@ -89,12 +87,12 @@
                 <field name="l10n_ro_edi_state"/>
             </xpath>
             <xpath expr="//filter[@name='to_check']" position="after">
-                <filter string="Sending E-Factura" name="l10n_ro_edi_state_invoice_sending"
-                        domain="[('l10n_ro_edi_state', '=', 'invoice_sending')]"/>
-                <filter string="Error E-Factura" name="l10n_ro_edi_state_invoice_sending_failed"
-                        domain="[('l10n_ro_edi_document_ids.state', '=', 'invoice_sending_failed')]"/>
                 <filter string="Sent E-Factura" name="l10n_ro_edi_state_invoice_sent"
                         domain="[('l10n_ro_edi_state', '=', 'invoice_sent')]"/>
+                <filter string="Error E-Factura" name="l10n_ro_edi_state_invoice_sending_failed"
+                        domain="[('l10n_ro_edi_document_ids.state', '=', 'invoice_sending_failed')]"/>
+                <filter string="Validated E-Factura" name="l10n_ro_edi_state_invoice_validated"
+                        domain="[('l10n_ro_edi_state', '=', 'invoice_validated')]"/>
             </xpath>
             <xpath expr="//group" position="inside">
                 <filter string="E-Factura Status" name="l10n_ro_edi_state_group"
@@ -111,7 +109,7 @@
         <field name="state">code</field>
         <field name="code">
             if records:
-                records._l10n_ro_edi_fetch_invoice_sending_documents()
+                records._l10n_ro_edi_fetch_invoice_sent_documents()
         </field>
     </record>
 

--- a/addons/l10n_ro_edi/wizard/account_move_send.py
+++ b/addons/l10n_ro_edi/wizard/account_move_send.py
@@ -25,7 +25,7 @@ class AccountMoveSend(models.TransientModel):
             wizard.l10n_ro_edi_send_enable = any(
                 (move._need_ubl_cii_xml() or move.ubl_cii_xml_id) and
                 move.country_code == 'RO' and
-                move.l10n_ro_edi_state in (False, 'invoice_sending')
+                move.l10n_ro_edi_state in (False, 'invoice_sent')
                 for move in wizard.move_ids
             )
 
@@ -35,7 +35,7 @@ class AccountMoveSend(models.TransientModel):
         for wizard in self:
             wizard.l10n_ro_edi_send_readonly = (
                 not wizard.l10n_ro_edi_send_enable
-                or 'invoice_sending' in wizard.move_ids.mapped('l10n_ro_edi_state')
+                or 'invoice_sent' in wizard.move_ids.mapped('l10n_ro_edi_state')
             )
 
     @api.depends('l10n_ro_edi_send_readonly')
@@ -48,7 +48,7 @@ class AccountMoveSend(models.TransientModel):
         # EXTENDS 'account'
         super()._compute_warnings()
         for wizard in self:
-            if waiting_moves := wizard.move_ids.filtered(lambda m: m.l10n_ro_edi_state == 'invoice_sending'):
+            if waiting_moves := wizard.move_ids.filtered(lambda m: m.l10n_ro_edi_state == 'invoice_sent'):
                 wizard.warnings = {
                     **(wizard.warnings or {}),
                     'l10n_ro_edi_warning_waiting_moves': {


### PR DESCRIPTION
This commit implements the changes needed after receiving the first
feedback of the new `l10n_ro_edi` module.

Purpose:

Index key (received and saved as `key_download`) is an important number
that should be displayed so that the customer can easily reference the
invoice in the SPV.

For some customer, the state flow of E-Factura in Odoo is confusing as
it doesn't match what they're used to in the SPV. This might be caused
by the state name.

Changes:

- After receiving the `key_download`, log it in the invoice's chatter.
- Save the `key_download` data and pass it in-between documents, to make
  sure that relevant documents displays the index.
- Change the display name of the statuses of the document.
- Add a tooltip on the E-Factura status fields (move & document).
- Rename the selection key values of the romanian states: "invoice_sent"
  becomes "invoice_validated", and "invoice_sending" becomes
  "invoice_sent".

The create document function helpers are changed to have one dictionary
as the param signature so that we can pass on the new `key_loading` data
(and any other important data in the future, for easier stable fix), and
also to make it general (the same for all ro-documents)

task-id: 4059522