### PR TITLE
[IMP] hr_holidays: email template for cancelled TOR

### DIFF
--- a/addons/hr_holidays/tests/test_hr_departure_wizard.py
+++ b/addons/hr_holidays/tests/test_hr_departure_wizard.py
@@ -64,7 +64,7 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
             'departure_date': self.departure_date}
         self.assertTrue(message in leave.message_ids.mapped('body'))
 
-        cancel_message = "<p>The time off has been cancelled: The employee will leave the company on %(departure_date)s.</p>" % {
+        cancel_message = "<p>The time off request has been cancelled for the following reason:</p><p>The employee will leave the company on %(departure_date)s.</p>" % {
             'departure_date': self.departure_date
         }
         self.assertTrue(cancel_message in self.env['hr.leave'].search([


### PR DESCRIPTION
When an approved Time Off Request (TOR) is canceled, the manager and/or HR officer is notified. Previously, the email template did not include a link to the TOR, making it difficult to navigate to it within Odoo. This PR improves the notification by using an email template that contains a "View Time Off" button, allowing managers and HR officers to easily navigate to the canceled leave.

Task-4169798

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
