### PR TITLE
[FIX] account: keep valid attachments on bill

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3209,8 +3209,6 @@ class AccountMove(models.Model):
                             invoices |= invoice
                             current_invoice = self.env['account.move']
                             add_file_data_results(file_data, invoice)
-                        if extend_with_existing_lines:
-                            return attachments_by_invoice
 
                 except RedirectWarning:
                     raise


### PR DESCRIPTION
To reporoduce:
==============
1. install "l10n_mx"
2. send an email to the vendor bill alias with both XML and PDF attached (use the ones on the ticket)
-> Odoo only retrieves the XML file and PDF is deleted

Problem:
========
when processing the files, `l10n_mx` may set `process_if_existing_lines = True` on some files, if one of these files is processed first, the other files will be ignored then deleted.

Solution:
=========
process all files.

opw-4054484

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
