### PR TITLE
[FIX] hr: No content view causes a crash

### DIFF
--- a/addons/hr/static/src/views/hr_graph_controller.xml
+++ b/addons/hr/static/src/views/hr_graph_controller.xml
@@ -4,8 +4,8 @@
         <t t-call="web.ActionHelper" position="replace">
             <t t-if="!model.hasData() or model.useSampleModel and props.info.noContentHelp">
                 <HrActionHelper
-                    noContentTitle.translate="'No Data'"
-                    noContentParagraph.translate="'This report gives you an overview of your employees based on the measures of your choice.'"
+                    noContentTitle.translate="No Data"
+                    noContentParagraph.translate="This report gives you an overview of your employees based on the measures of your choice."
                 />
             </t>
         </t>

--- a/addons/hr/static/src/views/hr_pivot_controller.xml
+++ b/addons/hr/static/src/views/hr_pivot_controller.xml
@@ -3,7 +3,10 @@
     <t t-name="hr.PivotView" t-inherit="web.PivotView">
         <t t-call="web.ActionHelper" position="replace">
             <t t-if="!model.hasData() or model.useSampleModel and props.info.noContentHelp">
-                <HrActionHelper noContentHelp="props.info.noContentHelp" />
+                <HrActionHelper
+                    noContentTitle.translate="No Data"
+                    noContentParagraph.translate="This report gives you an overview of your employees based on the measures of your choice."
+                />
             </t>
         </t>
     </t>

--- a/addons/hr_org_chart/static/src/views/hr_employee_hierarchy/hr_employee_hierarchy_controller.xml
+++ b/addons/hr_org_chart/static/src/views/hr_employee_hierarchy/hr_employee_hierarchy_controller.xml
@@ -4,8 +4,8 @@
         <t t-call="web.ActionHelper" position="replace">
             <t t-if="props.info.noContentHelp">
                 <HrActionHelper
-                    noContentTitle.translate="'No Data'"
-                    noContentParagraph.translate="'In the Organigram you will have a clear overview of the hierarchy of employees.'"
+                    noContentTitle.translate="No Data"
+                    noContentParagraph.translate="In the Organigram you will have a clear overview of the hierarchy of employees."
                 />
             </t>
         </t>


### PR DESCRIPTION
A previous [pr](https://github.com/odoo/odoo/pull/176212) introduced a no content helper component. Unfortunately, this component was not used properly and would cause a traceback when using odoo in debug mode (props validation error).

Steps to reproduce the bug:
1. Be in debug mode
2. open Employee app
3. click the Pivot view
5. type some nonsense into the search bar and observe the traceback.

This pr addresses this bug by making sure the props are used properly.

task-4193259

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
