### PR TITLE
[FIX] core: allow running test with `-p 0`

### DIFF
--- a/addons/auth_ldap/tests/test_auth_ldap.py
+++ b/addons/auth_ldap/tests/test_auth_ldap.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 
 import odoo
 from odoo.modules.registry import Registry, DummyRLock
-from odoo.tests import HOST
 from odoo.tests.common import BaseCase, tagged, get_db_name
 
 
@@ -58,15 +57,13 @@ class TestAuthLDAP(BaseCase):
             cr.execute("SELECT id FROM res_users WHERE login = 'test_ldap_user'")
             self.assertFalse(cr.rowcount, "User should not be present")
 
-        body = self.opener.get(
-            f"http://{HOST}:{odoo.tools.config['http_port']}/web/login"
-        ).text
+        body = self.url_open("/web/login").text
         csrf = re.search(r'csrf_token: "(\w*?)"', body).group(1)
 
         with patch.object(self.registry["res.company.ldap"], "_get_ldap_dicts", _get_ldap_dicts),\
             patch.object(self.registry["res.company.ldap"], "_authenticate", _authenticate):
             res = self.opener.post(
-                f"http://{HOST}:{odoo.tools.config['http_port']}/web/login",
+                f"{self.base_url()}/web/login",
                 data={
                     "login": "test_ldap_user",
                     "password": "test",

--- a/addons/bus/tests/common.py
+++ b/addons/bus/tests/common.py
@@ -11,8 +11,8 @@ try:
 except ImportError:
     websocket = None
 
-import odoo.tools
-from odoo.tests import HOST, HttpCase
+from odoo.tests.common import HOST
+from odoo.tests import HttpCase
 from ..websocket import CloseCode, Websocket, WebsocketConnectionHandler
 from ..models.bus import dispatch, hashable, channel_with_db
 
@@ -24,7 +24,7 @@ class WebsocketCase(HttpCase):
         if websocket is None:
             cls._logger.warning("websocket-client module is not installed")
             raise unittest.SkipTest("websocket-client module is not installed")
-        cls._BASE_WEBSOCKET_URL = f"ws://{HOST}:{odoo.tools.config['http_port']}/websocket"
+        cls._BASE_WEBSOCKET_URL = f"ws://{HOST}:{cls.http_port()}/websocket"
         cls._WEBSOCKET_URL = f"{cls._BASE_WEBSOCKET_URL}?version={WebsocketConnectionHandler._VERSION}"
         websocket_allowed_patch = patch.object(WebsocketConnectionHandler, "websocket_allowed", return_value=True)
         cls.startClassPatcher(websocket_allowed_patch)

--- a/addons/project/tests/test_project_sharing_portal_access.py
+++ b/addons/project/tests/test_project_sharing_portal_access.py
@@ -7,7 +7,7 @@ from lxml import etree
 from re import search
 
 from odoo import Command
-from odoo.tools import mute_logger
+from odoo.tools import mute_logger, config
 from odoo.exceptions import AccessError
 from odoo.tests import HttpCase, tagged
 
@@ -103,7 +103,7 @@ class TestProjectSharingPortalAccess(TestProjectSharingCommon):
         project_share_wizard_confirmation.action_send_mail()
         mail_partner = self.env['mail.message'].search([('partner_ids', '=', partner_portal_no_user.id)], limit=1)
         self.assertTrue(mail_partner, 'A mail should have been sent to the non portal user')
-        self.assertIn('href="http://localhost:8069/web/signup', str(mail_partner.body), 'The message link should contain the url to register to the portal')
+        self.assertIn(f'href="http://localhost:{config["http_port"]}/web/signup', str(mail_partner.body), 'The message link should contain the url to register to the portal')
         self.assertIn('token=', str(mail_partner.body), 'The message link should contain a personalized token to register to the portal')
 
 

--- a/addons/test_website/tests/test_page.py
+++ b/addons/test_website/tests/test_page.py
@@ -1,8 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests import HttpCase, tagged
-from odoo.tests.common import HOST
-from odoo.tools import config, mute_logger
+from odoo.tools import mute_logger
 
 
 @tagged('-at_install', 'post_install')
@@ -12,7 +11,7 @@ class WithContext(HttpCase):
         website = self.env['website'].browse([1])
         website.write({
             'name': 'Test Website',
-            'domain': f'http://{HOST}:{config["http_port"]}',
+            'domain': self.base_url(),
             'homepage_url': '/unexisting',
         })
         home_url = '/'

--- a/addons/website/tests/test_assets.py
+++ b/addons/website/tests/test_assets.py
@@ -20,8 +20,8 @@ class TestWebsiteAssets(odoo.tests.HttpCase):
         [w.write({'domain': f'inactive-{w.id}.test'}) for w in Website.search([])]
         # Don't use HOST, hardcode it so it doesn't get changed one day and make
         # the test useless
-        domain_1 = "http://127.0.0.1:%s" % config['http_port']
-        domain_2 = "http://localhost:%s" % config['http_port']
+        domain_1 = f"http://127.0.0.1:{self.http_port()}"
+        domain_2 = f"http://localhost:{self.http_port()}"
         Website.browse(1).domain = domain_1
 
         self.authenticate('admin', 'admin')

--- a/addons/website/tests/test_attachment.py
+++ b/addons/website/tests/test_attachment.py
@@ -1,7 +1,5 @@
 import odoo.tests
-from odoo.tests.common import HOST
-from odoo.tools import config
-from odoo.addons.website.tools import create_image_attachment
+from ..tools import create_image_attachment
 
 
 @odoo.tests.common.tagged('post_install', '-at_install')
@@ -30,11 +28,10 @@ class TestWebsiteAttachment(odoo.tests.HttpCase):
         req = self.url_open('/web/image/test.an_image_url')
         self.assertEqual(req.status_code, 200)
 
-        base = "http://%s:%s" % (HOST, config['http_port'])
-
+        base = self.base_url()
         req = self.opener.get(base + '/web/image/test.an_image_redirect_301', allow_redirects=False)
         self.assertEqual(req.status_code, 301)
-        self.assertURLEqual(req.headers.get('Location'), '/web/image/test.an_image_url')
+        self.assertURLEqual(req.headers['Location'], '/web/image/test.an_image_url')
 
         req = self.opener.get(base + '/web/image/test.an_image_redirect_301', allow_redirects=True)
         self.assertEqual(req.status_code, 200)

--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -294,7 +294,7 @@ class WithContext(HttpCase):
         # Set another page (/page_1) as homepage
         website.write({
             'homepage_url': self.page.url,
-            'domain': f"http://{HOST}:{config['http_port']}",
+            'domain': self.base_url(),
         })
         assert self.page.url != '/'
 
@@ -323,7 +323,7 @@ class WithContext(HttpCase):
         # If one has set the `homepage_url` to a specific page URL..
         website.write({
             'name': 'Test Website',
-            'domain': f'http://{HOST}:{config["http_port"]}',
+            'domain': self.base_url(),
             'homepage_url': test_page.url,
         })
         home_url_full = website.domain + '/'
@@ -362,7 +362,7 @@ class WithContext(HttpCase):
         website = self.env['website'].browse([1])
         website.write({
             'name': 'Test Website',
-            'domain': f'http://{HOST}:{config["http_port"]}',
+            'domain': self.base_url(),
             'homepage_url': False,
         })
         contactus_url = '/contactus'

--- a/addons/website/tests/test_page_manager.py
+++ b/addons/website/tests/test_page_manager.py
@@ -1,10 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import odoo.tests
-
-from odoo.tests.common import HOST
-from odoo.tools import config
 
 
 @odoo.tests.common.tagged('post_install', '-at_install')
@@ -22,7 +18,7 @@ class TestWebsitePageManager(odoo.tests.HttpCase):
         self.start_tour(url, 'website_page_manager_session_forced', login="admin")
 
         alternate_website = self.env['website'].search([('name', '=', 'My Website 2')], limit=1)
-        alternate_website.domain = f'http://{HOST}:{config["http_port"]}'
+        alternate_website.domain = self.base_url()
         self.start_tour('/odoo/action-website.action_website_pages_list', 'website_page_manager_direct_access', login='admin')
 
     def test_generic_page_diverged_not_shown(self):

--- a/addons/website/tools.py
+++ b/addons/website/tools.py
@@ -10,7 +10,6 @@ from werkzeug.test import EnvironBuilder
 
 import odoo.http
 from odoo.tools.misc import hmac, DotDict, frozendict
-from odoo.tools import config
 
 HOST = '127.0.0.1'
 
@@ -240,12 +239,11 @@ def create_image_attachment(env, image_path, image_name):
     :param image_name: the name to give to the image (e.g. 's_banner_default_image.jpg')
     :return: the image attachment
     """
-    IrAttachment = env['ir.attachment']
-    base = 'http://%s:%s' % (HOST, config['http_port'])
-    img = IrAttachment.create({
+    Attachments = env['ir.attachment']
+    img = Attachments.create({
         'public': True,
         'name': image_name,
         'type': 'url',
-        'url': base + image_path,
+        'url': Attachments.get_base_url() + image_path,
     })
     return img

--- a/addons/website_sale/tests/test_website_sale_image.py
+++ b/addons/website_sale/tests/test_website_sale_image.py
@@ -7,8 +7,6 @@ from PIL import Image
 
 from odoo.fields import Command
 from odoo.tests import HttpCase, tagged
-from odoo.tests.common import HOST
-from odoo.tools import config
 
 
 @tagged('post_install', '-at_install')
@@ -345,13 +343,11 @@ class TestWebsiteSaleRemoveImage(HttpCase):
     def setUpClass(cls):
         super().setUpClass()
         # Attachment needed for the replacement of images
-        IrAttachment = cls.env['ir.attachment']
-        base = "http://%s:%s" % (HOST, config['http_port'])
-        IrAttachment.create({
+        cls.env['ir.attachment'].create({
             'public': True,
             'name': 's_default_image.jpg',
             'type': 'url',
-            'url': base + '/web/image/website.s_banner_default_image.jpg',
+            'url': f'{cls.base_url()}/web/image/website.s_banner_default_image.jpg',
         })
 
         # First image (blue) for the template.

--- a/odoo/addons/base/tests/test_xmlrpc.py
+++ b/odoo/addons/base/tests/test_xmlrpc.py
@@ -130,7 +130,7 @@ class TestXMLRPC(common.HttpCase):
         )
 
     def _json_call(self, *args):
-        self.opener.post("http://%s:%s/jsonrpc" % (common.HOST, odoo.tools.config['http_port']), json={
+        self.opener.post(f"{self.base_url()}/jsonrpc", json={
             'jsonrpc': '2.0',
             'id': None,
             'method': 'call',

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1784,8 +1784,16 @@ class HttpCase(TransactionCase):
         ICP.set_param('web.base.url', cls.base_url())
         ICP.env.flush_all()
         # v8 api with correct xmlrpc exception handling.
-        cls.xmlrpc_url = f'http://{HOST}:{odoo.tools.config["http_port"]:d}/xmlrpc/2/'
+        cls.xmlrpc_url = f'{cls.base_url()}/xmlrpc/2/'
         cls._logger = logging.getLogger('%s.%s' % (cls.__module__, cls.__name__))
+
+    @classmethod
+    def base_url(cls):
+        return f"http://{HOST}:{cls.http_port():d}"
+
+    @classmethod
+    def http_port(cls):
+        return odoo.service.server.server.httpd.server_port
 
     def setUp(self):
         super().setUp()
@@ -1986,10 +1994,6 @@ class HttpCase(TransactionCase):
         finally:
             browser.stop()
             self._wait_remaining_requests()
-
-    @classmethod
-    def base_url(cls):
-        return f"http://{HOST}:{odoo.tools.config['http_port']}"
 
     def start_tour(self, url_path, tour_name, step_delay=None, **kwargs):
         """Wrapper for `browser_js` to start the given `tour_name` with the


### PR DESCRIPTION
While it's possible to run Odoo with `-p 0`, previously the test suite would then generate URLs with a port of 0, means the http tests were unable to get the server's port and connect to it.

By retrieving the actual port the server is bound to, we can run http tests / tours with `-p 0` and things will work correctly, even tour watching / debugging should work correctly.
