### PR TITLE
[IMP] spreadsheet_dashboard: store sample dashboard json file path

### DIFF
--- a/addons/spreadsheet_dashboard/models/spreadsheet_dashboard.py
+++ b/addons/spreadsheet_dashboard/models/spreadsheet_dashboard.py
@@ -12,6 +12,7 @@ class SpreadsheetDashboard(models.Model):
     name = fields.Char(required=True, translate=True)
     dashboard_group_id = fields.Many2one('spreadsheet.dashboard.group', required=True)
     sequence = fields.Integer()
+    sample_dashboard_file_path = fields.Char(export_string_translation=False)
     is_published = fields.Boolean(default=True)
     company_id = fields.Many2one('res.company')
     group_ids = fields.Many2many('res.groups', default=lambda self: self.env.ref('base.group_user'))


### PR DESCRIPTION
Currently, users with an fresh empty database will only see empty dashboards. They will go through a list of empty tables and charts without any data and probably miss the potential of the dashboard app.

For a proper onboarding experience, they should be greeted with a sample dashboard to give them a better idea of the dashboard look and use.

Technically, we store the sample json file path to use it when the main model has no records.

task-3947773

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
