### PR TITLE
[FIX] base: Lao default date format

### DIFF
--- a/doc/cla/corporate/newlogic.md
+++ b/doc/cla/corporate/newlogic.md
@@ -1,0 +1,16 @@
+Thailand, 2024-04-01
+
+Newlogic Pte Ltd agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Jérémy Bethmont jeremy@newlogic.com https://github.com/jerem
+
+List of contributors:
+
+Jérémy Bethmont jeremy@newlogic.com https://github.com/jerem
+Baptiste baptiste@newlogic.com https://github.com/baptiste-n42

--- a/odoo/addons/base/data/res.lang.csv
+++ b/odoo/addons/base/data/res.lang.csv
@@ -44,7 +44,7 @@
 "base.lang_km","Khmer / ភាសាខ្មែរ","km_KH","km","Left-to-Right","[3,0]",".",",","%d %B %Y","%H:%M:%S","7"
 "base.lang_ko_KP","Korean (KP) / 한국어 (KP)","ko_KP","ko_KP","Left-to-Right","[3,0]",".",",","%m/%d/%Y","%I:%M:%S %p","1"
 "base.lang_ko_KR","Korean (KR) / 한국어 (KR)","ko_KR","ko_KR","Left-to-Right","[3,0]",".",",","%Y년 %m월 %d일","%H시 %M분 %S초","7"
-"base.lang_lo_LA","Lao / ພາສາລາວ","lo_LA","lo","Left-to-Right","[3,0]",".",",","%d/%m/y","%H:%M:%S","7"
+"base.lang_lo_LA","Lao / ພາສາລາວ","lo_LA","lo","Left-to-Right","[3,0]",".",",","%d/%m/%Y","%H:%M:%S","7"
 "base.lang_lv","Latvian / latviešu valoda","lv_LV","lv","Left-to-Right","[3,0]",","," ","%Y.%m.%d.","%H:%M:%S","1"
 "base.lang_lt","Lithuanian / Lietuvių kalba","lt_LT","lt","Left-to-Right","[3,0]",",",".","%Y-%m-%d","%H:%M:%S","1"
 "base.lang_lb","Luxembourgish","lb_LU","lb","Left-to-Right","[3,0]",","," ","%d/%m/%Y","%H:%M:%S","1"


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The date format in Lao contain a typo: `%d/%m/y` should be `%d/%m/%Y`

Desired behavior after PR is merged:

The date format should be `%d/%m/%Y`


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
