### PR TITLE
[FIX] account_edi_ubl_cii: use company registry for bis3 DK

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -99,6 +99,8 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
                 # DK-R-014: For Danish Suppliers it is mandatory to specify schemeID as "0184" (DK CVR-number) when
                 # PartyLegalEntity/CompanyID is used for AccountingSupplierParty
                 vals['company_id_attrs'] = {'schemeID': '0184'}
+                if partner.company_registry:
+                    vals['company_id'] = partner.company_registry
 
         return vals_list
 


### PR DESCRIPTION
For DK the expected company ID is the CVR, which corresponds to the company registry, not the VAT identifier.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
