### PR TITLE
[FIX] mail: align discuss sidebar badge with category actions

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -178,7 +178,7 @@
                 </div>
             </t>
             <span t-if="thread.selfMember?.message_unread_counter > 0 and !thread.isMuted and thread.importantCounter === 0" class="o-mail-DiscussSidebar-unreadIndicator position-absolute" name="unread-indicator" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }" title="Thread has unread messages"><i class="fa fa-circle smaller"/></span>
-            <span t-if="thread.importantCounter > 0" t-attf-class="o-mail-DiscussSidebar-badge badge rounded-pill o-discuss-badge fw-bold {{thread.isMuted ? 'o-muted' : ''}}" t-att-class="{ 'ms-1 me-2': !store.discuss.isSidebarCompact, 'position-absolute top-0 o-compact': store.discuss.isSidebarCompact }" t-esc="thread.importantCounter"/>
+            <span t-if="thread.importantCounter > 0" t-attf-class="o-mail-DiscussSidebar-badge badge rounded-pill o-discuss-badge fw-bold {{thread.isMuted ? 'o-muted' : ''}}" t-att-class="{ 'ms-1 me-3': !store.discuss.isSidebarCompact, 'position-absolute top-0 o-compact': store.discuss.isSidebarCompact }" t-esc="thread.importantCounter"/>
         </div>
     </t>
 


### PR DESCRIPTION
Before / After
<img width="298" alt="Screenshot 2024-09-18 at 15 12 57" src="https://github.com/user-attachments/assets/7876591b-1320-49ea-b485-b69cb6a3ad4e"> <img width="301" alt="Screenshot 2024-09-18 at 15 10 32" src="https://github.com/user-attachments/assets/9f1ea6c0-7791-4be6-b61a-733f2510100d">
