### PR TITLE
[FIX] mail: filter only active user for discuss channel member

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -316,9 +316,10 @@ class Channel(models.Model):
     def _subscribe_users_automatically_get_members(self):
         """ Return new members per channel ID """
         return dict(
-            (channel.id, (channel.group_ids.users.partner_id - channel.channel_partner_ids).ids)
-            for channel in self
-        )
+            (channel.id,
+             ((channel.group_ids.users.partner_id.filtered(lambda p: p.active) - channel.channel_partner_ids).ids))
+                for channel in self
+            )
 
     def action_unfollow(self):
         self._action_unfollow(self.env.user.partner_id)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- While automatically subscribing new users to the discussion channel, we encounter a unique constraint violation `discuss_channel_member_partner_unique`. This happens because, when determining the `new_member`, we retrieve all users (both active and inactive 'channel.group_ids.users.partner_id'). [ref](https://github.com/odoo/odoo/blob/eac6b58a68948a2cdc0b97e7c62c92ff6270fd7a/addons/mail/models/discuss/discuss_channel.py#L330-L334) However, when checking for already
subscribed members, inactive users are ignored due to the `channel_partner_ids` computation. As a result, an inactive user who is already subscribed is incorrectly considered a `new_member`.

Current behavior before PR:

- Upgrade process got blocked if the inactive user already exists as member of the channe

Desired behavior after PR is merged:

- Adding inactive user to the discuss channel is pointless so we ensure only active user

OPW- 4169746
UPG- 2020544
TGB- 1531


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
