### PR TITLE
[FIX] spreadsheet: fix partial reload

### DIFF
--- a/addons/spreadsheet/static/src/pivot/odoo_pivot.js
+++ b/addons/spreadsheet/static/src/pivot/odoo_pivot.js
@@ -6,11 +6,12 @@ import { user } from "@web/core/user";
 import { NO_RECORD_AT_THIS_POSITION, OdooPivotModel } from "./pivot_model";
 import { EvaluationError, PivotRuntimeDefinition, registries, helpers } from "@odoo/o-spreadsheet";
 import { LOADING_ERROR } from "@spreadsheet/data_sources/data_source";
-import { deepEqual, omit } from "@web/core/utils/objects";
+import { omit } from "@web/core/utils/objects";
 import { OdooPivotLoader } from "./odoo_pivot_loader";
 
 const { pivotRegistry, supportedPivotPositionalFormulaRegistry } = registries;
-const { pivotTimeAdapter, toString, areDomainArgsFieldsValid, toNormalizedPivotValue } = helpers;
+const { pivotTimeAdapter, toString, areDomainArgsFieldsValid, toNormalizedPivotValue, deepEquals } =
+    helpers;
 
 /**
  * @typedef {import("@odoo/o-spreadsheet").FunctionResultObject} FunctionResultObject
@@ -81,15 +82,15 @@ export class OdooPivot {
         const actualDefinition = this.coreDefinition;
         this.coreDefinition = nextDefinition;
         if (
-            deepEqual(actualDefinition.columns, nextDefinition.columns) &&
-            deepEqual(actualDefinition.rows, nextDefinition.rows) &&
-            deepEqual(actualDefinition.sortedColumn, nextDefinition.sortedColumn) &&
-            deepEqual(actualDefinition.domain, nextDefinition.domain) &&
-            deepEqual(actualDefinition.context, nextDefinition.context) &&
-            deepEqual(actualDefinition.actionXmlId, nextDefinition.actionXmlId) &&
-            deepEqual(actualDefinition.model, nextDefinition.model)
+            deepEquals(actualDefinition.columns, nextDefinition.columns) &&
+            deepEquals(actualDefinition.rows, nextDefinition.rows) &&
+            deepEquals(actualDefinition.sortedColumn, nextDefinition.sortedColumn) &&
+            deepEquals(actualDefinition.domain, nextDefinition.domain) &&
+            deepEquals(actualDefinition.context, nextDefinition.context) &&
+            deepEquals(actualDefinition.actionXmlId, nextDefinition.actionXmlId) &&
+            deepEquals(actualDefinition.model, nextDefinition.model)
         ) {
-            if (deepEqual(actualDefinition.measures, nextDefinition.measures)) {
+            if (deepEquals(actualDefinition.measures, nextDefinition.measures)) {
                 // Nothing change for the table structure, no need to reload the data
                 return;
             }
@@ -107,6 +108,9 @@ export class OdooPivot {
     }
 
     isMeasuresTheSameForData(actualMeasures, nextMeasures) {
+        if (actualMeasures.length !== nextMeasures.length) {
+            return false;
+        }
         for (const measure of actualMeasures) {
             const updatedMeasure = nextMeasures.find((m) => m.id === measure.id);
             if (


### PR DESCRIPTION
Steps to reproduce:
- Insert a dynamic pivot table in a spreadsheet
- Add a new measure => The pivot table is reloaded, but thanks to a side effect [1]
- Add another measure => The pivot table is not reloaded [2]

[1] The pivot table is reloaded because the check for the diff in the pivot definition was done with a `deepEquals` which do not ignore undefined values. So when the pivot definition is updated with a new measure, the pivot definition is updated with the column/row from the side panel, with order and granularity potentially undefined, which triggers a reload.

[2] The pivot table was not reloaded because the check for the diff in the pivot measures didn't take into account the length of the measures.

This commit fixes the issues by:
[1] Using JSON.stringify
[2] Adding a check on the length of the measures

Task: 4193170

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
