### PR TITLE
[FIX] crm,calendar: ensure activitygroup popup close on mobile on activityclicked 

### DIFF
--- a/addons/calendar/static/src/activity/activity_menu_patch.js
+++ b/addons/calendar/static/src/activity/activity_menu_patch.js
@@ -6,7 +6,7 @@ import { patch } from "@web/core/utils/patch";
 patch(ActivityMenu.prototype, {
     openActivityGroup(group) {
         if (group.model === "calendar.event") {
-            document.body.click();
+            this.dropdown.close();
             this.action.doAction("calendar.action_calendar_event", {
                 additionalContext: {
                     default_mode: "day",

--- a/addons/crm/static/src/activity_menu_patch.js
+++ b/addons/crm/static/src/activity_menu_patch.js
@@ -23,7 +23,7 @@ patch(ActivityMenu.prototype, {
         // fetch the data from the button otherwise fetch the ones from the parent (.o_ActivityMenuView_activityGroup).
         const context = {};
         if (group.model === "crm.lead") {
-            document.body.click(); // hack to close dropdown
+            this.dropdown.close();
             if (filter === "my") {
                 context["search_default_activities_overdue"] = 1;
                 context["search_default_activities_today"] = 1;


### PR DESCRIPTION
Previous solution didn't work on mobile:
document.body.click(); // hack to close dropdown

Reproduce
---
- -i mail,crm,helpdesk
- On mobile: Click on "Activities" (fa-clock-o):
	- Selecting "Helpdesk Ticket" -> OK
	- Selecting "Lead/Opportunity" -> BUG 
	- Selecting "Calendar activity" -> BUG 

(it opens the leads with activities,
but it doesn't close the Activity popover, so user can't see it)

opw-4171180