### PR TITLE
[FIX] hr_calendar: display Sunday working hours

### DIFF
--- a/addons/hr_calendar/models/res_partner.py
+++ b/addons/hr_calendar/models/res_partner.py
@@ -101,7 +101,7 @@ class Partner(models.Model):
     def _interval_to_business_hours(self, working_intervals):
         # This is the format expected by the fullcalendar library to do the overlay
         return [{
-            "daysOfWeek": [interval[0].weekday() + 1],
+            "daysOfWeek": [(interval[0].weekday() + 1) % 7],
             "startTime":  interval[0].astimezone(timezone(self.env.user.tz or 'UTC')).strftime("%H:%M"),
             "endTime": interval[1].astimezone(timezone(self.env.user.tz or 'UTC')).strftime("%H:%M"),
         } for interval in working_intervals] if working_intervals else [{

--- a/addons/hr_calendar/tests/common.py
+++ b/addons/hr_calendar/tests/common.py
@@ -69,7 +69,8 @@ class TestHrCalendarCommon(common.TransactionCase):
                     (0, 0, {'name': 'Tuesday Evening', 'dayofweek': '1', 'hour_from': 15, 'hour_to': 22, 'day_period': 'afternoon'}),
                     (0, 0, {'name': 'Wednesday Evening', 'dayofweek': '2', 'hour_from': 15, 'hour_to': 22, 'day_period': 'afternoon'}),
                     (0, 0, {'name': 'Thursday Evening', 'dayofweek': '3', 'hour_from': 15, 'hour_to': 22, 'day_period': 'afternoon'}),
-                    (0, 0, {'name': 'Friday Evening', 'dayofweek': '4', 'hour_from': 15, 'hour_to': 22, 'day_period': 'afternoon'}),
+                    (0, 0, {'name': 'Friday Evening', 'dayofweek': '4', 'hour_from': 15, 'hour_to': 21, 'day_period': 'afternoon'}),
+                    (0, 0, {'name': 'Sunday Evening', 'dayofweek': '6', 'hour_from': 15, 'hour_to': 16, 'day_period': 'afternoon'}),
                 ],
             },
         ])

--- a/addons/hr_calendar/tests/test_working_hours.py
+++ b/addons/hr_calendar/tests/test_working_hours.py
@@ -192,7 +192,8 @@ class TestWorkingHours(TestHrCalendarCommon):
             {'daysOfWeek': [4], 'startTime': '08:00', 'endTime': '12:00'},
             {'daysOfWeek': [4], 'startTime': '13:00', 'endTime': '22:00'},
             {'daysOfWeek': [5], 'startTime': '08:00', 'endTime': '12:00'},
-            {'daysOfWeek': [5], 'startTime': '13:00', 'endTime': '22:00'},
+            {'daysOfWeek': [5], 'startTime': '13:00', 'endTime': '21:00'},
+            {'daysOfWeek': [0], 'startTime': '15:00', 'endTime': '16:00'},
         ])
 
     def test_multi_companies_2_employees_1_partner_1_selected_companies(self):
@@ -232,7 +233,8 @@ class TestWorkingHours(TestHrCalendarCommon):
             {'daysOfWeek': [4], 'startTime': '08:00', 'endTime': '12:00'},
             {'daysOfWeek': [4], 'startTime': '13:00', 'endTime': '22:00'},
             {'daysOfWeek': [5], 'startTime': '08:00', 'endTime': '12:00'},
-            {'daysOfWeek': [5], 'startTime': '13:00', 'endTime': '22:00'},
+            {'daysOfWeek': [5], 'startTime': '13:00', 'endTime': '21:00'},
+            {'daysOfWeek': [0], 'startTime': '15:00', 'endTime': '16:00'},
         ])
 
     def test_work_hours_of_employee_without_time_zone(self):


### PR DESCRIPTION
Issue
-----
Sunday working hours set in the working schedule do not appear in the calendar. Unlike other working hours which are displayed in white.

Cause
-----
Fullcalendar uses 0-based indexing starting on Sunday, the correct conversion from backend to fullcalendar library is 6 -> 0 for Sunday.

opw-4152047
