### PR TITLE
[FIX] web_editor: fix grid gutter and horizontal padding in mobile view

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.frontend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.frontend.scss
@@ -40,8 +40,18 @@
         grid-template-columns: repeat(12, 1fr);
         row-gap: 0px;
         column-gap: 0px;
+
+        // Adapt the horizontal margins of a direct row child of a grid item, to
+        // make them compensate the grid item horizontal padding (to avoid an
+        // overflow).
+        .o_grid_item > .row {
+            --grid-inner-row-gutter-x: clamp(0px, 2 * var(--grid-item-padding-x), 30px);
+            margin-left: calc(-0.5 * var(--grid-inner-row-gutter-x));
+            margin-right: calc(-0.5 * var(--grid-inner-row-gutter-x));
+        }
+
+        --gutter-x: 0px;
     }
-    --gutter-x: 0px;
     --grid-item-padding-y: 10px;
     --grid-item-padding-x: 10px;
 
@@ -50,6 +60,12 @@
         min-width: 0;
         margin: 0 !important;
         padding: var(--grid-item-padding-y) var(--grid-item-padding-x) !important;
+
+        @include media-breakpoint-down(lg) {
+            // Force the horizontal padding to 15px in mobile view, to be
+            // consistent with the normal mode.
+            padding: var(--grid-item-padding-y) calc(0.5 * var(--gutter-x)) !important;
+        }
     }
 }
 
@@ -61,14 +77,6 @@
     display: flex !important;
     row-gap: 0px !important;
     column-gap: 0px !important;
-}
-
-// Adapt the horizontal margins of a direct row child of a grid item, to make
-// them compensate the grid item horizontal padding (to avoid an overflow).
-.o_grid_item > .row {
-    --grid-inner-row-gutter-x: clamp(0px, 2 * var(--grid-item-padding-x), 30px);
-    margin-left: calc(-0.5 * var(--grid-inner-row-gutter-x));
-    margin-right: calc(-0.5 * var(--grid-inner-row-gutter-x));
 }
 
 .o_grid_item_image {


### PR DESCRIPTION
When a snippet is in grid mode, the grid items horizontal padding can be modified with the "Padding (Y, X)" option. When we are in mobile view, the display is back to `flex`, in order for the layout to look like the snippets in normal mode.

However, while the normal mode columns all have the same padding, which depends on the `--gutter-x` CSS variable, the grid items still keep the horizontal grid padding, making them misaligned with the other contents.

An other inconsistency in grid mode is the `--gutter-x` variable: in order for the container to be well aligned with the header, it was set to 0 (except when the container is full-width, where it is 30px). The issue is that this rule is applied on mobile too, making the container inconsistent with the normal snippets.

This commit fixes these issues by blocking the horizontal grid padding in mobile view, and by setting the `--gutter-x` variable rule only for the desktop view.

This commit also moves the rule added in commit [1], which is used to compensate the margins of the rows that are direct children of grid items. Indeed, now that the padding is not variable in mobile view, this rule is only needed in desktop view.

[1]: https://github.com/odoo/odoo/commit/d7c2f8b4a3535f5c15043226a296d10be4208cec

task-4194685