### PR TITLE
[FIX] stock: Use partner on picking for delivery address on delivery slip

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -912,7 +912,7 @@ class Picking(models.Model):
 
     def should_print_delivery_address(self):
         self.ensure_one()
-        return self.move_ids and self.move_ids[0].partner_id and self._is_to_external_location()
+        return self.move_ids and (self.move_ids[0].partner_id or self.partner_id) and self._is_to_external_location()
 
     def _is_to_external_location(self):
         self.ensure_one()

--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -11,7 +11,7 @@
                         <div name="outgoing_delivery_address"
                             t-if="o.should_print_delivery_address()">
                             <span><strong>Delivery Address:</strong></span>
-                            <div t-field="o.move_ids[0].partner_id"
+                            <div t-out="o.move_ids[0].partner_id or o.partner_id"
                                 t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
                         </div>
                         <div name="outgoing_warehouse_address"

--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -21,7 +21,7 @@
                                 <div class="col-6" name="div_outgoing_address">
                                     <div t-if="o.should_print_delivery_address()">
                                         <span><strong>Delivery Address:</strong></span>
-                                        <div t-field="o.move_ids[0].partner_id"
+                                        <div t-out="o.move_ids[0].partner_id or o.partner_id"
                                             t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'>
                                                 <div class="bg-light border-1 rounded h-100 d-flex flex-column align-items-center justify-content-center p-4 opacity-75 text-muted text-center">
                                                     <strong>Delivery address</strong>
@@ -193,7 +193,7 @@
                                     </tr>
                                 </tbody>
                             </table>
-                            
+
                             <t t-set="no_reserved_product" t-value="o.move_ids.filtered(lambda x: x.product_uom_qty != x.quantity and x.move_line_ids and x.state!='done')"/>
                             <p t-if="o.state in ['draft', 'waiting', 'confirmed'] or no_reserved_product"><i class="fa fa-exclamation-triangle" />
                                 All products could not be reserved. Click on the "Check Availability" button to try to reserve products.


### PR DESCRIPTION
Version: 17.0+

Issue:
If there is no partner on the stock moves, the delivery address will not display on the delivery slip.

Purpose of this PR:
Change the logic to use the stock.picking partner so that the delivery address will be printed on the delivery slip.

Steps to reproduce on runbot:
1) create a receipt transfer
2) return the receipt transfer
3) print the delivery slip for the return
4) view that there is no delivery address, only the warehouse address

Notes:
There are three conditions that must be met for the delivery address to be printed on the delivery slip.
- there are stock moves
- the first stock move has a partner
- the picking type code is outgoing

With the above workflow, the stock moves are not assigned a partner although a partner is assigned on the picking.

opw-4177811

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
