### PR TITLE
[FIX] account_debit_note: allow debit note journal type recomputation

### DIFF
--- a/addons/account_debit_note/wizard/account_debit_note.py
+++ b/addons/account_debit_note/wizard/account_debit_note.py
@@ -24,7 +24,7 @@ class AccountDebitNote(models.TransientModel):
                                      "We won't copy them for debit notes from credit notes. ")
     # computed fields
     move_type = fields.Char(compute="_compute_from_moves")
-    journal_type = fields.Char(compute="_compute_from_moves")
+    journal_type = fields.Char(compute="_compute_journal_type")
     country_code = fields.Char(related='move_ids.company_id.country_id.code')
 
     @api.model
@@ -45,6 +45,10 @@ class AccountDebitNote(models.TransientModel):
         for record in self:
             move_ids = record.move_ids
             record.move_type = move_ids[0].move_type if len(move_ids) == 1 or not any(m.move_type != move_ids[0].move_type for m in move_ids) else False
+
+    @api.depends('move_type')
+    def _compute_journal_type(self):
+        for record in self:
             record.journal_type = record.move_type in ['in_refund', 'in_invoice'] and 'purchase' or 'sale'
 
     def _prepare_default_values(self, move):


### PR DESCRIPTION
Steps to reproduce:
- Install Accounting and account_debit_note
- Accounting > Customers > Invoices > Select any
- Gear Icon > Debit note
- Try to select an entry in 'Use Specific Journal'

No journal is available to pick from, this happens because 'Use specific journal' filters journal_id with the domain [('type', '=', journal_type)], and journal_type mistakenly has the value False.

The root cause of this issue is the strengthened recompuation protection added in 20c2e5996651168db3a6d75ace6a8907c1661792. The ORM will no longer allow recomputation of fields without a default if they share a compute method with another field which has a default value. (In an onchange flow).

At the time of the wizard's creation we update the cache in onchange() to contain False for each value without a default. In 17.0 and earlier we used to invalidate that cached value, leading to the computation of journal_type, but that behavior has changed since.

To avoid uncessary recomputation of 'move_type' (which is given a default value) we protect its compute method. However 'move_type' shares its compute method with journal_type, so we also prevent the computation of journal_type in the process.

We end up with our debit note wizard which has never made a call to _compute_from_moves (meaning is has no journal_type) and thus filter journal_id by [('type', '=', False)], which is forbidden as journal_id.type is a required field, preventing us from selecting a journal.

opw-4124278

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
