### PR TITLE
[FIX] *: ensure various tests run with consistent pricelist

### DIFF
--- a/addons/sale_timesheet/tests/test_sale_timesheet_ui.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet_ui.py
@@ -42,4 +42,6 @@ class TestSaleTimesheetUi(HttpCase):
         if not loaded_demo_data(self.env):
             _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
             return
+
+        self.env['product.pricelist'].with_context(active_test=False).search([]).unlink()
         self.start_tour('/odoo', 'sale_timesheet_tour', login='admin', timeout=100)

--- a/addons/website_event_sale/tests/test_frontend_buy_tickets.py
+++ b/addons/website_event_sale/tests/test_frontend_buy_tickets.py
@@ -1,88 +1,88 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
-import odoo.tests
-
 from datetime import timedelta
 
+import odoo.tests
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
-from odoo.addons.website_event_sale.tests.common import TestWebsiteEventSaleCommon
 from odoo.fields import Datetime
+
+from .common import TestWebsiteEventSaleCommon
 
 
 @odoo.tests.common.tagged('post_install', '-at_install')
 class TestUi(HttpCaseWithUserDemo, TestWebsiteEventSaleCommon):
-
     def setUp(self):
         super().setUp()
 
         if self.env['ir.module.module']._get('payment_custom').state != 'installed':
             self.skipTest("Transfer provider is not installed")
 
-        self.env.ref('payment.payment_provider_transfer').write({
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.env.ref('payment.payment_provider_transfer').write({
             'state': 'enabled',
             'is_published': True,
         })
 
-        self.event_2 = self.env['event.event'].create({
+        cls.event_2 = cls.env['event.event'].create({
             'name': 'Conference for Architects TEST',
-            'user_id': self.env.ref('base.user_admin').id,
+            'user_id': cls.env.ref('base.user_admin').id,
             'date_begin': (Datetime.today() + timedelta(days=5)).strftime('%Y-%m-%d 07:00:00'),
             'date_end': (Datetime.today() + timedelta(days=5)).strftime('%Y-%m-%d 16:30:00'),
             'website_published': True,
         })
 
-        self.env['event.event.ticket'].create([{
+        cls.env['event.event.ticket'].create([{
             'name': 'Standard',
-            'event_id': self.event_2.id,
-            'product_id': self.env.ref('event_product.product_product_event').id,
+            'event_id': cls.event_2.id,
+            'product_id': cls.env.ref('event_product.product_product_event').id,
             'start_sale_datetime': (Datetime.today() - timedelta(days=5)).strftime('%Y-%m-%d 07:00:00'),
             'end_sale_datetime': (Datetime.today() + timedelta(90)).strftime('%Y-%m-%d'),
             'price': 1000.0,
         }, {
             'name': 'VIP',
-            'event_id': self.event_2.id,
-            'product_id': self.env.ref('event_product.product_product_event').id,
+            'event_id': cls.event_2.id,
+            'product_id': cls.env.ref('event_product.product_product_event').id,
             'end_sale_datetime': (Datetime.today() + timedelta(90)).strftime('%Y-%m-%d'),
             'price': 1500.0,
         }])
 
-        self.event_3 = self.env['event.event'].create({
+        cls.event_3 = cls.env['event.event'].create({
             'name': 'Last ticket test',
-            'user_id': self.env.ref('base.user_admin').id,
+            'user_id': cls.env.ref('base.user_admin').id,
             'date_begin': (Datetime.today() + timedelta(days=5)).strftime('%Y-%m-%d 07:00:00'),
             'date_end': (Datetime.today() + timedelta(days=5)).strftime('%Y-%m-%d 16:30:00'),
             'website_published': True,
         })
 
-        self.env['event.event.ticket'].create([{
+        cls.env['event.event.ticket'].create([{
             'name': 'VIP',
-            'event_id': self.event_3.id,
-            'product_id': self.env.ref('event_product.product_product_event').id,
+            'event_id': cls.event_3.id,
+            'product_id': cls.env.ref('event_product.product_product_event').id,
             'end_sale_datetime': (Datetime.today() + timedelta(90)).strftime('%Y-%m-%d'),
             'price': 1500.0,
             'seats_max': 2,
         }])
 
         # flush event to ensure having tickets available in the tests
-        self.env.flush_all()
+        cls.env.flush_all()
 
-        (self.env.ref('base.partner_admin') + self.partner_demo).write({
+        (cls.env.ref('base.partner_admin') + cls.partner_demo).write({
             'street': '215 Vine St',
             'city': 'Scranton',
             'zip': '18503',
-            'country_id': self.env.ref('base.us').id,
-            'state_id': self.env.ref('base.state_us_39').id,
+            'country_id': cls.env.ref('base.us').id,
+            'state_id': cls.env.ref('base.state_us_39').id,
             'phone': '+1 555-555-5555',
             'email': 'admin@yourcompany.example.com',
         })
 
-        self.env['account.journal'].create({'name': 'Cash - Test', 'type': 'cash', 'code': 'CASH - Test'})
+        cls.env['account.journal'].create({'name': 'Cash - Test', 'type': 'cash', 'code': 'CASH - Test'})
 
     def test_admin(self):
-        if self.env['ir.module.module']._get('payment_custom').state != 'installed':
-            self.skipTest("Transfer provider is not installed")
-
+        self.env['product.pricelist'].with_context(active_test=False).search([]).unlink()
         # Seen that:
         # - this test relies on demo data that are entirely in USD (pricelists)
         # - that main demo company is gelocated in US
@@ -101,9 +101,7 @@ class TestUi(HttpCaseWithUserDemo, TestWebsiteEventSaleCommon):
         self.start_tour("/", 'event_buy_tickets', login="admin")
 
     def test_demo(self):
-        if self.env['ir.module.module']._get('payment_custom').state != 'installed':
-            self.skipTest("Transfer provider is not installed")
-
+        self.env['product.pricelist'].with_context(active_test=False).search([]).unlink()
         transfer_provider = self.env.ref('payment.payment_provider_transfer')
         transfer_provider.write({
             'state': 'enabled',
@@ -117,9 +115,6 @@ class TestUi(HttpCaseWithUserDemo, TestWebsiteEventSaleCommon):
         self.start_tour("/", 'event_buy_tickets', login="demo")
 
     def test_buy_last_ticket(self):
-        if self.env['ir.module.module']._get('payment_custom').state != 'installed':
-            self.skipTest("Transfer provider is not installed")
-
         transfer_provider = self.env.ref('payment.payment_provider_transfer')
         transfer_provider.write({
             'state': 'enabled',
@@ -130,5 +125,6 @@ class TestUi(HttpCaseWithUserDemo, TestWebsiteEventSaleCommon):
         self.start_tour("/", 'event_buy_last_ticket')
 
     def test_pricelists_different_currencies(self):
+        self.env.user.groups_id += self.env.ref('product.group_product_pricelist')
         self.start_tour("/", 'event_sale_pricelists_different_currencies', login='admin')
     # TO DO - add public test with new address when convert to web.tour format.

--- a/addons/website_sale_loyalty/tests/test_shop_sale_coupon.py
+++ b/addons/website_sale_loyalty/tests/test_shop_sale_coupon.py
@@ -410,6 +410,7 @@ class TestWebsiteSaleCoupon(HttpCase):
             1. Raise an error
             2. Not delete the coupon
         """
+        self.env['product.pricelist'].with_context(active_test=False).search([]).unlink()
         website = self.env['website'].browse(1)
 
         # Create product

--- a/addons/website_sale_loyalty/tests/test_website_sale_loyalty_delivery.py
+++ b/addons/website_sale_loyalty/tests/test_website_sale_loyalty_delivery.py
@@ -11,6 +11,8 @@ class TestWebsiteSaleDelivery(HttpCase):
     def setUp(self):
         super().setUp()
 
+        self.env['product.pricelist'].with_context(active_test=False).search([]).unlink()
+
         self.env.ref('base.user_admin').write({
             'name': 'Mitchell Admin',
             'street': '215 Vine St',


### PR DESCRIPTION
Because runbot always runs post_install tests with multi-currency pricelists enabled (because it installs `l10n_be` which activates the EUR currency, which enables multi-currency, which through `product` enables pricelists) some tests don't cope well with pricelists / multi-currency not being enabled, enable the pricelists feature for those which require it.

Furthermore, because it's possible for pricelists to exist even though the feature is not enabled some tests will correctly handle either there being no pricelists or there being a default pricelist, but not the intermediate state where pricelists are disabled *but* `pos_pricer` has been installed and has created a weirdo universally applicable pricelist with a 20% discount, which causes lookups for specific prices to fail (as the final price is 20% lower than looked for).

Fix those tests by deleting all pricelists before they run.
