### PR TITLE
[FIX] spreadsheet: add weekstart to locale

### DIFF
--- a/addons/spreadsheet/models/res_lang.py
+++ b/addons/spreadsheet/models/res_lang.py
@@ -35,4 +35,5 @@ class Lang(models.Model):
             "dateFormat": strftime_format_to_spreadsheet_date_format(self.date_format),
             "timeFormat": strftime_format_to_spreadsheet_time_format(self.time_format),
             "formulaArgSeparator": ";" if self.decimal_point == "," else ",",
+            "weekStart": int(self.week_start),
         }


### PR DESCRIPTION
Since b736a617e68454475a5e634667f215eed1d997b3, o-spreadsheet locale supports weekstart. This commit adds weekstart to the locale when the locale is provided from the server.

Task: 4194152

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
