### PR TITLE
[FIX] account: missing Print & Send button for refunds

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -607,6 +607,9 @@
             <field name="inherit_id" ref="account.view_invoice_tree"/>
             <field name="mode">primary</field>
             <field name="arch" type="xml">
+                <xpath expr="//list/header" position="inside">
+                    <button name="action_send_and_print" type="object" string="Print &amp; Send"/>
+                </xpath>
                 <field name="currency_id" position="attributes">
                     <attribute name="string">Credit Note Currency</attribute>
                 </field>


### PR DESCRIPTION
With previous changes we moved the button "Print & Send" of place and forgot to re-add in in the refund list view.

See https://github.com/odoo/odoo/commit/73c9fb48c5890f956a1bef1c271f3e954e5b5386 
task-no
