### PR TITLE
[FIX] website: prevent website search box cache

### DIFF
--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2597,7 +2597,7 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
 </template>
 
 <template id="website_search_box" name="Website Searchbox">
-    <div t-attf-class="input-group #{_classes}" role="search">
+    <div t-attf-class="input-group #{_classes}" role="search" t-nocache="The searchbox should not cache previous searches.">
         <t t-set="search_placeholder">Search...</t>
         <input type="search" name="search" t-att-class="'search-query form-control oe_search_box border-0 bg-light %s' % _input_classes" t-att-placeholder="placeholder if placeholder else search_placeholder" t-att-value="search"/>
         <button type="submit" t-att-class="'btn oe_search_button %s' % (_submit_classes or 'btn-light')" aria-label="Search" title="Search">


### PR DESCRIPTION
__Current behavior before commit:__
When making a search through `/website/search`, the `website_search_box`
view is cached. This includes the search term and the search count.
Therefore when a user makes a search, a previous search term might be
displayed. It may even be a search that another user made.

This bug appeared since the search bar has been added to header
templates [`7559626`][1].

__Description of the fix:__
Add `t-nocache` to the whole searchbox so that the search term and the
search count is updated with each search.

__Steps to reproduce the issue in local:__
(For the issue to appear consistently everytime there should be only a
single worker)
1. Click on the search button in the website header and make a search
2. Do the same thing again with another search
3. Click again on the search button

The previous search term is shown inside the searchbar

opw-4114511

[1]: https://github.com/odoo/odoo/commit/7559626