### PR TITLE
core: make odoo's logging configuration optional / opt-out

### DIFF
--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -558,8 +558,13 @@ class ir_cron(models.Model):
                 self.env.reset()
                 self = self.env()[self._name]
 
-            log_depth = (None if _logger.isEnabledFor(logging.DEBUG) else 1)
-            odoo.netsvc.log(_logger, logging.DEBUG, 'cron.object.execute', (self.env.cr.dbname, self._uid, '*', cron_name, server_action_id), depth=log_depth)
+            _logger.debug(
+                "cron.object.execute(%r, %d, '*', %r, %d)",
+                self.env.cr.dbname,
+                self._uid,
+                cron_name,
+                server_action_id,
+            )
             _logger.info('Job %r (%s) starting', cron_name, self.id)
             start_time = time.time()
             self.env['ir.actions.server'].browse(server_action_id).run()

--- a/odoo/cli/db.py
+++ b/odoo/cli/db.py
@@ -115,7 +115,7 @@ class Db(Command):
                     else f'--{k}',
                 v,
             ]
-        ])
+        ], setup_logging=True)
         # force db management active to bypass check when only a
         # `check_db_management_enabled` version is available.
         config['list_db'] = True

--- a/odoo/cli/neutralize.py
+++ b/odoo/cli/neutralize.py
@@ -21,7 +21,7 @@ class Neutralize(Command):
         group.add_option("--stdout", action="store_true", dest="to_stdout",
                          help="Output the neutralization SQL instead of applying it")
         parser.add_option_group(group)
-        opt = odoo.tools.config.parse_config(args)
+        opt = odoo.tools.config.parse_config(args, setup_logging=True)
 
         dbname = odoo.tools.config['db_name']
         if not dbname:

--- a/odoo/cli/obfuscate.py
+++ b/odoo/cli/obfuscate.py
@@ -149,7 +149,7 @@ class Obfuscate(Command):
             sys.exit(parser.print_help())
 
         try:
-            opt = odoo.tools.config.parse_config(cmdargs)
+            opt = odoo.tools.config.parse_config(cmdargs, setup_logging=True)
             if not opt.pwd:
                 _logger.error("--pwd is required")
                 sys.exit("ERROR: --pwd is required")

--- a/odoo/cli/populate.py
+++ b/odoo/cli/populate.py
@@ -38,7 +38,7 @@ class Populate(Command):
                          dest='separator',
                          help="Single character separator for char/text fields.",
                          default=DEFAULT_SEPARATOR)
-        opt = odoo.tools.config.parse_config(cmdargs)
+        opt = odoo.tools.config.parse_config(cmdargs, setup_logging=True)
 
         # deduplicate models if necessary, and keep the last corresponding
         # factor for each model

--- a/odoo/cli/server.py
+++ b/odoo/cli/server.py
@@ -132,7 +132,7 @@ def import_translation():
 
 def main(args):
     check_root_user()
-    odoo.tools.config.parse_config(args)
+    odoo.tools.config.parse_config(args, setup_logging=True)
     check_postgres_user()
     report_configuration()
 

--- a/odoo/cli/shell.py
+++ b/odoo/cli/shell.py
@@ -56,7 +56,7 @@ class Shell(Command):
 
     def init(self, args):
         config.parser.prog = f'{Path(sys.argv[0]).name} {self.name}'
-        config.parse_config(args)
+        config.parse_config(args, setup_logging=True)
         odoo.cli.server.report_configuration()
         odoo.service.server.start(preload=[], stop=True)
         signal.signal(signal.SIGINT, raise_keyboard_interrupt)

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -369,7 +369,7 @@ class configmanager(object):
         # generate default config
         self._parse_config()
 
-    def parse_config(self, args=None):
+    def parse_config(self, args: list[str] | None = None, *, setup_logging: bool | None = None) -> None:
         """ Parse the configuration file (if any) and the command-line
         arguments.
 
@@ -385,7 +385,18 @@ class configmanager(object):
             odoo.tools.config.parse_config(sys.argv[1:])
         """
         opt = self._parse_config(args)
-        odoo.netsvc.init_logger()
+        if setup_logging is not False:
+            odoo.netsvc.init_logger()
+            # warn after having done setup, so it has a chance to show up
+            # (mostly once this warning is bumped to DeprecationWarning proper)
+            if setup_logging is None:
+                warnings.warn(
+                    "As of Odoo 18, it's recommended to specify whether"
+                    " you want Odoo to setup its own logging (or want to"
+                    " handle it yourself)",
+                    category=PendingDeprecationWarning,
+                    stacklevel=2,
+                )
         self._warn_deprecated_options()
         odoo.modules.module.initialize_sys_path()
         return opt


### PR DESCRIPTION
While Odoo commits plenty of library sins from its origin (and primary use case) as an application & framework, few are as egregious as its taking unconditional control of the warnings and logging systems as soon as it's initialized.

Fix this, by making logging configuration conditional.
