### PR TITLE
[IMP] mail: darker composer bg in dark theme

### DIFF
--- a/addons/mail/static/src/core/common/composer.dark.scss
+++ b/addons/mail/static/src/core/common/composer.dark.scss
@@ -1,3 +1,7 @@
+.o-mail-Composer {
+    --mail-Composer-bg: #{mix($gray-100, $o-view-background-color)};
+}
+
 .o-mail-Composer-actions button {
     @media (hover: hover) {
         &:hover {

--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -47,6 +47,10 @@
     }
 }
 
+.o-mail-Composer-bg {
+    background-color: var(--mail-Composer-bg, $o-view-background-color);
+}
+
 .o-mail-Composer-inputStyle {
     padding-top: 10px; // carefully crafted to have the text in the middle in chat window
     padding-bottom: 10px;

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -29,7 +29,7 @@
                 <i class="fa fa-lg fa-times-circle rounded-circle p-0 ms-1 cursor-pointer" title="Stop replying" t-on-click="() => props.messageToReplyTo.cancel()"/>
             </div>
             <div class="o-mail-Composer-coreMain d-flex flex-nowrap align-items-start flex-grow-1" t-att-class="{ 'flex-column' : extended }">
-                <div class="d-flex bg-view flex-grow-1 border"
+                <div class="d-flex o-mail-Composer-bg flex-grow-1 border"
                     t-att-class="{
                         'o-mail-Composer-compactContainer m-1 shadow-sm border-secondary': compact and !props.composer.message,
                         'o-mobile rounded-3': isMobileOS,
@@ -39,7 +39,7 @@
                     }"
                 >
                     <div class="position-relative flex-grow-1">
-                        <textarea class="o-mail-Composer-input o-mail-Composer-inputStyle form-control bg-view border-0 rounded-3 shadow-none overflow-auto"
+                        <textarea class="o-mail-Composer-input o-mail-Composer-inputStyle form-control o-mail-Composer-bg border-0 rounded-3 shadow-none overflow-auto"
                             t-ref="textarea"
                             style="height:40px;"
                             t-on-keydown="onKeydown"
@@ -63,7 +63,7 @@
                             disabled="1"
                         />
                     </div>
-                    <div class="o-mail-Composer-actions d-flex bg-view"
+                    <div class="o-mail-Composer-actions d-flex o-mail-Composer-bg"
                         t-att-class="{
                             'ms-1': compact and ui.isSmall,
                             'mx-1': compact and !ui.isSmall,


### PR DESCRIPTION
There was too much contrast between message list and composer, making composer too distracting when reading messages.

This commit fixes issue by slightly darkening composer background in dark theme. White theme is unchanged and is still white.


Before
<img width="511" alt="Screenshot 2024-09-18 at 17 10 53" src="https://github.com/user-attachments/assets/ebfd4dfd-bf96-470d-804a-6716ca83eeac">
After
<img width="509" alt="Screenshot 2024-09-18 at 17 10 48" src="https://github.com/user-attachments/assets/7566f806-203d-4596-8a4b-a64d5457ad8d">
