### PR TITLE
[IMP] stock: Add visibility days to orderpoint forecast

### DIFF
--- a/addons/stock/static/src/stock_forecasted/forecasted_details.xml
+++ b/addons/stock/static/src/stock_forecasted/forecasted_details.xml
@@ -81,6 +81,16 @@
                     <td t-out="line.delivery_date or ''"
                         t-attf-class="#{! line.replenishment_filled and 'o_grid_warning'}"/>
                 </tr>
+                <tr t-if="this.props.docs.qty_to_order">
+                    <td>To Order</td>
+                    <td t-out="this.props.docs.lead_days_date"/>
+                    <td t-out="_formatFloat(this.props.docs.qty_to_order)" class="text-end"/>
+                </tr>
+                <tr t-if="this.props.docs.qty_to_order !== this.props.docs.qty_to_order_with_visibility_days">
+                    <td>To Order with Visibility Days</td>
+                    <td t-out="this.props.docs.visibility_days_date"/>
+                    <td t-out="_formatFloat(this.props.docs.qty_to_order_with_visibility_days)" class="text-end"/>
+                </tr>
             </tbody>
             <thead>
                 <tr class="o_forecasted_row bg-200">

--- a/addons/stock/static/src/stock_forecasted/stock_forecasted.js
+++ b/addons/stock/static/src/stock_forecasted/stock_forecasted.js
@@ -54,7 +54,14 @@ export class StockForecasted extends Component {
             context: this.context,
             docids: [this.productId],
         });
-        this.docs = { ...reportValues.docs, ...reportValues.precision };
+        this.docs = {
+            ...reportValues.docs,
+            ...reportValues.precision,
+            lead_days_date: this.context.lead_days_date,
+            qty_to_order: this.context.qty_to_order,
+            visibility_days_date: this.context.visibility_days_date,
+            qty_to_order_with_visibility_days: this.context.qty_to_order_with_visibility_days
+        };
     }
 
     async _getResModel(){

--- a/addons/stock/static/src/widgets/json_widget.xml
+++ b/addons/stock/static/src/widgets/json_widget.xml
@@ -26,6 +26,18 @@
                         = <t t-out="jsonValue.lead_days_date"/>
                     </td>
                 </tr>
+                <tr t-if="jsonValue.visibility_days > 0">
+                    <td>Visibility days</td>
+                    <td class="text-end text-nowrap">
+                        + <t t-out="jsonValue.visibility_days"/> Day(s)
+                    </td>
+                </tr>
+                <tr t-if="jsonValue.visibility_days > 0" class="table-info fw-bold">
+                    <td>Forecasted Date + Visibility Days</td>
+                    <td class="text-end text-nowrap">
+                        = <t t-out="jsonValue.visibility_days_date"/>
+                    </td>
+                </tr>
             </tbody>
         </table>
     </div>

--- a/addons/stock/wizard/stock_replenishment_info.py
+++ b/addons/stock/wizard/stock_replenishment_info.py
@@ -4,11 +4,13 @@
 import babel.dates
 from json import dumps
 from datetime import datetime, time
+from dateutil.relativedelta import relativedelta
 
 
 from odoo import api, fields, models, SUPERUSER_ID, _
 from odoo.osv.expression import AND
 from odoo.tools.date_utils import get_month, subtract
+from odoo.tools.float_utils import float_compare
 from odoo.tools.misc import get_lang, format_date
 
 
@@ -55,6 +57,8 @@ class StockReplenishmentInfo(models.TransientModel):
                 'product_max_qty': self.env['ir.qweb.field.float'].value_to_html(orderpoint.product_max_qty, {'decimal_precision': 'Product Unit of Measure'}),
                 'product_uom_name': orderpoint.product_uom_name,
                 'virtual': orderpoint.trigger == 'manual' and orderpoint.create_uid.id == SUPERUSER_ID,
+                'visibility_days': orderpoint.visibility_days if float_compare(orderpoint.qty_forecast, orderpoint.product_min_qty, precision_rounding=orderpoint.product_uom.rounding) < 0 else 0,
+                'visibility_days_date': format_date(self.env, replenishment_report.orderpoint_id.lead_days_date + relativedelta(days=orderpoint.visibility_days))
             })
 
     @api.depends('orderpoint_id')


### PR DESCRIPTION
As the visibility days are computed somewhat invisibly, we add a bit more *visibility* to it for the user.

- Displays the visibility date in the orderpoint information when there is something to order (as it's computed the same way).
- Displays the qty to order at the normal forecasted date (without the visibility days) and the qty to order at the combined date in the forecast report from a specific orderpoint.

Task-3930803

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
