### PR TITLE
[FIX] web_tour: sharing_url do not depend of url

### DIFF
--- a/addons/web_tour/models/tour.py
+++ b/addons/web_tour/models/tour.py
@@ -21,10 +21,10 @@ class Tour(models.Model):
         ('uniq_name', 'unique(name)', "A tour already exists with this name . Tour's name must be unique!"),
     ]
 
-    @api.depends("url")
+    @api.depends("name")
     def _compute_sharing_url(self):
         for tour in self:
-            tour.sharing_url = tour.url and f"{tour.get_base_url()}/odoo?tour={tour.name}"
+            tour.sharing_url = f"{tour.get_base_url()}/odoo?tour={tour.name}"
 
     @api.model
     def consume(self, tourName):


### PR DESCRIPTION
Before this commit, the sharing_url was compute on url and was not set if there was no url. But the sharing url doesn't depend on the url, but the name.

Now, the sharing_url depends on name.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
