### PR TITLE
[FIX] stock: Fix forecast report for multi-step push rules

### DIFF
--- a/addons/stock/report/report_stock_quantity.py
+++ b/addons/stock/report/report_stock_quantity.py
@@ -13,7 +13,7 @@ class ReportStockQuantity(models.Model):
         'product.product': ['product_tmpl_id'],
         'product.template': ['type'],
         'stock.location': ['parent_path'],
-        'stock.move': ['company_id', 'date', 'location_dest_id', 'location_id', 'product_id', 'product_qty', 'state'],
+        'stock.move': ['company_id', 'date', 'location_dest_id', 'location_final_id', 'location_id', 'product_id', 'product_qty', 'state'],
         'stock.quant': ['company_id', 'location_id', 'product_id', 'quantity'],
         'stock.warehouse': ['view_location_id'],
     }
@@ -56,7 +56,7 @@ WITH
         SELECT m.id, m.product_id, pt.id, m.product_qty, m.date, m.state, m.company_id, source.w_id, dest.w_id
         FROM stock_move m
         LEFT JOIN warehouse_cte source ON source.sl_id = m.location_id
-        LEFT JOIN warehouse_cte dest ON dest.sl_id = m.location_dest_id
+        LEFT JOIN warehouse_cte dest ON dest.sl_id = COALESCE(m.location_final_id, m.location_dest_id)
         LEFT JOIN product_product pp on pp.id=m.product_id
         LEFT JOIN product_template pt on pt.id=pp.product_tmpl_id
         WHERE pt.type = 'product' AND

--- a/addons/stock/report/stock_forecasted.py
+++ b/addons/stock/report/stock_forecasted.py
@@ -33,7 +33,11 @@ class StockForecasted(models.AbstractModel):
         out_domain = move_domain + [
             '&',
             ('location_id', 'in', wh_location_ids),
+            '|',
             ('location_dest_id', 'not in', wh_location_ids),
+            '&',
+            ('location_final_id', '!=', False),
+            ('location_final_id', 'not in', wh_location_ids),
         ]
         in_domain = move_domain + [
             '&',

--- a/addons/stock/tests/test_report.py
+++ b/addons/stock/tests/test_report.py
@@ -348,6 +348,59 @@ class TestReports(TestReportsCommon):
             [], ['product_qty:sum'])
         self.assertEqual(report_records[0][0], 10.0)
 
+    def test_report_quantity_4(self):
+        """ Checks the predicted quantity works in a multi-step setup.
+        """
+        now = datetime.now()
+        customer_loc, supplier_loc = self.env['stock.warehouse']._get_partner_locations()
+        self.wh_2.write({'reception_steps': 'two_steps', 'delivery_steps': 'pick_ship'})
+
+        # Pick move for delivery of 5 units in 2 days
+        move_pick = self.env['stock.move'].create({
+            'name': 'Out',
+            'picking_type_id': self.wh_2.pick_type_id.id,
+            'location_id': self.wh_2.lot_stock_id.id,
+            'location_final_id': customer_loc.id,
+            'product_id': self.product1.id,
+            'product_uom_qty': 5.0,
+            'date': now + timedelta(days=2),
+        })
+        move_pick._action_confirm()
+        self.env.flush_all()
+        report_records = self.env['report.stock.quantity']._read_group(
+            [('state', '=', 'forecast'), ('product_id', '=', self.product1.id), ('date', '=', now.date())],
+            [], ['product_qty:sum'])
+        self.assertFalse(report_records[0][0], "Forecast should still be at 0 today, so no records.")
+        report_records = self.env['report.stock.quantity']._read_group(
+            [('state', '=', 'forecast'), ('product_id', '=', self.product1.id), ('date', '=', (now + timedelta(days=2)).date())],
+            [], ['product_qty:sum'])
+        self.assertEqual(report_records[0][0], -5)
+
+        # In move for receipt of 10 units tomorrow
+        move_in = self.env['stock.move'].create({
+            'name': 'In',
+            'picking_type_id': self.wh_2.in_type_id.id,
+            'location_id': supplier_loc.id,
+            'location_final_id': self.wh_2.lot_stock_id.id,
+            'product_id': self.product1.id,
+            'product_uom_qty': 10.0,
+            'date': now + timedelta(days=1),
+        })
+        move_in._action_confirm()
+        self.env.flush_all()
+        report_records = self.env['report.stock.quantity']._read_group(
+            [('state', '=', 'forecast'), ('product_id', '=', self.product1.id), ('date', '=', now.date())],
+            [], ['product_qty:sum'])
+        self.assertFalse(report_records[0][0], "Forecast should still be at 0 today, so no records.")
+        report_records = self.env['report.stock.quantity']._read_group(
+            [('state', '=', 'forecast'), ('product_id', '=', self.product1.id), ('date', '=', (now + timedelta(days=1)).date())],
+            [], ['product_qty:sum'])
+        self.assertEqual(report_records[0][0], 10)
+        report_records = self.env['report.stock.quantity']._read_group(
+            [('state', '=', 'forecast'), ('product_id', '=', self.product1.id), ('date', '=', (now + timedelta(days=2)).date())],
+            [], ['product_qty:sum'])
+        self.assertEqual(report_records[0][0], 5)
+
     def test_report_forecast_1(self):
         """ Checks report data for product is empty. Then creates and process
         some operations and checks the report data accords rigthly these operations.
@@ -1336,6 +1389,26 @@ class TestReports(TestReportsCommon):
                 'forecast_availability': 3.0,
             }
         ])
+
+    def test_report_forecast_14_ongoing_multi_step_delivery(self):
+        """ Check that an ongoing multi-step delivery is properly picked up by the forecast report.
+        """
+        customer_loc, __ = self.env['stock.warehouse']._get_partner_locations()
+        self.wh_2.write({'delivery_steps': 'pick_ship'})
+
+        # Pick move for future delivery
+        move_pick = self.env['stock.move'].create({
+            'name': 'Out',
+            'picking_type_id': self.wh_2.pick_type_id.id,
+            'location_id': self.wh_2.lot_stock_id.id,
+            'location_final_id': customer_loc.id,
+            'product_id': self.product1.id,
+            'product_uom_qty': 5.0,
+        })
+        move_pick._action_confirm()
+        _, _, lines = self.get_report_forecast(product_template_ids=self.product1.product_tmpl_id.ids, context={'warehouse': self.wh_2.id})
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines[0]['move_out']['id'], move_pick.id)
 
     def test_report_reception_1_one_receipt(self):
         """ Create 2 deliveries and 1 receipt where some of the products being received


### PR DESCRIPTION
Following #156437, the new default setup for multi-step deliveries is through the new push rules. This means that when you trigger a delivery to a customer, it will first create the PICK before creating the delivery.

This means that now we need to check on the `location_final_id` if it exists before checking the `location_dest_id`, as it holds the real destination of the move to consider it as an 'out' move or not.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
