### PR TITLE
[FIX] mail: canned responses text overflow

### DIFF
--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -149,7 +149,7 @@
     </t>
 
     <t t-name="mail.Composer.suggestionCannedResponse">
-        <strong class="px-2 py-1 align-self-center flex-shrink-0 text-truncate">
+        <strong class="px-2 py-1 align-self-center flex-shrink-1 text-truncate">
             <t t-esc="option.source"/>
         </strong>
         <em class="text-600 text-truncate align-self-center">


### PR DESCRIPTION
Purpose of this PR:
When a canned response have a long shortcut text, the text overflow the navigablelist.

Before
![image](https://github.com/user-attachments/assets/d592f059-cf42-4b91-9cd8-062c304b887e)
After
![image](https://github.com/user-attachments/assets/62e3bc02-cc70-45fc-a06e-f41ff386a346)
