### PR TITLE
[FIX] account: fix blank customer on payment and receipt

### DIFF
--- a/addons/account/views/report_payment_receipt_templates.xml
+++ b/addons/account/views/report_payment_receipt_templates.xml
@@ -17,11 +17,11 @@
                     <div class="row">
                         <div class="col-6" t-if="o.partner_type">
                             <t t-if="o.partner_type == 'customer'">
-                                Customer:
+                                Customer: 
                             </t>
                             <t t-else="o.partner_type == 'supplier'">
-                                Vendor:
-                            </t><span t-field="o.partner_id">Marc Demo</span>
+                                Vendor: 
+                            </t><span t-field="o.partner_id" data-oe-demo="Marc Demo"/>
                         </div>
                         <div name="payment_method"
                              t-if="values['display_payment_method'] and o.payment_method_id"


### PR DESCRIPTION
## Before this commit:
When creating a Payment/Receipt without specifying a partner, the system defaulted to `Marc Demo` as the customer on the printed PDF.

## After this commit:
The customer field on the PDF remains blank if no partner is specified. It only displays the customer name when a partner is specified.

> Task: 4182618
