### PR TITLE
[IMP] im_livechat, mail: call invitation in live chat

### DIFF
--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -311,7 +311,7 @@ class ChannelMember(models.Model):
                     "serverInfo": self._get_rtc_server_info(rtc_session, ice_servers),
                 },
             )
-        if len(self.channel_id.rtc_session_ids) == 1 and self.channel_id.channel_type in {'chat', 'group'}:
+        if len(self.channel_id.rtc_session_ids) == 1 and self.channel_id.channel_type != "channel":
             self.channel_id.message_post(body=_("%s started a live conference", self.partner_id.name or self.guest_id.name), message_type='notification')
             self._rtc_invite_members()
 

--- a/addons/mail/static/src/core/common/sound_effects_service.js
+++ b/addons/mail/static/src/core/common/sound_effects_service.js
@@ -1,5 +1,6 @@
 import { browser } from "@web/core/browser/browser";
 import { registry } from "@web/core/registry";
+import { url } from "@web/core/utils/urls";
 
 export class SoundEffects {
     /**
@@ -43,7 +44,7 @@ export class SoundEffects {
         if (!soundEffect.audio) {
             const audio = new browser.Audio();
             const ext = audio.canPlayType("audio/ogg; codecs=vorbis") ? ".ogg" : ".mp3";
-            audio.src = soundEffect.path + ext;
+            audio.src = url(soundEffect.path + ext);
             soundEffect.audio = audio;
         }
         if (!soundEffect.audio.paused) {

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -884,9 +884,7 @@ export class Thread extends Record {
     }
 
     /** @param {Object} [options] */
-    open(options) {
-        this.setAsDiscussThread();
-    }
+    open(options) {}
 
     openChatWindow({ fromMessagingMenu } = {}) {
         const cw = this.store.ChatWindow.insert(

--- a/addons/mail/static/src/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/core/public_web/thread_model_patch.js
@@ -82,7 +82,7 @@ patch(Thread.prototype, {
             this.openChatWindow(options);
             return;
         }
-        super.open();
+        this.setAsDiscussThread();
     },
     async unpin() {
         this.isLocallyPinned = false;

--- a/addons/mail/static/src/discuss/call/common/call_invitations.xml
+++ b/addons/mail/static/src/discuss/call/common/call_invitations.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.CallInvitations">
-        <div t-if="store.ringingThreads.length > 0" class="o-discuss-CallInvitations position-absolute top-0 end-0 d-flex flex-column p-2">
+        <div t-if="store.ringingThreads.length > 0" class="o-discuss-CallInvitations position-fixed top-0 end-0 d-flex flex-column p-2">
             <t t-foreach="store.ringingThreads" t-as="thread" t-key="thread.localId">
                 <CallInvitation thread="thread"/>
             </t>


### PR DESCRIPTION
This enables call invitations for live chats: the intent is to disable
call invitations on channels; since there are many members, it would
make too much noise. However, this was implemented checking that the
channel is of type chat or group which disables it for live chats.

At the same time, this commit fixes incorrect routes for discuss audio
files. When embed in an external page, origin should be provided.

task-4107799