### PR TITLE
[FIX] mrp: do sanity check at _run_procurement

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -75,6 +75,8 @@ class StockRule(models.Model):
             if not mo:
                 procurement_qty = procurement.product_qty
                 batch_size = procurement.values.get('batch_size', procurement_qty)
+                if batch_size <= 0:
+                    batch_size = procurement_qty
                 vals = rule._prepare_mo_vals(*procurement, bom)
                 while float_compare(procurement_qty, 0, precision_rounding=procurement.product_uom.rounding) > 0:
                     current_qty = min(procurement_qty, batch_size)


### PR DESCRIPTION
We want to use batch_size in multiple places, so it's better to have a check at a more global level in addition to local checks.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
