### PR TITLE
[FIX] project: correct task Kanban card

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -675,14 +675,14 @@
                         <field name="color" widget="kanban_color_picker"/>
                     </t>
                     <t t-name="kanban-card">
+                        <field name="name" class="fw-bold fs-5"/>
                         <div t-att-class="['1_done', '1_canceled'].includes(record.state.raw_value) ? 'opacity-50' : ''">
-                            <field name="name" class="fw-bold fs-5"/>
                             <div class="text-muted">
                                 <field t-if="record.parent_id.raw_value" invisible="context.get('default_parent_id', False)" name="parent_id"/>
                                 <field invisible="context.get('default_project_id', False)" name="project_id" options="{'no_open': True}"/>
-                                <field t-if="record.partner_id.value" t-att-title="record.partner_id.value" name="partner_id" class="text-truncate d-block"/>
+                                <field t-if="record.partner_id.value" t-att-title="record.partner_id.value" name="partner_id" class="text-truncate"/>
                                 <span t-if="record.allow_milestones.raw_value and record.milestone_id.raw_value" t-att-class="record.has_late_and_unreached_milestone.raw_value and !record.state.raw_value.startsWith('1_') ? 'text-danger' : ''">
-                                    <field name="milestone_id" options="{'no_open': True}" />
+                                    <field name="milestone_id" options="{'no_open': True}" class="d-block"/>
                                 </span>
                             </div>
                         </div>


### PR DESCRIPTION
Before:
1.The worksheet template was displayed alongside the task name.
2.The city was not displayed next to the partner name on the task kanban card.

After:
1.The worksheet template is now display on a separate line, below the task name.
2.The city is now displayed next to the partner name on the task kanban card.

Task-4188560