### PR TITLE
[FIX] mail: visible hover effect on chat window actions

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.dark.scss
+++ b/addons/mail/static/src/core/common/chat_window.dark.scss
@@ -3,7 +3,5 @@
 }
 
 .o-mail-ChatWindow-command {
-    &:hover, &.o-active {
-        background-color: $gray-200;
-    }
+    --mail-ChatWindow-commandHoverBg: #{mix($gray-200, $gray-300)};
 }

--- a/addons/mail/static/src/core/common/chat_window.scss
+++ b/addons/mail/static/src/core/common/chat_window.scss
@@ -20,7 +20,7 @@
 .o-mail-ChatWindow-command {
     color: inherit !important;
     &:hover:not(.o-actionsMenu), &.o-active, &.o-hover {
-        background-color: rgba(0, 0, 0, 0.05);
+        background-color: var(--mail-ChatWindow-commandHoverBg, mix($gray-100, $gray-200));
     }
     &:not(.o-active):not(.o-hover) .fa-caret-down {
         opacity: 50%;


### PR DESCRIPTION
Dark theme actions hover effect was barely noticeable. This commit improves effect to match with other parts of UI such as composer actions.

Before
<img width="456" alt="Screenshot 2024-09-18 at 17 28 10" src="https://github.com/user-attachments/assets/41f06484-ed5e-41a6-b4c6-189fd69fd960">
After
<img width="451" alt="Screenshot 2024-09-18 at 17 27 45" src="https://github.com/user-attachments/assets/8029bfff-653e-4bdb-8a9b-866ea41b9229">
