### PR TITLE
[FIX] website: race condition in restricted editor tour

### DIFF
--- a/addons/test_website/static/tests/tours/restricted_editor.js
+++ b/addons/test_website/static/tests/tours/restricted_editor.js
@@ -13,7 +13,7 @@ const checkNoTranslate = {
 };
 const translate = [{
     content: "Open Edit menu",
-    trigger: ".o_menu_systray .o_edit_website_container button:contains(edit)",
+    trigger: ".o_menu_systray .o_edit_website_container button.o-dropdown-toggle-custo:contains(edit)",
     run: "click",
 }, {
     content: "Click on translate button",


### PR DESCRIPTION
With enough modules installed, the edit / translate menu can appear before the `websiteRootInstance` is loaded, which suppresses the switch to translation mode (tours are pretty prototypical "clicks too fast" users), which fails step "Check has error dialog" as there is no error since we didn't even attempt to switch to edition mode.

- Update the tour to only click the edit button if it's a dropdown.
- Update the `translatable` flag to check if the website root instance is ready, this way `Edit > Translate` is only accessible if the public root is loaded.
- Remove the suppression condition, which should now be unnecessary.
- Simplify the tail code a bit.
