### PR TITLE
[FIX] mrp: ensure available product is reserved for backorder

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -2055,6 +2055,15 @@ class MrpProduction(models.Model):
                 'state': 'done',
             })
 
+        # It is prudent to reserve any quantity that has become available to the backorder
+        # production's move_raw_ids after the production which spawned them has been marked done.
+        backorders_to_assign = backorders.filtered(
+            lambda order:
+            order.picking_type_id.reservation_method == 'at_confirm'
+        )
+        for backorder in backorders_to_assign:
+            backorder.action_assign()
+
         report_actions = self._get_autoprint_done_report_actions()
         if self.env.context.get('skip_redirection'):
             if report_actions:
@@ -2134,7 +2143,9 @@ class MrpProduction(models.Model):
         productions_auto = set()
         for production in self:
             if not float_is_zero(production.qty_producing, precision_rounding=production.product_uom_id.rounding):
-                production.move_raw_ids.filtered('manual_consumption').picked = True
+                production.move_raw_ids.filtered(
+                    lambda move: move.manual_consumption and not move.picked
+                ).picked = True
                 continue
             if production._auto_production_checks():
                 productions_auto.add(production.id)


### PR DESCRIPTION
Community-side fix for creating move lines instead of moves for
production backorders. This change ensures that product quantity
which was *intended* to be used by one production will rightly
get reserved by that production's backorder.

Additionally, we now use more care when marking moves as picked
because this field has an inverse which will mark all of the
move's move lines as consumed / done, despite them being
incomplete.

opw-4148050