### PR TITLE
[FIX] purchase: filter products by selected company in purchase orders

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -236,7 +236,7 @@
                                         required="not display_type"
                                         width="35%"
                                         context="{'partner_id': parent.partner_id, 'quantity': product_qty, 'company_id': parent.company_id, 'use_partner_name': False}"
-                                        force_save="1" domain="[('purchase_ok', '=', True)]"/>
+                                        force_save="1" domain="[('purchase_ok', '=', True), '|', ('company_id', '=', False), ('company_id', 'parent_of', parent.company_id)]"/>
                                     <field name="name" widget="section_and_note_text"/>
                                     <field name="date_planned" optional="hide" required="not display_type" force_save="1"/>
                                     <field name="analytic_distribution" widget="analytic_distribution"


### PR DESCRIPTION
Problem:
When creating a purchase order (PO) for a company with branches, products from all branches are shown in the product list, even if only the main company is selected. However, users are not allowed to create POs for products belonging to other branches, leading to confusion.

Steps to reproduce:
- Create a company with branches.
- Configure some products for the main company and others for the branches.
- In the company selector, choose the main company, keeping branches selected.
- While creating a PO, products from the branches appear in the product list.

opw-4116680

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
