### PR TITLE
[FIX] point_of_sale: Prevent duplicate receipt emails

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1221,6 +1221,8 @@ class PosOrder(models.Model):
         return attachment
 
     def action_send_receipt(self, email, ticket_image, basic_image):
+        if self.env['mail.mail'].sudo().search(['&', ('subject', 'like', self.name), ('email_to', '=', email)]):
+            raise UserError(_('A receipt has already been sent to this email address: %s', email))
         self.env['mail.mail'].sudo().create(self._prepare_mail_values(email, ticket_image, basic_image)).send()
         self.email = email
 

--- a/addons/pos_sms/models/pos_order.py
+++ b/addons/pos_sms/models/pos_order.py
@@ -1,13 +1,23 @@
-from odoo import models
+from odoo import models, _
+from odoo.exceptions import UserError
 
 
 class PosOrder(models.Model):
     _inherit = 'pos.order'
 
-    def action_sent_message_on_sms(self, phone, _):
+    def action_sent_message_on_sms(self, phone, ticket, basic):
         if not (self and self.config_id.module_pos_sms and self.config_id.sms_receipt_template_id and phone):
             return
         self.ensure_one()
+
+        sms_logs = self.env['sms.sms'].search([
+            ('number', '=', phone),
+            ('mail_message_id', '=', self.name)
+        ])
+
+        if sms_logs:
+            raise UserError(_('A receipt has already been sent to this number: %s', phone))
+
         sms_composer = self.env['sms.composer'].with_context(active_id=self.id).create(
             {
                 'composition_mode': 'comment',


### PR DESCRIPTION
Previously, it was possible to send a receipt to the same email address multiple times from the receipt screen. This update addresses that issue by restricting users to send the receipt to each email address only once. Same applies to SMS.

related: https://github.com/odoo/enterprise/pull/70224


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
