### PR TITLE
[FIX] account: remove `text-wrap` class from invoice `textarea`

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
@@ -16,7 +16,7 @@
                         </span>
                         <t t-if="columnIsProductAndLabel.value and label">
                             <textarea
-                                class="o_input d-print-none text-wrap border-0 fst-italic"
+                                class="o_input d-print-none border-0 fst-italic"
                                 rows="1"
                                 type="text"
                                 t-att-class="sectionAndNoteClasses"
@@ -38,7 +38,7 @@
                             </span>
                         </a>
                         <textarea t-if="(columnIsProductAndLabel.value and label) or (!columnIsProductAndLabel.value and !productName and label)"
-                            class="o_input d-print-none text-wrap border-0 fst-italic"
+                            class="o_input d-print-none border-0 fst-italic"
                             placeholder="Enter a description"
                             readonly="1"
                             rows="1"
@@ -64,7 +64,7 @@
                     </t>
                     <t t-else="">
                         <textarea
-                            class="o_input d-print-none text-wrap border-0 fst-italic"
+                            class="o_input d-print-none border-0 fst-italic"
                             placeholder="Enter a description"
                             rows="1"
                             type="text"
@@ -110,7 +110,7 @@
                     </div>
                     <t t-if="columnIsProductAndLabel.value and (label or labelVisibility.value)">
                         <textarea
-                            class="o_input d-print-none text-wrap border-0 fst-italic"
+                            class="o_input d-print-none border-0 fst-italic"
                             placeholder="Enter a description"
                             rows="1"
                             type="text"
@@ -134,7 +134,7 @@
                     </t>
                     <t t-else="">
                         <textarea
-                            class="o_input d-print-none text-wrap border-0 fst-italic"
+                            class="o_input d-print-none border-0 fst-italic"
                             rows="1"
                             type="text"
                             t-att-class="sectionAndNoteClasses"


### PR DESCRIPTION
Versions
--------
- saas-17.4+

Steps
-----
1. Create an invoice;
2. enter a product;
3. hit enter to add a label;
4. hit enter to add newlines to the label;
5. confirm.

Issue
-----
On Firefox, the added newlines don't show in the invoice lines tab, but do show in the journal items tabs.

On Chrome, they show in the journal items tab, as well as invoice lines tab until they become uneditable by confirming the invoice.

Cause
-----
Bootstrap's `text-wrap` class added in 4f325ef62026 collapses sequential whitespace into a single space, wrapping text if necessary.

For `input` and `div` elements, this makes sense.

For `textarea`, wrapping is standard, and unlike `input`, it allows pressing Enter to start a new line, but because of `text-wrap`, these get collapsed into a single space, making it difficult for the user to see the actual layout of what they're editing.

Solution
--------
Remove the `text-wrap` class from `textarea` elements to keep line breaks visible regardless of invoice state.

opw-4126094
