### PR TITLE
[IMP] auth_totp*: clean unit tests

### DIFF
--- a/addons/auth_totp/tests/test_totp.py
+++ b/addons/auth_totp/tests/test_totp.py
@@ -7,8 +7,6 @@ from passlib.totp import TOTP
 
 from odoo import http
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
-from odoo.exceptions import AccessDenied
-from odoo.service import common as auth, model
 from odoo.tests import tagged, get_db_name, loaded_demo_data
 from odoo.tools import mute_logger
 

--- a/addons/auth_totp/tests/test_totp.py
+++ b/addons/auth_totp/tests/test_totp.py
@@ -7,7 +7,7 @@ from passlib.totp import TOTP
 
 from odoo import http
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
-from odoo.tests import tagged, get_db_name, loaded_demo_data
+from odoo.tests import tagged, get_db_name
 from odoo.tools import mute_logger
 
 from ..controllers.home import Home
@@ -50,10 +50,6 @@ class TestTOTP(HttpCaseWithUserDemo, TestTOTPMixin):
         self.install_totphook()
 
     def test_totp(self):
-        # TODO: Make this work if no demo data + hr installed
-        if not loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
         # 1. Enable 2FA
         self.start_tour('/odoo', 'totp_tour_setup', login='demo')
 
@@ -93,10 +89,6 @@ class TestTOTP(HttpCaseWithUserDemo, TestTOTPMixin):
 
 
     def test_totp_administration(self):
-        # TODO: Make this work if no demo data + hr installed
-        if not loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
         self.start_tour('/odoo', 'totp_tour_setup', login='demo')
         self.start_tour('/odoo', 'totp_admin_disables', login='admin')
         self.start_tour('/', 'totp_login_disabled', login=None)
@@ -107,10 +99,6 @@ class TestTOTP(HttpCaseWithUserDemo, TestTOTPMixin):
         Ensure we don't leak the session info from an half-logged-in
         user.
         """
-        # TODO: Make this work if no demo data + hr installed
-        if not loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
 
         self.start_tour('/odoo', 'totp_tour_setup', login='demo')
         self.url_open('/web/session/logout')

--- a/addons/auth_totp_portal/tests/test_tour.py
+++ b/addons/auth_totp_portal/tests/test_tour.py
@@ -6,7 +6,7 @@ from passlib.totp import TOTP
 from odoo import http
 from odoo.addons.auth_totp.controllers.home import Home
 from odoo.addons.base.tests.common import HttpCaseWithUserPortal
-from odoo.tests import tagged, loaded_demo_data
+from odoo.tests import tagged
 
 _logger = logging.getLogger(__name__)
 
@@ -17,10 +17,6 @@ class TestTOTPortal(HttpCaseWithUserPortal):
     Largely replicates TestTOTP
     """
     def test_totp(self):
-        # TODO: Make this work if no demo data + hr installed
-        if not loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
         totp = None
         # test endpoint as doing totp on the client side is not really an option
         # (needs sha1 and hmac + BE packing of 64b integers)

--- a/addons/auth_totp_portal/tests/test_tour.py
+++ b/addons/auth_totp_portal/tests/test_tour.py
@@ -1,10 +1,6 @@
 import logging
-import time
 
-from passlib.totp import TOTP
-
-from odoo import http
-from odoo.addons.auth_totp.controllers.home import Home
+from odoo.addons.auth_totp.tests.test_totp import TestTOTPMixin
 from odoo.addons.base.tests.common import HttpCaseWithUserPortal
 from odoo.tests import tagged
 
@@ -12,35 +8,12 @@ _logger = logging.getLogger(__name__)
 
 
 @tagged('post_install', '-at_install')
-class TestTOTPortal(HttpCaseWithUserPortal):
+class TestTOTPortal(HttpCaseWithUserPortal, TestTOTPMixin):
     """
     Largely replicates TestTOTP
     """
     def test_totp(self):
-        totp = None
-        # test endpoint as doing totp on the client side is not really an option
-        # (needs sha1 and hmac + BE packing of 64b integers)
-        def totp_hook(self, secret=None):
-            nonlocal totp
-            if totp is None:
-                totp = TOTP(secret)
-            if secret:
-                return totp.generate().token
-            else:
-                # on check, take advantage of window because previous token has been
-                # "burned" so we can't generate the same, but tour is so fast
-                # we're pretty certainly within the same 30s
-                return totp.generate(time.time() + 30).token
-        # because not preprocessed by ControllerType metaclass
-        totp_hook.routing_type = 'json'
-        # patch Home to add test endpoint
-        Home.totp_hook = http.route('/totphook', type='json', auth='none')(totp_hook)
-        self.env.registry.clear_cache('routing')
-        # remove endpoint and destroy routing map
-        @self.addCleanup
-        def _cleanup():
-            del Home.totp_hook
-            self.env.registry.clear_cache('routing')
+        self.install_totphook()
 
         self.start_tour('/my/security', 'totportal_tour_setup', login='portal')
         # also disables totp otherwise we can't re-login

--- a/odoo/addons/test_apikeys/static/tests/apikey_flow.js
+++ b/odoo/addons/test_apikeys/static/tests/apikey_flow.js
@@ -62,7 +62,26 @@ registry.category("web_tour.tours").add('apikeys_tour_setup', {
     run: "click",
 },
 {
-    content: "check that our key is present (FIXME: requires HR to be installed)",
+    // HR is not installed: The profile is a dialog which closes automatically. Re-open the profile.
+    isActive: ["body:not(:has(a[name='page_account_security']))"],
+    content: 'Open user account menu',
+    trigger: '.o_user_menu .dropdown-toggle',
+    run: 'click',
+},
+{
+    isActive: ["body:not(:has(a[name='page_account_security']))"],
+    content: "Open preferences / profile screen",
+    trigger: '[data-menu=settings]',
+    run: 'click',
+},
+{
+    isActive: ["body:not(:has(a[name='page_account_security'].active))"],
+    content: "Switch to security tab",
+    trigger: 'a[role=tab]:contains("Account Security")',
+    run: 'click',
+},
+{
+    content: "check that our key is present",
     trigger: '[name=api_key_ids] td:contains("my key")',
 }]});
 

--- a/odoo/addons/test_apikeys/tests/test_flow.py
+++ b/odoo/addons/test_apikeys/tests/test_flow.py
@@ -24,10 +24,6 @@ class TestAPIKeys(HttpCaseWithUserDemo, TestTOTPMixin):
             del self.registry['ir.logging'].send_key
 
     def test_addremove(self):
-        # TODO: Make this work if no demo data + hr installed
-        if not loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
         db = get_db_name()
         self.start_tour('/odoo', 'apikeys_tour_setup', login='demo')
         demo_user = self.env['res.users'].search([('login', '=', 'demo')])
@@ -47,14 +43,10 @@ class TestAPIKeys(HttpCaseWithUserDemo, TestTOTPMixin):
         self.start_tour('/odoo', 'apikeys_tour_teardown', login='demo')
 
     def test_apikeys_totp(self):
-        # TODO: Make this work if no demo data + hr installed
-        if not loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
         db = get_db_name()
         self.install_totphook()
         self.start_tour('/odoo', 'apikeys_tour_setup', login='demo')
         self.start_tour('/odoo', 'totp_tour_setup', login='demo')
         [(_, [key], [])] = self.messages  # pylint: disable=unbalanced-tuple-unpacking
         uid = self.xmlrpc_common.authenticate(db, 'demo', key, {})
-        self.assertEqual(uid, self.env.ref('base.user_demo').id)
+        self.assertEqual(uid, self.user_demo.id)


### PR DESCRIPTION
- Remove unused imports
- Get rid of the use of the demo data and the warnings related to it
- Remove of duplicated code regarding a mock of TOTP hook, using a factorization method that was already exising, doing exactly the same thing.