### PR TITLE
[IMP] hr: change the string in the res.settings

### DIFF
--- a/addons/hr/views/res_config_settings_views.xml
+++ b/addons/hr/views/res_config_settings_views.xml
@@ -67,7 +67,7 @@
                         </setting>
                     </block>
                     <block title="Employee Update Rights" name="employee_rights_setting_container">
-                        <setting help="Allow employees to update their own data" title="Allow employees to update their own data.">
+                        <setting help="Allow employees to update Work Information on My Profile" title="Allow employees to update Work Information on My Profile.">
                             <field name="hr_employee_self_edit"/>
                         </setting>
                     </block>


### PR DESCRIPTION
In this PR, hr settings have the option `hr_employee_self_edit​` described as "Allow employees to update their own data".

This is a bit unclear so we have changed it to "Allow employees to update Work Information on My Profile".

Task-4179070
