### PR TITLE
[FIX] web_tour: observer in tour_interactive

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_interactive.js
+++ b/addons/web_tour/static/src/tour_service/tour_interactive.js
@@ -4,6 +4,7 @@ import { getScrollParent } from "@web_tour/tour_service/tour_utils";
 import * as hoot from "@odoo/hoot-dom";
 import { utils } from "@web/core/ui/ui_service";
 import { TourStep } from "./tour_step";
+import { MacroMutationObserver } from "@web/core/macro";
 
 /**
  * @typedef ConsumeEvent
@@ -36,7 +37,8 @@ export class TourInteractive {
         this.pointer = pointer;
         this.debouncedToggleOpen = debounce(this.pointer.showContent, 50, true);
         this.onTourEnd = onTourEnd;
-        this.observerDisconnect = hoot.observe(document.body, () => this._onMutation());
+        this.observer = new MacroMutationObserver(() => this._onMutation());
+        this.observer.observe(document.body);
         this.currentActionIndex = tourState.getCurrentIndex();
         this.play();
     }
@@ -78,7 +80,7 @@ export class TourInteractive {
     play() {
         this.removeListeners();
         if (this.currentActionIndex === this.actions.length) {
-            this.observerDisconnect();
+            this.observer.disconnect();
             this.onTourEnd();
             return;
         }

--- a/addons/web_tour/static/tests/tour_service.test.js
+++ b/addons/web_tour/static/tests/tour_service.test.js
@@ -1334,6 +1334,7 @@ test("check tooltip position", async () => {
     expect(tooltip.getBoundingClientRect().bottom).toBeLessThan(
         button3.getBoundingClientRect().top
     );
+    await contains(".button3").click();
 });
 
 test("check rainbowManMessage", async () => {


### PR DESCRIPTION
In this commit, we use MacroMutationObserver object to observe mutations in iframe and shadowDOM of the focussed element.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
