### PR TITLE
[FIX] loyalty: add description field to reward form for gift cards

### DIFF
--- a/addons/loyalty/views/loyalty_reward_views.xml
+++ b/addons/loyalty/views/loyalty_reward_views.xml
@@ -53,7 +53,7 @@
                             </div>
                         </group>
                     </group>
-                    <group invisible="program_type in ('gift_card','ewallet')">
+                    <group>
                         <field name="description" string="Description on order"/>
                         <field name="discount_line_product_id" string="Discount product" groups="base.group_no_one"/>
                     </group>


### PR DESCRIPTION
Gift cards would have a description in the original language of the
creator and could never be changed.

Adds the description field to the form view of the loyalty rewards even
for gift cards and ewallet programs.


opw-4177262
