### PR TITLE
[IMP] stock: allow custom domain in SML X2many field

### DIFF
--- a/addons/stock/static/src/fields/stock_move_line_x2_many_field.js
+++ b/addons/stock/static/src/fields/stock_move_line_x2_many_field.js
@@ -42,10 +42,13 @@ export class SMLX2ManyField extends X2ManyField {
         const productName = this.props.record.data.product_id[1];
         const title = _t("Add line: %s", productName);
         const alreadySelected = this.props.record.data.move_line_ids.records.filter((line) => line.data.quant_id?.[0]);
-        const domain = [
+        let domain = [
             ["product_id", "=", this.props.record.data.product_id[0]],
             ["location_id", "child_of", this.props.context.default_location_id],
         ];
+        if (this.props.domain) {
+            domain = [...domain, ...this.props.domain()];
+        }
         if (alreadySelected.length) {
             domain.push(["id", "not in", alreadySelected.map((line) => line.data.quant_id[0])]);
         }


### PR DESCRIPTION
The custom stock.move.line's x2many field computes a domain automatically for the SML that can be selected from the stock.move records (e.g. when trying to find a specific lot, etc. to fulfill a demand).

This commit makes it possible to include the domain defined on the field in the final constructed domain, making it possible to somewhat customize this behaviour without the need for a js override.

Task-4116000

-----------

Example of customization made possible with this:
Have a computed field `x_allowed_lot_ids` on the stock.move and restrict the selection of the lots to this domain by modifying the view `stock.view_stock_move_operations`:
```xml
<field name="move_line_ids" domain="[('lot_id', 'in', x_allowed_lot_ids)]" [...] widget="sml_x2_many"/>
```

without this commit, the `domain` attribute set on the field is simply ignored and it would require a more complex js custo (we could live with it)