### PR TITLE
[FIX] point_of_sale: show correct product list price

### DIFF
--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -106,7 +106,7 @@ class ProductProduct(models.Model):
     @api.model
     def _load_pos_data_fields(self, config_id):
         return [
-            'id', 'display_name', 'lst_price', 'standard_price', 'categ_id', 'pos_categ_ids', 'taxes_id', 'barcode', 'name',
+            'id', 'display_name', 'lst_price', 'list_price', 'standard_price', 'categ_id', 'pos_categ_ids', 'taxes_id', 'barcode', 'name',
             'default_code', 'to_weight', 'uom_id', 'description_sale', 'description', 'product_tmpl_id', 'tracking', 'type', 'service_tracking', 'is_storable',
             'write_date', 'available_in_pos', 'attribute_line_ids', 'active', 'image_128', 'combo_ids', 'product_template_variant_value_ids',
         ]

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -274,7 +274,7 @@ export class ProductScreen extends Component {
     }
 
     getProductPrice(product) {
-        return this.pos.getProductPriceFormatted(product);
+        return this.pos.getProductPriceFormatted(product, product.list_price);
     }
 
     getProductImage(product) {

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -422,8 +422,8 @@ export class PosStore extends Reactive {
             return "flex-row-reverse justify-content-between m-1";
         }
     }
-    getProductPriceFormatted(product) {
-        const formattedUnitPrice = this.env.utils.formatCurrency(this.getProductPrice(product));
+    getProductPriceFormatted(product, p) {
+        const formattedUnitPrice = this.env.utils.formatCurrency(this.getProductPrice(product, p));
 
         if (product.to_weight) {
             return `${formattedUnitPrice}/${product.uom_id.name}`;


### PR DESCRIPTION
In saas-17.4, instead of directly showing a list of `product.product` records in the `ProductScreen` in pos, we show the products "grouped" by `product_template_id`.

With this change, one would expect when seeing a product with variants to be shown the base price of the corresponding `product.template` record.

Instead, we simply show one of the variants. The problem is that the variant shown might have a price extra. In that case, instead of showing the base price, we show the price of the variant, which includes the price extra.

Ex:
1. Create a product template with price 100 and no variants.
2. In pos you will see the corresponding `product.product` record and the price will be the correct 100.
3. Create 2 variants for the `product.template` ( create_variant: always ), each variant having a price extra of 10, respectively 20.
4. Open pos and observe that the product no longer has price 100, but in fact either 10 or 20.

In this commit we make it such that when showing the price of a product, we take into consideration the `list_price`, not the `lst_price` of the specific `product.product` record.

Task: 4188122





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
