### PR TITLE
[IMP] point_of_sale: add translation support for the public_description field

### DIFF
--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -18,6 +18,7 @@ class ProductTemplate(models.Model):
         help="Category used in the Point of Sale.")
     public_description = fields.Html(
         string="Product Description",
+        translate=True
     )
 
     @api.ondelete(at_uninstall=False)

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -398,7 +398,7 @@ export class TicketScreen extends Component {
             return _t("Paid");
         } else {
             const screen = order.get_screen_data();
-            return this._getOrderStates().get(this._getScreenToStatusMap()[screen.name]).text;
+            return this._getOrderStates().get(this._getScreenToStatusMap()[screen.name])?.text;
         }
     }
     /**


### PR DESCRIPTION
Before this commit:
===
The public_description field of product.template did not support translation.

After this commit:
===
The public_description field of  product.template now supports translation.

Fix:
===
When marking a delivery order as "Mark as Ready," add a check in the get_status function.

Task-4193467

Related: https://github.com/odoo/enterprise/pull/70214