### PR TITLE
[FIX] sale_mrp: Incorrect move kit qty after change on SOL

### DIFF
--- a/addons/sale_mrp/models/sale_order_line.py
+++ b/addons/sale_mrp/models/sale_order_line.py
@@ -130,7 +130,7 @@ class SaleOrderLine(models.Model):
         # Specific case when we change the qty on a SO for a kit product.
         # We don't try to be too smart and keep a simple approach: we use the quantity of entire
         # kits that are currently in delivery
-        bom = self.env['mrp.bom']._bom_find(self.product_id, bom_type='phantom')[self.product_id]
+        bom = self.env['mrp.bom'].sudo()._bom_find(self.product_id, bom_type='phantom', company_id=self.company_id.id)[self.product_id]
         if bom:
             moves = self.move_ids.filtered(lambda r: r.state != 'cancel' and not r.scrapped)
             filters = self._get_incoming_outgoing_moves_filter()


### PR DESCRIPTION
We can have a user that has enough rights to generate sales orders, but not enough right to check a BoM.
When creating a new sale order for a kit, everything works fine.

Before this commit, if we updated the quantity on the sale order line, the quantity on the moves would become incorrect.

After this commit, the BoM is always found in order to correctly recompute the quantity on the moves.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
