### PR TITLE
[FIX] l10n_ar: Can't force the field

### DIFF
--- a/addons/l10n_ar/i18n/es_419.po
+++ b/addons/l10n_ar/i18n/es_419.po
@@ -200,11 +200,10 @@ msgstr "<strong>Cond. IVA: </strong>"
 #: model:ir.model.fields,help:l10n_ar.field_account_move__l10n_ar_afip_concept
 #: model:ir.model.fields,help:l10n_ar.field_account_payment__l10n_ar_afip_concept
 msgid ""
-"A concept is suggested regarding the type of the products on the invoice but "
-"it is allowed to force a different type if required."
+"A concept is suggested regarding the type of the products on the invoice. "
 msgstr ""
 "Un concepto es sugerido tomando en cuenta el tipo de productos en la "
-"factura, pero es posible forzar un concepto diferente si es necesario."
+"factura."
 
 #. module: l10n_ar
 #: model:l10n_latam.document.type,name:l10n_ar.dc_ac_dis_cf

--- a/addons/l10n_ar/i18n/l10n_ar.pot
+++ b/addons/l10n_ar/i18n/l10n_ar.pot
@@ -188,8 +188,7 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_ar.field_account_move__l10n_ar_afip_concept
 #: model:ir.model.fields,help:l10n_ar.field_account_payment__l10n_ar_afip_concept
 msgid ""
-"A concept is suggested regarding the type of the products on the invoice but "
-"it is allowed to force a different type if required."
+"A concept is suggested regarding the type of the products on the invoice. "
 msgstr ""
 
 #. module: l10n_ar

--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -28,8 +28,7 @@ class AccountMove(models.Model):
     # Mostly used on reports
     l10n_ar_afip_concept = fields.Selection(
         compute='_compute_l10n_ar_afip_concept', selection='_get_afip_invoice_concepts', string="AFIP Concept",
-        help="A concept is suggested regarding the type of the products on the invoice but it is allowed to force a"
-        " different type if required.")
+        help="A concept is suggested regarding the type of the products on the invoice.")
     l10n_ar_afip_service_start = fields.Date(string='AFIP Service Start Date')
     l10n_ar_afip_service_end = fields.Date(string='AFIP Service End Date')
 


### PR DESCRIPTION
We changed the help of the field because it cannot be forced on at any time 
Adhoc-task-side: 43686

Description of the issue/feature this PR addresses:

Current behavior before PR:
Currently, the field gives incorrect information that the concept can be forced at some point, and this is not the case.

Desired behavior after PR is merged:
We cut the help so that it does not give wrong information.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
