### PR TITLE
[IMP] calendar: can override privacy domain

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -770,13 +770,7 @@ class Meeting(models.Model):
         grouped_fields = {group_field.split(':')[0] for group_field in groupby + fields_aggregates}
         private_fields = grouped_fields - self._get_public_fields()
         if not self.env.su and private_fields:
-            # Sub query user settings from calendars that are not private ('public' and 'confidential').
-            public_calendars_settings = self.env['res.users.settings'].sudo()._search([('calendar_default_privacy', '!=', 'private')])
-            # display public, confidential events and events with default privacy when owner's default privacy is not private
-            domain = AND([domain, [
-                '|', '|', '|', ('privacy', '=', 'public'), ('privacy', '=', 'confidential'), ('user_id', '=', self.env.user.id),
-                '&', ('privacy', '=', False), ('user_id.res_users_settings_id', 'in', public_calendars_settings)
-            ]])
+            domain = AND([domain, self._get_default_privacy_domain()])
             return super(Meeting, self).read_group(domain, fields, groupby, offset=offset, limit=limit, orderby=orderby, lazy=lazy)
         return super(Meeting, self).read_group(domain, fields, groupby, offset=offset, limit=limit, orderby=orderby, lazy=lazy)
 
@@ -887,6 +881,15 @@ class Meeting(models.Model):
             ])
             recurrent_events_without_channel.videocall_channel_id = videocall_channel
         return videocall_channel
+
+    def _get_default_privacy_domain(self):
+        # Sub query user settings from calendars that are not private ('public' and 'confidential').
+        public_calendars_settings = self.env['res.users.settings'].sudo()._search([('calendar_default_privacy', '!=', 'private')])
+        # display public, confidential events and events with default privacy when owner's default privacy is not private
+        return [
+            '|', '|', '|', ('privacy', '=', 'public'), ('privacy', '=', 'confidential'), ('user_id', '=', self.env.user.id),
+            '&', ('privacy', '=', False), ('user_id.res_users_settings_id', 'in', public_calendars_settings)
+        ]
 
     # ------------------------------------------------------------
     # ACTIONS


### PR DESCRIPTION
Move the read_group privacy domain to a new method so that it can be overrided in other modules.

Task-4191434

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
