### PR TITLE
[FIX] gamification: display reached goals by default

### DIFF
--- a/addons/gamification/views/gamification_goal_views.xml
+++ b/addons/gamification/views/gamification_goal_views.xml
@@ -116,7 +116,7 @@
                         '|',
                             ('state', '=', 'inprogress'),
                             '&amp;',
-                                ('state', 'in', ('done', 'failed')),
+                                ('state', 'in', ('reached', 'failed')),
                                 ('end_date', '>=', context_today().strftime('%Y-%m-%d'))
                     ]"/>
                 <filter name="closed" string="Done"


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

The default filter for gamification goals called "Running" is supposed to show the currently active goals. In addition to goals that are in state "in_progress", it's supposed to show reached and failed goals too, but it doesn't, because it refers to a state called "done" which doesn't exist. When a goal is reached, the final state isn't "done" but "reached".

**Current behavior before PR:**

Users reach their goals, go to the goal kanban view, and only see their unreached and failed goals. It's fairly demotivating.

**Desired behavior after PR is merged:**

The goals' default filter "Running" shows active goals that are in progress, failed, or reached.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
