### PR TITLE
[FIX] account: prevent archiving journal used in payment methods

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -14362,6 +14362,14 @@ msgstr ""
 
 #. module: account
 #. odoo-python
+#: code:addons/account/models/account_journal.py:0
+#, python-format
+msgid ""
+"This journal is associated with a payment method. You cannot archive it"
+msgstr ""
+
+#. module: account
+#. odoo-python
 #: code:addons/account/models/company.py:0
 #, python-format
 msgid "This journal is not in strict mode."

--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -797,6 +797,11 @@ class AccountJournal(models.Model):
             res += [(journal.id, name)]
         return res
 
+    def action_archive(self):
+        if self.env['account.payment.method.line'].search_count([('journal_id', '=', self.id)], limit=1):
+            raise ValidationError(_("This journal is associated with a payment method. You cannot archive it"))
+        return super().action_archive()
+
     def action_configure_bank_journal(self):
         """ This function is called by the "configure" button of bank journals,
         visible on dashboard if no bank statement source has been defined yet

--- a/addons/account/tests/test_account_journal.py
+++ b/addons/account/tests/test_account_journal.py
@@ -165,3 +165,22 @@ class TestAccountJournal(AccountTestInvoicingCommon):
         ])
 
         self.assertEqual(sorted(new_journals.mapped("code")), ["GEN1", "OD_BL"], "The journals should be set correctly")
+
+    def test_archive_used_journal(self):
+        journal = self.env['account.journal'].create({
+            'name': 'Test Journal',
+            'type': 'sale',
+            'code': 'A',
+        })
+        check_method = self.env['account.payment.method'].sudo().create({
+                'name': 'Test',
+                'code': 'check_printing_expense_test',
+                'payment_type': 'outbound',
+        })
+        self.env['account.payment.method.line'].create({
+            'name': 'Check',
+            'payment_method_id': check_method.id,
+            'journal_id': journal.id
+            })
+        with self.assertRaises(ValidationError):
+            journal.action_archive()


### PR DESCRIPTION
You should not be able to archive a journal used in a payment method.

Steps to reproduce:
-------------------
* Go on any journal used in a payment method (e.g. Cash)
* Archive the journal
> Observation: You are still able to use the payment method without the
journal being active

Note:
---------------
Similar fix was done for the point of sale here :
https://github.com/odoo/odoo/pull/177751

opw-4070620
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
