### PR TITLE
[FIX] website_sale_loyalty: prevent error when applying discount code in order

### DIFF
--- a/addons/website_sale_loyalty/controllers/main.py
+++ b/addons/website_sale_loyalty/controllers/main.py
@@ -14,6 +14,8 @@ class WebsiteSale(main.WebsiteSale):
     @http.route()
     def pricelist(self, promo, **post):
         order = request.website.sale_get_order()
+        if not order:
+            return request.redirect('/shop')
         coupon_status = order._try_apply_code(promo)
         if coupon_status.get('not_found'):
             return super(WebsiteSale, self).pricelist(promo, **post)


### PR DESCRIPTION
When user tries to apply a discount code in order,
a traceback will appear.

Steps to reproduce the error:
- Install ```website_sale_loyalty```
- Activate ```Demo``` payment provider
- Go to Website > Shop > Add a product to cart > View cart
- Pay with Demo > Pay
- Click the back button
- Apply Coupon code

Traceback:
```
ValueError: not enough values to unpack (expected 1, got 0)
  File "odoo/models.py", line 5975, in ensure_one
    _id, = self._ids
ValueError: Expected singleton: sale.order()
  File "odoo/http.py", line 2383, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1913, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1976, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1943, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2100, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 227, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 757, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/website_sale_loyalty/controllers/main.py", line 17, in pricelist
    coupon_status = order._try_apply_code(promo)
  File "addons/sale_loyalty/models/sale_order.py", line 1197, in _try_apply_code
    self.ensure_one()
  File "odoo/models.py", line 5978, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
```

https://github.com/odoo/odoo/blob/9a9063a2d1f385b02f8453b766ec225def531d7e/addons/website_sale_loyalty/controllers/main.py#L16
When user clicks the back button and applies the coupon,
```order``` will be empty, So, it will lead to the above traceback.

sentry-5856780654

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
