### PR TITLE
[FIX] hr_recruitment: add `company_id` field in applicant view

### DIFF
--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -323,6 +323,7 @@
                 <field name="user_id"/>
                 <field name="active"/>
                 <field name="application_status" />
+                <field name="company_id" invisible="1"/> <!-- We need to keep this field as it is used in the domain of user_id in the model -->
                 <progressbar field="kanban_state" colors='{"done": "success", "blocked": "danger"}'/>
                 <templates>
                     <t t-name="kanban-menu">


### PR DESCRIPTION
Steps to reproduce:
1. make an applicant, leave recruiter field empty
2. Go to kanban view and try to assign a recruiter on the applicant

Error:
```
UncaughtPromiseError > EvalError
Uncaught Promise > Can not evaluate python expression: ([('share', '=', False), ('company_ids', 'in', company_id)])
Error: Name 'company_id' is not defined
```

The issue happens because the `company_id` field is missing from the view and as a result this field cannot be found.

This commit adds the field so that the domain can be calculated correctly.

opw-4188706


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
