### PR TITLE
[FIX] account: portal view invoice early payment discounts

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5148,11 +5148,17 @@ class AccountMove(models.Model):
             discount_date = epd_installment['line'].discount_date
             discount_amount_currency = epd_installment['discount_amount_currency']
             days_left = (discount_date - fields.Date.context_today(self)).days  # should never be lower than 0 since epd is valid
-            discount_msg = _(
-                "Discount of %(amount)s if paid %(when)s",
-                amount=self.currency_id.format(discount_amount_currency),
-                when=_("within %(days)s days", days=days_left) if days_left > 0 else _("today"),
-            )
+            if days_left > 0:
+                discount_msg = _(
+                    "Discount of %(amount)s if paid within %(days)s days",
+                    amount=self.currency_id.format(discount_amount_currency),
+                    days=days_left,
+                )
+            else:
+                discount_msg = _(
+                    "Discount of %(amount)s if paid today",
+                    amount=self.currency_id.format(discount_amount_currency),
+                )
 
             additional_info.update({
                 'epd_discount_amount_currency': discount_amount_currency,

--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -125,7 +125,7 @@
                                 Already Paid: <span t-out="amount_paid" t-options="{'widget': 'monetary', 'display_currency': currency}"/>
                             </div>
                             <div t-if="payment_state == 'partially_paid'" class="alert alert-warning px-2 py-1 text-center mb-2">
-                                Left to pay:
+                                Left to Pay:
                                 <span t-out="amount_due" t-options="{'widget': 'monetary', 'display_currency': currency}"/>
                                 <div t-if="installment_state and is_last_installment" class="w-100 mt-2">
                                     <i class="fa fa-clock-o"/>

--- a/addons/account_payment/views/account_portal_templates.xml
+++ b/addons/account_payment/views/account_portal_templates.xml
@@ -218,7 +218,7 @@
                                             <t t-call="payment.summary_item">
                                                 <t t-set="name" t-value="'reference_full'"/>
                                                 <t t-set="label">Reference</t>
-                                                <t t-set="value" t-value="next_payment_reference"/>
+                                                <t t-set="value" t-value="invoice_name"/>
                                                 <t t-set="include_separator" t-value="True"/>
                                             </t>
                                         </div>


### PR DESCRIPTION
In the previous commit https://github.com/odoo/odoo/commit/67e2270d56a81d385db3ca27d29fa3945501fca8, when using early payment discounts, a discount message is now displayed on the portal view. However, the translation of this message is not optimal, and this commit aims to fix it.

For example, in Dutch
Korting van € 100 indien vandaag betaald
Korting van € 100 indien betaald binnen 10 dagen

In the first case, "betaald" is after "today" while in the second case, it is before the "within 10 days"

Also, for consistency, turns this string "Left to pay" into title-case "Left to Pay"

Also, fixes the "Reference" in the portal payment wizard when paying the full amount. It was displayed the same reference as when paying only the installment, but with the full amount, the invoice name should be used as the reference.

task-4193178

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
