### PR TITLE
[FIX] base_automation: on_stage_set uses filter_pre_domain

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -725,6 +725,7 @@ class BaseAutomation(models.Model):
                 records = create.origin(self.with_env(automations.env), vals_list, **kw)
                 # check postconditions, and execute actions on the records that satisfy them
                 for automation in automations.with_context(old_values=None):
+                    records = automation._filter_pre(records)
                     automation._process(automation._filter_post(records, feedback=True))
                 return records.with_env(self.env)
 

--- a/addons/test_base_automation/models/test_base_automation.py
+++ b/addons/test_base_automation/models/test_base_automation.py
@@ -28,6 +28,10 @@ class LeadTest(models.Model):
         'test_base_automation.stage', string='Stage',
         compute='_compute_stage_id', readonly=False, store=True)
 
+    type = fields.Selection([
+        ('lead', 'Lead'), ('opportunity', 'Opportunity')], required=True, index=True,
+        default=lambda self: 'lead' if self.env['res.users'].has_group('crm.group_use_lead') else 'opportunity')
+
     @api.depends('state')
     def _compute_stage_id(self):
         Stage = self.env['test_base_automation.stage']

--- a/addons/test_base_automation/tests/test_flow.py
+++ b/addons/test_base_automation/tests/test_flow.py
@@ -125,6 +125,25 @@ class BaseAutomationTest(TransactionCaseWithUserDemo):
         self.assertEqual(lead2.state, 'draft')
         self.assertEqual(lead2.user_id, self.user_demo)
 
+    def test_111_on_stage_set_pian(self):
+        """ Test case: on_stage_set, with filter_pre_domain and filter_domain"""
+        stage = self.create_stage()
+        create_automation(
+            self,
+            model_id=self.lead_model.id,
+            trigger='on_stage_set',
+            filter_domain="[('stage_id', '=', %s)]" % stage.id,
+            filter_pre_domain='[("type", "=", "lead")]',
+            _actions={'state': 'code', 'code': "record.write({'user_id': %s})" % (self.user_demo.id)},
+        )
+        # Creating a lead should trigger the automation
+        lead = self.create_lead(type='lead', stage_id=stage.id)
+        self.assertEqual(lead.user_id, self.user_demo)
+
+        # Creating an opportunity shouldn't trigger the automation
+        opportunity = self.create_lead(type='opportunity', stage_id=stage.id)
+        self.assertNotEqual(opportunity.user_id, self.user_demo, "This automation should run only on leads not opportunities")
+
     def test_001_on_create_or_write(self):
         """
         Test case: on save, with filter_domain


### PR DESCRIPTION
Reproduce
---
- -i crm,base_automation
- create new base.automation (Settings/Technical/Automation / Automation Rules)
	- "Model": "Lead/Opportunity"
	- "Trigger": "Stage is set to" "New"
	- "Domain": `[("type", "=","opportunity")]`
	- Create new action in "Actions To Do":
		- "Type": "Create Activity"
		- "Activity Type": "Email"
		- "Due Date In": 5
		- "User Type": Dynamic User
- Create new Opportunity -> activity is created (automation ran, all good)
- Create new LEAD -> activity is created (automation ran, BUG: IT SHOULD NOT )

opw-4149735

Post notes:
---
- it seems like a missing case in the test_base_automation
- after https://github.com/odoo/odoo/pull/114352 I have hard time understanding desired design of `filter_domain` and `filter_pre_domain`, perhaps we don't want to use `filter_pre_domain` at all in this case?
