### PR TITLE
[IMP] point_of_sale: remove expand button from core dialog in POS

### DIFF
--- a/addons/point_of_sale/static/src/overrides/core/dialog/dialog.xml
+++ b/addons/point_of_sale/static/src/overrides/core/dialog/dialog.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="point_of_sale.Dialog.header" t-inherit="web.Dialog.header" t-inherit-mode="extension">
+        <xpath expr="//button[hasclass('o_expand_button')]" position="attributes" >
+            <attribute name="t-if">false</attribute>
+        </xpath>
+    </t>
+</templates>


### PR DESCRIPTION
Before the expand button was displayed on form view when opening it from PoS, but this fonctionnality is not handled in POS, so it's better to remove it.

