### PR TITLE
[FIX] point_of_sale: set offline only when ConnectionLostError

### DIFF
--- a/addons/point_of_sale/static/src/app/models/data_service.js
+++ b/addons/point_of_sale/static/src/app/models/data_service.js
@@ -374,18 +374,18 @@ export class PosData extends Reactive {
 
             return result;
         } catch (error) {
-            const uuids = this.network.unsyncData.map((d) => d.uuid);
-            const skipError = error.constructor.name != "ConnectionLostError";
-            if (queue && !uuids.includes(uuid) && method !== "sync_from_ui" && !skipError) {
-                this.network.unsyncData.push({
-                    args: [...arguments],
-                    date: DateTime.now(),
-                    try: 1,
-                    uuid: uuidv4(),
-                });
+            if (error instanceof ConnectionLostError) {
+                const uuids = this.network.unsyncData.map((d) => d.uuid);
+                if (queue && !uuids.includes(uuid) && method !== "sync_from_ui") {
+                    this.network.unsyncData.push({
+                        args: [...arguments],
+                        date: DateTime.now(),
+                        try: 1,
+                        uuid: uuidv4(),
+                    });
+                }
+                this.setOffline();
             }
-
-            this.setOffline();
             throw error;
         } finally {
             this.network.loading = false;


### PR DESCRIPTION
When catching an error in the execute method, `setOffline` is called no matter the error.  But in case of an RPCError, it doesn't make sense.

The fix here, is to call `setOffline` only when we have a `ConnectionLostError`.

