### PR TITLE
[FIX] l10n_cl: Remove condition for credit notes for foreign suppliers

### DIFF
--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -59,8 +59,7 @@ class AccountMove(models.Model):
             country_id = rec.partner_id.country_id
             latam_document_type_code = rec.l10n_latam_document_type_id.code
             if (rec.journal_id.type == 'purchase' and tax_payer_type == '4' and country_id.code != 'CL' and
-                latam_document_type_code == '61' and
-               '46' in rec.l10n_cl_reference_ids.mapped('l10n_cl_reference_doc_type_selection')):
+                latam_document_type_code == '61':
                 continue
             if (not tax_payer_type or not vat) and (country_id.code == "CL" and latam_document_type_code
                                                   and latam_document_type_code not in ['35', '38', '39', '41']):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The if condition included a field that, besides that has been deprecated in new versions, it belongs to enterprise.


Current behavior before PR:
An exception would appear in a credit note generated for foreign customers (usually when creating a credit note for a purchase invoice type 46).

Desired behavior after PR is merged:
By removing the field credit notes are allowed for foreign customers. We don't check now if the credit note is related to a doc type 46 or not, nevertheless trying to do so would be too costly, since the field we need to check is in model related documents belonging to enterprise. We can live without this validation.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
