### PR TITLE
[IMP] point_of_sale: auto select partner after creating it

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
@@ -92,6 +92,12 @@ export class PartnerList extends Component {
     get isBalanceDisplayed() {
         return false;
     }
+    async editPartner(p) {
+        const partner = await this.pos.editPartner(p);
+        if (partner) {
+            this.clickPartner(partner);
+        }
+    }
     clickPartner(partner) {
         this.props.getPayload(partner);
         this.props.close();

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.xml
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.xml
@@ -5,7 +5,7 @@
         <Dialog bodyClass="'partner-list overflow-y-auto'" contentClass="'h-100'">
             <t t-set-slot="header">
                 <button t-if="!ui.isSmall" class="btn btn-primary" role="img" aria-label="Add a customer"
-                        t-on-click="() => this.pos.editPartner()"
+                        t-on-click="() => this.editPartner()"
                         title="Add a customer">
                 Create 
                 </button>

--- a/addons/point_of_sale/static/src/app/store/make_awaitable_dialog.js
+++ b/addons/point_of_sale/static/src/app/store/make_awaitable_dialog.js
@@ -18,6 +18,23 @@ export function makeAwaitable(dialog, comp, props, options) {
     });
 }
 
+export function makeActionAwaitable(action, config, additionalArgs) {
+    return new Promise((resolve) => {
+        action.doAction(config, {
+            ...additionalArgs,
+            props: {
+                ...additionalArgs?.props,
+                onSave: (record) => {
+                    action.doAction({
+                        type: "ir.actions.act_window_close",
+                    });
+                    resolve(record);
+                },
+            },
+        });
+    });
+}
+
 export function ask(dialog, props, options, comp = ConfirmationDialog) {
     return new Promise((resolve) => {
         dialog.add(

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -17,7 +17,11 @@ import { TicketScreen } from "@point_of_sale/app/screens/ticket_screen/ticket_sc
 import { EditListPopup } from "@point_of_sale/app/store/select_lot_popup/select_lot_popup";
 import { ProductConfiguratorPopup } from "./product_configurator_popup/product_configurator_popup";
 import { ComboConfiguratorPopup } from "./combo_configurator_popup/combo_configurator_popup";
-import { makeAwaitable, ask } from "@point_of_sale/app/store/make_awaitable_dialog";
+import {
+    makeAwaitable,
+    ask,
+    makeActionAwaitable,
+} from "@point_of_sale/app/store/make_awaitable_dialog";
 import { deserializeDate } from "@web/core/l10n/dates";
 import { PartnerList } from "../screens/partner_list/partner_list";
 import { ScaleScreen } from "../screens/scale_screen/scale_screen";
@@ -1403,18 +1407,16 @@ export class PosStore extends Reactive {
     /**
      * @param {import("@point_of_sale/app/models/res_partner").ResPartner?} partner leave undefined to create a new partner
      */
-    editPartner(partner) {
-        this.action.doAction("point_of_sale.res_partner_action_edit_pos", {
-            props: {
-                resId: partner?.id,
-                onSave: (record) => {
-                    this.data.read("res.partner", record.config.resIds);
-                    this.action.doAction({
-                        type: "ir.actions.act_window_close",
-                    });
-                },
-            },
-        });
+    async editPartner(partner) {
+        const record = await makeActionAwaitable(
+            this.action,
+            "point_of_sale.res_partner_action_edit_pos",
+            {
+                props: { resId: partner?.id },
+            }
+        );
+        const newPartner = await this.data.read("res.partner", record.config.resIds);
+        return newPartner[0];
     }
     /**
      * @param {import("@point_of_sale/app/models/product_product").ProductProduct?} product leave undefined to create a new product


### PR DESCRIPTION
Before this commit, after creating a new partner, the user had to manually select it from the list of partners. This commit makes the system automatically select the newly created partner.

