### PR TITLE
[IMP] web_tour: only use groups for display if in debug mode

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_step_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_step_automatic.js
@@ -47,11 +47,13 @@ export class TourStepAutomatic extends TourStep {
             },
             {
                 action: async () => {
-                    console.groupCollapsed(this.describeMe);
-                    if (debugMode !== false) {
+                    if (debugMode === false) {
+                        console.log(this.describeMe);
+                    } else {
+                        console.groupCollapsed(this.describeMe);
                         console.log(this.stringify);
+                        console.groupEnd();
                     }
-                    console.groupEnd();
                     this._timeout = browser.setTimeout(
                         () => this.throwError(),
                         (this.timeout || 10000) + this.tour.stepDelay

--- a/addons/web_tour/static/tests/tour_service.test.js
+++ b/addons/web_tour/static/tests/tour_service.test.js
@@ -232,6 +232,7 @@ test("next step with new anchor at same position", async () => {
 test("a failing tour logs the step that failed in run", async () => {
     patchWithCleanup(browser.console, {
         groupCollapsed: (s) => expect.step(`log: ${s}`),
+        log: (s) => expect.step(`log: ${s}`),
         warn: (s) => {},
         error: (s) => expect.step(`error: ${s}`),
     });
@@ -339,6 +340,7 @@ test("a failing tour logs the step that failed", async () => {
     patchWithCleanup(browser.console, {
         dir: (s) => expect.step(`runbot: ${s.replace(/[\s-]*/g, "")}`),
         groupCollapsed: (s) => expect.step(`log: ${s}`),
+        log: (s) => expect.step(`log: ${s}`),
         warn: (s) => expect.step(`warn: ${s.replace(/[\s-]*/gi, "")}`),
         error: (s) => expect.step(`error: ${s}`),
     });
@@ -989,13 +991,23 @@ test("manual tour with inactive steps", async () => {
 });
 
 test("automatic tour with alternative trigger", async () => {
+    let suppressLog = false;
     patchWithCleanup(browser.console, {
         groupCollapsed: (s) => {
             expect.step("on step");
+            suppressLog = true;
+        },
+        groupEnd: () => {
+            suppressLog = false;
         },
         log: (s) => {
+            if (suppressLog) {
+                return;
+            }
             if (s.toLowerCase().includes("tour tour_des_flandres succeeded")) {
                 expect.step("succeeded");
+            } else if (s !== "tour succeeded") {
+                expect.step("on step");
             }
         },
     });


### PR DESCRIPTION
The `groupCollapsed` / `groupEnd` pair causes unnecessary noise in the python logs, and even in the JS side it's kinda odd to have a folded group which by definition can't have content.
