### PR TITLE
[FIX] l10n_ar_pos: make sure the consumidor final anonimo is loaded

### DIFF
--- a/addons/l10n_ar_pos/models/__init__.py
+++ b/addons/l10n_ar_pos/models/__init__.py
@@ -3,3 +3,4 @@ from . import pos_session
 from . import res_partner
 from . import l10n_ar_afip_responsibility_type
 from . import l10n_latam_identification_type
+from . import pos_config

--- a/addons/l10n_ar_pos/models/pos_config.py
+++ b/addons/l10n_ar_pos/models/pos_config.py
@@ -1,0 +1,11 @@
+from odoo import models
+
+
+class PosConfig(models.Model):
+    _inherit = 'pos.config'
+
+    def get_limited_partners_loading(self):
+        partner_ids = super().get_limited_partners_loading()
+        if (self.env.ref('l10n_ar.par_cfa').id,) not in partner_ids:
+            partner_ids.append((self.env.ref('l10n_ar.par_cfa').id,))
+        return partner_ids


### PR DESCRIPTION
Before this commit, when loading a POs session, the default "consumido final anonimo" might not get loaded. This leads to errors either when opening the session or when attempting to create POs orders.

This commit ensures the defult partner is loaded in the POS at all times.

related PRs (fix from PEBR):
https://github.com/odoo/enterprise/pull/65296
https://github.com/odoo/enterprise/pull/70251

opw-4188710
opw-4178688