### PR TITLE
[IMP] web: make selected tags bold in dropdown

### DIFF
--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
@@ -169,7 +169,7 @@ export class Many2ManyTagsField extends Component {
             resId: record.resId,
             context: this.props.context,
             title: _t("Edit: %s", record.data.display_name),
-        })
+        });
     }
 
     get tags() {
@@ -198,6 +198,12 @@ export class Many2ManyTagsField extends Component {
         return Domain.and([
             getFieldDomain(this.props.record, this.props.name, this.props.domain),
         ]).toList(this.props.context);
+    }
+
+    getOptionClassnames(record) {
+        const records = this.props.record.data[this.props.name].records;
+        const isSelected = records.some((r) => r.resId === record.id);
+        return isSelected ? "dropdown-item-selected" : "";
     }
 }
 
@@ -264,7 +270,7 @@ export const many2ManyTagsField = {
         const noCreate = Boolean(options.no_create);
         const canCreate = noCreate ? false : hasCreatePermission;
         const hasEditPermission = attrs.can_write ? evaluateBooleanExpr(attrs.can_write) : true;
-        const canEditTags = Boolean(options.edit_tags) ? hasEditPermission : false;
+        const canEditTags = options.edit_tags ? hasEditPermission : false;
         const noQuickCreate = Boolean(options.no_quick_create);
         const noCreateEdit = Boolean(options.no_create_edit);
         return {

--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.scss
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.scss
@@ -42,6 +42,10 @@
             max-width: var(--Tag-max-width, 200px);
         }
     }
+
+    .dropdown-item-selected > a {
+        font-weight: bold !important;
+    }
 }
 
 .o_list_view .o_field_widget.o_field_many2many_tags {

--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.xml
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.xml
@@ -23,6 +23,7 @@
                     isToMany="true"
                     nameCreateField="props.nameCreateField"
                     noSearchMore="props.noSearchMore"
+                    getOptionClassnames.bind="getOptionClassnames"
                 />
             </div>
         </div>

--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -203,6 +203,7 @@ export class Many2XAutocomplete extends Component {
         autocomplete_container: { type: Function, optional: true },
         dropdown: { type: Boolean, optional: true },
         autofocus: { type: Boolean, optional: true },
+        getOptionClassnames: { type: Function, optional: true },
     };
     static defaultProps = {
         searchLimit: 7,
@@ -213,6 +214,7 @@ export class Many2XAutocomplete extends Component {
         quickCreate: null,
         context: {},
         dropdown: true,
+        getOptionClassnames: () => "",
     };
     setup() {
         this.orm = useService("orm");
@@ -322,6 +324,7 @@ export class Many2XAutocomplete extends Component {
             value: result[0],
             label: result[1] ? result[1].split("\n")[0] : _t("Unnamed"),
             displayName: result[1],
+            classList: this.props.getOptionClassnames({ id: result[0], display_name: result[1] }),
         };
     }
     async loadOptionsSource(request) {

--- a/addons/web/static/tests/views/fields/many2many_tags_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_field.test.js
@@ -152,7 +152,7 @@ test("Many2ManyTagsField with and without color", async () => {
 });
 
 test("Many2ManyTagsField with color: rendering and edition", async () => {
-    expect.assertions(24);
+    expect.assertions(26);
 
     Partner._records[0].timmy = [12, 14];
     PartnerType._records.push({ id: 13, name: "red", color: 8 });
@@ -189,9 +189,9 @@ test("Many2ManyTagsField with color: rendering and edition", async () => {
 
     // add an other existing tag
     await contains("div[name='timmy'] .o-autocomplete.dropdown input").click();
-
+    expect(`.dropdown-item-selected`).toHaveCount(2);
+    expect(queryAllTexts`.dropdown-item-selected`).toEqual(["gold", "silver"]);
     expect(".o-autocomplete--dropdown-menu li").toHaveCount(5);
-
     expect(".o-autocomplete--dropdown-menu li a:eq(2)").toHaveText("red");
 
     await contains(".o-autocomplete--dropdown-menu li a:eq(2)").click();


### PR DESCRIPTION
Before this commit, the user could not see the selected tags in the dropdown nor the "Search more" dialog.
This commit makes the tags bold in the dropdown and in the "Search more" dialog.

task-3919307