### PR TITLE
[REF] stock: Refactor sequence of picking types

### DIFF
--- a/addons/mrp/models/stock_warehouse.py
+++ b/addons/mrp/models/stock_warehouse.py
@@ -183,15 +183,6 @@ class StockWarehouse(models.Model):
         })
         return values
 
-    def _get_sequence_values(self, name=False, code=False):
-        values = super(StockWarehouse, self)._get_sequence_values(name=name, code=code)
-        values.update({
-            'pbm_type_id': {'name': _('%(name)s Sequence picking before manufacturing', name=self.name), 'prefix': self.code + '/PC/', 'padding': 5, 'company_id': self.company_id.id},
-            'sam_type_id': {'name': _('%(name)s Sequence stock after manufacturing', name=self.name), 'prefix': self.code + '/SFP/', 'padding': 5, 'company_id': self.company_id.id},
-            'manu_type_id': {'name': _('%(name)s Sequence production', name=self.name), 'prefix': self.code + '/MO/', 'padding': 5, 'company_id': self.company_id.id},
-        })
-        return values
-
     def _get_picking_type_create_values(self, max_sequence):
         data, next_sequence = super(StockWarehouse, self)._get_picking_type_create_values(max_sequence)
         data.update({
@@ -203,7 +194,7 @@ class StockWarehouse(models.Model):
                 'default_location_src_id': self.lot_stock_id.id,
                 'default_location_dest_id': self.pbm_loc_id.id,
                 'sequence': next_sequence + 1,
-                'sequence_code': 'PC',
+                'sequence_code': self.code + '/PC/',
                 'company_id': self.company_id.id,
             },
             'sam_type_id': {
@@ -214,7 +205,7 @@ class StockWarehouse(models.Model):
                 'default_location_src_id': self.sam_loc_id.id,
                 'default_location_dest_id': self.lot_stock_id.id,
                 'sequence': next_sequence + 3,
-                'sequence_code': 'SFP',
+                'sequence_code': self.code + '/SFP/',
                 'company_id': self.company_id.id,
             },
             'manu_type_id': {
@@ -223,7 +214,7 @@ class StockWarehouse(models.Model):
                 'use_create_lots': True,
                 'use_existing_lots': True,
                 'sequence': next_sequence + 2,
-                'sequence_code': 'MO',
+                'sequence_code': self.code + '/MO/',
                 'company_id': self.company_id.id,
             },
         })

--- a/addons/mrp_subcontracting/models/stock_warehouse.py
+++ b/addons/mrp_subcontracting/models/stock_warehouse.py
@@ -130,13 +130,14 @@ class StockWarehouse(models.Model):
 
     def _get_picking_type_create_values(self, max_sequence):
         data, next_sequence = super(StockWarehouse, self)._get_picking_type_create_values(max_sequence)
+        count = self.env['ir.sequence'].search_count([('prefix', '=like', self.code + '/SBC%/%')])
         data.update({
             'subcontracting_type_id': {
                 'name': _('Subcontracting'),
                 'code': 'mrp_operation',
                 'use_create_components_lots': True,
                 'sequence': next_sequence + 2,
-                'sequence_code': 'SBC',
+                'sequence_code': self.code + (('/SBC' + str(count) + '/') if count else '/SBC/'),
                 'company_id': self.company_id.id,
             },
             'subcontracting_resupply_type_id': {
@@ -146,31 +147,12 @@ class StockWarehouse(models.Model):
                 'use_existing_lots': True,
                 'default_location_dest_id': self._get_subcontracting_location().id,
                 'sequence': next_sequence + 3,
-                'sequence_code': 'RES',
+                'sequence_code': self.code + (('/RES' + str(count) + '/') if count else '/RES/'),
                 'print_label': True,
                 'company_id': self.company_id.id,
             }
         })
         return data, max_sequence + 4
-
-    def _get_sequence_values(self, name=False, code=False):
-        values = super(StockWarehouse, self)._get_sequence_values(name=name, code=code)
-        count = self.env['ir.sequence'].search_count([('prefix', '=like', self.code + '/SBC%/%')])
-        values.update({
-            'subcontracting_type_id': {
-                'name': _('%(name)s Sequence subcontracting', name=self.name),
-                'prefix': self.code + (('/SBC' + str(count) + '/') if count else '/SBC/'),
-                'padding': 5,
-                'company_id': self.company_id.id
-            },
-            'subcontracting_resupply_type_id': {
-                'name': _('%(name)s Sequence Resupply Subcontractor', name=self.name),
-                'prefix': self.code + (('/RES' + str(count) + '/') if count else '/RES/'),
-                'padding': 5,
-                'company_id': self.company_id.id
-            },
-        })
-        return values
 
     def _get_picking_type_update_values(self):
         data = super(StockWarehouse, self)._get_picking_type_update_values()

--- a/addons/point_of_sale/models/stock_warehouse.py
+++ b/addons/point_of_sale/models/stock_warehouse.py
@@ -8,18 +8,6 @@ class Warehouse(models.Model):
 
     pos_type_id = fields.Many2one('stock.picking.type', string="Point of Sale Operation Type")
 
-    def _get_sequence_values(self, name=False, code=False):
-        sequence_values = super(Warehouse, self)._get_sequence_values(name=name, code=code)
-        sequence_values.update({
-            'pos_type_id': {
-                'name': _('%(name)s Picking POS', name=self.name),
-                'prefix': self.code + '/POS/',
-                'padding': 5,
-                'company_id': self.company_id.id,
-            }
-        })
-        return sequence_values
-
     def _get_picking_type_update_values(self):
         picking_type_update_values = super(Warehouse, self)._get_picking_type_update_values()
         picking_type_update_values.update({
@@ -36,7 +24,7 @@ class Warehouse(models.Model):
                 'default_location_src_id': self.lot_stock_id.id,
                 'default_location_dest_id': self.env.ref('stock.stock_location_customers').id,
                 'sequence': max_sequence + 1,
-                'sequence_code': 'POS',
+                'sequence_code': self.code + '/POS/',
                 'company_id': self.company_id.id,
             }
         })

--- a/addons/stock/tests/test_move2.py
+++ b/addons/stock/tests/test_move2.py
@@ -3031,6 +3031,9 @@ class TestRoutes(TestStockCommon):
             'default_location_dest_id': new_loc.id,
             'warehouse_id': self.wh.id,
         })
+        self.assertEqual(picking_type.sequence_id.prefix, "NPT")
+        self.assertIn(self.wh.name, picking_type.sequence_id.name)
+        self.assertIn("NPT", picking_type.sequence_id.name)
         route = self.env['stock.route'].create({
             'name': 'new route',
             'rule_ids': [(0, False, {
@@ -3068,6 +3071,9 @@ class TestRoutes(TestStockCommon):
         self.assertEqual(move1.location_dest_id, new_loc)
         positive_quant = product.stock_quant_ids.filtered(lambda q: q.quantity > 0)
         self.assertEqual(positive_quant.location_id, new_loc)
+        picking_type.sequence_id.prefix = "WH/%(year)s/%(month)s/NPT/"
+        picking_type.write({"sequence_code": "WH/%(year)s/%(month)s/NPT2/"})
+        self.assertEqual(picking_type.sequence_id.prefix, "WH/%(year)s/%(month)s/NPT2/")
 
     def test_mtso_mto_adjust_01(self):
         """ Run '_adjust_procure_method' for products A & B:

--- a/addons/stock/tests/test_warehouse.py
+++ b/addons/stock/tests/test_warehouse.py
@@ -789,13 +789,22 @@ class TestWarehouse(TestStockCommon):
         wh.code = "chic"
         warehouse = wh.save()
         self.assertEqual(warehouse.int_type_id.barcode, 'CHICINT')
+        self.assertIn("Chicago", warehouse.int_type_id.sequence_id.name)
         self.assertEqual(warehouse.int_type_id.sequence_id.prefix, 'chic/INT/')
+        warehouse.int_type_id.sequence_code = "custom/INT/%(year)s/"
 
         wh = Form(warehouse)
         wh.code = 'CH'
         wh.save()
         self.assertEqual(warehouse.int_type_id.barcode, 'CHINT')
-        self.assertEqual(warehouse.int_type_id.sequence_id.prefix, 'CH/INT/')
+        self.assertIn("Chicago", warehouse.int_type_id.sequence_id.name)
+        self.assertEqual(warehouse.int_type_id.sequence_id.prefix, 'custom/INT/%(year)s/')
+
+        wh = Form(warehouse)
+        wh.name = 'Chicago2'
+        wh.save()
+        self.assertIn("Chicago2", warehouse.int_type_id.sequence_id.name)
+        self.assertEqual(warehouse.int_type_id.sequence_id.prefix, 'custom/INT/%(year)s/')
 
     def test_location_warehouse(self):
         """ Check that the closest warehouse is selected


### PR DESCRIPTION
Refactor sequence of picking types

Do not completely change the sequence prefix when changing sequence_code in picking types

If the prefix of a sequence has been changed to add `%(year)s` (for example), we want the sequence_code of the picking types to remain the same when changing the prefix, so the best way to achieve this is to replace the old code with the new one.

@Tecnativa TT50872

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
