### PR TITLE
[IMP] mrp_subcontracting: Better user experience

### DIFF
--- a/addons/mrp_subcontracting/models/mrp_bom.py
+++ b/addons/mrp_subcontracting/models/mrp_bom.py
@@ -25,3 +25,8 @@ class MrpBom(models.Model):
     def _check_subcontracting_no_operation(self):
         if self.filtered_domain([('type', '=', 'subcontract'), '|', ('operation_ids', '!=', False), ('byproduct_ids', '!=', False)]):
             raise ValidationError(_('You can not set a Bill of Material with operations or by-product line as subcontracting.'))
+
+    @api.onchange('type')
+    def _onchange_type(self):
+        if self.type == 'subcontract':
+            self.operation_ids = False


### PR DESCRIPTION
**Before commit**
  - When a user duplicates a BOM that has been associated with 'Operations' and then changes the BOM type to 'Subcontracting' and saves, the system will display a warning.

**After commit**
  - When the BOM type is changed to Subcontracting, operation_ids will be set to False.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
