### PR TITLE
[FIX] Payment : Fix Kanban view of payment providers.

### DIFF
--- a/addons/payment/views/payment_provider_views.xml
+++ b/addons/payment/views/payment_provider_views.xml
@@ -156,8 +156,8 @@
                         </aside>
                         <main class="ms-2">
                             <field name="name" class="mb-0 fw-bold fs-4"/>
-                            <t t-if="installed">
-                                <div class="d-flex">
+                            <div class="d-flex">
+                                <t t-if="installed">
                                     <field name="state"
                                         widget="label_selection"
                                         options="{'classes': {'enabled': 'success', 'test': 'warning', 'disabled' : 'light'}}"/>
@@ -173,9 +173,9 @@
                                             </span>
                                         </div>
                                     </t>
-                                </div>
-                            </t>
-                            <span t-if="to_upgrade" class="badge text-bg-primary ms-1">Enterprise</span>
+                                </t>
+                                <span t-if="to_upgrade" class="badge text-bg-primary">Enterprise</span>
+                            </div>
                             <footer>
                                 <button t-if="!installed and !selection_mode and !to_buy" type="object" class="btn btn-sm btn-primary ms-auto" name="button_immediate_install">Install</button>
                                 <button t-if="installed and is_disabled and !selection_mode" type="edit" class="btn btn-sm btn-secondary ms-auto">Activate</button>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
- Fixed the Kanban view of Payment Provider. Fixed the Enterprise Label.

**Impacted versions:**
* master

**Steps to Reproduce :**
- Go to the Invoicing --> Configuration --> Payment Providers.   
- Check the Enterprise Label From Payment Provider's kanban view.

**Current behavior before PR:**
System shows the large Enterprise Label on Payment Provider.

**Desired behavior after PR is merged:**
After this PR merge, System will correctly shows the Enterprise Label

![Payment-Providers](https://github.com/user-attachments/assets/68978d4c-54a2-4929-bda3-c1c0cc6d1b7e)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
