### PR TITLE
[FIX] website, web_editor, *: fix homepage interactive tour

### DIFF
--- a/addons/mass_mailing/static/tests/tours/mailing_editor.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_editor.js
@@ -39,7 +39,7 @@ registry.category("web_tour.tours").add('mailing_editor', {
     },
 }, {
     content: 'wait for the snippet menu to finish the drop process',
-    trigger: 'body:not(:has(.o_we_already_dragging))',
+    trigger: 'body:not(:has(.o_we_ongoing_insertion))',
 }, {
     content: 'verify that the title was inserted properly in the editor',
     trigger: '[name="body_arch"] :iframe .o_editable h1',

--- a/addons/test_website/static/tests/tours/custom_snippets.js
+++ b/addons/test_website/static/tests/tours/custom_snippets.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { dragNDrop, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
+import { insertSnippet, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
 
 /**
  * The purpose of this tour is to check the custom snippets flow:
@@ -26,7 +26,7 @@ registerWebsitePreviewTour('test_custom_snippet', {
     edition: true,
     test: true,
 }, () => [
-    ...dragNDrop({
+    ...insertSnippet({
         id: 's_banner',
         name: 'Banner',
         groupName: "Intro",

--- a/addons/test_website/static/tests/tours/image_link.js
+++ b/addons/test_website/static/tests/tours/image_link.js
@@ -1,4 +1,4 @@
-import { dragNDrop, registerWebsitePreviewTour } from '@website/js/tours/tour_utils';
+import { insertSnippet, registerWebsitePreviewTour } from '@website/js/tours/tour_utils';
 
 /**
  * The purpose of this tour is to check the link on image flow.
@@ -22,7 +22,7 @@ registerWebsitePreviewTour('test_image_link', {
     url: '/',
     edition: true,
 }, () => [
-    ...dragNDrop({
+    ...insertSnippet({
         id: 's_text_image',
         name: 'Text - Image',
         groupName: "Content",

--- a/addons/test_website/static/tests/tours/image_upload_progress.js
+++ b/addons/test_website/static/tests/tours/image_upload_progress.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { dragNDrop, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
+import { insertSnippet, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
 
 import { FileSelectorControlPanel } from "@web_editor/components/media_dialog/file_selector";
 import { patch } from "@web/core/utils/patch";
@@ -47,12 +47,12 @@ const setupSteps = function () {
                 unpatchMediaDialog = patchMediaDialog();
             },
         },
-        ...dragNDrop({
+        ...insertSnippet({
             id: "s_text_image",
             name: "Text - Image",
             groupName: "Content",
         }),
-        ...dragNDrop({
+        ...insertSnippet({
             id: "s_image_gallery",
             name: "Image Gallery",
             groupName: "Images",

--- a/addons/test_website/static/tests/tours/replace_media.js
+++ b/addons/test_website/static/tests/tours/replace_media.js
@@ -4,7 +4,7 @@ import { patch } from "@web/core/utils/patch";
 import { VideoSelector } from '@web_editor/components/media_dialog/video_selector';
 import {
     changeOption,
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
 
@@ -37,7 +37,7 @@ registerWebsitePreviewTour('test_replace_media', {
             });
         },
     },
-    ...dragNDrop({
+    ...insertSnippet({
         name: 'Title - Image',
         id: 's_picture',
         groupName: "Images",

--- a/addons/test_website/static/tests/tours/reset_views.js
+++ b/addons/test_website/static/tests/tours/reset_views.js
@@ -22,7 +22,7 @@ registerWebsitePreviewTour(
     () => [
         {
             content: "Drag the Intro snippet group and drop it in #oe_structure_test_website_page.",
-            trigger: '#oe_snippets .oe_snippet[name="Intro"] .oe_snippet_thumbnail:not(.o_we_already_dragging)',
+            trigger: '#oe_snippets .oe_snippet[name="Intro"] .oe_snippet_thumbnail:not(.o_we_ongoing_insertion)',
             // id starting by 'oe_structure..' will actually create an inherited view
             run: "drag_and_drop :iframe #oe_structure_test_website_page",
         },

--- a/addons/test_website/static/tests/tours/restricted_editor.js
+++ b/addons/test_website/static/tests/tours/restricted_editor.js
@@ -104,7 +104,7 @@ registerWebsitePreviewTour('test_restricted_editor_test_admin', {
     },
     {
         content: "Drag the Intro snippet group",
-        trigger: '#oe_snippets .oe_snippet[name="Intro"] .oe_snippet_thumbnail:not(.o_we_already_dragging)',
+        trigger: '#oe_snippets .oe_snippet[name="Intro"] .oe_snippet_thumbnail:not(.o_we_ongoing_insertion)',
         run: "drag_and_drop :iframe [data-oe-expression='record.website_description']",
     },
     {

--- a/addons/web_editor/static/src/js/editor/add_snippet_dialog.js
+++ b/addons/web_editor/static/src/js/editor/add_snippet_dialog.js
@@ -174,7 +174,7 @@ export class AddSnippetDialog extends Component {
             }
             clonedSnippetEl.classList.remove("oe_snippet_body");
             const snippetPreviewWrapEl = document.createElement("div");
-            snippetPreviewWrapEl.classList.add("o_snippet_preview_wrap", "position-relative", "fade");
+            snippetPreviewWrapEl.classList.add("o_snippet_preview_wrap", "position-relative", "d-none");
             snippetPreviewWrapEl.dataset.snippetId = snippet.name;
             snippetPreviewWrapEl.dataset.snippetKey = snippet.key;
             snippetPreviewWrapEl.appendChild(clonedSnippetEl);
@@ -258,11 +258,14 @@ export class AddSnippetDialog extends Component {
                         resolve();
                     } else {
                         imgEl.onload = () => resolve();
+                        // If the image could not be loaded, we still want the
+                        // "d-none" class to be removed.
+                        imgEl.onerror = () => resolve();
                     }
                 });
             }));
 
-            snippetPreviewWrapEl.classList.add("show");
+            snippetPreviewWrapEl.classList.remove("d-none");
         };
     }
     /**

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -3584,7 +3584,7 @@ class SnippetsMenu extends Component {
             el: this.snippetsAreaRef.el,
             elements: ".oe_snippet.o_we_draggable",
             scrollingElement: $scrollingElement[0],
-            handle: '.oe_snippet_thumbnail:not(.o_we_already_dragging)',
+            handle: '.oe_snippet_thumbnail:not(.o_we_ongoing_insertion)',
             cancel: '.oe_snippet.o_disabled',
             dropzones: () => {
                 return $dropZones.toArray();
@@ -3613,7 +3613,7 @@ class SnippetsMenu extends Component {
 
                 this.options.wysiwyg.odooEditor.automaticStepUnactive();
 
-                this.$el.find('.oe_snippet_thumbnail').addClass('o_we_already_dragging');
+                this.$el.find('.oe_snippet_thumbnail').addClass('o_we_ongoing_insertion');
                 this.options.wysiwyg.odooEditor.observerUnactive('dragAndDropCreateSnippet');
 
                 dropped = false;
@@ -3784,7 +3784,7 @@ class SnippetsMenu extends Component {
                                 this._disableUndroppableSnippets();
                                 this.options.wysiwyg.odooEditor.unbreakableStepUnactive();
                                 this.options.wysiwyg.odooEditor.historyStep();
-                                this.$el.find('.oe_snippet_thumbnail').removeClass('o_we_already_dragging');
+                                this.$el.find('.oe_snippet_thumbnail').removeClass('o_we_ongoing_insertion');
                             });
                         });
                     } else {
@@ -3796,7 +3796,7 @@ class SnippetsMenu extends Component {
                     if (dragAndDropResolve) {
                         dragAndDropResolve();
                     }
-                    this.$el.find('.oe_snippet_thumbnail').removeClass('o_we_already_dragging');
+                    this.$el.find('.oe_snippet_thumbnail').removeClass('o_we_ongoing_insertion');
                 }
                 this._onDropZoneStop();
             },
@@ -5001,6 +5001,8 @@ class SnippetsMenu extends Component {
 
             this.options.wysiwyg.odooEditor.historyPauseSteps();
             if (isSnippetGroupClicked) {
+                const thumbnailEl = initialSnippetEl.querySelector(".oe_snippet_thumbnail");
+                thumbnailEl.classList.add("o_we_ongoing_insertion");
                 // When the "snippet group block" is clicked, we add drop zones on
                 // the page where the snippet can be placed, then we detect
                 // the drop zone closest to the middle of the page.
@@ -5049,7 +5051,7 @@ class SnippetsMenu extends Component {
                 }
                 this.options.wysiwyg.odooEditor.historyUnpauseSteps();
                 for (const snippetThumbnail of snippetThumbnails) {
-                    snippetThumbnail.classList.remove('o_we_already_dragging');
+                    snippetThumbnail.classList.remove('o_we_ongoing_insertion');
                 }
                 return;
             }
@@ -5085,7 +5087,7 @@ class SnippetsMenu extends Component {
                                 this._disableUndroppableSnippets();
                                 this.options.wysiwyg.odooEditor.historyStep();
                                 for (const snippetThumbnail of snippetThumbnails) {
-                                    snippetThumbnail.classList.remove('o_we_already_dragging');
+                                    snippetThumbnail.classList.remove('o_we_ongoing_insertion');
                                 }
                             });
                         });
@@ -5110,7 +5112,7 @@ class SnippetsMenu extends Component {
                             this.options.wysiwyg.odooEditor.automaticStepSkipStack();
                             this.options.wysiwyg.odooEditor.historyUnpauseSteps();
                             for (const snippetThumbnail of snippetThumbnails) {
-                                snippetThumbnail.classList.remove('o_we_already_dragging');
+                                snippetThumbnail.classList.remove('o_we_ongoing_insertion');
                             }
                             resolve();
                         }

--- a/addons/web_editor/static/src/xml/snippets.xml
+++ b/addons/web_editor/static/src/xml/snippets.xml
@@ -183,7 +183,7 @@
                                     <t t-if="snippet.disabled">
                                         <img src="/web_editor/static/src/img/snippet_disabled.svg" class="o_snippet_undroppable"/>
                                     </t>
-                                    <div class="oe_snippet_thumbnail" t-att-class="{ 'o_we_already_dragging': snippet.renaming }" t-att-data-snippet="snippet.baseBody.dataset.snippet">
+                                    <div class="oe_snippet_thumbnail" t-att-class="{ 'o_we_ongoing_insertion': snippet.renaming }" t-att-data-snippet="snippet.baseBody.dataset.snippet">
                                         <div class="oe_snippet_thumbnail_img" t-attf-style="background-image: url({{snippet.thumbnailSrc}});"/>
                                         <t t-if="snippet.isCustom and snippet.renaming">
                                             <we-input class="o_we_user_value_widget w-100 mx-1">

--- a/addons/web_tour/static/src/tour_service/tour_utils.js
+++ b/addons/web_tour/static/src/tour_service/tour_utils.js
@@ -33,7 +33,16 @@ export function getScrollParent(element) {
     if (!element) {
         return null;
     }
-    if (element.scrollHeight > element.clientHeight) {
+    // We cannot only rely on the fact that the element’s scrollHeight is
+    // greater than its clientHeight. This might not be the case when a step
+    // starts, and the scrollbar could appear later. For example, when clicking
+    // on a "building block" in the "building block previews modal" during a
+    // tour (in website edit mode). When the modal opens, not all "building
+    // blocks" are loaded yet, and the scrollbar is not present initially.
+    const overflowY = window.getComputedStyle(element).overflowY;
+    const isScrollable = overflowY === "auto" || overflowY === "scroll" ||
+        (overflowY === "visible" && element === element.ownerDocument.scrollingElement);
+    if (isScrollable) {
         return element;
     } else {
         return getScrollParent(element.parentNode);

--- a/addons/website/static/src/js/tours/homepage.js
+++ b/addons/website/static/src/js/tours/homepage.js
@@ -4,7 +4,7 @@ import {
     changeBackgroundColor,
     clickOnSnippet,
     clickOnText,
-    dragNDrop,
+    insertSnippet,
     goBackToBlocks,
     registerThemeHomepageTour,
 } from "@website/js/tours/tour_utils";
@@ -53,17 +53,17 @@ const snippets = [
 ];
 
 registerThemeHomepageTour('homepage', () => [
-    ...dragNDrop(snippets[0], "top"),
+    ...insertSnippet(snippets[0], "top"),
     ...clickOnText(snippets[0], "h1"),
     goBackToBlocks(),
-    ...dragNDrop(snippets[1]),
-    ...dragNDrop(snippets[2]),
+    ...insertSnippet(snippets[1]),
+    ...insertSnippet(snippets[2]),
     ...clickOnSnippet(snippets[2], "top"),
     changeBackgroundColor(),
     goBackToBlocks(),
-    ...dragNDrop(snippets[3]),
-    ...dragNDrop(snippets[4], "top"),
-    ...dragNDrop(snippets[5]),
-    ...dragNDrop(snippets[6]),
-    ...dragNDrop(snippets[7]),
+    ...insertSnippet(snippets[3]),
+    ...insertSnippet(snippets[4], "top"),
+    ...insertSnippet(snippets[5]),
+    ...insertSnippet(snippets[6]),
+    ...insertSnippet(snippets[7]),
 ]);

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -310,7 +310,9 @@ export function insertSnippet(snippet, position = "bottom") {
         },
         {
             content: markup(_t("Click on the <b>%s</b> building block.", snippet.name)),
-            trigger: `:iframe .o_snippet_preview_wrap[data-snippet-id="${snippet.id}"]`,
+            // FIXME `:not(.d-none)` should obviously not be needed but it seems
+            // currently needed when using a tour in user/interactive mode.
+            trigger: `:iframe .o_snippet_preview_wrap[data-snippet-id="${snippet.id}"]:not(.d-none)`,
             noPrepend: true,
             tooltipPosition: "top",
             run: "click",

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -237,7 +237,7 @@ export function clickOnSnippet(snippet, position = "bottom") {
 export function clickOnSave(position = "bottom", timeout) {
     return [
         {
-            trigger: "#oe_snippets:not(:has(.o_we_already_dragging))",
+            trigger: "#oe_snippets:not(:has(.o_we_ongoing_insertion))",
         },
         {
             trigger: "body:not(:has(.o_dialog))",
@@ -288,39 +288,45 @@ export function clickOnText(snippet, element, position = "bottom") {
 }
 
 /**
- * Drag a snippet from the Blocks area and drop it in the Edit area
+ * Selects a category or an inner snippet from the snippets menu and insert it
+ * in the page.
  * @param {*} snippet contain the id and the name of the targeted snippet. If it
  * contains a group it means that the snippet is shown in the "add snippets"
  * dialog.
  * @param {*} position Where the purple arrow will show up
  */
-export function dragNDrop(snippet, position = "bottom") {
+export function insertSnippet(snippet, position = "bottom") {
     const blockEl = snippet.groupName || snippet.name;
-    let dragNDropSteps = [{
+    const insertSnippetSteps = [{
         trigger: ".o_website_preview.editor_enable.editor_has_snippets",
         noPrepend: true,
-    },
-    {
-        trigger: `#oe_snippets .oe_snippet[name="${blockEl}"].o_we_draggable .oe_snippet_thumbnail:not(.o_we_already_dragging)`,
-        content: markup(_t("Drag the <b>%s</b> block and drop it at the bottom of the page.", blockEl)),
-        tooltipPosition: position,
-        // Normally no main snippet can be dropped in the default footer but
-        // targeting it allows to force "dropping at the end of the page".
-        run: "drag_and_drop :iframe #wrapwrap > footer",
     }];
     if (snippet.groupName) {
-        dragNDropSteps.push({
-            content: markup(_t("Click on the <b>%s</b> building block.", snippet.name)),
-            trigger: `:iframe .o_snippet_preview_wrap[data-snippet-id="${snippet.id}"]`,
-            noPrepend: true,
+        insertSnippetSteps.push({
+            content: markup(_t("Click on the <b>%s</b> category.", blockEl)),
+            trigger: `#oe_snippets .oe_snippet[name="${blockEl}"].o_we_draggable .oe_snippet_thumbnail:not(.o_we_ongoing_insertion)`,
             tooltipPosition: position,
             run: "click",
         },
         {
-            trigger: `#oe_snippets .oe_snippet[name="${blockEl}"].o_we_draggable .oe_snippet_thumbnail:not(.o_we_already_dragging)`,
+            content: markup(_t("Click on the <b>%s</b> building block.", snippet.name)),
+            trigger: `:iframe .o_snippet_preview_wrap[data-snippet-id="${snippet.id}"]`,
+            noPrepend: true,
+            tooltipPosition: "top",
+            run: "click",
+        },
+        {
+            trigger: `#oe_snippets .oe_snippet[name="${blockEl}"].o_we_draggable .oe_snippet_thumbnail:not(.o_we_ongoing_insertion)`,
+        });
+    } else {
+        insertSnippetSteps.push({
+            content: markup(_t("Drag the <b>%s</b> block and drop it at the bottom of the page.", blockEl)),
+            trigger: `#oe_snippets .oe_snippet[name="${blockEl}"].o_we_draggable .oe_snippet_thumbnail:not(.o_we_ongoing_insertion)`,
+            tooltipPosition: position,
+            run: "drag_and_drop :iframe #wrapwrap > footer",
         });
     }
-    return dragNDropSteps;
+    return insertSnippetSteps;
 }
 
 export function goBackToBlocks(position = "bottom") {

--- a/addons/website/static/tests/tours/carousel_content_removal.js
+++ b/addons/website/static/tests/tours/carousel_content_removal.js
@@ -1,13 +1,13 @@
 /** @odoo-module */
 
-import { dragNDrop, registerWebsitePreviewTour } from '@website/js/tours/tour_utils';
+import { insertSnippet, registerWebsitePreviewTour } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour("carousel_content_removal", {
     test: true,
     url: '/',
     edition: true,
 }, () => [
-    ...dragNDrop({
+    ...insertSnippet({
         id: 's_carousel',
         name: 'Carousel',
         groupName: "Intro",

--- a/addons/website/static/tests/tours/conditional_visibility.js
+++ b/addons/website/static/tests/tours/conditional_visibility.js
@@ -5,7 +5,7 @@ import {
     clickOnEditAndWaitEditMode,
     clickOnSave,
     clickOnSnippet,
-    dragNDrop,
+    insertSnippet,
     goBackToBlocks,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
@@ -55,7 +55,7 @@ registerWebsitePreviewTour('conditional_visibility_1', {
     url: '/',
     test: true,
 }, () => [
-...dragNDrop(snippets[0]),
+...insertSnippet(snippets[0]),
 ...clickOnSnippet(snippets[0]),
 changeOption('ConditionalVisibility', 'we-toggler'),
 {
@@ -113,7 +113,7 @@ registerWebsitePreviewTour("conditional_visibility_3", {
 () => [
 checkEyeIcon("Text - Image", true),
 // Drag a "Banner" snippet on the website.
-...dragNDrop(snippets[1]),
+...insertSnippet(snippets[1]),
 // Click on the "Banner" snippet.
 ...clickOnSnippet(snippets[1]),
 changeOption("ConditionalVisibility", "we-toggler"),
@@ -121,7 +121,7 @@ changeOption("ConditionalVisibility", '[data-name="visibility_conditional"]'),
 checkEyeIcon("Banner", true),
 goBackToBlocks(),
 // Drag a "Popup" snippet on the website.
-...dragNDrop(snippets[2]),
+...insertSnippet(snippets[2]),
 {
     content: "Toggle the visibility of the popup",
     trigger: ".o_we_invisible_el_panel .o_we_invisible_entry:contains('Popup')",
@@ -209,7 +209,7 @@ registerWebsitePreviewTour("conditional_visibility_5", {
         content: "Check that the footer is visible",
         trigger: ":iframe #wrapwrap footer",
     },
-    ...dragNDrop(snippets[0]),
+    ...insertSnippet(snippets[0]),
     {
         content: "Click on the image of the dragged snippet",
         trigger: ":iframe .s_text_image img",

--- a/addons/website/static/tests/tours/default_shape_gets_palette_colors.js
+++ b/addons/website/static/tests/tours/default_shape_gets_palette_colors.js
@@ -4,7 +4,7 @@ import { queryFirst } from "@odoo/hoot-dom";
 import {
     changeOption,
     clickOnSnippet,
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
 } from "@website/js/tours/tour_utils";
 
@@ -13,7 +13,7 @@ registerWebsitePreviewTour("default_shape_gets_palette_colors", {
     url: '/',
     edition: true,
 }, () => [
-    ...dragNDrop({
+    ...insertSnippet({
         id: 's_text_image',
         name: 'Text - Image',
         groupName: "Content",

--- a/addons/website/static/tests/tours/drag_and_drop_on_non_editable.js
+++ b/addons/website/static/tests/tours/drag_and_drop_on_non_editable.js
@@ -1,13 +1,13 @@
 /** @odoo-module **/
 
-import { dragNDrop, goBackToBlocks, registerWebsitePreviewTour } from '@website/js/tours/tour_utils';
+import { insertSnippet, goBackToBlocks, registerWebsitePreviewTour } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour("test_drag_and_drop_on_non_editable", {
     test: true,
     url: "/",
     edition: true,
 }, () => [
-    ...dragNDrop({
+    ...insertSnippet({
         id: "s_company_team",
         name: "Team",
         groupName: "People",
@@ -27,7 +27,7 @@ registerWebsitePreviewTour("test_drag_and_drop_on_non_editable", {
     },
     {
         content: "Drag and drop the Text Highlight building block next to the Team block media.",
-        trigger: `#oe_snippets .oe_snippet[name="Text Highlight"].o_we_draggable .oe_snippet_thumbnail:not(.o_we_already_dragging)`,
+        trigger: `#oe_snippets .oe_snippet[name="Text Highlight"].o_we_draggable .oe_snippet_thumbnail:not(.o_we_ongoing_insertion)`,
         run: "drag_and_drop :iframe .s_company_team .o_not_editable > .o_editable_media",
     },
     {

--- a/addons/website/static/tests/tours/drop_404_ir_attachment_url.js
+++ b/addons/website/static/tests/tours/drop_404_ir_attachment_url.js
@@ -2,7 +2,7 @@
 
 import {
     changeOption,
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
 
@@ -11,7 +11,7 @@ registerWebsitePreviewTour('drop_404_ir_attachment_url', {
     url: '/',
     edition: true,
 }, () => [
-    ...dragNDrop({
+    ...insertSnippet({
         id: 's_404_snippet',
         name: '404 Snippet',
         groupName: "Images",

--- a/addons/website/static/tests/tours/dropdowns_and_header_hide_on_scroll.js
+++ b/addons/website/static/tests/tours/dropdowns_and_header_hide_on_scroll.js
@@ -4,7 +4,7 @@ import {
     clickOnSave,
     changeOption,
     checkIfVisibleOnScreen,
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
     selectHeader,
 } from "@website/js/tours/tour_utils";
@@ -36,7 +36,7 @@ registerWebsitePreviewTour("dropdowns_and_header_hide_on_scroll", {
     url: "/",
     edition: true,
 }, () => [
-    ...dragNDrop({id: "s_media_list", name: "Media List", groupName: "Content"}),
+    ...insertSnippet({id: "s_media_list", name: "Media List", groupName: "Content"}),
     selectHeader(),
     changeOption("undefined", 'we-select[data-variable="header-scroll-effect"]'),
     changeOption("undefined", 'we-button[data-name="header_effect_fixed_opt"]'),

--- a/addons/website/static/tests/tours/edit_link_popover.js
+++ b/addons/website/static/tests/tours/edit_link_popover.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import {
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
 } from "@website/js/tours/tour_utils";
 import { browser } from "@web/core/browser/browser";
@@ -34,7 +34,7 @@ registerWebsitePreviewTour('edit_link_popover_1', {
     edition: true,
 }, () => [
     // 1. Test links in page content (web_editor)
-    ...dragNDrop({
+    ...insertSnippet({
         id: 's_text_image',
         name: 'Text - Image',
         groupName: "Content",
@@ -152,7 +152,7 @@ registerWebsitePreviewTour('edit_link_popover_2', {
     edition: true,
 }, () => [
     // 1. Test links in page content (web_editor)
-    ...dragNDrop({
+    ...insertSnippet({
         id: 's_text_image',
         name: 'Text - Image',
         groupName: "Content",

--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -4,7 +4,7 @@ import {
     clickOnEditAndWaitEditMode,
     clickOnExtraMenuItem,
     clickOnSave,
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
 
@@ -201,7 +201,7 @@ registerWebsitePreviewTour('edit_menus', {
         run: "click",
     },
     // Drag a block to be able to scroll later.
-    ...dragNDrop({id: "s_media_list", name: "Media List", groupName: "Content"}),
+    ...insertSnippet({id: "s_media_list", name: "Media List", groupName: "Content"}),
     ...clickOnSave(),
     clickOnExtraMenuItem({}, true),
     {

--- a/addons/website/static/tests/tours/editable_root_as_custom_snippet.js
+++ b/addons/website/static/tests/tours/editable_root_as_custom_snippet.js
@@ -5,7 +5,7 @@ import {
     clickOnEditAndWaitEditMode,
     clickOnSave,
     clickOnSnippet,
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
 
@@ -36,7 +36,7 @@ registerWebsitePreviewTour("editable_root_as_custom_snippet", {
         trigger: ':iframe a[href="/"].nav-link.active',
     },
     ...clickOnEditAndWaitEditMode(),
-    ...dragNDrop({id: "s_title", name: "Custom Title", groupName: "Custom"}),
+    ...insertSnippet({id: "s_title", name: "Custom Title", groupName: "Custom"}),
     {
         content: "Check that the custom snippet does not have branding",
         trigger: ':iframe #wrap .s_title.custom:not([data-oe-model]):not([data-oe-id]):not([data-oe-field]):not([data-oe-xpath])',

--- a/addons/website/static/tests/tours/focus_blur_snippets.js
+++ b/addons/website/static/tests/tours/focus_blur_snippets.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { dragNDrop, registerWebsitePreviewTour } from '@website/js/tours/tour_utils';
+import { insertSnippet, registerWebsitePreviewTour } from '@website/js/tours/tour_utils';
 
 const blockIDToData = {
     parent: {
@@ -54,7 +54,7 @@ registerWebsitePreviewTour("focus_blur_snippets", {
     url: "/",
     edition: true,
 }, () => [
-    ...dragNDrop({
+    ...insertSnippet({
         id: "s_focusblur",
         name: "s_focusblur",
         groupName: "Content",

--- a/addons/website/static/tests/tours/grid_layout.js
+++ b/addons/website/static/tests/tours/grid_layout.js
@@ -4,7 +4,7 @@ import {
     changeOption,
     clickOnSave,
     clickOnSnippet,
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
 
@@ -19,7 +19,7 @@ registerWebsitePreviewTour('website_replace_grid_image', {
     url: '/',
     edition: true,
 }, () => [
-    ...dragNDrop(snippet),
+    ...insertSnippet(snippet),
     ...clickOnSnippet(snippet),
     {
         content: "Toggle to grid mode",
@@ -65,9 +65,9 @@ registerWebsitePreviewTour("scroll_to_new_grid_item", {
     edition: true,
 }, () => [
     // Drop enough snippets to scroll.
-    ...dragNDrop({id: "s_text_image", name: "Text - Image", groupName: "Content"}),
-    ...dragNDrop({id: "s_image_text", name: "Image - Text", groupName: "Content"}),
-    ...dragNDrop({id: "s_image_text", name: "Image - Text", groupName: "Content"}),
+    ...insertSnippet({id: "s_text_image", name: "Text - Image", groupName: "Content"}),
+    ...insertSnippet({id: "s_image_text", name: "Image - Text", groupName: "Content"}),
+    ...insertSnippet({id: "s_image_text", name: "Image - Text", groupName: "Content"}),
     // Toggle the first snippet to grid mode.
     ...clickOnSnippet({id: "s_text_image", name: "Text - Image"}),
     changeOption("layout_column", 'we-button[data-name="grid_mode"]'),

--- a/addons/website/static/tests/tours/link_to_document.js
+++ b/addons/website/static/tests/tours/link_to_document.js
@@ -1,4 +1,4 @@
-import { dragNDrop, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
+import { insertSnippet, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
 /**
  * The purpose of this tour is to check the Linktools to create a link to an
  * uploaded document.
@@ -11,7 +11,7 @@ registerWebsitePreviewTour(
         edition: true,
     },
     () => [
-        ...dragNDrop({
+        ...insertSnippet({
             name: "Banner",
             id: "s_banner",
             groupName: "Intro",

--- a/addons/website/static/tests/tours/link_tools.js
+++ b/addons/website/static/tests/tours/link_tools.js
@@ -5,7 +5,7 @@ import {
     clickOnEditAndWaitEditMode,
     clickOnElement,
     clickOnSave,
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
 import { boundariesIn, setSelection } from '@web_editor/js/editor/odoo-editor/src/utils/utils';
@@ -22,7 +22,7 @@ registerWebsitePreviewTour('link_tools', {
     edition: true,
 }, () => [
     // 1. Create a new link from scratch.
-    ...dragNDrop({
+    ...insertSnippet({
         id: 's_text_image',
         name: 'Text - Image',
         groupName: "Content",
@@ -137,7 +137,7 @@ registerWebsitePreviewTour('link_tools', {
     },
     // 4. Add link on image.
     ...clickOnEditAndWaitEditMode(),
-    ...dragNDrop({
+    ...insertSnippet({
         id: 's_three_columns',
         name: 'Columns',
         groupName: "Columns",

--- a/addons/website/static/tests/tours/media_dialog.js
+++ b/addons/website/static/tests/tours/media_dialog.js
@@ -3,7 +3,7 @@
 import {
     changeOption,
     clickOnSave,
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
 
@@ -12,7 +12,7 @@ registerWebsitePreviewTour("website_media_dialog_undraw", {
     url: '/',
     edition: true,
 }, () => [
-...dragNDrop({
+...insertSnippet({
     id: 's_text_image',
     name: 'Text - Image',
     groupName: "Content",
@@ -36,7 +36,7 @@ registerWebsitePreviewTour("website_media_dialog_external_library", {
     url: "/",
     edition: true,
 }, () => [
-    ...dragNDrop({
+    ...insertSnippet({
         id: "s_text_image",
         name: "Text - Image",
         groupName: "Content",
@@ -86,7 +86,7 @@ registerWebsitePreviewTour('website_media_dialog_icons', {
     url: '/',
     edition: true,
 }, () => [
-    ...dragNDrop({
+    ...insertSnippet({
         id: 's_social_media',
         name: 'Social Media',
     }),
@@ -126,7 +126,7 @@ registerWebsitePreviewTour("website_media_dialog_image_shape", {
     url: "/",
     edition: true,
 }, () => [
-    ...dragNDrop({
+    ...insertSnippet({
         id: "s_text_image",
         name: "Text - Image",
         groupName: "Content",

--- a/addons/website/static/tests/tours/multi_edition.js
+++ b/addons/website/static/tests/tours/multi_edition.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { clickOnSave, dragNDrop, registerWebsitePreviewTour } from '@website/js/tours/tour_utils';
+import { clickOnSave, insertSnippet, registerWebsitePreviewTour } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour('website_multi_edition', {
     test: true,
@@ -12,7 +12,7 @@ registerWebsitePreviewTour('website_multi_edition', {
         trigger: ':iframe body:not(:has(.s_text_image)):not(:has(.s_hr))',
     },
     // Edit the main element of the page
-    ...dragNDrop({
+    ...insertSnippet({
         id: 's_text_image',
         name: 'Text - Image',
         groupName: "Content",
@@ -22,7 +22,7 @@ registerWebsitePreviewTour('website_multi_edition', {
         trigger: ".o_website_preview.editor_enable.editor_has_snippets",
     },
     {
-        trigger: `#oe_snippets .oe_snippet[name="Separator"].o_we_draggable .oe_snippet_thumbnail:not(.o_we_already_dragging)`,
+        trigger: `#oe_snippets .oe_snippet[name="Separator"].o_we_draggable .oe_snippet_thumbnail:not(.o_we_ongoing_insertion)`,
         content: "Drag the Separator building block and drop it at the bottom of the page.",
         run: "drag_and_drop :iframe .oe_drop_zone:last",
     },

--- a/addons/website/static/tests/tours/parallax.js
+++ b/addons/website/static/tests/tours/parallax.js
@@ -5,7 +5,7 @@ import {
     clickOnEditAndWaitEditMode,
     clickOnSave,
     clickOnSnippet,
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
 } from "@website/js/tours/tour_utils";
 
@@ -16,7 +16,7 @@ registerWebsitePreviewTour("test_parallax", {
     url: "/",
     edition: true,
 }, () => [
-    ...dragNDrop(coverSnippet),
+    ...insertSnippet(coverSnippet),
     ...clickOnSnippet(coverSnippet),
     changeOption("BackgroundOptimize", "we-toggler"),
     changeOption("BackgroundOptimize", 'we-button[data-gl-filter="blur"]'),

--- a/addons/website/static/tests/tours/powerbox_snippet.js
+++ b/addons/website/static/tests/tours/powerbox_snippet.js
@@ -1,11 +1,11 @@
-import {clickOnSnippet, dragNDrop, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
+import {clickOnSnippet, insertSnippet, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
 
 registerWebsitePreviewTour("website_powerbox_snippet",{
     edition: true,
     test: true,
 },
 () => [
-...dragNDrop({
+...insertSnippet({
     id: "s_text_block",
     name: "Text",
     groupName: "Text",

--- a/addons/website/static/tests/tours/rte.js
+++ b/addons/website/static/tests/tours/rte.js
@@ -3,7 +3,7 @@
 import {
     clickOnEditAndWaitEditMode,
     clickOnSave,
-    dragNDrop,
+    insertSnippet,
     goToTheme,
     registerWebsitePreviewTour,
 } from "@website/js/tours/tour_utils";
@@ -117,7 +117,7 @@ registerWebsitePreviewTour('rte_translator', {
 {
     trigger: "body:not(:has(.modal))",
 },
-...dragNDrop({
+...insertSnippet({
     id: "s_cover",
     name: "Cover",
     groupName: "Intro",

--- a/addons/website/static/tests/tours/snippet_background_edition.js
+++ b/addons/website/static/tests/tours/snippet_background_edition.js
@@ -7,7 +7,7 @@ import {
     clickOnEditAndWaitEditMode,
     clickOnSave,
     clickOnSnippet,
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
 
@@ -106,7 +106,7 @@ registerWebsitePreviewTour('snippet_background_edition', {
     test: true,
 },
 () => [
-...dragNDrop(snippets[0]),
+...insertSnippet(snippets[0]),
 ...clickOnSnippet(snippets[0]),
 
 // Set background image and save.

--- a/addons/website/static/tests/tours/snippet_countdown.js
+++ b/addons/website/static/tests/tours/snippet_countdown.js
@@ -3,7 +3,7 @@
 import {
     changeOption,
     clickOnSnippet,
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
 
@@ -12,7 +12,7 @@ registerWebsitePreviewTour('snippet_countdown', {
     url: '/',
     edition: true,
 }, () => [
-    ...dragNDrop({id: "s_countdown", name: "Countdown", groupName: "Content"}),
+    ...insertSnippet({id: "s_countdown", name: "Countdown", groupName: "Content"}),
     ...clickOnSnippet({id: 's_countdown', name: 'Countdown'}),
     changeOption('countdown', 'we-select:has([data-end-action]) we-toggler', 'end action'),
     changeOption('countdown', 'we-button[data-end-action="message"]', 'end action'),

--- a/addons/website/static/tests/tours/snippet_editor_panel_options.js
+++ b/addons/website/static/tests/tours/snippet_editor_panel_options.js
@@ -3,7 +3,7 @@
 import {
     changeOption,
     clickOnSave,
-    dragNDrop,
+    insertSnippet,
     goBackToBlocks,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
@@ -14,7 +14,7 @@ registerWebsitePreviewTour('snippet_editor_panel_options', {
     url: '/',
     edition: true,
 }, () => [
-...dragNDrop({
+...insertSnippet({
     id: 's_text_image',
     name: 'Text - Image',
     groupName: "Content",
@@ -86,7 +86,7 @@ registerWebsitePreviewTour('snippet_editor_panel_options', {
 },
 // Test keeping the text selection when adding columns to a snippet with none.
 goBackToBlocks(),
-...dragNDrop({
+...insertSnippet({
     id: 's_text_block',
     name: 'Text',
     groupName: "Text",

--- a/addons/website/static/tests/tours/snippet_empty_parent_autoremove.js
+++ b/addons/website/static/tests/tours/snippet_empty_parent_autoremove.js
@@ -3,7 +3,7 @@
 import {
     changeOption,
     clickOnSnippet,
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
 } from "@website/js/tours/tour_utils";
 
@@ -21,7 +21,7 @@ registerWebsitePreviewTour('snippet_empty_parent_autoremove', {
     edition: true,
 }, () => [
     // Base case: remove both columns from text - image
-    ...dragNDrop({
+    ...insertSnippet({
         id: 's_text_image',
         name: 'Text - Image',
         groupName: "Content",
@@ -44,7 +44,7 @@ registerWebsitePreviewTour('snippet_empty_parent_autoremove', {
     },
 
     // Cover: test that parallax, bg-filter and shape are not treated as content
-    ...dragNDrop({
+    ...insertSnippet({
         id: 's_cover',
         name: 'Cover',
         groupName: "Intro",

--- a/addons/website/static/tests/tours/snippet_image.js
+++ b/addons/website/static/tests/tours/snippet_image.js
@@ -1,13 +1,13 @@
 /** @odoo-module **/
 
-import {dragNDrop, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
+import {insertSnippet, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
 
 registerWebsitePreviewTour("snippet_image", {
     test: true,
     url: "/",
     edition: true,
 }, () => [
-    ...dragNDrop({id: "s_image", name: "Image"}),
+    ...insertSnippet({id: "s_image", name: "Image"}),
 {
     content: "Verify if the media dialog opens",
     trigger: ".o_select_media_dialog",
@@ -21,7 +21,7 @@ registerWebsitePreviewTour("snippet_image", {
     content: "Verify if the image placeholder has been removed",
     trigger: ":iframe footer:not(:has(.s_image > svg))",
 },
-    ...dragNDrop({id: "s_image", name: "Image"}),
+    ...insertSnippet({id: "s_image", name: "Image"}),
 {
     content: "Verify that the image placeholder is within the page",
     trigger: ":iframe footer .s_image > svg",

--- a/addons/website/static/tests/tours/snippet_image_gallery.js
+++ b/addons/website/static/tests/tours/snippet_image_gallery.js
@@ -5,7 +5,7 @@ import {
     changeOption,
     clickOnSave,
     clickOnSnippet,
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
 
@@ -14,7 +14,7 @@ registerWebsitePreviewTour('snippet_image_gallery', {
     url: '/',
     edition: true,
 }, () => [
-    ...dragNDrop({id: 's_images_wall', name: 'Images Wall', groupName: "Images"}),
+    ...insertSnippet({id: 's_images_wall', name: 'Images Wall', groupName: "Images"}),
     ...clickOnSave(),
     {
         content: 'Click on an image of the Image Wall',
@@ -32,7 +32,7 @@ registerWebsitePreviewTour("snippet_image_gallery_remove", {
     url: "/",
     edition: true,
 }, () => [
-    ...dragNDrop({
+    ...insertSnippet({
         id: "s_image_gallery",
         name: "Image Gallery",
         groupName: "Images",
@@ -79,7 +79,7 @@ registerWebsitePreviewTour("snippet_image_gallery_reorder", {
     url: "/",
     edition: true,
 }, () => [
-    ...dragNDrop({
+    ...insertSnippet({
         id: "s_image_gallery",
         name: "Image Gallery",
         groupName: "Images",
@@ -136,7 +136,7 @@ registerWebsitePreviewTour("snippet_image_gallery_thumbnail_update", {
     url: "/",
     edition: true,
 }, () => [
-    ...dragNDrop({
+    ...insertSnippet({
         id: "s_image_gallery",
         name: "Image Gallery",
         groupName: "Images",

--- a/addons/website/static/tests/tours/snippet_image_quality.js
+++ b/addons/website/static/tests/tours/snippet_image_quality.js
@@ -1,13 +1,13 @@
 /** @odoo-module */
 
-import { dragNDrop, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
+import { insertSnippet, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
 
 registerWebsitePreviewTour('website_image_quality', {
     test: true,
     url: '/',
     edition: true,
 }, () => [
-    ...dragNDrop({
+    ...insertSnippet({
         id: 's_text_image',
         name: 'Text - Image',
         groupName: "Content",

--- a/addons/website/static/tests/tours/snippet_images_wall.js
+++ b/addons/website/static/tests/tours/snippet_images_wall.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import {clickOnSnippet, dragNDrop, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
+import {clickOnSnippet, insertSnippet, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
 
 const wallRaceConditionClass = "image_wall_race_condition";
 const preventRaceConditionSteps = [{
@@ -54,7 +54,7 @@ registerWebsitePreviewTour("snippet_images_wall", {
     url: "/",
     edition: true,
 }, () => [
-    ...dragNDrop({
+    ...insertSnippet({
         id: "s_images_wall",
         name: "Images Wall",
         groupName: "Images",

--- a/addons/website/static/tests/tours/snippet_popup_add_remove.js
+++ b/addons/website/static/tests/tours/snippet_popup_add_remove.js
@@ -1,7 +1,7 @@
 /** @odoo-module */
 
 import {
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
 
@@ -10,7 +10,7 @@ registerWebsitePreviewTour('snippet_popup_add_remove', {
     url: '/',
     edition: true,
 }, () => [
-    ...dragNDrop({
+    ...insertSnippet({
         name: "Popup",
         id: "s_popup",
         groupName: "Content",
@@ -30,7 +30,7 @@ registerWebsitePreviewTour('snippet_popup_add_remove', {
     trigger: ':iframe #wrap.o_editable:not(:has([data-snippet="s_popup"]))',
 },
 // Test that undoing dropping the snippet removes the invisible elements panel.
-...dragNDrop({
+...insertSnippet({
     name: "Popup",
     id: "s_popup",
     groupName: "Content",

--- a/addons/website/static/tests/tours/snippet_popup_and_animations.js
+++ b/addons/website/static/tests/tours/snippet_popup_and_animations.js
@@ -5,7 +5,7 @@ import {
     clickOnEditAndWaitEditMode,
     clickOnElement,
     clickOnSave,
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
 } from "@website/js/tours/tour_utils";
 
@@ -41,9 +41,9 @@ registerWebsitePreviewTour("snippet_popup_and_animations", {
     url: "/",
     edition: true,
 }, () => [
-    ...dragNDrop(snippets[1]), // Media List
-    ...dragNDrop(snippets[1]), // Media List
-    ...dragNDrop(snippets[2]), // Columns
+    ...insertSnippet(snippets[1]), // Media List
+    ...insertSnippet(snippets[1]), // Media List
+    ...insertSnippet(snippets[2]), // Columns
     clickOnElement("3rd columns", ":iframe .s_three_columns .row > :last-child"),
     ...setOnScrollAnim(),
     {
@@ -94,14 +94,14 @@ registerWebsitePreviewTour("snippet_popup_and_animations", {
         trigger: ".o_we_invisible_el_panel .o_we_invisible_entry",
         run: "click",
     },
-    ...dragNDrop(snippets[0]), // Popup
-    ...dragNDrop(snippets[1]), // Media List
+    ...insertSnippet(snippets[0]), // Popup
+    ...insertSnippet(snippets[1]), // Media List
     {
         trigger: ".o_website_preview.editor_enable.editor_has_snippets",
     },
     {
         content: "Drag the Columns snippet group and drop it at the bottom of the popup.",
-        trigger: '#oe_snippets .oe_snippet[name="Columns"] .oe_snippet_thumbnail:not(.o_we_already_dragging)',
+        trigger: '#oe_snippets .oe_snippet[name="Columns"] .oe_snippet_thumbnail:not(.o_we_ongoing_insertion)',
         run: "drag_and_drop :iframe #wrap .s_popup .modal-content.oe_structure .oe_drop_zone:last",
     },
     {

--- a/addons/website/static/tests/tours/snippet_popup_and_scrollbar.js
+++ b/addons/website/static/tests/tours/snippet_popup_and_scrollbar.js
@@ -2,7 +2,7 @@
 
 import {
     changeOption,
-    dragNDrop,
+    insertSnippet,
     goBackToBlocks,
     registerWebsitePreviewTour,
 } from "@website/js/tours/tour_utils";
@@ -44,8 +44,8 @@ registerWebsitePreviewTour("snippet_popup_and_scrollbar", {
     url: "/",
     edition: true,
 }, () => [
-    ...dragNDrop(snippets[1]), // Media List
-    ...dragNDrop(snippets[0]), // Popup
+    ...insertSnippet(snippets[1]), // Media List
+    ...insertSnippet(snippets[0]), // Popup
     checkScrollbar(false),
     {
         content: 'Click on the s_popup snippet',
@@ -57,7 +57,7 @@ registerWebsitePreviewTour("snippet_popup_and_scrollbar", {
     goBackToBlocks(),
     {
         content: "Drag the Content snippet group and drop it at the bottom of the popup.",
-        trigger: '#oe_snippets .oe_snippet[name="Content"] .oe_snippet_thumbnail:not(.o_we_already_dragging)',
+        trigger: '#oe_snippets .oe_snippet[name="Content"] .oe_snippet_thumbnail:not(.o_we_ongoing_insertion)',
         run: "drag_and_drop :iframe #wrap .s_popup .oe_drop_zone:last",
     },
     {
@@ -106,7 +106,7 @@ registerWebsitePreviewTour("snippet_popup_and_scrollbar", {
     goBackToBlocks(),
     {
         content: "Drag the Content snippet group and drop it at the bottom of the popup.",
-        trigger: '#oe_snippets .oe_snippet[name="Content"] .oe_snippet_thumbnail:not(.o_we_already_dragging)',
+        trigger: '#oe_snippets .oe_snippet[name="Content"] .oe_snippet_thumbnail:not(.o_we_ongoing_insertion)',
         run: "drag_and_drop :iframe #wrap .s_popup .oe_drop_zone:last",
     },
     {
@@ -135,7 +135,7 @@ registerWebsitePreviewTour("snippet_popup_and_scrollbar", {
     goBackToBlocks(),
     {
         content: "Drag the Content snippet group and drop it in the Cookies Bar.",
-        trigger: '#oe_snippets .oe_snippet[name="Content"] .oe_snippet_thumbnail:not(.o_we_already_dragging)',
+        trigger: '#oe_snippets .oe_snippet[name="Content"] .oe_snippet_thumbnail:not(.o_we_ongoing_insertion)',
         run: "drag_and_drop :iframe #website_cookies_bar .modal-content.oe_structure",
     },
     {

--- a/addons/website/static/tests/tours/snippet_popup_display_on_click.js
+++ b/addons/website/static/tests/tours/snippet_popup_display_on_click.js
@@ -5,7 +5,7 @@ import {
     clickOnElement,
     clickOnSave,
     changeOption,
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
 import { browser } from "@web/core/browser/browser";
@@ -15,8 +15,8 @@ registerWebsitePreviewTour("snippet_popup_display_on_click", {
     url: "/",
     edition: true,
 }, () => [
-    ...dragNDrop({id: "s_text_image", name: "Image - Text", groupName: "Content"}),
-    ...dragNDrop({id: "s_popup", name: "Popup", groupName: "Content"}),
+    ...insertSnippet({id: "s_text_image", name: "Image - Text", groupName: "Content"}),
+    ...insertSnippet({id: "s_popup", name: "Popup", groupName: "Content"}),
     {
         content: "Click inside the popup to access its options menu.",
         trigger: ":iframe .s_popup .s_banner",
@@ -71,7 +71,7 @@ registerWebsitePreviewTour("snippet_popup_display_on_click", {
         trigger: ".o_website_preview[data-view-xmlid='website.contactus']",
     },
     ...clickOnEditAndWaitEditMode(),
-    ...dragNDrop({id: "s_text_image", name: "Image - Text", groupName: "Content"}),
+    ...insertSnippet({id: "s_text_image", name: "Image - Text", groupName: "Content"}),
     clickOnElement("text image snippet button", ":iframe .s_text_image .btn-secondary"),
     {
         content: "Add a link to the homepage in the URL input",

--- a/addons/website/static/tests/tours/snippet_rating.js
+++ b/addons/website/static/tests/tours/snippet_rating.js
@@ -2,7 +2,7 @@
 import {
     changeOption,
     clickOnSnippet,
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
 
@@ -11,7 +11,7 @@ registerWebsitePreviewTour("snippet_rating", {
     url: "/",
     edition: true,
 }, () => [
-    ...dragNDrop({ id: "s_rating", name: "Rating" }),
+    ...insertSnippet({ id: "s_rating", name: "Rating" }),
     ...clickOnSnippet({ id: "s_rating", name: "Rating" }),
     changeOption("Rating", "we-select:has([data-select-class]) we-toggler"),
     changeOption("Rating", 'we-button[data-select-class="s_rating_inline"]'),

--- a/addons/website/static/tests/tours/snippet_social_media.js
+++ b/addons/website/static/tests/tours/snippet_social_media.js
@@ -4,7 +4,7 @@ import {
     clickOnEditAndWaitEditMode,
     clickOnSave,
     clickOnSnippet,
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
 
@@ -89,7 +89,7 @@ registerWebsitePreviewTour('snippet_social_media', {
     url: '/',
     edition: true,
 }, () => [
-    ...dragNDrop({id: 's_social_media', name: 'Social Media'}),
+    ...insertSnippet({id: 's_social_media', name: 'Social Media'}),
     ...clickOnSnippet({id: 's_social_media', name: 'Social Media'}),
     ...addNewSocialNetwork(7, 7, 'https://www.youtu.be/y7TlnAv6cto'),
     {

--- a/addons/website/static/tests/tours/snippet_table_of_content.js
+++ b/addons/website/static/tests/tours/snippet_table_of_content.js
@@ -4,7 +4,7 @@ import { isVisible } from '@odoo/hoot-dom';
 import {
     clickOnEditAndWaitEditMode,
     clickOnSave,
-    dragNDrop,
+    insertSnippet,
     goBackToBlocks,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
@@ -30,11 +30,10 @@ registerWebsitePreviewTour('snippet_table_of_content', {
     url: '/',
     edition: true,
 }, () => [
-    ...dragNDrop({id: "s_table_of_content", name: "Table of Content", groupName: "Text"}),
-    // We don't use the dragNDrop function here to avoid snippets being dropped inside the toc's.
+    ...insertSnippet({id: "s_table_of_content", name: "Table of Content", groupName: "Text"}),
     {
         content: "Drag the Text snippet group and drop it.",
-        trigger: '#oe_snippets .oe_snippet[name="Text"] .oe_snippet_thumbnail:not(.o_we_already_dragging)',
+        trigger: '#oe_snippets .oe_snippet[name="Text"] .oe_snippet_thumbnail:not(.o_we_ongoing_insertion)',
         run: "drag_and_drop :iframe #wrap",
     },
     {
@@ -43,10 +42,10 @@ registerWebsitePreviewTour('snippet_table_of_content', {
         run: "click",
     },
     // To make sure that the public widgets of the two previous ones started.
-    ...dragNDrop({id: "s_banner", name: "Banner", groupName: "Intro"}),
+    ...insertSnippet({id: "s_banner", name: "Banner", groupName: "Intro"}),
     {
         content: "Drag the Intro snippet group and drop it.",
-        trigger: '#oe_snippets .oe_snippet[name="Intro"] .oe_snippet_thumbnail:not(.o_we_already_dragging)',
+        trigger: '#oe_snippets .oe_snippet[name="Intro"] .oe_snippet_thumbnail:not(.o_we_ongoing_insertion)',
         run: "drag_and_drop :iframe #wrap",
     },
     {

--- a/addons/website/static/tests/tours/snippet_translation.js
+++ b/addons/website/static/tests/tours/snippet_translation.js
@@ -6,7 +6,7 @@ import {
     clickOnEditAndWaitEditMode,
     clickOnEditAndWaitEditModeInTranslatedPage,
     clickOnSave,
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
 
@@ -26,7 +26,7 @@ registerWebsitePreviewTour('snippet_translation', {
         }
     },
     ...clickOnEditAndWaitEditMode(),
-    ...dragNDrop({id: "s_cover", name: "Cover", groupName: "Intro"}),
+    ...insertSnippet({id: "s_cover", name: "Cover", groupName: "Intro"}),
     {
         content: "Check that contact us contain Parseltongue",
         trigger: ':iframe .s_cover .btn-outline-secondary:contains("Contact us in Parseltongue")',
@@ -67,7 +67,7 @@ registerWebsitePreviewTour('snippet_translation_changing_lang', {
     },
     ...clickOnSave(),
     ...clickOnEditAndWaitEditModeInTranslatedPage(),
-    ...dragNDrop({name: "Cover", id: "s_cover", groupName: "Intro"}),
+    ...insertSnippet({name: "Cover", id: "s_cover", groupName: "Intro"}),
     {
         content: "Check that contact us contain Parseltongue",
         trigger: ':iframe .s_cover .btn-outline-secondary:contains("Contact us in Parseltongue")',

--- a/addons/website/static/tests/tours/snippet_version.js
+++ b/addons/website/static/tests/tours/snippet_version.js
@@ -2,7 +2,7 @@
 
 import {
     clickOnSave,
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour
 } from '@website/js/tours/tour_utils';
 
@@ -11,12 +11,12 @@ registerWebsitePreviewTour("snippet_version_1", {
     url: "/",
     test: true,
 }, () => [
-    ...dragNDrop({
+    ...insertSnippet({
         id: 's_test_snip',
         name: 'Test snip',
         groupName: "Content",
     }),
-    ...dragNDrop({
+    ...insertSnippet({
         id: 's_text_image',
         name: 'Text - Image',
         groupName: "Content",

--- a/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
+++ b/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
@@ -2,7 +2,7 @@
 
 import {
     clickOnEditAndWaitEditMode,
-    dragNDrop,
+    insertSnippet,
     goBackToBlocks,
 } from "@website/js/tours/tour_utils";
 import { patch } from "@web/core/utils/patch";
@@ -136,7 +136,7 @@ registry.category("web_tour.tours").add("snippets_all_drag_and_drop", {
     // This first step is needed as it will be used later for inner snippets
     // Without this, it will dropped inside the footer and will need an extra
     // selector.
-    ...dragNDrop({
+    ...insertSnippet({
         id: "s_text_image",
         name: "Text - Image",
         groupName: "Content"

--- a/addons/website/static/tests/tours/start_cloned_snippet.js
+++ b/addons/website/static/tests/tours/start_cloned_snippet.js
@@ -19,7 +19,7 @@ registerWebsitePreviewTour('website_start_cloned_snippet', {
             trigger: ".o_website_preview.editor_enable.editor_has_snippets",
         },
         {
-            trigger: `#oe_snippets .oe_snippet[name="${countdownSnippet.name}"].o_we_draggable .oe_snippet_thumbnail:not(.o_we_already_dragging)`,
+            trigger: `#oe_snippets .oe_snippet[name="${countdownSnippet.name}"].o_we_draggable .oe_snippet_thumbnail:not(.o_we_ongoing_insertion)`,
             run: "drag_and_drop :iframe #wrapwrap #wrap",
         },
         ...clickOnSnippet(countdownSnippet),

--- a/addons/website/static/tests/tours/text_animations.js
+++ b/addons/website/static/tests/tours/text_animations.js
@@ -1,7 +1,7 @@
 /** @odoo-module */
 
 import {
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
 
@@ -10,7 +10,7 @@ registerWebsitePreviewTour("text_animations", {
     url: "/",
     edition: true,
 }, () => [
-    ...dragNDrop({
+    ...insertSnippet({
         id: "s_cover",
         name: "Cover",
         groupName: "Intro",

--- a/addons/website/static/tests/tours/text_highlights.js
+++ b/addons/website/static/tests/tours/text_highlights.js
@@ -1,7 +1,7 @@
 /** @odoo-module */
 
 import {
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
     selectElementInWeSelectWidget,
 } from '@website/js/tours/tour_utils';
@@ -11,7 +11,7 @@ registerWebsitePreviewTour("text_highlights", {
     url: "/",
     edition: true,
 }, () => [
-    ...dragNDrop({
+    ...insertSnippet({
         id: "s_cover",
         name: "Cover",
         groupName: "Intro",

--- a/addons/website/static/tests/tours/website_click_tests.js
+++ b/addons/website/static/tests/tours/website_click_tests.js
@@ -4,7 +4,7 @@ import {
     clickOnEditAndWaitEditMode,
     clickOnSave,
     clickOnSnippet,
-    dragNDrop,
+    insertSnippet,
     goBackToBlocks,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
@@ -37,7 +37,7 @@ registerWebsitePreviewTour('website_click_tour', {
         run: "click",
     },
     goBackToBlocks(),
-    ...dragNDrop(cover),
+    ...insertSnippet(cover),
     ...clickOnSnippet(cover),
     ...clickOnSave(),
 ]);

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -5,7 +5,7 @@ import {
     changeOption,
     clickOnEditAndWaitEditMode,
     clickOnSave,
-    dragNDrop,
+    insertSnippet,
     goBackToBlocks,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
@@ -921,7 +921,7 @@ registerWebsitePreviewTour("website_form_editable_content", {
         trigger: ".o_website_preview.editor_enable.editor_has_snippets",
     },
     {
-        trigger: `#oe_snippets .oe_snippet[name="Form"].o_we_draggable .oe_snippet_thumbnail:not(.o_we_already_dragging)`,
+        trigger: `#oe_snippets .oe_snippet[name="Form"].o_we_draggable .oe_snippet_thumbnail:not(.o_we_ongoing_insertion)`,
         run: "drag_and_drop :iframe #wrap",
     },
     {
@@ -941,7 +941,7 @@ registerWebsitePreviewTour("website_form_editable_content", {
         trigger: ".o_we_add_snippet_btn",
         run: "click",
     },
-    ...dragNDrop({id: "s_three_columns", name: "Columns", groupName: "Columns"}),
+    ...insertSnippet({id: "s_three_columns", name: "Columns", groupName: "Columns"}),
     {
         content: "Select the first column",
         trigger: ":iframe .s_three_columns .row > :nth-child(1)",
@@ -986,7 +986,7 @@ registerWebsitePreviewTour("website_form_special_characters", {
         trigger: ".o_website_preview.editor_enable.editor_has_snippets",
     },
     {
-        trigger: `#oe_snippets .oe_snippet[name="Form"].o_we_draggable .oe_snippet_thumbnail:not(.o_we_already_dragging)`,
+        trigger: `#oe_snippets .oe_snippet[name="Form"].o_we_draggable .oe_snippet_thumbnail:not(.o_we_ongoing_insertion)`,
         run: "drag_and_drop :iframe #wrap",
     },
     {

--- a/addons/website/static/tests/tours/website_no_dirty_page.js
+++ b/addons/website/static/tests/tours/website_no_dirty_page.js
@@ -4,12 +4,12 @@ import { browser } from '@web/core/browser/browser';
 import {
     clickOnEditAndWaitEditMode,
     clickOnSave,
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
 
 const makeSteps = (steps = []) => [
-    ...dragNDrop({
+    ...insertSnippet({
         id: "s_text_image",
         name: "Text - Image",
         groupName: "Content",
@@ -106,7 +106,7 @@ registerWebsitePreviewTour('website_no_dirty_lazy_image', {
     url: '/',
     edition: true,
 }, () => [
-    ...dragNDrop({
+    ...insertSnippet({
         id: 's_text_image',
         name: 'Text - Image',
         groupName: "Content",

--- a/addons/website/static/tests/tours/website_text_edition.js
+++ b/addons/website/static/tests/tours/website_text_edition.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import {
-    dragNDrop,
+    insertSnippet,
     goBackToBlocks,
     goToTheme,
     registerWebsitePreviewTour,
@@ -26,7 +26,7 @@ registerWebsitePreviewTour('website_text_edition', {
         run: `edit ${WEBSITE_MAIN_COLOR} && click body`,
     },
     goBackToBlocks(),
-    ...dragNDrop({id: "s_text_block", name: "Text", groupName: "Text"}),
+    ...insertSnippet({id: "s_text_block", name: "Text", groupName: "Text"}),
     {
         content: "Click on the text block first paragraph (to auto select)",
         trigger: ':iframe .s_text_block p',

--- a/addons/website/static/tests/tours/website_text_font_size.js
+++ b/addons/website/static/tests/tours/website_text_font_size.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import {
-    dragNDrop,
+    insertSnippet,
     goToTheme,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
@@ -40,7 +40,7 @@ function checkComputedFontSize(fontSizeClass, stage) {
 
 function getFontSizeTestSteps(fontSizeClass) {
     return [
-        ...dragNDrop({id: "s_text_block", name: "Text", groupName: "Text"}),
+        ...insertSnippet({id: "s_text_block", name: "Text", groupName: "Text"}),
         {
             content: `[${fontSizeClass}] Click on the text block first paragraph (to auto select)`,
             trigger: ":iframe .s_text_block p",

--- a/addons/website/static/tests/tours/website_update_column_count.js
+++ b/addons/website/static/tests/tours/website_update_column_count.js
@@ -2,7 +2,7 @@
 
 import {
     clickOnSnippet,
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
     toggleMobilePreview,
 } from '@website/js/tours/tour_utils';
@@ -43,7 +43,7 @@ registerWebsitePreviewTour("website_update_column_count", {
     url: "/",
     edition: true,
 }, () => [
-...dragNDrop({
+...insertSnippet({
     id: "s_three_columns",
     name: "Columns",
     groupName: "Columns",
@@ -166,8 +166,8 @@ registerWebsitePreviewTour("website_mobile_order_with_drag_and_drop", {
     url: "/",
     edition: true,
 }, () => [
-    ...dragNDrop({id: "s_three_columns", name: "Columns", groupName: "Columns"}),
-    ...dragNDrop({id: "s_text_image", name: "Text - Image", groupName: "Content"}),
+    ...insertSnippet({id: "s_three_columns", name: "Columns", groupName: "Columns"}),
+    ...insertSnippet({id: "s_text_image", name: "Text - Image", groupName: "Content"}),
     ...toggleMobilePreview(true),
     // Add a mobile order to the "Columns" snippet columns.
     ...changeFirstAndSecondColumnsMobileOrder(columnsSnippetRow, "Columns"),

--- a/addons/website/static/tests/tours/widget_lifecycle.js
+++ b/addons/website/static/tests/tours/widget_lifecycle.js
@@ -3,7 +3,7 @@
 import {
     clickOnEditAndWaitEditMode,
     clickOnSave,
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
 
@@ -19,7 +19,7 @@ registerWebsitePreviewTour("widget_lifecycle", {
     url: "/",
     edition: true,
 }, () => [
-    ...dragNDrop({
+    ...insertSnippet({
         id: "s_countdown",
         name: "Countdown",
         groupName: "Content",

--- a/addons/website_event/static/src/js/tours/event_tour.js
+++ b/addons/website_event/static/src/js/tours/event_tour.js
@@ -5,7 +5,7 @@ import EventAdditionalTourSteps from "@event/js/tours/event_steps";
 
 import { markup } from "@odoo/owl";
 import { patch } from "@web/core/utils/patch";
-import { dragNDrop } from '@website/js/tours/tour_utils';
+import { insertSnippet } from '@website/js/tours/tour_utils';
 
 patch(EventAdditionalTourSteps.prototype, {
 
@@ -22,7 +22,7 @@ patch(EventAdditionalTourSteps.prototype, {
                 tooltipPosition: 'bottom',
                 run: "click",
             },
-            ...dragNDrop({
+            ...insertSnippet({
                 id: "s_image_text",
                 name: "Image - Text",
                 groupName: "Content",

--- a/addons/website_event/static/tests/tours/website_event.js
+++ b/addons/website_event/static/tests/tours/website_event.js
@@ -2,7 +2,7 @@
 
 import { _t } from "@web/core/l10n/translation";
 import {
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
 
@@ -49,7 +49,7 @@ registerWebsitePreviewTour("website_event_tour", {
     tooltipPosition: "right",
     run: "click",
 },
-...dragNDrop({
+...insertSnippet({
     id: "s_image_text",
     name: "Image - Text",
     groupName: "Content",

--- a/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_block_with_edit.js
+++ b/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_block_with_edit.js
@@ -3,7 +3,7 @@
 import {
     clickOnEditAndWaitEditMode,
     clickOnSave,
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
 
@@ -13,7 +13,7 @@ registerWebsitePreviewTour('snippet_newsletter_block_with_edit', {
     edition: true,
 }, () => [
     // Put a Newsletter block.
-    ...dragNDrop({
+    ...insertSnippet({
         id: 's_newsletter_block',
         name: 'Newsletter Block',
         groupName: "Contact & Forms",

--- a/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_popup_edition.js
+++ b/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_popup_edition.js
@@ -2,7 +2,7 @@
 
 import {
     clickOnSave,
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
 import snippetNewsletterPopupUseTour from "@website_mass_mailing/../tests/tours/snippet_newsletter_popup_use";
@@ -12,7 +12,7 @@ registerWebsitePreviewTour("snippet_newsletter_popup_edition", {
     url: "/",
     edition: true,
 }, () => [
-    ...dragNDrop({
+    ...insertSnippet({
         id: 's_newsletter_subscribe_popup',
         name: 'Newsletter Popup',
         groupName: "Contact & Forms",

--- a/addons/website_payment/static/tests/tours/donation.js
+++ b/addons/website_payment/static/tests/tours/donation.js
@@ -3,7 +3,7 @@
 import {
     clickOnSave,
     registerWebsitePreviewTour,
-    dragNDrop,
+    insertSnippet,
 } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour('donation_snippet_edition', {
@@ -11,7 +11,7 @@ registerWebsitePreviewTour('donation_snippet_edition', {
     url: '/',
     edition: true,
 }, () => [
-        ...dragNDrop({
+        ...insertSnippet({
             id: "s_donation",
             name: "Donation",
             groupName: "Contact & Forms",

--- a/addons/website_sale/static/src/js/tours/website_sale_shop.js
+++ b/addons/website_sale/static/src/js/tours/website_sale_shop.js
@@ -2,7 +2,7 @@
 
 import { _t } from "@web/core/l10n/translation";
 import {
-    dragNDrop,
+    insertSnippet,
     goBackToBlocks,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
@@ -70,7 +70,7 @@ goBackToBlocks(),
     isActive: ["auto"],
     trigger: "body:not(.modal-open)",
 },
-...dragNDrop({
+...insertSnippet({
     id: "s_text_image",
     name: "Text - Image",
     groupName: "Content",

--- a/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { goToCart, assertCartContains } from '@website_sale/js/tours/tour_utils';
-import { registerWebsitePreviewTour, clickOnEditAndWaitEditMode, clickOnSnippet, dragNDrop, selectElementInWeSelectWidget, clickOnSave, clickOnElement, assertPathName } from '@website/js/tours/tour_utils';
+import { registerWebsitePreviewTour, clickOnEditAndWaitEditMode, clickOnSnippet, insertSnippet, selectElementInWeSelectWidget, clickOnSave, clickOnElement, assertPathName } from '@website/js/tours/tour_utils';
 
 
 function editAddToCartSnippet() {
@@ -17,7 +17,7 @@ registerWebsitePreviewTour('add_to_cart_snippet_tour', {
         test: true,
     },
     () => [
-        ...dragNDrop({name: 'Add to Cart Button'}),
+        ...insertSnippet({name: 'Add to Cart Button'}),
 
         // Basic product with no variants
         ...clickOnSnippet({id: 's_add_to_cart'}),

--- a/addons/website_sale/static/tests/tours/website_sale_category_page_and_products_snippet.js
+++ b/addons/website_sale/static/tests/tours/website_sale_category_page_and_products_snippet.js
@@ -15,7 +15,7 @@ registerWebsitePreviewTour('category_page_and_products_snippet_edition', {
     },
     {
         content: "Drag and drop the Products snippet group inside the category area.",
-        trigger: '#oe_snippets .oe_snippet[name="Products"] .oe_snippet_thumbnail:not(.o_we_already_dragging)',
+        trigger: '#oe_snippets .oe_snippet[name="Products"] .oe_snippet_thumbnail:not(.o_we_ongoing_insertion)',
         run: "drag_and_drop :iframe #category_header",
     },
     {

--- a/addons/website_sale/static/tests/tours/website_sale_snippet_products.js
+++ b/addons/website_sale/static/tests/tours/website_sale_snippet_products.js
@@ -5,7 +5,7 @@ import {
     changeOption,
     clickOnSave,
     clickOnSnippet,
-    dragNDrop,
+    insertSnippet,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
 import { goToCart } from '@website_sale/js/tours/tour_utils';
@@ -50,7 +50,7 @@ registerWebsitePreviewTour('website_sale.snippet_products', {
         templatesSteps = templatesSteps.concat(changeTemplate(templateKey));
     }
     return [
-        ...dragNDrop(productsSnippet),
+        ...insertSnippet(productsSnippet),
         ...clickOnSnippet(productsSnippet),
         ...templatesSteps,
         ...changeTemplate('dynamic_filter_template_product_product_add_to_cart'),
@@ -69,7 +69,7 @@ registerWebsitePreviewTour('website_sale.products_snippet_recently_viewed', {
     edition: true,
 },
 () => [
-    ...dragNDrop(productsSnippet),
+    ...insertSnippet(productsSnippet),
     ...clickOnSnippet(productsSnippet),
     ...changeTemplate('dynamic_filter_template_product_product_add_to_cart'),
     changeOption(optionBlock, 'we-select[data-name="filter_opt"] we-toggler', 'filter'),


### PR DESCRIPTION
mass_mailing, test_website, web_tour, website_event,
website_mass_mailing, website_payment, website_sale

This commit adapts the "homepage" tour following the change in the way
building blocks are inserted into a page (now, the blocks are displayed
in a modal). Change introduced by this commit [1].

Here are the changes made in this PR:

- The "dragNDrop" function of "tour_utils" has been changed and is now
called "insertSnippet". Instead of dragging and dropping a category,
users now simply need to click on the category.

- Before this commit, the "tour pointers" that indicated to users that
they needed to scroll the "snippets modal" were misaligned. Their
position did not account for the iframe offset of the modal.

- Before this commit, the position of the "tour pointers" displayed on
the building blocks in the modal was not updated when the modal was
scrolled.

[1]: https://github.com/odoo/odoo/commit/edf81c13d8f2f6d29a77d68cbfa0dc9216da3c2a

task-4072655