### PR TITLE
[FIX] mail: unwanted flickering in chatwindow

### DIFF
--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -38,7 +38,9 @@
                     }"
                 >
                     <div class="position-relative flex-grow-1">
-                        <textarea class="o-mail-Composer-input form-control bg-view px-3 border-0 rounded-3 shadow-none overflow-auto"
+                        <t t-set="inputClasses" t-value="'form-control px-3 border-0 rounded-3'"/>
+                        <textarea class="o-mail-Composer-input bg-view shadow-none overflow-auto"
+                            t-att-class="inputClasses"
                             t-ref="textarea"
                             style="height:40px;"
                             t-on-keydown="onKeydown"
@@ -56,7 +58,8 @@
                              the textarea properly without flicker.
                         -->
                         <textarea
-                            class="o-mail-Composer-fake position-absolute"
+                            class="o-mail-Composer-fake overflow-hidden position-absolute"
+                            t-att-class="inputClasses"
                             t-model="props.composer.textInputContent"
                             t-ref="fakeTextarea"
                             disabled="1"


### PR DESCRIPTION
When the message in the chatwindow is too long, the textarea in the chatwindow is constantly showing the scorllbar. This causes the chatwindow to flicker when the user is typing a message.

This commit fixes the issue by setting excatly the right class for the fake textarea in the chatwindow so that it can get the real height of the textarea.

Current behavior before PR:
![1](https://github.com/user-attachments/assets/f78e4b24-6718-44cb-856c-b0654aaa8de0)

Desired behavior after PR is merged:
![动画](https://github.com/user-attachments/assets/9a520eaf-92be-4882-b2aa-36832a25da02)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
