### PR TITLE
[FIX] point_of_sale: order categories by `id` for consistent ordering

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -95,9 +95,9 @@ export class ProductScreen extends Component {
             : this.pos.models["pos.category"].filter((category) => !category.parent_id);
     }
     getCategoriesAndSub() {
-        return this.getAncestorsAndCurrent().flatMap((category) =>
-            this.getChildCategoriesInfo(category)
-        );
+        return this.getAncestorsAndCurrent()
+            .flatMap((category) => this.getChildCategoriesInfo(category))
+            .toSorted((a, b) => a.id - b.id);
     }
 
     getChildCategoriesInfo(selectedCategory) {


### PR DESCRIPTION
Problem:
When clicking on a category with child categories in PoS, the order of the child categories changes unpredictably, leading to inconsistencies.

Steps to reproduce:
- Create PoS categories:
    > Parent A category > Child1 A category > Child2 B category
    > Parent B category > Child1 B category > Child2 A category
- Open PoS and navigate between categories.
- You'll notice inconsistent ordering when selecting child categories and their subcategories.

opw-4184020

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
