### PR TITLE
[FIX] im_livechat: keep live chat when reloading from different origin

### DIFF
--- a/addons/im_livechat/static/src/embed/common/store_service_patch.js
+++ b/addons/im_livechat/static/src/embed/common/store_service_patch.js
@@ -13,6 +13,10 @@ patch(Store.prototype, {
         const livechatService = this.env.services["im_livechat.livechat"];
         if (livechatService.state === SESSION_STATE.PERSISTED) {
             await super.initialize();
+            livechatService.thread ??= this.store.Thread.get({
+                id: livechatService.savedState?.store["discuss.channel"][0].id,
+                model: "discuss.channel",
+            });
             if (!livechatService.thread) {
                 livechatService.leave({ notifyServer: false });
             }


### PR DESCRIPTION
Since [1], thread is not a getter anymore. As a result, when a page reload occurs, the current live chat thread is lost.

Steps to reproduce:
- Embed the live chat in an external page.
- Start chatting.
- Reload the page.
- There chat window is not displayed.

It does not occur on the odoo website since the server sends the current thread at each reload but it is not possible in CORS context because is relies on website visitors which are not available. This PR ensures the thread is correctly set after reload.

[1]: https://github.com/odoo/odoo/pull/173197