### PR TITLE
[FIX] web_editor, website: resolve first enable link traceback

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
@@ -115,6 +115,12 @@ export class LinkPopoverWidget {
             const popover = Popover.getInstance(this.target);
             popover.tip.classList.add('o_edit_menu_popover');
         })
+        .on("shown.bs.popover.link_popover", () => {
+            if (!this.target.getAttribute("aria-describedby") && popoverShown) {
+                this.popover = Popover.getInstance(this.target);
+                this.popover.show();
+            }
+        })
         .popover('show');
 
         this.popover = Popover.getInstance(this.target);

--- a/addons/website/static/src/components/autocomplete_with_pages/autocomplete_with_pages.js
+++ b/addons/website/static/src/components/autocomplete_with_pages/autocomplete_with_pages.js
@@ -150,7 +150,7 @@ export class AutoCompleteWithPages extends AutoComplete {
      */
     close() {
         this.props.onInput({
-            inputValue: this.inputRef.el.value,
+            inputValue: this.targetDropdown.value,
         });
         super.close();
     }

--- a/addons/website/static/tests/tours/link_tools.js
+++ b/addons/website/static/tests/tours/link_tools.js
@@ -296,28 +296,15 @@ wTourUtils.registerWebsitePreviewTour('link_tools', {
         trigger: "iframe .s_text_image p a[href='http://callmemaybe.com']:contains('callmemaybe.com')",
     },
     // 10. Test that UI stays up-to-date.
-    // TODO this step which was added by https://github.com/odoo/odoo/commit/9fc283b514d420fdfd66123845d9ec3563572692
-    // for no apparent reason (the X-original-commit of that one does not add
-    // this step) is not required for the test to work (it passes more often
-    // without this step than with it). It is a cause of race condition (last
-    // check: 31 over 162 tries failed on this). It however makes sense: the
-    // popover should indeed be shown and stay shown at this point. To be
-    // reenabled once the related feature is robust.
-    /*
     {
         content: "Popover should be shown",
         trigger: "iframe .o_edit_menu_popover .o_we_url_link:contains('http://callmemaybe.com')",
         isCheck: true,
     },
-    */
     {
         content: "Edit link label",
         trigger: "iframe .s_text_image p a",
         run(actions) {
-            // See SHOPS_STEP_DISABLED. TODO. These steps do not consistently
-            // update the link for some reason... to investigate.
-            /*
-            // Simulating text input.
             const link = this.$anchor[0];
             actions.text("callmemaybe.com/shops");
             // Trick the editor into keyboardType === 'PHYSICAL' and delete the
@@ -325,47 +312,30 @@ wTourUtils.registerWebsitePreviewTour('link_tools', {
             link.dispatchEvent(new KeyboardEvent("keydown", { key: "Backspace", bubbles: true }));
             // Trigger editor's '_onInput' handler, which leads to a history step.
             link.dispatchEvent(new InputEvent('input', {inputType: 'insertText', bubbles: true}));
-            */
         },
     },
-    // See SHOPS_STEP_DISABLED. TODO.
-    /*
+    {
+        content: "Resolve above step promises",
+        trigger: "iframe .s_text_image img",
+    },
     {
         content: "Check that links's href was updated",
         trigger: "iframe .s_text_image p a[href='http://callmemaybe.com/shop']:contains('callmemaybe.com/shop')",
-        isCheck: true,
     },
-    */
-    // TODO this step is disabled for now because it is a cause of race
-    // condition (last check: 57 over 162 tries failed on this). The popover
-    // seems to sometimes unexpectedly close. Probably why the "Popover should
-    // be shown" step above had to be disabled as well.
-    /*
     {
         content: "Check popover content is up-to-date",
         trigger: "iframe .popover div a:contains('http://callmemaybe.com/shop')",
         isCheck: true,
     },
-    */
-    // TODO this step is disabled for now because writing "/shop" in above steps
-    // currently is not considered most of the time all of a sudden... to
-    // investigate (it was not needed in 16.4). See SHOPS_STEP_DISABLED.
-    /*
     {
         content: "Check Link tools URL input content is up-to-date",
         trigger: "#o_link_dialog_url_input",
         run() {
-            // FIXME this was changed with 69a27360c98aee3d97eb42e9a27a751311791e15
-            // to omit the http:// part... but this part is removed
-            // inconsistently. Trying to fix the test actually made it so
-            // http:// is still there at this point... make it consistent and
-            // then remove http:// here again.
-            if (this.$anchor[0].value !== 'http://callmemaybe.com/shop') {
+            if (this.$anchor[0].value !== "callmemaybe.com/shop") {
                 throw new Error("Tour step failed");
             }
         }
     },
-    */
     // 11. Pick a URL with auto-complete
     {
         content: "Enter partial URL",
@@ -391,16 +361,11 @@ wTourUtils.registerWebsitePreviewTour('link_tools', {
         content: "Check that the link's href was updated and click on it",
         trigger: "iframe .s_text_image p a[href='/this-address-does-not-exist']",
     },
-    // TODO this step is disabled for now because it is a cause of race
-    // condition (last check: 3 times over 95). The popover seems to sometimes
-    // unexpectedly close.
-    /*
     {
         content: "Check popover content is up-to-date (2)",
         trigger: "iframe .popover div a:contains('/this-address-does-not-exist')",
         isCheck: true,
     },
-    */
     // 13. Check that ZWS is not added in the link label input.
     clickOnImgStep,
     {


### PR DESCRIPTION
Purpose:
Address the problematic steps in the link_tools tour that were previously disabled and marked as TODO in [1].

Solution:
1. Ensure proper popover instance handling:
   - Sometimes, the popover instance was not retrieved correctly, though it was checked in the .shown.bs.popover method of the popover.
   - If the aria-describedby attribute is not present, create and show a new popover instance.

2. Fix issue in autocomplete_with_pages file:
   - The link reset issue was occurring when the link was edited through text link.
   - Update the value to the current existing value instead of inputRef value.

3. Handle unresolved promises in input event:
   - After changing text in the input event, there were unresolved promises.
   - As we are in link edit mode, switch to another element to ensure promises are resolved.

This PR aims to resolve all the previously disabled steps in the link_tools tour.

[1]: https://github.com/odoo/odoo/pull/154827

task-3761631