### PR TITLE
[FIX] hr_holidays: prevent in-use leave type allocation requirement edit

### DIFF
--- a/addons/hr_holidays/i18n/hr_holidays.pot
+++ b/addons/hr_holidays/i18n/hr_holidays.pot
@@ -3324,6 +3324,7 @@ msgid "Sick Time Off"
 msgstr ""
 
 #. module: hr_holidays
+#. odoo-python
 #: code:addons/hr_holidays/models/hr_leave_accrual_plan.py:0
 #, python-format
 msgid ""
@@ -3503,6 +3504,15 @@ msgid ""
 "The accrual starts after a defined period from the allocation start date. "
 "This field defines the number of days, months or years after which accrual "
 "is used."
+msgstr ""
+
+#. module: hr_holidays
+#. odoo-python
+#: code:addons/hr_holidays/models/hr_leave_type.py:0
+#, python-format
+msgid ""
+"The allocation requirement of a time off type cannot be changed once leaves "
+"of that type have been taken. You should create a new time off type instead."
 msgstr ""
 
 #. module: hr_holidays

--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -10,6 +10,7 @@ from collections import defaultdict
 from datetime import time, timedelta
 
 from odoo import api, fields, models
+from odoo.exceptions import UserError
 from odoo.osv import expression
 from odoo.tools import format_date
 from odoo.tools.translate import _
@@ -180,6 +181,11 @@ class HolidaysType(models.Model):
                 holiday_type.has_valid_allocation = bool(allocation)
             else:
                 holiday_type.has_valid_allocation = True
+
+    @api.constrains('requires_allocation')
+    def check_allocation_requirement_edit_validity(self):
+        if self.env['hr.leave'].search_count([('holiday_status_id', 'in', self.ids)], limit=1):
+            raise UserError(_("The allocation requirement of a time off type cannot be changed once leaves of that type have been taken. You should create a new time off type instead."))
 
     def _search_max_leaves(self, operator, value):
         value = float(value)


### PR DESCRIPTION
Steps to reproduce:
- Time off > Configuration > Time off types > New
- Set 'Requires Allocation' to 'No Limit'
- Takes leaves of this type
- Set 'Requires Allocation' to 'Yes'
- Approvals > Allocations > New > Select your time off type
- Edit validity period to start after the leaves you took
- Confirm > Click on the newly created allocation
- Displays -X remaining out of Y

The allocations try to cover leaves taken before the requirement was changed, when we'd expect leaves taken under No Limit mode not to require any. This is problematic because it can happen with past leaves as well, which we cannot get rid of on production databases.

Since Odoo does not track which allocation requirement mode leave are taken under nor the date and content of edits to that parameter, we cannot tell apart leaves of the same type when distributing allocated days. Tracking either would certainly require edits to the model which rules out stable versions, so instead the edits to allocation requirement should be restricted in favor of creating new time off types when we want to switch that parameter.

opw-3919886

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
