### PR TITLE
[IMP] event{_sale}: improve barcode scanner flow to easily handle larger crowd

### DIFF
--- a/addons/event/__manifest__.py
+++ b/addons/event/__manifest__.py
@@ -57,6 +57,7 @@ Key Features
             'event/static/src/icon_selection_field/icon_selection_field.xml',
             'event/static/src/template_reference_field/*',
             'event/static/src/js/tours/**/*',
+            'event/static/src/views/*',
         ],
         'web.assets_frontend': [
             'event/static/src/js/tours/**/*',

--- a/addons/event/controllers/main.py
+++ b/addons/event/controllers/main.py
@@ -89,7 +89,7 @@ class EventController(Controller):
             }
         else:
             return {
-                'name': _('Registration Desk'),
+                'name': _('Event Registrations'),
                 'country': False,
                 'city': False,
                 'company_name': request.env.company.name,

--- a/addons/event/i18n/event.pot
+++ b/addons/event/i18n/event.pot
@@ -1918,6 +1918,12 @@ msgid "Event Registration Answer"
 msgstr ""
 
 #. module: event
+#. odoo-python
+#: code:addons/event/controllers/main.py:0
+msgid "Event Registrations"
+msgstr ""
+
+#. module: event
 #: model:ir.model.fields,field_description:event.field_event_registration__event_user_id
 msgid "Event Responsible"
 msgstr ""
@@ -3351,6 +3357,12 @@ msgid "Scan a badge"
 msgstr ""
 
 #. module: event
+#. odoo-javascript
+#: code:addons/event/static/src/client_action/event_barcode.xml:0
+msgid "Scan or Tap"
+msgstr ""
+
+#. module: event
 #: model_terms:ir.ui.view,arch_db:event.res_config_settings_view_form
 msgid "Schedule & Tracks"
 msgstr ""
@@ -3959,6 +3971,12 @@ msgstr ""
 msgid ""
 "Under this technical menu you will find all scheduled communication related "
 "to your events."
+msgstr ""
+
+#. module: event
+#. odoo-javascript
+#: code:addons/event/static/src/client_action/event_registration_summary_dialog.xml:0
+msgid "Undo"
 msgstr ""
 
 #. module: event

--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -182,6 +182,8 @@ class EventRegistration(models.Model):
         res = attendee._get_registration_summary()
         if attendee.state == 'cancel':
             status = 'canceled_registration'
+        elif attendee.state == 'draft':
+            status = 'unconfirmed_registration'
         elif attendee.event_id.is_finished:
             status = 'not_ongoing_event'
         elif attendee.state != 'done':

--- a/addons/event/static/src/client_action/event_barcode.js
+++ b/addons/event/static/src/client_action/event_barcode.js
@@ -116,11 +116,16 @@ export class EventScanView extends Component {
 
     onClickSelectAttendee() {
         if (this.isMultiEvent) {
-            this.actionService.doAction("event.event_registration_action");
+            this.actionService.doAction("event.event_registration_action", {
+                additionalContext: {
+                    is_registration_desk_view: true,
+                },
+            });
         } else {
             this.actionService.doAction("event.event_registration_action_kanban", {
                 additionalContext: {
                     active_id: this.eventId,
+                    is_registration_desk_view: true,
                     search_default_unconfirmed: true,
                     search_default_confirmed: true,
                 },

--- a/addons/event/static/src/client_action/event_barcode.scss
+++ b/addons/event/static/src/client_action/event_barcode.scss
@@ -24,6 +24,30 @@
         max-width: 200px;
         max-height: 100px;
     }
+    .o_barcode_mobile_container {
+        margin-top: 40px;
+        margin-bottom: -40px;
+        img {
+            height: 185px;
+            width: 275px;
+        }
+        // In order to have the o_mobile_barcode button on both the image and the label,
+        // We use negative margin at the bottom and 0 opacity (since not needed in the view)
+        .o_mobile_barcode {
+            opacity: 0;
+            height: 225px;
+            width: 275px;
+            bottom: -40px;
+        }
+        .o_barcode_laser {
+            height: 3px;
+            width: 125%;
+            left: -12.5%;
+        }
+    }
+    @include media-breakpoint-down(md) {
+        padding: 0 1em 1em .75em;
+    }
     @include media-breakpoint-up(md) {
         flex: 0 0 auto;
         width: 550px;
@@ -32,7 +56,7 @@
         -moz-border-radius: 10px;
         box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.6);
         font-size: 1.2em;
-        padding: 3em;
+        padding: 0 1em 1em .75em;
     }
 }
 .o_notification_manager {

--- a/addons/event/static/src/client_action/event_barcode.xml
+++ b/addons/event/static/src/client_action/event_barcode.xml
@@ -5,8 +5,8 @@
     <t t-name="event.EventScanView">
         <div class="o_event_barcode_bg o_home_menu_background">
             <div class="o_event_barcode_main bg-view">
-                <a href="#" class="o_event_previous_menu float-start"><i class="oi oi-chevron-left" t-on-click.prevent="() => this.onClickBackToEvents()"></i></a>
-                <div class="text-center">
+                <a t-if="!isDisplayStandalone" href="#" class="o_event_previous_menu float-start"><i class="oi oi-chevron-left fa-lg mt-3" t-on-click.prevent="() => this.onClickBackToEvents()"></i></a>
+                <div class="mt48">
                     <h1 t-out="data.name"/>
                     <p>
                         <t t-if="data.city and data.country">
@@ -18,16 +18,16 @@
                     <h2><small>Welcome to</small> <t t-out="data.company_name"/></h2>
                     <img t-if="data.company_id" t-attf-src="/web/image/res.company/{{data.company_id}}/logo_web" alt="Company Logo" class="o_event_barcode_company_image"/>
                 </div>
-                <div class="row">
-                    <div class="col-sm-5 mt16">
+                <div class="d-flex flex-column justify-content-center">
+                    <div class="mt16">
                         <BarcodeScanner onBarcodeScanned="(ev) => this.onBarcodeScanned(ev)"/>
-                        <h5 class="mt8 mb0 text-muted">Scan a badge</h5>
+                        <h5 class="my-5 text-muted">Scan or Tap</h5>
                     </div>
-                    <div class="col-sm-2 mt32">
+                    <div>
                         <h4 class="mt0 mb8"><i>or</i></h4>
                     </div>
-                    <div class="col-sm-5 mt16">
-                        <button class="o_event_select_attendee btn btn-primary mb16" t-on-click="() => this.onClickSelectAttendee()">
+                    <div class="mt32">
+                        <button class="o_event_select_attendee btn btn-primary w-100 mb16" t-on-click="() => this.onClickSelectAttendee()">
                             <div class="mb16 mt16">Select Attendee</div>
                         </button>
                     </div>

--- a/addons/event/static/src/client_action/event_registration_summary_dialog.js
+++ b/addons/event/static/src/client_action/event_registration_summary_dialog.js
@@ -20,9 +20,10 @@ export class EventRegistrationSummaryDialog extends Component {
     static components = { Dialog };
     static props = {
         close: Function,
-        doNextScan: Function,
-        playSound: Function,
-        registration: Object,
+        doNextScan: { type: Function, optional: true },
+        model: { type: Object, optional: true },
+        playSound: { type: Function, optional: true },
+        registration: { type: Object },
     };
 
     setup() {
@@ -46,15 +47,15 @@ export class EventRegistrationSummaryDialog extends Component {
         }
 
         onMounted(() => {
-            if (this.props.registration.status === 'already_registered' || this.props.registration.status === 'need_manual_confirmation') {
+            if (['already_registered', 'need_manual_confirmation'].includes(this.props.registration.status) && this.props.playSound) {
                 this.props.playSound("notify");
-            } else if (this.props.registration.status === 'not_ongoing_event' || this.props.registration.status === 'canceled_registration') {
+            } else if (['not_ongoing_event', 'canceled_registration'].includes(this.props.registration.status) && this.props.playSound) {
                 this.props.playSound("error");
             } else if (this.props.registration.status === 'confirmed_registration' && this.printSettings.autoPrint && this.useIotPrinter && this.hasSelectedPrinter()) {
                 this.onRegistrationPrintPdf();
             }
             // Without this, repeat barcode scans don't work as focus is lost
-            this.continueButtonRef.el.focus();
+            this.continueButtonRef.el?.focus();
         });
     }
 
@@ -73,6 +74,25 @@ export class EventRegistrationSummaryDialog extends Component {
     async onRegistrationConfirm() {
         await this.orm.call("event.registration", "action_set_done", [this.registration.id]);
         this.registrationStatus.value = "confirmed_registration";
+        this.props.close();
+        if (this.props.model) {
+            this.props.model.load();
+        }
+        if (this.props.doNextScan) {
+            this.onScanNext();
+        }
+    }
+
+    async undoRegistration() {
+        if (["confirmed_registration", "already_registered"].includes(this.registrationStatus.value)) {
+            await this.orm.call("event.registration", "action_confirm", [this.registration.id]);
+        } else if (this.registrationStatus.value == "unconfirmed_registration") {
+            await this.orm.call("event.registration", "action_set_draft", [this.registration.id]);
+        }
+        this.props.close();
+        if (this.props.model) {
+            this.props.model.load();
+        }
     }
 
     async onRegistrationPrintPdf() {

--- a/addons/event/static/src/client_action/event_registration_summary_dialog.xml
+++ b/addons/event/static/src/client_action/event_registration_summary_dialog.xml
@@ -6,12 +6,15 @@
        <Dialog size="'md'" title="'Home'">
             <div class="row">
                 <div class="col-lg-10 w-100 fs-2">
-                    <div t-if="registrationStatus.value === 'confirmed_registration'" class="alert alert-success text-center" role="alert">
-                        <i class="fa fa-solid fa-check-circle me-2"/>
+                    <div t-if="['confirmed_registration', 'unconfirmed_registration'].includes(registrationStatus.value)" class="alert alert-success d-flex justify-content-center" role="alert">
+                        <i class="fa fa-solid fa-check-circle align-self-center me-2 ms-0 ms-sm-5"/>
                         <span>Successfully registered!</span>
+                        <button type="button" class="btn btn-link ms-3 ms-sm-5" t-on-click="undoRegistration">
+                            Undo
+                        </button>
                     </div>
-                    <div t-else="" class="alert alert-warning text-center" role="alert">
-                        <i class="fa fa-solid fa-exclamation-circle me-2"/>
+                    <div t-else="" class="alert alert-warning d-flex justify-content-center" role="alert">
+                        <i class="fa fa-solid fa-exclamation-circle me-2 align-self-center ms-0 ms-sm-5"/>
                         <t t-if="registrationStatus.value === 'need_manual_confirmation'">
                             <span>This ticket is for another event!<br/>
                             Confirm attendance?</span>
@@ -25,6 +28,9 @@
                         <t t-elif="registrationStatus.value == 'already_registered'">
                             <span>Ticket already scanned!</span>
                         </t>
+                        <button type="button" class="btn btn-link ms-3 ms-sm-5" t-on-click="undoRegistration">
+                            Undo
+                        </button>
                     </div>
                 </div>
             </div>
@@ -72,8 +78,7 @@
                 </div>
             </div>
             <t t-set-slot="footer">
-                <button t-if="needManualConfirmation" class="btn btn-primary" t-on-click="() => this.onRegistrationConfirm()">Confirm</button>
-                <button t-ref="continueButton" class="btn btn-primary" t-on-click="() => this.onScanNext()">Continue</button>
+                <button t-ref="continueButton" class="btn btn-primary" t-on-click="() => this.onRegistrationConfirm()">Continue</button>
                 <button t-att-disabled="!hasSelectedPrinter()" class="btn btn-primary" t-on-click="() => this.onRegistrationPrintPdf()">Print</button>
                 <button class="btn btn-secondary" t-on-click="() => this.onRegistrationView()">Edit</button>
             </t>

--- a/addons/event/static/src/scss/event.scss
+++ b/addons/event/static/src/scss/event.scss
@@ -30,6 +30,16 @@
             min-height: 95px;
         }
     }
+    .o_kanban_record_title {
+        margin-right: 35px;
+    }
+    .o_kanban_event_registration_event_name{
+        margin-right: 35px;
+    }
+    .o_event_registration_kanban_badge {
+        font-size: 1.2rem;
+        padding: 7px 5px;
+    }
 }
 
 .o_event_registration_view_tree {

--- a/addons/event/static/src/views/event_registration_kanban_controller.js
+++ b/addons/event/static/src/views/event_registration_kanban_controller.js
@@ -1,0 +1,43 @@
+import { kanbanView } from "@web/views/kanban/kanban_view";
+import { KanbanController } from "@web/views/kanban/kanban_controller";
+import { EventRegistrationSummaryDialog } from "@event/client_action/event_registration_summary_dialog";
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+
+export class EventRegistrationKanbanController extends KanbanController {
+
+    setup() {
+        super.setup()
+        this.dialog = useService("dialog");
+        this.orm = useService("orm");
+    }
+
+    async openRecord(record, mode) {
+        if (this.props.context.is_registration_desk_view) {
+            const barcode = record.data.barcode;
+            const eventId = record.data.event_id[0];
+
+            const result = await this.orm.call("event.registration", "register_attendee", [], {
+                barcode: barcode,
+                event_id: eventId,
+            });
+
+            this.dialog.add(
+                EventRegistrationSummaryDialog,
+                {
+                    model: this.model,
+                    registration: result
+                }
+            );
+        } else {
+            return super.openRecord(record, mode);
+        }
+    }
+}
+
+export const EventRegistrationKanbanView = {
+    ...kanbanView,
+   Controller: EventRegistrationKanbanController,
+}
+
+registry.category("views").add("registration_summary_dialog_kanban", EventRegistrationKanbanView);

--- a/addons/event/static/src/views/event_registration_list_controller.js
+++ b/addons/event/static/src/views/event_registration_list_controller.js
@@ -1,0 +1,43 @@
+import { EventRegistrationSummaryDialog } from "@event/client_action/event_registration_summary_dialog";
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+import { listView } from "@web/views/list/list_view";
+import { ListController } from "@web/views/list/list_controller";
+
+export class EventRegistrationListController extends ListController {
+
+    setup() {
+        super.setup();
+        this.dialog = useService("dialog");
+        this.orm = useService("orm");
+    }
+
+    async openRecord(record) {
+        if (this.props.context.is_registration_desk_view) {
+            const barcode = record.data.barcode;
+            const eventId = record.data.event_id[0];
+
+            const result = await this.orm.call("event.registration", "register_attendee", [], {
+                barcode: barcode,
+                event_id: eventId,
+            });
+
+            this.dialog.add(
+                EventRegistrationSummaryDialog,
+                {
+                    model: this.model,
+                    registration: result
+                }
+            );
+        } else {
+            return super.openRecord(record);
+        }
+    }
+}
+
+export const EventRegistrationListView = {
+    ...listView,
+   Controller: EventRegistrationListController,
+}
+
+registry.category("views").add("registration_summary_dialog_list", EventRegistrationListView);

--- a/addons/event/views/event_registration_views.xml
+++ b/addons/event/views/event_registration_views.xml
@@ -8,7 +8,8 @@
         <field name="arch" type="xml">
             <tree string="Registration" multi_edit="1" sample="1"
                   expand="1" default_order="create_date desc"
-                  class="o_event_registration_view_tree">
+                  class="o_event_registration_view_tree" js_class="registration_summary_dialog_list">
+                <field name="barcode" column_invisible="True"/>
                 <field name="active" column_invisible="True"/>
                 <field name="create_date" optional="show" string="Registration Date"/>
                 <field name="name"/>
@@ -132,15 +133,17 @@
         <field name="model">event.registration</field>
         <field name="priority">10</field>
         <field name="arch" type="xml">
-            <kanban class="o_event_attendee_kanban_view" default_order="name, create_date desc" sample="1">
+            <kanban class="o_event_attendee_kanban_view" default_order="name, create_date desc" sample="1" js_class="registration_summary_dialog_kanban">
                 <field name="name"/>
                 <field name="partner_id"/>
                 <field name="state"/>
                 <field name="email"/>
                 <field name="event_ticket_id"/>
                 <field name="active"/>
+                <field name="barcode"/>
                 <templates>
                     <t t-name="event_attendees_kanban_icons_desktop">
+                        <!-- Will be removed in master -->
                         <div class="d-none d-md-block h-100">
                             <div id="event_attendees_kanban_icons_desktop" class="h-100 float-end p-2 d-flex align-items-end flex-column gap-1">
                                 <t t-if="record.active.raw_value">
@@ -157,6 +160,7 @@
                         </div>
                     </t>
                     <t t-name="event_attendees_kanban_icons_mobile">
+                        <!-- Will be removed in master -->
                         <div id="event_attendees_kanban_icons_mobile" class="d-md-none d-flex align-items-end flex-column gap-1 h-100 ps-4">
                             <t t-if="record.active.raw_value">
                                 <a class="btn btn-secondary d-flex justify-content-center align-items-center h-100 w-100"
@@ -180,6 +184,7 @@
                                     <div class="oe_kanban_content h-100">
                                         <div class="o_kanban_record_body h-100 d-flex flex-column">
                                             <b class="o_kanban_record_title"><field name="name"/></b>
+                                            <field name="state" widget="badge" decoration-success="state == 'done'" class="position-absolute top-0 end-0 o_event_registration_kanban_badge"/>
                                             <div class="o_kanban_event_registration_event_name">
                                                 <field class="o_text_overflow text-primary" name="event_id" invisible="context.get('default_event_id')"/>
                                             </div>
@@ -195,10 +200,6 @@
                                             </div>
                                         </div>
                                     </div>
-                                </div>
-                                <div id="event_attendees_kanban_icons" class="col-4 col-md-3">
-                                    <t t-call="event_attendees_kanban_icons_desktop"/>
-                                    <t t-call="event_attendees_kanban_icons_mobile"/>
                                 </div>
                             </div>
                         </div>
@@ -336,7 +337,7 @@
     <record id="event_registration_action_kanban" model="ir.actions.act_window">
         <field name="res_model">event.registration</field>
         <field name="name">Attendees</field>
-        <field name="view_mode">kanban,tree,form,calendar,graph</field>
+        <field name="view_mode">kanban,tree,form</field>
         <field name="domain">[('event_id', '=', active_id)]</field>
         <field name="context">{'default_event_id': active_id}</field>
         <field name="help" type="html">
@@ -351,7 +352,8 @@
     <record id="event_registration_action" model="ir.actions.act_window">
         <field name="res_model">event.registration</field>
         <field name="name">Attendees</field>
-        <field name="view_mode">kanban,tree,form,calendar,graph</field>
+        <field name="view_mode">kanban,tree,form</field>
+        <field name="context">{'search_default_filter_is_ongoing': True}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 No Attendees expected yet!

--- a/addons/event_sale/views/event_registration_views.xml
+++ b/addons/event_sale/views/event_registration_views.xml
@@ -23,7 +23,7 @@
         <field name="inherit_id" ref="event.event_registration_view_kanban"/>
         <field name="arch" type="xml">
             <xpath expr="//div[hasclass('o_kanban_event_registration_event_name')]" position="inside">
-                <span invisible="context.get('default_event_id')" class="text-muted"> - </span><field name="sale_status"/>
+                <!-- This is a dummy record and will be removed in the master -->
             </xpath>
         </field>
     </record>

--- a/addons/hr_attendance/static/src/components/kiosk_barcode/kiosk_barcode.js
+++ b/addons/hr_attendance/static/src/components/kiosk_barcode/kiosk_barcode.js
@@ -9,6 +9,7 @@ export class KioskBarcodeScanner extends BarcodeScanner {
         barcodeSource: String,
         token: String,
     };
+    static template = "hr_attendance.BarcodeScanner";
     setup() {
         super.setup();
         this.scanBarcode = () => scanBarcode(this.env, this.facingMode, this.props.token);

--- a/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.xml
+++ b/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.xml
@@ -5,7 +5,7 @@
     <img t-att-src="companyImageUrl" alt="Company Logo" class="o_hr_attendance_kiosk_company_image align-self-center"/>
 </t>
 
-<t t-inherit="barcodes.BarcodeScanner" t-inherit-mode="extension">
+<t t-name="hr_attendance.BarcodeScanner" t-inherit="barcodes.BarcodeScanner" t-inherit-mode="primary">
     <xpath expr="//div[hasclass('o_barcode_mobile_container')]" position="replace">
         <button t-if="isBarcodeScannerSupported" t-on-click="openMobileScanner" class="o_mobile_barcode btn btn-light btn-lg p-5 rounded-3">
             <i class="fa fa-3x fa-barcode mb-3"/>


### PR DESCRIPTION
**Purpose:**
Enhance the barcode scanner interface and optimize the attendee registration process for more efficient handling of large volumes of attendees.

**Specifications:**
Change barcode scanner template.
- Make barcode template same as 'stock_barcode'
- Add a dynamic title

Modify attendees page.
- Remove check/uncheck button
- Replace payment status by status
- Keep status as a badge
- Only keep kanban and list view
- When clicking on record, it opens a dialog box same as if barcode is scanned (kanban and list).

Edit the dialog box which opens when user is marked attended.
- Keep status in one line.
- Add an undo button.
- Add Print and Edit buttons in footer which are 'Print Ticket' and 'Open Details' currently.

Removed a kanban view from event_sale module
- 'event_registration_view_kanban' view was no longer needed as replaced 'sales_status' wth 'status'
 
Mockup link: https://app.excalidraw.com/l/65VNwvy7c4X/88aC6OMVygk

Task-4159794