### PR TITLE
[IMP] {mrp_, stock_}account, stock: add WIP accounting

### DIFF
--- a/addons/account/data/template/account.account-generic_coa.csv
+++ b/addons/account/data/template/account.account-generic_coa.csv
@@ -4,6 +4,7 @@
 "stock_in","Stock Interim (Received)","1102","asset_current","","True"
 "stock_out","Stock Interim (Delivered)","1103","asset_current","","True"
 "cost_of_production","Cost of Production","1104","asset_current","","True"
+"wip","Work in Progress","1105","asset_current","","True"
 "receivable","Account Receivable","1210","asset_receivable","","True"
 "to_receive_rec","Products to receive","1211","asset_current","","True"
 "prepaid_expenses","Prepaid Expenses","1280","asset_current","","False"

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -558,10 +558,17 @@ class MrpWorkorder(models.Model):
         vals['leave_id'] = leave.id
         self.write(vals)
 
-    def _cal_cost(self):
+    def _cal_cost(self, date=False):
+        """Returns total cost of time spent on workorder.
+
+        :param date datetime: Only calculate for time_ids that ended before this date
+        """
         total = 0
         for wo in self:
-            duration = sum(wo.time_ids.mapped('duration'))
+            if date:
+                duration = sum(wo.time_ids.filtered(lambda t: t.date_end <= date).mapped('duration'))
+            else:
+                duration = sum(wo.time_ids.mapped('duration'))
             total += (duration / 60.0) * wo.workcenter_id.costs_hour
         return total
 

--- a/addons/mrp_account/__init__.py
+++ b/addons/mrp_account/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import models
 from . import report
+from . import wizard
 
 
 def _configure_journals(env):

--- a/addons/mrp_account/__manifest__.py
+++ b/addons/mrp_account/__manifest__.py
@@ -24,6 +24,7 @@ If the automated inventory valuation is active, the necessary accounting entries
         "views/product_views.xml",
         "views/mrp_production_views.xml",
         "views/analytic_account_views.xml",
+        "views/account_move_views.xml",
         "views/mrp_workcenter_views.xml",
         "report/report_mrp_templates.xml",
         "wizard/mrp_wip_accounting.xml",

--- a/addons/mrp_account/__manifest__.py
+++ b/addons/mrp_account/__manifest__.py
@@ -25,7 +25,8 @@ If the automated inventory valuation is active, the necessary accounting entries
         "views/mrp_production_views.xml",
         "views/analytic_account_views.xml",
         "views/mrp_workcenter_views.xml",
-        "report/report_mrp_templates.xml"
+        "report/report_mrp_templates.xml",
+        "wizard/mrp_wip_accounting.xml",
     ],
     'demo': [
         'data/mrp_account_demo.xml',

--- a/addons/mrp_account/security/ir.model.access.csv
+++ b/addons/mrp_account/security/ir.model.access.csv
@@ -3,3 +3,5 @@ access_mrp_bom_invoice_bom_readonly,mrp.bom,mrp.model_mrp_bom,account.group_acco
 access_mrp_bom_invoice_bom,mrp.bom,mrp.model_mrp_bom,account.group_account_invoice,1,0,0,0
 access_mrp_bom_line_invoice_bom_readonly,mrp.bom.line,mrp.model_mrp_bom_line,account.group_account_readonly,1,0,0,0
 access_mrp_bom_line_invoice_bom,mrp.bom.line,mrp.model_mrp_bom_line,account.group_account_invoice,1,0,0,0
+access_mrp_wip_accounting,access.wip.accounting,model_mrp_account_wip_accounting,account.group_account_manager,1,1,1,0
+access_mrp_wip_accounting_line,access.wip.accounting.line,model_mrp_account_wip_accounting_line,account.group_account_manager,1,1,1,1

--- a/addons/mrp_account/views/account_move_views.xml
+++ b/addons/mrp_account/views/account_move_views.xml
@@ -1,0 +1,17 @@
+<odoo>
+    <record id="view_move_form_inherit_mrp_account" model="ir.ui.view">
+        <field name="name">account.move.inherit.mrp.account</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button class="oe_stat_button" name="action_view_wip_production" type="object" icon="fa-wrench" invisible="wip_production_count == 0" groups="mrp.group_mrp_user">
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_value"><field name="wip_production_count"/></span>
+                        <span class="o_stat_text">Manufacturing</span>
+                    </div>
+                </button>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/mrp_account/wizard/__init__.py
+++ b/addons/mrp_account/wizard/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import mrp_wip_accounting

--- a/addons/mrp_account/wizard/mrp_wip_accounting.py
+++ b/addons/mrp_account/wizard/mrp_wip_accounting.py
@@ -1,0 +1,135 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from dateutil.relativedelta import relativedelta
+
+from odoo import fields, models, _, api, Command
+from odoo.exceptions import UserError
+from odoo.tools import format_list
+
+
+class MrpWipAccountingLine(models.TransientModel):
+    _name = 'mrp.account.wip.accounting.line'
+    _description = 'Account move line to be created when posting WIP account move'
+
+    account_id = fields.Many2one('account.account', "Account")
+    label = fields.Char("Label")
+    debit = fields.Monetary("Debit", compute='_compute_debit', store=True, readonly=False)
+    credit = fields.Monetary("Credit", compute='_compute_credit', store=True, readonly=False)
+    currency_id = fields.Many2one('res.currency', "Currency", default=lambda self: self.env.company.currency_id)
+    wip_accounting_id = fields.Many2one('mrp.account.wip.accounting', "WIP accounting wizard")
+
+    _sql_constraints = [
+        ('check_debit_credit', 'CHECK ( debit = 0 OR credit = 0 )',
+         'A single line cannot be both credit and debit.')
+    ]
+
+    @api.depends('credit')
+    def _compute_debit(self):
+        for record in self:
+            if not record.currency_id.is_zero(record.credit):
+                record.debit = 0
+
+    @api.depends('debit')
+    def _compute_credit(self):
+        for record in self:
+            if not record.currency_id.is_zero(record.debit):
+                record.credit = 0
+
+
+class MrpWipAccounting(models.TransientModel):
+    _name = 'mrp.account.wip.accounting'
+    _description = 'Wizard to post Manufacturing WIP account move'
+
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        productions = self.env['mrp.production'].browse(self.env.context.get('active_ids'))
+        # ignore selected MOs that aren't a WIP
+        productions = productions.filtered(lambda mo: mo.state in ['progress', 'to_close', 'confirmed'])
+        if 'journal_id' in fields_list:
+            default = self.env['ir.property']._get_default_property('property_stock_journal', 'product.category')[1]
+            if default:
+                res['journal_id'] = default[1]
+        if 'reference' in fields_list:
+            res['reference'] = _('Manufacturing WIP - %(orders_list)s', orders_list=productions and format_list(self.env, productions.mapped('name')) or _("Manual Entry"))
+        if 'line_ids' in fields_list:
+            res['line_ids'] = self._get_line_vals(productions)
+        return res
+
+    date = fields.Date("Date", default=fields.Datetime.now)
+    reversal_date = fields.Date(
+        "Reversal Date", compute="_compute_reversal_date", required=True,
+        readonly=False, store=True, precompute=True)
+    journal_id = fields.Many2one('account.journal', "Journal", required=True)
+    reference = fields.Char("Reference")
+    line_ids = fields.One2many('mrp.account.wip.accounting.line', 'wip_accounting_id', "WIP accounting lines")
+
+    def _get_overhead_account(self):
+        overhead_account = self.env.company.account_production_wip_overhead_account_id
+        if overhead_account:
+            return overhead_account.id
+        cop_acc = self.env['ir.property']._get_default_property('property_stock_account_production_cost_id', 'product.category')[1]
+        if cop_acc:
+            return cop_acc[1]
+        return self.env['ir.property']._get_default_property('property_stock_account_input_categ_id', 'product.category')[1]
+
+    def _get_line_vals(self, productions=False):
+        if not productions:
+            productions = self.env['mrp.production']
+        compo_value = sum(
+            ml.quantity_product_uom * (ml.product_id.lot_valuated and ml.lot_id and ml.lot_id.standard_price or ml.product_id.standard_price)
+            for ml in productions.move_raw_ids.move_line_ids.filtered(lambda ml: ml.picked and ml.quantity)
+        )
+        overhead_value = productions.workorder_ids._cal_cost()
+        sval_acc = self.env['ir.property']._get_default_property('property_stock_valuation_account_id', 'product.category')[1]
+        sval_acc = sval_acc[1] if sval_acc else False
+        return [
+            Command.create({
+                'label': _("WIP - Component Value"),
+                'credit': compo_value,
+                'account_id': sval_acc,
+            }),
+            Command.create({
+                'label': _("WIP - Overhead"),
+                'credit': overhead_value,
+                'account_id': self._get_overhead_account(),
+            }),
+            Command.create({
+                'label': _("Manufacturing WIP - %(orders_list)s", orders_list=productions and format_list(self.env, productions.mapped('name')) or _("Manual Entry")),
+                'debit': compo_value + overhead_value,
+                'account_id': self.env.company.account_production_wip_account_id.id,
+            })
+        ]
+
+    @api.depends('date')
+    def _compute_reversal_date(self):
+        for wizard in self:
+            if not wizard.reversal_date or wizard.reversal_date <= wizard.date:
+                wizard.reversal_date = wizard.date + relativedelta(days=1)
+            else:
+                wizard.reversal_date = wizard.reversal_date
+
+    def confirm(self):
+        self.ensure_one()
+        if self.env.company.currency_id.compare_amounts(sum(self.line_ids.mapped('credit')), sum(self.line_ids.mapped('debit'))) != 0:
+            raise UserError(_("Please make sure the total credit amount equals the total debit amount."))
+        if self.reversal_date <= self.date:
+            raise UserError(_("Reversal date must be after the posting date."))
+        move = self.env['account.move'].sudo().create({
+            'journal_id': self.journal_id.id,
+            'date': self.date,
+            'ref': self.reference,
+            'move_type': 'entry',
+            'line_ids': [
+                Command.create({
+                    'name': line.label,
+                    'account_id': line.account_id.id,
+                    'debit': line.debit,
+                    'credit': line.credit,
+                }) for line in self.line_ids
+            ]
+        })
+        move._post()
+        move._reverse_moves(default_values_list=[{
+            'ref': _("Reversal of: %s", self.reference),
+            'date': self.reversal_date,
+        }])._post()

--- a/addons/mrp_account/wizard/mrp_wip_accounting.xml
+++ b/addons/mrp_account/wizard/mrp_wip_accounting.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="view_wip_accounting_form" model="ir.ui.view">
+            <field name="name">Post WIP Accounting Entry</field>
+            <field name="model">mrp.account.wip.accounting</field>
+            <field name="arch" type="xml">
+                <form string="Post Manufacturing WIP">
+                    <group>
+                        <group>
+                            <field name="journal_id"/>
+                            <field name="reference"/>
+                        </group>
+                        <group>
+                            <field name="date"/>
+                            <field name="reversal_date"/>
+                        </group>
+                    </group>
+                    <field name="line_ids">
+                        <list editable="bottom">
+                            <field name="account_id"/>
+                            <field name="label"/>
+                            <field name="debit" sum="Total Debit"/>
+                            <field name="credit" sum="Total Credit"/>
+                            <field name="currency_id" column_invisible="True"/>
+                        </list>
+                    </field>
+                    <footer>
+                        <button name="confirm" string="Post WIP" data-hotkey="q" colspan="1" type="object" class="btn-primary"/>
+                        <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+
+        <record id="action_wip_accounting" model="ir.actions.act_window">
+            <field name="name">Post WIP Accounting Entry</field>
+            <field name="res_model">mrp.account.wip.accounting</field>
+            <field name="view_mode">form</field>
+            <field name="binding_model_id" ref="mrp.model_mrp_production"/>
+            <field name="groups_id" eval="[(4, ref('account.group_account_user'))]"/>
+            <field name="target">new</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/mrp_account/wizard/mrp_wip_accounting.xml
+++ b/addons/mrp_account/wizard/mrp_wip_accounting.xml
@@ -16,6 +16,7 @@
                             <field name="reversal_date"/>
                         </group>
                     </group>
+                    <field name="mo_ids" invisible="1"/>
                     <field name="line_ids">
                         <list editable="bottom">
                             <field name="account_id"/>

--- a/addons/stock_account/__init__.py
+++ b/addons/stock_account/__init__.py
@@ -39,3 +39,4 @@ def _configure_journals(env):
             data['account.journal'] = ChartTemplate._get_stock_account_journal(template_code)
         ChartTemplate._load_data(data)
         ChartTemplate._post_load_data(template_code, company, template_data)
+        ChartTemplate._load_wip_accounts(company, full_data['res.company'])

--- a/addons/stock_account/models/__init__.py
+++ b/addons/stock_account/models/__init__.py
@@ -5,6 +5,7 @@ from . import account_chart_template
 from . import account_move
 from . import analytic_account
 from . import product
+from . import res_company
 from . import stock_move
 from . import stock_location
 from . import stock_lot
@@ -13,3 +14,4 @@ from . import stock_picking
 from . import stock_quant
 from . import stock_valuation_layer
 from . import res_config_settings
+from . import template_generic_coa

--- a/addons/stock_account/models/res_company.py
+++ b/addons/stock_account/models/res_company.py
@@ -1,0 +1,9 @@
+from odoo import models, fields
+
+
+class ResCompany(models.Model):
+    _name = "res.company"
+    _inherit = "res.company"
+
+    account_production_wip_account_id = fields.Many2one('account.account', string='Production WIP Account', check_company=True)
+    account_production_wip_overhead_account_id = fields.Many2one('account.account', string='Production WIP Overhead Account', check_company=True)

--- a/addons/stock_account/models/template_generic_coa.py
+++ b/addons/stock_account/models/template_generic_coa.py
@@ -1,0 +1,24 @@
+from odoo import models
+from odoo.addons.account.models.chart_template import template
+
+
+class AccountChartTemplate(models.AbstractModel):
+    _inherit = "account.chart.template"
+
+    @template('generic_coa', 'res.company')
+    def _get_generic_coa_res_company(self):
+        res = super()._get_generic_coa_res_company()
+        res[self.env.company.id].update({
+            'account_production_wip_account_id': 'wip',
+            'account_production_wip_overhead_account_id': 'cost_of_production',
+        })
+        return res
+
+    def _load_wip_accounts(self, company, template_data):
+        company = company or self.env.company
+        if company.id in template_data:
+            company_data = template_data[company.id]
+            if 'account_production_wip_account_id' in company_data:
+                company.account_production_wip_account_id = self.ref(company_data['account_production_wip_account_id'])
+            if 'account_production_wip_overhead_account_id' in company_data:
+                company.account_production_wip_overhead_account_id = self.ref(company_data['account_production_wip_overhead_account_id'])


### PR DESCRIPTION
Adds in the feature to post WIP accounting entries along with some extra supporting bells and whistles:

- add in the necessary accounts
- make move line's date update beyond its current 2 versions (i.e. create + done dates only) so that we can more dynamically monitor when quantities have been done
- ensure strong link between the posted entries and the origin MOs

Note:
- that WIP = MO that is still being worked on, i.e. not draft, cancelled, or done (if they are selected, they will be ignored for the costs computation)
- WIP will only take into account ml done quantities/WOs based on date/end date that is the day of or before the selected accounting date

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
