### PR TITLE
[FIX] account: Tax report lines grouping

### DIFF
--- a/addons/account/models/account_move_line_tax_details.py
+++ b/addons/account/models/account_move_line_tax_details.py
@@ -465,7 +465,7 @@ class AccountMoveLine(models.Model):
 
                 sub.base_line_id,
                 sub.tax_line_id,
-                sub.display_type,
+                sub.display_type = 'rounding' AS is_rounding_line,
                 sub.src_line_id,
 
                 sub.tax_id,


### PR DESCRIPTION
Open POS Session
Add a product with tax
Checkout and Pay order
Close POS Session

Now create an invoice, with same product and tax
Confirm

Open Tax Reports
Two entries will be present, with correct amounts
Activate 'Group by: Account>Tax' option

Issue: Base line amount is not correct
This occurs because in the tax details query we group by display_type of
the lines. This was done in https://github.com/odoo/enterprise/commit/d302b2091231bc5314cc42463b6294fc5a07d37d
to know when we are dealing with a rounding line but in the FW port to
Odoo 16 the code was changed to group by display_type.
When POS creates closing session move, lines will not have the proper
display_type assigned, so for example, tax lines will have display_type
'product'.

The invoice tax line will have the correct display_type 'tax', so the
tax report engine does not merge correctly the results of the query

A solution is to restore the original behavior by separating only rounding
lines.

opw-4125791