### PR TITLE
[FIX] *: whitespace normalisation

### DIFF
--- a/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
+++ b/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
@@ -117,25 +117,25 @@ class TestPDFQuoteBuilder(HttpCase, SaleCommon):
             ]
         })
         self.sale_order.commitment_date = datetime.datetime(2121, 12, 21, 12, 21, 12)
-        form_field_expected_value_map = {
-            new_form_fields[0]: "No",  # boolean
-            new_form_fields[1]: self.sale_order.name,  # char
-            new_form_fields[2]: "11/04/2020",  # date
-            new_form_fields[3]: "Dec 21, 2121, 1:21:12 PM",  # datetime
-            new_form_fields[4]: "4.99",  # float
-            new_form_fields[5]: "10",  # integer
-            new_form_fields[6]: "Quotation",  # selection
-            new_form_fields[7]: "$\xa0720.01",  # monetary
+        expected_values = [
+            "No",  # boolean
+            self.sale_order.name,  # char
+            "11/04/2020",  # date
+            "Dec 21, 2121, 1:21:12 PM",  # datetime
+            "4.99",  # float
+            "10",  # integer
+            "Quotation",  # selection
+            "$ 720.01",  # monetary
 
-            new_form_fields[8]: f"{sol_1.display_name}, {sol_2.display_name}",  # one2many
-            new_form_fields[9]: f"{self.sale_order.company_id.display_name}",  # many2one
-            new_form_fields[10]: "test tax, test tax2",  # many2many
-        }
-        for form_field, expected_value in form_field_expected_value_map.items():
+            f"{sol_1.display_name}, {sol_2.display_name}",  # one2many
+            f"{self.sale_order.company_id.display_name}",  # many2one
+            "test tax, test tax2",  # many2many
+        ]
+        for form_field, expected_value in zip(new_form_fields, expected_values):
             result = self.env['ir.actions.report']._get_value_from_path(
                 form_field, self.sale_order, sol_1
             )
-            self.assertEqual(result, expected_value)
+            self.assertEqual(' '.join(result.split()), expected_value)
 
     def _test_custom_content_kanban_like(self):
         # TODO VCR finish tour and uncomment

--- a/addons/test_mail_full/tests/test_mail_performance.py
+++ b/addons/test_mail_full/tests/test_mail_performance.py
@@ -274,7 +274,7 @@ class TestPortalFormatPerformance(FullBaseMailPerformance):
             self.assertEqual(format_res['author_id'], (record.customer_id.id, record.customer_id.display_name))
             self.assertEqual(format_res['author_avatar_url'], f'/web/image/mail.message/{message.id}/author_avatar/50x50')
             self.assertEqual(format_res['date'], datetime(2023, 5, 15, 10, 30, 5))
-            self.assertEqual(format_res['published_date_str'], 'May 15, 2023, 10:30:05 AM')
+            self.assertEqual(' '.join(format_res['published_date_str'].split()), 'May 15, 2023, 10:30:05 AM')
             self.assertEqual(format_res['id'], message.id)
             self.assertFalse(format_res['is_internal'])
             self.assertFalse(format_res['is_message_subtype_note'])
@@ -298,7 +298,7 @@ class TestPortalFormatPerformance(FullBaseMailPerformance):
             self.assertEqual(format_res['rating']['publisher_avatar'], f'/web/image/res.partner/{self.partner_admin.id}/avatar_128/50x50')
             self.assertEqual(format_res['rating']['publisher_comment'], 'Comment')
             self.assertEqual(format_res['rating']['publisher_id'], self.partner_admin.id)
-            self.assertEqual(format_res['rating']['publisher_datetime'], 'May 13, 2023, 10:30:05 AM')
+            self.assertEqual(" ".join(format_res['rating']['publisher_datetime'].split()), 'May 13, 2023, 10:30:05 AM')
             self.assertEqual(format_res['rating']['publisher_name'], self.partner_admin.display_name)
             self.assertDictEqual(
                 format_res['rating_stats'],


### PR DESCRIPTION
Date and monetary formatting can lead to "interesting" whitespace depending on dependencies and all, and their versions.

Normalise whitespace to alias NBSP and SP in a few tests which otherwise may fail depending on the babel version.
