### PR TITLE
[FIX] mrp: prevent error when opening BOM Overview

### DIFF
--- a/addons/mrp/report/mrp_report_bom_structure.py
+++ b/addons/mrp/report/mrp_report_bom_structure.py
@@ -98,7 +98,7 @@ class ReportBomStructure(models.AbstractModel):
         if searchVariant:
             product = self.env['product.product'].browse(int(searchVariant))
         else:
-            product = bom.product_id or bom.product_tmpl_id.product_variant_id
+            product = bom.product_id or bom.product_tmpl_id.product_variant_id or bom.product_tmpl_id.with_context(active_test=False).product_variant_ids[:1]
 
         if bom:
             bom_uom_name = bom.product_uom_id.name
@@ -474,7 +474,7 @@ class ReportBomStructure(models.AbstractModel):
         if product_id:
             product = self.env['product.product'].browse(int(product_id))
         else:
-            product = bom.product_id or bom.product_tmpl_id.product_variant_id or bom.product_tmpl_id.with_context(active_test=False).product_variant_id
+            product = bom.product_id or bom.product_tmpl_id.product_variant_id or bom.product_tmpl_id.with_context(active_test=False).product_variant_ids[:1]
 
         if self.env.context.get('warehouse'):
             warehouse = self.env['stock.warehouse'].browse(self.env.context.get('warehouse'))


### PR DESCRIPTION
When the Customer archives the product and opens the BOM overview,
a traceback will appear.

Steps to reproduce the error:
- Go to Mrp > Configuration > Settings > Enable By-Products
- Create a new BOM > Select Product A > Select By-product in By-products > Save
- Archive Product A > Return to BOM
- Open BOM overview

Traceback:
```
ValueError: not enough values to unpack (expected 1, got 0)
  File "odoo/models.py", line 5975, in ensure_one
    _id, = self._ids
ValueError: Expected singleton: product.product()
  File "odoo/http.py", line 2383, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1913, in _serve_db
    return self._transactioning(
  File "odoo/http.py", line 1976, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1943, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2187, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 227, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 757, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 35, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 459, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/mrp/report/mrp_report_bom_structure.py", line 16, in get_html
    res = self._get_report_data(bom_id=bom_id, searchQty=searchQty, searchVariant=searchVariant)
  File "addons/mrp/report/mrp_report_bom_structure.py", line 119, in _get_report_data
    lines = self._get_bom_data(bom, warehouse, product=product, line_qty=bom_quantity, level=0)
  File "addons/mrp/report/mrp_report_bom_structure.py", line 315, in _get_bom_data
    byproducts, byproduct_cost_portion = self._get_byproducts_lines(product, bom, current_quantity, level + 1, bom_report_line['bom_cost'], index)
  File "addons/mrp/report/mrp_report_bom_structure.py", line 421, in _get_byproducts_lines
    if byproduct._skip_byproduct_line(product):
  File "addons/mrp/models/mrp_bom.py", line 740, in _skip_byproduct_line
    return not product._match_all_variant_values(self.bom_product_template_attribute_value_ids)
  File "addons/mrp/models/product.py", line 342, in _match_all_variant_values
    self.ensure_one()
  File "odoo/models.py", line 5978, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
```

https://github.com/odoo/odoo/blob/b0684bd80f31a808521cf5229b9ac8a621e39afc/addons/mrp/models/mrp_bom.py#L600 When Customer archives the product and opens the BOM overview,
Here, ```product``` will be empty,
So, it will lead to the above traceback.

sentry-5844550626

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
