### PR TITLE
[FIX] l10n_latam_check: Restrict draft payment with other operations

### DIFF
--- a/addons/l10n_latam_check/i18n/l10n_latam_check.pot
+++ b/addons/l10n_latam_check/i18n/l10n_latam_check.pot
@@ -390,6 +390,15 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_latam_check/models/account_payment.py:0
 #, python-format
+msgid ""
+"This third party check is already used to make one or more payments. Please reset them to draft first.\n"
+"Payments made with this check: %s"
+msgstr ""
+
+#. module: l10n_latam_check
+#. odoo-python
+#: code:addons/l10n_latam_check/models/account_payment.py:0
+#, python-format
 msgid "Unmark sent is not implemented for electronic or deferred checks"
 msgstr ""
 

--- a/addons/l10n_latam_check/models/account_payment.py
+++ b/addons/l10n_latam_check/models/account_payment.py
@@ -273,6 +273,14 @@ class AccountPayment(models.Model):
         self.filtered(lambda x: x.payment_method_line_id.code == 'check_printing' and x.l10n_latam_manual_checks).write({'is_move_sent': True})
         return res
 
+    def action_draft(self):
+        if self.l10n_latam_check_operation_ids.filtered(lambda x: x.state == "posted"):
+            raise ValidationError(_(
+               "This third party check is already used to make one or more payments. Please reset them to draft first.\n"
+                "Payments made with this check: %s",
+                "".join(f'\n    - {payment.name}' for payment in self.l10n_latam_check_operation_ids)))
+        return super().action_draft()
+
     @api.model
     def _get_trigger_fields_to_synchronize(self):
         res = super()._get_trigger_fields_to_synchronize()


### PR DESCRIPTION
Version: 16.0+

Issue:
A vendor bill paid with an existing check remains paid although the check has been removed. This is because the vendor payment is made with the check and the payment is still reconciled with the vendor bill. This will lead to inconsistent/erroneous display of the payment status of the vendor bill.

Purpose of this PR:
Prevent the check payments with other operations from being reset to draft or removed. Instead raise an error to notify the user that the payment is used for other account moves.

Steps to reproduce in runbot:
1) set up latam checks in database
2) make an invoice and use a check as payment
3) make a bill and use the existing check to pay for the bill 
4) go back to the invoice and reset the payment to draft and delete the payment 
5) the vendor payment will remain and be marked as paid/partial paid

opw-4189731
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
