### PR TITLE
[FIX] crm: update lead language based on partner

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -406,16 +406,15 @@ class Lead(models.Model):
     @api.depends('partner_id')
     def _compute_lang_id(self):
         """ compute the lang based on partner when partner_id has changed """
-        wo_lang = self.filtered(lambda lead: not lead.lang_id and lead.partner_id)
-        if not wo_lang:
-            return
-        # prepare cache
-        lang_codes = [code for code in wo_lang.mapped('partner_id.lang') if code]
-        lang_id_by_code = dict(
-            (code, self.env['res.lang']._lang_get_id(code))
-            for code in lang_codes
-        )
-        for lead in wo_lang:
+        lang_codes = [code for code in self.mapped('partner_id.lang') if code]
+        if lang_codes:
+            lang_id_by_code = {
+                code: self.env['res.lang']._lang_get_id(code)
+                for code in lang_codes
+            }
+        else:
+            lang_id_by_code = {}
+        for lead in self.filtered('partner_id'):
             lead.lang_id = lang_id_by_code.get(lead.partner_id.lang, False)
 
     @api.depends('partner_id')


### PR DESCRIPTION
* This refix what have been done in https://github.com/odoo/odoo/pull/95962/commits/445fd4654dad3e459d86e3ec3661f7a513363d67
* STEP TO REPRODUCE: create a new lead, first set partner A with en lang , lang in lead is en -> then edit lead change to partner B -> lang not update at all

* NOTE: this issue is not in >=16.0

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
