### PR TITLE
[FIX] pos_online_payment: prevent error when try to add payment in kanban view

### DIFF
--- a/addons/point_of_sale/views/pos_payment_views.xml
+++ b/addons/point_of_sale/views/pos_payment_views.xml
@@ -56,7 +56,7 @@
         <field name="name">Payments</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">pos.payment</field>
-        <field name="view_mode">tree,kanban,form</field>
+        <field name="view_mode">tree,form</field>
         <field name="view_id" eval="False"/>
         <field name="domain">[]</field>
         <field name="context">{'search_default_group_by_payment_method': 1}</field>


### PR DESCRIPTION
This error occurs when attempting to add a payment using the ``Quick Add`` feature in the Kanban view.

Steps to reproduce:
- Install the ``pos_online_payment`` module
- Point of Sale > Orders > Payments > Go to Kanban view
- Click on the ``Quick Add`` button and ``Add``

Traceback:
``KeyError: 'payment_method_id'``

The error in [1] occurred because the ``payment_method_id`` was not found in the vals.

This commit will fix the above error by removing the Kanban view from payments because we never allow payment creation.

[1]- https://github.com/odoo/odoo/blob/42ab53925b140508e2aa837ce09c914b8f243b21/addons/pos_online_payment/models/pos_payment.py#L20

sentry-5750182450

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
