### PR TITLE
[IMP] Point of Sale: Updated Control Button Tags for Clarity

### DIFF
--- a/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.xml
+++ b/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.xml
@@ -33,11 +33,11 @@
         </xpath>
         <xpath expr="//button[hasclass('o_fiscal_position_button')]" position="after">
             <button t-if="pos.config.takeaway"
-                t-attf-class="{{ currentOrder.takeaway ? 'btn-primary' : 'btn-secondary'}} btn btn-lg py-5"
+                t-attf-class="btn-secondary btn btn-lg py-5"
                 t-on-click="clickTakeAway">
-                <i t-attf-class="{{ currentOrder.takeaway ? 'fa fa-car' : 'fa fa-cutlery'}} me-1"></i>
-                <span t-if="currentOrder.takeaway">Takeaway</span>
-                <span t-else="">Dine in</span>
+                <i t-attf-class="{{ currentOrder.takeaway ? 'fa fa-cutlery' : 'fa fa-car' }} me-1"></i>
+                <span t-if="currentOrder.takeaway">Switch to Dine in</span>
+                <span t-else="">Switch to Takeaway</span>
             </button>
         </xpath>
         <xpath expr="//button[hasclass('o_fiscal_position_button')]" position="attributes">

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -73,8 +73,8 @@ registry.category("web_tour.tours").add("pos_restaurant_sync", {
                 run: "click",
             },
             // Dine in / Takeaway can be toggled.
-            ProductScreen.clickControlButton("Dine in"),
-            ProductScreen.clickControlButton("Takeaway"),
+            ProductScreen.clickControlButton("Switch to Takeaway"),
+            ProductScreen.clickControlButton("Switch to Dine in"),
             ProductScreen.clickDisplayedProduct("Coca-Cola"),
             ProductScreen.clickDisplayedProduct("Coca-Cola"),
             ProductScreen.clickDisplayedProduct("Coca-Cola"),


### PR DESCRIPTION
Previously, it was unclear whether the mode in bars/restaurants was set to "Dine In" or "Takeaway."

We have now improved this by changing the button label for better clarity:

When in "Dine In" mode, the button now reads "Switch to Takeaway," indicating that the current mode is dine-in. When in "Takeaway" mode, the button now reads "Switch to Dine In," indicating that the current mode is takeaway. This change ensures users can easily recognize the current mode at a glance.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
