### PR TITLE
[16.0][FIX] purchase: Set the same invoice lines when Auto-Complete an order on the invoice vs create invoice from order

### DIFF
--- a/addons/purchase/tests/test_purchase_invoice.py
+++ b/addons/purchase/tests/test_purchase_invoice.py
@@ -880,7 +880,9 @@ class TestInvoicePurchaseMatch(TestPurchaseToInvoiceCommon):
         invoice1 = po1.invoice_ids
         self.assertEqual(invoice1.invoice_user_id, self.env.user)
         # creating bill with Auto_complete feature
+        po2.order_line.qty_to_invoice = 0
         move_form = Form(self.env['account.move'].with_context(default_move_type='in_invoice'))
         move_form.purchase_vendor_bill_id = self.env['purchase.bill.union'].browse(-po2.id)
         invoice2 = move_form.save()
         self.assertEqual(invoice2.invoice_user_id, self.env.user)
+        self.assertNotIn(self.product_order, invoice2.invoice_line_ids.mapped("product_id"))

--- a/addons/purchase/tests/test_purchase_order_report.py
+++ b/addons/purchase/tests/test_purchase_order_report.py
@@ -37,7 +37,7 @@ class TestPurchaseOrderReport(AccountTestInvoicingCommon):
             ],
         })
         po.button_confirm()
-
+        po.order_line.qty_received = 1
         f = Form(self.env['account.move'].with_context(default_move_type='in_invoice'))
         f.invoice_date = f.date
         f.partner_id = po.partner_id


### PR DESCRIPTION
Set the same invoice lines when Auto-Complete an order on the invoice vs create invoice from order

Example use case:
- Purchase order with 2 lines: Product A, qty_to_invoice=1 + Product B, qty_to_invoice=0.
- When creating an invoice from the order (Create Bill button) the invoice will be created only with the product A line.
- Auto-complete the purchase order from an invoice will set only product A as invoice lines.

@Tecnativa TT50620

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
