### PR TITLE
[FIX] hr_holidays: make `_compute_number_of_days` consistent

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -196,7 +196,10 @@ class HolidaysAllocation(models.Model):
     @api.depends('number_of_days')
     def _compute_number_of_hours_display(self):
         for allocation in self:
-            allocation.number_of_hours_display = allocation.number_of_days * HOURS_PER_DAY
+            hours_per_day = allocation.employee_id.sudo().resource_calendar_id.hours_per_day\
+                    or allocation.holiday_status_id.company_id.resource_calendar_id.hours_per_day\
+                    or HOURS_PER_DAY
+            allocation.number_of_hours_display = allocation.number_of_days * hours_per_day
 
     @api.depends('number_of_hours_display', 'number_of_days_display')
     def _compute_duration_display(self):


### PR DESCRIPTION
Steps to reproduce:
Make a regular allocation for a time off type that can be taken in hours for an employee that has a working schedule other than standard 40h/week, and click save.

The number of hours is updated to an amount different to what was entered.

The issue is that https://github.com/odoo/odoo/pull/163711 changes the computation of number of hours to only work with the standard `HOURS_PER_DAY` without considering the employee's schedule, meanwhile `_compute_number_of_days` still takes the employee's schedule into account, causing an inconsistency leading to the bug.

This commit, makes the computation of days and hours consistent, so at least the amount entered is kept.

opw-4190998

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
