### PR TITLE
[FIX] l10n_{pe,ar}_pos: show identification type in shop session

### DIFF
--- a/addons/l10n_ar_pos/models/pos_session.py
+++ b/addons/l10n_ar_pos/models/pos_session.py
@@ -13,8 +13,16 @@ class PosSession(models.Model):
             params['res.partner']['fields'] += ['l10n_ar_afip_responsibility_type_id', 'l10n_latam_identification_type_id']
             params['l10n_ar.afip.responsibility.type'] = {'domain': [], 'fields': ['name']}
             params['l10n_latam.identification.type'] = {
-                'domain': [('l10n_ar_afip_code', '!=', False), ('active', '=', True)],
+                'domain': [('l10n_ar_afip_code', '!=', False), ('active', '=', True), ('country_id', 'in', [self.company_id.country_id.id, False])],
                 'fields': ['name']
             }
 
         return params
+
+    def load_data(self, models_to_load, only_data=False):
+        response = super().load_data(models_to_load, only_data)
+
+        if not only_data:
+            response['custom']['consumidor_final_anonimo_id'] = self.env.ref('l10n_ar.par_cfa').id
+
+        return response

--- a/addons/l10n_ar_pos/static/src/overrides/models/pos_store.js
+++ b/addons/l10n_ar_pos/static/src/overrides/models/pos_store.js
@@ -12,9 +12,10 @@ patch(PosStore.prototype, {
         if (this.isArgentineanCompany()) {
             this.consumidorFinalAnonimoId = this.data.custom.consumidor_final_anonimo_id;
 
-            this["l10n_latam.identification.type"] = this.data["l10n_latam.identification.type"];
+            this["l10n_latam.identification.type"] =
+                this.models["l10n_latam.identification.type"].getAll();
             this["l10n_ar.afip.responsibility.type"] =
-                this.data["l10n_ar.afip.responsibility.type"];
+                this.models["l10n_ar.afip.responsibility.type"].getAll();
         }
     },
     isArgentineanCompany() {

--- a/addons/l10n_pe_pos/models/pos_session.py
+++ b/addons/l10n_pe_pos/models/pos_session.py
@@ -23,7 +23,7 @@ class PosSession(models.Model):
             'fields': ["name", "country_id", "state_id"],
         }
         params['l10n_latam.identification.type'] = {
-            'domain': [("l10n_pe_vat_code", "!=", False)],
+            'domain': [("l10n_pe_vat_code", "!=", False), ('country_id', 'in', [self.company_id.country_id.id, False])],
             'fields': ['name'],
         }
 

--- a/addons/l10n_pe_pos/static/src/overrides/models/pos_store.js
+++ b/addons/l10n_pe_pos/static/src/overrides/models/pos_store.js
@@ -8,12 +8,13 @@ patch(PosStore.prototype, {
     async processServerData() {
         await super.processServerData(...arguments);
         if (this.isPeruvianCompany()) {
-            this["res.city"] = this.data["res.city"];
+            this["res.city"] = this.models["res.city"].getAll();
             this.consumidorFinalAnonimoId = this.data.custom["consumidor_final_anonimo_id"];
             this.default_l10n_latam_identification_type_id =
                 this.data.custom["default_l10n_latam_identification_type_id"];
-            this["l10n_latam.identification.type"] = this.data["l10n_latam.identification.type"];
-            this["l10n_pe.res.city.district"] = this.data["l10n_pe.res.city.district"];
+            this["l10n_latam.identification.type"] =
+                this.models["l10n_latam.identification.type"].getAll();
+            this["l10n_pe.res.city.district"] = this.models["l10n_pe.res.city.district"].getAll();
         }
     },
     isPeruvianCompany() {


### PR DESCRIPTION
Currently, when modifying customer details, the selection for the identification type is empty.

Steps to reproduce:
-------------------
* Install **l10n_pe_pos**
* Switch to the **PE Company**
* Open pos session
* Try modifying a customer
> Observation: The selection for the field **Identification Type** is empty

Why the fix:
------------
In the customer editor view, the selection is loaded with `t-foreach="pos['l10n_latam.identification.type']"`.

This field is supposed to be set in the pos data with `this["l10n_latam.identification.type"] = this.data["l10n_latam.identification.type"];`

However, `this.data["l10n_latam.identification.type"` is an empty list. We follow the instuctions from the new relational model https://github.com/odoo/odoo/commit/28b7d698be8255f933ba5314e44e7059746fc234 to retreive the fields.

We also change the domain used when loading the `l10n_latam.identification.type` to the pos session to account for database that have installed multiple localization. If you install both `l10n_pe_pos` and `l10n_ar_pos`, and you are currently using the PE Company, you will alse see the types that are related to the AR company and not the current one. We alse include those coming from the base `l10n_latam` module and are not related to a specific country.

opw-4178323

Enterprise PR: https://github.com/odoo/enterprise/pull/70177