### PR TITLE
[FIX] html_editor: don't display toolbar only select a zws

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -4,7 +4,6 @@ import {
     isMediaElement,
     isProtected,
     isProtecting,
-    isTextNode,
     paragraphRelatedElements,
     previousLeaf,
 } from "@html_editor/utils/dom_info";
@@ -581,10 +580,6 @@ export class SelectionPlugin extends Plugin {
             (nodes) => {
                 const edgeNodes = getUnselectedEdgeNodes(selection);
                 return nodes.filter((node) => !edgeNodes.has(node));
-            },
-            // Filter whitespace
-            (nodes) => {
-                return nodes.filter((node) => !isTextNode(node) || node.textContent !== "\n");
             },
             // Custom modifiers
             ...(this.resources.modifyTraversedNodes || []),

--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -1,5 +1,7 @@
 import { Plugin } from "@html_editor/plugin";
+import { isZWS } from "@html_editor/utils/dom_info";
 import { reactive } from "@odoo/owl";
+import { isTextNode } from "@web/views/view_compiler";
 import { Toolbar } from "./toolbar";
 import { hasTouch } from "@web/core/browser/feature_detection";
 import { registry } from "@web/core/registry";
@@ -129,6 +131,12 @@ export class ToolbarPlugin extends Plugin {
         }
     }
 
+    getFilterTraverseNodes() {
+        return this.shared
+            .getTraversedNodes()
+            .filter((node) => !isTextNode(node) || (node.textContent !== "\n" && !isZWS(node)));
+    }
+
     updateToolbarVisibility(selectionData) {
         if (this.config.disableFloatingToolbar) {
             return;
@@ -144,7 +152,7 @@ export class ToolbarPlugin extends Plugin {
         if (this.overlay.isOpen) {
             if (
                 !inEditable ||
-                ((isCollapsed || !this.shared.getTraversedNodes().length) && !this.isMobileToolbar)
+                ((isCollapsed || !this.getFilterTraverseNodes().length) && !this.isMobileToolbar)
             ) {
                 const preventClosing = selectionData.documentSelection?.anchorNode?.closest?.(
                     "[data-prevent-closing-overlay]"
@@ -176,7 +184,7 @@ export class ToolbarPlugin extends Plugin {
         if (!selection) {
             return;
         }
-        const nodes = this.shared.getTraversedNodes();
+        const nodes = this.getFilterTraverseNodes();
         for (const buttonGroup of this.buttonGroups) {
             if (buttonGroup.namespace === this.state.namespace) {
                 for (const button of buttonGroup.buttons) {

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -17,6 +17,7 @@ import { convertNumericToUnit, getCSSVariableValue, getHtmlStyle } from "../src/
 import { setupEditor } from "./_helpers/editor";
 import { unformat } from "./_helpers/format";
 import { getContent, moveSelectionOutsideEditor, setContent } from "./_helpers/selection";
+import { strong } from "./_helpers/tags";
 
 test.tags("desktop")(
     "toolbar is only visible when selection is not collapsed in desktop",
@@ -556,6 +557,24 @@ test.tags("desktop")(
 
         // This selection is possible when you double-click at the end of a line.
         setContent(el, "<p>a[</p>\n<p>]b</p>");
+        await tick(); // selectionChange
+        await animationFrame();
+        expect(".o-we-toolbar").toHaveCount(0);
+    }
+);
+
+test.tags("desktop")(
+    "close the toolbar if the selection contains any nodes (traverseNode = [], ignore zws)",
+    async () => {
+        const { el } = await setupEditor(`<p>ab${strong("\u200B", "first")}cd</p>`);
+        expect(".o-we-toolbar").toHaveCount(0);
+
+        setContent(el, `<p>a[b${strong("\u200B", "first")}c]d</p>`);
+        await tick(); // selectionChange
+        await animationFrame();
+        expect(".o-we-toolbar").toHaveCount(1);
+
+        setContent(el, `<p>ab${strong("[\u200B]", "first")}cd</p>`);
         await tick(); // selectionChange
         await animationFrame();
         expect(".o-we-toolbar").toHaveCount(0);


### PR DESCRIPTION
Before this PR, when only a zws (empty element) was selected, the toolbar was opened. For the user, the selection appears collapsed but the toolbar is still displayed.

How to reproduce:
- Go to an editor with text (‘abc’)
- Place the selection between ‘a’ and ‘b’.
- Press "ctrl + b"
- Press "shift + arrowright"
- press "shift + arrowleft"

Before this commit:
    The selection appears collapsed but the toolbar is displayed

After this commit:
    The toolbar is not displayed.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
