### PR TITLE
[FIX] sale_timesheet: treat vendor bills as expenses in project updates

### DIFF
--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -417,7 +417,7 @@ class Project(models.Model):
             return profitability_items
         aa_line_read_group = self.env['account.analytic.line'].sudo()._read_group(
             self.sudo()._get_profitability_aal_domain(),
-            ['timesheet_invoice_type', 'timesheet_invoice_id', 'currency_id'],
+            ['timesheet_invoice_type', 'timesheet_invoice_id', 'currency_id', 'category'],
             ['amount:sum', 'id:array_agg'],
         )
         can_see_timesheets = with_action and len(self) == 1 and self.user_has_groups('hr_timesheet.group_hr_timesheet_approver')
@@ -426,7 +426,9 @@ class Project(models.Model):
         total_revenues = {'invoiced': 0.0, 'to_invoice': 0.0}
         total_costs = {'billed': 0.0, 'to_bill': 0.0}
         convert_company = self.company_id or self.env.company
-        for timesheet_invoice_type, dummy, currency, amount, ids in aa_line_read_group:
+        for timesheet_invoice_type, dummy, currency, category, amount, ids in aa_line_read_group:
+            if category == 'vendor_bill':
+                continue  # This is done to prevent expense duplication with product re-invoice policies
             amount = currency._convert(amount, self.currency_id, convert_company)
             invoice_type = timesheet_invoice_type
             cost = costs_dict.setdefault(invoice_type, {'billed': 0.0, 'to_bill': 0.0})

--- a/addons/sale_timesheet/tests/test_reinvoice.py
+++ b/addons/sale_timesheet/tests/test_reinvoice.py
@@ -366,3 +366,47 @@ class TestReInvoice(TestCommonSaleTimesheet):
 
         # The actual test :
         wizard.create_invoices()  # No exception should be raised, there is indeed something to be invoiced since it was reversed
+
+    def test_project_update_reinvoiced_vendor_bill_product(self):
+        project_product, expense_product = self.env['product.product'].create([{
+            'name': 'Project creation',
+            'type': 'service',
+            'service_tracking': 'task_in_project',
+        }, {
+            'name': 'Expense Product',
+            'expense_policy': 'sales_price',
+            'list_price': 20,
+        }])
+        sale_order = self.env['sale.order'].create({'partner_id': self.partner_a.id})
+        self.env['sale.order.line'].create({
+            'product_id': project_product.id,
+            'order_id': sale_order.id,
+        })
+        sale_order.action_confirm()
+        project = sale_order.project_ids
+        self.assertTrue(project, 'Project should have been created on sale order confirmation')
+
+        vendor_bill = self.env['account.move'].create({
+            'partner_id': self.partner_a.id,
+            'invoice_date': sale_order.date_order,
+            'journal_id': self.env['account.journal'].search([('code', '=', 'BILL'), ('company_id', '=', self.env.company.id)]).id,
+            'move_type': 'in_invoice',
+        })
+        self.env['account.move.line'].create({
+            'product_id': expense_product.id,
+            'move_id': vendor_bill.id,
+            'account_id': self.env['account.account'].search([('code', '=', '600000'), ('company_id', '=', self.env.company.id)]).id,
+            'analytic_distribution': {project.analytic_account_id.id: 100},
+            'price_unit': 20,
+        })
+        vendor_bill.action_post()  # An analytic line is created for the vendor bill move line
+        self.assertEqual(project.analytic_account_id.vendor_bill_count, 1, 'Vendor bill should be linked to project account')
+        self.assertTrue(vendor_bill.line_ids.analytic_line_ids, 'Analytic line should be created for the account move line')
+        self.assertTrue(sale_order.order_line.analytic_line_ids, 'Analytic line should be linked to the sale order line created by the re-invoiced expense product')
+
+        # Only the original vendor bill amount should appear on the project update, to stay consistent with the corresponding hr_expense behavior
+        updates = project._get_profitability_items()
+        data_line = updates['costs']['data'][0]
+        self.assertEqual(data_line['id'], 'other_purchase_costs')
+        self.assertEqual(data_line['billed'], -20)
+        self.assertEqual(updates['costs']['total']['billed'], -20, 'Only the vendor bill should be deducted')


### PR DESCRIPTION
Steps to reproduce:
- Install Project and sale_timesheet and Accounting
- Settings > Enable 'Analytic Accounting'
- Create a service product generating a project and task
- New Product > Set 'Re-invoice Expenses' to 'Cost'
- (If you have hr_expense you need to tick 'Can be expensed')

- Create a new quotation for your project generating product > Confirm
- Accounting > Vendors > Bills > New > Add your expense product
- Set the analytic distribution to your project's (S000... - Customer)
- Fill in Vendor, Bill Date and Price with arbritrary values > Confirm
- Project > ':' Menu on your project's card > Project Updates

The analytic line created on vendor bill confirmation is also linked to the sale order line created by the re-invoiced product on the original SO. This error notably does not occur without the sale_timesheet module, and the same flow with hr_expense instead of a vendor bill works flawlessly.

Project Updates shows the expense twice under Costs because unlike with the hr_expense module, no expense_id is linked to the account_move_line (Since regular vendor bills do no handle that field). This means we fail to filter the analytic_line in `_get_profitability_aal_domain`, thus reading the same update analytic line and deducting the amount twice.

Given that the vendor bill was meant to be treated as an expense, and that the same flow using hr_expense instead of a vendor bill results in only 1 line of costs, we want to replicate that behavior here, but we don't have a clean way to filter for these types of analytic lines. As a workaround we use the property of `_get_costs_items_from_purchase` to label updates in the 'other_purchase_costs' category to single out vendor bill updates and skip processing them the second time they come up.

opw-4042729

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
