### PR TITLE
[IMP] point_of_sale: inventory management real time by default

### DIFF
--- a/addons/point_of_sale/models/res_company.py
+++ b/addons/point_of_sale/models/res_company.py
@@ -9,9 +9,9 @@ class ResCompany(models.Model):
     _inherit = ['res.company', 'pos.load.mixin']
 
     point_of_sale_update_stock_quantities = fields.Selection([
-            ('closing', 'At the session closing (faster)'),
-            ('real', 'In real time (accurate but slower)'),
-            ], default='closing', string="Update quantities in stock",
+            ('closing', 'At the session closing'),
+            ('real', 'In real time'),
+            ], default='real', string="Update quantities in stock",
             help="At the session closing: A picking is created for the entire session when it's closed\n In real time: Each order sent to the server create its own picking")
     point_of_sale_use_ticket_qr_code = fields.Boolean(
         string='Self-service invoicing',

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -56,6 +56,7 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
             'groups_id': [
                 (4, cls.env.ref('base.group_user').id),
                 (4, cls.env.ref('point_of_sale.group_pos_user').id),
+                (4, cls.env.ref('stock.group_stock_user').id),
             ],
             'tz': 'America/New_York',
         })


### PR DESCRIPTION
There are two options to update the inventory in pos
   - At end of session (default)
   - Real time In the options, it says that [pos] is faster when selecting the "At end of session" option. But if we select that option all the inventory calculations will be delayed at the closing, so closing will become slower.

In this commit we set the default to "Real time".

Task: 3890309






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
