### PR TITLE
[IMP] point_of_sale: add basic receipt option for gifts

### DIFF
--- a/addons/l10n_fr_pos_cert/static/src/xml/OrderReceipt.xml
+++ b/addons/l10n_fr_pos_cert/static/src/xml/OrderReceipt.xml
@@ -11,7 +11,7 @@
 
     <t t-name="l10n_fr_pos_cert.OrderReceipt" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension">
         <xpath expr="//Orderline" position="inside">
-            <t t-if="props.data.l10n_fr_hash !== false and line.price_type === 'manual'">
+            <t t-if="props.data.l10n_fr_hash !== false and line.price_type === 'manual' and !props.basic_receipt">
                 <div class="pos-receipt-right-padding">
                     Old unit price:
                     <span class="oldPrice">

--- a/addons/l10n_gcc_pos/static/src/overrides/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/l10n_gcc_pos/static/src/overrides/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -30,7 +30,7 @@
         </xpath>
         <xpath expr="//span[@t-esc='props.formatCurrency(props.data.amount_total)']/.." position="after">
             <div t-if="props.data.is_gcc_country" class="pos-receipt-amount pos-receipt-amount-arabic" t-translation="off">
-                TOTAL / الإجمالي
+                TOTAL / اﻹجمالي
                 <span t-esc="props.formatCurrency(props.data.amount_total)" class="pos-receipt-right-align"/>
             </div>
         </xpath>

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -120,6 +120,7 @@ class PosConfig(models.Model):
     set_maximum_difference = fields.Boolean('Set Maximum Difference', help="Set a maximum difference allowed between the expected and counted money during the closing of the session.")
     receipt_header = fields.Text(string='Receipt Header', help="A short text that will be inserted as a header in the printed receipt.")
     receipt_footer = fields.Text(string='Receipt Footer', help="A short text that will be inserted as a footer in the printed receipt.")
+    basic_receipt = fields.Boolean(string='Basic Receipt', help="Print basic ticket without prices. Can be used for gifts.")
     proxy_ip = fields.Char(string='IP Address', size=45,
         help='The hostname or ip address of the hardware proxy, Will be autodetected if left empty.')
     active = fields.Boolean(default=True)

--- a/addons/point_of_sale/models/res_config_settings.py
+++ b/addons/point_of_sale/models/res_config_settings.py
@@ -115,6 +115,7 @@ class ResConfigSettings(models.TransientModel):
     pos_is_closing_entry_by_product = fields.Boolean(related='pos_config_id.is_closing_entry_by_product', readonly=False)
     pos_order_edit_tracking = fields.Boolean(related="pos_config_id.order_edit_tracking", readonly=False)
     pos_orderlines_sequence_in_cart_by_category = fields.Boolean(related='pos_config_id.orderlines_sequence_in_cart_by_category', readonly=False)
+    pos_basic_receipt = fields.Boolean(related='pos_config_id.basic_receipt', readonly=False)
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.js
+++ b/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.js
@@ -26,9 +26,11 @@ export class Orderline extends Component {
         },
         showTaxGroupLabels: { type: Boolean, optional: true },
         slots: { type: Object, optional: true },
+        basic_receipt: { type: Boolean, optional: true },
     };
     static defaultProps = {
         class: {},
         showTaxGroupLabels: false,
+        basic_receipt: false,
     };
 }

--- a/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.xml
@@ -13,7 +13,7 @@
                         <span class="text-wrap" t-esc="line.productName"/>
                         <t t-slot="product-name"/>
                     </div>
-                    <div class="product-price price fw-bolder">
+                    <div t-if="!props.basic_receipt" class="product-price price fw-bolder">
                         <t t-if="line.price === 'free'">Free</t>
                         <t t-else="" t-esc="line.price"/>
                     </div>
@@ -22,15 +22,17 @@
                 <ul class="info-list d-flex flex-column">
                     <li class="price-per-unit">
                         <span class="qty px-1 border rounded text-bg-view fw-bolder me-1" t-esc="line.qty"/>
-                        x
-                        <t t-if="line.price !== 0">
-                            <s t-esc="line.oldUnitPrice" t-if="line.oldUnitPrice" />
-                            <t t-esc="line.unitPrice" />
+                        <t t-if="!props.basic_receipt">
+                            x
+                            <t t-if="line.price !== 0">
+                                <s t-esc="line.oldUnitPrice" t-if="line.oldUnitPrice" />
+                                <t t-esc="line.unitPrice" />
+                            </t>
+                            /
                         </t>
-                        /
                         <t t-if="line.unit" t-esc="line.unit" />
                     </li>
-                    <li t-if="line.price !== 0 and line.discount and line.discount !== '0'">
+                    <li t-if="line.price !== 0 and line.discount and line.discount !== '0' and !props.basic_receipt">
                         With a <em><t t-esc="line.discount" />% </em> discount
                     </li>
                     <li t-if="line.customerNote" class="customer-note w-100 p-2 mt-2 rounded text-break text-bg-warning bg-opacity-25">

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.js
@@ -14,6 +14,10 @@ export class OrderReceipt extends Component {
     static props = {
         data: Object,
         formatCurrency: Function,
+        basic_receipt: { type: Boolean, optional: true },
+    };
+    static defaultProps = {
+        basic_receipt: false,
     };
     omit(...args) {
         return omit(...args);

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -6,98 +6,99 @@
             <ReceiptHeader data="props.data.headerData" />
             <OrderWidget lines="props.data.orderlines" t-slot-scope="scope">
                 <t t-set="line" t-value="scope.line"/>
-                <Orderline line="omit(scope.line, 'customerNote')" class="{ 'px-0': true }" showTaxGroupLabels="showTaxGroupLabels">
+                <Orderline basic_receipt="props.basic_receipt" line="omit(scope.line, 'customerNote')" class="{ 'px-0': true }" showTaxGroupLabels="showTaxGroupLabels">
                     <li t-if="line.customerNote" class="customer-note w-100 p-2 my-1 rounded text-break">
                         <i class="fa fa-sticky-note me-1" role="img" aria-label="Customer Note" title="Customer Note"/>
                         <t t-esc="line.customerNote" />
                     </li>
                 </Orderline>
             </OrderWidget>
+            <t t-if="!props.basic_receipt">
+                <div t-if="props.data.tax_details.length > 0" class="pos-receipt-taxes">
+                    <div class="text-center">--------------------------------</div>
+                    <div class="d-flex">
+                        <span t-if="showTaxGroupLabels" class="me-2" style="visibility: hidden;">A</span>
+                        <span class="fw-bolder">Untaxed Amount</span>
+                        <span t-esc="props.formatCurrency(props.data.total_without_tax)" class="ms-auto"/>
+                    </div>
 
-            <div t-if="props.data.tax_details.length > 0" class="pos-receipt-taxes">
+                    <div t-foreach="props.data.tax_details" t-as="tax" t-key="tax.id" class="d-flex">
+                        <t t-if="showTaxGroupLabels">
+                            <span t-if="tax.tax_group_id.pos_receipt_label" t-esc="tax.tax_group_id.pos_receipt_label" class="me-2"/>
+                            <span t-else="" class="me-2" style="visibility: hidden;">A</span>
+                        </t>
+                        <span>
+                            <span t-esc="tax.name"/>
+                            on
+                            <span t-esc="props.formatCurrency(tax.base)"/>
+                        </span>
+                        <span t-esc="props.formatCurrency(tax.amount)" class="ms-auto"/>
+                    </div>
+                </div>
+
+        <!-- Total -->
                 <div class="text-center">--------------------------------</div>
-                <div class="d-flex">
-                    <span t-if="showTaxGroupLabels" class="me-2" style="visibility: hidden;">A</span>
-                    <span class="fw-bolder">Untaxed Amount</span>
-                    <span t-esc="props.formatCurrency(props.data.total_without_tax)" class="ms-auto"/>
-                </div>
-
-                <div t-foreach="props.data.tax_details" t-as="tax" t-key="tax.id" class="d-flex">
-                    <t t-if="showTaxGroupLabels">
-                        <span t-if="tax.tax_group_id.pos_receipt_label" t-esc="tax.tax_group_id.pos_receipt_label" class="me-2"/>
-                        <span t-else="" class="me-2" style="visibility: hidden;">A</span>
-                    </t>
-                    <span>
-                        <span t-esc="tax.name"/>
-                        on
-                        <span t-esc="props.formatCurrency(tax.base)"/>
-                    </span>
-                    <span t-esc="props.formatCurrency(tax.amount)" class="ms-auto"/>
-                </div>
-            </div>
-
-      <!-- Total -->
-            <div class="text-center">--------------------------------</div>
-            <div class="pos-receipt-amount">
-                TOTAL
-                <span t-esc="props.formatCurrency(props.data.amount_total)" class="pos-receipt-right-align"/>
-            </div>
-            <t t-if="props.data.rounding_applied">
                 <div class="pos-receipt-amount">
-                  Rounding
-                <span t-esc='props.formatCurrency(props.data.rounding_applied)' class="pos-receipt-right-align"/>
+                    TOTAL
+                    <span t-esc="props.formatCurrency(props.data.amount_total)" class="pos-receipt-right-align"/>
                 </div>
-                <div class="pos-receipt-amount">
-                  To Pay
-                 <span t-esc='props.formatCurrency(props.data.amount_total + props.data.rounding_applied)' class="pos-receipt-right-align"/>
-              </div>
+                <t t-if="props.data.rounding_applied">
+                    <div class="pos-receipt-amount">
+                    Rounding
+                    <span t-esc='props.formatCurrency(props.data.rounding_applied)' class="pos-receipt-right-align"/>
+                    </div>
+                    <div class="pos-receipt-amount">
+                    To Pay
+                    <span t-esc='props.formatCurrency(props.data.amount_total + props.data.rounding_applied)' class="pos-receipt-right-align"/>
+                </div>
+                </t>
+
+                <!-- Payment Lines -->
+
+                <div class="paymentlines text-start" t-foreach="props.data.paymentlines" t-as="line" t-key="line_index">
+                    <t t-esc="line.name" />
+                    <span t-esc="props.formatCurrency(line.amount)" class="pos-receipt-right-align"/>
+                </div>
+
+                <div  t-if="props.data.change != 0" class="pos-receipt-amount receipt-change">
+                    CHANGE
+                    <span t-esc="props.formatCurrency(props.data.change)" class="pos-receipt-right-align"/>
+                </div>
+
+                <!-- Extra Payment Info -->
+
+                <t t-if="props.data.total_discount">
+                    <div class="text-center">
+                        Discounts
+                        <span t-esc="props.formatCurrency(props.data.total_discount)" class="pos-receipt-right-align"/>
+                    </div>
+                </t>
+
+                <div class="before-footer" />
+
+                <div t-if="props.data.pos_qr_code">
+                    <br/>
+                    <div class="pos-receipt-order-data mb-2">
+                        Need an invoice for your purchase ?
+                    </div>
+                </div>
+
+                <div t-if="['qr_code', 'qr_code_and_url'].includes(props.data.headerData.company.point_of_sale_ticket_portal_url_display_mode) and props.data.pos_qr_code" class="mb-2">
+                    <img id="posqrcode" t-att-src="props.data.pos_qr_code" class="pos-receipt-logo"/>
+                </div>
+
+                <div t-if="props.data.pos_qr_code">
+                    <div class="pos-receipt-order-data">
+                        Unique Code: <t t-esc="props.data.ticket_code"/>
+                    </div>
+                </div>
+
+                <div t-if="['url', 'qr_code_and_url'].includes(props.data.headerData.company.point_of_sale_ticket_portal_url_display_mode) and props.data.pos_qr_code">
+                    <div class="pos-receipt-order-data" t-attf-class="{{ props.data.ticket_portal_url_display_mode === 'qr_code_and_url' ? 'mt-3' : '' }}">
+                        Portal URL: <t t-out="props.data.base_url"/>/pos/ticket
+                    </div>
+                </div>
             </t>
-
-            <!-- Payment Lines -->
-
-            <div class="paymentlines text-start" t-foreach="props.data.paymentlines" t-as="line" t-key="line_index">
-                <t t-esc="line.name" />
-                <span t-esc="props.formatCurrency(line.amount)" class="pos-receipt-right-align"/>
-            </div>
-
-            <div  t-if="props.data.change != 0" class="pos-receipt-amount receipt-change">
-                CHANGE
-                <span t-esc="props.formatCurrency(props.data.change)" class="pos-receipt-right-align"/>
-            </div>
-
-            <!-- Extra Payment Info -->
-
-            <t t-if="props.data.total_discount">
-                <div class="text-center">
-                    Discounts
-                    <span t-esc="props.formatCurrency(props.data.total_discount)" class="pos-receipt-right-align"/>
-                </div>
-            </t>
-
-            <div class="before-footer" />
-
-            <div t-if="props.data.pos_qr_code">
-                <br/>
-                <div class="pos-receipt-order-data mb-2">
-                    Need an invoice for your purchase ?
-                </div>
-            </div>
-
-            <div t-if="['qr_code', 'qr_code_and_url'].includes(props.data.headerData.company.point_of_sale_ticket_portal_url_display_mode) and props.data.pos_qr_code" class="mb-2">
-                <img id="posqrcode" t-att-src="props.data.pos_qr_code" class="pos-receipt-logo"/>
-            </div>
-
-            <div t-if="props.data.pos_qr_code">
-                <div class="pos-receipt-order-data">
-                    Unique Code: <t t-esc="props.data.ticket_code"/>
-                </div>
-            </div>
-
-            <div t-if="['url', 'qr_code_and_url'].includes(props.data.headerData.company.point_of_sale_ticket_portal_url_display_mode) and props.data.pos_qr_code">
-                <div class="pos-receipt-order-data" t-attf-class="{{ props.data.ticket_portal_url_display_mode === 'qr_code_and_url' ? 'mt-3' : '' }}">
-                    Portal URL: <t t-out="props.data.base_url"/>/pos/ticket
-                </div>
-            </div>
 
             <!-- Footer -->
            <div t-if="props.data.footer"  class="pos-receipt-center-align" style="white-space:pre-line">

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.xml
@@ -17,9 +17,14 @@
                             </div>
                             <hr />
                             <div class="receipt-options d-flex flex-column gap-2">
-                                <button class="button print btn btn-lg btn-secondary w-100 py-3" t-on-click="() => doPrint.call()">
-                                    <i t-attf-class="fa {{doPrint.status === 'loading' ? 'fa-fw fa-spin fa-circle-o-notch' : 'fa-print'}} me-1" />Print Receipt
-                                </button>
+                                <div class="d-flex gap-1">
+                                    <button class="button print btn btn-lg btn-secondary w-100 py-3" t-on-click="() => doFullPrint.call()">
+                                        <i t-attf-class="fa {{doFullPrint.status === 'loading' ? 'fa-fw fa-spin fa-circle-o-notch' : 'fa-print'}} me-1" />Print Full Receipt
+                                    </button>
+                                    <button t-if="pos.config.basic_receipt" class="button print btn btn-lg btn-secondary w-100 py-3" t-on-click="() => doBasicPrint.call()">
+                                        <i t-attf-class="fa {{doBasicPrint.status === 'loading' ? 'fa-fw fa-spin fa-circle-o-notch' : 'fa-print'}} me-1" />Print Basic Receipt
+                                    </button>
+                                </div>
                                 <div class="d-flex gap-1" t-att-class="{'flex-column': this.ui.isSmall}">
                                     <div class="flex-grow-1 p-0 border-0 position-relative send-receipt-input">
                                         <input type="text" class="border p-3 bg-view w-100 pe-5" t-attf-placeholder="{{ state.mode === 'email' ? 'e.g. john.doe@mail.com' : 'e.g. 0123456789' }}" t-model="state.input" />

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -61,7 +61,7 @@ export class TicketScreen extends Component {
         this.dialog = useService("dialog");
         this.numberBuffer = useService("number_buffer");
         this.doPrint = useTrackedAsync((_selectedSyncedOrder) =>
-            this.pos.printReceipt(_selectedSyncedOrder)
+            this.pos.printReceipt({ order: _selectedSyncedOrder })
         );
         this.numberBuffer.use({
             triggerAtInput: (event) => this._onUpdateSelectedOrderline(event),

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1378,12 +1378,13 @@ export class PosStore extends Reactive {
         const baseUrl = this.session._base_url;
         return order.export_for_printing(baseUrl, headerData);
     }
-    async printReceipt(order = this.get_order()) {
+    async printReceipt({ basic = false, order = this.get_order() } = {}) {
         await this.printer.print(
             OrderReceipt,
             {
                 data: this.orderExportForPrinting(order),
                 formatCurrency: this.env.utils.formatCurrency,
+                basic_receipt: basic,
             },
             { webPrintFallback: true }
         );

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -310,6 +310,9 @@
                                     </div>
                                 </div>
                             </setting>
+                            <setting help="Print basic ticket without prices. Can be used for gifts.">
+                                <field name="pos_basic_receipt"/>
+                            </setting>
                         </block>
 
                         <block title="Payment Terminals" help="Those settings are common to all PoS." id="pos_payment_terminals_section">

--- a/addons/pos_loyalty/models/pos_order.py
+++ b/addons/pos_loyalty/models/pos_order.py
@@ -166,8 +166,8 @@ class PosOrder(models.Model):
         fields.extend(['is_reward_line', 'reward_id', 'coupon_id', 'reward_identifier_code', 'points_cost'])
         return fields
 
-    def _add_mail_attachment(self, name, ticket):
-        attachment = super()._add_mail_attachment(name, ticket)
+    def _add_mail_attachment(self, name, ticket, basic_receipt):
+        attachment = super()._add_mail_attachment(name, ticket, basic_receipt)
         gift_card_programs = self.config_id._get_program_ids().filtered(lambda p: p.program_type == 'gift_card' and
                                                                                   p.pos_report_print_id)
         if gift_card_programs:

--- a/addons/pos_sale/static/src/overrides/components/orderline/orderline.xml
+++ b/addons/pos_sale/static/src/overrides/components/orderline/orderline.xml
@@ -13,7 +13,7 @@
                         <td class="text-truncate" style="max-width: 275px;"
                             t-esc="soLine.product_name" />
                         <td class="text-truncate">: </td>
-                        <td class="text-truncate"><t t-esc="soLine.total" /> (tax incl.)</td>
+                        <td t-if="!props.basic_receipt" class="text-truncate"><t t-esc="soLine.total" /> (tax incl.)</td>
                     </tr>
                 </table>
             </t>


### PR DESCRIPTION
Enhanced the POS system by introducing a basic receipt option specifically for gift transactions. This allows users to easily print receipts for gift items.

Task ID: 4081593

related: https://github.com/odoo/enterprise/pull/70165



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
