### PR TITLE
[FIX] mail: infinite loop member list with same names

### DIFF
--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -548,7 +548,12 @@ export class Thread extends Record {
                     !this.store.Thread.onlineMemberStatuses.includes(member.persona?.im_status)
             );
         },
-        sort: (m1, m2) => (m1.persona?.name < m2.persona?.name ? -1 : 1),
+        sort: (m1, m2) => {
+            if (m1.persona?.name === m2.persona?.name) {
+                return m1.id - m2.id;
+            }
+            return m1.persona?.name < m2.persona?.name ? -1 : 1;
+        },
     });
 
     get nonEmptyMessages() {


### PR DESCRIPTION
This PR fixes an infinite loop that occurs when opening a member list with two members sharing the same name on firefox. This occurs because the sort function on `offlineMembers` is non deterministic when two members have the same name. It will first put the first member above the other one, then the opposite and so on. This PR updates the sort function to rely on id when two members have the same name, making the sort deterministic.