### PR TITLE
[FIX] mail: canned responses text overflow

### DIFF
--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -140,7 +140,7 @@
     </t>
 
     <t t-name="mail.Composer.suggestionCannedResponse">
-        <strong class="px-2 py-1 align-self-center flex-shrink-0 text-truncate">
+        <strong class="px-2 py-1 align-self-center flex-shrink-1 text-truncate">
             <t t-esc="option.source"/>
         </strong>
         <em class="text-600 text-truncate align-self-center">


### PR DESCRIPTION
Purpose of this PR:
When a canned response have a long shortcut text, the text overflow the navigablelist.

Before:
![image](https://github.com/user-attachments/assets/a0e9c341-8f83-40c9-b89b-541767d61d74)

After:
![image](https://github.com/user-attachments/assets/a30ac3b7-d1ad-4561-a5d3-2f4c87fda375)
