### PR TITLE
[IMP] auth_passkey: simplify kanban archs

### DIFF
--- a/addons/auth_passkey/views/res_users_views.xml
+++ b/addons/auth_passkey/views/res_users_views.xml
@@ -9,29 +9,16 @@
                 <group string="Passkeys">
                     <field colspan="4" name="auth_passkey_key_ids" string="">
                         <kanban create="false" can_open="false">
-                            <field name="name"/>
-                                <templates>
-                                    <t t-name="kanban-menu">
-                                        <a role="menuitem" type="delete" class="dropdown-item">Delete</a>
-                                    </t>
-                                    <t t-name="kanban-box">
-                                        <div class="oe_kanban_card">
-                                            <div class="oe_kanban_details">
-                                                <div class="o_kanban_record_top">
-                                                    <div class="o_kanban_record_headings">
-                                                        <strong class="o_kanban_record_title">
-                                                            <field name="name"/>
-                                                        </strong>
-                                                    </div>
-                                                </div>
-                                                <ul>
-                                                    <li>Created: <field name="create_date"/></li>
-                                                    <li>Last used: <field name="write_date"/></li>
-                                                </ul>
-                                            </div>
-                                        </div>
-                                    </t>
-                                </templates>
+                            <templates>
+                                <t t-name="kanban-menu">
+                                    <a role="menuitem" type="delete" class="dropdown-item">Delete</a>
+                                </t>
+                                <t t-name="kanban-card">
+                                    <field name="name" class="fw-bold fs-5"/>
+                                    <small>Created: <field name="create_date"/></small>
+                                    <small>Last used: <field name="write_date"/></small>
+                                </t>
+                            </templates>
                         </kanban>
                     </field>
                 </group>
@@ -55,28 +42,15 @@
                         </div>
                         <field colspan="4" name="auth_passkey_key_ids">
                             <kanban create="false" can_open="false">
-                                <field name="name"/>
                                 <templates>
                                     <t t-name="kanban-menu">
                                         <a role="menuitem" type="object" name="action_rename_passkey" class="dropdown-item">Rename</a>
                                         <a role="menuitem" type="object" name="action_delete_passkey" class="dropdown-item">Delete</a>
                                     </t>
-                                    <t t-name="kanban-box">
-                                        <div class="oe_kanban_card">
-                                            <div class="oe_kanban_details">
-                                                <div class="o_kanban_record_top">
-                                                    <div class="o_kanban_record_headings">
-                                                        <strong class="o_kanban_record_title">
-                                                            <field name="name"/>
-                                                        </strong>
-                                                    </div>
-                                                </div>
-                                                <ul>
-                                                    <li>Created: <field name="create_date"/></li>
-                                                    <li>Last used: <field name="write_date"/></li>
-                                                </ul>
-                                            </div>
-                                        </div>
+                                    <t t-name="kanban-card">
+                                        <field name="name" class="fw-bold fs-5"/>
+                                        <small>Created: <field name="create_date"/></small>
+                                        <small>Last used: <field name="write_date"/></small>
                                     </t>
                                 </templates>
                             </kanban>


### PR DESCRIPTION
In this commit we have simplified the kanban arch for the auth_passkey. The goal is to simplify them, make them easier to read, and use bootstrap utility classnames.

- Previously, we used `kanban-box`, but now we are using `kanban-card` instead.
- Deprecated `oe_kanban_global_click` and `oe_kanban_global_click_edit`.
- More use of `<field/>` tags
- Removed the `oe_kanban_colorpicker` class and replaced it with the `kanban_color_picker` widget.
- Changed type='edit' to type='open' to open records. since version 16, records always open in edit mode by default.
- `kanban_image` from rendering context, is deprecated so we use `<field name=... widget=image/>` instead

Task-3992107
