### PR TITLE
[IMP] mail: remove dead code

### DIFF
--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -168,12 +168,6 @@ export class Message extends Record {
     starred = false;
 
     /**
-     * We exclude the milliseconds because datetime string from the server don't
-     * have them. Message without date like transient message can be missordered
-     */
-    now = DateTime.now().set({ milliseconds: 0 });
-
-    /**
      * True if the backend would technically allow edition
      * @returns {boolean}
      */


### PR DESCRIPTION
`message.now` isn't used anywhere any more.
