### PR TITLE
[FIX] base: fix traceback when user removes all devices in preferences

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1998,8 +1998,9 @@ class CheckIdentity(models.TransientModel):
         return method()
 
     def revoke_all_devices(self):
+        current_password = self.password
         self._check_identity()
-        self.env.user._change_password(self.password)
+        self.env.user._change_password(current_password)
         self.sudo().unlink()
         return {'type': 'ir.actions.client', 'tag': 'reload'}
 


### PR DESCRIPTION
Currently, a traceback occurs when the user tries to `log out from all devices`.

To reproduce this issue:

1) Open the `Preferences` from the profile
2) Click `Log out from all devices` from the Account Security page 
3) Give the current password and click `Log out from all devices`

Error:- 
```
AttributeError: 'bool' object has no attribute 'strip'
```

When the user clicks on the `Log out from all devices`, the `revoke_all_devices` method triggers in which the `_check_identity` method is triggered.

https://github.com/odoo/odoo/blob/a7db2d8f1336035f6e45d04da7c2ebec5f3d9dba/odoo/addons/base/models/res_users.py#L2000-L2002

But here in the `_check_identity()` current password is set to False. This leads to a traceback from the `_change_password` method.

https://github.com/odoo/odoo/blob/a7db2d8f1336035f6e45d04da7c2ebec5f3d9dba/odoo/addons/base/models/res_users.py#L1982-L1988

https://github.com/odoo/odoo/blob/a7db2d8f1336035f6e45d04da7c2ebec5f3d9dba/odoo/addons/base/models/res_users.py#L977-L978

Note:-
I don't know the scope of setting the password as False, 
So instead of removing that line, I passed the current password as a variable.

sentry-5867375557

