### PR TITLE
[FIX] Remove some "Vertical Alignment" options + flex display

### DIFF
--- a/addons/website/static/src/snippets/s_card_offset/000.scss
+++ b/addons/website/static/src/snippets/s_card_offset/000.scss
@@ -1,6 +1,0 @@
-.s_card_offset {
-    .o_grid_item {
-        display: flex;
-        flex-direction: column;
-    }
-}

--- a/addons/website/static/src/snippets/s_carousel_intro/000.scss
+++ b/addons/website/static/src/snippets/s_carousel_intro/000.scss
@@ -31,10 +31,5 @@
                 width: auto;
             }
         }
-
-        .s_carousel_intro_item .row > div {
-            display: flex;
-            flex-direction: column;
-        }
     }
 }

--- a/addons/website/static/src/snippets/s_image_title/000.scss
+++ b/addons/website/static/src/snippets/s_image_title/000.scss
@@ -1,6 +1,0 @@
-.s_image_title {
-    .row > div {
-        display: flex;
-        flex-direction: column;
-    }
-}

--- a/addons/website/static/src/snippets/s_pricelist_cafe/000.scss
+++ b/addons/website/static/src/snippets/s_pricelist_cafe/000.scss
@@ -1,9 +1,4 @@
 .s_pricelist_cafe {
-    .s_pricelist_cafe_col {
-        display: flex;
-        flex-direction: column;
-    }
-
     @include media-breakpoint-down(lg) {
         // By default, it hides the default shape on medium breakpoints
         // in order to have clear sections.

--- a/addons/website/views/snippets/s_card_offset.xml
+++ b/addons/website/views/snippets/s_card_offset.xml
@@ -5,10 +5,10 @@
     <section class="s_card_offset o_cc o_cc1 pt64 pb64">
         <div class="container">
             <div class="row o_grid_mode" data-row-count="9">
-                <div class="o_grid_item o_grid_item_image g-height-8 g-col-lg-12 col-lg-12 rounded o_colored_level o_cc o_cc5 overflow-hidden" style="z-index: 1; grid-area: 2 / 1 / 10 / 13; --grid-item-padding-x: 0px; --grid-item-padding-y: 0px; border-radius: 6.4px !important;">
-                    <img src="/web/image/website.s_card_offset_default_image" class="img img-fluid mx-auto" alt=""/>
+                <div class="o_grid_item o_grid_item_image g-height-8 g-col-lg-12 col-lg-12 o_colored_level" style="z-index: 1; grid-area: 2 / 1 / 10 / 13; --grid-item-padding-x: 0px; --grid-item-padding-y: 0px;">
+                    <img src="/web/image/website.s_card_offset_default_image" class="img img-fluid mx-auto rounded" alt=""/>
                 </div>
-                <div class="o_grid_item g-height-7 g-col-lg-5 col-lg-5 rounded o_colored_level o_cc o_cc1 justify-content-center order-lg-0 shadow" style="z-index: 2; grid-area: 1 / 7 / 8 / 12; --grid-item-padding-x: 32px; box-shadow: rgba(0, 0, 0, 0.15) 0px 0px 0px 10px !important;">
+                <div class="o_grid_item g-height-7 g-col-lg-5 col-lg-5 offset-1 offset-lg-0 col-10 rounded o_colored_level o_cc o_cc1 shadow" style="z-index: 2; grid-area: 1 / 7 / 8 / 12; --grid-item-padding-y: 40px; --grid-item-padding-x: 32px; box-shadow: rgba(0, 0, 0, 0.15) 0px 0px 0px 10px !important;">
                     <h3>Why Our Product is the Future of Innovation</h3>
                     <p class="lead">Write one or two paragraphs describing your product or services. To be successful your content needs to be useful to your readers.</p>
                     <p class="lead">Start with the customer – find out what they want and give it to them.</p>
@@ -17,31 +17,5 @@
         </div>
     </section>
 </template>
-
-<template id="s_card_offset_options" inherit_id="website.snippet_options">
-    <!--  Box Vertical Alignment -->
-    <xpath expr="//div[@data-js='WebsiteAnimate']" position="after">
-        <div data-selector=".s_card_offset .o_grid_item" data-exclude=".o_grid_item_image">
-            <we-button-group string="Vert. Alignment" title="Vertical Alignment">
-                <we-button title="Align Top"
-                        data-select-class=""
-                        data-img="/website/static/src/img/snippets_options/align_solo_top.svg"/>
-                <we-button title="Align Middle"
-                        data-select-class="justify-content-center"
-                        data-img="/website/static/src/img/snippets_options/align_solo_middle.svg"/>
-                <we-button title="Align Bottom"
-                        data-select-class="justify-content-end"
-                        data-img="/website/static/src/img/snippets_options/align_solo_bottom.svg"/>
-            </we-button-group>
-        </div>
-    </xpath>
-</template>
-
-<!-- Assets -->
-<record id="website.s_card_offset_000_scss" model="ir.asset">
-    <field name="name">Card Offset 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_card_offset/000.scss</field>
-</record>
 
 </odoo>

--- a/addons/website/views/snippets/s_carousel_intro.xml
+++ b/addons/website/views/snippets/s_carousel_intro.xml
@@ -14,7 +14,7 @@
                             <div class="o_grid_item g-height-8 g-col-lg-5 col-lg-5" style="z-index: 1; grid-area: 1 / 1 / 9 / 6;" data-name="Block">
                                 <h1 class="display-3-fs">Driving innovation together</h1>
                             </div>
-                            <div class="o_grid_item g-height-4 g-col-lg-4 col-lg-4 justify-content-center" style="z-index: 2; grid-area: 1 / 7 / 5 / 11;" data-name="Block">
+                            <div class="o_grid_item g-height-3 g-col-lg-4 col-lg-4" style="z-index: 2; grid-area: 2 / 7 / 5 / 11; --grid-item-padding-y: 0px;" data-name="Block">
                                 <p class="lead">Empowering teams to collaborate and innovate, creating impactful solutions that drive business growth and deliver lasting value.</p>
                             </div>
                             <div class="o_grid_item o_grid_item_image g-height-4 g-col-lg-6 col-lg-6" style="z-index: 3; grid-area: 5 / 7 / 9 / 13;" data-name="Block">
@@ -30,7 +30,7 @@
                             <div class="o_grid_item g-height-5 g-col-lg-6 col-lg-6" style="z-index: 1; grid-area: 1 / 7 / 6 / 13;" data-name="Block">
                                 <h2 class="display-3-fs">Innovating for business success</h2>
                             </div>
-                            <div class="o_grid_item g-height-4 g-col-lg-4 col-lg-4 justify-content-end" style="z-index: 2; grid-area: 5 / 7 / 9 / 11;" data-name="Block">
+                            <div class="o_grid_item g-height-2 g-col-lg-4 col-lg-4" style="z-index: 2; grid-area: 7 / 7 / 9 / 11; --grid-item-padding-y: 20px;" data-name="Block">
                                 <p class="lead">Creating solutions that drive growth and long-term value.</p>
                             </div>
                             <div class="o_grid_item o_grid_item_image g-height-7 g-col-lg-5 col-lg-5" style="z-index: 3; grid-area: 2 / 1 / 9 / 6;" data-name="Block">
@@ -43,10 +43,10 @@
                 <div class="s_carousel_intro_item carousel-item o_cc o_cc1 px-0 pt72 pb96" data-name="Slide">
                     <div class="container">
                         <div class="row o_grid_mode" data-row-count="8">
-                            <div class="o_grid_item g-height-8 g-col-lg-4 col-lg-4" style="z-index: 1; grid-area: 1 / 1 / 9 / 5;" data-name="Box">
+                            <div class="o_grid_item g-height-8 g-col-lg-5 col-lg-5" style="z-index: 1; grid-area: 1 / 1 / 9 / 6;" data-name="Box">
                                 <h2 class="display-3-fs">Leading the future with innovation and strategy</h2>
                             </div>
-                            <div class="o_grid_item g-height-8 g-col-lg-3 col-lg-3 justify-content-end" style="z-index: 2; grid-area: 1 / 10 / 9 / 13;" data-name="Box">
+                            <div class="o_grid_item g-height-4 g-col-lg-4 col-lg-4" style="z-index: 2; grid-area: 5 / 9 / 9 / 13;" data-name="Box">
                                 <p class="lead">We combine strategic insights and innovative solutions to drive business success, ensuring sustainable growth and competitive advantage in a dynamic market.</p>
                             </div>
                             <div class="o_grid_item o_grid_item_image g-height-8 g-col-lg-3 col-lg-3" style="z-index: 3; grid-area: 1 / 6 / 9 / 9;" data-name="Box">
@@ -135,22 +135,6 @@
                 <we-button data-select-class="container-fluid"
                         data-img="/website/static/src/img/snippets_options/content_width_full.svg"
                         title="Full"/>
-            </we-button-group>
-        </div>
-    </xpath>
-
-    <xpath expr="//div[@data-js='WebsiteAnimate']" position="after">
-        <div data-selector=".s_carousel_intro_item .row > div" data-exclude=".o_grid_item_image">
-            <we-button-group string="Vert. Alignment" title="Vertical Alignment">
-                <we-button title="Align Top"
-                        data-select-class=""
-                        data-img="/website/static/src/img/snippets_options/align_solo_top.svg"/>
-                <we-button title="Align Middle"
-                        data-select-class="justify-content-center"
-                        data-img="/website/static/src/img/snippets_options/align_solo_middle.svg"/>
-                <we-button title="Align Bottom"
-                        data-select-class="justify-content-end"
-                        data-img="/website/static/src/img/snippets_options/align_solo_bottom.svg"/>
             </we-button-group>
         </div>
     </xpath>

--- a/addons/website/views/snippets/s_image_title.xml
+++ b/addons/website/views/snippets/s_image_title.xml
@@ -9,38 +9,12 @@
                 <div class="o_grid_item g-height-9 g-col-lg-8 col-lg-8" style="--grid-item-padding-y: 32px; grid-area: 1 / 1 / 10 / 9; z-index: 1;">
                     <h1 class="display-3">A Deep Dive into Innovation and Excellence</h1>
                 </div>
-                <div class="o_grid_item g-height-9 g-col-lg-7 col-lg-7 justify-content-end" style="--grid-item-padding-y: 32px; grid-area: 1 / 6 / 10 / 13; z-index: 2;">
+                <div class="o_grid_item g-height-3 g-col-lg-7 col-lg-7" style="--grid-item-padding-y: 24px; grid-area: 7 / 6 / 10 / 13; z-index: 2;">
                     <p class="lead" style="text-align: end;">Transform your environment with our new design collection, where elegance meets functionality. Elevate your space with pieces that blend style and comfort seamlessly.</p>
                 </div>
             </div>
         </div>
     </section>
 </template>
-
-<template id="s_image_title_options" inherit_id="website.snippet_options">
-    <!--  Box Vertical Alignment -->
-    <xpath expr="//div[@data-js='WebsiteAnimate']" position="after">
-        <div data-selector=".s_image_title .row > div" data-exclude=".o_grid_item_image">
-            <we-button-group string="Vert. Alignment" title="Vertical Alignment">
-                <we-button title="Align Top"
-                        data-select-class=""
-                        data-img="/website/static/src/img/snippets_options/align_solo_top.svg"/>
-                <we-button title="Align Middle"
-                        data-select-class="justify-content-center"
-                        data-img="/website/static/src/img/snippets_options/align_solo_middle.svg"/>
-                <we-button title="Align Bottom"
-                        data-select-class="justify-content-end"
-                        data-img="/website/static/src/img/snippets_options/align_solo_bottom.svg"/>
-            </we-button-group>
-        </div>
-    </xpath>
-</template>
-
-<!-- Assets -->
-<record id="website.s_image_title_000_scss" model="ir.asset">
-    <field name="name">Image Title 000 SCSS</field>
-    <field name="bundle">web.assets_frontend</field>
-    <field name="path">website/static/src/snippets/s_image_title/000.scss</field>
-</record>
 
 </odoo>

--- a/addons/website/views/snippets/s_pricelist_cafe.xml
+++ b/addons/website/views/snippets/s_pricelist_cafe.xml
@@ -11,8 +11,8 @@
                     <p class="lead">Explore our curated selection of coffee, tea, and more. Delight in every sip!</p>
                 </div>
             </div>
-            <div class="row">
-                <div class="s_pricelist_cafe_col col-lg-4 justify-content-start py-5 o_cc o_cc5 s_col_no_resize">
+            <div class="row align-items-center">
+                <div class="s_pricelist_cafe_col col-lg-4 py-5 o_cc o_cc5 s_col_no_resize">
                     <h3>Coffees</h3>
                     <ul class="list-unstyled my-3">
                         <t t-call="website.s_pricelist_cafe_item">
@@ -32,10 +32,10 @@
                         </t>
                     </ul>
                 </div>
-                <div class="s_pricelist_cafe_col col-lg-4 justify-content-center d-lg-flex d-none o_snippet_mobile_invisible s_col_no_resize">
+                <div class="s_pricelist_cafe_col col-lg-4 d-lg-block d-none o_snippet_mobile_invisible s_col_no_resize">
                     <img class="img img-fluid d-block mx-auto rounded-circle shadow" src="/web/image/website.s_pricelist_cafe_default_image" alt=""/>
                 </div>
-                <div class="s_pricelist_cafe_col col-lg-4 justify-content-start py-5 o_cc o_cc1 s_col_no_resize">
+                <div class="s_pricelist_cafe_col col-lg-4 py-5 o_cc o_cc1 s_col_no_resize">
                     <h3>Teas</h3>
                     <ul class="list-unstyled my-3">
                         <t t-call="website.s_pricelist_cafe_item">
@@ -82,24 +82,12 @@
 </template>
 
 <template id="s_pricelist_cafe_options" inherit_id="website.snippet_options">
-    <!--  Box Vertical Alignment -->
-    <xpath expr="//div[@data-js='WebsiteAnimate']" position="after">
-        <div data-selector=".s_pricelist_cafe_col">
-            <we-button-group string="Vert. Alignment" title="Vertical Alignment">
-                <we-button title="Align Top"
-                        data-select-class="justify-content-start"
-                        data-img="/website/static/src/img/snippets_options/align_solo_top.svg"/>
-                <we-button title="Align Middle"
-                        data-select-class="justify-content-center"
-                        data-img="/website/static/src/img/snippets_options/align_solo_middle.svg"/>
-                <we-button title="Align Bottom"
-                        data-select-class="justify-content-end"
-                        data-img="/website/static/src/img/snippets_options/align_solo_bottom.svg"/>
-            </we-button-group>
-        </div>
-    </xpath>
-    <!-- Add products -->
     <xpath expr="//t[@t-call='website.snippet_options_background_options']" position="before">
+        <!-- Vertical Alignment -->
+        <div data-js="vAlignment" id="row_valign_snippet_option" data-selector=".s_pricelist_cafe" data-target=".row:has(.s_pricelist_cafe_col)">
+            <t t-call="website.vertical_alignment_option"/>
+        </div>
+        <!-- Add products -->
         <div data-js="MultipleItems" data-selector=".s_pricelist_cafe">
             <t t-call="website.s_pricelist_cafe_add_product_widget">
                 <t t-set="apply_to" t-valuef="> :has(.s_pricelist_cafe_item):not(:has(.row > div:has(.s_pricelist_cafe_item)))"/>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -654,6 +654,23 @@
     </we-row>
 </template>
 
+<template id="vertical_alignment_option">
+    <we-button-group t-att-class="indent and 'o_we_sublevel_1'" string="Vert. Alignment" title="Vertical Alignment" data-dependencies="normal_mode">
+        <we-button title="Align Top"
+                    data-select-class="align-items-start"
+                    data-img="/website/static/src/img/snippets_options/align_top.svg"/>
+        <we-button title="Align Middle"
+                    data-select-class="align-items-center"
+                    data-img="/website/static/src/img/snippets_options/align_middle.svg"/>
+        <we-button title="Align Bottom"
+                    data-select-class="align-items-end"
+                    data-img="/website/static/src/img/snippets_options/align_bottom.svg"/>
+        <we-button title="Stretch to Equal Height"
+                    data-select-class="align-items-stretch"
+                    data-img="/website/static/src/img/snippets_options/align_stretch.svg"/>
+    </we-button-group>
+</template>
+
 <template id="snippet_options" inherit_id="web_editor.snippet_options" primary="True">
     <!-- =================================================================== -->
     <!-- Modify generic snippet options                                      -->
@@ -859,21 +876,12 @@
     </div>
 
     <!--  Vertical Alignment -->
-    <div data-js="vAlignment" id="row_valign_snippet_option" data-selector=".s_text_image, .s_image_text, .s_three_columns, .s_showcase, .s_numbers, .s_faq_collapse, .s_references, .s_accordion_image, .s_shape_image" data-target=".row">
-        <we-button-group class="o_we_sublevel_1" string="Vert. Alignment" title="Vertical Alignment" data-dependencies="normal_mode">
-            <we-button title="Align Top"
-                       data-select-class="align-items-start"
-                       data-img="/website/static/src/img/snippets_options/align_top.svg"/>
-            <we-button title="Align Middle"
-                       data-select-class="align-items-center"
-                       data-img="/website/static/src/img/snippets_options/align_middle.svg"/>
-            <we-button title="Align Bottom"
-                       data-select-class="align-items-end"
-                       data-img="/website/static/src/img/snippets_options/align_bottom.svg"/>
-            <we-button title="Stretch to Equal Height"
-                       data-select-class="align-items-stretch"
-                       data-img="/website/static/src/img/snippets_options/align_stretch.svg"/>
-        </we-button-group>
+    <div data-js="vAlignment" id="row_valign_snippet_option"
+         data-selector=".s_text_image, .s_image_text, .s_three_columns, .s_showcase, .s_numbers, .s_faq_collapse, .s_references, .s_accordion_image, .s_shape_image"
+         data-target=".row">
+        <t t-call="website.vertical_alignment_option">
+            <t t-set="indent" t-value="True"/>
+        </t>
     </div>
 
     <!-- Move snippets around -->

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -294,7 +294,7 @@
                 <t t-snippet="website.s_product_catalog" string="Pricelist" group="text">
                     <keywords>menu, pricing</keywords>
                 </t>
-                <t t-snippet="website.s_pricelist_cafe" string="Pricelist cafe" group="text">
+                <t t-snippet="website.s_pricelist_cafe" string="Pricelist Cafe" group="text">
                     <keywords>menu, pricing, shop, table, cart, product, cost, charges, fees, tarifs, prices, expenses, columns</keywords>
                 </t>
                 <t t-snippet="website.s_pricelist_boxed" string="Pricelist Boxed" group="text">

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -834,7 +834,7 @@
 
     <!-- Grid only -->
     <div data-js="layout_column"
-        data-selector="section.s_masonry_block, section.s_image_frame, section.s_contact_info"
+        data-selector="section.s_masonry_block, section.s_quadrant, section.s_image_frame, section.s_contact_info"
         data-target="> *:has(> .row)">
         <t t-call="website.grid_layout_options"/>
     </div>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -851,7 +851,7 @@
 
     <!-- Grid only -->
     <div data-js="layout_column"
-        data-selector="section.s_masonry_block, section.s_quadrant, section.s_image_frame, section.s_contact_info"
+        data-selector="section.s_masonry_block, section.s_quadrant, section.s_image_frame, section.s_card_offset, section.s_contact_info"
         data-target="> *:has(> .row)">
         <t t-call="website.grid_layout_options"/>
     </div>


### PR DESCRIPTION
This PR regroups some fixes about snippets with columns wrongly set to `display: flex` in order to have a "Vertical Alignment" option to align the content in it. Indeed, `display: flex` should be avoided, as any element in it tries to fill the available space, making the images not have their real size.