### PR TITLE
[FIX] l10n_in{,_pos}: traceback when sell product with hsn code

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -190,6 +190,6 @@ class AccountMove(models.Model):
                 'discount': line.discount or 0.0,
                 'product': line.product_id,
                 'uom': line.product_uom_id,
-                'taxes': line.tax_ids,
+                'taxes_data': line.tax_ids,
             })
         return self.env['account.tax']._l10n_in_get_hsn_summary_table(base_lines, display_uom)

--- a/addons/l10n_in/models/account_tax.py
+++ b/addons/l10n_in/models/account_tax.py
@@ -50,7 +50,7 @@ class AccountTax(models.Model):
             quantity = base_line['quantity']
             product = base_line['product']
             uom = base_line['uom']
-            taxes = base_line['taxes']
+            taxes = base_line['taxes_data']
 
             final_price_unit = price_unit * (1 - (discount / 100))
 

--- a/addons/l10n_in/static/src/helpers/hsn_summary.js
+++ b/addons/l10n_in/static/src/helpers/hsn_summary.js
@@ -21,7 +21,7 @@ patch(accountTaxHelpers, {
             const quantity = base_line.quantity;
             const product = base_line.product;
             const uom = base_line.uom || {};
-            const taxes = base_line.taxes;
+            const taxes = base_line.taxes_data;
 
             const final_price_unit = price_unit * (1 - discount / 100);
 

--- a/addons/l10n_in/tests/test_hsn_summary.py
+++ b/addons/l10n_in/tests/test_hsn_summary.py
@@ -63,8 +63,8 @@ class TestHSNsummary(TestTaxCommon):
         new_base_lines = []
         for base_line in base_lines:
             base_line = dict(base_line)
-            taxes = base_line['taxes']
-            base_line['taxes'] = [self._jsonify_tax(tax) for tax in taxes]
+            taxes = base_line['taxes_data']
+            base_line['taxes_data'] = [self._jsonify_tax(tax) for tax in taxes]
             base_line['product'] = self._jsonify_product(base_line['product'], taxes)
             base_line['uom'] = self._jsonify_uom(base_line['uom'])
             new_base_lines.append(base_line)
@@ -97,7 +97,7 @@ class TestHSNsummary(TestTaxCommon):
             'discount': discount,
             'product': product,
             'uom': uom,
-            'taxes': taxes or self.env['account.tax'],
+            'taxes_data': taxes or self.env['account.tax'],
         }
 
     def test_l10n_in_hsn_summary_1(self):

--- a/addons/l10n_in_pos/models/__init__.py
+++ b/addons/l10n_in_pos/models/__init__.py
@@ -5,3 +5,4 @@ from . import pos_order
 from . import pos_order_line
 from . import product_product
 from . import account_move
+from . import account_tax

--- a/addons/l10n_in_pos/models/account_tax.py
+++ b/addons/l10n_in_pos/models/account_tax.py
@@ -1,0 +1,11 @@
+from odoo import api, models
+
+
+class AccountTax(models.Model):
+    _inherit = 'account.tax'
+
+    @api.model
+    def _load_pos_data_fields(self, config_id):
+        fields = super()._load_pos_data_fields(config_id)
+        fields += ['l10n_in_tax_type']
+        return fields


### PR DESCRIPTION
Steps:
----------
Step 1: Set up POS configuration with an Indian company (l10n_in).
Step 2: Enter HSN code for a product.
Step 3: Complete a regular order flow in POS.
A traceback occurs on the receipt page after payment.

Issue:
--------
Traceback appears after payment on Reciept page.

Cause:
-----------
`l10n_in_tax_type` field does not load in pos.
`taxes_data` is passed as base_line for tax computation in l10n_in for accountTaxHelpers in js, but `taxes` is used instead of `taxes_data`.

FIX:
----------
`l10n_in_tax_type` field is correctly loaded in POS. Use `taxes_data` for tax computation in the base_line

task- 4085939

