### PR TITLE
[IMP] mail: do not bloat UI with new message notifications

### DIFF
--- a/addons/mail/static/src/core/common/out_of_focus_service.js
+++ b/addons/mail/static/src/core/common/out_of_focus_service.js
@@ -24,6 +24,7 @@ export class OutOfFocusService {
         this.audio = undefined;
         this.multiTab = services.multi_tab;
         this.notificationService = services.notification;
+        this.closeFuncs = [];
     }
 
     async notify(message, channel) {
@@ -110,7 +111,10 @@ export class OutOfFocusService {
      * @param {Object} options
      */
     async sendOdooNotification(message, options) {
-        this.notificationService.add(message, options);
+        this.closeFuncs.push(this.notificationService.add(message, options));
+        if (this.closeFuncs.length > 3) {
+            this.closeFuncs.shift()();
+        }
         this._playSound();
     }
 


### PR DESCRIPTION
When a new message is received on a channel different from the
currently displayed one, a notification is added. However, if many
messages are received in a short period, the notifications can bloat
the UI. This PR ensures that we display no more than three new message
notifications to avoid this issue. Notifications are removed in a FIFO
fashion.

Before:
![no_replace](https://github.com/user-attachments/assets/22785c4b-8e86-4086-a36e-08b2a1cdaaac)

After:
![replace_notif](https://github.com/user-attachments/assets/c2f9a6e7-64de-451c-9889-6464e0a20732)
